### PR TITLE
writevtk

### DIFF
--- a/doc/ug/io.tex
+++ b/doc/ug/io.tex
@@ -525,19 +525,23 @@ filenames including a running index (\texttt{data_0.vtk},
 
 \begin{essyntax}
   writevtk \var{filename} 
-  \opt{\alt{all \asep \var{type}}}
+  \opt{\alt{all \asep \var{types}}}
 \end{essyntax}
 
 \begin{arguments}
 \item[\var{filename}]
   Name of the file to export the particle positions into.
-
-\item[\opt{\alt{all \asep \var{type}}}] Specifies which particle type
-  should be exportet. The default is \keyword{all}. Alternatively, a
-  type number can be given. Exporting the positions of all particles
-  but in separate files might make sense if one wants to distinguish
-  the different particle types in the visualization (i.e. by color or
-  size).
+\item[\opt{\alt{all \asep \var{type}}}] Specifies a list of particle
+  types which should be exportet. The default is
+  \keyword{all}. Alternatively, a list of type number can be
+  given. Exporting the positions of all particles but in separate
+  files might make sense if one wants to distinguish the different
+  particle types in the visualization (i.e. by color or size).  To
+  export a type \texttt{1} use something along \texttt{writevtk
+    "test.tcl" "1"}.  To export types \texttt{1}, \texttt{5},
+  \texttt{7}, which are not to be distinguished in the visualization,
+  use \texttt{writevtk "test.tcl" "7 1 5"}.  The order in the list is
+  arbitrary, but duplicates are \emph{not} ignored!
 \end{arguments}
 
 \section{Reading and Writing PDB/PSF files}

--- a/scripts/vtk.tcl
+++ b/scripts/vtk.tcl
@@ -27,37 +27,44 @@
 #############################################################
 
 #dumps particle positions into a file so that paraview can visualize them
-proc writevtk {filename {type "all"}} {
+proc writevtk {filename {types "all"}} {
 	set max_pid [setmd max_part]
 	set n 0
 	set fp [open $filename "w"]
 
 	for { set pid 0 } { $pid <= $max_pid } { incr pid } {
-		if {[part $pid print type] == $type || ([part $pid print type] != "na" && $type == "all")} then {
-			incr n
+		foreach type $types {
+			if {[part $pid print type] == $type || ([part $pid print type] != "na" && $type == "all")} then {
+				incr n
+			}
 		}
 	}
 
 	puts $fp "# vtk DataFile Version 2.0\nparticles\nASCII\nDATASET UNSTRUCTURED_GRID\nPOINTS $n floats"
 
 	for { set pid 0 } { $pid <= $max_pid } { incr pid } {
-		if {[part $pid print type] == $type || ([part $pid print type] != "na" && $type == "all")} then {
-			set xpos [expr [lindex [part $pid print folded_pos] 0]]
-			set ypos [expr [lindex [part $pid print folded_pos] 1]]
-			set zpos [expr [lindex [part $pid print folded_pos] 2]]
-			puts $fp "$xpos $ypos $zpos"
+		foreach type $types {
+			if {[part $pid print type] == $type || ([part $pid print type] != "na" && $type == "all")} then {
+				set xpos [expr [lindex [part $pid print folded_pos] 0]]
+				set ypos [expr [lindex [part $pid print folded_pos] 1]]
+				set zpos [expr [lindex [part $pid print folded_pos] 2]]
+				puts $fp "$xpos $ypos $zpos"
+			}
 		}
 	}
 
 	puts $fp "POINT_DATA $n"
-        puts $fp "SCALARS velocity float 3"
-        puts $fp "LOOKUP_TABLE default"
+	puts $fp "SCALARS velocity float 3"
+	puts $fp "LOOKUP_TABLE default"
+
 	for { set pid 0 } { $pid <= $max_pid } { incr pid } {
-		if {[part $pid print type] == $type || ([part $pid print type] != "na" && $type == "all")} then {
-			set xvel [expr [lindex [part $pid print v] 0]]
-			set yvel [expr [lindex [part $pid print v] 1]]
-			set zvel [expr [lindex [part $pid print v] 2]]
-			puts $fp "$xvel $yvel $zvel"
+		foreach type $types {
+			if {[part $pid print type] == $type || ([part $pid print type] != "na" && $type == "all")} then {
+				set xvel [expr [lindex [part $pid print v] 0]]
+				set yvel [expr [lindex [part $pid print v] 1]]
+				set zvel [expr [lindex [part $pid print v] 2]]
+				puts $fp "$xvel $yvel $zvel"
+			}
 		}
 	}
 


### PR DESCRIPTION
With this patch, `writevtk` is able to export a list of types. It is backwards compatible and the new features are documented.