### PR TITLE
More restrictive adding of pairs to verlet lists

### DIFF
--- a/src/core/iccp3m.cpp
+++ b/src/core/iccp3m.cpp
@@ -378,7 +378,7 @@ void build_verlet_lists_and_calc_verlet_ia_iccp3m()
 	  dist2 = distance2vec(p1[i].r.p, p2[j].r.p, vec21);
 
 	  VERLET_TRACE(fprintf(stderr,"%d: pair %d %d has distance %f\n",this_node,p1[i].p.identity,p2[j].p.identity,sqrt(dist2)));
-	  if(dist2 <= SQR(get_ia_param(p1[i].p.type, p2[j].p.type)->max_cut + skin)) {
+	  if(verlet_list_criterion(p1+i,p2+j, dist2)) {
 	    ONEPART_TRACE(if(p1[i].p.identity==check_id) fprintf(stderr,"%d: OPT: Verlet Pair %d %d (Cells %d,%d %d,%d dist %f)\n",this_node,p1[i].p.identity,p2[j].p.identity,c,i,n,j,sqrt(dist2)));
 	    ONEPART_TRACE(if(p2[j].p.identity==check_id) fprintf(stderr,"%d: OPT: Verlet Pair %d %d (Cells %d %d dist %f)\n",this_node,p1[i].p.identity,p2[j].p.identity,c,n,sqrt(dist2)));
 
@@ -460,7 +460,7 @@ void calc_link_cell_iccp3m()
 	for(j = j_start; j < np2; j++) {
 	    {
 	      dist2 = distance2vec(p1[i].r.p, p2[j].r.p, vec21);
-	      if(dist2 <= SQR(get_ia_param(p1[i].p.type, p2[j].p.type)->max_cut + skin)) {
+	      if(verlet_list_criterion(p1+i,p2+j,dist2)) {
 		/* calc non bonded interactions */
 		add_non_bonded_pair_force_iccp3m(&(p1[i]), &(p2[j]), vec21, sqrt(dist2), dist2);
 	      }

--- a/src/core/interaction_data.cpp
+++ b/src/core/interaction_data.cpp
@@ -479,7 +479,7 @@ double calc_electrostatics_cutoff()
   switch (coulomb.method) {
 #ifdef P3M 
   case COULOMB_ELC_P3M:
-    returnelc_params.space_layer;
+    return elc_params.space_layer;
   case COULOMB_P3M_GPU:
   case COULOMB_P3M: 
     /* do not use precalculated r_cut here, might not be set yet */

--- a/src/core/interaction_data.cpp
+++ b/src/core/interaction_data.cpp
@@ -479,7 +479,7 @@ double calc_electrostatics_cutoff()
   switch (coulomb.method) {
 #ifdef P3M 
   case COULOMB_ELC_P3M:
-    return elc_params.space_layer;
+    return max(elc_params.space_layer,p3m.params.r_cut_iL* box_l[0]);
   case COULOMB_P3M_GPU:
   case COULOMB_P3M: 
     /* do not use precalculated r_cut here, might not be set yet */

--- a/src/core/interaction_data.cpp
+++ b/src/core/interaction_data.cpp
@@ -107,6 +107,13 @@ double max_cut_bonded;
 /** maximal cutoff of type-independent short range ia, mainly
     electrostatics and DPD*/
 double max_cut_global;
+/** Everything which is in the global cutoff except real space cutoffs
+    of dipolar and Coulomb mehtods */
+double max_cut_global_without_coulomb_and_dipolar;
+
+// Real space cutoff of long range methods 
+double coulomb_cutoff;
+double dipolar_cutoff;
 
 /** Array containing all tabulated forces*/
 DoubleList tabulated_forces;
@@ -459,14 +466,11 @@ static void recalc_maximal_cutoff_bonded()
   }
 }
 
-static void recalc_global_maximal_nonbonded_cutoff()
-{
-  /* user defined minimal global cut. This makes sure that data of
-   pairs of particles with a distance smaller than this are always
-   available on the same node (through ghosts). Required for example
-   for the relative virtual sites algorithm. */
-  max_cut_global = min_global_cut;
 
+
+double calc_electrostatics_cutoff()
+{
+// Electrostatics cutoff
 #ifdef ELECTROSTATICS
   /* Cutoff for the real space electrostatics.
      Note that the box length may have changed,
@@ -475,43 +479,35 @@ static void recalc_global_maximal_nonbonded_cutoff()
   switch (coulomb.method) {
 #ifdef P3M 
   case COULOMB_ELC_P3M:
-    if (max_cut_global < elc_params.space_layer)
-      max_cut_global = elc_params.space_layer;
-    // fall through
+    returnelc_params.space_layer;
   case COULOMB_P3M_GPU:
-  case COULOMB_P3M: {
+  case COULOMB_P3M: 
     /* do not use precalculated r_cut here, might not be set yet */
-    double r_cut = p3m.params.r_cut_iL* box_l[0];
-    if (max_cut_global < r_cut)
-      max_cut_global = r_cut;
-    break;
-  }
+    return p3m.params.r_cut_iL* box_l[0];
 #endif
 #ifdef EWALD_GPU
   case COULOMB_EWALD_GPU:
-    if (max_cut_global < ewaldgpu_params.rcut)
-        max_cut_global = ewaldgpu_params.rcut;
-  break;
+    return ewaldgpu_params.rcut;
 #endif
   case COULOMB_DH:
-    if (max_cut_global < dh_params.r_cut)
-      max_cut_global = dh_params.r_cut;
-    break;
+      return dh_params.r_cut;
   case COULOMB_RF:
   case COULOMB_INTER_RF:
-    if (max_cut_global < rf_params.r_cut)
-      max_cut_global = rf_params.r_cut;
-    break;
+    return rf_params.r_cut;
 #ifdef SCAFACOS
   case COULOMB_SCAFACOS:
-      max_cut_global = std::max(max_cut_global, Electrostatics::Scafacos::get_r_cut());
-      break;
+      return  Electrostatics::Scafacos::get_r_cut());
 #endif
   default:
     break;
   }
 #endif /*ifdef ELECTROSTATICS */
-  
+return 0;
+}
+
+
+double calc_dipolar_cutoff()
+{
 #ifdef DIPOLES
   switch (coulomb.Dmethod) {
 #ifdef DP3M
@@ -519,16 +515,27 @@ static void recalc_global_maximal_nonbonded_cutoff()
     // fall through
   case DIPOLAR_P3M: {
     /* do not use precalculated r_cut here, might not be set yet */
-    double r_cut = dp3m.params.r_cut_iL* box_l[0];
-    if (max_cut_global < r_cut)
-      max_cut_global = r_cut;
-    break;
+    return dp3m.params.r_cut_iL* box_l[0];
   }
 #endif /*ifdef DP3M */
   default:
       break;
   }       
 #endif
+return 0;
+}
+
+
+static void recalc_global_maximal_nonbonded_and_long_range_cutoff()
+{
+  /* user defined minimal global cut. This makes sure that data of
+   pairs of particles with a distance smaller than this are always
+   available on the same node (through ghosts). Required for example
+   for the relative virtual sites algorithm. */
+   max_cut_global = min_global_cut;
+
+  
+
 
 #ifdef DPD
   if (dpd_r_cut != 0) {
@@ -544,6 +551,19 @@ static void recalc_global_maximal_nonbonded_cutoff()
   }
 #endif
 
+// global cutoff without dipolar and coulomb methods is needed
+// for more selective additoin of particle pairs to verlet lists
+max_cut_global_without_coulomb_and_dipolar=max_cut_global;
+
+
+
+  // Electrostatics and magnetostatics
+  coulomb_cutoff= calc_electrostatics_cutoff();
+  max_cut_global =max(max_cut_global,coulomb_cutoff);
+  
+  dipolar_cutoff= calc_dipolar_cutoff();
+  max_cut_global =max(max_cut_global,dipolar_cutoff);
+
 }
 
 static void recalc_maximal_cutoff_nonbonded()
@@ -552,7 +572,7 @@ static void recalc_maximal_cutoff_nonbonded()
 
   CELL_TRACE(fprintf(stderr, "%d: recalc_maximal_cutoff_nonbonded\n", this_node));
 
-  recalc_global_maximal_nonbonded_cutoff();
+  recalc_global_maximal_nonbonded_and_long_range_cutoff();
 
   CELL_TRACE(fprintf(stderr, "%d: recalc_maximal_cutoff_nonbonded: max_cut_global = %f\n", this_node, max_cut_global));
 
@@ -697,10 +717,12 @@ static void recalc_maximal_cutoff_nonbonded()
       data_sym->particlesInteract =
 	data->particlesInteract = (max_cut_current > 0.0);
       
-      /* take into account any electrostatics */
-      if (max_cut_global > max_cut_current)
-	max_cut_current = max_cut_global;
+      /* Bigger cutoffs are chosen due to dpd and the like. 
+         Coulomb and dipolar interactions are handled in the Verlet lists
+	 separately. */
 
+      max_cut_current =max(max_cut_current,max_cut_global_without_coulomb_and_dipolar);
+      
       data_sym->max_cut =
 	data->max_cut = max_cut_current;
 

--- a/src/core/interaction_data.cpp
+++ b/src/core/interaction_data.cpp
@@ -479,7 +479,7 @@ double calc_electrostatics_cutoff()
   switch (coulomb.method) {
 #ifdef P3M 
   case COULOMB_ELC_P3M:
-    return max(elc_params.space_layer,p3m.params.r_cut_iL* box_l[0]);
+    return std::max(elc_params.space_layer,p3m.params.r_cut_iL* box_l[0]);
   case COULOMB_P3M_GPU:
   case COULOMB_P3M: 
     /* do not use precalculated r_cut here, might not be set yet */
@@ -559,10 +559,10 @@ max_cut_global_without_coulomb_and_dipolar=max_cut_global;
 
   // Electrostatics and magnetostatics
   coulomb_cutoff= calc_electrostatics_cutoff();
-  max_cut_global =max(max_cut_global,coulomb_cutoff);
+  max_cut_global =std::max(max_cut_global,coulomb_cutoff);
   
   dipolar_cutoff= calc_dipolar_cutoff();
-  max_cut_global =max(max_cut_global,dipolar_cutoff);
+  max_cut_global =std::max(max_cut_global,dipolar_cutoff);
 
 }
 
@@ -721,7 +721,7 @@ static void recalc_maximal_cutoff_nonbonded()
          Coulomb and dipolar interactions are handled in the Verlet lists
 	 separately. */
 
-      max_cut_current =max(max_cut_current,max_cut_global_without_coulomb_and_dipolar);
+      max_cut_current =std::max(max_cut_current,max_cut_global_without_coulomb_and_dipolar);
       
       data_sym->max_cut =
 	data->max_cut = max_cut_current;

--- a/src/core/interaction_data.hpp
+++ b/src/core/interaction_data.hpp
@@ -1200,6 +1200,14 @@ extern double max_cut;
 extern double max_cut_nonbonded;
 /** Maximal interaction cutoff (real space/short range bonded interactions). */
 extern double max_cut_bonded;
+/** Cutoff of coulomb real space part */
+extern double coulomb_cutoff;
+/** Cutoff of dipolar real space part */
+extern double dipolar_cutoff;
+
+
+
+
 /** Minimal global interaction cutoff. Particles with a distance
     smaller than this are guaranteed to be available on the same node
     (through ghosts).  */

--- a/src/core/verlet.cpp
+++ b/src/core/verlet.cpp
@@ -95,30 +95,6 @@ void free_pairList(PairList *list)
 
 /** Returns true if the particles are to be considered for short range 
     interactions */
-bool verlet_list_criterion(Particle* p1, Particle* p2,double dist2)
-{
-  if (dist2 > SQR(max_cut +skin))
-    return false;
-
-    
-  // Within short-range distance (incl dpd and the like)
-  if(dist2 <= SQR(get_ia_param(p1->p.type, p2->p.type)->max_cut + skin))
-    return true;
-
-  // Within real space cutoff of electrostatics and both charged
-  #ifdef ELECTROSTATICS
-    if ((dist2 <= SQR(coulomb_cutoff + skin)) && (p1->p.q!=0) && (p2->p.q!=0))
-      return true;
-  #endif
-
-  // Within dipolar cutoff and both cary magnetic moments
-  #ifdef DIPOLES
-  if ((dist2 <= SQR(dipolar_cutoff+skin)) && (p1->p.dipm!=0) && (p2->p.dipm!=0))
-    return true;
-  #endif
-  
-  return false;
-}
 
 
 void build_verlet_lists()

--- a/src/core/verlet.hpp
+++ b/src/core/verlet.hpp
@@ -103,5 +103,8 @@ void calculate_verlet_virials(int v_comp);
 /*@}*/
 
 
+/** Returns true if the particles are to be considered for short range 
+    interactions */
+bool verlet_list_criterion(Particle* p1, Particle* p2,double dist2);
 
 #endif

--- a/src/core/verlet.hpp
+++ b/src/core/verlet.hpp
@@ -50,6 +50,9 @@
  *  For more information see \ref verlet.cpp "verlet.c".
  */
 #include "particle_data.hpp"
+#include "interaction_data.hpp"
+#include "integrate.hpp"
+
 
 /************************************************
  * data types
@@ -103,8 +106,33 @@ void calculate_verlet_virials(int v_comp);
 /*@}*/
 
 
+
+
 /** Returns true if the particles are to be considered for short range 
     interactions */
-bool verlet_list_criterion(Particle* p1, Particle* p2,double dist2);
+inline bool verlet_list_criterion(const Particle* p1, const Particle* p2,double dist2)
+{
+  if (dist2 > SQR(max_cut +skin))
+    return false;
+
+    
+  // Within short-range distance (incl dpd and the like)
+  if(dist2 <= SQR(get_ia_param(p1->p.type, p2->p.type)->max_cut + skin))
+    return true;
+
+  // Within real space cutoff of electrostatics and both charged
+  #ifdef ELECTROSTATICS
+    if ((dist2 <= SQR(coulomb_cutoff + skin)) && (p1->p.q!=0) && (p2->p.q!=0))
+      return true;
+  #endif
+
+  // Within dipolar cutoff and both cary magnetic moments
+  #ifdef DIPOLES
+  if ((dist2 <= SQR(dipolar_cutoff+skin)) && (p1->p.dipm!=0) && (p2->p.dipm!=0))
+    return true;
+  #endif
+  
+  return false;
+}
 
 #endif


### PR DESCRIPTION
This will exclude pairs, which are more distant than short-range cutoff + skin
But still within coulomb and dipolar real space cutoff, if the particles both
don't carry charges/dipoles. This is done by excluding the dipolar/coulomb
part in ia_params[i,j].max_cut and storing them separately.
This results in performance and memory improvements for systems with only a small fraction
of particles carrying dipoles/charges.

