### PR TITLE
More CUDA Cmake improvements

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,9 @@
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -O3 -arch=sm_20")
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -g -G")
+else()
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -O3")
+endif()
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode=arch=compute_20,code=sm_20 -gencode=arch=compute_30,code=sm_30")
 
 file(GLOB_RECURSE EspressoCore_SRC
           "*.cpp"
@@ -37,6 +42,8 @@ if(WITH_CUDA)
   cuda_add_library(EspressoCuda SHARED ${EspressoCuda_SRC} config-version.cpp config-features.cpp)
   
   add_dependencies(EspressoCore EspressoCuda)
+  set_target_properties(EspressoCuda PROPERTIES MACOSX_RPATH TRUE)
+  CUDA_ADD_CUFFT_TO_TARGET(EspressoCuda)
   target_link_libraries(EspressoCore EspressoCuda)
 endif(WITH_CUDA)
 


### PR DESCRIPTION
More improvements to the recent build system changes. Unfortunately, it's still not fully working on my Mac.

This is what I get with CMake:
```
Linking CXX shared library libEspressoCuda.dylib
Undefined symbols for architecture x86_64:
  "cuda_mpi_send_forces(float*, float*, CUDA_fluid_composition*)", referenced from:
      copy_forces_from_GPU() in EspressoCuda_generated_cuda_common_cuda.cu.o
  "cuda_mpi_get_particles(CUDA_particle_data*)", referenced from:
      copy_part_data_to_gpu() in EspressoCuda_generated_cuda_common_cuda.cu.o
  "copy_CUDA_energy_to_energy(CUDA_energy)", referenced from:
      copy_energy_from_GPU() in EspressoCuda_generated_cuda_common_cuda.cu.o
  "cuda_bcast_global_part_params()", referenced from:
      p3m_gpu_init(int, int*, double, double*) in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "errexit()", referenced from:
      _cuda_safe_mem(cudaError, char const*, unsigned int) in EspressoCuda_generated_cuda_common_cuda.cu.o
      _cuda_check_errors(dim3 const&, dim3 const&, char const*, char const*, unsigned int) in EspressoCuda_generated_cuda_common_cuda.cu.o
      gpu_change_number_of_part_to_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
      gpu_init_particle_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
      copy_forces_from_GPU() in EspressoCuda_generated_cuda_common_cuda.cu.o
  "EspressoSystemInterface::m_instance", referenced from:
      p3m_gpu_init(int, int*, double, double*) in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<Vector<3, double> >::operator=(SystemInterface::const_iterator<Vector<3, double> > const&)", referenced from:
      vtable for EspressoSystemInterface::const_iterator<Vector<3, double> > in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<Vector<3, double> >::operator++()", referenced from:
      vtable for EspressoSystemInterface::const_iterator<Vector<3, double> > in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<double>::operator=(SystemInterface::const_iterator<double> const&)", referenced from:
      vtable for EspressoSystemInterface::const_iterator<double> in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<double>::operator++()", referenced from:
      vtable for EspressoSystemInterface::const_iterator<double> in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<Vector<3, double> >::operator*() const", referenced from:
      vtable for EspressoSystemInterface::const_iterator<Vector<3, double> > in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<Vector<3, double> >::operator==(SystemInterface::const_iterator<Vector<3, double> > const&) const", referenced from:
      vtable for EspressoSystemInterface::const_iterator<Vector<3, double> > in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<Vector<3, double> >::operator!=(SystemInterface::const_iterator<Vector<3, double> > const&) const", referenced from:
      vtable for EspressoSystemInterface::const_iterator<Vector<3, double> > in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<double>::operator*() const", referenced from:
      vtable for EspressoSystemInterface::const_iterator<double> in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<double>::operator==(SystemInterface::const_iterator<double> const&) const", referenced from:
      vtable for EspressoSystemInterface::const_iterator<double> in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "EspressoSystemInterface::const_iterator<double>::operator!=(SystemInterface::const_iterator<double> const&) const", referenced from:
      vtable for EspressoSystemInterface::const_iterator<double> in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "vtable for EspressoSystemInterface", referenced from:
      p3m_gpu_init(int, int*, double, double*) in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "_coulomb", referenced from:
      p3m_gpu_add_farfield_force() in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "_idum", referenced from:
      gpu_change_number_of_part_to_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
  "_iv", referenced from:
      gpu_change_number_of_part_to_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
  "_iy", referenced from:
      gpu_change_number_of_part_to_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
  "_n_part", referenced from:
      gpu_change_number_of_part_to_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
      assign_forces(CUDA_particle_data const*, P3MGpuData, float*, float) in EspressoCuda_generated_p3m_gpu_cuda.cu.o
  "_this_node", referenced from:
      _cuda_check_errors(dim3 const&, dim3 const&, char const*, char const*, unsigned int) in EspressoCuda_generated_cuda_common_cuda.cu.o
      gpu_change_number_of_part_to_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
      gpu_init_particle_comm() in EspressoCuda_generated_cuda_common_cuda.cu.o
      copy_part_data_to_gpu() in EspressoCuda_generated_cuda_common_cuda.cu.o
      copy_forces_from_GPU() in EspressoCuda_generated_cuda_common_cuda.cu.o
      cuda_get_device_props(int, EspressoGpuDevice&) in EspressoCuda_generated_cuda_init_cuda.cu.o
      p3m_gpu_init(int, int*, double, double*) in EspressoCuda_generated_p3m_gpu_cuda.cu.o
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

And this is what I get with Autotools:
```
  CXXLD    _tcl.la
libtool: warning: ignoring multiple '-rpath's for a libtool library
Undefined symbols for architecture x86_64:
  "_Tcl_CreateInterp", referenced from:
      __pyx_pw_10espressomd_4_tcl_14TclInterpreter_1__init__(_object*, _object*, _object*) in _tcl.o
  "_Tcl_DeleteInterp", referenced from:
      __pyx_pw_10espressomd_4_tcl_14TclInterpreter_5__del__(_object*, _object*) in _tcl.o
  "_Tcl_Eval", referenced from:
      __pyx_pw_10espressomd_4_tcl_14TclInterpreter_3eval(_object*, _object*) in _tcl.o
  "_Tcl_GetStringResult", referenced from:
      __pyx_pw_10espressomd_4_tcl_14TclInterpreter_3eval(_object*, _object*) in _tcl.o
  "tcl_appinit(Tcl_Interp*)", referenced from:
      __pyx_pw_10espressomd_4_tcl_14TclInterpreter_1__init__(_object*, _object*, _object*) in _tcl.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
