### PR TITLE
Fix CUDA on Mac OS X. Fix CUDA in conjunction with mpifake.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -450,7 +450,16 @@ AS_IF([test x$with_cuda != xno],[
         LDFLAGS="$LDFLAGS -L$cuda_path/lib"
     ])
 
-    NVCCFLAGS="$NVCCFLAGS -I$cuda_path/include -I/usr/include/mpi"
+    NVCCFLAGS="$NVCCFLAGS -I$cuda_path/include"
+    AS_IF([test x"$use_mpi_fake" = xyes], [
+        NVCCFLAGS="$NVCCFLAGS -I./mpifake"
+    ],[
+        NVCCFLAGS="$NVCCFLAGS -I/usr/include/mpi"
+    ])
+    case $target in
+        x86_64-apple-darwin*)
+                NVCCFLAGS="$NVCCFLAGS -m64";;
+    esac
     CFLAGS="$CFLAGS -I$cuda_path/include"
 
     # NVCC


### PR DESCRIPTION
nvcc on OS X compiles 32-bit binaries even on 64-bit systems. So check whether we're compiling for 64-bit Macs and set `-m64` accordingly.

Use `-I./mpifake` instead of `-I/usr/include/mpi` in nvcc flags if compiling with mpifake.
