### PR TITLE
Remove RTLD_GLOBAL for all libraries except OpenMPI

### DIFF
--- a/samples/python/not-working/globals.py
+++ b/samples/python/not-working/globals.py
@@ -17,9 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 #  
 from __future__ import print_function
-import ctypes
-import sys
-sys.setdlopenflags((sys.getdlopenflags() | ctypes.RTLD_GLOBAL ))
 
 import espresso as es
 import numpy

--- a/samples/python/not-working/hello_parallel_world.py
+++ b/samples/python/not-working/hello_parallel_world.py
@@ -17,9 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 #  
 from __future__ import print_function
-import ctypes
-import sys
-sys.setdlopenflags((sys.getdlopenflags() | ctypes.RTLD_GLOBAL ))
 
 import espresso as es
 import numpy

--- a/samples/python/not-working/thermostat_test.py
+++ b/samples/python/not-working/thermostat_test.py
@@ -19,9 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 #  
 from __future__ import print_function
-import ctypes
-import sys
-sys.setdlopenflags((sys.getdlopenflags() | ctypes.RTLD_GLOBAL ))
 import espresso as es
 print(dir(es))
 

--- a/src/python/espressomd/__init__.py
+++ b/src/python/espressomd/__init__.py
@@ -17,11 +17,6 @@
 #
 #
 # Define the espressomd package
-import sys
-import ctypes
-
-# OpenMPI magic
-sys.setdlopenflags((sys.getdlopenflags() | ctypes.RTLD_GLOBAL))
 
 # Initialize MPI, start the main loop on the slaves
 import espressomd._init


### PR DESCRIPTION
The real issue underlying #404 is that each Python module is statically linked against libEspresso. Because we use `dlopen` with `RTLD_GLOBAL`, nobody noticed it yet.
This is a pull request that removes `RTLD_GLOBAL` except for when used with OpenMPI. Before merging it, you need to modify the build system so that libEspresso, libEspressoTcl and libEspressoTcl4Py are built as shared libraries instead of as static libraries. Besides, you need to add `-ldl` to the `LDFLAGS` when building with OpenMPI. I tried to do that myself, but my automake+libtool skills are insufficient.