### PR TITLE
Bootstrap can now be called from within a build directory.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+
+cd `dirname $0`
+
 autoreconf -iv -Wall
 autoreconf -fv -Wall


### PR DESCRIPTION
Super simple change, only relies on "dirname", which is in POSIX. Get's rid of the annoyance of having to cd to the toplevel directory to bootstrap and then back to configure.
