### PR TITLE
Update the 02-charged_system tutorial

### DIFF
--- a/doc/tutorials/02-charged_system/02-charged_system.tex
+++ b/doc/tutorials/02-charged_system/02-charged_system.tex
@@ -58,7 +58,9 @@ conveniently, one would like to specify the density and the number of
 particles of the system as parameters:
 
 \begin{tclcode}
-  set n_part 200; set density 0.7
+  # Simulation box setup
+  set n_part 200
+  set density 0.7
   set box_l [expr pow($n_part/$density,1./3.)]
 \end{tclcode}
 
@@ -69,30 +71,31 @@ parameter of this simulation; it is calculated from the number of
 particles and the system density. This allows to change the parameters
 later easily, e.~g.\ to simulate a bigger system.
 
-The parameters of the simulation engine are modified by the
+The parameters of the simulation engine are modified using the
 \verb|setmd| command. For example
 
 \begin{tclcode}
   setmd box_l $box_l $box_l $box_l
   setmd periodic 1 1 1
 \end{tclcode}
-% make font-lock happy $
 
 defines a cubic simulation box of size \verb|box_l|, and periodic
 boundary conditions in all spatial dimensions. We now fill this
 simulation box with particles
 
 \begin{tclcode}
-  set q 1; set type 0
+  # Particle creation
+  set q 1
+  set type 0
   for {set i 0} { $i < $n_part } {incr i} {
     set posx [expr $box_l*[t_random]]
     set posy [expr $box_l*[t_random]]
     set posz [expr $box_l*[t_random]]
-    set q [expr -$q]; set type [expr 1-$type]
+    set q [expr -$q];
+    set type [expr 1-$type]
     part $i pos $posx $posy $posz q $q type $type
   }
 \end{tclcode}
-% make font-lock happy $
 
 This loop adds \verb|n_part| particles at random positions, one by
 one.  In this construct, only two commands are not standard Tcl
@@ -100,33 +103,39 @@ commands: the random number generator \verb|t_random| and the
 \verb|part| command, which is used to specify particle properties,
 here the position, the charge \verb|q| and the type. In \es\ the
 particle type is just an integer number which allows to group
-particles; it does not imply any physical parameters. Here we use it
-to tag the charges: positive charges have type 0, negative charges
-have type 1.
+particles; it does not imply any physical parameters. Here we 
+alternate between creating positive charges of type 0 and negative
+charges of type 1.
 
 Now we define the ensemble that we will be simulating. This is done
 using the \verb|thermostat| command. We also set some integration
 scheme parameters:
 
 \begin{tclcode}
-  setmd time_step 0.01; setmd skin 0.4
-  set temp 1; set gamma 1
+  # Thermostat setup
+  setmd time_step 0.01
+  setmd skin 0.3
+  set temp 1
+  set gamma 1
   thermostat langevin $temp $gamma
 \end{tclcode}
 
 This switches on the Langevin thermostat for the NVT ensemble, with
-temperature \verb|temp| and friction \verb|gamma|. The skin depth
+temperature \verb|temp| and friction coefficient \verb|gamma|. The skin depth
 \verb|skin| is a parameter for the link--cell system which tunes its
-performance, but cannot be discussed here.
+performance, but shall not be discussed here.
 
 Before we can really start the simulation, we have to specify the
 interactions between our particles.  We use a simple, purely repulsive
-Lennard-Jones interaction to model the hard core repulsion, and the
+Lennard-Jones interaction to model a hard core repulsion. Additionally the
 charges interact via the Coulomb potential:
 
 \begin{tclcode}
-  set sig 1.0; set cut [expr 1.12246*$sig]
-  set eps 1.0; set shift [expr 0.25*$eps]
+  # Interaction setup
+  set sig 1.0
+  set cut [expr 1.12246*$sig]
+  set eps 1.0
+  set shift [expr 0.25*$eps]
   inter 0 0 lennard-jones $eps $sig $cut $shift 0
   inter 1 0 lennard-jones $eps $sig $cut $shift 0
   inter 1 1 lennard-jones $eps $sig $cut $shift 0
@@ -138,35 +147,39 @@ purely repulsive Lennard--Jones potential for the interaction between
 all combinations of the two particle types 0 and 1; by using different
 parameters for different combinations, one could simulate differently
 sized particles.  The last line sets the Bjerrum length to the value
