### PR TITLE
configure is now looking for Tcl/Tk 8.6, whereas before it was only look...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -538,7 +538,7 @@ if test .$with_tk != .no; then
 	fi
 	# now test whether Tk can be found
 	if test .$with_tk = .yes; then
-		for version in $TK_VERSION tk8.5 tk8.4 tk8.3 tk8.2 tk; do
+		for version in $TK_VERSION tk8.6 tk8.5 tk8.4 tk8.3 tk8.2 tk; do
 			ES_ADDPATH_CHECK_LIB($version, Tk_Init, [use_tk=$version], [])
 			if test .$use_tk != .; then break; fi
 		done


### PR DESCRIPTION
configure script was not searching for Tcl/Tk 8.6 before, just 8.5 and below. I added tk8.6 to the list...
