### PR TITLE
Python bond fixes/extensions the 2nd

### DIFF
--- a/src/python/espressomd/actors.pyx
+++ b/src/python/espressomd/actors.pyx
@@ -6,10 +6,10 @@ cdef class Actor:
 
     # Keys in active_list have to match the method name.
     active_list = dict(ElectrostaticInteraction=False,
-                      MagnetostaticInteraction=False,
-                      MagnetostaticExtension=False,
-                      HydrodynamicInteraction=False,
-                      ElectrostaticExtensions=False)
+                       MagnetostaticInteraction=False,
+                       MagnetostaticExtension=False,
+                       HydrodynamicInteraction=False,
+                       ElectrostaticExtensions=False)
 
     def __cinit__(self, *args, **kwargs):
         self._isactive = False
@@ -124,7 +124,6 @@ cdef class Actor:
 
 
 class Actors:
-
 
     active_actors = []
 

--- a/src/python/espressomd/actors.pyx
+++ b/src/python/espressomd/actors.pyx
@@ -44,7 +44,7 @@ cdef class Actor:
 
     def is_valid(self):
         """Check, if the data stored in the instance still matches what is in Espresso"""
-        # check, if the bond parameters saved in the class still match those
+        # check, if the parameters saved in the class still match those
         # saved in Espresso
         temp_params = self._get_params_from_es_core()
         if self._params != temp_params:

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -174,12 +174,18 @@ def cylindrical_average(system=None, center=None, direction=None,
                         types=[-1]):
 
     # Check the input types
-    check_type_or_throw_except(center,      3, float, "center has to be 3 floats")
-    check_type_or_throw_except(direction,   3, float, "direction has to be 3 floats")
-    check_type_or_throw_except(length,      1, float, "length has to be a float")
-    check_type_or_throw_except(radius,      1, float, "radius has to be a floats")
-    check_type_or_throw_except(bins_axial,  1, int,   "bins_axial has to be an int")
-    check_type_or_throw_except(bins_radial, 1, int,   "bins_radial has to be an int")
+    check_type_or_throw_except(
+        center,      3, float, "center has to be 3 floats")
+    check_type_or_throw_except(
+        direction,   3, float, "direction has to be 3 floats")
+    check_type_or_throw_except(
+        length,      1, float, "length has to be a float")
+    check_type_or_throw_except(
+        radius,      1, float, "radius has to be a floats")
+    check_type_or_throw_except(
+        bins_axial,  1, int,   "bins_axial has to be an int")
+    check_type_or_throw_except(
+        bins_radial, 1, int,   "bins_radial has to be an int")
 
     # Convert Python types to C++ types
     cdef vector[double] c_center = center
@@ -267,8 +273,8 @@ def pressure(self, v_comp=0):
     total_bonded = 0
     for i in range(c_analyze.n_bonded_ia):
         if (bonded_ia_params[i].type != 0):
-            p["bonded", i] = c_analyze.obsstat_bonded( & c_analyze.total_pressure, i)[0]
-            total_bonded += c_analyze.obsstat_bonded(& c_analyze.total_pressure, i)[0]
+            p["bonded", i] = c_analyze.obsstat_bonded(& c_analyze.total_pressure, i)[0]
+            total_bonded += c_analyze.obsstat_bonded( & c_analyze.total_pressure, i)[0]
     p["bonded"] = total_bonded
 
     # Non-Bonded interactions, total as well as intra and inter molecular
@@ -283,12 +289,12 @@ def pressure(self, v_comp=0):
     for i in range(c_analyze.n_particle_types):
         for j in range(c_analyze.n_particle_types):
             #      if checkIfParticlesInteract(i, j):
-            p["nonBonded", i, j] = c_analyze.obsstat_nonbonded( & c_analyze.total_pressure, i, j)[0]
-            total_non_bonded = c_analyze.obsstat_nonbonded( & c_analyze.total_pressure, i, j)[0]
-            total_intra += c_analyze.obsstat_nonbonded_intra( & c_analyze.total_pressure_non_bonded, i, j)[0]
-            p["nonBondedIntra", i, j] = c_analyze.obsstat_nonbonded_intra( & c_analyze.total_pressure_non_bonded, i, j)[0]
-            p["nonBondedInter", i, j] = c_analyze.obsstat_nonbonded_inter( & c_analyze.total_pressure_non_bonded, i, j)[0]
-            total_inter += c_analyze.obsstat_nonbonded_inter( & c_analyze.total_pressure_non_bonded, i, j)[0]
+            p["nonBonded", i, j] = c_analyze.obsstat_nonbonded(& c_analyze.total_pressure, i, j)[0]
+            total_non_bonded = c_analyze.obsstat_nonbonded(& c_analyze.total_pressure, i, j)[0]
+            total_intra += c_analyze.obsstat_nonbonded_intra(& c_analyze.total_pressure_non_bonded, i, j)[0]
+            p["nonBondedIntra", i, j] = c_analyze.obsstat_nonbonded_intra(& c_analyze.total_pressure_non_bonded, i, j)[0]
+            p["nonBondedInter", i, j] = c_analyze.obsstat_nonbonded_inter(& c_analyze.total_pressure_non_bonded, i, j)[0]
+            total_inter += c_analyze.obsstat_nonbonded_inter(& c_analyze.total_pressure_non_bonded, i, j)[0]
     p["nonBondedIntra"] = total_intra
     p["nonBondedInter"] = total_inter
     p["nonBondedInter"] = total_inter
@@ -350,7 +356,7 @@ def stress_tensor(self, v_comp=0):
     total_bonded = np.zeros((3, 3))
     for i in range(c_analyze.n_bonded_ia):
         if (bonded_ia_params[i].type != 0):
-            p["bonded", i] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_bonded(& c_analyze.total_p_tensor, i), 9), (3, 3))
+            p["bonded", i] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_bonded( & c_analyze.total_p_tensor, i), 9), (3, 3))
             total_bonded += p["bonded", i]
     p["bonded"] = total_bonded
 
@@ -364,13 +370,13 @@ def stress_tensor(self, v_comp=0):
         for j in range(c_analyze.n_particle_types):
             #      if checkIfParticlesInteract(i, j):
 
-            p["nonBonded", i, j] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_nonbonded(& c_analyze.total_p_tensor, i, j), 9), (3, 3))
+            p["nonBonded", i, j] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_nonbonded( & c_analyze.total_p_tensor, i, j), 9), (3, 3))
             total_non_bonded += p["nonBonded", i, j]
 