-10, and then instructs \es\ to use P$^3$M for the Coulombic
+10, and then instructs \es\ to use the P$^3$M method for the Coulombic
 interaction and to try to find suitable parameters for an rms force
 error below $10^{-3}$, with a fixed mesh size of 32. The mesh is fixed
 here to speed up the tuning; for a real simulation, one will also tune
-this parameter. The \verb|puts| statement will show the parameters and
-timings that the tuning found. Tuning takes some time; if you run many
+this parameter. The \verb|puts| statement will print the parameters and
+timings that the tuning found to the screen. Tuning takes some time; if you run many
 simulations with similar parameters, you might want to save and reload
 the P$^3$M parameters. You can obtain the P$^3$M parameters by
 \verb|inter coulomb|:
 
 \begin{tclcode}
   set p3m_params [inter coulomb]
+  puts $p3m_params
 \end{tclcode}
 
 They are printed in a format suitable to feed them back to the
 \verb|inter| command:
 
 \begin{tclcode}
-  eval inter $p3m_params
-  eval inter $p3m_params
+  foreach f $prm_params {
+    eval inter $f
+  }
 \end{tclcode}
 
 \section{Running the simulation}
 
-Now we can integrate the system:
+Now we can integrate the particle trajectories for a couple of time
+steps:
 
 \begin{tclcode}
+  # Main integration loop
   set integ_steps 200
