### PR TITLE
Little addittion to wall constraint

### DIFF
--- a/doc/ug/part.tex
+++ b/doc/ug/part.tex
@@ -926,7 +926,7 @@ with a dipole moment.
 
 The resulting surface in variant \variant{1} is a plane defined by the
 normal vector \var{n_x} \var{n_y} \var{n_z} and the distance
-\var{d} from the origin. The force acts in direction of the normal. 
+\var{d} from the origin (in the direction of the normal vector). The force acts in direction of the normal. 
 Note that the \var{d} describes the distance from the origin in units
 of the normal vector so that the product of $d$ and $n$ is a point on the
 surface. Therefore negative distances are quite common!


### PR DESCRIPTION
From the text, it was not clear that, that the distance is measured in the direction of the normal vector. Although this seems to be clear, if the normal vector points away from the origin, it makes a huge different in the contrary case. Imagine a wall with normal (0,0,-1). In order to place it at z=5, the distance has to be set to -5. 
It is worth emphasizing this.