### PR TITLE
Python PEP8 naming convention

### DIFF
--- a/doc/tutorials/04-lattice_boltzmann/src/lb_stokes_force.tcl
+++ b/doc/tutorials/04-lattice_boltzmann/src/lb_stokes_force.tcl
@@ -28,14 +28,14 @@
 # in z direction. We create walls in the xz and yz plane at the box 
 # boundaries, where the velocity is fixed to $v. 
 #
-set box_width 14
-set box_length 14
+set box_width 64
+set box_length 64
 
 
 # The temperature is zero.
 thermostat lb 0.
 # Espresso complains if we don't give a skin
-setmd skin 0.4
+setmd skin 0.5
 
 # The boundary speed 
 set v 0.01
@@ -53,7 +53,7 @@ setmd box_l [ expr $box_width+2*$agrid ]  [ expr $box_width+2*$agrid ] $box_leng
 # MD timestep and LB timestep are identical 
 setmd time_step $tau
 # Invoke LB fluid
-lbfluid visc $kinematic_visc dens $density  agrid $agrid tau $tau friction $friction
+lbfluid gpu visc $kinematic_visc dens $density  agrid $agrid tau $tau friction $friction
 
 # Four walls make an infinite square channel along z direction
 lbboundary wall normal -1. 0. 0. dist [ expr -(1+$box_width) ] velocity 0.00 0 $v 

--- a/doc/tutorials/04-lattice_boltzmann/src/lb_stokes_force.tcl
+++ b/doc/tutorials/04-lattice_boltzmann/src/lb_stokes_force.tcl
@@ -28,14 +28,14 @@
 # in z direction. We create walls in the xz and yz plane at the box 
 # boundaries, where the velocity is fixed to $v. 
 #
-set box_width 64
-set box_length 64
+set box_width 14
+set box_length 14
 
 
 # The temperature is zero.
 thermostat lb 0.
 # Espresso complains if we don't give a skin
-setmd skin 0.5
+setmd skin 0.4
 
 # The boundary speed 
 set v 0.01
@@ -53,7 +53,7 @@ setmd box_l [ expr $box_width+2*$agrid ]  [ expr $box_width+2*$agrid ] $box_leng
 # MD timestep and LB timestep are identical 
 setmd time_step $tau
 # Invoke LB fluid
-lbfluid gpu visc $kinematic_visc dens $density  agrid $agrid tau $tau friction $friction
+lbfluid visc $kinematic_visc dens $density  agrid $agrid tau $tau friction $friction
 
 # Four walls make an infinite square channel along z direction
 lbboundary wall normal -1. 0. 0. dist [ expr -(1+$box_width) ] velocity 0.00 0 $v 

--- a/samples/python/cellsystem_test.py
+++ b/samples/python/cellsystem_test.py
@@ -22,15 +22,15 @@ from __future__ import print_function
 import ctypes
 import sys
 sys.setdlopenflags((sys.getdlopenflags() | ctypes.RTLD_GLOBAL ))
-import espresso as es
+import espressomd as es
+
 print(dir(es))
 
-cs=es.cellsystem.Cellsystem()
-gh=es.global_variables.GlobalsHandle()
+cs=es.cellsystem.CellSystem()
 
 # domain decomposition with verlet list: three equivalent commands
-cs.setDomainDecomposition()
-cs.setDomainDecomposition(True)
-cs.setDomainDecomposition(useVerletList=True)
+cs.set_domain_decomposition()
+cs.set_domain_decomposition(True)
+cs.set_domain_decomposition(use_verlet_lists=True)
 
 

--- a/samples/python/coulomb_debye_hueckel.py
+++ b/samples/python/coulomb_debye_hueckel.py
@@ -69,8 +69,7 @@ system = espressomd.System()
 system.time_step = 0.01
 system.skin      = 0.4
  
-#es._espressoHandle.Tcl_Eval('thermostat langevin 1.0 1.0')
-thermostat.Thermostat().setLangevin(1.0,1.0)
+thermostat.Thermostat().set_langevin(1.0,1.0)
 
 # warmup integration (with capped LJ potential)
 warm_steps   = 100
@@ -92,14 +91,14 @@ int_n_times = 10
 
 system.box_l = [box_l,box_l,box_l]
 
-system.nonBondedInter[0,0].lennardJones.setParams(
+system.nonBondedInter[0,0].lennard_jones.set_params(
     epsilon=lj_eps, sigma=lj_sig,
     cutoff=lj_cut, shift="auto")
-system.nonBondedInter.setForceCap(lj_cap)
+system.nonBondedInter.set_force_cap(lj_cap)
 
 
 print("LJ-parameters:")
-print(system.nonBondedInter[0,0].lennardJones.getParams())
+print(system.nonBondedInter[0,0].lennard_jones.get_params())
 
 # Particle setup
 #############################################################
@@ -156,8 +155,8 @@ Stop if minimal distance is larger than {}
 
 # set LJ cap
 lj_cap = 20
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # Warmup Integration Loop
 i = 0
@@ -173,7 +172,7 @@ while (i < warm_n_times and act_min_dist < min_dist):
 
 #   Increase LJ cap
   lj_cap = lj_cap + 10
-  system.nonBondedInter.setForceCap(lj_cap)
+  system.nonBondedInter.set_force_cap(lj_cap)
 
 # Just to see what else we may get from the c code
 print("""
@@ -206,8 +205,8 @@ print("\nStart integration: run %d times %d steps" % (int_n_times, int_steps))
 
 # remove force capping
 lj_cap = 0 
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # print initial energies
 #energies = es._espressoHandle.Tcl_Eval('analyze energy')

--- a/samples/python/debye_hueckel.py
+++ b/samples/python/debye_hueckel.py
@@ -70,7 +70,7 @@ system.time_step = 0.01
 system.skin      = 0.4
  
 #es._espressoHandle.Tcl_Eval('thermostat langevin 1.0 1.0')
-thermostat.Thermostat().setLangevin(1.0,1.0)
+thermostat.Thermostat().set_langevin(1.0,1.0)
 
 # warmup integration (with capped LJ potential)
 warm_steps   = 100
@@ -92,14 +92,14 @@ int_n_times = 10
 
 system.box_l = [box_l,box_l,box_l]
 
-system.nonBondedInter[0,0].lennardJones.setParams(
+system.nonBondedInter[0,0].lennard_jones.set_params(
     epsilon=lj_eps, sigma=lj_sig,
     cutoff=lj_cut, shift="auto")
-system.nonBondedInter.setForceCap(lj_cap)
+system.nonBondedInter.set_force_cap(lj_cap)
 
 
 print("LJ-parameters:")
-print(system.nonBondedInter[0,0].lennardJones.getParams())
+print(system.nonBondedInter[0,0].lennard_jones.get_params())
 
 # Particle setup
 #############################################################
@@ -156,8 +156,8 @@ Stop if minimal distance is larger than {}
 
 # set LJ cap
 lj_cap = 20
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # Warmup Integration Loop
 i = 0
@@ -173,7 +173,7 @@ while (i < warm_n_times and act_min_dist < min_dist):
 
 #   Increase LJ cap
   lj_cap = lj_cap + 10
-  system.nonBondedInter.setForceCap(lj_cap)
+  system.nonBondedInter.set_force_cap(lj_cap)
 
 # Just to see what else we may get from the c code
 print("""
@@ -206,8 +206,8 @@ print("\nStart integration: run %d times %d steps" % (int_n_times, int_steps))
 
 # remove force capping
 lj_cap = 0 
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # print initial energies
 #energies = es._espressoHandle.Tcl_Eval('analyze energy')

--- a/samples/python/lj_liquid.py
+++ b/samples/python/lj_liquid.py
@@ -56,7 +56,7 @@ system = espressomd.System()
 system.time_step = 0.01
 system.skin      = 0.4
 #es._espressoHandle.Tcl_Eval('thermostat langevin 1.0 1.0')
-system.thermostat.setLangevin(kT=1.0,gamma=1.0)
+system.thermostat.set_langevin(kT=1.0,gamma=1.0)
 
 # warmup integration (with capped LJ potential)
 warm_steps   = 100
@@ -78,13 +78,13 @@ int_n_times = 5
 
 system.box_l = [box_l,box_l,box_l]
 
-system.nonBondedInter[0,0].lennardJones.setParams(
+system.nonBondedInter[0,0].lennard_jones.set_params(
     epsilon=lj_eps, sigma=lj_sig,
     cutoff=lj_cut, shift="auto")
-system.nonBondedInter.setForceCap(lj_cap)
+system.nonBondedInter.set_force_cap(lj_cap)
 
 print("LJ-parameters:")
-print(system.nonBondedInter[0,0].lennardJones.getParams())
+print(system.nonBondedInter[0,0].lennard_jones.get_params())
 
 # Particle setup
 #############################################################
@@ -124,8 +124,8 @@ Stop if minimal distance is larger than {}
 
 # set LJ cap
 lj_cap = 20
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # Warmup Integration Loop
 i = 0
@@ -141,7 +141,7 @@ while (i < warm_n_times and act_min_dist < min_dist):
 
 #   Increase LJ cap
   lj_cap = lj_cap + 10
-  system.nonBondedInter.setForceCap(lj_cap)
+  system.nonBondedInter.set_force_cap(lj_cap)
 
 # Just to see what else we may get from the c code
 print("""
@@ -174,8 +174,8 @@ print("\nStart integration: run %d times %d steps" % (int_n_times, int_steps))
 
 # remove force capping
 lj_cap = 0 
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # print initial energies
 #energies = es._espressoHandle.Tcl_Eval('analyze energy')

--- a/samples/python/p3m.py
+++ b/samples/python/p3m.py
@@ -58,7 +58,7 @@ system = espressomd.System()
 system.time_step = 0.01
 system.skin      = 0.4
 #es._espressoHandle.Tcl_Eval('thermostat langevin 1.0 1.0')
-thermostat.Thermostat().setLangevin(1.0,1.0)
+thermostat.Thermostat().set_langevin(1.0,1.0)
 
 # warmup integration (with capped LJ potential)
 warm_steps   = 100
@@ -80,14 +80,14 @@ int_n_times = 10
 
 system.box_l = [box_l,box_l,box_l]
 
-system.nonBondedInter[0,0].lennardJones.setParams(
+system.nonBondedInter[0,0].lennard_jones.set_params(
     epsilon=lj_eps, sigma=lj_sig,
     cutoff=lj_cut, shift="auto")
-system.nonBondedInter.setForceCap(lj_cap)
+system.nonBondedInter.set_force_cap(lj_cap)
 
 
 print("LJ-parameters:")
-print(system.nonBondedInter[0,0].lennardJones.getParams())
+print(system.nonBondedInter[0,0].lennard_jones.get_params())
 
 # Particle setup
 #############################################################
@@ -115,11 +115,11 @@ for i in range(n_part/2-1):
   system.part[2*i+1].q = 1.0
 # P3M setup after charge assigned
 #############################################################
-p3m=electrostatics.P3M_GPU(bjerrum_length=1.0,accuracy=1e-2)
+p3m=electrostatics.P3M(bjerrum_length=1.0,accuracy=1e-2)
 system.actors.add(p3m)
 
 print("P3M parameter:\n")
-p3m_params=p3m.getParams()
+p3m_params=p3m.get_params()
 for key in p3m_params.keys():
   print("{} = {}".format(key,p3m_params[key]))
 
@@ -143,8 +143,8 @@ Stop if minimal distance is larger than {}
 
 # set LJ cap
 lj_cap = 20
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # Warmup Integration Loop
 i = 0
@@ -156,7 +156,7 @@ while (i < warm_n_times and act_min_dist < min_dist):
 
 #   Increase LJ cap
   lj_cap = lj_cap + 10
-  system.nonBondedInter.setForceCap(lj_cap)
+  system.nonBondedInter.set_force_cap(lj_cap)
 
 # Just to see what else we may get from the c code
 print("""
@@ -187,8 +187,8 @@ print("\nStart integration: run %d times %d steps" % (int_n_times, int_steps))
 
 # remove force capping
 lj_cap = 0 
-system.nonBondedInter.setForceCap(lj_cap)
-print(system.nonBondedInter[0,0].lennardJones)
+system.nonBondedInter.set_force_cap(lj_cap)
+print(system.nonBondedInter[0,0].lennard_jones)
 
 # print initial energies
 energies = analyze.energy(system=system)

--- a/samples/python/p3m.py
+++ b/samples/python/p3m.py
@@ -115,7 +115,7 @@ for i in range(n_part/2-1):
   system.part[2*i+1].q = 1.0
 # P3M setup after charge assigned
 #############################################################
-p3m=electrostatics.P3M(bjerrum_length=1.0,accuracy=1e-2)
+p3m=electrostatics.P3M_GPU(bjerrum_length=1.0,accuracy=1e-2)
 system.actors.add(p3m)
 
 print("P3M parameter:\n")

--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -33,7 +33,7 @@ from cellsystem import CellSystem
 
 cdef class System:
     doge = 1
-    part = particle_data.particleList()
+    part = particle_data.ParticleList()
     nonBondedInter = interactions.NonBondedInteractions()
     bondedInter = interactions.BondedInteractions()
     cellSystem = CellSystem()
@@ -367,22 +367,22 @@ cdef class System:
             global max_cut_bonded
             return max_cut_bonded
 
-    def changeVolumeAndRescaleParticles(dNew, dir="xyz"):
+    def change_volume_and_rescale_particles(d_new, dir="xyz"):
         """Change box size and rescale particle coordinates
-           changeVolumeAndRescaleParticles(dNew, dir="xyz")
-           dNew: new length, dir=coordinate tow work on, "xyz" for isotropic
+           change_volume_and_rescale_particles(d_new, dir="xyz")
+           d_new: new length, dir=coordinate tow work on, "xyz" for isotropic
         """
-        if dNew < 0:
+        if d_new < 0:
             raise ValueError("No negative lengths")
         if dir == "xyz":
-            dNew = dNew**(1. / 3.)
-            rescale_boxl(3, dNew)
+            d_new = d_new**(1. / 3.)
+            rescale_boxl(3, d_new)
         elif dir == "x":
-            rescale_boxl(0, dNew)
+            rescale_boxl(0, d_new)
         elif dir == "y":
-            rescale_boxl(1, dNew)
+            rescale_boxl(1, d_new)
         elif dir == "z":
-            rescale_boxl(2, dNew)
+            rescale_boxl(2, d_new)
         else:
             raise ValueError(
                 'Usage: changeVolume { <V_new> | <L_new> { "x" | "y" | "z" | "xyz" } }')

--- a/src/python/espressomd/actors.pyx
+++ b/src/python/espressomd/actors.pyx
@@ -3,7 +3,9 @@ from highlander import ThereCanOnlyBeOne
 
 
 cdef class Actor:
-    activeList = dict(ElectrostaticInteraction=False,
+
+    # Keys in active_list have to match the method name.
+    active_list = dict(ElectrostaticInteraction=False,
                       MagnetostaticInteraction=False,
                       MagnetostaticExtension=False,
                       HydrodynamicInteraction=False,
@@ -11,140 +13,142 @@ cdef class Actor:
 
     def __cinit__(self, *args, **kwargs):
         self._isactive = False
-        self._params = self.defaultParams()
+        self._params = self.default_params()
         self.system = None
 
         # Check if all required keys are given
-        for k in self.requiredKeys():
+        for k in self.required_keys():
             if k not in kwargs:
                 raise ValueError(
-                    "At least the following keys have to be given as keyword arguments: " + self.requiredKeys().__str__() + " got " + kwargs.__str__())
+                    "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__() + " got " + kwargs.__str__())
             self._params[k] = kwargs[k]
 
         for k in kwargs:
-            if k in self.validKeys():
+            if k in self.valid_keys():
                 self._params[k] = kwargs[k]
             else:
                 raise KeyError("%s is not a vaild key" % k)
 
     def _activate(self):
-        inter = self._getInteractionType()
-        if Actor.activeList[inter]:
+        inter = self._get_interaction_type()
+        if Actor.active_list[inter]:
             raise ThereCanOnlyBeOne(self.__class__.__bases__[0])
-        Actor.activeList[inter] = True
-        self.validateParams()
-        self._activateMethod()
+        Actor.active_list[inter] = True
+        self.validate_params()
+        self._activate_method()
         self._isactive = True
 
     def _deactivate(self):
-        self._deactivateMethod()
+        self._deactivate_method()
         self._isactive = False
 
-    def isValid(self):
+    def is_valid(self):
         """Check, if the data stored in the instance still matches what is in Espresso"""
         # check, if the bond parameters saved in the class still match those
         # saved in Espresso
-        tempParams = self._getParamsFromEsCore()
-        if self._params != tempParams:
+        temp_params = self._get_params_from_es_core()
+        if self._params != temp_params:
             return False
 
         # If we're still here, the instance is valid
         return True
 
-    def getParams(self):
+    def get_params(self):
         """Get interaction parameters"""
         # If this instance refers to an actual interaction defined in the es core, load
         # current parameters from there
-        update = self._getParamsFromEsCore()
+        update = self._get_params_from_es_core()
         self._params.update(update)
         return self._params
 
-    def setParams(self, **p):
+    def set_params(self, **p):
         """Update parameters. Only given """
         # Check, if any key was passed, which is not known
         for k in p.keys():
-            if k not in self.validKeys():
+            if k not in self.valid_keys():
                 raise ValueError(
-                    "Only the following keys are supported: " + self.validKeys().__str__())
+                    "Only the following keys are supported: " + self.valid_keys().__str__())
 
         # When an interaction is newly activated, all required keys must be
         # given
-        if not self.isActive():
-            for k in self.requiredKeys():
+        if not self.is_active():
+            for k in self.required_keys():
                 if k not in p:
                     raise ValueError(
-                        "At least the following keys have to be given as keyword arguments: " + self.requiredKeys().__str__())
+                        "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__())
 
         self._params.update(p)
         # vaidate updated parameters
-        self.validateParams()
+        self.validate_params()
         # Put in values given by the user
-        self._setParamsInEsCore()
+        self._set_params_in_es_core()
 
-    def _getInteractionType(self):
+    def _get_interaction_type(self):
         return self.__class__.__bases__[0].__name__
 
-    def isActive(self):
+    def is_active(self):
         print self.__class__.__name__, self._isactive
         return self._isactive
 
-    def validKeys(self):
+    def valid_keys(self):
         raise Exception(
-            "Subclasses of %s must define the validKeys() method." % self._getInteractionType())
+            "Subclasses of %s must define the valid_keys() method." % self._get_interaction_type())
 
-    def requiredKeys(self):
+    def required_keys(self):
         raise Exception(
-            "Subclasses of %s must define the requiredKeys() method." % self._getInteractionType())
+            "Subclasses of %s must define the required_keys() method." % self._get_interaction_type())
 
-    def validateParams(self):
+    def validate_params(self):
         raise Exception(
-            "Subclasses of %s must define the validateParams() method." % self._getInteractionType())
+            "Subclasses of %s must define the validate_params() method." % self._get_interaction_type())
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         raise Exception(
-            "Subclasses of %s must define the _getParamsFromEsCore() method." % self._getInteractionType())
+            "Subclasses of %s must define the _get_params_from_es_core() method." % self._get_interaction_type())
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         raise Exception(
-            "Subclasses of %s must define the _setParamsInEsCore() method." % self._getInteractionType())
+            "Subclasses of %s must define the _set_params_in_es_core() method." % self._get_interaction_type())
 
