### PR TITLE
UG corrections, cylindrical_average

### DIFF
--- a/doc/ug/analysis.tex
+++ b/doc/ug/analysis.tex
@@ -22,7 +22,9 @@
 \index{analysis}
 \newescommand{analyze}
 
-\todo{Add a comment to the UG that the analysis routines in \es{} with Python currently require the user to `from espressomd import analyze.'}
+\todo{Add a comment to the UG that the analysis routines in \es{} with
+  Python currently require the user to `from espressomd import
+  analyze.'}
 
 \es has two fundamentally different classes of observables for
 analyzing the systems.  On the one hand, some observables are
@@ -182,7 +184,7 @@ of the currently identified properties.
 \begin{essyntax}
   analyze cylindrical_average \var{center} \var{direction}
   \var{length} \var{radius} \var{bins\_axial} \var{bins\_radial}
-  \var{types} \var{xrange} \var{yrange}
+  \opt{\var{types}}
 \end{essyntax}
 
 The command returns a list of lists.  The outer list contains all data

--- a/doc/ug/inter.tex
+++ b/doc/ug/inter.tex
@@ -973,7 +973,6 @@ general tabulated potentials.
 	vtol=\arg{double}
 ]
 \end{pysyntax}
- \PythonSyntaxOff
 
 \begin{essyntax}
   inter \var{bondid}
@@ -1652,7 +1651,6 @@ If \var{K_\mathrm{cut}} and \var{r_\mathrm{cut}} are given by the user, then \ke
 \index{Debye-H\"uckel potential|mainindex}
 \index{interactions!Debye-H\"uckel|mainindex}
 
-\PythonSyntaxOn
 \begin{pysyntax}
   \object{
     electrostatics
@@ -1680,7 +1678,6 @@ If \var{K_\mathrm{cut}} and \var{r_\mathrm{cut}} are given by the user, then \ke
     }[
     ]
 \end{pysyntax}
-\PythonSyntaxOff
 
 \begin{essyntax}
     \require{1}{\variant{1}

--- a/doc/ug/part.tex
+++ b/doc/ug/part.tex
@@ -26,7 +26,6 @@
 \subsection{Defining particle properties}
 \label{ssec:particleproperties}
 
-\PythonSyntaxOn
 \begin{pysyntax}
   \property{
     espressomd.System()
@@ -66,7 +65,6 @@
       `rotational_friction':\arg{float}\}}
   }
 \end{pysyntax}
-\PythonSyntaxOff
 \begin{essyntax}
   part
   \var{pid}

--- a/doc/ug/pypresso.tex
+++ b/doc/ug/pypresso.tex
@@ -14,15 +14,15 @@
 \bool_new:N \l_pypresso_enable_bool
 \bool_set_false:N \l_pypresso_enable_bool
 
-\NewDocumentCommand \PythonSyntaxOn { }
- {
-  \bool_set_true:N \l_pypresso_enable_bool
- }
-
-\NewDocumentCommand \PythonSyntaxOff { }
- {
-  \bool_set_false:N \l_pypresso_enable_bool
- }
+% \NewDocumentCommand \PythonSyntaxOn { }
+%  {
+%   \bool_set_true:N \l_pypresso_enable_bool
+%  }
+%
+% \NewDocumentCommand \PythonSyntaxOff { }
+%  {
+%   \bool_set_false:N \l_pypresso_enable_bool
+%  }
 
 \cs_new_protected:Npn \pypresso_object:nnnnn #1#2#3#4#5
  {

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -1038,6 +1038,10 @@ int calc_cylindrical_average(std::vector<double> center, std::vector<double> dir
   double binwd_axial  = length / bins_axial;
   double binwd_radial = radius / bins_radial;
 
+  // Select all particle types if the only entry in types is -1
+  bool all_types = false;
+  if (types.size() == 1 && types[0] == -1) all_types = true;
+
   distribution.insert( std::pair<std::string, std::vector<std::vector<std::vector<double> > > >
                                 ("density",   std::vector<std::vector<std::vector<double> > >(types.size())) );
   distribution.insert( std::pair<std::string, std::vector<std::vector<std::vector<double> > > >
@@ -1073,7 +1077,7 @@ int calc_cylindrical_average(std::vector<double> center, std::vector<double> dir
 
   for (int part_id = 0; part_id < n_part; part_id++) {
     for (unsigned int type_id = 0; type_id < types.size(); type_id++) {
-      if ( types[type_id] == partCfg[part_id].p.type ) {
+      if ( types[type_id] == partCfg[part_id].p.type || all_types) {
         pos[0] = partCfg[part_id].r.p[0];
         pos[1] = partCfg[part_id].r.p[1];
         pos[2] = partCfg[part_id].r.p[2];

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -170,7 +170,7 @@ def nbhood(system=None, pos=None, r_catch=None, plane='3d'):
 def cylindrical_average(system=None, center=None, direction=None,
                         length=None, radius=None,
                         bins_axial=None, bins_radial=None,
-                        types=None):
+                        types=[-1]):
 
     # Check the input types
     checkTypeOrExcept(center,      3, float, "center has to be 3 floats"   )

--- a/src/tcl/statistics_tcl.cpp
+++ b/src/tcl/statistics_tcl.cpp
@@ -439,7 +439,7 @@ static int tclcommand_analyze_parse_cylindrical_average(Tcl_Interp *interp, int 
 
   // Parse the arguments
 
-  if ( argc < 7 ) {
+  if ( argc < 6 ) {
     puts("Too few arguments");
     return TCL_ERROR;
   }
@@ -474,9 +474,15 @@ static int tclcommand_analyze_parse_cylindrical_average(Tcl_Interp *interp, int 
     return TCL_ERROR;
   }
 
-  if ( !ARG_IS_INTLIST(6,types_il) ) {
-    puts("Argument 7: Types has to be an int list");
-    return TCL_ERROR;
+  if ( argc > 6 ) {
+    if ( !ARG_IS_INTLIST(6,types_il) ) {
+      puts("Argument 7: Types has to be an int list");
+      return TCL_ERROR;
+    }
+  } else {
+    realloc_intlist(&types_il, 1);
+    types_il.n = 1;
+    types_il.e[0] = -1;
   }
 
   // Convert double list and int list to std::vector


### PR DESCRIPTION
Correct mistake in the UG, make 'types' optional for cylindrical_average, get rid of PythonSyntaxOn/Off in the UG