### PR TITLE
Block2pcl

### DIFF
--- a/tools/blockfile.py
+++ b/tools/blockfile.py
@@ -60,138 +60,147 @@ re_float = re.compile('[0-9\.]+')
 
 re_col_types = {}
 for col_type in col_types:
-	re_col_types[col_type] = re.compile(col_type)
+    re_col_types[col_type] = re.compile(col_type)
 
 def load_col_types(blockfile_support_tcl):
-	global col_types, re_col_types
-	col_types, re_col_types = {}, {}
-	with __builtin__.open(blockfile_support_tcl) as f:
-		for i in re.finditer('"(\^[a-z_]+\$*)"\s*{.*?; incr idx ([0-9]*)\s*}', f.read(), re.DOTALL):
-			var_name, var_cols = i.group(1), i.group(2)
-			if var_cols == '': var_cols = 1
-			else: var_cols = int(var_cols)
-			col_types[var_name] = var_cols
-	for col_type in col_types:
-		re_col_types[col_type] = re.compile(col_type)
+    global col_types, re_col_types
+    col_types, re_col_types = {}, {}
+    with __builtin__.open(blockfile_support_tcl) as f:
+        for i in re.finditer('"(\^[a-z_]+\$*)"\s*{.*?; incr idx ([0-9]*)\s*}', f.read(), re.DOTALL):
+            var_name, var_cols = i.group(1), i.group(2)
+            if var_cols == '': var_cols = 1
+            else: var_cols = int(var_cols)
+            col_types[var_name] = var_cols
+    for col_type in col_types:
+        re_col_types[col_type] = re.compile(col_type)
 
 def process(block):
