### PR TITLE
missing () and ** instead of pow() in testcases

### DIFF
--- a/testsuite/bonded_coulomb.tcl
+++ b/testsuite/bonded_coulomb.tcl
@@ -84,9 +84,9 @@ for { set i 0 } { $i < $n_parts } { incr i } {
     set f_bonded_coulomb [lindex $forces_bonded_coulomb $i]
     puts "dh $f_dh"
     puts "bc $f_bonded_coulomb"
-    set rms [expr $rms + ([lindex $f_dh 0] - [lindex $f_bonded_coulomb 0])**2]
-    set rms [expr $rms + ([lindex $f_dh 1] - [lindex $f_bonded_coulomb 1])**2]
-    set rms [expr $rms + ([lindex $f_dh 2] - [lindex $f_bonded_coulomb 2])**2]
+    set rms [expr $rms + pow([lindex $f_dh 0] - ([lindex $f_bonded_coulomb 0]), 2)]
+    set rms [expr $rms + pow([lindex $f_dh 1] - ([lindex $f_bonded_coulomb 1]), 2)]
+    set rms [expr $rms + pow([lindex $f_dh 2] - ([lindex $f_bonded_coulomb 2]), 2)]
 }
 
 set rms [expr { sqrt($rms/$n_parts) }]

--- a/testsuite/ek_electrostatics_coupling_x.tcl
+++ b/testsuite/ek_electrostatics_coupling_x.tcl
@@ -91,7 +91,7 @@ for { set i 10 } { $i < 90 } { incr i } {
     part 0 pos $l 0 0 q 1.0
     integrate 0
     set E_i [lindex [part 0 pr f] 0]
-    set tol [expr sqrt(($E_i - $ref_field)**2)]
+    set tol [expr sqrt(pow($E_i - ($ref_field), 2))]
     if { $tol >= $field_tol } {
 	error_exit "Force deviation $tol bigger than tolerance $field_tol"
     }

--- a/testsuite/ek_electrostatics_coupling_y.tcl
+++ b/testsuite/ek_electrostatics_coupling_y.tcl
@@ -90,7 +90,7 @@ for { set i 10 } { $i < 90 } { incr i } {
     part 0 pos 0 $l 0 q 1.0
     integrate 0
     set E_i [lindex [part 0 pr f] 1]
-    set tol [expr sqrt(($E_i - $ref_field)**2)]
+    set tol [expr sqrt(pow($E_i - ($ref_field), 2))]
     if { $tol >= $field_tol } {
 	error_exit "Force deviation $tol bigger than tolerance $field_tol"
     }

--- a/testsuite/ek_electrostatics_coupling_z.tcl
+++ b/testsuite/ek_electrostatics_coupling_z.tcl
@@ -91,7 +91,7 @@ for { set i 10 } { $i < 90 } { incr i } {
     part 0 pos 0 0 $l q 1.0
     integrate 0
     set E_i [lindex [part 0 pr f] 2]
-    set tol [expr sqrt(($E_i - $ref_field)**2)]
+    set tol [expr sqrt(pow($E_i - ($ref_field), 2))]
     if { $tol >= $field_tol } {
 	error_ext "Force deviation $tol bigger than tolerance $field_tol"
     }


### PR DESCRIPTION
expr $a - $b is only valid syntax for $b >= 0 because TCL sucks
** requires TCL >= 8.5