-    def defaultParams(self):
+    def default_params(self):
         raise Exception(
-            "Subclasses of %s must define the defaultParams() method." % self._getInteractionType())
+            "Subclasses of %s must define the default_params() method." % self._get_interaction_type())
 
-    def _activateMethod(self):
+    def _activate_method(self):
         raise Exception(
-            "Subclasses of %s must define the _activateMethod() method." % self._getInteractionType())
+            "Subclasses of %s must define the _activate_method() method." % self._get_interaction_type())
 
-    def _deactivateMethod(self):
+    def _deactivate_method(self):
         raise Exception(
-            "Subclasses of %s must define the _deactivateMethod() method." % self._getInteractionType())
+            "Subclasses of %s must define the _deactivate_method() method." % self._get_interaction_type())
 
 
 class Actors:
-    activeActors = []
+
+
+    active_actors = []
 
     def __init__(self, _system=None):
         self.system = _system
 
     def add(self, actor):
-        if not actor in Actors.activeActors:
+        if not actor in Actors.active_actors:
             actor.system = self.system
-            Actors.activeActors.append(actor)
+            Actors.active_actors.append(actor)
             actor._activate()
         else:
             raise ThereCanOnlyBeOne(actor)
 
     def __str__(self):
         print "Active Actors:"
-        for actor in Actors.activeActors:
+        for actor in Actors.active_actors:
             print actor
         return ""
 
     def get(self):
         # for actor in Actors.activeActors:
         #     print actor.__class__.__name__
-        return "%s" % Actors.activeActors
+        return "%s" % Actors.active_actors
 
     def deactivate(self, actor):
         actor._deactivate()

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -43,8 +43,8 @@ def mindist(system=None, p1='default', p2='default'):
       p1, p2: lists of particle types
     """
 
-    cdef IntList * set1
-    cdef IntList * set2
+    cdef int_list * set1
+    cdef int_list * set2
 
     if p1 == 'default' and p2 == 'default':
         result = c_analyze.mindist(NULL, NULL)
@@ -62,8 +62,8 @@ def mindist(system=None, p1='default', p2='default'):
                 raise ValueError(
                     "Particle types in p1 and p2 have to be of type int" + str(p2[i]))
 
-        set1 = create_IntList_from_python_object(p1)
-        set2 = create_IntList_from_python_object(p2)
+        set1 = create_int_list_from_python_object(p1)
+        set2 = create_int_list_from_python_object(p2)
 
         result = c_analyze.mindist(set1, set2)
 
@@ -134,12 +134,12 @@ def nbhood(system=None, pos=None, r_catch=None, plane='3d'):
     """
 
     cdef int planedims[3]
-    cdef IntList * il = NULL
+    cdef int_list * il = NULL
     cdef double c_pos[3]
 
