### PR TITLE
Fixed compiler warnings for cython.

### DIFF
--- a/cython/interaction_data.pxd
+++ b/cython/interaction_data.pxd
@@ -15,6 +15,8 @@ cdef extern from "../src/interaction_data.h":
     double LJ_min
 
   cdef IA_parameters *get_ia_param(int i, int j)
+
+cdef extern from "../src/lj.h":
   cdef int lennard_jones_set_params(int part_type_a, int part_type_b,
                                         double eps, double sig, double cut,
                                         double shift, double offset,

--- a/cython/lb.pxd
+++ b/cython/lb.pxd
@@ -1,5 +1,8 @@
-cdef extern from "config.h":
+cdef extern from "../src/config.h":
   pass
+
+#cdef extern from "../src/lattice.h":
+#  int lattice_switch
 
 cdef extern from "lb.h":
   int lb_lbfluid_set_tau(double p_tau)
@@ -7,8 +10,22 @@ cdef extern from "lb.h":
   int lb_lbfluid_get_density(double* p_dens)
   int lb_lbfluid_set_visc(double p_visc)
   int lb_lbfluid_get_visc(double* p_visc)
-  int lb_lbfluid_set_agrid(double agrid)
+  int lb_lbfluid_set_agrid(double p_agrid)
   int lb_lbfluid_get_agrid(double* p_agrid)
   int lb_lbfluid_set_friction(double friction)
   int lb_lbfluid_get_friction(double* p_friction)
+  int lb_lbfluid_set_gamma_odd(double p_gamma_odd)
+  int lb_lbfluid_get_gamma_odd(double* p_gamma_odd)
+  int lb_lbfluid_set_gamma_even(double p_gamma_even)
+  int lb_lbfluid_get_gamma_even(double* p_gamma_even)
+  int lb_lbfluid_set_ext_force(double p_fx, double p_fy, double p_fz)
+  int lb_lbfluid_get_ext_force(double* p_fx, double* p_fy, double* p_fz)
+  int lb_lbfluid_set_bulk_visc(double p_bulk_visc)
+  int lb_lbfluid_get_bulk_visc(double* p_bulk_visc)
+  int lb_lbfluid_print_vtk_velocity(char* filename)
+  int lb_lbfluid_print_vtk_boundary(char* filename)
+  int lb_lbfluid_print_velocity(char* filename)
+  int lb_lbfluid_print_boundary(char* filename)
+  int lb_lbfluid_save_checkpoint(char* filename, int binary)
+  int lb_lbfluid_load_checkpoint(char* filename, int binary)
   void cython_lb_init(int switch)

--- a/cython/lb.pyx
+++ b/cython/lb.pyx
@@ -4,35 +4,6 @@ include "myconfig.pxi"
 import numpy as np
 cimport lb
 
-#cdef extern from "../src/lattice.h":
-#  int lattice_switch
-#don t work within header lb.pxd no idea why
-cdef extern from "../src/lb.h":
-  int lb_lbfluid_set_tau(double p_tau)
-  int lb_lbfluid_set_density(double p_dens)
-  int lb_lbfluid_get_density(double* p_dens)
-  int lb_lbfluid_set_visc(double p_visc)
-  int lb_lbfluid_get_visc(double* p_visc)
-  int lb_lbfluid_set_agrid(double p_agrid)
-  int lb_lbfluid_get_agrid(double* p_agrid)
-  int lb_lbfluid_set_friction(double friction)
-  int lb_lbfluid_get_friction(double* p_friction)
-  int lb_lbfluid_set_gamma_odd(double p_gamma_odd)
-  int lb_lbfluid_get_gamma_odd(double* p_gamma_odd)
-  int lb_lbfluid_set_gamma_even(double p_gamma_even)
-  int lb_lbfluid_get_gamma_even(double* p_gamma_even)
-  int lb_lbfluid_set_ext_force(double p_fx, double p_fy, double p_fz)
-  int lb_lbfluid_get_ext_force(double* p_fx, double* p_fy, double* p_fz)
-  int lb_lbfluid_set_bulk_visc(double p_bulk_visc)
-  int lb_lbfluid_get_bulk_visc(double* p_bulk_visc)
-  int lb_lbfluid_print_vtk_velocity(char* filename)
-  int lb_lbfluid_print_vtk_boundary(char* filename)
-  int lb_lbfluid_print_velocity(char* filename)
-  int lb_lbfluid_print_boundary(char* filename)
-  int lb_lbfluid_save_checkpoint(char* filename, int binary)
-  int lb_lbfluid_load_checkpoint(char* filename, int binary)
-  void cython_lb_init(int switch)
-
 cdef class LBparaHandle:
   cdef int switch
   cdef int checkpoint_binary

--- a/cython/make_myconfig.py
+++ b/cython/make_myconfig.py
@@ -111,8 +111,9 @@ import re
 def feature_value(myconfig, f):
     without_c_comments=re.sub("/\*.*?\*/", " ", myconfig, flags=re.DOTALL)
     without_cpp_comments=re.sub("//.*", " ", without_c_comments)
-    found=re.search(".*(define) "+f,without_cpp_comments)
-    m=re.match(".*(#define)\s*("+f+")\s+(\.*)", without_cpp_comments, re.DOTALL)
+    # The following regex requires the string to have at least a space or line break after the constant name
+    m=re.match(".*(#define)\s*("+f+")\s+(\.*)", without_cpp_comments + "\n", re.DOTALL)
+    print f,m
     if m:
         if m.group(3) != "":
             return m.group(3)

--- a/cython/setup.py
+++ b/cython/setup.py
@@ -13,7 +13,17 @@ ext_params['extra_compile_args'] = ["-fPIC"]
 ext_params["depends"] = ["myconfig.pxi"]
 #ext_params['extra_link_args'] = ["-Wl", "-Wl"]  # TODO: ad-neeeded ignored
 
-#include myconfig.pxi dependency!!
+# Convert the cython myconfig.pxi to a python dictionary (we can't just include it)
+config = {}
+with open("myconfig.pxi") as f:
+    myconfig = f.readlines()
+    for line in myconfig:
+        line = line.split(" = ")
+        try:
+            config[line[0][4:]] = int(line[1][:-1])
+        except ValueError:
+            config[line[0][4:]] = line[1][:-1]
+
 
 libs = ['Espresso','tcl8.5', 'mpi', 'fftw3']
 lib_dirs = ['']
@@ -23,7 +33,6 @@ ext_modules=[
     Extension("particle_data", ["particle_data.pyx"], libraries=libs, **ext_params),
     Extension("interaction_data", ["interaction_data.pyx"], libraries=libs, **ext_params),
     Extension("global_variables", ["global_variables.pyx"], libraries=libs, **ext_params),
-    Extension("lb", ["lb.pyx"], libraries=libs, **ext_params),
     Extension("debye_hueckel", ["debye_hueckel.pyx"], libraries=libs, **ext_params),
     Extension("integrate", ["integrate.pyx"], libraries=libs, **ext_params),
     Extension("thermostat", ["thermostat.pyx"], libraries=libs, **ext_params),
@@ -35,6 +44,9 @@ ext_modules=[
     Extension("analyze", ["analyze.pyx"], libraries=libs, **ext_params),
     Extension("utils", ["utils.pyx"], libraries=libs, **ext_params),
 ]
+
+if config["LB"] == 1:
+    ext_modules.append(Extension("lb", ["lb.pyx"], libraries=libs, **ext_params))
 
 setup(
 #  name = 'BLAS and LAPACK wrapper',

--- a/src/dihedral.h
+++ b/src/dihedral.h
@@ -29,6 +29,7 @@
 #include "utils.h"
 #include "interaction_data.h"
 #include "communication.h"
+#include "grid.h"
 
 #define ANGLE_NOT_DEFINED -100
 


### PR DESCRIPTION
Implicit declarations due to missing header includes.
Parse myconfig for use in setup.py.
