### PR TITLE
fix build with cython-0.22

### DIFF
--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -185,5 +185,5 @@ cdef class ParticleHandle(object):
   cdef public int id
   cdef bint valid
   cdef Particle particleData
-  cdef int updateParticleData(self)
+  cdef int updateParticleData(self) except -1
 


### PR DESCRIPTION
Reported to me by @tomspur, found on Fedora, details here: http://koji.fedoraproject.org/koji/buildinfo?buildID=619654.

It might be time for a new release, too!