### PR TITLE
Fix to the Langevin Dynamics bug

### DIFF
--- a/doc/ug/setup.tex
+++ b/doc/ug/setup.tex
@@ -219,22 +219,36 @@ the same temperature.
 \subsection{Langevin thermostat}
 
 \begin{essyntax}
-  thermostat langevin \var{temperature} \var{gamma}
+  thermostat langevin \var{temperature} \var{gamma\_trans} \opt{\var{gamma\_rotate}} \opt{on/off} \opt{on/off}
 \end{essyntax}
+
+\warning{The behavior of the Langevin Thermostat has changed in this version of \es{}. Before the term \var{gamma} was called the `friction coefficient', but was in fact the inverse relaxation time. The code has been modified such that this value is now a proper friction coefficient.
+
+A warning message has been added to the source (core/thermostat.cpp), which can be commented out if you have verified that your simulation results are not affected by this change.}
 
 The Langevin thermostat consists of a friction and noise term coupled
 via the fluctuation-dissipation theorem. The friction term is a
-function of the particle velocities. For a more detailed explanation,
-refer to \cite{grest86a}.
+function of the particle velocities. By specifying \var{gamma\_trans} the diffusion coefficient for the particle becomes
+\begin{equation}
+D = \frac{\var{temperature}}{\var{gamma\_trans}}.
+\end{equation}
+The relaxation time is given by \var{gamma\_trans}/MASS, with MASS the particle's mass. For a more detailed explanation,
+refer to \cite{grest86a}. In the near future an anisotropic diffusion coefficient tensor will be made available to simulate anisotropic colloids (rods, etc.) properly.
 
 If the feature \feature{ROTATION} is compiled in, the rotational
-degrees of freedom are also coupled to the thermostat.
+degrees of freedom are also coupled to the thermostat. If only the first two arguments are specified then the diffusion coefficient for the rotation is set to the same value as that for the translation.
+
+\warning{This is again a change, since originally it was set to 1/3 of the value of \var{gamma\_trans} for some (unclear) reason. If you want to reproduce this behavior, this can be simply done by setting the value of \var{gamma\_rotate} appropriately.}
+
+A separate rotational diffusion coefficient can be set by inputting \var{gamma\_rotate}. This also allows one to properly match the translational and rotational diffusion coefficients of a sphere. Finally, the two options \opt{on/off} allow one to switch the translational and rotational thermalization on or off separately, maintaining the frictional behavior. This can be useful, for instance, in high P{\'e}clet number active matter systems, where one only wants to thermalize the rotational degrees of freedom and translational motion is effected by the self-propulsion.
 
 Using the Langevin thermostat, it is posible to set a temperature and
 a friction coefficient for every particle individually via the feature
 \feature{LANGEVIN_PER_PARTICLE}. Consult the reference of the
 \texttt{part} command (chapter \ref{chap:part}) for information on how
 to achieve this.
+
+\warning{The behavior of the \feature{LANGEVIN_PER_PARTICLE} thermostat has undergone a similar change.}
 
 \subsection{GHMC thermostat}
 

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -44,7 +44,11 @@ double temperature = 0.0;
 /* Langevin friction coefficient gamma. */
 double langevin_gamma = 0.0;
 /* Friction coefficient gamma for rotation */
-double langevin_gamma_rotation;
+double langevin_gamma_rotation = 0.0;
+/* Langevin for translations */
+bool langevin_trans = true;
+/* Langevin for rotations */
+bool langevin_rotate = true;
 
 /* NPT ISOTROPIC THERMOSTAT */
 // INSERT COMMENT
@@ -101,7 +105,10 @@ void thermo_init_langevin()
 #endif
   
 #ifdef ROTATION 
-  langevin_gamma_rotation = langevin_gamma/3;
+  if ( langevin_gamma_rotation == 0.0 )
+  {
+    langevin_gamma_rotation = langevin_gamma/3.0;
+  }
 #if defined (FLATNOISE)
   langevin_pref2_rotation = sqrt(24.0*temperature*langevin_gamma_rotation/time_step);
 #elif defined (GAUSSRANDOMCUT) || defined (GAUSSRANDOM)

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -107,7 +107,7 @@ void thermo_init_langevin()
 #ifdef ROTATION 
   if ( langevin_gamma_rotation == 0.0 )
   {
-    langevin_gamma_rotation = langevin_gamma/3.0;
+    langevin_gamma_rotation = langevin_gamma;
   }
 #if defined (FLATNOISE)
   langevin_pref2_rotation = sqrt(24.0*temperature*langevin_gamma_rotation/time_step);

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -418,19 +418,19 @@ inline void friction_thermo_langevin_rotation(Particle *p)
   {
 #if defined (FLATNOISE)
 #ifdef ROTATIONAL_INERTIA
-    p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] *p->p.rinertia[j] + switch_rotate*langevin_pref2_rotation*sqrt(p->p.rinertia[j]) * (d_random()-0.5);
+    p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] + switch_rotate*langevin_pref2_rotation*(d_random()-0.5);
 #else
     p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] + switch_rotate*langevin_pref2_rotation*(d_random()-0.5);
 #endif
 #elif defined (GAUSSRANDOMCUT)
 #ifdef ROTATIONAL_INERTIA
-    p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] *p->p.rinertia[j] + switch_rotate*langevin_pref2_rotation*sqrt(p->p.rinertia[j]) * gaussian_random_cut();
+    p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] + switch_rotate*langevin_pref2_rotation*gaussian_random_cut();
 #else
     p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] + switch_rotate*langevin_pref2_rotation*gaussian_random_cut();
 #endif
 #elif defined (GAUSSRANDOM)
 #ifdef ROTATIONAL_INERTIA
-    p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] *p->p.rinertia[j] + switch_rotate*langevin_pref2_rotation*sqrt(p->p.rinertia[j]) * gaussian_random();
+    p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] + switch_rotate*langevin_pref2_rotation*gaussian_random();
 #else
     p->f.torque[j] = -langevin_gamma_rotation*p->m.omega[j] + switch_rotate*langevin_pref2_rotation*gaussian_random();
 #endif

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -72,6 +72,15 @@ extern double temperature;
 /** Langevin friction coefficient gamma. */
 extern double langevin_gamma;
 
+/** Langevin friction coefficient gamma. */
+extern double langevin_gamma_rotation;
+
+/** Langevin for translations */
+extern bool langevin_trans;
+
+/** Langevin for rotations */
+extern bool langevin_rotate;
+
 /** Friction coefficient for nptiso-thermostat's inline-function friction_therm0_nptiso */
 extern double nptiso_gamma0;
 /** Friction coefficient for nptiso-thermostat's inline-function friction_thermV_nptiso */

--- a/src/tcl/thermostat_tcl.cpp
+++ b/src/tcl/thermostat_tcl.cpp
@@ -179,6 +179,9 @@ int tclcommand_thermostat_parse_langevin(Tcl_Interp *interp, int argc, char **ar
   mpi_bcast_parameter(FIELD_TEMPERATURE);
   mpi_bcast_parameter(FIELD_LANGEVIN_GAMMA);
 
+  fprintf(stderr,"WARNING: The behavior of the Langevin thermostat has changed\n");
+  fprintf(stderr,"         as of this version! Please consult the user's guide.\n");
+
   return (TCL_OK);
 }
 

--- a/src/tcl/thermostat_tcl.cpp
+++ b/src/tcl/thermostat_tcl.cpp
@@ -101,27 +101,33 @@ int tclcommand_thermostat_parse_langevin(Tcl_Interp *interp, int argc, char **ar
        rot = true;
 
   /* check number of arguments */
-  if (argc < 4) {
+  if (argc < 4) 
+  {
     Tcl_AppendResult(interp, "wrong # args:  should be \n\"",
 		     argv[0]," ",argv[1]," <temp> <gamma_trans> [<gamma_rot> <on/off> <on/off>]\"", (char *)NULL);
     return (TCL_ERROR);
   }
 
   /* check argument types */
-  if ( !ARG_IS_D(2, temp) || !ARG_IS_D(3, gammat)) {
+  if ( !ARG_IS_D(2, temp) || !ARG_IS_D(3, gammat)) 
+  {
     Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs two DOUBLES", (char *)NULL);
     return (TCL_ERROR);
   }
 
-  if (argc < 5) {
-    if ( !ARG_IS_D(4, gammar) ) {
+  if (argc > 4 && argc < 6) 
+  {
+    if ( !ARG_IS_D(4, gammar) ) 
+    {
       Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs three DOUBLES", (char *)NULL);
       return (TCL_ERROR);
     }
   }
 
-  if (argc < 6) {
-    if ( !ARG_IS_S(5, "on") && !ARG_IS_S(5, "off") ) {
+  if (argc > 5 && argc < 7) 
+  {
+    if ( !ARG_IS_S(5, "on") && !ARG_IS_S(5, "off") ) 
+    {
       Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs on/off", (char *)NULL);
       return (TCL_ERROR);
     }
@@ -138,7 +144,8 @@ int tclcommand_thermostat_parse_langevin(Tcl_Interp *interp, int argc, char **ar
     }
   }
 
-  if (argc < 7) {
+  if (argc > 6 && argc < 8) 
+  {
     if ( !ARG_IS_S(6, "on") && !ARG_IS_S(6, "off") ) {
       Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs on/off", (char *)NULL);
       return (TCL_ERROR);
@@ -171,6 +178,7 @@ int tclcommand_thermostat_parse_langevin(Tcl_Interp *interp, int argc, char **ar
   mpi_bcast_parameter(FIELD_THERMO_SWITCH);
   mpi_bcast_parameter(FIELD_TEMPERATURE);
   mpi_bcast_parameter(FIELD_LANGEVIN_GAMMA);
+
   return (TCL_OK);
 }
 

--- a/src/tcl/thermostat_tcl.cpp
+++ b/src/tcl/thermostat_tcl.cpp
@@ -49,14 +49,23 @@ int tclcommand_thermostat_parse_off(Tcl_Interp *interp, int argc, char **argv)
   mpi_bcast_parameter(FIELD_TEMPERATURE);
   /* langevin thermostat */
   langevin_gamma = 0;
+  /* Friction coefficient gamma for rotation */
+  langevin_gamma_rotation = 0;
   mpi_bcast_parameter(FIELD_LANGEVIN_GAMMA);
-  /* dpd thermostat */
+  /* Langevin for translations */
+  langevin_trans = true;
+  /* Langevin for rotations */
+  langevin_rotate = true;
+
 #ifdef DPD
+  /* dpd thermostat */
   dpd_switch_off();
 #endif
+
 #ifdef INTER_DPD
   inter_dpd_switch_off();
 #endif
+
 #ifdef NPT
   /* npt isotropic thermostat */
   nptiso_gamma0 = 0;
@@ -64,6 +73,7 @@ int tclcommand_thermostat_parse_off(Tcl_Interp *interp, int argc, char **argv)
   nptiso_gammav = 0;
   mpi_bcast_parameter(FIELD_NPTISO_GV);
 #endif
+
 #ifdef GHMC
   /* ghmc thermostat */
   ghmc_nmd = 1;
@@ -75,6 +85,7 @@ int tclcommand_thermostat_parse_off(Tcl_Interp *interp, int argc, char **argv)
   ghmc_tscale = GHMC_TSCALE_OFF;
   mpi_bcast_parameter(FIELD_GHMC_SCALE);
 #endif
+
   /* switch thermostat off */
   thermo_switch = THERMO_OFF;
   mpi_bcast_parameter(FIELD_THERMO_SWITCH);
@@ -83,29 +94,79 @@ int tclcommand_thermostat_parse_off(Tcl_Interp *interp, int argc, char **argv)
 
 int tclcommand_thermostat_parse_langevin(Tcl_Interp *interp, int argc, char **argv) 
 {
-  double temp, gamma;
+  double temp,
+         gammat = 0.0,
+         gammar = 0.0;
+  bool trans = true,
+       rot = true;
 
   /* check number of arguments */
   if (argc < 4) {
     Tcl_AppendResult(interp, "wrong # args:  should be \n\"",
-		     argv[0]," ",argv[1]," <temp> <gamma>\"", (char *)NULL);
+		     argv[0]," ",argv[1]," <temp> <gamma_trans> [<gamma_rot> <on/off> <on/off>]\"", (char *)NULL);
     return (TCL_ERROR);
   }
 
   /* check argument types */
-  if ( !ARG_IS_D(2, temp) || !ARG_IS_D(3, gamma)) {
+  if ( !ARG_IS_D(2, temp) || !ARG_IS_D(3, gammat)) {
     Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs two DOUBLES", (char *)NULL);
     return (TCL_ERROR);
   }
 
-  if (temp < 0 || gamma < 0) {
-    Tcl_AppendResult(interp, "temperature and gamma must be positive", (char *)NULL);
+  if (argc < 5) {
+    if ( !ARG_IS_D(4, gammar) ) {
+      Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs three DOUBLES", (char *)NULL);
+      return (TCL_ERROR);
+    }
+  }
+
+  if (argc < 6) {
+    if ( !ARG_IS_S(5, "on") && !ARG_IS_S(5, "off") ) {
+      Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs on/off", (char *)NULL);
+      return (TCL_ERROR);
+    }
+    else
+    {
+      if ( ARG_IS_S(5, "on") )
+      {
+        trans = true;
+      }
+      else
+      {
+        trans = false;
+      }
+    }
+  }
+
+  if (argc < 7) {
+    if ( !ARG_IS_S(6, "on") && !ARG_IS_S(6, "off") ) {
+      Tcl_AppendResult(interp, argv[0]," ",argv[1]," needs on/off", (char *)NULL);
+      return (TCL_ERROR);
+    }
+    else
+    {
+      if ( ARG_IS_S(6, "on") )
+      {
+        rot = true;
+      }
+      else
+      {
+        rot = false;
+      }
+    }
+  }
+
+  if (temp < 0 || gammat < 0 || gammar < 0) {
+    Tcl_AppendResult(interp, "temperature and friction must be positive", (char *)NULL);
     return (TCL_ERROR);
   }
 
   /* broadcast parameters */
   temperature = temp;
-  langevin_gamma = gamma;
+  langevin_gamma = gammat;
+  langevin_gamma_rotation = gammar;
+  langevin_trans = trans;
+  langevin_rotate = rot;
   thermo_switch = ( thermo_switch | THERMO_LANGEVIN );
   mpi_bcast_parameter(FIELD_THERMO_SWITCH);
   mpi_bcast_parameter(FIELD_TEMPERATURE);
@@ -321,6 +382,12 @@ int tclcommand_thermostat_print_all(Tcl_Interp *interp)
     Tcl_PrintDouble(interp, temperature, buffer);
     Tcl_AppendResult(interp,"{ langevin ",buffer, (char *)NULL);
     Tcl_PrintDouble(interp, langevin_gamma, buffer);
+    Tcl_AppendResult(interp," ",buffer, (char *)NULL);
+    Tcl_PrintDouble(interp, langevin_gamma_rotation, buffer);
+    Tcl_AppendResult(interp," ",buffer, (char *)NULL);
+    Tcl_PrintDouble(interp, langevin_trans, buffer);
+    Tcl_AppendResult(interp," ",buffer, (char *)NULL);
+    Tcl_PrintDouble(interp, langevin_rotate, buffer);
     Tcl_AppendResult(interp," ",buffer," } ", (char *)NULL);
   }
     
@@ -403,7 +470,7 @@ int tclcommand_thermostat_print_usage(Tcl_Interp *interp, int argc, char **argv)
   Tcl_AppendResult(interp, "Usage of tcl-command thermostat:\n", (char *)NULL);
   Tcl_AppendResult(interp, "'", argv[0], "' for status return or \n ", (char *)NULL);
   Tcl_AppendResult(interp, "'", argv[0], " set off' to deactivate it (=> NVE-ensemble) \n ", (char *)NULL);
-  Tcl_AppendResult(interp, "'", argv[0], " set langevin <temp> <gamma>' or \n ", (char *)NULL);
+  Tcl_AppendResult(interp, "'", argv[0], " set langevin <temp> <gamma_trans> [<gamma_rot> <on/off> <on/off>]' or \n ", (char *)NULL);
 #ifdef DPD
   tclcommand_thermostat_print_usage_dpd(interp,argc,argv);
 #endif

--- a/testsuite/mass-and-rinertia.tcl
+++ b/testsuite/mass-and-rinertia.tcl
@@ -32,10 +32,10 @@ setmd skin 1.0
 setmd time_step 0.01
 
 set n 500
-set mass 200
-set j1 300
-set j2 400
-set j3 500
+set mass 8
+set j1 6
+set j2 8
+set j3 10
 for {set i 0} {$i<$n} {incr i} {
   part $i pos 0 0 0 rinertia $j1 $j2 $j3 mass $mass
 }
@@ -48,9 +48,9 @@ set oy2 0.
 set oz2 0.
 
 
-set loops 3
+set loops 25
 puts "Thermalizing..."
-integrate 300
+integrate 1000
 puts "Measuring..."
 
 for {set i 0} {$i <$loops} {incr i} {


### PR DESCRIPTION
In this pull request, I have modified the behavior of the Langevin Thermostat, such that it now produces 'physically reasonable' behavior when specifying a proper friction coefficient. I've added a warning message in the code, such that the new behavior does not lead to confusion for the users and I have also documented the changes thoroughly in the User's Guide. I had to modify one of the test cases, which exploited the questionable behavior to reduce the execution time, but this one still verifies the important physics. I tried to run the full multi-config on my computer, but it failed due to quota issues, so I would recommend checking this before pulling my change into master.