### PR TITLE
Added codecov support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
  - sudo pip install cython --upgrade 
  - if [ "$with_mpi" != false ]; then sudo apt-get install libopenmpi-dev openmpi-bin; fi
  - if [ "$with_fftw" != false ]; then sudo apt-get install libfftw3-dev; fi
+ - pip install --user codecov
 
 env:
   - myconfig=default
@@ -23,9 +24,9 @@ compiler:
 matrix:
   include:
     - compiler: clang
-      env: with-mpi=false myconfig=default
+      env: with-mpi=false myconfig=default 
     - compiler: clang
-      env: with-mpi=false myconfig=maxset
+      env: with-mpi=false myconfig=maxset with_coverage=true
     - compiler: clang
       env: with-mpi=false myconfig=molcut
     - compiler: clang
@@ -38,3 +39,6 @@ matrix:
       env: with-mpi=false myconfig=maxset without-cuda
 
 script: ./maintainer/travis/build.sh
+
+after_success:
+ - codecov

--- a/maintainer/travis/build.sh
+++ b/maintainer/travis/build.sh
@@ -93,6 +93,9 @@ fi
 
 # CONFIGURE
 start "CONFIGURE"
+if $with_coverage ; then
+    configure_params="CPPFLAGS=\"-coverage -O0\" CXXFLAGS=\"-coverage -O0\" $configure_params"
+fi
 
 if $with_mpi; then
     configure_params="--with-mpi $configure_params"
@@ -159,3 +162,7 @@ if $make_check; then
 
     end "TEST"
 fi
+
+for i in `find . -name  "*.gcno"` ; do
+    (cd `dirname $i` ; gcov `basename $i` > coverage.log 2>&1 )
+done


### PR DESCRIPTION
This might be pretty much useful to pinpoint which parts of the code need a test to be added to the testsuite. 

After the discussion during the developer meeting, I looked around for some solution that could help tracing how good the testcases are. There are several options around to integrate the CI builds with output from code coverage tools, such as [gcov](https://en.wikipedia.org/wiki/Gcov). I found particularly simple to add in travis support for [codecov](https://codecov.io).

With this patch I added code coverage to one of the element of the travis matrix. The outcome can be seen, for example, in this snapshot:

![screen shot 2015-10-15 at 13 51 26](https://cloud.githubusercontent.com/assets/466063/10512919/2ae4b5ba-7344-11e5-9944-abb1e050b3c1.png)


You can have a look directly at [the annotated code files of this patch](https://codecov.io/github/Marcello-Sega/espresso/src/core/integrate.cpp?ref=1c74fd659c32bdde7b5c4900527e2507e98194fe) (this is an example of the coverage of `integrate.cpp` with the `maxset` option,  which for example does not cover NPT.

Codecov support is free (as in free beer) for open source projects.

There is also a [plugin for chrome](https://chrome.google.com/webstore/detail/codecov-extension/keefkhehidemnokodkdkejapdgfjmijf?hl=en-US), for example, to show directly the code coverage in the github page, as in these snapshots

![screen shot 2015-10-15 at 13 47 42](https://cloud.githubusercontent.com/assets/466063/10512810/628f76ae-7343-11e5-9c51-464810f649fd.png)

![screen shot 2015-10-15 at 13 47 52](https://cloud.githubusercontent.com/assets/466063/10512820/6e4451e0-7343-11e5-97b3-a56ed28a3835.png)



  