-  for {set i 0} { $i < 20 } { incr i} {
+  for { set i 0 } { $i < 20 } { incr i } {
     set temp [expr [analyze energy kinetic]/((3/2.0)*$n_part)]
     puts "t=[setmd time] E=[analyze energy total], T=$temp"
     integrate $integ_steps
@@ -179,15 +192,14 @@ steps, the potential, electrostatic and kinetic energies are printed
 out. The latter one is printed as temperature, by rescaling by the
 number of degrees of freedom (3) multiplied by $1/2kT$. Note that
 energies are measured in $kT$, so that only the factor $1/2$
-remains. Also note that $3/2$ is written as $3/2.0$; otherwise Tcl
-will perform an integer division, resulting in 1 instead of $1.5$.
+remains. Also note that $3/2$ should be written as $3/2.0$; to ensure
+that Tcl does not perform integer division (resuting in $1$ instead of
+$1.5$).
 
 Note, that in \es\ there are usually 3 translational degrees per
 particle. However, if \verb|ROTATION| is compiled in, there are in
 addition 3 rotational degrees of freedom, which also contribute to the
-kinetic energy.  You can get this number in the following way
-\footnote{Note: there also exists a predefined tcl function {\it
-    degrees\_of\_freedom} which does the same.}:
+kinetic energy.  You can get this number in the following way:
 
 \begin{tclcode}
   if { [regexp "ROTATION" [code_info]] } {
@@ -196,42 +208,49 @@ kinetic energy.  You can get this number in the following way
     set deg_free 3
   }
 \end{tclcode}
+or even
+\begin{tclcode}
+    set deg_free [degrees_of_freedom]
+\end{tclcode}
+which does exactly the same.
 
 Then all you need to do is to replace the hardcoded 3 by \verb|$deg_free|.
 
 However, if you run the simulation, it will still
 crash: \es\ complains about particle coordinates being out of range.
 The reason for this is simple: Due to the initial random setup, the
-overlap energy is around a million kT, which we first have to remove
-from the system. In \es, this is can be accelerated by capping the
+overlap energy is around a million $kT$, which we first have to remove
+from the system. In \es, this is can be accelerated by limiting the maximum
 forces, i.~e.\ modifying the Lennard--Jones force such that it is
-constant below a certain distance. Before the integration loop, we
+constant below a certain distance. Before the main integration loop, we
 therefore insert this equilibration loop:
 
 \begin{tclcode}
+  # Warmup integration loop
+  set integ_steps 200
   for {set cap 20} {$cap < 200} {incr cap 20} {
     inter forcecap $cap
     integrate $integ_steps
   }
   inter forcecap 0
 \end{tclcode}
-% make font-lock happy $
 
-This loop integrates the system with a force cap of initially 20 and
+This loop integrates the system with a force cap value of initially 20 and
 finally 200.  The last command switches the force cap off again. With
-this equilibration, the simulation script runs fine. As a control
-that the equilibration loop works correctly, you might want to add the
-energy and force printing of the integration loop. You can then
-observe how the temperature initially overshoots and then relaxes to
-its target value by the action of the thermostat.
+this equilibration, the simulation script runs fine. As a check
+that the equilibration loop works correctly, you might want to copy the
+energy and force printing from the main integration loop. You can then
+observe how the temperature initially overshoots and is then relaxed to
+its target value by the thermostat.
 
 \section{Writing out data}
 
-However, it takes some time to simulate the system, and one will
-probably like to write out simulation data to configuration files, for
-later analysis. For this purpose \es\ has commands to write simulation
-data to a Tcl stream in an easily parsable form.  We add the following
-lines at end of integration loop to write the configuration files
+For later analysis of the simulation results, one will
+usually like to write out simulation data to configuration files.
+For this purpose \es\ has commands to write simulation
+data to a Tcl stream in an easily parseable form.  We add the following
+lines to the integration loop just after the \verb|integrate| line
+in order to write out the system configuration files
 ``config\_0'' through ``config\_19'':
 
 \begin{tclcode}
@@ -241,33 +260,32 @@ lines at end of integration loop to write the configuration files
   blockfile $f write particles {id pos type}
   close $f
 \end{tclcode}
-% make font-lock happy $
 
 The created files ``config\_...'' are human--readable and look like
 
 \begin{tclcode}
 {tclvariable 
-	{box_l 6.58633756008}
-	{density 0.7}
+    {box_l 6.58633756008}
+    {density 0.7}
 }
 {variable  {box_l 6.58633756008 6.58633756008 6.58633756008} }
 {particles {id pos type} 
-	{0 14.7658693713 29.5464807649 -17.5071728732 1}
-	{1 26.702434508 -37.4986024417 114.617582522 0}
+    {0 14.7658693713 29.5464807649 -17.5071728732 1}
+    {1 26.702434508 -37.4986024417 114.617582522 0}
+    [...]
 }
 \end{tclcode}
 
 As you can see, such a \emph{blockfile} consists of several Tcl lists,
-which are called \emph{blocks}, and can store any data available from
-the simulation. Reading a configuration is done by the following
-simple script:
+which we call \emph{blocks}, and it can store any data available from
+the simulation.
+Reading a configuration is done by the following simple script:
 
 \begin{tclcode}
   set f [open $filename "r"]
   while { [blockfile $f read auto] != "eof" } {}
   close $f
 \end{tclcode}
-% make font-lock happy $
 
 The \verb|blockfile read auto| commands will set the Tcl variables
 \verb|box_l| and \verb|density| to the values specified in the file
@@ -285,12 +303,24 @@ to avoid problems with the periodic boundary conditions.
   \label{fig:snapshot}
 \end{figure}
 
+The blockfile mechanism is typically used for one of two main
+purposes, checkpointing and offline analysis.
+Checkpointing is useful for long-running simulations: If you have
+a simulation that runs for several days, you may want to have it
+periodically write its current state to a blockfile. That way, the
+simulation can be resumed if your computer crashes while the
+simulation is running.
+Offline analysis refers to analyzing physical parameters of the
+simulation after the simulation has finished and will be discussed in
+the next section.
+
 \section{Analysis}
 
-With these configurations, we can now investigate the system. As an
+Having written out blockfiles during the simulation, we can now
+investigate the system. As an
 example, we will create a second script which calculates the averaged
 radial distribution functions $g_{++}(r)$ and $g_{+-}(r)$. The radial
-distribution function for a the current configuration can be obtained
+distribution function for the current configuration can be calculated
 using the \verb|analyze| command:
 
 \begin{tclcode}
@@ -307,50 +337,54 @@ The shown \verb|analyze rdf| command returns the distribution function
 of particles of type 1 around particles of type 0 (i.~e.\ of opposite
 charges) for radii between $0.9$ and half the box length, subdivided
 into $100$ bins.  Changing the first two parameters to either ``0 0''
-or ``1 1'' allows to determine the distribution for equal charges. The
-result is a list of $r$ and $g(r)$ pairs, which the following foreach
-loop divides up onto two lists \verb|rlist| and \verb|rdflist|.
-
-To average over a set of configurations, we put the two last code
-snippets into a loop like this:
+or ``1 1'' allows to determine the distribution of equal charges
+around each other. The
+result is a list of $r$ and $g(r)$ pairs, which the following code
+snippet transposes up into a pair of lists, \verb|rlist| and
+\verb|rdflist|.
+To average over all configurations, we loop additionally over all
+blockfiles.
 
 \begin{tclcode}
+  # Initialize the total RDF with zero
   set cnt 0
   for {set i 0} {$i < 100} {incr i} { lappend avg_rdf 0 }
-  foreach filename [lrange $argv 1 end] {
+  
+  foreach filename $argv {
+    # Read the file
     set f [open $filename "r"]
     while {[blockfile $f read auto] != "eof" } {}
     close $f
+    # Calculate the RDF
     set rdf [analyze rdf 0 1 0.9 [expr $box_l/2] 100]
+    # Convert the list of (r,g) tuples into two lists
     set rlist ""
     set rdflist ""
     foreach value [lindex $rdf 1] {
       lappend rlist [lindex $value 0]
       lappend rdflist [lindex $value 1]
     }
+    # Add this configuration's RDF to the total RDF
     set avg_rdf [vecadd $avg_rdf $rdflist]
     incr cnt
   }
+  # Divide by the number of configurations to get the average
   set avg_rdf [vecscale [expr 1.0/$cnt] $avg_rdf]
 \end{tclcode}
-% make font-lock happy $
 
 Initially, the sum of all $g(r)$, which is stored in \verb|avg_rdf|,
 is set to 0.  Then the loops over all configurations given by
 \verb|argv|, calculates $g(r)$ for each configuration and adds up all
 the $g(r)$ in \verb|avg_rdf|.  Finally, this sum is normalized by
 dividing by the number of configurations. Note again the
-``1.0/\$cnt''; also here, this
-is necessary, since ``1/\$cnt'' is interpreted as an integer division,
-which results in 0 for $\text{cnt}>1$.  \verb|argv| is a predefined
+\verb|1.0/\$cnt|; also here, this
+is necessary, since \verb|1/\$cnt| is interpreted as an integer division,
+which would result in 0 for $\text{cnt}>1$.  \verb|argv| is a predefined
 variable: it contains all the command line parameters. Therefore this
-script should be called like
+script should be called like this:
 \begin{verbatim}
-  Espresso <script> n_nodes [<config>...]
+  Espresso <script> config_*
 \end{verbatim}
-where \verb|n_nodes| is the number of CPUs \es should be running
-on. And because the first parameter is \verb|n_nodes|, we need to
-strip it off, which we do by the \verb|lrange| list operation of Tcl.
 
 \begin{figure}[tb]
   \centering
@@ -371,7 +405,6 @@ simple. Add to the end of the previous snippet the following lines:
   foreach r $rlist rdf $avg_rdf { puts $plot "$r $rdf" }
   close $plot
 \end{tclcode}
-%make font-lock happy: $
 
 This instructs the Tcl interpreter to write the \verb|avg_rdf| to the
 file \verb|rdf.data| in gnuplot--compatible format. Fig.~\ref{fig:rdf}
@@ -380,6 +413,21 @@ configurations. In addition, the distribution for a neutral system is
 given, which can be obtained from our simulation script by simply
 removing the command \verb|inter coulomb ...| and therefore not
 turning on P$^3$M.
+To plot your own results, run \verb|gnuplot| in a Terminal window
+and type the following:
+\begin{tclcode}
+plot "rdf.data" using 1:2	
+\end{tclcode}
+If you have written out RDFs for multiple combinations of species,
+you can plot them into one graph like this:
+\begin{tclcode}
+plot "rdf00.data" using 1:2 w l title "g++", \
+     "rdf11.data" using 1:2 w l title "g--", \
+     "rdf01.data" using 1:2 w l title "g+-"	
+\end{tclcode}
+
+
+\section{Further ideas}
 
 The code example given before is still quite simple, and the reader is
 encouraged to try to extend the example a little bit, e.~g. by using
@@ -395,6 +443,34 @@ simulations without the need of modifications to the simulation core
 was one of the main reasons why we decided to use a script language
 for controlling the simulation core.
 
+\section{Accelerating the simulation using a GPU}
+
+\es{} can make use of an Nvidia graphics processing unit (GPU) for 
+accelerating simulations.
+Of course, we expect that results of the GPU-based implementation of
+P$^3$M to be exactly identical to those of the traditional CPU
+implementation. So copy the results from the previous task to a
+different file name (e.g.~\verb|rdf_p3m_cpu.data|) for comparison.
+Additionally, we'd like to find out exactly how much faster the GPU
+implementation is. So first wrap your previous simulation script with
+a time measurement, run it again and note down the execution time.
+\begin{tclcode}
+	set starttime [clock seconds]
+	
+	# previous script code goes here
+	
+	set endtime [clock seconds]
+	puts "Simulation took [expr $endtime-$starttime] seconds"	
+\end{tclcode}
+
+To switch to the GPU-based implementation of 
+P$^3$M, go to the line of your simulation script that contains
+\verb|inter coulomb| and replace \verb|p3m| with \verb|p3m gpu|.
+Then run the simulation again and note down the execution time,
+which should be a lot shorter now. Plot the RDFs from both
+the CPU and the GPU simulation into one graph and check whether the
+results agree.
+
 \section{Using the MEMD algorithm}
 
 \es{} provides a variety of different electrostatics solvers. So far,
@@ -402,23 +478,25 @@ we have been introduced to P$^3$M, but in this section we will try
 something new. A fairly recent addition to the family of electrostatics
 solvers is the "Maxwell Equations Molecular Dynamics" (MEMD) algorithm.
 To use it, two parameters have to be set: A mesh size, and a method
-parameter called \verb|f_mass|, which can be estimated following the
-formula in the \es{} user guide. In this example, a good estimate for
+parameter called \verb|f_mass|, which can be estimated by a formula
+given in the \es{} user guide. In this example, a good estimate for
 the mesh size is 12, but this can be varied, affecting speed and
 accuracy of the algorithm.
 
-The MEMD algorithm relies on a very precise spatial distribution of
+The MEMD algorithm relies on a very specific spatial distribution of
 the particles across processors, and will therefore currently not work
 with Verlet lists. Since those are switched on by default, they will
-have to be turned off manually.
+have to be turned off manually by adding the following line before the
+\verb|setmd| commands:
 
 \begin{tclcode}
   cellsystem domain_decomposition -no_verlet_list
 \end{tclcode}
 
 
-Other than that, you will have to replace the setup of the P$^3$M
-interaction with an according MEMD call.
+Besides this, you will have to replace the initialization of the
+P$^3$M interaction (\verb|inter| \verb|coulomb|...) with an
+appropriate one for MEMD:
 
 \begin{tclcode}
   set memd_mesh 12
@@ -427,9 +505,7 @@ interaction with an according MEMD call.
 \end{tclcode}
 
 
-Be sure to comment out the P$^3$M part of your script, otherwise
-you will have both algorithms running at the same time, resulting
-in twice the electrostatic force. In the example script included
+In the example script included
 within the \es{} code, there is already an \verb|if|-construct 
 provided and you can switch between the methods at the very top
 of the script.
@@ -441,7 +517,7 @@ resulting radial distribution function of the two methods.
 
 \section{Partially periodic boundary conditions}
 
-\begin{figure}[t]
+\begin{figure}[h]
   \centering
   \includegraphics[width=0.7\textwidth]{figures/neutral-rho}
   \caption{Distribution of positive charges $\rho_+(z)$ (open squares)
@@ -451,10 +527,15 @@ resulting radial distribution function of the two methods.
 \end{figure}
 
 One of the strengths of \es{} is the possibility to simulate charged
-systems with partially periodic boundary conditions. As an example, we
-will modify our script to simulate our simple salt in a slit pore. The
-boundary conditions we define now as follows (note that you need the
-\verb|PARTIAL_PERIODIC| feature):
+systems with partially periodic boundary conditions.
+Before you proceed, check your \emph{myconfig.hpp} file to make
+sure that the \verb|PARTIAL_PERIODIC| feature is enabled.
+
+As an example of a system in partially-periodic boundary conditions,
+we will modify our script to simulate our simple salt in a slit pore.
+Remove the \verb|cellsystem|, \verb|setmd box_l| and \verb|setmd periodic| lines left
+over from your previous simulation simulation script and replace them
+with these lines:
 
 \begin{tclcode}
   set box_lxy [expr sqrt(2)*$box_l]
@@ -465,12 +546,11 @@ boundary conditions we define now as follows (note that you need the
   constraint wall normal 0 0 -1 dist [expr -$box_lz - 1.0] type 2
 \end{tclcode}
 
-which replaces the previous code setting \verb|box_l| and
-\verb|periodic|. The last two lines add two confining walls at the top
+The final two lines add two confining walls at the top
 and the bottom of the simulation box. The wall is given by its normal
-(pointing up and downwards here), and its distance from
-$(0,0,0)$. Therefore this defines one wall passing at $z=0$, and a
-second at $z=box_lz+1$. Finally, the type of the wall is used like a
+vector (pointing up and downwards here), and its distance from
+$(0,0,0)$. Therefore this defines one wall at $z=0$, and a second
+one at $z=$\verb|box_lz|$+1$. Finally, the type of the wall is used like a
 particle type to define the interaction of the walls with the particles.
 
 The addition of $1.0$ to the slit width is due to the fact that we will
@@ -480,15 +560,14 @@ way, the wall itself therefore has a thickness of $0.5$. To compensate
 for this, we simply make the box bigger by 1.
 
 We also need to choose the initial positions of our particles to match
-the new box dimensions. The particles are generated as before, but we
-draw the random position now as follows:
+the new box dimensions. Replace the appropriate part of your
+simulation script with this random drawing of particle positions:
 
 \begin{tclcode}
   set posx [expr $box_lxy*[t_random]]
   set posy [expr $box_lxy*[t_random]]
   set posz [expr ($box_lz-1.0)*[t_random] + 1.0]
 \end{tclcode}
-%make font-lock happy: $
 
 When defining the interactions, we now also need to add the
 interactions between the particles and the walls, which is the same as
@@ -499,7 +578,7 @@ between the particles:
   inter 1 2 lennard-jones $eps $sig $cut $shift 0
 \end{tclcode}
 
-For the electrostatic part, we also need to choose another algorithm,
+For the electrostatic part, we also need to choose a different algorithm,
 as P$^3$M can only handle fully periodic boundary conditions. We
 choose the MMM2D method:
 
@@ -515,7 +594,8 @@ equilibrating the system is now more difficult. First, we cannot
 simply ramp up all Lennard-Jones interactions anymore; otherwise,
 particles will penetrate the walls and break the confinement. Second,
 we need to ramp up the electrostatic interaction more carefully
-now. The following code gradually increases the Bjerrum length to the
+now. The following code replaces the equilibration loop previously 
+used. It gradually increases the Bjerrum length to the
 target value of 1.0, and caps only the Lennard-Jones interactions
 between the particles. The latter can be done by switching on
 individual force capping, and setting a force cap radius for the
@@ -535,7 +615,6 @@ for {set i 1} {$i < 10} {incr i} {
 inter forcecap 0
 inter coulomb 1.0 mmm2d 1e-4  
 \end{tclcode}
-%make font-lock happy: $
 
 Finally, when writing out, we should update the set of
 Tcl-variables to represent the asymmetric box, and write out
@@ -547,23 +626,24 @@ For a such a strongly confined system, the radially averaged
 distribution function is inappropriate. Instead, it would be more
 interesting to study the distribution of the particles along the slit
 width. \es{}  does not provide such a function, however, we can easily
-write one using the \verb|bin| command, which simply allows to bin a
-set of values given as a Tcl-list. Therefore, we first create the list
+write one using the \verb|bin| command, which simply allows us 
+to create a histogram based on a set of values given as a Tcl list.
+Therefore, we first create the list
 of z-coordinates, and then bin them:
 
 \begin{tclcode}
+  set bins 20
   set data ""
   for {set p 0} {$p <= [setmd max_part]} {incr p} {
     lappend data [lindex [part $p pr pos] 2]
   }
   set rho [bin -linbins 0.5 [expr $box_lz + 0.5] $bins $data]
 \end{tclcode}
-%make font-lock happy: $
 
-Here, \verb|bins| is a variable that you should set to the required
+Here, \verb|bins| is a variable that you should set to the desired
 number of bins (20 should be fine). Otherwise, this code can replace
-the analyze rdf command. The \verb|bin| command also allows to obtain
-the coordinates of the bins:
+the analyze rdf command. The \verb|bin| command can also be used to
+calculate the coordinates of the bins:
 
 \begin{tclcode}
   bin -linbins 0.5 [expr $box_lz + 0.5] $bins -binctrwdth
@@ -583,13 +663,12 @@ depending on the particle type:
     lappend data1 [lindex [part $p pr pos] 2]
   }
 \end{tclcode}
-%make font-lock happy: $
 
 The resulting distribution of charges is shown in
-Fig.~\ref{fig:neutralrho}, showing a layering effect of the
+Fig.~\ref{fig:neutralrho}. You can see a layering effect of the
 confinement on the charge distributions.
 
-\begin{figure}[t]
+\begin{figure}[h]
   \centering
   \includegraphics[width=0.7\textwidth]{figures/nonneutral-rho}
   \caption{Distribution of positive charges $\rho_+(z)$ (open squares)
@@ -604,7 +683,7 @@ confinement on the charge distributions.
 So far, the distributions of particles of type 0 and 1 are more or
 less the same, as one would expect. However, we can change this by
 introducing charged walls. That is done using the
-\verb|constrain plate| command:
+\verb|constraint plate| command:
 
 \begin{tclcode}
   set sigma [expr -0.25*$n_part/($box_lxy*$box_lxy)]
@@ -612,15 +691,21 @@ introducing charged walls. That is done using the
   constraint plate height [expr $box_lz + 1.0] sigma $sigma
 \end{tclcode}
 
+Note that you need to have both the \verb|constraint plate| and the 
+\verb|constraint wall| commands in your simulation script.
 This adds two plates at the bottom and top of the simulation box. The
-charged walls (the condensator \emph{plates}) are necessarily
+charged walls (the capacitor \emph{plates}) are necessarily
 perpendicular to the z-axis, since for all electrostatics methods for
-2d-periodic systems, the z-axis is the non-periodic one. Note that
+2d-periodic systems, \es{} assumes that the z-axis is the
+non-periodic axis.
+
+Note that
 this adds two walls with a total charge of \verb|n_part|/2, which
-would make the overall system charged. To maintain charge neutrality,
-we simply choose only half of the charges (i.e. 100) with altering
-charge as before, while the rest we simply choose all with positive
-charge. For this system, you should obtain distributions as shown in
+would make the overall system charged. So to maintain charge
+neutrality, we need to only create half of the charges (i.e. 100)
+with alternating charges as before, while the rest is created
+with positive charge.
+For this system, you should obtain distributions as shown in
 Fig.~\ref{fig:nonneutralrho}. The distribution of charges differs
 strongly between the two types of charges; while the positive charges
 layer at the walls, the negative charges accumulate in the center of

--- a/doc/tutorials/02-charged_system/scripts/analyze.tcl
+++ b/doc/tutorials/02-charged_system/scripts/analyze.tcl
@@ -21,7 +21,7 @@
 set cnt 0
 for {set i 0} {$i < 100} {incr i} { lappend avg_rdf 0 }
 
-foreach filename [lrange $argv 1 end] {
+foreach filename $argv {
 
     set f [open $filename "r"]
     while { [blockfile $f read auto] != "eof" } {}

--- a/doc/tutorials/02-charged_system/scripts/analyze_rho.tcl
+++ b/doc/tutorials/02-charged_system/scripts/analyze_rho.tcl
@@ -25,7 +25,7 @@ for {set i 0} {$i < $bins} {incr i} {
     lappend avg_rho1 0
 }
 
-foreach filename [lrange $argv 1 end] {
+foreach filename $argv {
     set f [open $filename "r"]
     while { [blockfile $f read auto] != "eof" } {}
     close $f

--- a/doc/tutorials/02-charged_system/scripts/replay.tcl
+++ b/doc/tutorials/02-charged_system/scripts/replay.tcl
@@ -20,7 +20,7 @@
 #  
 set conn 0
 
-foreach filename [lrange $argv 1 end] {
+foreach filename $argv {
     set f [open $filename "r"]
     while { [blockfile $f read auto] != "eof" } {}
     close $f


### PR DESCRIPTION
I've updated and checked the 02-charged_system tutorial and confirmed all the scripts work with the current Espresso master.

The only remaining issue is that the tutorial makes use of the undocumented `bin` command, see #409. While that command does its job just fine, it's not exactly good style to be using undocumented features in a tutorial.