### PR TITLE
Pull particle_exists (particle_data.cpp) out of the #ifdef

### DIFF
--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -2276,6 +2276,7 @@ void pointer_to_rotational_inertia(Particle *p, double*& res)
 {
   res = p->p.rinertia;
 }
+#endif
 
 bool particle_exists(int part) {
     if (!particle_node)
@@ -2289,4 +2290,3 @@ bool particle_exists(int part) {
    return false;
 } 
 
-#endif


### PR DESCRIPTION
particle_exists() does not depend on the ROTATIONAL_INTERTIA feature.

Fixes the problem of the python interface (if built without ROTATIONAL_INTERTIA):
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "espressomd/__init__.py", line 33, in <module>
    from espressomd.system import System
  File "espressomd/system.py", line 3, in <module>
    from espressomd import _system
  File "espressomd/_system.pyx", line 27, in init espressomd._system (_system.cpp:7031)
    import particle_data
ImportError: espressomd/particle_data.so: undefined symbol: _Z15particle_existsi