-            p["nonBondedIntra", i, j] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_nonbonded_intra(& c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
+            p["nonBondedIntra", i, j] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_nonbonded_intra( & c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
             total_non_bonded_intra += p["nonBondedIntra", i, j]
 
-            p["nonBondedInter", i, j] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_nonbonded_inter(& c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
+            p["nonBondedInter", i, j] = np.reshape(create_nparray_from_double_array(c_analyze.obsstat_nonbonded_inter( & c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
             total_non_bonded_inter += p["nonBondedInter", i, j]
 
     p["nonBondedIntra"] = total_non_bonded_intra
@@ -437,7 +443,7 @@ def energy(system, etype='all', id1='default', id2='default'):
     e = {}
 
     if c_analyze.total_energy.init_status == 0:
-        c_analyze.init_energies(& c_analyze.total_energy)
+        c_analyze.init_energies( & c_analyze.total_energy)
         c_analyze.master_energy_calc()
 
     # Individual components of the pressur
@@ -459,8 +465,8 @@ def energy(system, etype='all', id1='default', id2='default'):
     total_bonded = 0
     for i in range(c_analyze.n_bonded_ia):
         if (bonded_ia_params[i].type != 0):
-            e["bonded", i] = c_analyze.obsstat_bonded( & c_analyze.total_energy, i)[0]
-            total_bonded += c_analyze.obsstat_bonded(& c_analyze.total_energy, i)[0]
+            e["bonded", i] = c_analyze.obsstat_bonded(& c_analyze.total_energy, i)[0]
+            total_bonded += c_analyze.obsstat_bonded( & c_analyze.total_energy, i)[0]
     e["bonded"] = total_bonded
 
     # Non-Bonded interactions, total as well as intra and inter molecular
@@ -475,8 +481,8 @@ def energy(system, etype='all', id1='default', id2='default'):
     for i in range(c_analyze.n_particle_types):
         for j in range(c_analyze.n_particle_types):
             #      if checkIfParticlesInteract(i, j):
-            e["nonBonded", i, j] = c_analyze.obsstat_nonbonded( & c_analyze.total_energy, i, j)[0]
-            total_non_bonded = c_analyze.obsstat_nonbonded( & c_analyze.total_energy, i, j)[0]
+            e["nonBonded", i, j] = c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
+            total_non_bonded = c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
 #        total_intra +=c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
 #        e["nonBondedIntra",i,j] =c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
 #        e["nonBondedInter",i,j] =c_analyze.obsstat_nonbonded_inter(&c_analyze.total_energy_non_bonded, i, j)[0]
@@ -509,7 +515,7 @@ def energy(system, etype='all', id1='default', id2='default'):
 def calc_re(system=None, chain_start=None, number_of_chains=None, chain_length=None):
     cdef double * re = NULL
     check_topology(system, chain_start, number_of_chains, chain_length)
-    c_analyze.calc_re(& re)
+    c_analyze.calc_re( & re)
     tuple_re = (re[0], re[1], re[2])
     free(re)
     return tuple_re
@@ -518,7 +524,7 @@ def calc_re(system=None, chain_start=None, number_of_chains=None, chain_length=N
 def calc_rg(system=None, chain_start=None, number_of_chains=None, chain_length=None):
     cdef double * rg = NULL
     check_topology(system, chain_start, number_of_chains, chain_length)
-    c_analyze.calc_rg(& rg)
+    c_analyze.calc_rg( & rg)
     tuple_rg = (rg[0], rg[1], rg[2])
     free(rg)
     return tuple_rg
@@ -527,7 +533,7 @@ def calc_rg(system=None, chain_start=None, number_of_chains=None, chain_length=N
 def calc_rh(system=None, chain_start=None, number_of_chains=None, chain_length=None):
     cdef double * rh = NULL
     check_topology(system, chain_start, number_of_chains, chain_length)
-    c_analyze.calc_rh(& rh)
+    c_analyze.calc_rh( & rh)
     tuple_rh = (rh[0], rh[1], rh[2])
     free(rh)
     return tuple_rh

--- a/src/python/espressomd/code_info.pyx
+++ b/src/python/espressomd/code_info.pyx
@@ -122,7 +122,7 @@ def features():
         f.append("DPD_MASS_LIN")
 
     IF STAT_DEBUG == 1:
-        f.append("STAT_DEBUG")        
+        f.append("STAT_DEBUG")
 
     IF OIF_LOCAL_FORCES == 1:
         f.append("OIF_LOCAL_FORCES")

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -30,13 +30,16 @@ IF ELECTROSTATICS and P3M:
 
         def validate_params(self):
             default_params = self.default_params()
-            check_type_or_throw_except(self._params["maxPWerror"], 1, float, "")
+            check_type_or_throw_except(
+                self._params["maxPWerror"], 1, float, "")
             check_range_or_except(
                 self._params["maxPWerror"], 0, False, "inf", True)
             check_type_or_throw_except(self._params["gap_size"], 1, float, "")
-            check_range_or_except(self._params["gap_size"], 0, False, "inf", True)
+            check_range_or_except(
+                self._params["gap_size"], 0, False, "inf", True)
             check_type_or_throw_except(self._params["far_cut"], 1, float, "")
-            check_type_or_throw_except(self._params["neutralize"], 1, type(True), "")
+            check_type_or_throw_except(
+                self._params["neutralize"], 1, type(True), "")
 
         def valid_keys(self):
             return "maxPWerror", "gap_size", "far_cut", "neutralize"

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -87,7 +87,7 @@ IF ELECTROSTATICS:
 
         IF CUDA:
             cdef extern from "p3m_gpu.hpp":
-                void p3m_gpu_init(int cao, int *mesh, double alpha, double *box)
+                void p3m_gpu_init(int cao, int * mesh, double alpha, double * box)
 
             cdef inline python_p3m_gpu_init(params):
                 cdef int cao

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -24,8 +24,10 @@ def integrate(nSteps, recalc_forces=False, reuse_forces=False):
 
     check_type_or_throw_except(
         nSteps, 1, int, "Integrate requires a positive integer for the number of steps")
-    check_type_or_throw_except(recalc_forces, 1, bool, "recalc_forces has to be a bool")
-    check_type_or_throw_except(reuse_forces, 1, bool, "reuse_forces has to be a bool")
+    check_type_or_throw_except(
+        recalc_forces, 1, bool, "recalc_forces has to be a bool")
+    check_type_or_throw_except(
+        reuse_forces, 1, bool, "reuse_forces has to be a bool")
 
     if (python_integrate(nSteps, recalc_forces, reuse_forces)):
         print (mpiRuntimeErrorCollectorGather())
@@ -39,10 +41,14 @@ def set_integrator_nvt():
 def set_integrator_isotropic_npt(ext_pressure=0.0, piston=0.0, xdir=0, ydir=0, zdir=0, cubic_box=False):
     check_type_or_throw_except(
         ext_pressure, 1, float, "NPT parameter ext_pressure must be a float")
-    check_type_or_throw_except(piston, 1, float, "NPT parameter piston must be a float")
-    check_type_or_throw_except(xdir, 1, int, "NPT parameter xdir must be an int")
-    check_type_or_throw_except(ydir, 1, int, "NPT parameter ydir must be an int")
-    check_type_or_throw_except(zdir, 1, int, "NPT parameter zdir must be an int")
+    check_type_or_throw_except(
+        piston, 1, float, "NPT parameter piston must be a float")
+    check_type_or_throw_except(
+        xdir, 1, int, "NPT parameter xdir must be an int")
+    check_type_or_throw_except(
+        ydir, 1, int, "NPT parameter ydir must be an int")
+    check_type_or_throw_except(
+        zdir, 1, int, "NPT parameter zdir must be an int")
     if (integrate_set_npt_isotropic(ext_pressure, piston, xdir, ydir, zdir, cubic_box)):
         print (mpiRuntimeErrorCollectorGather())
         raise Exception("Encoutered errors setting up the NPT integrator")

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -24,7 +24,6 @@ include "myconfig.pxi"
 
 cdef class NonBondedInteraction(object):
 
-
     cdef public object _part_types
     cdef object _params
 
@@ -150,7 +149,6 @@ cdef class NonBondedInteraction(object):
 
 cdef class LennardJonesInteraction(NonBondedInteraction):
 
-
     if LENNARD_JONES == 1:
         def validate_params(self):
             if self._params["epsilon"] < 0:
@@ -213,7 +211,6 @@ cdef class LennardJonesInteraction(NonBondedInteraction):
 # Generic Lennard Jones
 
 cdef class GenericLennardJonesInteraction(NonBondedInteraction):
-
 
     if LENNARD_JONES_GENERIC == 1:
         def validate_params(self):
@@ -308,7 +305,6 @@ cdef class GenericLennardJonesInteraction(NonBondedInteraction):
 
 class NonBondedInteractionHandle(object):
 
-
     """Provides access to all Non-bonded interactions between
     two particle types."""
 
@@ -329,11 +325,11 @@ class NonBondedInteractionHandle(object):
         # Here, add one line for each nonbonded ia
         self.lennard_jones = LennardJonesInteraction(_type1, _type2)
         IF LENNARD_JONES_GENERIC:
-            self.generic_lennard_jones = GenericLennardJonesInteraction(_type1, _type2)
+            self.generic_lennard_jones = GenericLennardJonesInteraction(
+                _type1, _type2)
 
 
 cdef class NonBondedInteractions:
-
 
     """Access to non-bonded interaction parameters via [i,j], where i,j are particle 
     types. Returns NonBondedInteractionHandle.
@@ -360,8 +356,8 @@ cdef class NonBondedInteractions:
 cdef class BondedInteraction(object):
 
     # This means, the instance does not yet represent a bond in the simulation
-    _bond_id=-1
-    
+    _bond_id = -1
+
     def __init__(self, *args, **kwargs):
         """Either called with an interaction id, in which case, the interaction will represent
            the bonded interaction as it is defined in Espresso core
@@ -462,22 +458,21 @@ cdef class BondedInteraction(object):
             "Subclasses of BondedInteraction must define the required_keys() method.")
 
     def __repr__(self):
-        if self._bond_id==-1:
-            id_str="inactive"
+        if self._bond_id == -1:
+            id_str = "inactive"
         else:
-           id_str=str(self._bond_id)
+            id_str = str(self._bond_id)
 
+        return self.__class__.__name__ + "(" + id_str + "): " + self._params.__str__()
 
-        return self.__class__.__name__+"("+id_str+"): "+self._params.__str__()
-
-    def __richcmp__(self,other,i):
-       if i!=2: raise Exception("only == supported")
-       if self.__class__ != other.__class__:
+    def __richcmp__(self, other, i):
+        if i != 2:
+            raise Exception("only == supported")
+        if self.__class__ != other.__class__:
             return False
-       if self._bond_id != other._bond_id:
+        if self._bond_id != other._bond_id:
             return False
-       return self._params==other._params
-
+        return self._params == other._params
 
 
 class BondedInteractionNotDefined(object):
@@ -955,6 +950,7 @@ ELSE:
 
 
 class Oif_Global_Forces(BondedInteraction):
+
     def type_number(self):
         return BONDED_IA_OIF_GLOBAL_FORCES
 
@@ -981,6 +977,7 @@ class Oif_Global_Forces(BondedInteraction):
         oif_global_forces_set_params(
             self._bond_id, self._params["A0_g"], self._params["ka_g"], self._params["V0"], self._params["kv"])
 
+
 class Oif_Local_Forces(BondedInteraction):
 
     def type_number(self):
@@ -996,7 +993,8 @@ class Oif_Local_Forces(BondedInteraction):
         return "r0", "ks", "kslin", "phi0", "kb", "A01", "A02", "kal"
 
     def set_default_params(self):
-        self._params = {"r0": 1., "ks": 0., "kslin": 0., "phi0": 0., "kb": 0., "A01": 0., "A02": 0., "kal": 0.}
+        self._params = {"r0": 1., "ks": 0., "kslin": 0.,
+                        "phi0": 0., "kb": 0., "A01": 0., "A02": 0., "kal": 0.}
 
     def _get_params_from_es_core(self):
         return \
@@ -1012,15 +1010,6 @@ class Oif_Local_Forces(BondedInteraction):
     def _set_params_in_es_core(self):
         oif_local_forces_set_params(
             self._bond_id, self._params["r0"], self._params["ks"], self._params["kslin"], self._params["phi0"], self._params["kb"], self._params["A01"], self._params["A02"], self._params["kal"])
-
-
-    
-
-
-
-
-
-
 
 
 bonded_interaction_classes = {
@@ -1092,11 +1081,9 @@ class BondedInteractions:
     # Support iteration over active bonded interactions
     def __iter__(self):
         for i in range(n_bonded_ia):
-          if bonded_ia_params[i].type != -1:
-              yield self[i]
+            if bonded_ia_params[i].type != -1:
+                yield self[i]
 
-    def add(self,bonded_ia):
-       """Add a bonded ia to the simulation>"""
-       self[n_bonded_ia]=bonded_ia
-
-
+    def add(self, bonded_ia):
+        """Add a bonded ia to the simulation>"""
+        self[n_bonded_ia] = bonded_ia

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -462,10 +462,10 @@ cdef class BondedInteraction(object):
             "Subclasses of BondedInteraction must define the required_keys() method.")
 
     def __repr__(self):
-        if self._bondId==-1:
+        if self._bond_id==-1:
             id_str="inactive"
         else:
-           id_str=str(self._bondId)
+           id_str=str(self._bond_id)
 
 
         return self.__class__.__name__+"("+id_str+"): "+self._params.__str__()
@@ -474,7 +474,7 @@ cdef class BondedInteraction(object):
        if i!=2: raise Exception("only == supported")
        if self.__class__ != other.__class__:
             return False
-       if self._bondId != other._bondId:
+       if self._bond_id != other._bond_id:
             return False
        return self._params==other._params
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -1010,7 +1010,7 @@ bonded_interaction_classes = {
     int(BONDED_IA_RIGID_BOND): RigidBond,
     int(BONDED_IA_DIHEDRAL): Dihedral,
     int(BONDED_IA_TABULATED): Tabulated,
-    int(BONDED_IA_SUBT_LJ):	Subt_Lj,
+    int(BONDED_IA_SUBT_LJ):        Subt_Lj,
     int(BONDED_IA_VIRTUAL_BOND): Virtual,
     int(BONDED_IA_ENDANGLEDIST): Endangledist,
     int(BONDED_IA_OVERLAPPED): Overlapped,
@@ -1068,3 +1068,15 @@ class BondedInteractions:
 
         # Set the parameters of the BondedInteraction instance in the Es core
         value._set_params_in_es_core()
+
+    # Support iteration over active bonded interactions
+    def __iter__(self):
+        for i in range(n_bonded_ia):
+          if bonded_ia_params[i].type != -1:
+              yield self[i]
+
+    def add(self,bonded_ia):
+       """Add a bonded ia to the simulation>"""
+       self[n_bonded_ia]=bonded_ia
+
+

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -470,6 +470,15 @@ cdef class BondedInteraction(object):
 
         return self.__class__.__name__+"("+id_str+"): "+self._params.__str__()
 
+    def __richcmp__(self,other,i):
+       if i!=2: raise Exception("only == supported")
+       if self.__class__ != other.__class__:
+            return False
+       if self._bondId != other._bondId:
+            return False
+       return self._params==other._params
+
+
 
 class BondedInteractionNotDefined(object):
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -359,7 +359,9 @@ cdef class NonBondedInteractions:
 
 cdef class BondedInteraction(object):
 
-
+    # This means, the instance does not yet represent a bond in the simulation
+    _bond_id=-1
+    
     def __init__(self, *args, **kwargs):
         """Either called with an interaction id, in which case, the interaction will represent
            the bonded interaction as it is defined in Espresso core
@@ -458,6 +460,15 @@ cdef class BondedInteraction(object):
     def required_keys(self):
         raise Exception(
             "Subclasses of BondedInteraction must define the required_keys() method.")
+
+    def __repr__(self):
+        if self._bondId==-1:
+            id_str="inactive"
+        else:
+           id_str=str(self._bondId)
+
+
+        return self.__class__.__name__+"("+id_str+"): "+self._params.__str__()
 
 
 class BondedInteractionNotDefined(object):

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -43,7 +43,6 @@ cdef class HydrodynamicInteraction(Actor):
 IF LB_GPU or LB:
     cdef class LB_FLUID(HydrodynamicInteraction):
 
-
         ####################################################
         #
         # validate the given parameters on actor initalization

--- a/src/python/espressomd/magnetostatic_extensions.pyx
+++ b/src/python/espressomd/magnetostatic_extensions.pyx
@@ -24,19 +24,19 @@ from actors import Actor
 IF DIPOLES == 1:
     class MagnetostaticExtension(Actor):
 
-
         pass
 
     class DLC(MagnetostaticExtension):
 
-
         def validate_params(self):
             default_params = self.default_params()
-            check_type_or_throw_except(self._params["maxPWerror"], 1, float, "")
+            check_type_or_throw_except(
+                self._params["maxPWerror"], 1, float, "")
             check_range_or_except(
                 self._params["maxPWerror"], 0, False, "inf", True)
             check_type_or_throw_except(self._params["gap_size"], 1, float, "")
-            check_range_or_except(self._params["gap_size"], 0, False, "inf", True)
+            check_range_or_except(
+                self._params["gap_size"], 0, False, "inf", True)
             check_type_or_throw_except(self._params["far_cut"], 1, float, "")
 
         def valid_keys(self):

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -24,7 +24,6 @@ from globals cimport temperature
 IF DIPOLES == 1:
     cdef class MagnetostaticInteraction(Actor):
 
-
         def validate_params(self):
             if not (("bjerrum_length" in self._params) ^ ("prefactor" in self._params)):
                 raise ValueError(
@@ -169,7 +168,7 @@ IF DP3M == 1:
         def python_dp3m_adaptive_tune(self):
             cdef char * log = NULL
             cdef int response
-            response = dp3m_adaptive_tune(& log)
+            response = dp3m_adaptive_tune( & log)
             return response, log
 
         def python_dp3m_set_params(self, p_r_cut, p_mesh, p_cao, p_alpha, p_accuracy):

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -207,7 +207,6 @@ cdef extern from "interaction_data.hpp":
 
 cdef class ParticleHandle(object):
 
-
     cdef public int id
     cdef bint valid
     cdef particle particle_data

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -139,7 +139,7 @@ cdef class ParticleHandle:
 
             # And add the new ones
             for bond in bonds:
-                self.add_verified_bond(bond)
+                self.add_bond(bond)
 
         def __get__(self):
             self.update_particle_data()
@@ -687,7 +687,7 @@ cdef class ParticleHandle:
         bond_info[0] = bond[0]._bond_id
         for i in range(1,len(bond)):
             bond_info[i]=bond[i]
-        if change_particle_bond(self.id, bond_nfo, 1):
+        if change_particle_bond(self.id, bond_info, 1):
             raise Exception("Deleting the bond failed.")
 
     def check_bond_or_throw_exception(self, bond):
@@ -715,12 +715,12 @@ cdef class ParticleHandle:
         
         # Validity of the numeric id
         if bond[0]._bond_id >= n_bonded_ia:
-            raise ValueError("The bond type", bond._bondId, "does not exist.")
+            raise ValueError("The bond type", bond._bond_id, "does not exist.")
         
         # Number of partners
         if bonded_ia_params[bond[0]._bond_id].num != len(bond)-1:
-            raise ValueError("Bond of type", bond._bondId, "needs", bonded_ia_params[
-                             bond[0]._bondId], "partners.")
+            raise ValueError("Bond of type", bond._bond_id, "needs", bonded_ia_params[
+                             bond[0]._bond_id], "partners.")
         
         # Type check on partners
         for y in bond[1:]:

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -728,10 +728,6 @@ cdef class ParticleHandle:
         if change_particle_bond(self.id, NULL, 1):
             raise Exception("Deleting all bonds failed.")
 
-    def delete_all_bonds(self):
-        if change_particle_bond(self.id, NULL, 1):
-            raise Exception("Deleting all bonds failed.")
-
 cdef class ParticleList:
     """Provides access to the particles via [i], where i is the particle id. Returns a ParticleHandle object """
 

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -38,12 +38,12 @@ PARTICLE_EXT_TORQUE = 16
 cdef class ParticleHandle:
     def __cinit__(self, _id):
         #    utils.init_intlist(self.particle_data.el)
-        utils.init_intlist( & (self.particle_data.bl))
+        utils.init_intlist(& (self.particle_data.bl))
         self.id = _id
 
     cdef int update_particle_data(self) except -1:
         #    utils.realloc_intlist(self.particle_data.el, 0)
-        utils.realloc_intlist( & (self.particle_data.bl), 0)
+        utils.realloc_intlist(& (self.particle_data.bl), 0)
 
         if get_particle_data(self.id, & self.particle_data):
             raise Exception("Error updating particle data")
@@ -73,7 +73,8 @@ cdef class ParticleHandle:
 
         def __set__(self, _pos):
             cdef double mypos[3]
-            check_type_or_throw_except(_pos, 3, float, "Postion must be 3 floats")
+            check_type_or_throw_except(
+                _pos, 3, float, "Postion must be 3 floats")
             for i in range(3):
                 mypos[i] = _pos[i]
             if place_particle(self.id, mypos) == -1:
@@ -91,7 +92,8 @@ cdef class ParticleHandle:
 
         def __set__(self, _v):
             cdef double myv[3]
-            check_type_or_throw_except(_v, 3, float, "Velocity has to be floats")
+            check_type_or_throw_except(
+                _v, 3, float, "Velocity has to be floats")
             for i in range(3):
                 myv[i] = _v[i]
             if set_particle_v(self.id, myv) == 1:
@@ -130,7 +132,7 @@ cdef class ParticleHandle:
             if not hasattr(_bonds, "__getitem__"):
                 raise ValueError(
                     "bonds have to specified as a tuple of tuples. (Lists can also be used)")
-            bonds=list(_bonds) # as we modify it
+            bonds = list(_bonds)  # as we modify it
 
             # Assigning to the bond property means replacing the existing value
             # i.e., we delete all existing bonds
@@ -171,14 +173,15 @@ cdef class ParticleHandle:
             """Particle mass"""
 
             def __set__(self, _mass):
-                check_type_or_throw_except(_mass, 1, float, "Mass has to be 1 floats")
+                check_type_or_throw_except(
+                    _mass, 1, float, "Mass has to be 1 floats")
                 if set_particle_mass(self.id, _mass) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
                 self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_mass( & (self.particle_data), x)
+                pointer_to_mass(& (self.particle_data), x)
                 return x[0]
 
     IF ROTATION == 1:
@@ -188,7 +191,8 @@ cdef class ParticleHandle:
 
             def __set__(self, _o):
                 cdef double myo[3]
-                check_type_or_throw_except(_o, 3, float, "Omega_lab has to be 3 floats")
+                check_type_or_throw_except(
+                    _o, 3, float, "Omega_lab has to be 3 floats")
                 for i in range(3):
                     myo[i] = _o[i]
                 if set_particle_omega_lab(self.id, myo) == 1:
@@ -197,7 +201,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double o[3]
-                convert_omega_body_to_space(& (self.particle_data), o)
+                convert_omega_body_to_space( & (self.particle_data), o)
                 return np.array([o[0], o[1], o[2]])
 
     # ROTATIONAL_INERTIA
@@ -217,7 +221,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double * rinertia = NULL
-                pointer_to_rotational_inertia( & (self.particle_data), rinertia)
+                pointer_to_rotational_inertia(& (self.particle_data), rinertia)
                 return np.array([rinertia[0], rinertia[1], rinertia[2]])
 
 # Omega (angular velocity) body frame
@@ -236,7 +240,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double * o = NULL
-                pointer_to_omega_body( & (self.particle_data), o)
+                pointer_to_omega_body(& (self.particle_data), o)
                 return np.array([o[0], o[1], o[2]])
 
 
@@ -246,7 +250,8 @@ cdef class ParticleHandle:
 
             def __set__(self, _t):
                 cdef double myt[3]
-                check_type_or_throw_except(_t, 3, float, "Torque has to be 3 floats")
+                check_type_or_throw_except(
+                    _t, 3, float, "Torque has to be 3 floats")
                 for i in range(3):
                     myt[i] = _t[i]
                 if set_particle_torque_lab(self.id, myt) == 1:
@@ -255,7 +260,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double x[3]
-                convert_torques_body_to_space(& (self.particle_data), x)
+                convert_torques_body_to_space( & (self.particle_data), x)
                 return np.array([x[0], x[1], x[2]])
 
 # Quaternion
@@ -274,7 +279,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_quat(& (self.particle_data), x)
+                pointer_to_quat( & (self.particle_data), x)
                 return np.array([x[0], x[1], x[2], x[3]])
 # Director ( z-axis in body fixed frame)
         property director:
@@ -293,7 +298,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_quatu(& (self.particle_data), x)
+                pointer_to_quatu( & (self.particle_data), x)
                 return np.array([x[0], x[1], x[2]])
 
 # Charge
@@ -303,7 +308,8 @@ cdef class ParticleHandle:
 
             def __set__(self, _q):
                 cdef double myq
-                check_type_or_throw_except(_q, 1, float, "Charge has to be floats")
+                check_type_or_throw_except(
+                    _q, 1, float, "Charge has to be floats")
                 myq = _q
                 if set_particle_q(self.id, myq) == 1:
                     raise Exception("set particle position first")
@@ -311,7 +317,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_q(& (self.particle_data), x)
+                pointer_to_q( & (self.particle_data), x)
                 return x[0]
 
     def delete(self):
@@ -336,7 +342,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef int * x = NULL
-                pointer_to_virtual(& (self.particle_data), x)
+                pointer_to_virtual( & (self.particle_data), x)
                 return x[0]
 
     IF VIRTUAL_SITES_RELATIVE == 1:
@@ -367,7 +373,7 @@ cdef class ParticleHandle:
                 cdef int * rel_to = NULL
                 cdef double * dist = NULL
                 cdef double * q = NULL
-                pointer_to_vs_relative( & (self.particle_data), rel_to, dist, q)
+                pointer_to_vs_relative(& (self.particle_data), rel_to, dist, q)
                 return (rel_to[0], dist[0], np.array((q[0], q[1], q[2], q[3])))
 
         # vs_auto_relate_to
@@ -407,7 +413,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_dip(& (self.particle_data), x)
+                pointer_to_dip( & (self.particle_data), x)
                 return np.array([x[0], x[1], x[2]])
 
         # Scalar magnitude of dipole moment
@@ -423,7 +429,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef double * x = NULL
-                pointer_to_dipm(& (self.particle_data), x)
+                pointer_to_dipm( & (self.particle_data), x)
                 return x[0]
 
     IF EXTERNAL_FORCES:
@@ -448,7 +454,7 @@ cdef class ParticleHandle:
                 self.update_particle_data()
                 cdef double * ext_f = NULL
                 cdef int * ext_flag = NULL
-                pointer_to_ext_force( & (self.particle_data), ext_flag, ext_f)
+                pointer_to_ext_force(& (self.particle_data), ext_flag, ext_f)
                 if (ext_flag[0] & PARTICLE_EXT_FORCE):
                     return np.array([ext_f[0], ext_f[1], ext_f[2]])
                 else:
@@ -471,7 +477,7 @@ cdef class ParticleHandle:
                 self.update_particle_data()
                 fixed_coord_flag = np.array([0, 0, 0], dtype=int)
                 cdef int * ext_flag = NULL
-                pointer_to_fix(& (self.particle_data), ext_flag)
+                pointer_to_fix( & (self.particle_data), ext_flag)
                 for i in map(long, range(3)):
                     if (ext_flag[0] & COORD_FIXED(i)):
                         fixed_coord_flag[i] = 1
@@ -499,7 +505,7 @@ cdef class ParticleHandle:
                     self.update_particle_data()
                     cdef double * ext_t = NULL
                     cdef int * ext_flag = NULL
-                    pointer_to_ext_torque( & (self.particle_data), ext_flag, ext_t)
+                    pointer_to_ext_torque(& (self.particle_data), ext_flag, ext_t)
                     if (ext_flag[0] & PARTICLE_EXT_TORQUE):
                         return np.array([ext_t[0], ext_t[1], ext_t[2]])
                     else:
@@ -510,28 +516,30 @@ cdef class ParticleHandle:
             """Friction coefficient per particle in Langevin"""
 
             def __set__(self, _gamma):
-                check_type_or_throw_except(_gamma, 1, float, "gamma has to be a float")
+                check_type_or_throw_except(
+                    _gamma, 1, float, "gamma has to be a float")
                 if set_particle_gamma(self.id, _gamma) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
                 self.update_particle_data()
                 cdef double * gamma = NULL
-                pointer_to_gamma(& (self.particle_data), gamma)
+                pointer_to_gamma( & (self.particle_data), gamma)
                 return gamma[0]
 
         property temp:
             """Temperature per particle in Langevin"""
 
             def __set__(self, _temp):
-                check_type_or_throw_except(_temp, 1, float, "temp has to be a float")
+                check_type_or_throw_except(
+                    _temp, 1, float, "temp has to be a float")
                 if set_particle_temperature(self.id, _temp) == 1:
                     raise Exception("set particle position first")
 
             def __get__(self):
                 self.update_particle_data()
                 cdef double * temp = NULL
-                pointer_to_temperature(& (self.particle_data), temp)
+                pointer_to_temperature( & (self.particle_data), temp)
                 return temp[0]
 
     IF ROTATION_PER_PARTICLE:
@@ -550,7 +558,7 @@ cdef class ParticleHandle:
             def __get__(self):
                 self.update_particle_data()
                 cdef short int * _rot = NULL
-                pointer_to_rotation(& (self.particle_data), _rot)
+                pointer_to_rotation( & (self.particle_data), _rot)
                 if _rot[0] == 1:
                     rot = True
                 else:
@@ -577,7 +585,7 @@ cdef class ParticleHandle:
                 cdef int * num_partners = NULL
                 cdef int * partners = NULL
                 py_partners = []
-                pointer_to_exclusions( & (self.particle_data), num_partners, partners)
+                pointer_to_exclusions(& (self.particle_data), num_partners, partners)
                 for i in range(num_partners[0]):
                     py_partners.append(partners[i])
                 return np.array(py_partners)
@@ -644,7 +652,7 @@ cdef class ParticleHandle:
                 swim = {}
                 mode = "N/A"
                 cdef particle_parameters_swimming * _swim = NULL
-                pointer_to_swimming( & (self.particle_data), _swim)
+                pointer_to_swimming(& (self.particle_data), _swim)
                 IF LB or LB_GPU:
                     if _swim.push_pull == -1:
                         mode = 'pusher'
@@ -677,16 +685,16 @@ cdef class ParticleHandle:
         # be changed
         cdef int bond_info[5]
         bond_info[0] = bond[0]._bond_id
-        for i in range(1,len(bond)):
-            bond_info[i]=bond[i]
+        for i in range(1, len(bond)):
+            bond_info[i] = bond[i]
         if change_particle_bond(self.id, bond_info, 0):
             raise Exception("Adding the bond failed.")
 
     def delete_verified_bond(self, bond):
         cdef int bond_info[5]
         bond_info[0] = bond[0]._bond_id
-        for i in range(1,len(bond)):
-            bond_info[i]=bond[i]
+        for i in range(1, len(bond)):
+            bond_info[i] = bond[i]
         if change_particle_bond(self.id, bond_info, 1):
             raise Exception("Deleting the bond failed.")
 
@@ -699,44 +707,42 @@ cdef class ParticleHandle:
         * If the number of bond partners fits the bond type
         Throw an exception if any of these are not met"""
 
-
         # Has it []-access
         if not hasattr(bond, "__getitem__"):
-            raise ValueError("Bond needs to be a tuple or list containing bond type and partners")
+            raise ValueError(
+                "Bond needs to be a tuple or list containing bond type and partners")
 
-        
         # Bond type or numerical bond id
         if not isinstance(bond[0], BondedInteraction):
-            if isinstance(bond[0],int):
-                bond[0]=BondedInteractions()[bond[0]]
+            if isinstance(bond[0], int):
+                bond[0] = BondedInteractions()[bond[0]]
             else:
                 raise Exception(
                     "1st element of Bond has to be of type BondedInteraction or int.")
-        
+
         # Validity of the numeric id
         if bond[0]._bond_id >= n_bonded_ia:
             raise ValueError("The bond type", bond._bond_id, "does not exist.")
-        
+
         # Number of partners
-        if bonded_ia_params[bond[0]._bond_id].num != len(bond)-1:
+        if bonded_ia_params[bond[0]._bond_id].num != len(bond) - 1:
             raise ValueError("Bond of type", bond._bond_id, "needs", bonded_ia_params[
                              bond[0]._bond_id], "partners.")
-        
+
         # Type check on partners
         for y in bond[1:]:
             if not isinstance(y, int):
                 raise ValueError("Partners have to be integer.")
 
-    
     def add_bond(self, _bond):
         """Add a single bond to the particle"""
-        bond=list(_bond) # As we will modify it
+        bond = list(_bond)  # As we will modify it
         self.check_bond_or_throw_exception(bond)
         self.add_verified_bond(bond)
 
     def delete_bond(self, _bond):
         """Delete a single bond from the particle"""
-        bond=list(_bond) # as we modify it
+        bond = list(_bond)  # as we modify it
         self.check_bond_or_throw_exception(bond)
         self.delete_verified_bond(bond)
 

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -130,9 +130,7 @@ cdef class ParticleHandle:
             if not hasattr(_bonds, "__getitem__"):
                 raise ValueError(
                     "bonds have to specified as a tuple of tuples. (Lists can also be used)")
-            # Check individual bonds
-            for bond in _bonds:
-                self.check_bond_or_throw_exception(bond)
+            bonds=list(_bonds) # as we modify it
 
             # Assigning to the bond property means replacing the existing value
             # i.e., we delete all existing bonds
@@ -140,7 +138,7 @@ cdef class ParticleHandle:
                 raise Exception("Deleting existing bonds failed.")
 
             # And add the new ones
-            for bond in _bonds:
+            for bond in bonds:
                 self.add_verified_bond(bond)
 
         def __get__(self):

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -20,7 +20,6 @@ cimport thermostat
 
 cdef class Thermostat:
 
-
     def __init__(self):
         pass
 

--- a/testsuite/python/cellsystem.py
+++ b/testsuite/python/cellsystem.py
@@ -1,22 +1,22 @@
 
 #
 # Copyright (C) 2013,2014 The ESPResSo project
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-#  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Tests particle property setters/getters
 import unittest as ut
 import espressomd
@@ -24,24 +24,23 @@ import numpy as np
 from espressomd.interactions import FeneBond
 
 
-
 class CellSystem(ut.TestCase):
-  S=espressomd.System()
-  
-  def test_cellSystem(self):
-     self.S.cellSystem.setNsquare(useVerletLists=False)
-     s=self.S.cellSystem.getState()
-     self.assertEqual(s,{"useVerletLists":0,"type":"nsquare"})
-     self.S.cellSystem.setLayered(nLayers=5)
-     s=self.S.cellSystem.getState()
-     self.assertEqual(s,{"type":"layered","nLayers":5})
-     
-     self.S.cellSystem.setDomainDecomposition(useVerletLists=True)
-     s=self.S.cellSystem.getState()
-     self.assertEqual(s,{"useVerletLists":1,"type":"domainDecomposition"})
-     
+    S = espressomd.System()
+
+    def test_cellSystem(self):
+        self.S.cellSystem.setNsquare(useVerletLists=False)
+        s = self.S.cellSystem.getState()
+        self.assertEqual(s, {"useVerletLists": 0, "type": "nsquare"})
+        self.S.cellSystem.setLayered(nLayers=5)
+        s = self.S.cellSystem.getState()
+        self.assertEqual(s, {"type": "layered", "nLayers": 5})
+
+        self.S.cellSystem.setDomainDecomposition(useVerletLists=True)
+        s = self.S.cellSystem.getState()
+        self.assertEqual(
+            s, {"useVerletLists": 1, "type": "domainDecomposition"})
 
 
 if __name__ == "__main__":
- print("Features: ",espressomd.features())
- ut.main()
+    print("Features: ", espressomd.features())
+    ut.main()

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -1,109 +1,107 @@
 #
 # Copyright (C) 2013,2014 The ESPResSo project
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-#  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Tests particle property setters/getters
 import unittest as ut
 import espressomd
 import numpy as np
-from espressomd.electrostatics import P3M,DH
+from espressomd.electrostatics import P3M, DH
 
 
 class ElectrostaticInteractionsTests(ut.TestCase):
     # Handle to espresso system
-    system=espressomd.System()
+    system = espressomd.System()
 
-    def paramsMatch(self,inParams,outParams):
+    def paramsMatch(self, inParams, outParams):
         """Check, if the parameters set and gotten back match.
         Only check keys present in inParams.
         """
 
         for k in inParams.keys():
             if k not in outParams:
-                print(k,"missing from returned parameters")
+                print(k, "missing from returned parameters")
                 return False
-            if outParams[k]!=inParams[k]:
-                print("Mismatch in parameter ",k,inParams[k],outParams[k])
+            if outParams[k] != inParams[k]:
+                print("Mismatch in parameter ", k, inParams[k], outParams[k])
                 return False
-    
+
         return True
 
-
     def setUp(self):
-        self.system.box_l = 10,10,10
-        self.system.part[0].pos =0,0,0
-        self.system.part[1].pos =0.1,0.1,0.1
-        self.system.part[0].q =1
-        self.system.part[1].q =-1
-      
+        self.system.box_l = 10, 10, 10
+        self.system.part[0].pos = 0, 0, 0
+        self.system.part[1].pos = 0.1, 0.1, 0.1
+        self.system.part[0].q = 1
+        self.system.part[1].q = -1
 
-    def generateTestForElectrostaticInteraction(_interClass,_params):
+    def generateTestForElectrostaticInteraction(_interClass, _params):
         """Generates test cases for checking interaction parameters set and gotten back
         from Es actually match. Only keys which are present  in _params are checked
         1st: Interaction parameters as dictionary, i.e., {"k"=1.,"r_0"=0.
         2nd: Name of the interaction property to set (i.e. "P3M")
         """
-        params=_params
-        interClass=_interClass
-
+        params = _params
+        interClass = _interClass
 
         def func(self):
             # This code is run at the execution of the generated function.
-            # It will use the state of the variables in the outer function, 
+            # It will use the state of the variables in the outer function,
             # which was there, when the outer function was called
-            
+
             # set Parameter
-            Inter=interClass(**params)
+            Inter = interClass(**params)
             Inter.validateParams()
             Inter._setParamsInEsCore()
-            
+
             # Read them out again
-            outParams=Inter.getParams()
-      
-      
-            self.assertTrue(self.paramsMatch(params,outParams), "Missmatch of parameters.\nParameters set "+params.__str__()+" vs. output parameters "+outParams.__str__())
+            outParams = Inter.getParams()
+
+            self.assertTrue(self.paramsMatch(params, outParams), "Missmatch of parameters.\nParameters set " +
+                            params.__str__() + " vs. output parameters " + outParams.__str__())
 
         return func
 
-    test_P3M=generateTestForElectrostaticInteraction(P3M,dict(bjerrum_length = 1.0,\
-                                                              epsilon = 0.0,\
-                                                              inter = 1000,\
-                                                              mesh_off = [0.5,0.5,0.5],\
-                                                              r_cut = 2.4,\
-                                                              mesh = [2,2,2],\
-                                                              cao = 1,\
-                                                              alpha = 12,\
-                                                              accuracy = 0.01))
+    test_P3M = generateTestForElectrostaticInteraction(P3M, dict(bjerrum_length=1.0,
+                                                                 epsilon=0.0,
+                                                                 inter=1000,
+                                                                 mesh_off=[
+                                                                     0.5, 0.5, 0.5],
+                                                                 r_cut=2.4,
+                                                                 mesh=[
+                                                                     2, 2, 2],
+                                                                 cao=1,
+                                                                 alpha=12,
+                                                                 accuracy=0.01))
 
     # test_P3M_GPU=
-     test_DH=generateTestForElectrostaticInteraction(DH,dict(bjerrum_length = 1.0,\
-                                                                kappa = 2.3,\
-                                                                r_cut=2))
-     test_CDH=generateTestForElectrostaticInteraction(CDH,dict(bjerrum_length = 1.0,\
-                                                                kappa = 2.3,\
-                                                                r_cut=2,\
-                                                                r0=1,\
-                                                                r1=2,\
-                                                                eps_int=0.8,\
-                                                                eps_ext=1,
-                                                                alpha=2))
+        test_DH = generateTestForElectrostaticInteraction(DH, dict(bjerrum_length=1.0,
+                                                                   kappa=2.3,
+                                                                   r_cut=2))
+        test_CDH = generateTestForElectrostaticInteraction(CDH, dict(bjerrum_length=1.0,
+                                                                     kappa=2.3,
+                                                                     r_cut=2,
+                                                                     r0=1,
+                                                                     r1=2,
+                                                                     eps_int=0.8,
+                                                                     eps_ext=1,
+                                                                     alpha=2))
 
 
 if __name__ == "__main__":
-    print("Features: ",espressomd.features())
+    print("Features: ", espressomd.features())
     ut.main()
-

--- a/testsuite/python/ewald_gpu.py
+++ b/testsuite/python/ewald_gpu.py
@@ -1,53 +1,55 @@
 #
 # Copyright (C) 2013,2014 The ESPResSo project
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-#  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Tests particle property setters/getters
 import espressomd
 import unittest as ut
 import numpy as np
 from espressomd.electrostatics import EwaldGpu
 
+
 class ewald_GPU_test(ut.TestCase):
-    es=espressomd.System()
-    test_params={}
-    test_params["bjerrum_length"]=2
-    test_params["num_kx"]=2
-    test_params["num_ky"]=2
-    test_params["num_kz"]=2
-    test_params["K_max"]=10
-    test_params["time_calc_steps"]=100
-    test_params["rcut"]=0.9
-    test_params["accuracy"]=1e-1
-    test_params["precision"]=1e-2
-    test_params["alpha"]=3.5
+    es = espressomd.System()
+    test_params = {}
+    test_params["bjerrum_length"] = 2
+    test_params["num_kx"] = 2
+    test_params["num_ky"] = 2
+    test_params["num_kz"] = 2
+    test_params["K_max"] = 10
+    test_params["time_calc_steps"] = 100
+    test_params["rcut"] = 0.9
+    test_params["accuracy"] = 1e-1
+    test_params["precision"] = 1e-2
+    test_params["alpha"] = 3.5
 
     def runTest(self):
-        ewald=EwaldGpu(bjerrum_length=self.test_params["bjerrum_length"], num_kx=self.test_params["num_kx"], num_ky=self.test_params["num_ky"], num_kz=self.test_params["num_kz"], rcut=self.test_params["rcut"], accuracy=self.test_params["accuracy"], precision=self.test_params["precision"], alpha=self.test_params["alpha"], time_calc_steps=self.test_params["time_calc_steps"], K_max=self.test_params["K_max"])
+        ewald = EwaldGpu(bjerrum_length=self.test_params["bjerrum_length"], num_kx=self.test_params["num_kx"], num_ky=self.test_params["num_ky"], num_kz=self.test_params["num_kz"], rcut=self.test_params[
+                         "rcut"], accuracy=self.test_params["accuracy"], precision=self.test_params["precision"], alpha=self.test_params["alpha"], time_calc_steps=self.test_params["time_calc_steps"], K_max=self.test_params["K_max"])
         self.es.actors.add(ewald)
-        set_params=ewald._getParamsFromEsCore()
-        SAME=True
+        set_params = ewald._getParamsFromEsCore()
+        SAME = True
         for i in self.test_params.keys():
             if set_params[i] != self.test_params[i]:
                 print "Parameter mismatch: ", i, set_params[i], self.test_params[i]
-                SAME=False
+                SAME = False
                 break
         return SAME
 
 if __name__ == "__main__":
- print("Features: ",espressomd.features())
- ut.main()
+    print("Features: ", espressomd.features())
+    ut.main()

--- a/testsuite/python/magnetostaticInteractions.py
+++ b/testsuite/python/magnetostaticInteractions.py
@@ -1,21 +1,21 @@
 #
 # Copyright (C) 2013,2014 The ESPResSo project
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-#  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Tests particle property setters/getters
 import unittest as ut
 import espressomd
@@ -25,82 +25,81 @@ from espressomd.magnetostatics import *
 
 class MagnetostaticsInteractionsTests(ut.TestCase):
     # Handle to espresso system
-    system=espressomd.System()
+    system = espressomd.System()
 
-    def paramsMatch(self,inParams,outParams):
+    def paramsMatch(self, inParams, outParams):
         """Check, if the parameters set and gotten back match.
         Only check keys present in inParams.
         """
 
         # Delete the bjerrum_length from outparams, because
-	# it is calculated from the prefactor in some cases
-	# and therefore not necessarily in inparams.
-	if "bjerrum_length" in outParams:
-	    del outParams["bjerrum"]
+        # it is calculated from the prefactor in some cases
+        # and therefore not necessarily in inparams.
+        if "bjerrum_length" in outParams:
+            del outParams["bjerrum"]
 
-	for k in inParams.keys():
+        for k in inParams.keys():
             if k not in outParams:
-                print(k,"missing from returned parameters")
+                print(k, "missing from returned parameters")
                 return False
-            if outParams[k]!=inParams[k]:
-                print("Mismatch in parameter ",k,inParams[k],outParams[k])
+            if outParams[k] != inParams[k]:
+                print("Mismatch in parameter ", k, inParams[k], outParams[k])
                 return False
-    
+
         return True
 
-
     def setUp(self):
-        self.system.box_l = 10,10,10
-        self.system.part[0].pos =0,0,0
-        self.system.part[1].pos =0.1,0.1,0.1
-        self.system.part[0].dip =1.3,2.1,-6
-        self.system.part[1].dip =4.3,4.1,7.5
-      
+        self.system.box_l = 10, 10, 10
+        self.system.part[0].pos = 0, 0, 0
+        self.system.part[1].pos = 0.1, 0.1, 0.1
+        self.system.part[0].dip = 1.3, 2.1, -6
+        self.system.part[1].dip = 4.3, 4.1, 7.5
 
-    def generateTestForMagnetostaticInteraction(_interClass,_params):
+    def generateTestForMagnetostaticInteraction(_interClass, _params):
         """Generates test cases for checking interaction parameters set and gotten back
         from Es actually match. Only keys which are present  in _params are checked
         1st: Interaction parameters as dictionary, i.e., {"k"=1.,"r_0"=0.
         2nd: Name of the interaction property to set (i.e. "P3M")
         """
-        params=_params
-        interClass=_interClass
-
+        params = _params
+        interClass = _interClass
 
         def func(self):
             # This code is run at the execution of the generated function.
-            # It will use the state of the variables in the outer function, 
+            # It will use the state of the variables in the outer function,
             # which was there, when the outer function was called
-            
+
             # set Parameter
-            Inter=interClass(**params)
+            Inter = interClass(**params)
             Inter.validateParams()
             Inter._setParamsInEsCore()
-            
+
             # Read them out again
-            outParams=Inter.getParams()
-      
-      
-            self.assertTrue(self.paramsMatch(params,outParams), "Missmatch of parameters.\nParameters set "+params.__str__()+" vs. output parameters "+outParams.__str__())
+            outParams = Inter.getParams()
+
+            self.assertTrue(self.paramsMatch(params, outParams), "Missmatch of parameters.\nParameters set " +
+                            params.__str__() + " vs. output parameters " + outParams.__str__())
 
         return func
 
-    test_DP3M=generateTestForMagnetostaticInteraction(DipolarP3M,dict(prefactor = 1.0,\
-                                                              epsilon = 0.0,\
-                                                              inter = 1000,\
-                                                              mesh_off = [0.5,0.5,0.5],\
-                                                              r_cut = 2.4,\
-                                                              mesh = [8,8,8],\
-                                                              cao = 1,\
-                                                              alpha = 12,\
-                                                              accuracy = 0.01))
+    test_DP3M = generateTestForMagnetostaticInteraction(DipolarP3M, dict(prefactor=1.0,
+                                                                         epsilon=0.0,
+                                                                         inter=1000,
+                                                                         mesh_off=[
+                                                                             0.5, 0.5, 0.5],
+                                                                         r_cut=2.4,
+                                                                         mesh=[
+                                                                             8, 8, 8],
+                                                                         cao=1,
+                                                                         alpha=12,
+                                                                         accuracy=0.01))
 
-
-    test_DdsCpu=generateTestForMagnetostaticInteraction(DipolarDirectSumCpu,dict(prefactor = 3.4))
-    test_DdsRCpu=generateTestForMagnetostaticInteraction(DipolarDirectSumWithReplicaCpu,dict(prefactor = 3.4,n_replica=2))
+    test_DdsCpu = generateTestForMagnetostaticInteraction(
+        DipolarDirectSumCpu, dict(prefactor=3.4))
+    test_DdsRCpu = generateTestForMagnetostaticInteraction(
+        DipolarDirectSumWithReplicaCpu, dict(prefactor=3.4, n_replica=2))
 
 
 if __name__ == "__main__":
-    print("Features: ",espressomd.features())
+    print("Features: ", espressomd.features())
     ut.main()
-

--- a/testsuite/python/nonBondedInteractions.py
+++ b/testsuite/python/nonBondedInteractions.py
@@ -1,21 +1,21 @@
 #
 # Copyright (C) 2013,2014 The ESPResSo project
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-#  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Tests particle property setters/getters
 import unittest as ut
 import espressomd
@@ -24,101 +24,101 @@ from espressomd.interactions import LennardJonesInteraction
 
 
 class NonBondedInteractionsTests(ut.TestCase):
-#  def __init__(self,particleId):
-#    self.pid=particleId
-  
+    #  def __init__(self,particleId):
+    #    self.pid=particleId
 
+    # Handle to espresso system
+    es = espressomd.System()
 
-  # Handle to espresso system
-  es=espressomd.System()
+    def intersMatch(self, inType, outType, inParams, outParams):
+        """Check, if the interaction type set and gotten back as well as the bond 
+        parameters set and gotten back match. Only check keys present in
+        inParams.
+        """
+        if inType != outType:
+            print("Type mismatch:", inType, outType)
+            return False
 
-  def intersMatch(self,inType,outType,inParams,outParams):
-    """Check, if the interaction type set and gotten back as well as the bond 
-    parameters set and gotten back match. Only check keys present in
-    inParams.
-    """
-    if inType!=outType:
-      print("Type mismatch:",inType,outType)
-      return False
+        for k in inParams.keys():
+            if k not in outParams:
+                print(k, "missing from returned parameters")
+                return False
+            if outParams[k] != inParams[k]:
+                print("Mismatch in parameter ", k, inParams[k], outParams[k])
+                return False
 
-    for k in inParams.keys():
-      if k not in outParams:
-        print(k,"missing from returned parameters")
-        return False
-      if outParams[k]!=inParams[k]:
-        print("Mismatch in parameter ",k,inParams[k],outParams[k])
-	return False
-    
-    return True
+        return True
 
+    def generateTestForNonBondedInteraction(_partType1, _partType2, _interClass, _params, _interName):
+        """Generates test cases for checking interaction parameters set and gotten back
+        from Es actually match. Only keys which are present  in _params are checked
+        1st and 2nd arg: Particle type ids to check on
+        3rd: Class of the interaction to test, ie.e, FeneBond, HarmonicBond
+        4th: Interaction parameters as dictionary, i.e., {"k"=1.,"r_0"=0.
+        5th: Name of the interaction property to set (i.e. "lennardJones")
+        """
+        partType1 = _partType1
+        partType2 = _partType2
+        interClass = _interClass
+        params = _params
+        interName = _interName
 
+        def func(self):
+            # This code is run at the execution of the generated function.
+            # It will use the state of the variables in the outer function,
+            # which was there, when the outer function was called
 
+            # Set parameters
+            getattr(self.es.nonBondedInter[partType1, partType2], interName).setParams(
+                **params)
 
+            # Read them out again
+            outInter = getattr(
+                self.es.nonBondedInter[partType1, partType2], interName)
+            outParams = outInter.getParams()
 
-  def generateTestForNonBondedInteraction(_partType1,_partType2,_interClass,_params,_interName):
-    """Generates test cases for checking interaction parameters set and gotten back
-    from Es actually match. Only keys which are present  in _params are checked
-    1st and 2nd arg: Particle type ids to check on
-    3rd: Class of the interaction to test, ie.e, FeneBond, HarmonicBond
-    4th: Interaction parameters as dictionary, i.e., {"k"=1.,"r_0"=0.
-    5th: Name of the interaction property to set (i.e. "lennardJones")
-    """
-    partType1=_partType1
-    partType2=_partType2
-    interClass=_interClass
-    params=_params
-    interName=_interName
+            self.assertTrue(self.intersMatch(interClass, type(outInter), params, outParams), interClass(
+                **params).typeName() + ": value set and value gotten back differ for particle types " + str(partType1) + " and " + str(partType2) + ": " + params.__str__() + " vs. " + outParams.__str__())
 
+        return func
 
-    def func(self):
-      # This code is run at the execution of the generated function.
-      # It will use the state of the variables in the outer function, 
-      # which was there, when the outer function was called
-      
-      # Set parameters
-      getattr(self.es.nonBondedInter[partType1,partType2],interName).setParams(**params)
-      
-      # Read them out again
-      outInter=getattr(self.es.nonBondedInter[partType1,partType2],interName)
-      outParams=outInter.getParams()
-      
-      
-      self.assertTrue(self.intersMatch(interClass,type(outInter),params,outParams), interClass(**params).typeName()+": value set and value gotten back differ for particle types "+str(partType1)+" and "+str(partType2)+": "+params.__str__()+" vs. "+outParams.__str__())
+    test_lj1 = generateTestForNonBondedInteraction(
+        0, 0, LennardJonesInteraction,
+        {"epsilon": 1., "sigma": 2., "cutoff": 3.,
+            "shift": 4., "offset": 5., "min": 7.},
+        "lennardJones")
+    test_lj2 = generateTestForNonBondedInteraction(
+        0, 0, LennardJonesInteraction,
+        {"epsilon": 1.3, "sigma": 2.2, "cutoff": 3.4,
+            "shift": 4.1, "offset": 5.1, "min": 7.1},
+        "lennardJones")
+    test_lj3 = generateTestForNonBondedInteraction(
+        0, 0, LennardJonesInteraction,
+        {"epsilon": 1.3, "sigma": 2.2, "cutoff": 3.4,
+            "shift": 4.1, "offset": 5.1, "min": 7.1},
+        "lennardJones")
 
-    return func
+    test_ljgen1 = generateTestForNonBondedInteraction(
+        0, 0, GenericLennardJonesInteraction,
+        {"epsilon": 1., "sigma": 2., "cutoff": 3., "shift": 4., "offset": 5.,
+            "e1": 7, "e2": 8, "b1": 9., "b2": 10., "lambda": 11., "delta": 12.},
+        "genericLennardJones")
+    test_ljgen2 = generateTestForNonBondedInteraction(
+        0, 0, GenericLennardJonesInteraction,
+        {"epsilon": 1.1, "sigma": 2.1, "cutoff": 3.1, "shift": 4.1, "offset": 5.1,
+            "e1": 71, "e2": 81, "b1": 9.1, "b2": 10.1, "lambda": 11.1, "delta": 12.1},
+        "genericLennardJones")
+    test_ljgen3 = generateTestForNonBondedInteraction(
+        0, 0, GenericLennardJonesInteraction,
+        {"epsilon": 1.2, "sigma": 2.2, "cutoff": 3.2, "shift": 4.2, "offset": 5.2,
+            "e1": 72, "e2": 82, "b1": 9.2, "b2": 10.2, "lambda": 11.2, "delta": 12.2},
+        "genericLennardJones")
 
-  test_lj1=generateTestForNonBondedInteraction(\
-    0,0,LennardJonesInteraction,\
-    {"epsilon":1.,"sigma":2.,"cutoff":3.,"shift":4.,"offset":5.,"min":7.},\
-    "lennardJones")
-  test_lj2=generateTestForNonBondedInteraction(\
-    0,0,LennardJonesInteraction,\
-    {"epsilon":1.3,"sigma":2.2,"cutoff":3.4,"shift":4.1,"offset":5.1,"min":7.1},\
-    "lennardJones")
-  test_lj3=generateTestForNonBondedInteraction(\
-    0,0,LennardJonesInteraction,\
-    {"epsilon":1.3,"sigma":2.2,"cutoff":3.4,"shift":4.1,"offset":5.1,"min":7.1},\
-    "lennardJones")
-    
-  test_ljgen1=generateTestForNonBondedInteraction(\
-    0,0,GenericLennardJonesInteraction,\
-    {"epsilon":1.,"sigma":2.,"cutoff":3.,"shift":4.,"offset":5.,"e1":7,"e2":8,"b1":9.,"b2":10.,"lambda":11.,"delta":12.},\
-    "genericLennardJones")
-  test_ljgen2=generateTestForNonBondedInteraction(\
-    0,0,GenericLennardJonesInteraction,\
-    {"epsilon":1.1,"sigma":2.1,"cutoff":3.1,"shift":4.1,"offset":5.1,"e1":71,"e2":81,"b1":9.1,"b2":10.1,"lambda":11.1,"delta":12.1},\
-    "genericLennardJones")
-  test_ljgen3=generateTestForNonBondedInteraction(\
-    0,0,GenericLennardJonesInteraction,\
-    {"epsilon":1.2,"sigma":2.2,"cutoff":3.2,"shift":4.2,"offset":5.2,"e1":72,"e2":82,"b1":9.2,"b2":10.2,"lambda":11.2,"delta":12.2},\
-    "genericLennardJones")
-
-  def test_forcecap(self):
-    self.es.nonBondedInter.setForceCap(17.5)
-    self.assertEqual(self.es.nonBondedInter.getForceCap(),17.5)
+    def test_forcecap(self):
+        self.es.nonBondedInter.setForceCap(17.5)
+        self.assertEqual(self.es.nonBondedInter.getForceCap(), 17.5)
 
 
 if __name__ == "__main__":
- print("Features: ",espressomd.features())
- ut.main()
-
+    print("Features: ", espressomd.features())
+    ut.main()

--- a/testsuite/python/p3m_gpu.py
+++ b/testsuite/python/p3m_gpu.py
@@ -1,53 +1,55 @@
 #
 # Copyright (C) 2013,2014 The ESPResSo project
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-#  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Tests particle property setters/getters
 import espressomd
 import unittest as ut
 import numpy as np
 from espressomd.electrostatics import P3M_GPU
 
+
 class P3M_GPU_test(ut.TestCase):
-    es=espressomd.System()
-    test_params={}
-    test_params["bjerrum_length"]=2
-    test_params["cao"]=2
-    test_params["inter"]=3
-    test_params["r_cut"]=0.9
-    test_params["accuracy"]=1e-1
-    test_params["mesh"]=[10, 10, 10]
-    test_params["epsilon"]=20.0
+    es = espressomd.System()
+    test_params = {}
+    test_params["bjerrum_length"] = 2
+    test_params["cao"] = 2
+    test_params["inter"] = 3
+    test_params["r_cut"] = 0.9
+    test_params["accuracy"] = 1e-1
+    test_params["mesh"] = [10, 10, 10]
+    test_params["epsilon"] = 20.0
     test_params["mesh_off"] = [0.8, 0.8, 0.8]
     test_params["alpha"] = 1.1
     test_params["tune"] = False
 
     def runTest(self):
-        p3m=P3M_GPU(bjerrum_length=self.test_params["bjerrum_length"], cao=self.test_params["cao"], inter=self.test_params["inter"], r_cut=self.test_params["r_cut"], accuracy=self.test_params["accuracy"], mesh=self.test_params["mesh"], epsilon=self.test_params["epsilon"], mesh_off=self.test_params["mesh_off"], alpha=self.test_params["alpha"], tune=self.test_params["tune"])
+        p3m = P3M_GPU(bjerrum_length=self.test_params["bjerrum_length"], cao=self.test_params["cao"], inter=self.test_params["inter"], r_cut=self.test_params["r_cut"], accuracy=self.test_params[
+                      "accuracy"], mesh=self.test_params["mesh"], epsilon=self.test_params["epsilon"], mesh_off=self.test_params["mesh_off"], alpha=self.test_params["alpha"], tune=self.test_params["tune"])
         self.es.Actors.add(p3m)
-        set_params=p3m._getParamsFromEsCore()
-        SAME=True
+        set_params = p3m._getParamsFromEsCore()
+        SAME = True
         for i in self.test_params.keys():
             if set_params[i] != self.test_params[i]:
                 print "Parameter mismatch: ", i
-                SAME=False
+                SAME = False
                 break
         return SAME
 
 if __name__ == "__main__":
- print("Features: ",espressomd.features())
- ut.main()
+    print("Features: ", espressomd.features())
+    ut.main()

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -1,21 +1,21 @@
 #
 # Copyright (C) 2013,2014 The ESPResSo project
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-#  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # Tests particle property setters/getters
 import unittest as ut
 import espressomd
@@ -23,122 +23,124 @@ import numpy as np
 from espressomd.interactions import FeneBond
 
 
-
 class ParticleProperties(ut.TestCase):
-  
-  # Particle id to work on
-  pid=17
-  
-  # Error tolerance when comparing arrays/tuples...
-  tol=1E-9
-  
-  # Handle for espresso system
-  es=espressomd.System()
 
-  f1=FeneBond(k=1,d_r_max=5)
-  es.bondedInter.add(f1)
-  f2=FeneBond(k=1,d_r_max=5)
-  es.bondedInter.add(f2)
+    # Particle id to work on
+    pid = 17
 
-  def arraysNearlyEqual(self,a,b):
-    """Test, if the magnitude of the difference between two arrays is smaller than the tolerance"""
+    # Error tolerance when comparing arrays/tuples...
+    tol = 1E-9
 
-    # Check length
-    if len(a) != len(b):
-      return False
+    # Handle for espresso system
+    es = espressomd.System()
 
+    f1 = FeneBond(k=1, d_r_max=5)
+    es.bondedInter.add(f1)
+    f2 = FeneBond(k=1, d_r_max=5)
+    es.bondedInter.add(f2)
 
-    # We have to use a loop, since we can't be sure, we're getting numpy arrays
-    sum=0.
-    for i in range(len(a)):
-      sum+= abs(a[i]-b[i])
+    def arraysNearlyEqual(self, a, b):
+        """Test, if the magnitude of the difference between two arrays is smaller than the tolerance"""
 
-    if sum >self.tol:
-      return False
+        # Check length
+        if len(a) != len(b):
+            return False
 
-    return True
-      
+        # We have to use a loop, since we can't be sure, we're getting numpy
+        # arrays
+        sum = 0.
+        for i in range(len(a)):
+            sum += abs(a[i] - b[i])
 
+        if sum > self.tol:
+            return False
 
+        return True
 
-  def setUp(self):
-    self.es.part[self.pid].pos =0,0,0
+    def setUp(self):
+        self.es.part[self.pid].pos = 0, 0, 0
 
-  def generateTestForVectorProperty(_propName,_value):
-    """Generates test cases for vectorial particle properties such as
-    position, velocity...
-    1st arg: name of the property (e.g., "pos"), 
-    2nd array: value to be used for testing. Has to be numpy.array of floats
-    """
-    # This is executed, when generateTestForVectorProperty() is called
-    propName=_propName
-    value=_value
+    def generateTestForVectorProperty(_propName, _value):
+        """Generates test cases for vectorial particle properties such as
+        position, velocity...
+        1st arg: name of the property (e.g., "pos"), 
+        2nd array: value to be used for testing. Has to be numpy.array of floats
+        """
+        # This is executed, when generateTestForVectorProperty() is called
+        propName = _propName
+        value = _value
 
-    def func(self):
-      # This code is run at the execution of the generated function.
-      # It will use the state of the variables in the outer function, 
-      # which was there, when the outer function was called
-      setattr(self.es.part[self.pid],propName,value)
-      print(propName,value,getattr(self.es.part[self.pid],propName))
-      self.assertTrue(self.arraysNearlyEqual(getattr(self.es.part[self.pid],propName), value),propName+": value set and value gotten back differ.")
+        def func(self):
+            # This code is run at the execution of the generated function.
+            # It will use the state of the variables in the outer function,
+            # which was there, when the outer function was called
+            setattr(self.es.part[self.pid], propName, value)
+            print(propName, value, getattr(self.es.part[self.pid], propName))
+            self.assertTrue(self.arraysNearlyEqual(getattr(self.es.part[
+                            self.pid], propName), value), propName + ": value set and value gotten back differ.")
 
-    return func
-  
-  def generateTestForScalarProperty(_propName,_value):
-    """Generates test cases for scalar particle properties such as
-    type, mass, charge...
-    1st arg: name of the property (e.g., "type"), 
-    2nd array: value to be used for testing. int or float
-    """
-    # This is executed, when generateTestForVectorProperty() is called
-    propName=_propName
-    value=_value
+        return func
 
-    def func(self):
-      # This code is run at the execution of the generated function.
-      # It will use the state of the variables in the outer function, 
-      # which was there, when the outer function was called
-      setattr(self.es.part[self.pid],propName,value)
-      print(propName,value,getattr(self.es.part[self.pid],propName))
-      self.assertTrue(getattr(self.es.part[self.pid],propName)==value,propName+": value set and value gotten back differ.")
+    def generateTestForScalarProperty(_propName, _value):
+        """Generates test cases for scalar particle properties such as
+        type, mass, charge...
+        1st arg: name of the property (e.g., "type"), 
+        2nd array: value to be used for testing. int or float
+        """
+        # This is executed, when generateTestForVectorProperty() is called
+        propName = _propName
+        value = _value
 
-    return func
+        def func(self):
+            # This code is run at the execution of the generated function.
+            # It will use the state of the variables in the outer function,
+            # which was there, when the outer function was called
+            setattr(self.es.part[self.pid], propName, value)
+            print(propName, value, getattr(self.es.part[self.pid], propName))
+            self.assertTrue(getattr(self.es.part[
+                            self.pid], propName) == value, propName + ": value set and value gotten back differ.")
 
+        return func
 
-  test_pos=generateTestForVectorProperty("pos",np.array([0.1,0.2,0.3]))
-  test_v=generateTestForVectorProperty("v",np.array([0.2,0.3,0.4]))
-  test_f=generateTestForVectorProperty("f",np.array([0.2,0.3,0.7]))
-  test_type=generateTestForScalarProperty("type",int(3))
+    test_pos = generateTestForVectorProperty("pos", np.array([0.1, 0.2, 0.3]))
+    test_v = generateTestForVectorProperty("v", np.array([0.2, 0.3, 0.4]))
+    test_f = generateTestForVectorProperty("f", np.array([0.2, 0.3, 0.7]))
+    test_type = generateTestForScalarProperty("type", int(3))
 
-  print f1,f2
-  test_bonds_property=generateTestForScalarProperty("bonds", ((f1,1),(f2,2)))
+    print f1, f2
+    test_bonds_property = generateTestForScalarProperty(
+        "bonds", ((f1, 1), (f2, 2)))
 
+    if "MASS" in espressomd.features():
+        test_mass = generateTestForScalarProperty("mass", 1.3)
 
-  if "MASS" in espressomd.features(): 
-    test_mass=generateTestForScalarProperty("mass",1.3)
-
-  if "ROTATION" in espressomd.features(): 
-    test_omega_lab=generateTestForVectorProperty("omega_lab",np.array([4.,2.,1.]))
-    test_omega_body=generateTestForVectorProperty("omega_body",np.array([4.,72.,1.]))
-    test_torque_lab=generateTestForVectorProperty("torque_lab",np.array([4.,72.,3.7]))
-    # The tested value has to be nromalized!
-    test_quat=generateTestForVectorProperty("quat",np.array([0.5,0.5,0.5,0.5]))
+    if "ROTATION" in espressomd.features():
+        test_omega_lab = generateTestForVectorProperty(
+            "omega_lab", np.array([4., 2., 1.]))
+        test_omega_body = generateTestForVectorProperty(
+            "omega_body", np.array([4., 72., 1.]))
+        test_torque_lab = generateTestForVectorProperty(
+            "torque_lab", np.array([4., 72., 3.7]))
+        # The tested value has to be nromalized!
+        test_quat = generateTestForVectorProperty(
+            "quat", np.array([0.5, 0.5, 0.5, 0.5]))
 #    test_director=generateTestForVectorProperty("director",np.array([0.5,0.4,0.3]))
 
+    if "ELECTROSTATICS" in espressomd.features():
+        test_charge = generateTestForScalarProperty("q", -19.7)
 
-  if "ELECTROSTATICS" in espressomd.features():
-    test_charge=generateTestForScalarProperty("q",-19.7)
+    if "DIPOLES" in espressomd.features():
+        test_dip = generateTestForVectorProperty(
+            "dip", np.array([0.5, -0.5, 3]))
+        test_dipm = generateTestForScalarProperty("dipm", -9.7)
 
-  if "DIPOLES" in espressomd.features():
-    test_dip=generateTestForVectorProperty("dip",np.array([0.5,-0.5,3]))
-    test_dipm=generateTestForScalarProperty("dipm",-9.7)
+    if "VIRTUAL_SITES" in espressomd.features():
+        test_virtual = generateTestForScalarProperty("virtual", 1)
+    if "VIRTUAL_SITES_RELATIVE" in espressomd.features():
+        test_zz_vs_relative = generateTestForScalarProperty(
+            "vs_relative", ((0, 5.0)))
 
-  if "VIRTUAL_SITES" in espressomd.features():
-    test_virtual=generateTestForScalarProperty("virtual",1)
-  if "VIRTUAL_SITES_RELATIVE" in espressomd.features():
-    test_zz_vs_relative=generateTestForScalarProperty("vs_relative",((0,5.0)))
-    
 
 if __name__ == "__main__":
- print("Features: ",espressomd.features())
- ut.main()
+    print("Features: ", espressomd.features())
+    ut.main()

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -25,8 +25,6 @@ from espressomd.interactions import FeneBond
 
 
 class ParticleProperties(ut.TestCase):
-#  def __init__(self,particleId):
-#    self.pid=particleId
   
   # Particle id to work on
   pid=17
@@ -36,6 +34,11 @@ class ParticleProperties(ut.TestCase):
   
   # Handle for espresso system
   es=espressomd.System()
+
+  f1=FeneBond(k=1,d_r_max=5)
+  es.bondedInter.add(f1)
+  f2=FeneBond(k=1,d_r_max=5)
+  es.bondedInter.add(f2)
 
   def arraysNearlyEqual(self,a,b):
     """Test, if the magnitude of the difference between two arrays is smaller than the tolerance"""
@@ -60,8 +63,6 @@ class ParticleProperties(ut.TestCase):
 
   def setUp(self):
     self.es.part[self.pid].pos =0,0,0
-    self.es.bondedInter[0]=FeneBond(k=1,d_r_max=5)
-    self.es.bondedInter[1]=FeneBond(k=1,d_r_max=5)
 
   def generateTestForVectorProperty(_propName,_value):
     """Generates test cases for vectorial particle properties such as
@@ -108,7 +109,9 @@ class ParticleProperties(ut.TestCase):
   test_v=generateTestForVectorProperty("v",np.array([0.2,0.3,0.4]))
   test_f=generateTestForVectorProperty("f",np.array([0.2,0.3,0.7]))
   test_type=generateTestForScalarProperty("type",int(3))
-  test_bonds_property=generateTestForScalarProperty("bonds", ((0,1),(1,2)))
+
+  print f1,f2
+  test_bonds_property=generateTestForScalarProperty("bonds", ((f1,1),(f2,2)))
 
 
   if "MASS" in espressomd.features(): 


### PR DESCRIPTION
This one is rebased to the pep8 naming convention refactor (#487), and needs to be merged after that one.