### PR TITLE
added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
 
 before_script:
   - if [[ $MPI = with ]]; then export CXX=mpic++; fi #there is MPICXX, but CXX overwrites it, so let's see CXX 
-  - sudo update-alternatives --install /bin/sh sh /bin/bash 100 # es_mpiexec does not work in dash, so let's use bash
 
 script: #Travis' cython is too old to compile the python-interface
   - ./bootstrap.sh &&

--- a/tools/es_mpiexec.in
+++ b/tools/es_mpiexec.in
@@ -76,7 +76,7 @@ if test "x$MYMPIEXEC" = "x"; then
     reason=170
 elif test -x "$MYMPIEXEC"; then
     mpiexec=$MYMPIEXEC
-elif command -v "$MPIEXEC" >&/dev/null 2>&1; then
+elif command -v "$MPIEXEC" >/dev/null 2>&1; then
 # POSIX compatible check if a program exists, without knowing its path
     mpiexec=$MPIEXEC
 else
@@ -85,7 +85,7 @@ else
 fi
 
 # and execute, if possible
-if command -v "$mpiexec" >&/dev/null 2>&1; then
+if command -v "$mpiexec" >/dev/null 2>&1; then
 
    exec $mpiexec "$@"
 


### PR DESCRIPTION
- Enables Travis continuous integration for github
- Currently only {with,without} fftw and {with,without} mpi is tested for gcc and clang
- more build environments can easily be added or copied from Jenkins
- main advantage: pull request will have be checked automatically by Travis (see the green check mark below) and
  https://travis-ci.org/ottxor/espresso
  https://travis-ci.org/ottxor/espresso/pull_requests
  without the need to run Jenkins.
