### PR TITLE
added the velocity functionality to rhomboid lb-boundary

### DIFF
--- a/src/tcl/lb-boundaries_tcl.cpp
+++ b/src/tcl/lb-boundaries_tcl.cpp
@@ -613,6 +613,31 @@ int tclcommand_lbboundary_rhomboid(LB_Boundary *lbb, Tcl_Interp *interp, int arg
 				
       argc -= 4; argv += 4;
     }
+    else if(ARG_IS_S(0, "velocity")) {
+        if(argc < 4) {
+            Tcl_AppendResult(interp, "lbboundary rhomboid velocity <vx> <vy> <vz> expected", (char *) NULL);
+            return (TCL_ERROR);
+        }
+        
+        if(Tcl_GetDouble(interp, argv[1], &(lbb->velocity[0])) == TCL_ERROR ||
+           Tcl_GetDouble(interp, argv[2], &(lbb->velocity[1])) == TCL_ERROR ||
+	       Tcl_GetDouble(interp, argv[3], &(lbb->velocity[2])) == TCL_ERROR)
+            return (TCL_ERROR);
+        
+        if (lattice_switch & LATTICE_LB_GPU) {	
+#ifdef LB_GPU
+            /* No velocity rescaling is required */
+#endif
+        } else {	
+#ifdef LB
+            lbb->velocity[0]*=lbpar.tau/lbpar.agrid;
+            lbb->velocity[1]*=lbpar.tau/lbpar.agrid;
+            lbb->velocity[2]*=lbpar.tau/lbpar.agrid;
+#endif
+        }
+        
+        argc -= 4; argv += 4;
+    }
     else if(ARG_IS_S(0, "direction")) {
       if (argc < 2) {
 				Tcl_AppendResult(interp, "lbboundary rhomboid direction {inside|outside} expected", (char *) NULL);


### PR DESCRIPTION
I added the velocity option to the lbboundary rhomboid (as was done for the wall previously) so that we can use it to start fluid at the beginning of the channel instead of setting it individually in tcl for each lbnode in each time step. I did not do it for sphere, cylinder, etc. because I did not know if there was some reason for not specifying it for all these other boundaries in the first place. 
Please, merge. Thank you.
Iva Jancigova (object-in-fluid)
