### PR TITLE
Fixed __builtin__ confusion from commit 1883077

### DIFF
--- a/tools/blockfile.py
+++ b/tools/blockfile.py
@@ -47,7 +47,7 @@ for col_type in col_types:
 def load_col_types(blockfile_support_tcl):
 	global col_types, re_col_types
 	col_types, re_col_types = {}, {}
-	with builtins.open(blockfile_support_tcl) as f:
+	with __builtin__.open(blockfile_support_tcl) as f:
 		for i in re.finditer('"(\^[a-z_]+\$*)"\s*{.*?; incr idx ([0-9]*)\s*}', f.read(), re.DOTALL):
 			var_name, var_cols = i.group(1), i.group(2)
 			if var_cols == '': var_cols = 1
@@ -132,7 +132,7 @@ class blockfile(object):
 		"""
 		Opens the blockfile.
 		"""
-		self.f = builtins.open(path)
+		self.f = __builtin__.open(path)
 	
 	def __iter__(self):
 		"""
@@ -174,5 +174,6 @@ if __name__ == "__main__":
 			sys.stderr.write("Please specify the path to scripts/blockfile_support.tcl from Espresso.\n")
 			sys.exit(1)
 		load_col_types(sys.argv[2])
+		from pprint import pprint
 		print(pprint(col_types))
 		sys.exit()


### PR DESCRIPTION
Commit 1883077 did `import __builtin__` on Python 2 and `import builtins as __builtin__` on Python 3, but used that module as `builtins` later in the code. See https://github.com/espressomd/espresso/commit/188307706f2abe3212619a11cd0644fadbb3d58e#diff-19
