### PR TITLE
Mmm1dgpu: move mpi.h dependencies out of .cu file

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -160,7 +160,7 @@ libEspresso_la_SOURCES += \
 # Generic actors
 libEspresso_la_SOURCES += \
 	actor/Actor.hpp \
-	actor/Mmm1dgpuForce.cu actor/Mmm1dgpuForce.hpp \
+	actor/Mmm1dgpuForce_cuda.cu actor/Mmm1dgpuForce.cpp actor/Mmm1dgpuForce.hpp \
 	actor/mmm-common_cuda.hpp actor/specfunc_cuda.hpp \
 	actor/HarmonicWell.cpp actor/HarmonicWell.hpp
 
@@ -186,7 +186,7 @@ CUDA_SOURCE_FILES = \
 	lbgpu_cuda.cu \
 	p3m_gpu_cuda.cu \
 	EspressoSystemInterface_cuda.cu \
-	actor/Mmm1dgpuForce.cu \
+	actor/Mmm1dgpuForce_cuda.cu \
 	actor/HarmonicWell_cuda.cu
 
 # include the dependency tracking files

--- a/src/core/actor/Mmm1dgpuForce.cpp
+++ b/src/core/actor/Mmm1dgpuForce.cpp
@@ -1,0 +1,46 @@
+#include "actor/Mmm1dgpuForce.hpp"
+#include "EspressoSystemInterface.hpp"
+#include "communication.hpp"
+#include "interaction_data.hpp"
+#include "forces.hpp"
+#include "grid.hpp"
+
+#ifdef MMM1D_GPU
+
+void addMmm1dgpuForce(double maxPWerror, double switch_rad, int bessel_cutoff)
+{
+	/* coulomb.prefactor apparently is not available yet at this point */
+	static Mmm1dgpuForce *mmm1dgpuForce = NULL;
+	if (!mmm1dgpuForce) // inter coulomb mmm1dgpu was never called before
+	{
+		mmm1dgpuForce = new Mmm1dgpuForce(espressoSystemInterface, 0, maxPWerror, switch_rad, bessel_cutoff);
+		potentials.push_back(mmm1dgpuForce);
+	}
+	/* set_params needs to be called both upon create and upon update because it is responsible for writing
+		to the struct from which the TCL command "inter coulomb" retrieves the current parameter set */
+	mmm1dgpuForce->set_params(0, 0, maxPWerror, switch_rad, bessel_cutoff, true);
+
+	// turn on MMM1DGPU
+	coulomb.method = COULOMB_MMM1D_GPU;
+	mpi_bcast_coulomb_params();
+}
+
+void Mmm1dgpuForce::disable()
+{
+	if (coulomb.method == COULOMB_MMM1D_GPU)
+	{
+		coulomb.method = COULOMB_NONE;
+		mpi_bcast_coulomb_params();
+	}
+}
+
+void Mmm1dgpuForce::check_periodicity()
+{
+	if (PERIODIC(0) || PERIODIC(1) || !PERIODIC(2))
+	{
+		std::cerr << "MMM1D requires periodicity (0,0,1)" << std::endl;
+		exit(EXIT_FAILURE);
+	}
+}
+
+#endif

--- a/src/core/actor/Mmm1dgpuForce.hpp
+++ b/src/core/actor/Mmm1dgpuForce.hpp
@@ -67,6 +67,10 @@ private:
 
 	// run a single force calculation and return the time it takes using high-precision CUDA timers
 	float force_benchmark(SystemInterface &s);
+	
+	// some functions to move MPI dependencies out of the .cu file
+	void disable();
+	void check_periodicity();
 };
 
 #endif

--- a/src/core/actor/Mmm1dgpuForce_cuda.cu
+++ b/src/core/actor/Mmm1dgpuForce_cuda.cu
@@ -21,7 +21,7 @@
 
 #ifdef MMM1D_GPU
 
-Mmm1dgpuForce *mmm1dgpuForce = 0;
+Mmm1dgpuForce *mmm1dgpuForce = NULL;
 
 // the code is mostly multi-GPU capable, but Espresso is not yet
 const int deviceCount = 1;
@@ -30,28 +30,12 @@ float multigpu_factors[] = {1.0};
 
 #include "mmm-common_cuda.hpp"
 #include "mmm1d.hpp"
-#include "grid.hpp"
 #include "interaction_data.hpp"
-#include "forces.hpp"
 #include "EspressoSystemInterface.hpp"
 
-void addMmm1dgpuForce(double maxPWerror, double switch_rad, int bessel_cutoff)
-{
-	/* coulomb.prefactor apparently is not available yet at this point */
-	static Mmm1dgpuForce *mmm1dgpuForce = NULL;
-	if (!mmm1dgpuForce) // inter coulomb mmm1dgpu was never called before
-	{
-		mmm1dgpuForce = new Mmm1dgpuForce(espressoSystemInterface, 0, maxPWerror, switch_rad, bessel_cutoff);
-		potentials.push_back(mmm1dgpuForce);
-	}
-	/* set_params needs to be called both upon create and upon update because it is responsible for writing
-		to the struct from which the TCL command "inter coulomb" retrieves the current parameter set */
-	mmm1dgpuForce->set_params(0, 0, maxPWerror, switch_rad, bessel_cutoff, true);
-	
-	// turn on MMM1DGPU
-	coulomb.method = COULOMB_MMM1D_GPU;
-	mpi_bcast_coulomb_params();
-}
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
 
 __device__ inline void atomicadd(float* address, float value)
 {
@@ -98,11 +82,7 @@ Mmm1dgpuForce::Mmm1dgpuForce(SystemInterface &s, mmm1dgpu_real _coulomb_prefacto
 		std::cerr << "Mmm1dgpuForce needs access to charges on GPU!" << std::endl;
 
 	// system sanity checks
-	if (PERIODIC(0) || PERIODIC(1) || !PERIODIC(2))
-	{
-		std::cerr << "MMM1D requires periodicity (0,0,1)" << std::endl;
-		exit(EXIT_FAILURE);
-	}
+	check_periodicity();
 
 	modpsi_init();
 }
@@ -169,11 +149,7 @@ Mmm1dgpuForce::~Mmm1dgpuForce()
 	modpsi_destroy();
 	cudaFree(dev_forcePairs);
 
-	if (coulomb.method == COULOMB_MMM1D_GPU)
-	{
-		coulomb.method = COULOMB_NONE;
-		mpi_bcast_coulomb_params();
-	}
+	disable();
 }
 
 __forceinline__ __device__ mmm1dgpu_real sqpow(mmm1dgpu_real x)

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -299,12 +299,16 @@ void copy_forces_from_GPU() {
 }
 
 void clear_energy_on_GPU() {
+  if ( !global_part_vars_host.communication_enabled || !global_part_vars_host.number_of_particles )
+    return;
   if (energy_device == NULL)
     cuda_safe_mem( cudaMalloc((void**) &energy_device, sizeof(CUDA_energy)) );
  cuda_safe_mem(cudaMemset(energy_device, 0, sizeof(CUDA_energy)) );
 }
 
 void copy_energy_from_GPU() {
+  if ( !global_part_vars_host.communication_enabled || !global_part_vars_host.number_of_particles )
+    return;
   cuda_safe_mem (cudaMemcpy(&energy_host, energy_device, sizeof(CUDA_energy), cudaMemcpyDeviceToHost));
   copy_CUDA_energy_to_energy(energy_host);
 }


### PR DESCRIPTION
This way, it compiles even if nvcc does not know where to find mpi.h.
