### PR TITLE
update particle numbers on the GPU on particle change

### DIFF
--- a/doc/ug/inter.tex
+++ b/doc/ug/inter.tex
@@ -1835,6 +1835,7 @@ by calling the above command, where \var{induced} returns $E_{induced}$,
   inter coulomb \var{l_B} mmm1d tune \var{maximal\_pairwise\_error}
   \begin{features}
     \required{ELECTROSTATICS}
+    \required{PARTIAL_PERIODIC}
   \end{features}
 \end{essyntax}
 MMM1D coulomb method for systems with periodicity 0 0 1. Needs the
@@ -1859,6 +1860,7 @@ test force calculations.
   \begin{features}
     \required{CUDA}
 	\required{ELECTROSTATICS}
+	\required{PARTIAL_PERIODIC}
 	\required{MMM1D_GPU}
   \end{features}
 \end{essyntax}

--- a/src/core/initialize.cpp
+++ b/src/core/initialize.cpp
@@ -279,6 +279,12 @@ void on_particle_change()
   lb_reinit_particles_gpu = 1;
 #endif
 #ifdef CUDA
+  if (reinit_particle_comm_gpu){
+    gpu_change_number_of_part_to_comm();
+    reinit_particle_comm_gpu = 0;
+  }
+  MPI_Bcast(gpu_get_global_particle_vars_pointer_host(), sizeof(CUDA_global_part_vars), MPI_BYTE, 0, comm_cart);
+
   reinit_particle_comm_gpu = 1;
 #endif
   invalidate_obs();


### PR DESCRIPTION
This commit fixes the mmm1dgpu energy calculation if the particle number change in the simulation. Prior to this commit the particle number for the GPU code has never changed.