-    checkTypeOrExcept(
+    check_type_or_throw_except(
         pos, 3, float, "_pos=(float,float,float) must be passed to nbhood")
-    checkTypeOrExcept(
+    check_type_or_throw_except(
         r_catch, 1, float, "r_catch=float needs to be passed to nbhood")
 
     # default 3d takes into account dist in x, y and z
@@ -159,10 +159,10 @@ def nbhood(system=None, pos=None, r_catch=None, plane='3d'):
     for i in range(3):
         c_pos[i] = pos[i]
 
-    il = <IntList * > malloc(sizeof(IntList))
+    il = <int_list * > malloc(sizeof(int_list))
     c_analyze.nbhood(c_pos, r_catch, il, planedims)
 
-    result = create_nparray_from_IntList(il)
+    result = create_nparray_from_int_list(il)
     realloc_intlist(il, 0)
     free(il)
     return result
@@ -174,12 +174,12 @@ def cylindrical_average(system=None, center=None, direction=None,
                         types=[-1]):
 
     # Check the input types
-    checkTypeOrExcept(center,      3, float, "center has to be 3 floats")
-    checkTypeOrExcept(direction,   3, float, "direction has to be 3 floats")
-    checkTypeOrExcept(length,      1, float, "length has to be a float")
-    checkTypeOrExcept(radius,      1, float, "radius has to be a floats")
-    checkTypeOrExcept(bins_axial,  1, int,   "bins_axial has to be an int")
-    checkTypeOrExcept(bins_radial, 1, int,   "bins_radial has to be an int")
+    check_type_or_throw_except(center,      3, float, "center has to be 3 floats")
+    check_type_or_throw_except(direction,   3, float, "direction has to be 3 floats")
+    check_type_or_throw_except(length,      1, float, "length has to be a float")
+    check_type_or_throw_except(radius,      1, float, "radius has to be a floats")
+    check_type_or_throw_except(bins_axial,  1, int,   "bins_axial has to be an int")
+    check_type_or_throw_except(bins_radial, 1, int,   "bins_radial has to be an int")
 
     # Convert Python types to C++ types
     cdef vector[double] c_center = center
@@ -239,7 +239,7 @@ def pressure(self, v_comp=0):
     """Pressure calculation
        pressure(v_comp=False)
        """
-    checkTypeOrExcept(v_comp, 1, int, "v_comp must be a boolean")
+    check_type_or_throw_except(v_comp, 1, int, "v_comp must be a boolean")
 #
     # Dict to store the results
     p = {}
@@ -322,7 +322,7 @@ def pressure(self, v_comp=0):
 def stress_tensor(self, v_comp=0):
     """stress_tensor(v_comp=0)
     """
-    checkTypeOrExcept(v_comp, 1, int, "v_comp must be a boolean")
+    check_type_or_throw_except(v_comp, 1, int, "v_comp must be a boolean")
 
     # Dict to store the results
     p = {}
@@ -407,7 +407,7 @@ def local_stress_tensor(system=None, periodicity=(1, 1, 1), range_start=(0.0, 0.
     """local_stress_tensor(periodicity=(1, 1, 1), range_start=(0.0, 0.0, 0.0), stress_range=(1.0, 1.0, 1.0), bins=(1, 1, 1))
     """
 
-    cdef DoubleList * local_stress_tensor = NULL
+    cdef double_list * local_stress_tensor = NULL
     cdef int[3] c_periodicity, c_bins
     cdef double[3] c_range_start, c_stress_range
 
@@ -419,7 +419,7 @@ def local_stress_tensor(system=None, periodicity=(1, 1, 1), range_start=(0.0, 0.
 
     if c_analyze.analyze_local_stress_tensor(c_periodicity, c_range_start, c_stress_range, c_bins, local_stress_tensor):
         raise Exception("Error while calculating local stress tensor")
-    stress_tensor = create_nparray_from_DoubleList(local_stress_tensor)
+    stress_tensor = create_nparray_from_double_list(local_stress_tensor)
     free(local_stress_tensor)
     return stress_tensor
 
@@ -534,11 +534,11 @@ def calc_rh(system=None, chain_start=None, number_of_chains=None, chain_length=N
 
 
 def check_topology(system=None, chain_start=None, number_of_chains=None, chain_length=None):
-    checkTypeOrExcept(
+    check_type_or_throw_except(
         chain_start, 1, int, "chain_start=int is a required argument")
-    checkTypeOrExcept(
+    check_type_or_throw_except(
         number_of_chains, 1, int, "number_of_chains=int is a required argument")
-    checkTypeOrExcept(
+    check_type_or_throw_except(
         chain_length, 1, int, "chain_length=int is a required argument")
     if not system:
         raise ValueError('Must pass an instance of ESPResSo to thi function')
@@ -567,8 +567,8 @@ def structure_factor(system=None, sf_type='default', sf_order='default'):
     """
     cdef double * sf
 
-    checkTypeOrExcept(sf_type, 1, int, "sf_type must be an int")
-    checkTypeOrExcept(sf_order, 1, int, "sf_order must be an int")
+    check_type_or_throw_except(sf_type, 1, int, "sf_type must be an int")
+    check_type_or_throw_except(sf_order, 1, int, "sf_order must be an int")
 
     # Used to take the WITHOUT_BONDS define
     c_analyze.updatePartCfg(0)

--- a/src/python/espressomd/c_analyze.pxd
+++ b/src/python/espressomd/c_analyze.pxd
@@ -35,7 +35,7 @@ cdef extern from "statistics.hpp":
 cdef extern from "statistics.hpp":
     ctypedef struct Observable_stat:
         int init_status
-        DoubleList data
+        double_list data
         int n_coulomb
         int n_dipolar
         int n_non_bonded
@@ -48,14 +48,14 @@ cdef extern from "statistics.hpp":
 cdef extern from "statistics.hpp":
     ctypedef struct Observable_stat_non_bonded:
         pass
-    cdef double mindist(IntList * set1, IntList * set2)
-    cdef void nbhood(double pos[3], double r_catch, IntList * il, int planedims[3])
+    cdef double mindist(int_list * set1, int_list * set2)
+    cdef void nbhood(double pos[3], double r_catch, int_list * il, int planedims[3])
     cdef double distto(double pos[3], int pid)
     cdef double * obsstat_bonded(Observable_stat * stat, int j)
     cdef double * obsstat_nonbonded(Observable_stat * stat, int i, int j)
     cdef double * obsstat_nonbonded_inter(Observable_stat_non_bonded * stat, int i, int j)
     cdef double * obsstat_nonbonded_intra(Observable_stat_non_bonded * stat, int i, int j)
-    cdef double mindist(IntList * set1, IntList * set2)
+    cdef double mindist(int_list * set1, int_list * set2)
     cdef vector[double] calc_linear_momentum(int include_particles, int include_lbfluid)
     cdef int calc_cylindrical_average(vector[double] center, vector[double] direction, double length,
                                       double radius, int bins_axial, int bins_radial, vector[int] types,
@@ -76,7 +76,7 @@ cdef extern from "pressure.hpp":
     cdef int analyze_stress_tensor(string pressure_to_calc, int v_comp, vector[double] & stress)
     cdef int analyze_stress_pair(string pressure_to_calc, int type1, int type2, int v_comp, vector[double] & stress)
     cdef int analyze_stress_single(string pressure_to_calc, int bond_or_type, int v_comp, vector[double] & stress)
-    cdef int analyze_local_stress_tensor(int * periodic, double * range_start, double * range, int * bins, DoubleList * local_stress_tensor)
+    cdef int analyze_local_stress_tensor(int * periodic, double * range_start, double * range, int * bins, double_list * local_stress_tensor)
 
 cdef extern from "energy.hpp":
     cdef Observable_stat total_energy

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -20,11 +20,11 @@ cimport cellsystem
 from globals cimport *
 
 cdef class CellSystem(object):
-    def setDomainDecomposition(self, useVerletLists=True):
+    def set_domain_decomposition(self, use_verlet_lists=True):
         """Activates domain decomposition cell system
-        setDomainDecomposition(useVerletList=True)
+        set_domain_decomposition(useVerletList=True)
         """
-        if useVerletLists:
+        if use_verlet_lists:
             dd.use_vList = 1
         else:
             dd.use_vList = 0
@@ -36,10 +36,10 @@ cdef class CellSystem(object):
         # return mpi_gather_runtime_errors(interp, TCL_OK)
         return True
 
-    def setNsquare(self, useVerletLists=True):
+    def set_n_square(self, use_verlet_lists=True):
         """Activates the nsquare force calculation
         """
-        if useVerletLists:
+        if use_verlet_lists:
             dd.use_vList = 1
         else:
             dd.use_vList = 0
@@ -48,18 +48,18 @@ cdef class CellSystem(object):
         # return mpi_gather_runtime_errors(interp, TCL_OK)
         return True
 
-    def setLayered(self, nLayers=""):
-        """setLayered(nLayers="")
+    def set_layered(self, n_layers=""):
+        """set_layered(nLayers="")
         Set the layerd cell system with nLayers layers"""
-        if nLayers != "":
-            if not isinstance(nLayers, int):
+        if n_layers != "":
+            if not isinstance(n_layers, int):
                 raise ValueError("layer height should be positive")
 
-            if not nLayers > 0:
+            if not n_layers > 0:
                 raise ValueError("the number of layers has to be >0")
 
             global n_layers
-            n_layers = int(nLayers)
+            n_layers = int(n_layers)
             global determine_n_layers
             determine_n_layers = 0
 
@@ -80,16 +80,16 @@ cdef class CellSystem(object):
             raise Exception("Broadcasting the node grid failed")
         return True
 
-    def getState(self):
+    def get_state(self):
         s = {}
         if cell_structure.type == CELL_STRUCTURE_LAYERED:
             s["type"] = "layered"
-            s["nLayers"] = n_layers
+            s["n_layers"] = n_layers
         if cell_structure.type == CELL_STRUCTURE_DOMDEC:
             s["type"] = "domainDecomposition"
-            s["useVerletLists"] = dd.use_vList
+            s["use_verlet_lists"] = dd.use_vList
         if cell_structure.type == CELL_STRUCTURE_NSQUARE:
             s["type"] = "nsquare"
-            s["useVerletLists"] = dd.use_vList
+            s["use_verlet_lists"] = dd.use_vList
 
         return s

--- a/src/python/espressomd/debye_hueckel.pxd
+++ b/src/python/espressomd/debye_hueckel.pxd
@@ -23,9 +23,9 @@ cdef extern from "config.hpp":
 
 IF ELECTROSTATICS == 1:
     cdef extern from "debye_hueckel.hpp":
-        ctypedef struct Debye_hueckel_params:
+        ctypedef struct debye_hueckel_params:
             double kappa
             double r_cut
 
-        Debye_hueckel_params dh_params
+        debye_hueckel_params dh_params
         int dh_set_params(double kappa, double r_cut)

--- a/src/python/espressomd/debye_hueckel.pyx
+++ b/src/python/espressomd/debye_hueckel.pyx
@@ -18,21 +18,21 @@
 #
 include "myconfig.pxi"
 IF ELECTROSTATICS == 1:
-    def setParams(kappa, rCut):
-        if rCut < 0:
-            raise ValueError("rCut must be > 0")
-        dh_set_params(kappa, rCut)
+    def set_params(kappa, r_cut):
+        if r_cut < 0:
+            raise ValueError("r_cut must be > 0")
+        dh_set_params(kappa, r_cut)
 
-    def setRcut(rCut):
-        if rCut < 0:
-            raise ValueError("rCut must be > 0")
-        dh_set_params(dh_params.kappa, rCut)
+    def set_rcut(r_cut):
+        if r_cut < 0:
+            raise ValueError("r_cut must be > 0")
+        dh_set_params(dh_params.kappa, r_cut)
 
-    def setKappa(kappa):
+    def set_kappa(kappa):
         dh_set_params(kappa, dh_params.r_cut)
 
-    def getRcut():
+    def get_rcut():
         return dh_params.r_cut
 
-    def getKappa():
+    def get_kappa():
         return dh_params.kappa

--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -136,7 +136,7 @@ IF ELECTROKINETICS == 1:
     def print_lbpar():
         ek_print_lbpar()
 
-    def setElectrostaticsCoupling(state):
+    def set_electrostatics_coupling(state):
         IF EK_ELECTROSTATIC_COUPLING == 1:
             ek_set_electrostatics_coupling(state)
             ek_init_wrapper()
@@ -144,7 +144,7 @@ IF ELECTROKINETICS == 1:
             raise Exception(
                 'missing feature', 'feature EK_ELECTROSTATICS_COUPLING needs to be enabled')
 
-    def setLbForce(force):
+    def set_lb_force(force):
         cdef double tmp[3]
         tmp[0] = force[0]
         tmp[1] = force[1]
@@ -153,44 +153,44 @@ IF ELECTROKINETICS == 1:
 
         ek_init_wrapper()
 
-    def netCharge():
+    def net_charge():
         return ek_calculate_net_charge()
 
-    def saveCheckpoint(path):
+    def save_checkpoint(path):
         if ek_save_checkpoint(path):
             raise Exception(
                 'EK checkpointing error', 'could not save checkpoint')
 
-    def loadCheckpoint(path):
+    def load_checkpoint(path):
         if ek_load_checkpoint(path):
             raise Exception(
                 'EK checkpointing error', 'could not load checkpoint')
 
-    def printDensityVTK(species_id, path):
+    def print_density_vtk(species_id, path):
         if ek_print_vtk_density(species_id, path):
             raise Exception('EK output error', 'could not save density VTK')
 
-    def printFluxVTK(species_id, path):
+    def print_flux_vtk(species_id, path):
         if ek_print_vtk_flux(species_id, path):
             raise Exception('EK output error', 'could not save flux VTK')
 
-    def printPotentialVTK(path):
+    def print_potential_vtk(path):
         if ek_print_vtk_potential(path):
             raise Exception('EK output error', 'could not save potential VTK')
 
-    def printLbForceVTK(path):
+    def print_lb_force_vtk(path):
         if ek_print_vtk_lbforce(path):
             raise Exception('EK output error', 'could not save lbforce VTK')
 
-    def printReactionTagsVTK(path):
+    def print_reaction_tags_vtk(path):
         if ek_print_vtk_reaction_tags(path):
             raise Exception(
                 'EK output error', 'could not save reaction tags VTK')
 
-    def printLbDensityVTK(path):
+    def print_lb_density_vtk(path):
         if ek_lb_print_vtk_density(path):
             raise Exception('EK output error', 'could not save lbdensity VTK')
 
-    def printVelocityVTK(path):
+    def print_velocity_vtk(path):
         if ek_lb_print_vtk_velocity(path):
             raise Exception('EK output error', 'could not save velocity VTK')

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -26,7 +26,7 @@ from electrostatics cimport *
 IF ELECTROSTATICS and P3M:
 
     cdef extern from "elc.hpp":
-        ctypedef struct ELC_struct:
+        ctypedef struct elc_struct "ELC_struct":
             double maxPWerror
             double gap_size
             double far_cut
@@ -35,4 +35,4 @@ IF ELECTROSTATICS and P3M:
         int ELC_set_params(double maxPWerror, double min_dist, double far_cut, int neutralize, double top, double bottom, int const_pot_on, double pot_diff)
 
         # links intern C-struct with python object
-        cdef extern ELC_struct elc_params
+        cdef extern elc_struct elc_params

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -28,34 +28,34 @@ IF ELECTROSTATICS and P3M:
 
     cdef class ELC(ElectrostaticExtensions):
 
-        def validateParams(self):
-            default_params = self.defaultParams()
-            checkTypeOrExcept(self._params["maxPWerror"], 1, float, "")
-            checkRangeOrExcept(
+        def validate_params(self):
+            default_params = self.default_params()
+            check_type_or_throw_except(self._params["maxPWerror"], 1, float, "")
+            check_range_or_except(
                 self._params["maxPWerror"], 0, False, "inf", True)
-            checkTypeOrExcept(self._params["gap_size"], 1, float, "")
-            checkRangeOrExcept(self._params["gap_size"], 0, False, "inf", True)
-            checkTypeOrExcept(self._params["far_cut"], 1, float, "")
-            checkTypeOrExcept(self._params["neutralize"], 1, type(True), "")
+            check_type_or_throw_except(self._params["gap_size"], 1, float, "")
+            check_range_or_except(self._params["gap_size"], 0, False, "inf", True)
+            check_type_or_throw_except(self._params["far_cut"], 1, float, "")
+            check_type_or_throw_except(self._params["neutralize"], 1, type(True), "")
 
-        def validKeys(self):
+        def valid_keys(self):
             return "maxPWerror", "gap_size", "far_cut", "neutralize"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return ["maxPWerror", "gap_size"]
 
-        def defaultParams(self):
+        def default_params(self):
             return {"maxPWerror": -1,
                     "gap_size": -1,
                     "far_cut": -1,
                     "neutralize": True}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             params = {}
             params.update(elc_params)
             return params
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             if coulomb.method == COULOMB_P3M_GPU:
                 raise Exception(
                     "ELC tuning failed, ELC is not set up to work with the GPU P3M")
@@ -63,8 +63,8 @@ IF ELECTROSTATICS and P3M:
                 raise ValueError(
                     "Choose a 3d electrostatics method prior to ELC")
 
-        def _activateMethod(self):
-            self._setParamsInEsCore()
+        def _activate_method(self):
+            self._set_params_in_es_core()
 
-        def _deactivateMethod(self):
+        def _deactivate_method(self):
             pass

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -44,7 +44,7 @@ IF ELECTROSTATICS:
 
         int coulomb_set_bjerrum(double bjerrum)
 
-        ctypedef struct Coublomb_parameters:
+        ctypedef struct Coulomb_parameters:
             double bjerrum
             double prefactor
             CoulombMethod method

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -27,7 +27,7 @@ IF ELECTROSTATICS:
     IF P3M:
         from p3m_common cimport p3m_parameter_struct
     cdef extern from "interaction_data.hpp":
-        cdef enum CoulombMethod:
+        cdef enum coulomb_method "CoulombMethod":
             COULOMB_NONE, \
                 COULOMB_DH, \
                 COULOMB_P3M, \
@@ -44,12 +44,12 @@ IF ELECTROSTATICS:
 
         int coulomb_set_bjerrum(double bjerrum)
 
-        ctypedef struct Coulomb_parameters:
+        ctypedef struct coulomb_parameters "Coublomb_parameters":
             double bjerrum
             double prefactor
-            CoulombMethod method
+            coulomb_method method
 
-        cdef extern Coulomb_parameters coulomb
+        cdef extern coulomb_parameters coulomb
 
     IF P3M:
         cdef extern from "p3m-common.hpp":
@@ -156,18 +156,18 @@ IF ELECTROSTATICS:
 
     cdef extern from "debye_hueckel.hpp":
         IF COULOMB_DEBYE_HUECKEL:
-            ctypedef struct Debye_hueckel_params:
+            ctypedef struct debye_hueckel_params "Debye_hueckel_params":
                 double r_cut
                 double kappa
                 double eps_int, eps_ext
                 double r0, r1
                 double alpha
         ELSE:
-            ctypedef struct Debye_hueckel_params:
+            ctypedef struct debye_hueckel_params "Debye_hueckel_params":
                 double r_cut
                 double kappa
 
-        cdef extern Debye_hueckel_params dh_params
+        cdef extern debye_hueckel_params dh_params
 
         int dh_set_params(double kappa, double r_cut)
         int dh_set_params_cdh(double kappa, double r_cut, double eps_int, double eps_ext, double r0, double r1, double alpha)
@@ -192,7 +192,7 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
             double tune_rcut(double accuracy, double precision, double alpha, double V, double q_sqr, int N)
             int determine_calc_time_steps()
 
-        ctypedef struct Ewaldgpu_params:
+        ctypedef struct ewald_gpu_params "Ewaldgpu_params":
             double rcut
             int num_kx
             int num_ky
@@ -205,7 +205,7 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
             int K_max  # Maximal reciprocal K-vector in tuning
             int time_calc_steps  # Steps in time_force_calc function
 
-        cdef extern Ewaldgpu_params ewaldgpu_params
+        cdef extern ewald_gpu_params ewaldgpu_params
 
         # ctypedef extern class EwaldgpuForce ewaldgpuForce
 #    cdef extern from "EspressoSystemInterface.cpp":

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -27,7 +27,7 @@ IF ELECTROSTATICS:
     IF P3M:
         from p3m_common cimport p3m_parameter_struct
     cdef extern from "interaction_data.hpp":
-        cdef enum coulomb_method "CoulombMethod":
+        cdef enum CoulombMethod:
             COULOMB_NONE, \
                 COULOMB_DH, \
                 COULOMB_P3M, \
@@ -44,12 +44,12 @@ IF ELECTROSTATICS:
 
         int coulomb_set_bjerrum(double bjerrum)
 
-        ctypedef struct coulomb_parameters "Coublomb_parameters":
+        ctypedef struct Coublomb_parameters:
             double bjerrum
             double prefactor
-            coulomb_method method
+            CoulombMethod method
 
-        cdef extern coulomb_parameters coulomb
+        cdef extern Coulomb_parameters coulomb
 
     IF P3M:
         cdef extern from "p3m-common.hpp":
@@ -85,19 +85,20 @@ IF ELECTROSTATICS:
             # links intern C-struct with python object
             cdef extern p3m_data_struct p3m
 
-        cdef extern from "p3m_gpu.hpp":
-            void p3m_gpu_init(int cao, int *mesh, double alpha, double *box)
+        IF CUDA:
+            cdef extern from "p3m_gpu.hpp":
+                void p3m_gpu_init(int cao, int *mesh, double alpha, double *box)
 
-        cdef inline python_p3m_gpu_init(params):
-            cdef int cao
-            cdef int mesh[3]
-            cdef double alpha
-            cdef double box[3]
-            cao = params["cao"]
-            mesh = params["mesh"]
-            alpha = params["alpha"]
-            box = params["box"]
-            p3m_gpu_init(cao, mesh, alpha, box)
+            cdef inline python_p3m_gpu_init(params):
+                cdef int cao
+                cdef int mesh[3]
+                cdef double alpha
+                cdef double box[3]
+                cao = params["cao"]
+                mesh = params["mesh"]
+                alpha = params["alpha"]
+                box = params["box"]
+                p3m_gpu_init(cao, mesh, alpha, box)
 
         # Convert C arguments into numpy array
         cdef inline python_p3m_set_mesh_offset(mesh_off):
@@ -156,18 +157,18 @@ IF ELECTROSTATICS:
 
     cdef extern from "debye_hueckel.hpp":
         IF COULOMB_DEBYE_HUECKEL:
-            ctypedef struct debye_hueckel_params "Debye_hueckel_params":
+            ctypedef struct Debye_hueckel_params:
                 double r_cut
                 double kappa
                 double eps_int, eps_ext
                 double r0, r1
                 double alpha
         ELSE:
-            ctypedef struct debye_hueckel_params "Debye_hueckel_params":
+            ctypedef struct Debye_hueckel_params:
                 double r_cut
                 double kappa
 
-        cdef extern debye_hueckel_params dh_params
+        cdef extern Debye_hueckel_params dh_params
 
         int dh_set_params(double kappa, double r_cut)
         int dh_set_params_cdh(double kappa, double r_cut, double eps_int, double eps_ext, double r0, double r1, double alpha)
@@ -192,7 +193,7 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
             double tune_rcut(double accuracy, double precision, double alpha, double V, double q_sqr, int N)
             int determine_calc_time_steps()
 
-        ctypedef struct ewald_gpu_params "Ewaldgpu_params":
+        ctypedef struct Ewaldgpu_params:
             double rcut
             int num_kx
             int num_ky
@@ -205,7 +206,7 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
             int K_max  # Maximal reciprocal K-vector in tuning
             int time_calc_steps  # Steps in time_force_calc function
 
-        cdef extern ewald_gpu_params ewaldgpu_params
+        cdef extern Ewaldgpu_params ewaldgpu_params
 
         # ctypedef extern class EwaldgpuForce ewaldgpuForce
 #    cdef extern from "EspressoSystemInterface.cpp":

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -29,7 +29,7 @@ cdef class ElectrostaticInteraction(actors.Actor):
 
 IF COULOMB_DEBYE_HUECKEL:
     cdef class CDH(ElectrostaticInteraction):
-        def validateParams(self):
+        def validate_params(self):
             if (self._params["bjerrum_length"] <= 0):
                 raise ValueError("Bjerrum_length should be a positive double")
             if (self._params["kappa"] < 0):
@@ -49,26 +49,26 @@ IF COULOMB_DEBYE_HUECKEL:
             if (self._params["alpha"] < 0):
                 raise ValueError("alpha should be a non-negative double")
 
-        def validKeys(self):
+        def valid_keys(self):
             return "bjerrum_length", "kappa", "r_cut", "eps_int", "eps_ext", "r0", "r1", "alpha"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "bjerrum_length", "kappa", "r_cut", "eps_int", "eps_ext", "r0", "r1", "alpha"
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             coulomb_set_bjerrum(self._params["bjerrum_length"])
             dh_set_params_cdh(self._params["kappa"], self._params["r_cut"], self._params[
                               "eps_int"], self._params["eps_ext"], self._params["r0"], self._params["r1"], self._params["alpha"])
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             params = {}
             params.update(dh_params)
             return params
 
-        def _activateMethod(self):
+        def _activate_method(self):
             coulomb.method = COULOMB_DH
 
-        def defaultParams(self):
+        def default_params(self):
             return {"bjerrum_length": -1,
                     "kappa": -1,
                     "r_cut": -1,
@@ -81,7 +81,7 @@ IF COULOMB_DEBYE_HUECKEL:
 ELSE:
     IF ELECTROSTATICS:
         cdef class DH(ElectrostaticInteraction):
-            def validateParams(self):
+            def validate_params(self):
                 if (self._params["bjerrum_length"] <= 0):
                     raise ValueError(
                         "Bjerrum_length should be a positive double")
@@ -90,26 +90,26 @@ ELSE:
                 if (self._params["r_cut"] < 0):
                     raise ValueError("r_cut should be a non-negative double")
 
-            def validKeys(self):
+            def valid_keys(self):
                 return "bjerrum_length", "kappa", "r_cut"
 
-            def requiredKeys(self):
+            def required_keys(self):
                 return "bjerrum_length", "kappa", "r_cut"
 
-            def _setParamsInEsCore(self):
+            def _set_params_in_es_core(self):
                 coulomb_set_bjerrum(self._params["bjerrum_length"])
                 dh_set_params(self._params["kappa"], self._params["r_cut"])
 
-            def _getParamsFromEsCore(self):
+            def _get_params_from_es_core(self):
                 params = {}
                 params.update(dh_params)
                 return params
 
-            def _activateMethod(self):
+            def _activate_method(self):
                 coulomb.method = COULOMB_DH
-                self._setParamsInEsCore()
+                self._set_params_in_es_core()
 
-            def defaultParams(self):
+            def default_params(self):
                 return {"bjerrum_length": -1,
                         "kappa": -1,
                         "r_cut": -1}
@@ -118,8 +118,8 @@ ELSE:
 IF P3M == 1:
     cdef class P3M(ElectrostaticInteraction):
 
-        def validateParams(self):
-            default_params = self.defaultParams()
+        def validate_params(self):
+            default_params = self.default_params()
             if not (self._params["bjerrum_length"] > 0.0):
                 raise ValueError("Bjerrum_length should be a positive double")
 
@@ -155,13 +155,13 @@ IF P3M == 1:
                 raise ValueError(
                     "mesh_off should be a list of length 3 and values between 0.0 and 1.0")
 
-        def validKeys(self):
+        def valid_keys(self):
             return "alpha_L", "r_cut_iL", "mesh", "mesh_off", "cao", "inter", "accuracy", "epsilon", "cao_cut", "a", "ai", "alpha", "r_cut", "inter2", "cao3", "additional_mesh", "bjerrum_length", "tune"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return ["bjerrum_length", "accuracy"]
 
-        def defaultParams(self):
+        def default_params(self):
             return {"cao": -1,
                     "inter": -1,
                     "r_cut": -1,
@@ -171,14 +171,14 @@ IF P3M == 1:
                     "mesh_off": [-1, -1, -1],
                     "tune": True}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             params = {}
             params.update(p3m.params)
             params["bjerrum_length"] = coulomb.bjerrum
             params["tune"] = self._params["tune"]
             return params
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             coulomb_set_bjerrum(self._params["bjerrum_length"])
             p3m_set_ninterpol(self._params["inter"])
             python_p3m_set_mesh_offset(self._params["mesh_off"])
@@ -196,19 +196,19 @@ IF P3M == 1:
                 raise Exception(
                     "failed to tune P3M parameters to required accuracy")
             print log
-            self._params.update(self._getParamsFromEsCore())
+            self._params.update(self._get_params_from_es_core())
 
-        def _activateMethod(self):
+        def _activate_method(self):
             if self._params["tune"]:
                 self._tune()
 
-            self._setParamsInEsCore()
+            self._set_params_in_es_core()
 
     IF CUDA:
         cdef class P3M_GPU(ElectrostaticInteraction):
 
-            def validateParams(self):
-                default_params = self.defaultParams()
+            def validate_params(self):
+                default_params = self.default_params()
                 if not (self._params["bjerrum_length"] > 0.0):
                     raise ValueError(
                         "Bjerrum_length should be a positive double")
@@ -246,13 +246,13 @@ IF P3M == 1:
                     raise ValueError(
                         "mesh_off should be a list of length 3 and values between 0.0 and 1.0")
 
-            def validKeys(self):
+            def valid_keys(self):
                 return "alpha_L", "r_cut_iL", "mesh", "mesh_off", "cao", "inter", "accuracy", "epsilon", "cao_cut", "a", "ai", "alpha", "r_cut", "inter2", "cao3", "additional_mesh", "bjerrum_length", "tune"
 
-            def requiredKeys(self):
+            def required_keys(self):
                 return ["bjerrum_length", "accuracy"]
 
-            def defaultParams(self):
+            def default_params(self):
                 return {"cao": -1,
                         "inter": -1,
                         "r_cut": -1,
@@ -264,7 +264,7 @@ IF P3M == 1:
                         "box": [-1, -1, -1],
                         "alpha": -1}
 
-            def _getParamsFromEsCore(self):
+            def _get_params_from_es_core(self):
                 params = {}
                 params.update(p3m.params)
                 params["bjerrum_length"] = coulomb.bjerrum
@@ -280,19 +280,19 @@ IF P3M == 1:
                     raise Exception(
                         "failed to tune P3M parameters to required accuracy")
                 print log
-                self._params.update(self._getParamsFromEsCore())
+                self._params.update(self._get_params_from_es_core())
 
-            def _activateMethod(self):
+            def _activate_method(self):
                 coulomb.method = COULOMB_P3M_GPU
                 if self._params["tune"]:
                     coulomb_set_bjerrum(self._params["bjerrum_length"])
                     self._tune()
 
                 coulomb_set_bjerrum(self._params["bjerrum_length"])
-                self._setParamsInEsCore()
+                self._set_params_in_es_core()
                 python_p3m_gpu_init(self._params)
 
-            def _setParamsInEsCore(self):
+            def _set_params_in_es_core(self):
                 python_p3m_set_params(self._params["r_cut"], self._params["mesh"], self._params[
                                       "cao"], self._params["alpha"], self._params["accuracy"])
                 p3m_set_eps(self._params["epsilon"])
@@ -309,16 +309,16 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
 
         def __cinit__(self):
             self.interface = EspressoSystemInterface._Instance()
-            default_params = self.defaultParams()
+            default_params = self.default_params()
             self.thisptr = new EwaldgpuForce(dereference(self.interface), default_params["rcut"], default_params["num_kx"], default_params["num_ky"], default_params["num_kz"], default_params["alpha"])
 
         def __dealloc__(self):
             del self.thisptr
 
-        def validKeys(self):
+        def valid_keys(self):
             return "bjerrum_length", "rcut", "num_kx", "num_ky", "num_kz", "K_max", "alpha", "accuracy", "precision", "time_calc_steps"
 
-        def defaultParams(self):
+        def default_params(self):
             return {"bjerrum_length": -1,
                     "rcut": -1,
                     "num_kx": -1,
@@ -332,8 +332,8 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
                     "K_max": -1,
                     "time_calc_steps": -1}
 
-        def validateParams(self):
-            default_params = self.defaultParams()
+        def validate_params(self):
+            default_params = self.default_params()
             if self._params["bjerrum_length"] <= 0.0 and self._params["bjerrum_length"] != default_params["bjerrum_length"]:
                 raise ValueError("Bjerrum_length should be a positive double")
             if self._params["num_kx"] < 0 and self._params["num_kx"] != default_params["num_kx"]:
@@ -351,12 +351,12 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
             if self._params["precision"] < 0 and self._params["precision"] != default_params["precision"]:
                 raise ValueError("precision has to be a positive double")
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "bjerrum_length", "accuracy", "precision", "K_max"
 
         def _tune(self):
             coulomb_set_bjerrum(self._params["bjerrum_length"])
-            default_params = self.defaultParams()
+            default_params = self.default_params()
             if self._params["time_calc_steps"] == default_params["time_calc_steps"]:
                 self._params[
                     "time_calc_steps"] = self.thisptr.determine_calc_time_steps()
@@ -367,21 +367,21 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
             if resp != 0:
                 print self.log
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             coulomb_set_bjerrum(self._params["bjerrum_length"])
             self.thisptr.set_params(self._params["rcut"], self._params[
                                     "num_kx"], self._params["num_ky"], self._params["num_kz"], self._params["alpha"])
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             params = {}
             params.update(ewaldgpu_params)
             params["bjerrum_length"] = coulomb.bjerrum
             return params
 
-        def _activateMethod(self):
+        def _activate_method(self):
             coulomb.method = COULOMB_EWALD_GPU
             if not self._params["isTuned"]:
                 self._tune()
                 self._params["isTuned"] = True
 
-            self._setParamsInEsCore()
+            self._set_params_in_es_core()

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -22,27 +22,27 @@ from utils cimport *
 def integrate(nSteps, recalc_forces=False, reuse_forces=False):
     """integrate(nSteps, recalc_forces=False, reuse_forces=False)"""
 
-    checkTypeOrExcept(
+    check_type_or_throw_except(
         nSteps, 1, int, "Integrate requires a positive integer for the number of steps")
-    checkTypeOrExcept(recalc_forces, 1, bool, "recalc_forces has to be a bool")
-    checkTypeOrExcept(reuse_forces, 1, bool, "reuse_forces has to be a bool")
+    check_type_or_throw_except(recalc_forces, 1, bool, "recalc_forces has to be a bool")
+    check_type_or_throw_except(reuse_forces, 1, bool, "reuse_forces has to be a bool")
 
     if (python_integrate(nSteps, recalc_forces, reuse_forces)):
         print (mpiRuntimeErrorCollectorGather())
         raise Exception("Encoutered errors during integrate")
 
 
-def setIntegratorNVT():
+def set_integrator_nvt():
     integrate_set_nvt()
 
 
-def setIntegratorIsotropicNPT(ext_pressure=0.0, piston=0.0, xdir=0, ydir=0, zdir=0, cubic_box=False):
-    checkTypeOrExcept(
+def set_integrator_isotropic_npt(ext_pressure=0.0, piston=0.0, xdir=0, ydir=0, zdir=0, cubic_box=False):
+    check_type_or_throw_except(
         ext_pressure, 1, float, "NPT parameter ext_pressure must be a float")
-    checkTypeOrExcept(piston, 1, float, "NPT parameter piston must be a float")
-    checkTypeOrExcept(xdir, 1, int, "NPT parameter xdir must be an int")
-    checkTypeOrExcept(ydir, 1, int, "NPT parameter ydir must be an int")
-    checkTypeOrExcept(zdir, 1, int, "NPT parameter zdir must be an int")
+    check_type_or_throw_except(piston, 1, float, "NPT parameter piston must be a float")
+    check_type_or_throw_except(xdir, 1, int, "NPT parameter xdir must be an int")
+    check_type_or_throw_except(ydir, 1, int, "NPT parameter ydir must be an int")
+    check_type_or_throw_except(zdir, 1, int, "NPT parameter zdir must be an int")
     if (integrate_set_npt_isotropic(ext_pressure, piston, xdir, ydir, zdir, cubic_box)):
         print (mpiRuntimeErrorCollectorGather())
         raise Exception("Encoutered errors setting up the NPT integrator")

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -24,7 +24,7 @@ cimport numpy as np
 from utils cimport *
 
 cdef extern from "interaction_data.hpp":
-    ctypedef struct IA_parameters:
+    ctypedef struct ia_parameters "IA_parameters":
         double LJ_eps
         double LJ_sig
         double LJ_cut
@@ -46,7 +46,7 @@ cdef extern from "interaction_data.hpp":
         double LJGEN_lambda
         double LJGEN_softrad
 
-    cdef IA_parameters * get_ia_param(int i, int j)
+    cdef ia_parameters * get_ia_param(int i, int j)
 
 cdef extern from "lj.hpp":
     cdef int lennard_jones_set_params(int part_type_a, int part_type_b,
@@ -210,7 +210,7 @@ cdef extern from "interaction_data.hpp":
         double distmax
 
 #* Union in which to store the parameters of an individual bonded interaction */
-    ctypedef union Bond_parameters:
+    ctypedef union bond_parameters "Bond_parameters":
         Fene_bond_parameters fene
         Oif_global_forces_bond_parameters oif_global_forces
         Oif_local_forces_bond_parameters oif_local_forces
@@ -228,13 +228,13 @@ cdef extern from "interaction_data.hpp":
         Angledist_bond_parameters angledist
         Endangledist_bond_parameters endangledist
 
-    ctypedef struct Bonded_ia_parameters:
+    ctypedef struct bonded_ia_parameters:
         int type
         int num
         #* union to store the different bonded interaction parameters. */
-        Bond_parameters p
+        bond_parameters p
 
-    Bonded_ia_parameters * bonded_ia_params
+    bonded_ia_parameters * bonded_ia_params
     cdef int n_bonded_ia
 
 cdef extern from "fene.hpp":
@@ -264,7 +264,7 @@ IF ROTATION:
 
 IF TABULATED == 1:
     cdef extern from "interaction_data.hpp":
-        cdef enum TabulatedBondedInteraction:
+        cdef enum tabulated_bonded_interaction "TabulatedBondedInteraction":
             TAB_UNKNOWN = 0, TAB_BOND_LENGTH, TAB_BOND_ANGLE, TAB_BOND_DIHEDRAL
     cdef extern from "tab.hpp":
         int tabulated_bonded_set_params(int bond_type, TabulatedBondedInteraction tab_type, char * filename)
@@ -275,7 +275,7 @@ IF BOND_ENDANGLEDIST == 1:
 
 IF OVERLAPPED == 1:
     cdef extern from "interaction_data.hpp":
-        cdef enum OverlappedBondedInteraction:
+        cdef enum overlapped_bonded_interaction "OverlappedBondedInteraction":
             OVERLAP_UNKNOWN = 0, OVERLAP_BOND_LENGTH, OVERLAP_BOND_ANGLE,\
                 OVERLAP_BOND_DIHEDRAL
     cdef extern from "overlap.hpp":
@@ -288,7 +288,7 @@ IF BOND_VIRTUAL == 1:
 
 
 cdef extern from "interaction_data.hpp":
-    cdef enum enumBondedInteraction "BondedInteraction":
+    cdef enum enum_bonded_interaction "BondedInteraction":
         BONDED_IA_NONE = -1,
         BONDED_IA_FENE,
         BONDED_IA_HARMONIC,

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -264,7 +264,7 @@ IF ROTATION:
 
 IF TABULATED == 1:
     cdef extern from "interaction_data.hpp":
-        cdef enum tabulated_bonded_interaction "TabulatedBondedInteraction":
+        cdef enum TabulatedBondedInteraction:
             TAB_UNKNOWN = 0, TAB_BOND_LENGTH, TAB_BOND_ANGLE, TAB_BOND_DIHEDRAL
     cdef extern from "tab.hpp":
         int tabulated_bonded_set_params(int bond_type, TabulatedBondedInteraction tab_type, char * filename)
@@ -275,7 +275,7 @@ IF BOND_ENDANGLEDIST == 1:
 
 IF OVERLAPPED == 1:
     cdef extern from "interaction_data.hpp":
-        cdef enum overlapped_bonded_interaction "OverlappedBondedInteraction":
+        cdef enum OverlappedBondedInteraction:
             OVERLAP_UNKNOWN = 0, OVERLAP_BOND_LENGTH, OVERLAP_BOND_ANGLE,\
                 OVERLAP_BOND_DIHEDRAL
     cdef extern from "overlap.hpp":

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -24,7 +24,8 @@ include "myconfig.pxi"
 
 cdef class NonBondedInteraction(object):
 
-    cdef public object _partTypes
+
+    cdef public object _part_types
     cdef object _params
 
     def __init__(self, *args, **kwargs):
@@ -35,121 +36,123 @@ cdef class NonBondedInteraction(object):
 
         # Interaction id as argument
         if len(args) == 2 and isinstance(args[0], int) and isinstance(args[1], int):
-            self._partTypes = args
+            self._part_types = args
 
             # Load the parameters currently set in the Espresso core
-            self._params = self._getParamsFromEsCore()
+            self._params = self._get_params_from_es_core()
 
         # Or have we been called with keyword args describing the interaction
         elif len(args) == 0:
             # Initialize default values
-            self._params = self.defaultParams()
-            self._partTypes = [-1, -1]
+            self._params = self.default_params()
+            self._part_types = [-1, -1]
 
             # Check if all required keys are given
-            for k in self.requiredKeys():
+            for k in self.required_keys():
                 if k not in kwargs:
                     raise ValueError(
-                        "At least the following keys have to be given as keyword arguments: " + self.requiredKeys().__str__())
+                        "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__())
 
             self._params = kwargs
 
             # Validation of parameters
-            self.validateParams()
+            self.validate_params()
 
         else:
             raise Exception(
                 "The constructor has to be called either with two particle type ids (as interger), or with a set of keyword arguments describing a new interaction")
 
-    def isValid(self):
+    def is_valid(self):
         """Check, if the data stored in the instance still matches what is in Espresso"""
 
         # check, if the bond parameters saved in the class still match those
         # saved in Espresso
-        tempParams = self._getParamsFromEsCore()
-        if self._params != tempParams:
+        temp_params = self._get_params_from_es_core()
+        if self._params != temp_params:
             return False
 
         # If we're still here, the instance is valid
         return True
 
-    def getParams(self):
+    def get_params(self):
         """Get interaction parameters"""
         # If this instance refers to an actual interaction defined in the es core, load
         # current parameters from there
-        if self._partTypes[0] >= 0 and self._partTypes[1] >= 0:
-            self._params = self._getParamsFromEsCore()
+        if self._part_types[0] >= 0 and self._part_types[1] >= 0:
+            self._params = self._get_params_from_es_core()
 
         return self._params
 
-    def setParams(self, **p):
+    def set_params(self, **p):
         """Update parameters. Only given """
         # Check, if any key was passed, which is not known
         for k in p.keys():
-            if k not in self.validKeys():
+            if k not in self.valid_keys():
                 raise ValueError(
-                    "Only the following keys are supported: " + self.validKeys().__str__())
+                    "Only the following keys are supported: " + self.valid_keys().__str__())
 
         # When an interaction is newly activated, all required keys must be
         # given
-        if not self.isActive():
-            for k in self.requiredKeys():
+        if not self.is_active():
+            for k in self.required_keys():
                 if k not in p:
                     raise ValueError(
-                        "At least the following keys have to be given as keyword arguments: " + self.requiredKeys().__str__())
+                        "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__())
 
         # If this instance refers to an interaction defined in the espresso core,
         # load the parameters from there
 
-        if self._partTypes[0] >= 0 and self._partTypes[1] >= 0:
-            self._params = self._getParamsFromEsCore()
+        if self._part_types[0] >= 0 and self._part_types[1] >= 0:
+            self._params = self._get_params_from_es_core()
 
         # Put in values given by the user
         self._params.update(p)
 
-        if self._partTypes[0] >= 0 and self._partTypes[1] >= 0:
-            self._setParamsInEsCore()
+        if self._part_types[0] >= 0 and self._part_types[1] >= 0:
+            self._set_params_in_es_core()
 
-    def validateParams(self):
+    def validate_params(self):
         return True
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         raise Exception(
-            "Subclasses of NonBondedInteraction must define the _getParamsFromEsCore() method.")
+            "Subclasses of NonBondedInteraction must define the _get_params_from_es_core() method.")
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         raise Exception(
-            "Subclasses of NonBondedInteraction must define the setParamsFromEsCore() method.")
+            "Subclasses of NonBondedInteraction must define the _set_params_in_es_core() method.")
 
-    def defaultParams(self):
+    def default_params(self):
         raise Exception(
-            "Subclasses of NonBondedInteraction must define the defaultParams() method.")
+            "Subclasses of NonBondedInteraction must define the default_params() method.")
 
-    def isActive(self):
+    def is_active(self):
         # If this instance refers to an actual interaction defined in the es core, load
         # current parameters from there
-        if self._partTypes[0] >= 0 and self._partTypes[1] >= 0:
-            self._params = self._getParamsFromEsCore()
+        if self._part_types[0] >= 0 and self._part_types[1] >= 0:
+            self._params = self._get_params_from_es_core()
         raise Exception(
-            "Subclasses of NonBondedInteraction must define the isActive() method.")
+            "Subclasses of NonBondedInteraction must define the is_active() method.")
 
-    def typeName(self):
+    def type_name(self):
         raise Exception(
-            "Subclasses of NonBondedInteraction must define the typeName() method.")
+            "Subclasses of NonBondedInteraction must define the type_name() method.")
 
-    def validKeys(self):
+    def valid_keys(self):
         raise Exception(
-            "Subclasses of NonBondedInteraction must define the validKeys() method.")
+            "Subclasses of NonBondedInteraction must define the valid_keys() method.")
 
-    def requiredKeys(self):
+    def required_keys(self):
         raise Exception(
-            "Subclasses of NonBondedInteraction must define the requiredKeys() method.")
+            "Subclasses of NonBondedInteraction must define the required_keys() method.")
 
 # Lennard Jones
 
 cdef class LennardJonesInteraction(NonBondedInteraction):
+
+
     if LENNARD_JONES == 1:
-        def validateParams(self):
+        def validate_params(self):
             if self._params["epsilon"] < 0:
                 raise ValueError("Lennard-Jones eps has to be >=0")
             if self._params["sigma"] < 0:
@@ -158,28 +161,28 @@ cdef class LennardJonesInteraction(NonBondedInteraction):
                 raise ValueError("Lennard-Jones cutoff has to be >=0")
             return True
 
-        def _getParamsFromEsCore(self):
-            cdef IA_parameters * iaParams
-            iaParams = get_ia_param(self._partTypes[0], self._partTypes[1])
+        def _get_params_from_es_core(self):
+            cdef ia_parameters * ia_params
+            ia_params = get_ia_param(self._part_types[0], self._part_types[1])
             return {
-                "epsilon": iaParams.LJ_eps,
-                "sigma": iaParams.LJ_sig,
-                "cutoff": iaParams.LJ_cut,
-                "shift": iaParams.LJ_shift,
-                "offset": iaParams.LJ_offset,
-                "min": iaParams.LJ_min}
+                "epsilon": ia_params.LJ_eps,
+                "sigma": ia_params.LJ_sig,
+                "cutoff": ia_params.LJ_cut,
+                "shift": ia_params.LJ_shift,
+                "offset": ia_params.LJ_offset,
+                "min": ia_params.LJ_min}
 
-        def isActive(self):
+        def is_active(self):
             return (self._params["epsilon"] > 0)
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
                 # Calc shift
                 self._params["shift"] = -((self._params["sigma"] / self._params["cutoff"])**12 - (
                     self._params["sigma"] / self._params["cutoff"])**6)
 
-            if lennard_jones_set_params(self._partTypes[0], self._partTypes[1],
+            if lennard_jones_set_params(self._part_types[0], self._part_types[1],
                                         self._params["epsilon"],
                                         self._params["sigma"],
                                         self._params["cutoff"],
@@ -189,7 +192,7 @@ cdef class LennardJonesInteraction(NonBondedInteraction):
                                         self._params["min"]):
                 raise Exception("Could not set Lennard Jones parameters")
 
-        def defaultParams(self):
+        def default_params(self):
             self._params = {
                 "epsilon": 0.,
                 "sigma": 0.,
@@ -198,20 +201,22 @@ cdef class LennardJonesInteraction(NonBondedInteraction):
                 "offset": 0.,
                 "min": 0.}
 
-        def typeName(self):
+        def type_name(self):
             return "LennardJones"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "epsilon", "sigma", "cutoff", "shift", "offset", "min"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "epsilon", "sigma", "cutoff", "shift"
 
 # Generic Lennard Jones
 
 cdef class GenericLennardJonesInteraction(NonBondedInteraction):
+
+
     if LENNARD_JONES_GENERIC == 1:
-        def validateParams(self):
+        def validate_params(self):
             if self._params["epsilon"] < 0:
                 raise ValueError("Generic Lennard-Jones eps has to be >=0")
             if self._params["sigma"] < 0:
@@ -220,34 +225,34 @@ cdef class GenericLennardJonesInteraction(NonBondedInteraction):
                 raise ValueError("Generic Lennard-Jones cutoff has to be >=0")
             return True
 
-        def _getParamsFromEsCore(self):
-            cdef IA_parameters * iaParams
-            iaParams = get_ia_param(self._partTypes[0], self._partTypes[1])
+        def _get_params_from_es_core(self):
+            cdef ia_parameters * ia_params
+            ia_params = get_ia_param(self._part_types[0], self._part_types[1])
             return {
-                "epsilon": iaParams.LJGEN_eps,
-                "sigma": iaParams.LJGEN_sig,
-                "cutoff": iaParams.LJGEN_cut,
-                "shift": iaParams.LJGEN_shift,
-                "offset": iaParams.LJGEN_offset,
-                "e1": iaParams.LJGEN_a1,
-                "e2": iaParams.LJGEN_a2,
-                "b1": iaParams.LJGEN_b1,
-                "b2": iaParams.LJGEN_b2,
-                "lambda": iaParams.LJGEN_lambda,
-                "delta": iaParams.LJGEN_softrad
+                "epsilon": ia_params.LJGEN_eps,
+                "sigma": ia_params.LJGEN_sig,
+                "cutoff": ia_params.LJGEN_cut,
+                "shift": ia_params.LJGEN_shift,
+                "offset": ia_params.LJGEN_offset,
+                "e1": ia_params.LJGEN_a1,
+                "e2": ia_params.LJGEN_a2,
+                "b1": ia_params.LJGEN_b1,
+                "b2": ia_params.LJGEN_b2,
+                "lambda": ia_params.LJGEN_lambda,
+                "delta": ia_params.LJGEN_softrad
             }
 
-        def isActive(self):
+        def is_active(self):
             return (self._params["epsilon"] > 0)
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
                 # Calc shift
                 self._params["shift"] = -(self._params["b1"] * (self._params["sigma"] / self._params["cutoff"])**self._params[
                                           "e1"] - self._params["b2"] * (self._params["sigma"] / self._params["cutoff"])**self._params["e2"])
             IF LJGEN_SOFTCORE:
-                if ljgen_set_params(self._partTypes[0], self._partTypes[1],
+                if ljgen_set_params(self._part_types[0], self._part_types[1],
                                     self._params["epsilon"],
                                     self._params["sigma"],
                                     self._params["cutoff"],
@@ -263,7 +268,7 @@ cdef class GenericLennardJonesInteraction(NonBondedInteraction):
                     raise Exception(
                         "Could not set Generic Lennard Jones parameters")
             ELSE:
-                if ljgen_set_params(self._partTypes[0], self._partTypes[1],
+                if ljgen_set_params(self._part_types[0], self._part_types[1],
                                     self._params["epsilon"],
                                     self._params["sigma"],
                                     self._params["cutoff"],
@@ -277,7 +282,7 @@ cdef class GenericLennardJonesInteraction(NonBondedInteraction):
                     raise Exception(
                         "Could not set Generic Lennard Jones parameters")
 
-        def defaultParams(self):
+        def default_params(self):
             self._params = {
                 "epsilon": 0.,
                 "sigma": 0.,
@@ -291,17 +296,18 @@ cdef class GenericLennardJonesInteraction(NonBondedInteraction):
                 "delta": 0.,
                 "lambda": 0.}
 
-        def typeName(self):
+        def type_name(self):
             return "GenericLennardJones"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2", "delta", "lambda"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2"
 
 
 class NonBondedInteractionHandle(object):
+
 
     """Provides access to all Non-bonded interactions between
     two particle types."""
@@ -310,7 +316,7 @@ class NonBondedInteractionHandle(object):
     type2 = -1
 
     # Here, one line per non-bonded ia
-    lennardJones = None
+    lennard_jones = None
 
     def __init__(self, _type1, _type2):
         """Takes two particle types as argument"""
@@ -320,11 +326,13 @@ class NonBondedInteractionHandle(object):
         self.type2 = _type2
 
         # Here, add one line for each nonbonded ia
-        self.lennardJones = LennardJonesInteraction(_type1, _type2)
-        self.genericLennardJones = LennardJonesInteraction(_type1, _type2)
+        self.lennard_jones = LennardJonesInteraction(_type1, _type2)
+        self.generic_lennard_jones = LennardJonesInteraction(_type1, _type2)
 
 
 cdef class NonBondedInteractions:
+
+
     """Access to non-bonded interaction parameters via [i,j], where i,j are particle 
     types. Returns NonBondedInteractionHandle.
     Also: access to force capping
@@ -339,62 +347,64 @@ cdef class NonBondedInteractions:
                 "NonBondedInteractions[] expects two particle types as indices.")
         return NonBondedInteractionHandle(key[0], key[1])
 
-    def setForceCap(self, cap):
+    def set_force_cap(self, cap):
         if forcecap_set_params(cap):
             raise Exception("Could not set forcecap")
 
-    def getForceCap(self):
+    def get_force_cap(self):
         return force_cap
 
 
 cdef class BondedInteraction(object):
+
+
     def __init__(self, *args, **kwargs):
         """Either called with an interaction id, in which case, the interaction will represent
            the bonded interaction as it is defined in Espresso core
            Or called with keyword arguments describing a new interaction."""
         # Interaction id as argument
         if len(args) == 1 and isinstance(args[0], int):
-            bondId = args[0]
+            bond_id = args[0]
             # Check, if the bond in Espresso core is really defined as a FENE
             # bond
-            if bonded_ia_params[bondId].type != self.typeNumber():
+            if bonded_ia_params[bond_id].type != self.type_number():
                 raise Exception(
-                    "The bond with this id is not defined as a " + self.typeName() + " bond in the Espresso core.")
+                    "The bond with this id is not defined as a " + self.type_name() + " bond in the Espresso core.")
 
-            self._bondId = bondId
+            self._bond_id = bond_id
 
             # Load the parameters currently set in the Espresso core
-            self._params = self._getParamsFromEsCore()
-            self._bondId = bondId
+            self._params = self._get_params_from_es_core()
+            self._bond_id = bond_id
 
         # Or have we been called with keyword args describing the interaction
         elif len(args) == 0:
             # Check if all required keys are given
-            for k in self.requiredKeys():
+            for k in self.required_keys():
                 if k not in kwargs:
                     raise ValueError(
-                        "At least the following keys have to be given as keyword arguments: " + self.requiredKeys().__str__())
+                        "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__())
 
             self.params = kwargs
 
             # Validation of parameters
-            self.validateParams()
+            self.validate_params()
 
         else:
             raise Exception(
                 "The constructor has to be called either with a bond id (as interger), or with a set of keyword arguments describing a new interaction")
 
-    def isValid(self):
+    def is_valid(self):
         """Check, if the data stored in the instance still matches what is in Espresso"""
         # Check if the bond type in Espresso still matches the bond type saved
         # in this class
-        if bonded_ia_params[self._bondId].type != self.typeNumber():
+        if bonded_ia_params[self._bond_id].type != self.type_number():
             return False
 
         # check, if the bond parameters saved in the class still match those
         # saved in Espresso
-        tempParams = self._getParamsFromEsCore()
-        if self._params != tempParams:
+        temp_params = self._get_params_from_es_core()
+        if self._params != temp_params:
             return False
 
         # If we're still here, the instance is valid
@@ -407,45 +417,45 @@ cdef class BondedInteraction(object):
         def __set__(self, p):
             # Check, if any key was passed, which is not known
             for k in p.keys():
-                if k not in self.validKeys():
+                if k not in self.valid_keys():
                     raise ValueError(
-                        "Only the following keys are supported: " + self.validKeys().__str__)
+                        "Only the following keys are supported: " + self.valid_keys().__str__)
 
             # Initialize default values
-            self.setDefaultParams()
+            self.set_default_params()
             # Put in values given by the user
             self._params.update(p)
 
-    def validateParams(self):
+    def validate_params(self):
         return True
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         raise Exception(
-            "Subclasses of BondedInteraction must define the _getParamsFromEsCore() method.")
+            "Subclasses of BondedInteraction must define the _get_params_from_es_core() method.")
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         raise Exception(
-            "Subclasses of BondedInteraction must define the setParamsFromEsCore() method.")
+            "Subclasses of BondedInteraction must define the _set_params_in_es_core() method.")
 
-    def setDefaultParams(self):
+    def set_default_params(self):
         raise Exception(
-            "Subclasses of BondedInteraction must define the setDefaultParams() method.")
+            "Subclasses of BondedInteraction must define the set_default_params() method.")
 
-    def typeNumber(self):
+    def type_number(self):
         raise Exception(
-            "Subclasses of BondedInteraction must define the typeNumber() method.")
+            "Subclasses of BondedInteraction must define the type_number() method.")
 
-    def typeName(self):
+    def type_name(self):
         raise Exception(
-            "Subclasses of BondedInteraction must define the typeName() method.")
+            "Subclasses of BondedInteraction must define the type_name() method.")
 
-    def validKeys(self):
+    def valid_keys(self):
         raise Exception(
-            "Subclasses of BondedInteraction must define the validKeys() method.")
+            "Subclasses of BondedInteraction must define the valid_keys() method.")
 
-    def requiredKeys(self):
+    def required_keys(self):
         raise Exception(
-            "Subclasses of BondedInteraction must define the requiredKeys() method.")
+            "Subclasses of BondedInteraction must define the required_keys() method.")
 
 
 class BondedInteractionNotDefined(object):
@@ -454,143 +464,143 @@ class BondedInteractionNotDefined(object):
         raise Exception(
             self.__class_s__.__name__ + " not compiled into Espresso core")
 
-    def typeNumber(self):
+    def type_number(self):
         raise Exception(("%s has to be defined in myconfig.hpp.") % self.name)
 
-    def typeName(self):
+    def type_name(self):
         raise Exception(("%s has to be defined in myconfig.hpp.") % self.name)
 
-    def validKeys(self):
+    def valid_keys(self):
         raise Exception(("%s has to be defined in myconfig.hpp.") % self.name)
 
-    def requiredKeys(self):
+    def required_keys(self):
         raise Exception(("%s has to be defined in myconfig.hpp.") % self.name)
 
-    def setDefaultParams(self):
+    def set_default_params(self):
         raise Exception(("%s has to be defined in myconfig.hpp.") % self.name)
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         raise Exception(("%s has to be defined in myconfig.hpp.") % self.name)
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         raise Exception(("%s has to be defined in myconfig.hpp.") % self.name)
 
 
 class FeneBond(BondedInteraction):
 
-    def typeNumber(self):
+    def type_number(self):
         return BONDED_IA_FENE
 
-    def typeName(self):
+    def type_name(self):
         return "FENE"
 
-    def validKeys(self):
+    def valid_keys(self):
         return "k", "d_r_max", "r_0"
 
-    def requiredKeys(self):
+    def required_keys(self):
         return "k", "d_r_max"
 
-    def setDefaultParams(self):
+    def set_default_params(self):
         self._params = {"r_0": 0.}
         # Everything else has to be supplied by the user, anyway
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         return \
-            {"k": bonded_ia_params[self._bondId].p.fene.k,
-             "d_r_max": bonded_ia_params[self._bondId].p.fene.drmax,
-             "r_0": bonded_ia_params[self._bondId].p.fene.r0}
+            {"k": bonded_ia_params[self._bond_id].p.fene.k,
+             "d_r_max": bonded_ia_params[self._bond_id].p.fene.drmax,
+             "r_0": bonded_ia_params[self._bond_id].p.fene.r0}
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         fene_set_params(
-            self._bondId, self._params["k"], self._params["d_r_max"], self._params["r_0"])
+            self._bond_id, self._params["k"], self._params["d_r_max"], self._params["r_0"])
 
 
 class HarmonicBond(BondedInteraction):
 
-    def typeNumber(self):
+    def type_number(self):
         return BONDED_IA_HARMONIC
 
-    def typeName(self):
+    def type_name(self):
         return "HARMONIC"
 
-    def validKeys(self):
+    def valid_keys(self):
         return "k", "r_0", "r_cut"
 
-    def requiredKeys(self):
+    def required_keys(self):
         return "k", "r_0"
 
-    def setDefaultParams(self):
+    def set_default_params(self):
         self._params = {"k'": 0., "r_0": 0., "r_cut": 0.}
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         return \
-            {"k": bonded_ia_params[self._bondId].p.harmonic.k,
-             "r_0": bonded_ia_params[self._bondId].p.harmonic.r,
-             "r_cut": bonded_ia_params[self._bondId].p.harmonic.r_cut}
+            {"k": bonded_ia_params[self._bond_id].p.harmonic.k,
+             "r_0": bonded_ia_params[self._bond_id].p.harmonic.r,
+             "r_cut": bonded_ia_params[self._bond_id].p.harmonic.r_cut}
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         harmonic_set_params(
-            self._bondId, self._params["k"], self._params["r_0"], self._params["r_cut"])
+            self._bond_id, self._params["k"], self._params["r_0"], self._params["r_cut"])
 
 
 IF ROTATION:
     class HarmonicDumbbellBond(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_HARMONIC_DUMBBELL
 
-        def typeName(self):
+        def type_name(self):
             return "HARMONIC_DUMBBELL"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "k1", "k2", "r_0", "r_cut"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "k1", "k2", "r_0"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"r_cut": 0.}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"k1": bonded_ia_params[self._bondId].p.harmonic_dumbbell.k1,
-                 "k2": bonded_ia_params[self._bondId].p.harmonic_dumbbell.k2,
-                 "r_0": bonded_ia_params[self._bondId].p.harmonic_dumbbell.r,
-                 "r_cut": bonded_ia_params[self._bondId].p.harmonic_dumbbell.r_cut}
+                {"k1": bonded_ia_params[self._bond_id].p.harmonic_dumbbell.k1,
+                 "k2": bonded_ia_params[self._bond_id].p.harmonic_dumbbell.k2,
+                 "r_0": bonded_ia_params[self._bond_id].p.harmonic_dumbbell.r,
+                 "r_cut": bonded_ia_params[self._bond_id].p.harmonic_dumbbell.r_cut}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             harmonic_dumbbell_set_params(
-                self._bondId, self._params["k1"], self._params["k2"],
+                self._bond_id, self._params["k1"], self._params["k2"],
                 self._params["r_0"], self._params["r_cut"])
 
 IF ROTATION != 1:
     class HarmonicDumbbellBond(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             raise Exception(
                 "HarmonicDumbbellBond: ROTATION has to be defined in myconfig.hpp.")
 
-        def typeName(self):
+        def type_name(self):
             raise Exception(
                 "HarmonicDumbbellBond: ROTATION has to be defined in myconfig.hpp.")
 
-        def validKeys(self):
+        def valid_keys(self):
             raise Exception(
                 "HarmonicDumbbellBond: ROTATION has to be defined in myconfig.hpp.")
 
-        def requiredKeys(self):
+        def required_keys(self):
             raise Exception(
                 "HarmonicDumbbellBond: ROTATION has to be defined in myconfig.hpp.")
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             raise Exception(
                 "HarmonicDumbbellBond: ROTATION has to be defined in myconfig.hpp.")
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             raise Exception(
                 "HarmonicDumbbellBond: ROTATION has to be defined in myconfig.hpp.")
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             raise Exception(
                 "HarmonicDumbbellBond: ROTATION has to be defined in myconfig.hpp.")
 
@@ -598,30 +608,30 @@ IF ROTATION != 1:
 IF BOND_CONSTRAINT == 1:
     class RigidBond(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_RIGID_BOND
 
-        def typeName(self):
+        def type_name(self):
             return "RIGID"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "r", "ptol", "vtol"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "r"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             # TODO rationality of Default Parameters has to be checked
             self._params = {"r": 0.,
                             "ptol": 0.001,
                             "vtol": 0.001}
 
-        def _getParamsFromEsCore(self):
-            return {"r": bonded_ia_params[self._bondId].p.rigid_bond.r, "ptol": bonded_ia_params[self._bondId].p.rigid_bond.ptol, "vtol": bonded_ia_params[self._bondId].p.rigid_bond.vtol}
+        def _get_params_from_es_core(self):
+            return {"r": bonded_ia_params[self._bond_id].p.rigid_bond.r, "ptol": bonded_ia_params[self._bond_id].p.rigid_bond.ptol, "vtol": bonded_ia_params[self._bond_id].p.rigid_bond.vtol}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             rigid_bond_set_params(
-                self._bondId, self._params["r"], self._params["ptol"], self._params["vtol"])
+                self._bond_id, self._params["r"], self._params["ptol"], self._params["vtol"])
 ELSE:
     class RigidBond(BondedInteractionNotDefined):
         name = "RIGID"
@@ -629,139 +639,139 @@ ELSE:
 
 class Dihedral(BondedInteraction):
 
-    def typeNumber(self):
+    def type_number(self):
         return BONDED_IA_DIHEDRAL
 
-    def typeName(self):
+    def type_name(self):
         return "DIHEDRAL"
 
-    def validKeys(self):
+    def valid_keys(self):
         return "mult", "bend", "phase"
 
-    def requiredKeys(self):
+    def required_keys(self):
         return "mult", "bend", "phase"
 
-    def setDefaultParams(self):
+    def set_default_params(self):
         self._params = {"mult'": 1., "bend": 0., "phase": 0.}
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         return \
-            {"mult": bonded_ia_params[self._bondId].p.dihedral.mult,
-             "bend": bonded_ia_params[self._bondId].p.dihedral.bend,
-             "phase": bonded_ia_params[self._bondId].p.dihedral.phase}
+            {"mult": bonded_ia_params[self._bond_id].p.dihedral.mult,
+             "bend": bonded_ia_params[self._bond_id].p.dihedral.bend,
+             "phase": bonded_ia_params[self._bond_id].p.dihedral.phase}
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         dihedral_set_params(
-            self._bondId, self._params["mult"], self._params["bend"], self._params["phase"])
+            self._bond_id, self._params["mult"], self._params["bend"], self._params["phase"])
 
 
 IF TABULATED == 1:
     class Tabulated(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_TABULATED
 
-        def typeName(self):
+        def type_name(self):
             return "TABULATED"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "type", "filename", "npoints", "minval", "maxval", "invstepsize"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "type", "filename", "npoints", "minval", "maxval", "invstepsize"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"type": 1, "filename": "", "npoints": 0, "minval": 0, "maxval": 1,
                             "invstepsize": 1}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"type": bonded_ia_params[self._bondId].p.tab.type,
-                 "filename": bonded_ia_params[self.bondId].p.tab.filename,
-                 "npoints": bonded_ia_params[self._bondId].p.tab.npoints,
-                 "minval": bonded_ia_params[self._bondId].p.tab.minval,
-                 "maxval": bonded_ia_params[self._bondId].p.tab.maxval,
-                 "invstepsize": bonded_ia_params[self._bondId].p.tab.invstepsize}
+                {"type": bonded_ia_params[self._bond_id].p.tab.type,
+                 "filename": bonded_ia_params[self.bond_id].p.tab.filename,
+                 "npoints": bonded_ia_params[self._bond_id].p.tab.npoints,
+                 "minval": bonded_ia_params[self._bond_id].p.tab.minval,
+                 "maxval": bonded_ia_params[self._bond_id].p.tab.maxval,
+                 "invstepsize": bonded_ia_params[self._bond_id].p.tab.invstepsize}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             tabulated_bonded_set_params(
-                self._bondId, self._params["type"], self._params["filename"])
+                self._bond_id, self._params["type"], self._params["filename"])
 
 
 IF TABULATED != 1:
     class Tabulated(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
-        def typeName(self):
+        def type_name(self):
             raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
-        def validKeys(self):
+        def valid_keys(self):
             raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
-        def requiredKeys(self):
+        def required_keys(self):
             raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
 
 class Subt_Lj(BondedInteraction):
     IF LENNARD_JONES == 1:
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_SUBT_LJ
 
-        def typeName(self):
+        def type_name(self):
             return "SUBT_LJ"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "r", "k"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "r", "k"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"k": 0, "r": 0}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"k": bonded_ia_params[self._bondId].p.subt_lj.k,
-                 "r": bonded_ia_params[self._bondId].p.subt_lj.r}
+                {"k": bonded_ia_params[self._bond_id].p.subt_lj.k,
+                 "r": bonded_ia_params[self._bond_id].p.subt_lj.r}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             subt_lj_set_params(
-                self._bondId, self._params["k"], self._params["r"])
+                self._bond_id, self._params["k"], self._params["r"])
 
 IF BOND_VIRTUAL == 1:
     class Virtual(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_VIRTUAL_BOND
 
-        def typeName(self):
+        def type_name(self):
             return "VIRTUAL"
 
-        def validKeys(self):
+        def valid_keys(self):
             return
 
-        def requiredKeys(self):
+        def required_keys(self):
             return
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             pass
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             pass
 
-        def _setParamsInEsCore(self):
-            virtual_set_params(self._bondId)
+        def _set_params_in_es_core(self):
+            virtual_set_params(self._bond_id)
 
 ELSE:
     class Virtual(BondedInteractionNotDefined):
@@ -770,30 +780,30 @@ ELSE:
 IF BOND_ENDANGLEDIST == 1:
     class Endangledist(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_ENDANGLEDIST
 
-        def typeName(self):
+        def type_name(self):
             return "ENDANGLEDIST"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "bend", "phi0", "distmin", "distmax"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "bend", "phi0", "distmin", "distmax"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"bend": 0, "phi0": 0, "distmin": 0, "distmax": 1}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"bend": bonded_ia_params[self._bondId].p.endangledist.bend,
-                 "phi0": bonded_ia_params[self._bondId].p.endangledist.phi0,
-                 "distmin": bonded_ia_params[self._bondId].p.endangledist.distmin,
-                 "distmax": bonded_ia_params[self._bondId].p.endangledist.distmax}
+                {"bend": bonded_ia_params[self._bond_id].p.endangledist.bend,
+                 "phi0": bonded_ia_params[self._bond_id].p.endangledist.phi0,
+                 "distmin": bonded_ia_params[self._bond_id].p.endangledist.distmin,
+                 "distmax": bonded_ia_params[self._bond_id].p.endangledist.distmax}
 
-        def _setParamsInEsCore(self):
-            endangledist_set_params(self._bondId, self._params["bend"], self._params["phi0"], self._params["distmin"],
+        def _set_params_in_es_core(self):
+            endangledist_set_params(self._bond_id, self._params["bend"], self._params["phi0"], self._params["distmin"],
                                     self._params["distmax"])
 
 ELSE:
@@ -803,29 +813,29 @@ ELSE:
 IF OVERLAPPED == 1:
     class Overlapped(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_OVERLAPPED
 
-        def typeName(self):
+        def type_name(self):
             return "OVERLAPPED"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "overlap_type", "filename"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "overlap_type", "filename"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"overlap_type": 0, "filename": ""}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"bend": bonded_ia_params[self._bondId].p.overlap.type,
-                 "phi0": bonded_ia_params[self._bondId].p.overlap.filename}
+                {"bend": bonded_ia_params[self._bond_id].p.overlap.type,
+                 "phi0": bonded_ia_params[self._bond_id].p.overlap.filename}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             overlapped_bonded_set_params(
-                self._bondId, self._params["overlap_type"], self._params["filename"])
+                self._bond_id, self._params["overlap_type"], self._params["filename"])
 
 ELSE:
     class Overlapped(BondedInteractionNotDefined):
@@ -834,29 +844,29 @@ ELSE:
 IF BOND_ANGLE == 1:
     class Angle_Harmonic(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_ANGLE_HARMONIC
 
-        def typeName(self):
+        def type_name(self):
             return "ANGLE_HARMONIC"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "bend", "phi0"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "bend", "phi0"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"bend": 0, "phi0": 0}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"bend": bonded_ia_params[self._bondId].p.angle_harmonic.bend,
-                 "phi0": bonded_ia_params[self._bondId].p.angle_harmonic.phi0}
+                {"bend": bonded_ia_params[self._bond_id].p.angle_harmonic.bend,
+                 "phi0": bonded_ia_params[self._bond_id].p.angle_harmonic.phi0}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             angle_harmonic_set_params(
-                self._bondId, self._params["bend"], self._params["phi0"])
+                self._bond_id, self._params["bend"], self._params["phi0"])
 ELSE:
     class Angle_Harmonic(BondedInteractionNotDefined):
         name = "BOND_ANGLE"
@@ -864,29 +874,29 @@ ELSE:
 IF BOND_ANGLE == 1:
     class Angle_Cosine(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_ANGLE_COSINE
 
-        def typeName(self):
+        def type_name(self):
             return "ANGLE_COSINE"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "bend", "phi0"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "bend", "phi0"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"bend": 0, "phi0": 0}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"bend": bonded_ia_params[self._bondId].p.angle_cosine.bend,
-                 "phi0": bonded_ia_params[self._bondId].p.angle_cosine.phi0}
+                {"bend": bonded_ia_params[self._bond_id].p.angle_cosine.bend,
+                 "phi0": bonded_ia_params[self._bond_id].p.angle_cosine.phi0}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             angle_cosine_set_params(
-                self._bondId, self._params["bend"], self._params["phi0"])
+                self._bond_id, self._params["bend"], self._params["phi0"])
 ELSE:
     class Angle_Cosine(BondedInteractionNotDefined):
         name = "BOND_ANGLE"
@@ -894,92 +904,92 @@ ELSE:
 IF BOND_ANGLE == 1:
     class Angle_Cossquare(BondedInteraction):
 
-        def typeNumber(self):
+        def type_number(self):
             return BONDED_IA_ANGLE_COSSQUARE
 
-        def typeName(self):
+        def type_name(self):
             return "ANGLE_COSSQUARE"
 
-        def validKeys(self):
+        def valid_keys(self):
             return "bend", "phi0"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return "bend", "phi0"
 
-        def setDefaultParams(self):
+        def set_default_params(self):
             self._params = {"bend": 0, "phi0": 0}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return \
-                {"bend": bonded_ia_params[self._bondId].p.angle_cossquare.bend,
-                 "phi0": bonded_ia_params[self._bondId].p.angle_cossquare.phi0}
+                {"bend": bonded_ia_params[self._bond_id].p.angle_cossquare.bend,
+                 "phi0": bonded_ia_params[self._bond_id].p.angle_cossquare.phi0}
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             angle_cossquare_set_params(
-                self._bondId, self._params["bend"], self._params["phi0"])
+                self._bond_id, self._params["bend"], self._params["phi0"])
 ELSE:
     class Angle_Cossquare(BondedInteractionNotDefined):
         name = "BOND_ANGLE"
 
 
 class Oif_Global_Forces(BondedInteraction):
-    def typeNumber(self):
+    def type_number(self):
         return BONDED_IA_OIF_GLOBAL_FORCES
 
-    def typeName(self):
+    def type_name(self):
         return "OIF_GLOBAL_FORCES"
 
-    def validKeys(self):
+    def valid_keys(self):
         return "A0_g", "ka_g", "V0", "kv"
 
-    def requiredKeys(self):
+    def required_keys(self):
         return "A0_g", "ka_g", "V0", "kv"
 
-    def setDefaultParams(self):
+    def set_default_params(self):
         self._params = {"A0_g": 1., "ka_g": 0., "V0": 1., "kv": 0.}
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         return \
-            {"A0_g": bonded_ia_params[self._bondId].p.oif_global_forces.A0_g,
-             "ka_g": bonded_ia_params[self._bondId].p.oif_global_forces.ka_g,
-             "V0": bonded_ia_params[self._bondId].p.oif_global_forces.V0,
-             "kv": bonded_ia_params[self._bondId].p.oif_global_forces.kv}
+            {"A0_g": bonded_ia_params[self._bond_id].p.oif_global_forces.A0_g,
+             "ka_g": bonded_ia_params[self._bond_id].p.oif_global_forces.ka_g,
+             "V0": bonded_ia_params[self._bond_id].p.oif_global_forces.V0,
+             "kv": bonded_ia_params[self._bond_id].p.oif_global_forces.kv}
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         oif_global_forces_set_params(
-            self._bondId, self._params["A0_g"], self._params["ka_g"], self._params["V0"], self._params["kv"])
+            self._bond_id, self._params["A0_g"], self._params["ka_g"], self._params["V0"], self._params["kv"])
 
 class Oif_Local_Forces(BondedInteraction):
 
-    def typeNumber(self):
+    def type_number(self):
         return BONDED_IA_OIF_LOCAL_FORCES
 
-    def typeName(self):
+    def type_name(self):
         return "OIF_LOCAL_FORCES"
 
-    def validKeys(self):
+    def valid_keys(self):
         return "r0", "ks", "kslin", "phi0", "kb", "A01", "A02", "kal"
 
-    def requiredKeys(self):
+    def required_keys(self):
         return "r0", "ks", "kslin", "phi0", "kb", "A01", "A02", "kal"
 
-    def setDefaultParams(self):
+    def set_default_params(self):
         self._params = {"r0": 1., "ks": 0., "kslin": 0., "phi0": 0., "kb": 0., "A01": 0., "A02": 0., "kal": 0.}
 
-    def _getParamsFromEsCore(self):
+    def _get_params_from_es_core(self):
         return \
-            {"r0": bonded_ia_params[self._bondId].p.oif_local_forces.r0,
-             "ks": bonded_ia_params[self._bondId].p.oif_local_forces.ks,
-             "kslin": bonded_ia_params[self._bondId].p.oif_local_forces.kslin,
-             "phi0": bonded_ia_params[self._bondId].p.oif_local_forces.phi0,
-             "kb": bonded_ia_params[self._bondId].p.oif_local_forces.kb,
-             "A01": bonded_ia_params[self._bondId].p.oif_local_forces.A01,
-             "A02": bonded_ia_params[self._bondId].p.oif_local_forces.A02,
-             "kal": bonded_ia_params[self._bondId].p.oif_local_forces.kal}
+            {"r0": bonded_ia_params[self._bond_id].p.oif_local_forces.r0,
+             "ks": bonded_ia_params[self._bond_id].p.oif_local_forces.ks,
+             "kslin": bonded_ia_params[self._bond_id].p.oif_local_forces.kslin,
+             "phi0": bonded_ia_params[self._bond_id].p.oif_local_forces.phi0,
+             "kb": bonded_ia_params[self._bond_id].p.oif_local_forces.kb,
+             "A01": bonded_ia_params[self._bond_id].p.oif_local_forces.A01,
+             "A02": bonded_ia_params[self._bond_id].p.oif_local_forces.A02,
+             "kal": bonded_ia_params[self._bond_id].p.oif_local_forces.kal}
 
-    def _setParamsInEsCore(self):
+    def _set_params_in_es_core(self):
         oif_local_forces_set_params(
-            self._bondId, self._params["r0"], self._params["ks"], self._params["kslin"], self._params["phi0"], self._params["kb"], self._params["A01"], self._params["A02"], self._params["kal"])
+            self._bond_id, self._params["r0"], self._params["ks"], self._params["kslin"], self._params["phi0"], self._params["kb"], self._params["A01"], self._params["A02"], self._params["kal"])
 
 
     
@@ -991,7 +1001,7 @@ class Oif_Local_Forces(BondedInteraction):
 
 
 
-bondedInteractionClasses = {
+bonded_interaction_classes = {
     int(BONDED_IA_FENE): FeneBond,
     int(BONDED_IA_HARMONIC): HarmonicBond,
     int(BONDED_IA_HARMONIC_DUMBBELL): HarmonicDumbbellBond,
@@ -1022,21 +1032,21 @@ class BondedInteractions:
                 "Index to BondedInteractions[] hast to be an integer referring to a bond id")
 
         # Find out the type of the interaction from Espresso
-        bondType = bonded_ia_params[key].type
+        bond_type = bonded_ia_params[key].type
 
         # Check if the bonded interaction exists in Espresso core
-        if bondType == -1:
+        if bond_type == -1:
             raise ValueError(
                 "The bonded interaction with the id " + str(key) + " is not yet defined.")
 
         # Find the appropriate class representing such a bond
-        bondClass = bondedInteractionClasses[bondType]
+        bond_class = bonded_interaction_classes[bond_type]
         # print bondType
         # print "  "
 
         # And return an instance of it, which refers to the bonded interaction
         # id in Espresso
-        return bondClass(key)
+        return bond_class(key)
 
     def __setitem__(self, key, value):
         # Validate arguments
@@ -1052,7 +1062,7 @@ class BondedInteractions:
                 "Only subclasses of BondedInteraction can be assigned.")
 
         # Save the bond id in the BondedInteraction instance
-        value._bondId = key
+        value._bond_id = key
 
         # Set the parameters of the BondedInteraction instance in the Es core
-        value._setParamsInEsCore()
+        value._set_params_in_es_core()

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -317,6 +317,7 @@ class NonBondedInteractionHandle(object):
 
     # Here, one line per non-bonded ia
     lennard_jones = None
+    generic_lennard_jones = None
 
     def __init__(self, _type1, _type2):
         """Takes two particle types as argument"""
@@ -327,7 +328,8 @@ class NonBondedInteractionHandle(object):
 
         # Here, add one line for each nonbonded ia
         self.lennard_jones = LennardJonesInteraction(_type1, _type2)
-        self.generic_lennard_jones = LennardJonesInteraction(_type1, _type2)
+        IF LENNARD_JONES_GENERIC:
+            self.generic_lennard_jones = GenericLennardJonesInteraction(_type1, _type2)
 
 
 cdef class NonBondedInteractions:

--- a/src/python/espressomd/lb.pxd
+++ b/src/python/espressomd/lb.pxd
@@ -278,7 +278,7 @@ IF LB_GPU or LB:
         # Python LB struct clone of C-struct
         #
         ##############################################
-        ctypedef struct LB_parameters:
+        ctypedef struct lb_parameters:
             double rho[2]
             double viscosity[2]
             double bulk_viscosity[2]
@@ -295,8 +295,8 @@ IF LB_GPU or LB:
 # init struct
 #
 ###############################################
-        ctypedef struct LB_parameters:
-            LB_parameters lb_params
+        ctypedef struct lb_parameters:
+            lb_parameters lb_params
 
 ##############################################
 #

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -43,13 +43,14 @@ cdef class HydrodynamicInteraction(Actor):
 IF LB_GPU or LB:
     cdef class LB_FLUID(HydrodynamicInteraction):
 
+
         ####################################################
         #
         # validate the given parameters on actor initalization
         #
         ####################################################
-        def validateParams(self):
-            default_params = self.defaultParams()
+        def validate_params(self):
+            default_params = self.default_params()
 
             IF SHANCHEN:
                 if not (self._params["dens"][0] > 0.0 and self._params["dens"][1] > 0.0):
@@ -67,7 +68,7 @@ IF LB_GPU or LB:
         # list of valid keys for parameters
         #
         ####################################################
-        def validKeys(self):
+        def valid_keys(self):
             return "gpu", "agrid", "dens", "fric", "ext_force", "visc", "tau"
 
         ####################################################
@@ -75,7 +76,7 @@ IF LB_GPU or LB:
         # list of esential keys required for the fluid
         #
         ####################################################
-        def requiredKeys(self):
+        def required_keys(self):
             init = 0
             if init:
                 init = 1
@@ -88,7 +89,7 @@ IF LB_GPU or LB:
         # list of default parameters
         #
         ####################################################
-        def defaultParams(self):
+        def default_params(self):
             IF SHANCHEN:
                 return {"gpu": "yes",
                         "agrid": -1.0,
@@ -126,8 +127,8 @@ IF LB_GPU or LB:
             if lb_set_lattice_switch(py_lattice_switch):
                 raise Exception("lb_set_lattice_switch error")
 
-        def _setParamsInEsCore(self):
-            default_params = self.defaultParams()
+        def _set_params_in_es_core(self):
+            default_params = self.default_params()
 
             if python_lbfluid_set_density(self._params["dens"]):
                 raise Exception("lb_lbfluid_set_density error")
@@ -158,8 +159,8 @@ IF LB_GPU or LB:
         # function that calls wrapper functions which get the parameters from C-Level
         #
         ####################################################
-        def _getParamsFromEsCore(self):
-            default_params = self.defaultParams()
+        def _get_params_from_es_core(self):
+            default_params = self.default_params()
             params = self._params
 
             if python_lbfluid_get_density(self._params["dens"]):
@@ -190,21 +191,21 @@ IF LB_GPU or LB:
 
         ####################################################
         #
-        # redef setParams for lb use
+        # redef set_params for lb use
         #
         ####################################################
 
-        def setParams(self, **_params):
+        def set_params(self, **_params):
             """Update parameters. Only given """
             # Check, if any key was passed, which is not known
             for k in _params.keys():
-                if k not in self.validKeys():
+                if k not in self.valid_keys():
                     raise ValueError(
-                        "Only the following keys are supported: " + self.validKeys().__str__())
+                        "Only the following keys are supported: " + self.valid_keys().__str__())
 
             print "_params", _params
 
-            self.validateParams()
+            self.validate_params()
 
             if "dens" in _params:
                 if python_lbfluid_set_density(_params["dens"]):
@@ -285,7 +286,7 @@ IF LB_GPU or LB:
 #        return self.checkpoint_binary
     #  def _activateMethod(self):
 
-    #    self._setParamsInEsCore()
+    #    self._set_params_in_es_core()
 
     # class DeviceList:
     #  def __getitem__(self, _dev):
@@ -317,9 +318,9 @@ IF LB_GPU or LB:
         # Activate Actor
         #
         ####################################################
-        def _activateMethod(self):
+        def _activate_method(self):
 
-            self._setParamsInEsCore()
+            self._set_params_in_es_core()
 
         ####################################################
         #
@@ -328,4 +329,4 @@ IF LB_GPU or LB:
         ####################################################
         # def _deactivateMethod(self):
 
-        #   self._setParamsInEsCore()
+        #   self._set_params_in_es_core()

--- a/src/python/espressomd/magnetostatic_extensions.pxd
+++ b/src/python/espressomd/magnetostatic_extensions.pxd
@@ -25,7 +25,7 @@ from utils cimport *
 IF DIPOLES == 1:
 
     cdef extern from "mdlc_correction.hpp":
-        ctypedef struct DLC_struct:
+        ctypedef struct dlc_struct "DLC_struct":
             double maxPWerror
             double gap_size
             double far_cut
@@ -33,4 +33,4 @@ IF DIPOLES == 1:
         int mdlc_set_params(double maxPWerror, double gap_size, double far_cut)
 
         # links intern C-struct with python object
-        cdef extern DLC_struct dlc_params
+        cdef extern dlc_struct dlc_params

--- a/src/python/espressomd/magnetostatic_extensions.pyx
+++ b/src/python/espressomd/magnetostatic_extensions.pyx
@@ -23,42 +23,45 @@ from actors import Actor
 
 IF DIPOLES == 1:
     class MagnetostaticExtension(Actor):
+
+
         pass
 
     class DLC(MagnetostaticExtension):
 
-        def validateParams(self):
-            default_params = self.defaultParams()
-            checkTypeOrExcept(self._params["maxPWerror"], 1, float, "")
-            checkRangeOrExcept(
-                self._params["maxPWerror"], 0, False, "inf", True)
-            checkTypeOrExcept(self._params["gap_size"], 1, float, "")
-            checkRangeOrExcept(self._params["gap_size"], 0, False, "inf", True)
-            checkTypeOrExcept(self._params["far_cut"], 1, float, "")
 
-        def validKeys(self):
+        def validate_params(self):
+            default_params = self.default_params()
+            check_type_or_throw_except(self._params["maxPWerror"], 1, float, "")
+            check_range_or_except(
+                self._params["maxPWerror"], 0, False, "inf", True)
+            check_type_or_throw_except(self._params["gap_size"], 1, float, "")
+            check_range_or_except(self._params["gap_size"], 0, False, "inf", True)
+            check_type_or_throw_except(self._params["far_cut"], 1, float, "")
+
+        def valid_keys(self):
             return "maxPWerror", "gap_size", "far_cut"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return ["maxPWerror", "gap_size"]
 
-        def defaultParams(self):
+        def default_params(self):
             return {"maxPWerror": -1,
                     "gap_size": -1,
                     "far_cut": -1}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             params = {}
             params.update(dlc_params)
             return params
 
-        def _setParamsInEsCore(self):
+        def _set_params_in_es_core(self):
             if mdlc_set_params(self._params["maxPWerror"], self._params["gap_size"], self._params["far_cut"]):
                 raise ValueError(
                     "Choose a 3d magnetostatics method prior to DLC")
 
-        def _activateMethod(self):
-            self._setParamsInEsCore()
+        def _activate_method(self):
+            self._set_params_in_es_core()
 
-        def _deactivateMethod(self):
+        def _deactivate_method(self):
             pass

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -3,7 +3,7 @@ include "myconfig.pxi"
 
 IF DIPOLES == 1:
     cdef extern from "interaction_data.hpp":
-        ctypedef enum DipolarInteraction:
+        ctypedef enum dipolar_interaction "DipolarInteraction":
             DIPOLAR_NONE = 0,
             DIPOLAR_P3M,
             DIPOLAR_MDLC_P3M,
@@ -13,10 +13,10 @@ IF DIPOLES == 1:
 
         int dipolar_set_Dbjerrum(double bjerrum)
 
-        ctypedef struct Coulomb_parameters:
+        ctypedef struct coulomb_parameters "Coulomb_parameters":
             double Dprefactor
-            DipolarInteraction Dmethod
-        cdef extern Coulomb_parameters coulomb
+            dipolar_interaction Dmethod
+        cdef extern coulomb_parameters coulomb
 
     cdef extern from "magnetic_non_p3m_methods.hpp":
         int dawaanr_set_params()

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -24,7 +24,8 @@ from globals cimport temperature
 IF DIPOLES == 1:
     cdef class MagnetostaticInteraction(Actor):
 
-        def validateParams(self):
+
+        def validate_params(self):
             if not (("bjerrum_length" in self._params) ^ ("prefactor" in self._params)):
                 raise ValueError(
                     "Either the bjerrum length or the explicit prefactor has to be given")
@@ -37,7 +38,7 @@ IF DIPOLES == 1:
                 if not self._params["prefactor"] > 0:
                     raise ValueError("prefactor should be a positive double")
 
-        def setMagnetostaticsPrefactor(self):
+        def set_magnetostatics_prefactor(self):
             """changes the magnetostatics prefactor, using either the bjrerrum
                length or the explicit prefactor given in the _params dictionary
                of the class."""
@@ -62,19 +63,19 @@ IF DIPOLES == 1:
                         self._params["bjerrum_length"] = self.params[
                             "prefactor"] / temperature
 
-        def getParams(self):
-            self._params = self._getParamsFromEsCore()
+        def get_params(self):
+            self._params = self._get_params_from_es_core()
             return self._params
 
-        def _getActiveMethodFromEsCore(self):
+        def _get_active_method_from_es_core(self):
             return coulomb.Dmethod
 
 
 IF DP3M == 1:
     cdef class DipolarP3M(MagnetostaticInteraction):
 
-        def validateParams(self):
-            super(DipolarP3M, self).validateParams()
+        def validate_params(self):
+            super(DipolarP3M, self).validate_params()
             default_params = self.defaultParams()
 
             if not (self._params["r_cut"] >= 0 or self._params["r_cut"] == default_params["r_cut"]):
@@ -109,13 +110,13 @@ IF DP3M == 1:
                 raise ValueError(
                     "mesh_off should be a list of length 3 and values between 0.0 and 1.0")
 
-        def validKeys(self):
+        def valid_keys(self):
             return "prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off", "cao", "inter", "accuracy", "epsilon", "cao_cut", "a", "ai", "alpha", "r_cut", "inter2", "cao3", "additional_mesh", "bjerrum_length", "tune"
 
-        def requiredKeys(self):
+        def required_keys(self):
             return ["accuracy", ]
 
-        def defaultParams(self):
+        def default_params(self):
             return {"cao": -1,
                     "inter": -1,
                     "r_cut": -1,
@@ -125,15 +126,15 @@ IF DP3M == 1:
                     "mesh_off": [-1, -1, -1],
                     "tune": True}
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             params = {}
             params.update(dp3m.params)
             params["prefactor"] = coulomb.Dprefactor
             params["tune"] = self._params["tune"]
             return params
 
-        def _setParamsInEsCore(self):
-            self.setMagnetostaticsPrefactor()
+        def _set_params_in_es_core(self):
+            self.set_magnetostatics_prefactor()
             dp3m_set_eps(self._params["epsilon"])
             dp3m_set_ninterpol(self._params["inter"])
             self.python_dp3m_set_mesh_offset(self._params["mesh_off"])
@@ -150,13 +151,13 @@ IF DP3M == 1:
                 raise Exception(
                     "failed to tune dipolar P3M parameters to required accuracy")
             print log
-            self._params.update(self._getParamsFromEsCore())
+            self._params.update(self._get_params_from_es_core())
 
-        def _activateMethod(self):
+        def _activate_method(self):
             if self._params["tune"]:
                 self._tune()
 
-            self._setParamsInEsCore()
+            self._set_params_in_es_core()
 
         def python_dp3m_set_mesh_offset(self, mesh_off):
             cdef double mesh_offset[3]
@@ -210,23 +211,23 @@ IF DIPOLES == 1:
            pairs. If the system has periodic boundaries, the minimum image
            convention is applied."""
 
-        def defaultParams(self):
+        def default_params(self):
             return {}
 
-        def requiredKeys(self):
+        def required_keys(self):
             return ()
 
-        def validKeys(self):
+        def valid_keys(self):
             return ("bjerrum_length", "prefactor")
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return {"prefactor": coulomb.Dprefactor}
 
-        def _activateMethod(self):
-            self._setParamsInEsCore(self)
+        def _activate_method(self):
+            self._set_params_in_es_core(self)
 
-        def _setParamsInEsCore(self):
-            self.setMagnetostaticsPrefactor()
+        def _set_params_in_es_core(self):
+            self.set_magnetostatics_prefactor()
             if dawaanr_set_params():
                 raise Exception(
                     "Could not activate magnetostatics method " + self.__class__.__name__)
@@ -237,23 +238,23 @@ IF DIPOLES == 1:
            pairs. If the system has periodic boundaries, n_replica
            copies are attached on each side. Spherical cutoff is applied."""
 
-        def defaultParams(self):
+        def default_params(self):
             return {}
 
-        def requiredKeys(self):
+        def required_keys(self):
             return ("n_replica",)
 
-        def validKeys(self):
+        def valid_keys(self):
             return ("bjerrum_length", "prefactor", "n_replica")
 
-        def _getParamsFromEsCore(self):
+        def _get_params_from_es_core(self):
             return {"prefactor": coulomb.Dprefactor, "n_replica": Ncut_off_magnetic_dipolar_direct_sum}
 
-        def _activateMethod(self):
-            self._setParamsInEsCore(self)
+        def _activate_method(self):
+            self._set_params_in_es_core(self)
 
-        def _setParamsInEsCore(self):
-            self.setMagnetostaticsPrefactor()
+        def _set_params_in_es_core(self):
+            self.set_magnetostatics_prefactor()
             if mdds_set_params(self._params["n_replica"]):
                 raise Exception(
                     "Could not activate magnetostatics method " + self.__class__.__name__)

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -35,34 +35,34 @@ cdef extern from "particle_data.hpp":
     # For all other properties, getter-funcionts have to be used on the c
     # level.
 
-    ctypedef struct ParticleProperties:
+    ctypedef struct particle_properties "ParticleProperties":
         int    identity
         int    mol_id
         int    type
 
-    ctypedef struct ParticlePosition:
+    ctypedef struct particle_position "ParticlePosition":
         double p[3]
 
-    ctypedef struct ParticleForce:
+    ctypedef struct particle_force "ParticleForce":
         double f[3]
 
-    ctypedef struct ParticleMomentum:
+    ctypedef struct particle_momentum "ParticleMomentum":
         double v[3]
 
-    ctypedef struct ParticleLocal:
+    ctypedef struct particle_local "ParticleLocal":
         pass
 
-    ctypedef struct Particle:
-        ParticleProperties p
-        ParticlePosition r
-        ParticleMomentum m
-        ParticleForce f
-        ParticleLocal l
-        IntList bl
+    ctypedef struct particle "Particle":
+        particle_properties p
+        particle_position r
+        particle_momentum m
+        particle_force f
+        particle_local l
+        int_list bl
 
     IF ENGINE:
         IF LB or LB_GPU:
-            ctypedef struct ParticleParametersSwimming:
+            ctypedef struct particle_parameters_swimming "ParticleParametersSwimming":
                 bool swimming
                 double f_swim
                 double v_swim
@@ -72,14 +72,14 @@ cdef extern from "particle_data.hpp":
                 double v_source[3]
                 double rotational_friction
         ELSE:
-            ctypedef struct ParticleParametersSwimming:
+            ctypedef struct particle_parameters_swimming "ParticleParametersSwimming":
                 bool swimming
                 double f_swim
                 double v_swim
 
     # Setter/getter/modifier functions functions
 
-    int get_particle_data(int part, Particle * data)
+    int get_particle_data(int part, particle * data)
 
     int place_particle(int part, double p[3])
 
@@ -96,19 +96,19 @@ cdef extern from "particle_data.hpp":
 
     IF MASS:
         int set_particle_mass(int part, double mass)
-        void pointer_to_mass(Particle * p, double * & res)
+        void pointer_to_mass(particle * p, double * & res)
 
     IF SHANCHEN:
         int set_particle_solvation(int part, double * solvation)
-        void pointer_to_solvation(Particle * p, double * & res)
+        void pointer_to_solvation(particle * p, double * & res)
 
     IF ROTATIONAL_INERTIA:
         int set_particle_rotational_inertia(int part, double rinertia[3])
-        void pointer_to_rotational_inertia(Particle * p, double * & res)
+        void pointer_to_rotational_inertia(particle * p, double * & res)
 
     IF ROTATION_PER_PARTICLE:
         int set_particle_rotation(int part, int rot)
-        void pointer_to_rotation(Particle * p, short int * & res)
+        void pointer_to_rotation(particle * p, short int * & res)
 
     IF ELECTROSTATICS:
         int set_particle_q(int part, double q)
@@ -121,64 +121,64 @@ cdef extern from "particle_data.hpp":
 
     IF ROTATION:
         int set_particle_quat(int part, double quat[4])
-        void pointer_to_quat(Particle * p, double * & res)
-        void pointer_to_quatu(Particle * p, double * & res)
+        void pointer_to_quat(particle * p, double * & res)
+        void pointer_to_quatu(particle * p, double * & res)
         int set_particle_omega_lab(int part, double omega[3])
         int set_particle_omega_body(int part, double omega[3])
         int set_particle_torque_lab(int part, double torque[3])
         int set_particle_torque_body(int part, double torque[3])
-        void pointer_to_omega_body(Particle * p, double * & res)
-        void pointer_to_torque_lab(Particle * p, double * & res)
+        void pointer_to_omega_body(particle * p, double * & res)
+        void pointer_to_torque_lab(particle * p, double * & res)
 
     IF MASS == 1:
-        void pointer_to_mass(Particle * p, double * & res)
+        void pointer_to_mass(particle * p, double * & res)
 
     IF DIPOLES:
         int set_particle_dip(int part, double dip[3])
-        void pointer_to_dip(Particle * P, double * & res)
+        void pointer_to_dip(particle * P, double * & res)
 
         int set_particle_dipm(int part, double dipm)
-        void pointer_to_dipm(Particle * P, double * & res)
+        void pointer_to_dipm(particle * P, double * & res)
 
     IF VIRTUAL_SITES:
         int set_particle_virtual(int part, int isVirtual)
-        void pointer_to_virtual(Particle * P, int * & res)
+        void pointer_to_virtual(particle * P, int * & res)
 
     IF LANGEVIN_PER_PARTICLE:
         int set_particle_temperature(int part, double T)
-        void pointer_to_temperature(Particle * p, double * & res)
+        void pointer_to_temperature(particle * p, double * & res)
 
         int set_particle_gamma(int part, double gamma)
-        void pointer_to_gamma(Particle * p, double * & res)
+        void pointer_to_gamma(particle * p, double * & res)
 
     IF VIRTUAL_SITES_RELATIVE:
-        void pointer_to_vs_relative(Particle * P, int * & res1, double * & res2, double * & res3)
+        void pointer_to_vs_relative(particle * P, int * & res1, double * & res2, double * & res3)
 
     IF ELECTROSTATICS:
-        void pointer_to_q(Particle * P, double * & res)
+        void pointer_to_q(particle * P, double * & res)
 
     IF EXTERNAL_FORCES:
         IF ROTATION:
             int set_particle_ext_torque(int part, int flag, double torque[3])
-            void pointer_to_ext_torque(Particle * P, int * & res1, double * & res2)
+            void pointer_to_ext_torque(particle * P, int * & res1, double * & res2)
 
         int set_particle_ext_force(int part, int flag, double force[3])
-        void pointer_to_ext_force(Particle * P, int * & res1, double * & res2)
+        void pointer_to_ext_force(particle * P, int * & res1, double * & res2)
 
         int set_particle_fix(int part,  int flag)
-        void pointer_to_fix(Particle * P, int * & res)
+        void pointer_to_fix(particle * P, int * & res)
 
     int change_particle_bond(int part, int * bond, int _delete)
 
     IF EXCLUSIONS:
         int change_exclusion(int part, int part2, int _delete)
-        void pointer_to_exclusions(Particle * p, int * & res1, int * & res2)
+        void pointer_to_exclusions(particle * p, int * & res1, int * & res2)
 
         void remove_all_exclusions()
 
     IF ENGINE:
-        int set_particle_swimming(int part, ParticleParametersSwimming swim)
-        void pointer_to_swimming(Particle * p, ParticleParametersSwimming * & swim)
+        int set_particle_swimming(int part, particle_parameters_swimming swim)
+        void pointer_to_swimming(particle * p, particle_parameters_swimming * & swim)
 
     int remove_particle(int part)
 
@@ -192,21 +192,23 @@ cdef extern from "virtual_sites_relative.hpp":
         int set_particle_vs_relative(int part, int vs_relative_to, double vs_distance, double * vs_quat)
 
 cdef extern from "rotation.hpp":
-    void convert_omega_body_to_space(Particle * p, double * omega)
-    void convert_torques_body_to_space(Particle * p, double * torque)
+    void convert_omega_body_to_space(particle * p, double * omega)
+    void convert_torques_body_to_space(particle * p, double * torque)
 
 # The bonded_ia_params stuff has to be included here, because the setter/getter
 # of the particles' bond property needs to now about the correct number of
 # bond partners
 cdef extern from "interaction_data.hpp":
-    ctypedef struct Bonded_ia_parameters:
+    ctypedef struct bonded_ia_parameters "Bonded_ia_parameters":
         int num
         pass
-    Bonded_ia_parameters * bonded_ia_params
+    bonded_ia_parameters * bonded_ia_params
     cdef int n_bonded_ia
 
 cdef class ParticleHandle(object):
+
+
     cdef public int id
     cdef bint valid
-    cdef Particle particleData
-    cdef int updateParticleData(self) except -1
+    cdef particle particle_data
+    cdef int update_particle_data(self) except -1

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -35,15 +35,15 @@ PARTICLE_EXT_TORQUE = 16
 
 cdef class ParticleHandle:
     def __cinit__(self, _id):
-        #    utils.init_intlist(self.particleData.el)
-        utils.init_intlist( & (self.particleData.bl))
+        #    utils.init_intlist(self.particle_data.el)
+        utils.init_intlist( & (self.particle_data.bl))
         self.id = _id
 
-    cdef int updateParticleData(self) except -1:
-        #    utils.realloc_intlist(self.particleData.el, 0)
-        utils.realloc_intlist( & (self.particleData.bl), 0)
+    cdef int update_particle_data(self) except -1:
+        #    utils.realloc_intlist(self.particle_data.el, 0)
+        utils.realloc_intlist( & (self.particle_data.bl), 0)
 
-        if get_particle_data(self.id, & self.particleData):
+        if get_particle_data(self.id, & self.particle_data):
             raise Exception("Error updating particle data")
         else:
             return 0
@@ -62,8 +62,8 @@ cdef class ParticleHandle:
                 raise ValueError("type must be an integer >= 0")
 
         def __get__(self):
-            self.updateParticleData()
-            return self.particleData.p.type
+            self.update_particle_data()
+            return self.particle_data.p.type
 
     # Position
     property pos:
@@ -71,17 +71,17 @@ cdef class ParticleHandle:
 
         def __set__(self, _pos):
             cdef double mypos[3]
-            checkTypeOrExcept(_pos, 3, float, "Postion must be 3 floats")
+            check_type_or_throw_except(_pos, 3, float, "Postion must be 3 floats")
             for i in range(3):
                 mypos[i] = _pos[i]
             if place_particle(self.id, mypos) == -1:
                 raise Exception("particle could not be set")
 
         def __get__(self):
-            self.updateParticleData()
-            return np.array([self.particleData.r.p[0],
-                             self.particleData.r.p[1],
-                             self.particleData.r.p[2]])
+            self.update_particle_data()
+            return np.array([self.particle_data.r.p[0],
+                             self.particle_data.r.p[1],
+                             self.particle_data.r.p[2]])
 
     # Velocity
     property v:
@@ -89,17 +89,17 @@ cdef class ParticleHandle:
 
         def __set__(self, _v):
             cdef double myv[3]
-            checkTypeOrExcept(_v, 3, float, "Velocity has to be floats")
+            check_type_or_throw_except(_v, 3, float, "Velocity has to be floats")
             for i in range(3):
                 myv[i] = _v[i]
             if set_particle_v(self.id, myv) == 1:
                 raise Exception("set particle position first")
 
         def __get__(self):
-            self.updateParticleData()
-            return np.array([self.particleData.m.v[0],
-                             self.particleData.m.v[1],
-                             self.particleData.m.v[2]])
+            self.update_particle_data()
+            return np.array([self.particle_data.m.v[0],
+                             self.particle_data.m.v[1],
+                             self.particle_data.m.v[2]])
 
     # Force
     property f:
@@ -107,17 +107,17 @@ cdef class ParticleHandle:
 
         def __set__(self, _f):
             cdef double myf[3]
-            checkTypeOrExcept(_f, 3, float, "Force has to be floats")
+            check_type_or_throw_except(_f, 3, float, "Force has to be floats")
             for i in range(3):
                 myf[i] = _f[i]
             if set_particle_f(self.id, myf) == 1:
                 raise Exception("set particle position first")
 
         def __get__(self):
-            self.updateParticleData()
-            return np.array([self.particleData.f.f[0],
-                             self.particleData.f.f[1],
-                             self.particleData.f.f[2]])
+            self.update_particle_data()
+            return np.array([self.particle_data.f.f[0],
+                             self.particle_data.f.f[1],
+                             self.particle_data.f.f[2]])
 
     # Bonds
     property bonds:
@@ -130,7 +130,7 @@ cdef class ParticleHandle:
                     "bonds have to specified as a tuple of tuples. (Lists can also be used)")
             # Check individual bonds
             for bond in _bonds:
-                self.checkBondOrThrowException(bond)
+                self.check_bond_or_throw_exception(bond)
 
             # Assigning to the bond property means replacing the existing value
             # i.e., we delete all existing bonds
@@ -139,26 +139,26 @@ cdef class ParticleHandle:
 
             # And add the new ones
             for bond in _bonds:
-                self.addVerifiedBond(bond)
+                self.add_verified_bond(bond)
 
         def __get__(self):
-            self.updateParticleData()
+            self.update_particle_data()
             bonds = []
             # Go through the bond list of the particle
             i = 0
-            while i < self.particleData.bl.n:
+            while i < self.particle_data.bl.n:
                 bond = []
                 # Bond type:
-                bondId = self.particleData.bl.e[i]
-                bond.append(bondId)
+                bond_id = self.particle_data.bl.e[i]
+                bond.append(bond_id)
                 # Number of partners
-                nPartners = bonded_ia_params[bondId].num
+                nPartners = bonded_ia_params[bond_id].num
 
                 i += 1
 
                 # Copy bond partners
                 for j in range(nPartners):
-                    bond.append(self.particleData.bl.e[i])
+                    bond.append(self.particle_data.bl.e[i])
                     i += 1
                 bonds.append(tuple(bond))
 
@@ -171,14 +171,14 @@ cdef class ParticleHandle:
             """Particle mass"""
 
             def __set__(self, _mass):
-                checkTypeOrExcept(_mass, 1, float, "Mass has to be 1 floats")
+                check_type_or_throw_except(_mass, 1, float, "Mass has to be 1 floats")
                 if set_particle_mass(self.id, _mass) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_mass( & (self.particleData), x)
+                pointer_to_mass( & (self.particle_data), x)
                 return x[0]
 
     IF ROTATION == 1:
@@ -188,16 +188,16 @@ cdef class ParticleHandle:
 
             def __set__(self, _o):
                 cdef double myo[3]
-                checkTypeOrExcept(_o, 3, float, "Omega_lab has to be 3 floats")
+                check_type_or_throw_except(_o, 3, float, "Omega_lab has to be 3 floats")
                 for i in range(3):
                     myo[i] = _o[i]
                 if set_particle_omega_lab(self.id, myo) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double o[3]
-                convert_omega_body_to_space(& (self.particleData), o)
+                convert_omega_body_to_space(& (self.particle_data), o)
                 return np.array([o[0], o[1], o[2]])
 
     # ROTATIONAL_INERTIA
@@ -207,7 +207,7 @@ cdef class ParticleHandle:
 
             def __set__(self, _rinertia):
                 cdef double rinertia[3]
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     _rinertia, 3, float, "Rotation_inertia has to be 3 floats")
                 for i in range(3):
                     rinertia[i] = _rinertia[i]
@@ -215,9 +215,9 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * rinertia = NULL
-                pointer_to_rotational_inertia( & (self.particleData), rinertia)
+                pointer_to_rotational_inertia( & (self.particle_data), rinertia)
                 return np.array([rinertia[0], rinertia[1], rinertia[2]])
 
 # Omega (angular velocity) body frame
@@ -226,7 +226,7 @@ cdef class ParticleHandle:
 
             def __set__(self, _o):
                 cdef double myo[3]
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     _o, 3, float, "Omega_body has to be 3 floats")
                 for i in range(3):
                     myo[i] = _o[i]
@@ -234,9 +234,9 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * o = NULL
-                pointer_to_omega_body( & (self.particleData), o)
+                pointer_to_omega_body( & (self.particle_data), o)
                 return np.array([o[0], o[1], o[2]])
 
 
@@ -246,16 +246,16 @@ cdef class ParticleHandle:
 
             def __set__(self, _t):
                 cdef double myt[3]
-                checkTypeOrExcept(_t, 3, float, "Torque has to be 3 floats")
+                check_type_or_throw_except(_t, 3, float, "Torque has to be 3 floats")
                 for i in range(3):
                     myt[i] = _t[i]
                 if set_particle_torque_lab(self.id, myt) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double x[3]
-                convert_torques_body_to_space(& (self.particleData), x)
+                convert_torques_body_to_space(& (self.particle_data), x)
                 return np.array([x[0], x[1], x[2]])
 
 # Quaternion
@@ -264,7 +264,7 @@ cdef class ParticleHandle:
 
             def __set__(self, _q):
                 cdef double myq[4]
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     _q, 4, float, "Quaternions has to be 4 floats")
                 for i in range(4):
                     myq[i] = _q[i]
@@ -272,9 +272,9 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_quat(& (self.particleData), x)
+                pointer_to_quat(& (self.particle_data), x)
                 return np.array([x[0], x[1], x[2], x[3]])
 # Director ( z-axis in body fixed frame)
         property director:
@@ -284,16 +284,16 @@ cdef class ParticleHandle:
                 raise Exception(
                     "Setting the director is not implemented in the c++-core of Espresso")
 #        cdef double myq[3]
-#        checkTypeOrExcept(_q,3,float,"Director has to be 3 floats")
+#        check_type_or_throw_except(_q,3,float,"Director has to be 3 floats")
 #        for i in range(3):
 #            myq[i]=_q[i]
 #        if set_particle_quatu(self.id, myq) == 1:
 #          raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_quatu(& (self.particleData), x)
+                pointer_to_quatu(& (self.particle_data), x)
                 return np.array([x[0], x[1], x[2]])
 
 # Charge
@@ -303,15 +303,15 @@ cdef class ParticleHandle:
 
             def __set__(self, _q):
                 cdef double myq
-                checkTypeOrExcept(_q, 1, float, "Charge has to be floats")
+                check_type_or_throw_except(_q, 1, float, "Charge has to be floats")
                 myq = _q
                 if set_particle_q(self.id, myq) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_q(& (self.particleData), x)
+                pointer_to_q(& (self.particle_data), x)
                 return x[0]
 
     def delete(self):
@@ -334,9 +334,9 @@ cdef class ParticleHandle:
                     raise ValueError("virtual must be an integer >= 0")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef int * x = NULL
-                pointer_to_virtual(& (self.particleData), x)
+                pointer_to_virtual(& (self.particle_data), x)
                 return x[0]
 
     IF VIRTUAL_SITES_RELATIVE == 1:
@@ -349,7 +349,7 @@ cdef class ParticleHandle:
                 _relto = x[0]
                 _dist = x[1]
                 q = x[3]
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     q, 4, float, "The relative orientation has to be specified as quaternion with 4 floats.")
                 cdef double _q[4]
                 for i in range(4):
@@ -363,11 +363,11 @@ cdef class ParticleHandle:
                         "vs_relative takes one int and one float as parameters.")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef int * rel_to = NULL
                 cdef double * dist = NULL
                 cdef double * q = NULL
-                pointer_to_vs_relative( & (self.particleData), rel_to, dist, q)
+                pointer_to_vs_relative( & (self.particle_data), rel_to, dist, q)
                 return (rel_to[0], dist[0], np.array((q[0], q[1], q[2], q[3])))
 
         # vs_auto_relate_to
@@ -385,7 +385,7 @@ cdef class ParticleHandle:
         # vs_auto_relate_to
         def vs_auto_relate_to(self, _relto):
             """Setup this particle as virtual site relative to the particle with the given id"""
-            checkTypeOrExcept(
+            check_type_or_throw_except(
                 _relto, 1, int, "Argument of vs_auto_relate_to has to be of type int")
             if vs_relate_to(self.id, _relto):
                 raise Exception("vs_relative setup failed.")
@@ -397,7 +397,7 @@ cdef class ParticleHandle:
 
             def __set__(self, _q):
                 cdef double myq[3]
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     _q, 3, float, "Dipole moment vector has to be 3 floats")
                 for i in range(3):
                     myq[i] = _q[i]
@@ -405,9 +405,9 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_dip(& (self.particleData), x)
+                pointer_to_dip(& (self.particle_data), x)
                 return np.array([x[0], x[1], x[2]])
 
         # Scalar magnitude of dipole moment
@@ -415,15 +415,15 @@ cdef class ParticleHandle:
             """Dipole moment (magnitude)"""
 
             def __set__(self, _q):
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     _q, 1, float, "Magnitude of dipole moment has to be 1 floats")
                 if set_particle_dipm(self.id, _q) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_dipm(& (self.particleData), x)
+                pointer_to_dipm(& (self.particle_data), x)
                 return x[0]
 
     IF EXTERNAL_FORCES:
@@ -433,7 +433,7 @@ cdef class ParticleHandle:
             def __set__(self, _ext_f):
                 cdef double ext_f[3]
                 cdef int ext_flag
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     _ext_f, 3, float, "External force vector has to be 3 floats")
                 for i in range(3):
                     ext_f[i] = _ext_f[i]
@@ -445,10 +445,10 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * ext_f = NULL
                 cdef int * ext_flag = NULL
-                pointer_to_ext_force( & (self.particleData), ext_flag, ext_f)
+                pointer_to_ext_force( & (self.particle_data), ext_flag, ext_f)
                 if (ext_flag[0] & PARTICLE_EXT_FORCE):
                     return np.array([ext_f[0], ext_f[1], ext_f[2]])
                 else:
@@ -459,7 +459,7 @@ cdef class ParticleHandle:
 
             def __set__(self, _fixed_coord_flag):
                 cdef int ext_flag
-                checkTypeOrExcept(
+                check_type_or_throw_except(
                     _fixed_coord_flag, 3, int, "Fix has to be 3 ints")
                 for i in map(long, range(3)):
                     if (_fixed_coord_flag[i]):
@@ -468,10 +468,10 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 fixed_coord_flag = np.array([0, 0, 0], dtype=int)
                 cdef int * ext_flag = NULL
-                pointer_to_fix(& (self.particleData), ext_flag)
+                pointer_to_fix(& (self.particle_data), ext_flag)
                 for i in map(long, range(3)):
                     if (ext_flag[0] & COORD_FIXED(i)):
                         fixed_coord_flag[i] = 1
@@ -484,7 +484,7 @@ cdef class ParticleHandle:
                 def __set__(self, _ext_t):
                     cdef double ext_t[3]
                     cdef int ext_flag
-                    checkTypeOrExcept(
+                    check_type_or_throw_except(
                         _ext_t, 3, float, "External force vector has to be 3 floats")
                     for i in range(3):
                         ext_t[i] = _ext_t[i]
@@ -496,10 +496,10 @@ cdef class ParticleHandle:
                         raise Exception("set particle position first")
 
                 def __get__(self):
-                    self.updateParticleData()
+                    self.update_particle_data()
                     cdef double * ext_t = NULL
                     cdef int * ext_flag = NULL
-                    pointer_to_ext_torque( & (self.particleData), ext_flag, ext_t)
+                    pointer_to_ext_torque( & (self.particle_data), ext_flag, ext_t)
                     if (ext_flag[0] & PARTICLE_EXT_TORQUE):
                         return np.array([ext_t[0], ext_t[1], ext_t[2]])
                     else:
@@ -510,28 +510,28 @@ cdef class ParticleHandle:
             """Friction coefficient per particle in Langevin"""
 
             def __set__(self, _gamma):
-                checkTypeOrExcept(_gamma, 1, float, "gamma has to be a float")
+                check_type_or_throw_except(_gamma, 1, float, "gamma has to be a float")
                 if set_particle_gamma(self.id, _gamma) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * gamma = NULL
-                pointer_to_gamma(& (self.particleData), gamma)
+                pointer_to_gamma(& (self.particle_data), gamma)
                 return gamma[0]
 
         property temp:
             """Temperature per particle in Langevin"""
 
             def __set__(self, _temp):
-                checkTypeOrExcept(_temp, 1, float, "temp has to be a float")
+                check_type_or_throw_except(_temp, 1, float, "temp has to be a float")
                 if set_particle_temperature(self.id, _temp) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef double * temp = NULL
-                pointer_to_temperature(& (self.particleData), temp)
+                pointer_to_temperature(& (self.particle_data), temp)
                 return temp[0]
 
     IF ROTATION_PER_PARTICLE:
@@ -548,9 +548,9 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef short int * _rot = NULL
-                pointer_to_rotation(& (self.particleData), _rot)
+                pointer_to_rotation(& (self.particle_data), _rot)
                 if _rot[0] == 1:
                     rot = True
                 else:
@@ -567,17 +567,17 @@ cdef class ParticleHandle:
                     if _partners.pop(0) == "delete":
                         delete = 1
                 for partner in _partners:
-                    checkTypeOrExcept(
+                    check_type_or_throw_except(
                         partner, 1, int, "PID of partner has to be an int")
                     if change_exclusion(self.id, partner, delete) == 1:
                         raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 cdef int * num_partners = NULL
                 cdef int * partners = NULL
                 py_partners = []
-                pointer_to_exclusions( & (self.particleData), num_partners, partners)
+                pointer_to_exclusions( & (self.particle_data), num_partners, partners)
                 for i in range(num_partners[0]):
                     py_partners.append(partners[i])
                 return np.array(py_partners)
@@ -587,7 +587,7 @@ cdef class ParticleHandle:
             """Set swimming parameters"""
 
             def __set__(self, _params):
-                cdef ParticleParametersSwimming swim
+                cdef particle_parameters_swimming swim
                 swim.swimming = True
                 swim.v_swim = 0.0
                 swim.f_swim = 0.0
@@ -605,11 +605,11 @@ cdef class ParticleHandle:
                         raise Exception(
                             "You can't set v_swim and f_swim at the same time")
                     if 'f_swim' in _params:
-                        checkTypeOrExcept(
+                        check_type_or_throw_except(
                             _params['f_swim'], 1, float, "f_swim has to be a float")
                         swim.f_swim = _params['f_swim']
                     if 'v_swim' in _params:
-                        checkTypeOrExcept(
+                        check_type_or_throw_except(
                             _params['v_swim'], 1, float, "v_swim has to be a float")
                         swim.v_swim = _params['v_swim']
 
@@ -626,12 +626,12 @@ cdef class ParticleHandle:
                                     "'mode' has to be either 'pusher' or 'puller'")
 
                         if 'dipole_length' in _params:
-                            checkTypeOrExcept(
+                            check_type_or_throw_except(
                                 _params['dipole_length'], 1, float, "dipole_length has to be a float")
                             swim.dipole_length = _params['dipole_length']
 
                         if 'rotational_friction' in _params:
-                            checkTypeOrExcept(
+                            check_type_or_throw_except(
                                 _params['rotational_friction'], 1, float, "rotational_friction has to be a float")
                             swim.rotational_friction = _params[
                                 'rotational_friction']
@@ -640,11 +640,11 @@ cdef class ParticleHandle:
                     raise Exception("set particle position first")
 
             def __get__(self):
-                self.updateParticleData()
+                self.update_particle_data()
                 swim = {}
                 mode = "N/A"
-                cdef ParticleParametersSwimming * _swim = NULL
-                pointer_to_swimming( & (self.particleData), _swim)
+                cdef particle_parameters_swimming * _swim = NULL
+                pointer_to_swimming( & (self.particle_data), _swim)
                 IF LB or LB_GPU:
                     if _swim.push_pull == -1:
                         mode = 'pusher'
@@ -671,26 +671,26 @@ cdef class ParticleHandle:
         del self
 
     # Bond related methods
-    def addVerifiedBond(self, bond, partner):
+    def add_verified_bond(self, bond, partner):
         """Add a bond, the validity of which has already been verified"""
         # If someone adds bond types with more than four partners, this has to
         # be changed
-        cdef int bondInfo[5]
-        bondInfo[0] = bond._bondId
+        cdef int bond_info[5]
+        bond_info[0] = bond._bond_id
 #    for i in range(len(bond)):
-#       bondInfo[i]=bond[i]
-        if change_particle_bond(self.id, bondInfo, 0):
+#       bond_info[i]=bond[i]
+        if change_particle_bond(self.id, bond_info, 0):
             raise Exception("Adding the bond failed.")
 
-    def deleteVerifiedBond(self, bond, partner):
-        cdef int bondInfo[5]
-        bondInfo[0] = bond._bondId
+    def delete_verified_bond(self, bond, partner):
+        cdef int bond_info[5]
+        bond_info[0] = bond._bond_id
 #    for i in range(len(bond)):
-#      bondInfo[i]=bond[i]
-        if change_particle_bond(self.id, bondInfo, 1):
+#      bond_info[i]=bond[i]
+        if change_particle_bond(self.id, bond_info, 1):
             raise Exception("Deleting the bond failed.")
 
-    def checkBondOrThrowException(self, bond, partner):
+    def check_bond_or_throw_exception(self, bond, partner):
         """Checks the validity of the given bond:
         * if the bond is given as an object
         * if all partners are of type int
@@ -702,37 +702,37 @@ cdef class ParticleHandle:
         if not isinstance(bond, BondedInteraction):
             raise Exception(
                 "Bond argument has to be of type BondedInteraction.")
-        if bond._bondId >= n_bonded_ia:
-            raise ValueError("The bond type", bond._bondId, "does not exist.")
+        if bond._bond_id >= n_bonded_ia:
+            raise ValueError("The bond type", bond._bond_id, "does not exist.")
         if not hasattr(partner, "__getitem"):
             partner = (partner,)
-        if bonded_ia_params[bond._bondId].num != len(partner):
-            raise ValueError("Bond of type", bond._bondId, "needs", bonded_ia_params[
-                             bond._bondId], "partners.")
+        if bonded_ia_params[bond._bond_id].num != len(partner):
+            raise ValueError("Bond of type", bond._bond_id, "needs", bonded_ia_params[
+                             bond._bond_id], "partners.")
 
         for y in partner:
             if not isinstance(y, int):
                 raise ValueError("Partners have to be integer.")
 
-    def addBond(self, bond, partner):
+    def add_bond(self, bond, partner):
         """Add a single bond to the particle"""
-        self.checkBondOrThrowException(bond, partner)
-        self.addVerifiedBond(bond, partner)
+        self.check_bond_or_throw_exception(bond, partner)
+        self.add_verified_bond(bond, partner)
 
-    def deleteBond(self, bond, partner):
+    def delete_bond(self, bond, partner):
         """Delete a single bond from the particle"""
-        self.checkBondOrThrowException(bond, partner)
-        self.deleteVerifiedBond(bond, partner)
+        self.check_bond_or_throw_exception(bond, partner)
+        self.delete_verified_bond(bond, partner)
 
-    def deleteAllBonds(self):
+    def delete_all_bonds(self):
         if change_particle_bond(self.id, NULL, 1):
             raise Exception("Deleting all bonds failed.")
 
-    def deleteAllBonds(self):
+    def delete_all_bonds(self):
         if change_particle_bond(self.id, NULL, 1):
             raise Exception("Deleting all bonds failed.")
 
-cdef class particleList:
+cdef class ParticleList:
     """Provides access to the particles via [i], where i is the particle id. Returns a ParticleHandle object """
 
     def __getitem__(self, key):

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -19,10 +19,12 @@
 cimport thermostat
 
 cdef class Thermostat:
+
+
     def __init__(self):
         pass
 
-    def getStatus(self):
+    def get_status(self):
         """Returns the thermostat status. Equivalent to the tcl command 'thermostat' with no arguments"""
 
         if temperature == -1:
@@ -32,7 +34,7 @@ cdef class Thermostat:
         if thermo_switch and THERMO_LANGEVIN:
             return "{ langevin " + str(temperature) + " " + str(langevin_gamma) + " }"
 
-    def turnOff(self):
+    def turn_off(self):
         """Turns off all the thermostat and sets all the thermostat variables to zero"""
 
         global temperature
@@ -47,7 +49,7 @@ cdef class Thermostat:
         # here other thermostats stuff
         return True
 
-    def setLangevin(self, kT="", gamma=""):
+    def set_langevin(self, kT="", gamma=""):
         """Sets the Langevin thermostat with required parameters 'temperature' 'gamma'"""
 
         if kT == "" or gamma == "":

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from utils cimport *
 import numpy as np
 cimport numpy as np
 
@@ -26,23 +25,21 @@ cdef extern from "stdlib.h":
     void * realloc(void * ptr, size_t size)
 
 cdef extern from "utils.hpp":
-    ctypedef struct IntList:
+    ctypedef struct int_list "IntList":
         int * e
         int n
-    cdef void init_intlist(IntList * il)
-    cdef void alloc_intlist(IntList * il, int size)
-    cdef void realloc_intlist(IntList * il, int size)
 
-    ctypedef struct DoubleList:
+    ctypedef struct double_list "DoubleList":
         double * e
         int n
-    cdef void init_intlist(IntList * il)
-    cdef void alloc_intlist(IntList * il, int size)
-    cdef void realloc_intlist(IntList * il, int size)
 
-cdef IntList * create_IntList_from_python_object(obj)
-cdef np.ndarray create_nparray_from_IntList(IntList * il)
-cdef np.ndarray create_nparray_from_DoubleList(DoubleList * dl)
+    cdef void init_intlist(int_list * il)
+    cdef void alloc_intlist(int_list * il, int size)
+    cdef void realloc_intlist(int_list * il, int size)
+
+cdef int_list * create_int_list_from_python_object(obj)
+cdef np.ndarray create_nparray_from_int_list(int_list * il)
+cdef np.ndarray create_nparray_from_double_list(double_list * dl)
 cdef np.ndarray create_nparray_from_double_array(double * x, int n)
-cdef checkTypeOrExcept(x, n, t, msg)
-cdef checkRangeOrExcept(x, v_min, incl_min, v_max, incl_max)
+cdef check_type_or_throw_except(x, n, t, msg)
+cdef check_range_or_except(x, v_min, incl_min, v_max, incl_max)

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -24,21 +24,21 @@ cdef extern from "stdlib.h":
     void * malloc(size_t size)
     void * realloc(void * ptr, size_t size)
 
-cdef np.ndarray create_nparray_from_IntList(IntList * il):
+cdef np.ndarray create_nparray_from_int_list(int_list * il):
     numpyArray = np.zeros(il.n)
     for i in range(il.n):
         numpyArray[i] = il.e[i]
 
     return numpyArray
 
-cdef np.ndarray create_nparray_from_DoubleList(DoubleList * dl):
+cdef np.ndarray create_nparray_from_double_list(double_list * dl):
     numpyArray = np.zeros(dl.n)
     for i in range(dl.n):
         numpyArray[i] = dl.e[i]
 
-cdef IntList * create_IntList_from_python_object(obj):
-    cdef IntList * il
-    il = <IntList * > malloc(sizeof(IntList))
+cdef int_list * create_int_list_from_python_object(obj):
+    cdef int_list * il
+    il = <int_list * > malloc(sizeof(int_list))
     init_intlist(il)
 
     alloc_intlist(il, len(obj))
@@ -47,7 +47,7 @@ cdef IntList * create_IntList_from_python_object(obj):
         print il.e[i]
     return il
 
-cdef checkTypeOrExcept(x, n, t, msg):
+cdef check_type_or_throw_except(x, n, t, msg):
     """Checks that x is of type t and that n values are given, otherwise throws ValueError with the message msg.
        If x is an array/list/tuple, the type checking is done on the elements, and
        all elements are checked.
@@ -78,7 +78,7 @@ cdef np.ndarray create_nparray_from_double_array(double * x, int n):
         numpyArray[i] = x[i]
     return numpyArray
 
-cdef checkRangeOrExcept(x, v_min, incl_min, v_max, incl_max):
+cdef check_range_or_except(x, v_min, incl_min, v_max, incl_max):
     """Checks that x is in range [v_min,v_max] (inlude boundaries via inlc_min/incl_max = true) or throws a ValueError. v_min/v_max = 'inf' to disable limit """
 
     # Array/list/tuple


### PR DESCRIPTION
Changed function/method/class/variable names in terms of the PEP8 naming convention