### PR TITLE
Fix compiling on Mac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,8 @@ EOF
 dnl overwrite _AC_PROC_CC_G to avoid check for -g and -O2 flags
 m4_define([_AC_PROG_CXX_G],[])
 
+AM_CONDITIONAL(DARWIN, [test $(uname) = "Darwin"])
+
 #############
 #### MPI ####
 #############

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -333,7 +333,7 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2,
   if ( thermo_switch & THERMO_DPD ) add_dpd_thermo_pair_force(p1,p2,d,dist,dist2);
 #endif
 
-  /** The inter dpd force should not be part of the virial
+  /** The inter dpd force should not be part of the virial */
       
 #ifdef INTER_DPD
   add_inter_dpd_pair_force(p1,p2,ia_params,d,dist,dist2);

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -76,6 +76,10 @@ int partCfgSorted = 0;
 /** bondlist for partCfg, if bonds are needed */
 IntList partCfg_bl = { NULL, 0, 0 };
 
+#if HAVE_CXX11
+  constexpr double ParticleProperties::mass;
+#endif
+
 /************************************************
  * local functions
  ************************************************/

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -72,7 +72,8 @@
     needed in the interaction calculation, but are just copies of
     particles stored on different nodes.
 */
-typedef struct {
+typedef struct ParticleProperties ParticleProperties;
+struct ParticleProperties {
   /** unique identifier for the particle. */
   int    identity;
   /** Molecule identifier. */
@@ -196,7 +197,7 @@ typedef struct {
   #endif
 
 #endif
-} ParticleProperties;
+};
 
 /** Positional information on a particle. Information that is
     communicated to calculate interactions with ghost particles. */

--- a/src/python/espressomd/Makefile.am
+++ b/src/python/espressomd/Makefile.am
@@ -87,6 +87,8 @@ PXDFILES = \
 	actors.pxd \
 	h5md.pxd
 
+LIBS +=	$(top_builddir)/src/core/libEspresso.la
+
 if TCL
 LIBS +=	$(top_builddir)/src/tcl/libEspressoTcl4Py.la
 PYXFILES += _tcl.pyx
@@ -142,11 +144,17 @@ SOFILES = $(PYXFILES:.pyx=.so)
 all-local: $(SOFILES)
 CLEANFILES += $(SOFILES)
 
+if DARWIN
+SOSUFFIX=dylib
+else
+SOSUFFIX=so
+endif
+
 $(SOFILES): %.so: %.la libEspresso.so
 	$(AM_V_GEN)test -L $@ || $(LN_S) @objdir@/$@ $@
 
 libEspresso.so:
-	$(AM_V_GEN)test -L $@ || $(LN_S) $(top_builddir)/src/core/.libs/libEspresso.so $@
+	$(AM_V_GEN)test -L $@ || $(LN_S) $(top_builddir)/src/core/.libs/libEspresso.$(SOSUFFIX) $@
 
 # build rule for myconfig.pxi
 # create gen_pxiconfig.cpp from features.def

--- a/src/tcl/Makefile.am
+++ b/src/tcl/Makefile.am
@@ -24,7 +24,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/core/mpifake
 endif
 AM_DEFAULT_SOURCE_EXT = .cpp
 
-noinst_LTLIBRARIES = libEspressoTcl.la
+lib_LTLIBRARIES = libEspressoTcl.la
 libEspressoTcl_la_SOURCES = \
 	TclOutputHelper.hpp \
 	bin_tcl.cpp \
@@ -183,7 +183,7 @@ Espresso_install_LDADD = libEspressoTcl.la ../core/libEspresso.la
 
 # generate the Tcl library for the python interpreter
 if PYTHON_INTERFACE
-noinst_LTLIBRARIES += libEspressoTcl4Py.la
+lib_LTLIBRARIES += libEspressoTcl4Py.la
 libEspressoTcl4Py_la_CPPFLAGS = -D ESPRESSO_SCRIPTS_DEFAULT=\"$(buildscriptsdir)\" $(AM_CPPFLAGS)
 libEspressoTcl4Py_la_SOURCES = scriptsdir.cpp
 libEspressoTcl4Py_la_LIBADD = libEspressoTcl.la


### PR DESCRIPTION
- Close unterminated comment
- Workaround for missing symbol ParticleProperties::mass
- Workaround for "static data member not allowed in anonymous struct"
- Fix unresolved symbols in Python interface
- Use correct shared library suffix
- Force building shared libraries for Tcl interface