### PR TITLE
Fixed ek_..._reaction_tag undefined symbol error

### DIFF
--- a/src/core/electrokinetics.hpp
+++ b/src/core/electrokinetics.hpp
@@ -158,7 +158,6 @@ int ek_print_vtk_potential(char* filename);
 int ek_print_vtk_particle_potential( char* filename );
 #endif
 int ek_print_vtk_lbforce(char* filename);
-int ek_print_vtk_reaction_tags(char* filename);
 int ek_lb_print_vtk_density(char* filename);
 int ek_lb_print_vtk_velocity(char* filename);
 int ek_init();
@@ -197,6 +196,7 @@ void ek_init_species_density_wallcharge(ekfloat* wallcharge_species_density, int
 #endif
 
 #ifdef EK_REACTION
+int ek_print_vtk_reaction_tags(char* filename);
 int ek_set_reaction( int reactant, int product0, int product1, 
                      float rho_reactant_reservoir, float rho_product0_reservoir, float rho_product1_reservoir, 
                      float reaction_ct_rate, float reaction_fraction_0, float reaction_fraction_1, 

--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -14,7 +14,8 @@ IF ELECTROKINETICS == 1:
         int ek_print_vtk_potential(char * filename)
 
         int ek_print_vtk_lbforce(char * filename)
-        int ek_print_vtk_reaction_tags(char * filename)
+        IF EK_REACTION == 1:
+            int ek_print_vtk_reaction_tags(char * filename)
         int ek_lb_print_vtk_density(char * filename)
         int ek_lb_print_vtk_velocity(char * filename)
 
@@ -181,12 +182,12 @@ IF ELECTROKINETICS == 1:
     def print_lb_force_vtk(path):
         if ek_print_vtk_lbforce(path):
             raise Exception('EK output error', 'could not save lbforce VTK')
-
-    def print_reaction_tags_vtk(path):
-        if ek_print_vtk_reaction_tags(path):
-            raise Exception(
-                'EK output error', 'could not save reaction tags VTK')
-
+    IF EK_REACTION == 1:
+        def print_reaction_tags_vtk(path):
+            if ek_print_vtk_reaction_tags(path):
+                raise Exception(
+                    'EK output error', 'could not save reaction tags VTK')
+    
     def print_lb_density_vtk(path):
         if ek_lb_print_vtk_density(path):
             raise Exception('EK output error', 'could not save lbdensity VTK')


### PR DESCRIPTION
Importing the electrokinetics module raised an undefined symbol error.
    
Needs to be tested when EK_REACTION works in python.