### PR TITLE
Fix Vector.hpp without C++11

### DIFF
--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -18,7 +18,9 @@
 */
 #include <algorithm>
 #include <cmath>
+#ifdef HAVE_CXX11
 #include <initializer_list>
+#endif
 
 template<int n, typename Scalar>
 class Vector {


### PR DESCRIPTION
initializer_list is a C++11 header. Even if you don't use anything from inside it, the compiler might give you an error if you include it but don't turn on C++11.

Original issue observed on GCC 4.8 with explicitly-disabled C++11.