### PR TITLE
fixed gpu implementation of [lbboundary delete]

### DIFF
--- a/src/tcl/lb-boundaries_tcl.cpp
+++ b/src/tcl/lb-boundaries_tcl.cpp
@@ -1289,23 +1289,21 @@ int tclcommand_lbboundary(ClientData data, Tcl_Interp *interp, int argc, char **
   else if(ARG_IS_S(1, "delete")) {
     if(argc < 3) {
       /* delete all */
-      if (lattice_switch & LATTICE_LB_GPU) {
-        Tcl_AppendResult(interp, "Cannot delete individual lb boundaries",(char *) NULL);
-        status = TCL_ERROR;
-      } else 
         mpi_bcast_lbboundary(-2);
-      status = TCL_OK;
+        status = TCL_OK;
     }
     else {
+      if (lattice_switch & LATTICE_LB_GPU) {
+        Tcl_AppendResult(interp, "Cannot delete individual lb boundaries",(char *) NULL);
+        return(TCL_ERROR);
+      } 
+
       if(Tcl_GetInt(interp, argv[2], &(c_num)) == TCL_ERROR) return (TCL_ERROR);
       if(c_num < 0 || c_num >= n_lb_boundaries) {
 	Tcl_AppendResult(interp, "Can not delete non existing lbboundary",(char *) NULL);
 	return (TCL_ERROR);
       }
-      if (lattice_switch & LATTICE_LB_GPU) {
-	mpi_bcast_lbboundary(-3);
-      } else 
-	mpi_bcast_lbboundary(c_num);
+      mpi_bcast_lbboundary(c_num);
       status = TCL_OK;    
     }
   }


### PR DESCRIPTION
; # a simple testcase
require_feature "LB_BOUNDARIES_GPU"

setmd box_l  10 10 2 ; setmd skin 0.4
thermostat off ; setmd time_step 1.0

lbfluid gpu  agrid 1 dens 1.0 visc 1.0 tau 1.0
lbboundary wall normal 0  1 0 dist 1  velocity 1. 0. 0.

integrate 2000
; # this should output  1.0  
puts "[lindex [lbnode 0 1 0 print u] 0 ] "

lbboundary delete

lbboundary wall normal 0  1 0 dist 1  velocity -1. 0. 0.
integrate 2000
; # this should output  -1.0   but in the old code 
; # the boundary is not reset, and keeps printing  1.0 
puts "[lindex [lbnode 0 1 0 print u] 0 ] "
