### PR TITLE
misaplaced a bracket causing compilation errors

### DIFF
--- a/src/lb.c
+++ b/src/lb.c
@@ -637,8 +637,8 @@ int lb_lbfluid_save_checkpoint(char* filename, int binary) {
 		}
 		fclose(cpfile);
 		return ES_OK;
-	}
 #endif
+	}
 
   return ES_ERROR;
 }


### PR DESCRIPTION
apologies for yet another pull request but Alex found a bug when LB_GPU is compiled in without LB causes compilation to fail.