-	"""
-	Processes the block and returns the block's type and the block's contents as a tuple.
-	"""
-	block_type = re_block_type.match(block).group(1)
-	
-	# particle data looks like this:
-	# {particles {id pos v q f} 
-	# 	{0 7.875 9.0 0.0 0.0 0.0 0.0 -0.6 7.29706 -1.08036 -3.39398}
-	# 	{1 7.875 9.0 1.2 0.0 0.0 0.0 -0.6 1.37885 -0.320172 -2.49209}
-	if block_type == 'particles':
-		particles = re_particles.match(block)
-		
-		# get the field labels and determine how many columns a field consists of (i.e. dimensionality of vector quantities)
-		fields = particles.group(1).split(' ')
-		field_lengths = [0]*len(fields)
-		for i,field in enumerate(fields):
-			for col_type in col_types:
-				if re_col_types[col_type].match(field) is not None:
-					field_lengths[i] = col_types[col_type]
-					break
-			if field_lengths[i] == 0:
-				raise Exception("Field '%s' is unknown. Dimensionality of this field cannot be determined." % field)
-		
-		# split the particle block into the individual particles
-		particles = [re_space.split(x) for x in re_particle.findall(particles.group(2))]
-		N = len(particles)
-		
-		# create one empty numpy array per field with the appropriate dimensionality
-		particle_data = {}
-		for i,field in enumerate(fields):
-			dtype = float
-			if re_col_types['^i'].match(field) is not None or re_col_types['^ty'].match(field) is not None:
-				# the ID and type fields are integer, everything else is a float
-				dtype = int
-			particle_data[field] = numpy.empty((N,field_lengths[i]), dtype=dtype)
-		
-		# fill the numpy arrays with the particle data
-		for i,particle in enumerate(particles):
-			fieldcount = 0
-			for j,field in enumerate(fields):
-				particle_data[field][i] = particle[fieldcount:fieldcount+field_lengths[j]]
-				fieldcount += field_lengths[j]
-		
-		return block_type, particle_data
-	
-	# variables look like this:
-	# {variable  {box_l 18.0 18.0 480.0} {test 18.0} {stringtest test} }
-	if block_type == 'variable':
-		variables = {}
-		# extract all variable names and values from the block
-		for m in re_variable.finditer(block):
-			try:
-				# convert it to an integer/float if it's a (list of) integer/float variable(s)
-				value = m.group(2).strip()
-				if re_int_list.match(value) is not None:
-					value = numpy.array(re_int.findall(value), dtype=int)
-				elif re_float_list.match(value) is not None:
-					value = numpy.array(re_float.findall(value), dtype=float)
-				variables[m.group(1)] = value
-			except:
-				# return it as a string if we can't convert it to a number
-				variables[m.group(1)] = m.group(2).strip()
-		
-		return block_type, variables
-	
-	# any other block types are returned as string
-	return block_type, block[len(block_type)+1:-2].strip()
+    """
+    Processes the block and returns the block's type and the block's contents as a tuple.
+    """
+    if re_block_type.match(block) != None:
+        block_type = re_block_type.match(block).group(1)
+    else:
+        return None
+    # particle data looks like this:
+    # {particles {id pos v q f} 
+    #   {0 7.875 9.0 0.0 0.0 0.0 0.0 -0.6 7.29706 -1.08036 -3.39398}
+    #   {1 7.875 9.0 1.2 0.0 0.0 0.0 -0.6 1.37885 -0.320172 -2.49209}
+    if block_type == 'particles':
+        particles = re_particles.match(block)
+        
+        # get the field labels and determine how many columns a field consists of (i.e. dimensionality of vector quantities)
+        fields = particles.group(1).split(' ')
+        field_lengths = [0]*len(fields)
+        for i,field in enumerate(fields):
+            for col_type in col_types:
+                if re_col_types[col_type].match(field) is not None:
+                    field_lengths[i] = col_types[col_type]
+                    break
+            if field_lengths[i] == 0:
+                raise Exception("Field '%s' is unknown. Dimensionality of this field cannot be determined." % field)
+        
+        # split the particle block into the individual particles
+        particles = [re_space.split(x) for x in re_particle.findall(particles.group(2))]
+        N = len(particles)
+        
+        # create one empty numpy array per field with the appropriate dimensionality
+        particle_data = {}
+        for i,field in enumerate(fields):
+            dtype = float
+            if re_col_types['^i'].match(field) is not None or re_col_types['^ty'].match(field) is not None:
+                # the ID and type fields are integer, everything else is a float
+                dtype = int
+            particle_data[field] = numpy.empty((N,field_lengths[i]), dtype=dtype)
+        
+        # fill the numpy arrays with the particle data
+        for i,particle in enumerate(particles):
+            fieldcount = 0
+            for j,field in enumerate(fields):
+                particle_data[field][i] = particle[fieldcount:fieldcount+field_lengths[j]]
+                fieldcount += field_lengths[j]
+        
+        return block_type, particle_data
+    
+    # variables look like this:
+    # {variable  {box_l 18.0 18.0 480.0} {test 18.0} {stringtest test} }
+    if block_type == 'variable':
+        variables = {}
+        # extract all variable names and values from the block
+        for m in re_variable.finditer(block):
+            try:
+                # convert it to an integer/float if it's a (list of) integer/float variable(s)
+                value = m.group(2).strip()
+                if re_int_list.match(value) is not None:
+                    value = numpy.array(re_int.findall(value), dtype=int)
+                elif re_float_list.match(value) is not None:
+                    value = numpy.array(re_float.findall(value), dtype=float)
+                variables[m.group(1)] = value
+            except:
+                # return it as a string if we can't convert it to a number
+                variables[m.group(1)] = m.group(2).strip()
+        
+        return block_type, variables
+    
+    # any other block types are returned as string
+    return block_type, block[len(block_type)+1:-2].strip()
 
 class blockfile(object):
-	f = None
-	
-	def __init__(self, path):
-		"""
-		Opens the blockfile.
-		"""
-		self.f = __builtin__.open(path)
-	
-	def __iter__(self):
-		"""
-		Iterator over all the blocks in the open blockfile.
-		The iterator returns each block as a tuple of block type and block contents.
-		"""
-		block = ''
-		while True:
-			block += self.f.readline() # this assumes that all blocks end with a newline
-			if block.count('{') == block.count('}'): # we have a full block:
-				yield process(block)
-				block = ''
-			if self.f.tell() == os.fstat(self.f.fileno()).st_size:
-				return
-	
-	def __del__(self):
-		"""
-		Closes the blockfile.
-		"""
-		self.close()
-	
-	def close(self):
-		"""
-		Closes the blockfile.
-		"""
-		self.f.close()
+    f = None
+    
+    def __init__(self, path):
+        """
+        Opens the blockfile.
+        """
+        self.f = __builtin__.open(path)
+    
+    def __iter__(self):
+        """
+        Iterator over all the blocks in the open blockfile.
+        The iterator returns each block as a tuple of block type and block contents.
+        """
+        block = ''
+        while True:
+            block += self.f.readline() # this assumes that all blocks end with a newline
+            if block.count('{') == block.count('}'): # we have a full block:
+                output = process(block)
+                if output != None:
+                    yield output
+                else:
+                    pass
+                block = ''
+            if self.f.tell() == os.fstat(self.f.fileno()).st_size:
+                return
+    
+    def __del__(self):
+        """
+        Closes the blockfile.
+        """
+        self.close()
+
+    def rewind(self):
+        self.f.seek(0)
+
+    def close(self):
+        """
+        Closes the blockfile.
+        """
+        self.f.close()
 
 if __name__ != "__main__":
