### PR TITLE
Langevin print fix

### DIFF
--- a/scripts/blockfile_support.tcl
+++ b/scripts/blockfile_support.tcl
@@ -378,7 +378,7 @@ proc blockfile_read_auto_integrate {channel read auto} {
 proc blockfile_write_thermostat {channel write thermostat} {
     blockfile $channel write start thermostat
     set data [join [thermostat] "\}\n\t\{"]
-    puts $channel "\n\t\{ off \}\n\t{$data}\n\}"
+    puts $channel "\n\t{$data}\n\}"
 }
 
 proc blockfile_read_auto_thermostat {channel read auto} {

--- a/src/tcl/thermostat_tcl.cpp
+++ b/src/tcl/thermostat_tcl.cpp
@@ -396,10 +396,8 @@ int tclcommand_thermostat_print_all(Tcl_Interp *interp)
     Tcl_AppendResult(interp," ",buffer, (char *)NULL);
     Tcl_PrintDouble(interp, langevin_gamma_rotation, buffer);
     Tcl_AppendResult(interp," ",buffer, (char *)NULL);
-    Tcl_PrintDouble(interp, langevin_trans, buffer);
-    Tcl_AppendResult(interp," ",buffer, (char *)NULL);
-    Tcl_PrintDouble(interp, langevin_rotate, buffer);
-    Tcl_AppendResult(interp," ",buffer," } ", (char *)NULL);
+    Tcl_AppendResult(interp," ", langevin_trans? "on": "off", (char *)NULL);
+    Tcl_AppendResult(interp," ", langevin_rotate? "on": "off", " } ", (char *)NULL);
   }
     
 #ifdef DPD


### PR DESCRIPTION
Reading a langevin thermostat from a blockfile fails with:
thermostat langevin needs on/off
while executing
"thermostat langevin 1.0 1.0 0.0 1.0 1.0 "
The input routine expects: thermostat set langevin <temp> <gamma_trans> [<gamma_rot> <on/off> <on/off>]

So the print function should print "on" or "off" and not bools as doubles.

Also, remove the additional "{ off }".