### PR TITLE
Fixes bugs in dipolar direct sum on gpu

### DIFF
--- a/src/core/actor/DipolarDirectSum.cpp
+++ b/src/core/actor/DipolarDirectSum.cpp
@@ -31,13 +31,14 @@ if (dipolarDirectSum)
 {
   forceActors.remove(dipolarDirectSum);
   energyActors.remove(dipolarDirectSum);
-  free(dipolarDirectSum);
+  delete(dipolarDirectSum);
+  dipolarDirectSum=NULL;
 
 }
 }
 
 
-DipolarDirectSum *dipolarDirectSum;
+DipolarDirectSum *dipolarDirectSum=0;
 
 #endif
 

--- a/src/core/actor/DipolarDirectSum.hpp
+++ b/src/core/actor/DipolarDirectSum.hpp
@@ -8,6 +8,7 @@
 #include "DipolarDirectSum_cuda.hpp"
 #include "grid.hpp" 
 #include "cuda_interface.hpp"
+#include "interaction_data.hpp"
 
 #ifndef ACTOR_DIPOLARDIRECTSUM_HPP
 #define ACTOR_DIPOLARDIRECTSUM_HPP
@@ -24,7 +25,10 @@ void DipolarDirectSum_kernel_wrapper_force(dds_float k, int n, float *pos, float
 class DipolarDirectSum : public Actor {
 public:
   DipolarDirectSum(SystemInterface &s) {
-    if(!s.requestFGpu())
+
+	k = coulomb.Dbjerrum;
+
+	if(!s.requestFGpu())
       std::cerr << "DipolarDirectSum needs access to forces on GPU!" << std::endl;
 
     if(!s.requestRGpu())

--- a/src/core/actor/DipolarDirectSum_cuda.cu
+++ b/src/core/actor/DipolarDirectSum_cuda.cu
@@ -136,7 +136,7 @@ __device__ dds_float dipole_ia_energy(int id,dds_float pf, float* r1, float *r2,
   dds_float dr[3];
 dds_float _r1[3],_r2[3],_dip1[3],_dip2[3];
 
-for (int i=i=0;i<3;i++)
+for (int i=0;i<3;i++)
 {
  _r1[i]=r1[i];
  _r2[i]=r2[i];
@@ -174,7 +174,6 @@ __global__ void DipolarDirectSum_kernel_force(dds_float pf,
 				     int n, float *pos, float* dip, float *f, float* torque, dds_float box_l[3], int periodic[3]) {
 
   int i = blockIdx.x * blockDim.x + threadIdx.x;
-
 
   if(i >= n)
     return;
@@ -215,7 +214,7 @@ __global__ void DipolarDirectSum_kernel_force(dds_float pf,
 
   for (int j=i+1;j<n;j++)
   {
-      dipole_ia_force(i,1,pos+3*i,pos+3*j,dip+3*i,dip+3*j,fi,ti,tj,1,box_l,periodic);
+      dipole_ia_force(i,pf,pos+3*i,pos+3*j,dip+3*i,dip+3*j,fi,ti,tj,1,box_l,periodic);
 //      printf("%d %d: %f %f %f\n",i,j,fi[0],fi[1],fi[2]); 
       for (int k=0;k<3;k++)
       {
@@ -285,7 +284,7 @@ __global__ void DipolarDirectSum_kernel_energy(dds_float pf,
   // Summation for particle i
   for (int j=i+1;j<n;j++)
   {
-      sum+=dipole_ia_energy(i,1,pos+3*i,pos+3*j,dip+3*i,dip+3*j,box_l,periodic);
+      sum+=dipole_ia_energy(i,pf,pos+3*i,pos+3*j,dip+3*i,dip+3*j,box_l,periodic);
   }
 
   // Save per thread result into block shared mem

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -32,6 +32,7 @@ tests = \
 	correlation_checkpoint.tcl \
 	constraints_rhomboid.tcl \
 	coulomb_cloud_wall.tcl \
+	dawaanr-and-dds-gpu.tcl \
 	dh.tcl \
 	dielectric.tcl \
 	dihedral.tcl \

--- a/testsuite/dawaanr-and-dds-gpu.tcl
+++ b/testsuite/dawaanr-and-dds-gpu.tcl
@@ -1,0 +1,168 @@
+
+
+# Copyright (C) 2010,2011,2012,2013,2014 The ESPResSo project
+# Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+#   Max-Planck-Institute for Polymer Research, Theory Group
+#  
+# This file is part of ESPResSo.
+#  
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#  
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#  
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+# 
+
+proc stopAll {} {
+  for {set i 0} {$i <=[setmd max_part] } {incr i} {
+    if { [part $i print pos] != "na" } {
+      part $i v 0 0 0 omega 0 0 0
+    }
+  }
+}
+
+proc error { msg } {
+  puts $msg
+}
+
+source "tests_common.tcl"
+require_feature "DIPOLES"
+require_feature "CUDA"
+require_feature "PARTIAL_PERIODIC"
+require_max_nodes_per_side 1
+
+source "tests_common.tcl"
+
+set tcl_precision 14
+
+proc vectorsTheSame {a b} {
+ set tol 3E-3
+ set diff [vecsub $a $b]
+ if { [veclen $diff] > $tol } {
+  return 0
+  puts "Difference: [veclen $diff]"
+ }
+ return 1
+}
+
+
+puts "----------------------------------------------"
+puts "- Testcase dawaanr-and-dds-gpu.tcl"
+puts "----------------------------------------------"
+
+set pf_dds_gpu 2.34
+set pf_dawaanr 3.524
+set ratio_dawaanr_dds_gpu [expr $pf_dawaanr / $pf_dds_gpu]
+
+set l 15 
+setmd box_l $l $l $l
+setmd periodic 0 0 0
+setmd time_step 0.0001
+setmd skin 0.1
+
+
+foreach n { 110 111 540 541 } {
+
+
+
+puts "$n particles "
+set dipole_modulus 1.3
+for {set i 0 } {$i < $n} {incr i} {
+ set posx [expr $l*[expr [t_random]]]
+ set posy [expr $l*[expr [t_random]]]
+ set posz [expr $l*[expr [t_random]]]
+ set costheta [expr 2*[expr [t_random]] - 1]
+ set sintheta [expr sin(acos($costheta))]
+ set phi [expr 2*3.1415926536*[expr [t_random]]] 
+ set dipx [expr $sintheta*cos($phi)*$dipole_modulus]
+ set dipy [expr $sintheta*sin($phi)*$dipole_modulus]
+ set dipz [expr $costheta*$dipole_modulus]
+
+ part [expr 2*$i] pos $posx $posy $posz type 0 dip $dipx $dipy $dipz v 0 0 0
+}
+inter 0 0 lennard-jones 10 0.5 0.55 auto
+thermostat langevin 0 10 
+minimize_energy 0 500 0.1 0.1
+stopAll
+
+inter 0 0 lennard-jones 0 0 0 0
+
+
+
+setmd skin 0
+setmd time_step 0.01
+
+inter magnetic $pf_dawaanr dawaanr
+integrate 0 recalc_forces
+
+set dawaanr_f ""
+set dawaanr_t ""
+
+for {set i 0} {$i<$n} {incr i} {
+  lappend dawaanr_f [part [expr 2*$i] print f]
+  lappend dawaanr_t [part [expr 2*$i] print torque]
+}
+set dawaanr_e [analyze energy total]
+
+inter magnetic 0
+
+integrate 0 recalc_forces
+
+inter magnetic $pf_dds_gpu dds-gpu
+
+integrate 0 recalc_forces
+
+set ddsgpu_f ""
+set ddsgpu_t ""
+
+for {set i 0} {$i<$n} {incr i} {
+  lappend ddsgpu_f [part [expr 2*$i] print f]
+  lappend ddsgpu_t [part [expr 2*$i] print torque]
+}
+
+set ddsgpu_e [analyze energy total]
+
+# compare
+
+for {set i 0} {$i<$n} {incr i} {
+  if { ! [vectorsTheSame [lindex $dawaanr_f $i] [vecscale $ratio_dawaanr_dds_gpu [lindex $ddsgpu_f $i]]] } {
+    error "Forces on particle don't match. $i  [vecsub [lindex $dawaanr_f $i] [vecscale $ratio_dawaanr_dds_gpu [lindex $ddsgpu_f $i]]]\n[lindex $dawaanr_f $i] [vecscale $ratio_dawaanr_dds_gpu [lindex $ddsgpu_f $i]]"
+  }
+  if { ! [vectorsTheSame [lindex $dawaanr_t $i] [vecscale $ratio_dawaanr_dds_gpu [lindex $ddsgpu_t $i]]] } {
+    error "torques on particle $i don't match.  [vecsub [lindex $dawaanr_t $i] [lindex $ddsgpu_t $i]] "
+  }
+}
+
+if { abs($dawaanr_e - $ddsgpu_e*$ratio_dawaanr_dds_gpu) > 0.001 } {
+  error "Energies for dawaanr $dawaanr_e and dds_gpu $ddsgpu_e don't match."
+}
+
+# Does the energy stay constant when swapping particles
+for {set i 0} {$i<1000} {incr i} {
+  set a [expr int(rand() *$n)*2]
+  set b [expr int(rand() *$n)*2]
+  set dipa [part $a print dip]
+  set posa [part $a print pos]
+  eval "part $a pos [part $b print pos] dip [part $b print dip]"
+  eval "part $b pos $posa dip $dipa"
+  integrate 0 recalc_forces
+  set E [analyze energy total]
+  if { abs($E -$ddsgpu_e) > 1E-3 } {
+    error "energy mismatch: $E $ddsgpu_e"
+  }
+}
+
+
+integrate 0 recalc_forces
+inter magnetic 0 
+part deleteall
+
+
+}


### PR DESCRIPTION
1. Avoid invalid frees
2. Missing Bjerum length (From B.M Tanygin, pull request #453 
3. Testcase comparing dipolar direct summation methods against each other and checking the scaling with Bjerrum length