-	def open(path):
-		"""
-		Opens the blockfile at path.
-		"""
-		return blockfile(path)
+    def open(path):
+        """
+        Opens the blockfile at path.
+        """
+        return blockfile(path)
 
 if __name__ == "__main__":
-	# If this script is called directly with the argument --extract, it extracts the list of column types from scripts/blockfile_support.tcl.
-	if len(sys.argv) > 1 and sys.argv[1] == '--extract':
-		if len(sys.argv) < 2 or not os.path.exists(sys.argv[2]):
-			sys.stderr.write("Please specify the path to scripts/blockfile_support.tcl from Espresso.\n")
-			sys.exit(1)
-		load_col_types(sys.argv[2])
-		from pprint import pprint
-		print(pprint(col_types))
-		sys.exit()
+    # If this script is called directly with the argument --extract, it extracts the list of column types from scripts/blockfile_support.tcl.
+    if len(sys.argv) > 1 and sys.argv[1] == '--extract':
+        if len(sys.argv) < 2 or not os.path.exists(sys.argv[2]):
+            sys.stderr.write("Please specify the path to scripts/blockfile_support.tcl from Espresso.\n")
+            sys.exit(1)
+        load_col_types(sys.argv[2])
+        from pprint import pprint
+        print(pprint(col_types))
+        sys.exit()

--- a/tools/blockfile.py
+++ b/tools/blockfile.py
@@ -170,6 +170,7 @@ class blockfile(object):
                     pass
                 block = ''
             if self.f.tell() == os.fstat(self.f.fileno()).st_size:
+                self._rewind()
                 return
     
     def __del__(self):
@@ -178,7 +179,7 @@ class blockfile(object):
         """
         self.close()
 
-    def rewind(self):
+    def _rewind(self):
         self.f.seek(0)
 
     def close(self):

--- a/tools/blockfile2pickle.py
+++ b/tools/blockfile2pickle.py
@@ -16,20 +16,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 #
-### This script extracts particle and interaction data from blockfiles ###
+
+### This script extracts tcl blockfiles and pickles the appropriate py class.
+
 import blockfile as bf
 import espressomd
 import espressomd._system as es
 from espressomd.particle_data import ParticleList
+from espressomd.interactions import NonBondedInteractions, BondedInteractions
 from sys import argv
 import pickle
+
+def safe_str2intflt(string):
+    """ Takes a string argument and exits if the argument is not a string.
+        Returns an integer, if conversion is possible, otherwise returns
+        a python float, otherwise return the original string """
+    if not isinstance(string, str):
+        raise TypeError("I want strings, not " + type(string) + "exiting.")
+    try: return int(string)
+    except ValueError: pass
+    try: return float(string)
+    except ValueError: return string
+
 
 # nagnagnag
 if len(argv) < 3:
     print "Usage:  ./pypresso ./blockfile2pickle.py <blockfile> <output-prefix>"
-    print "Output: <output-prefix>-<blocktype>.pcl"
-    print "Example output: lj_fluid-particle.pcl lj_fluid-interactions.pcl"
-    print "needs Espresso/tools/blockfile.py in the same dir"
+    print "Output: create files named <output-prefix>-<classname>.pcl in workdir"
+    print "Example output: lj_fluid-ParticleList.pcl lj_fluid-NonBondedInteractions.pcl"
+    print "Supports: particle, interaction"
+    print "Depends:  Espresso/tools/blockfile.py file in a sys.path dir"
 
 # initialize blockfile class from blockfile
 blocks = bf.open(argv[1])
@@ -40,27 +56,160 @@ b_list = []
 for i in blocks:
     b_list.append(i)
 
+# close the file. for this object, this is handled by __del__
+del blocks
+
 #loop over every block
 for k in b_list:
+    #turn tuple into list
+    k = list(k)
     # where k[0] is a string of the block type
     # and k[1] is a dict for every block argument.
     
     # if k is a particle block
     if k[0] == 'particles':
+        print "Particle Block found"
         if "pos" not in k[1] or "id" not in k[1]:
-            print "Error, id and/or pos missing in particle block"
-            exit(1)
-        # instance of the internal particle list
-        pl = ParticleList()
-        # Set appropriate params foreach particle
-        pl.add( k[1] )
-        # pickle it
-        with open(argv[2] + "-" + k[0] + ".pcl", 'w') as outfile:
-            pickle.dump(pl, outfile, -1)
+            print "Error, id and/or pos missing in particle block, skipping particle"
+            continue # the continue statement jumps to the next iteration.
 
-    elif k[0] == 'interactions':
+        print "Particle properties found:"
+        print k[1].keys()
+        # instance of the system internal particle list
+        pl = ParticleList()
+        # Set appropriate params foreach particle, since pl.add is so nice,
+        # we just have to pass the k[1] dict.
+        try: pl.add( k[1] )
+        except AttributeError: 
+            print "Error, the blockfile sets a particle parameter which is not compiled in."
+            print "To properly pickle a particle, all necessary features need to be compiled."
+            print "For example, if the particle property 'q' is set, we need ELECTROSTATICS."
+            print "skipping particle"
+            continue
+        # pickle it
+        with open(argv[2] + "-ParticleList.pcl", 'w') as outfile:
+            print "Pickling ParticleList"
+            pickle.dump(pl, outfile, -1)
+            del pl
+
+
+    # if k is an interactions block
+    elif k[0] == 'interactions' or k[0] == 'inter':
+        # here, the blockfile tool returns a string containing ugly escapes.
+        # this means we have to do some data processing.
+        if not isinstance(k[1], str):
+            print "Unexpected error, bf.blockfile did not return string for inter"
+            print "skipping interaction block"
+            continue
+        # split block into strings for every interaction directive and
+        # get rid of unnecessary characters
+        k[1] = [words.strip().strip('{').strip('}')
+                for words in k[1].split('\n')]
+        # split interaction strings into list of arguments and convert
+        # every numeric string into an integer or float.
+        # Then filter every empty string.
+        # Do that for every command invocation in block.
+        k[1] = [filter(lambda x: x!='',[safe_str2intflt(word) for word in words.split(' ')]) 
+                            for words in k[1]] 
+
+        # We need to differentiate between Bonded and Nonbonded
+        # The difference is: Nonbonded starts with two integers as part id,
+        # and Bonded starts with one integer as bond id.
+        # so: Nonbonded looks like this: [<numbers> <numbers> <letters> ...]
+        # bonded looks like this: [<numbers> <letters> ...]
+
+        #initialize system internal interaction objects
+        bia = BondedInteractions()
+        nia = NonBondedInteractions()
+        # keep track of whether or not nia or bia where actually used to init
+        # an interaction.
+        nia_success = False
+        bia_success = False
+        for arg_list in k[1]:
+            n_args = len(arg_list)
+            if (isinstance(arg_list[0], int) and isinstance(arg_list[1], int) 
+                                            and isinstance(arg_list[2], str)):
+                # NonBondedInteractions.
+                # figure out what interaction in particular we are looking at.
+                if arg_list[2] == 'lennard-jones':
+                    # Here, we found lennard-jones interaction. 
+                    # In this indentation level we write interaction specific
+                    # parsing code.
+                    print "Found lennard-jones interaction for particles"
+                    # test whether or not there are enough arguments for
+                    # the required parameters of lj
+                    if n_args < 6:
+                        print "Not enough arguments for lennard-jones, skipping"
+                        continue # The continue statement jumps to the next
+                                 # iteration of the innermost for-loop
+                    # create input dict for the lj kwargs
+                    in_dict =   {   
+                                    "epsilon": arg_list[3],
+                                    "sigma"  : arg_list[4],
+                                    "cutoff" : arg_list[5]
+                                }
+                    # optional arguments
+                    if 6 < n_args: in_dict["shift"]  = arg_list[6]
+                    if 7 < n_args: in_dict["offset"] = arg_list[7]
+                    if 8 < n_args: in_dict["min"]    = arg_list[8]
+                    if 9 < n_args: 
+                        print "Error: too many arguments for lennard-jones, skipping"
+                        continue
+                    # initialization of the interaction with nia.
+                    # Also: since set_params doesn't natively support dicts as *args
+                    #       we need to expand the in_dict as **kwargs, this is done
+                    #       by passing it to a function as **in_dict
+                    nia[arg_list[0], arg_list[1]].lennard_jones.set_params(**in_dict)
+                    nia_success = True # set this to true if nia actually did something
+                    
+                    # be nice to the user
+                    print "\nSetting up lennard-jones with the following params:"
+                    print in_dict
+                    print "for id %d and %d" %(arg_list[0], arg_list[1])
+                    print ""
+            
+                # HERE is the spot where you can implement the initialization
+                # for an individual NonBondedInteraction. One elif-statement for every
+                # type of interaction. No pickledump, this is already taken care of,
+                # just parse arg_list and init with nia. see above (lennard-jones) for
+                # an example. Don't forget to set nia_success to True if initialization 
+                # actually happens.
+                elif arg_list[2] == "MyNonBondedInteraction":
+                    pass
+                else:
+                    print "NonBondedInteraction " + arg_list[2] + " is unknown, skipping"
+                    continue
+        
+            elif isinstance(arg_list[0], int) and isinstance(arg_list[1], str):
+            #BondedInteractions
+
+            # HERE is the spot where you can implement the parser for BondedInteractions.
+            # But instead of using nia and nia_success, use bia and bia_success
+            # accordingly. See NonBondedInteractions above, specifically lennard-jones.
+                if arg_list[1] == "MyBondedInteraction":
+                    pass
+                
+                else:
+                    print "BondedInteraction" + arg_list[1] + " is unknown, skipping"
+                    continue
+            else:
+                print "Unknown interaction format, skipping"
+        
+        # end of arg_list for loop
+        if nia_success:
+            with open(argv[2] + "-NonBondedInteractions.pcl", "w") as outfile:
+                pickle.dump(nia, outfile, -1)
+                print "pickling NonBondedInteractions"
+            del nia, nia_success
+        if bia_success:
+            with open(argv[2] + "-BondedInteractions.pcl", "w") as outfile:
+                pickle.dump(bia, outfile, -1)
+                print "pickling NonBondedInteractions"
+            del bia, bia_success
+    elif k[0] == "MyBlockIdentifier":
         pass
+
     else:
-        print "blockfile type " + k[0] + " not implemented, skipping"
+        print "blocktype " + k[0] + " unknown, skipping"
 
 

--- a/tools/blockfile2pickle.py
+++ b/tools/blockfile2pickle.py
@@ -1,0 +1,66 @@
+#/usr/bin/env python2
+# Copyright (C) 2013,2014,2015,2016 The ESPResSo project
+#  
+# This file is part of ESPResSo.
+#  
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#  
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#  
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+#
+### This script extracts particle and interaction data from blockfiles ###
+import blockfile as bf
+import espressomd
+import espressomd._system as es
+from espressomd.particle_data import ParticleList
+from sys import argv
+import pickle
+
+# nagnagnag
+if len(argv) < 3:
+    print "Usage:  ./pypresso ./blockfile2pickle.py <blockfile> <output-prefix>"
+    print "Output: <output-prefix>-<blocktype>.pcl"
+    print "Example output: lj_fluid-particle.pcl lj_fluid-interactions.pcl"
+    print "needs Espresso/tools/blockfile.py in the same dir"
+
+# initialize blockfile class from blockfile
+blocks = bf.open(argv[1])
+b_list = []
+
+# create a list of tuples which contains block data
+# Each element returned by blocks' __iter__ is a tuple for a tcl block
+for i in blocks:
+    b_list.append(i)
+
+#loop over every block
+for k in b_list:
+    # where k[0] is a string of the block type
+    # and k[1] is a dict for every block argument.
+    
+    # if k is a particle block
+    if k[0] == 'particles':
+        if "pos" not in k[1] or "id" not in k[1]:
+            print "Error, id and/or pos missing in particle block"
+            exit(1)
+        # instance of the internal particle list
+        pl = ParticleList()
+        # Set appropriate params foreach particle
+        pl.add( k[1] )
+        # pickle it
+        with open(argv[2] + "-" + k[0] + ".pcl", 'w') as outfile:
+            pickle.dump(pl, outfile, -1)
+
+    elif k[0] == 'interactions':
+        pass
+    else:
+        print "blockfile type " + k[0] + " not implemented, skipping"
+
+


### PR DESCRIPTION
tools/blockfile2pickle.py

    This tools converts tcl blockfiles into appropriate member classes of
    the System class. Right now the script supports particles and the
    lennard-jones interaction.
    
    Since the tcl interface is as awful as it is, different commands have to
    be handled in a case-by-case basis. The script provides enough
    infrastructure for that endeavour, so that parsing of different commands
    can be implemented if need be.
    
    Specifically for parsing interactions, enough groundwork has been laid
    out so that all it takes is to create an appropriate dict for the
    corresponding <interaction>.set_params() method.

Also changed indentation of blockfile.py