### PR TITLE
MPI-IO

### DIFF
--- a/doc/ug/io.tex
+++ b/doc/ug/io.tex
@@ -360,6 +360,56 @@ binary particle data happens through
 For the exact format of the written binary sequence, see
 \texttt{src/tcl/binary_file_tcl.cpp}.
 
+
+\section{MPI-IO}
+\index{mpiio}
+
+When using \es with MPI, blockfiles and writemd have the disadvantage,
+that the master node does \textit{all} the output. This is done by
+sequentially communicating all particle data to the master node. MPI-IO
+offers the possibility to write out particle data in parallel using
+binary IO. To output variables and other non-array inforamtion, use
+normal blockfiles (section~\ref{sec:structured-file-format}).
+
+To dump data using MPI-IO, use the following syntax:
+\begin{essyntax}
+  mpiio \var{filename} \opt{read|write} \opt{pos|v|bond|type}
+\end{essyntax}
+This command writes data to several files using \var{filename} as
+filename prefix. Beware, that \var{filename} must not be a Tcl channel
+but a string which must not contain colons (MPI fails on these). The
+data can be positions (\keyword{pos}), velocities (\keyword{v}),
+particle types (\keyword{type}) and particle bonds (\keyword{bond}). The
+particle ids are always dumped. For safety reasons, MPI-IO will not
+overwrite existing files, so if the command fails and prints
+\texttt{MPI_ERR_IO} make sure the files are non-existent.
+
+The files produced by this command will be (assumed \var{filename} is
+``1''):
+\begin{description}[align=right,labelwidth=2cm]
+  \item [1.head] Internal information (Dumped fields, bond partner num); always produced
+  \item [1.pref] Internal information (Exscan results of nlocalparts);
+    always produced
+  \item [1.ids] Particle ids; always produced
+  \item [1.type] Particle types; optional
+  \item [1.pos] Particle positions; optional
+  \item [1.vel] Particle velocities; optional
+  \item [1.bond] Bond information; optional
+  \item [1.boff] Internal bond prefix information; optional, necessary
+    to read 1.bond
+\end{description}
+
+Currently, these files have to be read by exactly the same number of MPI
+processes that was used to dump them, otherwise an error is
+signalled. Also, the same type of machine (endianess, byte order) has to
+be used. Otherwise only garbage will be read. The read command replaces
+the particles, i.e. all previous existent particles will be
+\textit{deleted}.
+
+There is a python script (\texttt{tools/mpiio2blockfile.py}) which
+converts MPI-IO snapshots to regular \es blockfiles.
+
+
 \section{Writing VTF files}
 \label{sec:vtf}
 %\quickrefheading{Handling of VTF files}

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -116,7 +116,8 @@ libEspresso_la_SOURCES = \
 	integrate_sd.hpp integrate_sd.cpp \
 	EspressoSystemInterface.hpp EspressoSystemInterface.cpp \
 	PdbParser.cpp PdbParser.hpp \
-	utils/statistics/RunningAverage.cpp utils/statistics/RunningAverage.hpp
+	utils/statistics/RunningAverage.cpp utils/statistics/RunningAverage.hpp \
+	mpiio.cpp mpiio.hpp
 
 # nonbonded potentials and forces
 libEspresso_la_SOURCES += \

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -73,6 +73,7 @@
 #include "statistics_observable.hpp"
 #include "minimize_energy.hpp"
 #include "scafacos.hpp"
+#include "mpiio.hpp"
 
 using namespace std;
 
@@ -170,6 +171,7 @@ static int terminated = 0;
   CB(mpi_gather_cuda_devices_slave) \
   CB(mpi_thermalize_cpu_slave) \
   CB(mpi_scafacos_set_parameters_slave) \
+  CB(mpi_mpiio_slave) \
   
 // create the forward declarations
 #define CB(name) void name(int node, int param);
@@ -3261,3 +3263,39 @@ void mpi_gather_cuda_devices_slave(int dummy1, int dummy2) {
 #endif
 }
 
+
+void mpi_mpiio(const char *filename, unsigned fields, int write) {
+#ifdef HAVE_MPI
+  size_t flen = strlen(filename) + 1;
+  if (flen + 5 > INT_MAX) {
+    fprintf(stderr, "Seriously?\n");
+    errexit();
+  }
+  mpi_call(mpi_mpiio_slave, -1, (int) flen);
+  MPI_Bcast((void *) filename, (int) flen, MPI_CHAR, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&fields, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&write, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  if (write)
+    mpi_mpiio_common_write(filename, fields);
+  else
+    mpi_mpiio_common_read(filename, fields);
+#else
+  runtimeErrorMsg() << "ESPResSo is compiled without MPI support. No MPI-IO available.";
+#endif
+}
+
+void mpi_mpiio_slave(int dummy, int flen) {
+#ifdef HAVE_MPI
+  char *filename = new char[flen];
+  unsigned fields;
+  int write;
+  MPI_Bcast((void *) filename, flen, MPI_CHAR, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&fields, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&write, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  if (write)
+    mpi_mpiio_common_write(filename, fields);
+  else
+    mpi_mpiio_common_read(filename, fields);
+  delete[] filename;
+#endif
+}

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -637,6 +637,13 @@ std::vector<EspressoGpuDevice> mpi_gather_cuda_devices();
 /** CPU Thermostat */
 void mpi_thermalize_cpu(int temp);
 
+/** MPI-IO output function.
+ *  \param filename Filename prefix for the created files. Must be null-terminated.
+ *  \param fields Fields to dump (see mpiio_tcl.hpp).
+ *  \param write 1 to write, 0 to read
+ */
+void mpi_mpiio(const char *filename, unsigned fields, int write);
+
 /*@}*/
 
 /** \name Event codes for \ref mpi_bcast_event

--- a/src/core/mpiio.cpp
+++ b/src/core/mpiio.cpp
@@ -1,0 +1,472 @@
+/*
+  Copyright (C) 2010,2011,2012,2013,2014,2015,2016 The ESPResSo project
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+    Max-Planck-Institute for Polymer Research, Theory Group
+  
+  This file is part of ESPResSo.
+  
+  ESPResSo is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  ESPResSo is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+/** \file mpiio.cpp
+ *
+ * Concerning the file layots.
+ * - Scalar arrays are written like this:
+ *   rank0 --- rank1 --- rank2 ...
+ *   where each rank dumps its scalars in the ordering of the particles.
+ * - Vector arrays are written in the rank ordering like scalar arrays.
+ *   The ordering of the vector data is: v[0] v[1] v[2], so the data
+ *   looks like this:
+ *   v1[0] v1[1] v1[2] v2[0] v2[1] v2[2] v3[0] ...
+ *
+ * To be able to determine the rank bondaries (a multiple of
+ * nlocalparts), the file 1.pref is written, which dumps the Exscan
+ * results of nlocalparts, i.e. the prefixes in scalar arrays:
+ * - 1.prefs looks like this:
+ *   0 nlocalpats_rank0 nlocalparts_rank0+nlocalparts_rank1 ...
+ *
+ * Bonds are dumped as two arrays, namely 1.bond which stores the
+ * bonding partners of the particles and 1.boff which stores the
+ * iteration indices for each particle.
+ * - 1.boff is a scalar array of size (nlocalpart + 1) per rank.
+ * - The last element (at index nlocalpart) of 1.boff's subpart
+ *   [rank * (nlocalpart + 1) : (rank + 1) * (nlocalpart + 1)]
+ *   determines the number of bonds for processor "rank".
+ * - In this subarray one can find the bonding partners of particle
+ *   id[i]. The iteration indices for local part of 1.bonds are:
+ *   subarray[i] : subarray[i+1]
+ * - Take a look at the bond input code. It's easy to understand.
+ */
+
+#include <string>
+#include <vector>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include "config.hpp"
+#include "initialize.hpp"
+#include "particle_data.hpp"
+#include "interaction_data.hpp"
+#include "integrate.hpp"
+#include "cells.hpp"
+#include "utils.hpp"
+#include "mpiio.hpp"
+#include "../tcl/mpiio_tcl.hpp"
+
+#ifdef HAVE_MPI
+#include <mpi.h>
+
+/** Dumps arr of size len starting from prefix pref of type T using
+ * MPI_T as MPI datatype. Beware, that T and MPI_T have to match!
+ *
+ * \param fn The file name to dump to. Must not exist already
+ * \param arr The array to dump
+ * \param len The number of elements to dump
+ * \param pref The prefix for this process
+ * \param MPI_T The MPI_Datatype corresponding to the template parameter T.
+ */
+template <typename T>
+static void mpiio_dump_array(std::string fn, T* arr, size_t len,
+                             size_t pref, MPI_Datatype MPI_T)
+{
+  MPI_File f;
+  int ret;
+
+  ret = MPI_File_open(MPI_COMM_WORLD, fn.c_str(),
+                      // MPI_MODE_EXCL: Prohibit overwriting
+                      MPI_MODE_WRONLY | MPI_MODE_CREATE | MPI_MODE_EXCL,
+                      MPI_INFO_NULL, &f);
+  if (ret) {
+    char buf[MPI_MAX_ERROR_STRING];
+    int len;
+    MPI_Error_string(ret, buf, &len);
+    buf[len] = '\0';
+    fprintf(stderr, "MPI-IO Error: Could not open file \"%s\": %s\n",
+            fn.c_str(), buf);
+    errexit();
+  }
+  ret = MPI_File_set_view(f, pref * sizeof(T), MPI_T, MPI_T, "native",
+                          MPI_INFO_NULL);
+  ret |= MPI_File_write_all(f, arr, len, MPI_T, MPI_STATUS_IGNORE);
+  MPI_File_close(&f);
+  if (ret) {
+    fprintf(stderr, "MPI-IO Error: Could not write file \"%s\".\n",
+            fn.c_str());
+    errexit();
+  }
+}
+
+/** Dumps some generic infos like the dumped fields and info to process
+ *  the bond information offline (without ESPResSo). To be called by the
+ *  master node only.
+ *
+ * \param fn The filename to write to
+ * \param fields The dumped fields
+ */
+static void dump_info(std::string fn, unsigned fields)
+{
+  static std::vector<int> npartners;
+  int success;
+  FILE *f = fopen(fn.c_str(), "wb");
+  if (!f) {
+    fprintf(stderr, "MPI-IO Error: Could not open %s for writing.\n",
+            fn.c_str());
+    errexit();
+  }
+  success = (fwrite(&fields, sizeof(fields), 1, f) == 1);
+  // Pack the necessary information of bonded_ia_params:
+  // The number of partners. This is needed to interpret the bond IntList.
+  if (n_bonded_ia > npartners.size())
+    npartners.resize(n_bonded_ia);
+
+  for (int i = 0; i < n_bonded_ia; ++i) {
+    if (bonded_ia_params[i].type == BONDED_IA_NONE)
+      npartners[i] = 0;
+    else
+      npartners[i] = bonded_ia_params[i].num;
+  }
+  success = success && (fwrite(&n_bonded_ia, sizeof(int), 1, f) == 1);
+  success = success && (fwrite(npartners.data(), sizeof(int),
+                               n_bonded_ia, f) == n_bonded_ia);
+  fclose(f);
+  if (!success) {
+    fprintf(stderr, "MPI-IO Error: Failed to write %s.\n", fn.c_str());
+    errexit();
+  }
+}
+
+
+void mpi_mpiio_common_write(const char *filename, unsigned fields)
+{
+  std::string fnam(filename);
+  int nlocalpart = cells_get_n_particles(), pref = 0, bpref = 0;
+  int rank, ret;
+  // Keep static buffers in order not having to allocate them on every
+  // function call
+  static std::vector<double>pos, vel;
+  static std::vector<int>id, type, boff, bond;
+  Cell *cell;
+
+  // Nlocalpart prefixes
+  // Prefixes based for arrays: 3 * pref for vel, pos.
+  MPI_Exscan(&nlocalpart, &pref, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+  // Realloc static buffers if necessary
+  if (nlocalpart > id.size())
+    id.resize(nlocalpart);
+  if (fields & MPIIO_OUT_POS && 3 * nlocalpart > pos.size())
+    pos.resize(3 * nlocalpart);
+  if (fields & MPIIO_OUT_VEL && 3 * nlocalpart > vel.size())
+    vel.resize(3 * nlocalpart);
+  if (fields & MPIIO_OUT_TYP && nlocalpart > type.size())
+    type.resize(nlocalpart);
+  if (fields & MPIIO_OUT_BND && nlocalpart + 1 > boff.size())
+    boff.resize(nlocalpart + 1);
+  
+  // Pack the necessary information
+  // Esp. rescale the velocities.
+  boff[0] = 0;
+  int i1 = 0, i3 = 0;
+  for (int c = 0; c < local_cells.n; ++c) {
+    cell = local_cells.cell[c];
+    for (int j = 0; j < cell->n; ++j) {
+      id[i1] = cell->part[j].p.identity;
+      if (fields & MPIIO_OUT_POS) {
+        pos[i3] = cell->part[j].r.p[0];
+        pos[i3 + 1] = cell->part[j].r.p[1];
+        pos[i3 + 2] = cell->part[j].r.p[2];
+      }
+      if (fields & MPIIO_OUT_VEL) {
+        vel[i3] = cell->part[j].m.v[0] / time_step;
+        vel[i3 + 1] = cell->part[j].m.v[1] / time_step;
+        vel[i3 + 2] = cell->part[j].m.v[2] / time_step;
+      }
+      if (fields & MPIIO_OUT_TYP) {
+        type[i1] = cell->part[j].p.type;
+      }
+      if (fields & MPIIO_OUT_BND) {
+        boff[i1 + 1] = cell->part[j].bl.n;
+      }
+      i1++;
+      i3 += 3;
+    }
+  }
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0)
+    dump_info(fnam + ".head", fields);
+  mpiio_dump_array<int>(fnam + ".pref", &pref, 1, rank, MPI_INT);
+  mpiio_dump_array<int>(fnam + ".id", id.data(), nlocalpart, pref,
+                        MPI_INT);
+  if (fields & MPIIO_OUT_POS)
+    mpiio_dump_array<double>(fnam + ".pos", pos.data(), 3 * nlocalpart,
+                             3 * pref, MPI_DOUBLE);
+  if (fields & MPIIO_OUT_VEL)
+    mpiio_dump_array<double>(fnam + ".vel", vel.data(), 3 * nlocalpart,
+                             3 * pref, MPI_DOUBLE);
+  if (fields & MPIIO_OUT_TYP)
+    mpiio_dump_array<int>(fnam + ".type", type.data(), nlocalpart, pref,
+                          MPI_INT);
+  
+  if (fields & MPIIO_OUT_BND) {
+    // Convert the bond counts to bond prefixes
+    for (int i = 1; i <= nlocalpart; ++i)
+      boff[i] += boff[i - 1];
+    int numbonds = boff[nlocalpart];
+
+    // Realloc bond buffer if necessary
+    if (numbonds > bond.size())
+      bond.resize(numbonds);
+
+    // Pack the bond information
+    int i = 0;
+    for (int c = 0; c < local_cells.n; ++c) {
+      cell = local_cells.cell[c];
+      for (int j = 0; j < cell->n; ++j) {
+        for (int k = 0; k < cell->part[j].bl.n; ++k)
+          bond[i++] = cell->part[j].bl.e[k];
+      }
+    }
+    
+    // Determine the prefixes in the bond file
+    MPI_Exscan(&numbonds, &bpref, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    mpiio_dump_array<int>(fnam + ".boff", boff.data(), nlocalpart + 1,
+                          pref + rank, MPI_INT);
+    mpiio_dump_array<int>(fnam + ".bond", bond.data(), numbonds, bpref,
+                          MPI_INT);
+  }
+}
+
+
+/** Get the number of elements in a file by its file size and
+ *  elem_sz. I.e. query the file size using stat(2) and divide it by
+ *  elem_sz.
+ *
+ * \param fn The filename
+ * \param elem_sz Sizeof a single element
+ * \return The number of elements stored binary in the file
+ */
+static int get_num_elem(std::string fn, size_t elem_sz)
+{
+  // Could also be done via MPI_File_open, MPI_File_get_size,
+  // MPI_File_cose.
+  struct stat st;
+  errno = 0;
+  if (stat(fn.c_str(), &st) != 0) {
+    fprintf(stderr, "MPI-IO Input Error: Could not get file size of %s: %s\n",
+            fn.c_str(), strerror(errno));
+    errexit();
+  }
+  return st.st_size / elem_sz;
+}
+
+/** Reads a previously dumped array of size len starting from prefix
+ *  pref of type T using MPI_T as MPI datatype. Beware, that T and MPI_T
+ *  have to match!
+ */
+template <typename T>
+static void mpiio_read_array(std::string fn, T* arr, size_t len,
+                            size_t pref, MPI_Datatype MPI_T)
+{
+  MPI_File f;
+  int ret;
+
+  ret = MPI_File_open(MPI_COMM_WORLD, fn.c_str(), MPI_MODE_RDONLY,
+                      MPI_INFO_NULL, &f);
+  if (ret) {
+    char buf[MPI_MAX_ERROR_STRING];
+    int len;
+    MPI_Error_string(ret, buf, &len);
+    buf[len] = '\0';
+    fprintf(stderr, "MPI-IO Error: Could not open file \"%s\": %s\n",
+            fn.c_str(), buf);
+    errexit();
+  }
+  ret = MPI_File_set_view(f, pref * sizeof(T), MPI_T, MPI_T, "native",
+                          MPI_INFO_NULL);
+  ret |= MPI_File_read_all(f, arr, len, MPI_T, MPI_STATUS_IGNORE);
+  MPI_File_close(&f);
+  if (ret) {
+    fprintf(stderr, "MPI-IO Error: Could not read file \"%s\".\n",
+            fn.c_str());
+    errexit();
+  }
+}
+
+/** Read the header file and store the information in the pointer
+ *  "field". To be called by all processes.
+ *
+ * \param fn Filename of the head file
+ * \param rank The rank of the current process in MPI_COMM_WORLD
+ * \param file Pointer to store the fields to
+ */
+static void read_head(std::string fn, int rank, unsigned *fields)
+{
+  FILE *f;
+  if (rank == 0) {
+    if (!(f = fopen(fn.c_str(), "rb"))) {
+      fprintf(stderr, "MPI-IO: Could not open %s.head.\n", fn.c_str());
+      errexit();
+    }
+    if (fread((void *) fields, sizeof(unsigned), 1, f) != 1) {
+      fprintf(stderr, "MPI-IO: Read on %s.head failed.\n", fn.c_str());
+      errexit();
+    }
+    MPI_Bcast(fields, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
+  } else {
+    MPI_Bcast(fields, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
+  }
+}
+
+/** Reads the pref file and fills pref and nlocalpart with their
+ *  corresponding values. Needs to be called by all processes.
+ *
+ * \param fn The file name of the prefs file
+ * \param rank The rank of the current process in MPI_COMM_WORLD
+ * \param size The size of MPI_COMM_WORLD
+ * \param nglobalpart The global amount of particles
+ * \param prefs Pointer to store the prefix to
+ * \param nlocalpart Pointer to store the amount of local particles to
+ */
+static void read_prefs(std::string fn, int rank, int size,
+                       int nglobalpart, int *pref, int *nlocalpart)
+{
+  mpiio_read_array<int>(fn, pref, 1, rank, MPI_INT);
+  if (rank > 0)
+    MPI_Send(pref, 1, MPI_INT, rank - 1, 0, MPI_COMM_WORLD);
+  if (rank < size - 1)
+    MPI_Recv(nlocalpart, 1, MPI_INT, rank + 1, MPI_ANY_TAG,
+             MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+  else
+    *nlocalpart = nglobalpart;
+  *nlocalpart -= *pref;
+}
+
+void mpi_mpiio_common_read(const char *filename, unsigned fields)
+{
+  std::string fnam(filename);
+  int size, rank;
+  int nproc, nglobalpart, pref, nlocalpart, nlocalbond, bpref;
+  unsigned avail_fields;
+
+  local_remove_all_particles();
+
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  nproc = get_num_elem(fnam + ".pref", sizeof(int));
+  nglobalpart = get_num_elem(fnam + ".id", sizeof(int));
+
+  if (rank == 0 && nproc != size) {
+    fprintf(stderr,
+            "MPI-IO Error: Trying to read a file with a different COMM size than at point of writing.\n");
+    errexit();
+  }
+
+  // 1.head on master node:
+  // Read head to determine fields at time of writing.
+  // Compare this var to the current fields.
+  read_head(fnam + ".head", rank, &avail_fields);
+  if (rank == 0 && (fields & avail_fields) != fields) {
+    fprintf(stderr, "MPI-IO Error: Requesting to read fields which were not dumped.\n");
+    errexit();
+  }
+
+  // 1.pref on all nodes:
+  // Read own prefix (1 int at prefix rank).
+  // Communicate own prefix to rank-1
+  // Determine nlocalpart (prefix of rank+1 - own prefix) on every node.
+  read_prefs(fnam + ".pref", rank, size, nglobalpart, &pref, &nlocalpart);
+
+  // Prepare ESPResSo data structures
+  local_particles = (Particle **) Utils::realloc(local_particles,
+                                                 sizeof(Particle *) * nglobalpart);
+  for (int i = 0; i < nglobalpart; ++i)
+    local_particles[i] = NULL;
+  n_part = nglobalpart;
+  max_seen_particle = nglobalpart;
+
+  // 1.id on all nodes:
+  // Read nlocalpart ints at defined prefix.
+  std::vector<int> id(nlocalpart);
+  mpiio_read_array<int>(fnam + ".id", id.data(), nlocalpart, pref,
+                        MPI_INT);
+
+  if (fields & MPIIO_OUT_POS) {
+    // 1.pos on all nodes:
+    // Read nlocalpart * 3 doubles at defined prefix * 3
+    std::vector<double> pos(3 * nlocalpart);
+    mpiio_read_array<double>(fnam + ".pos", pos.data(), 3 * nlocalpart,
+                             3 * pref, MPI_DOUBLE);
+
+    for (int i = 0; i < nlocalpart; ++i) {
+      local_place_particle(id[i], &pos[3 * i], 1);
+    }
+  }
+
+  if (fields & MPIIO_OUT_TYP) {
+    // 1.type on all nodes:
+    // Read nlocalpart ints at defined prefix.
+    std::vector<int> type(nlocalpart);
+    mpiio_read_array<int>(fnam + ".type", type.data(), nlocalpart, pref,
+                          MPI_INT);
+
+    for (int i = 0; i < nlocalpart; ++i)
+      local_particles[id[i]]->p.type = type[i];
+  }
+
+  if (fields & MPIIO_OUT_VEL) {
+    // 1.vel on all nodes:
+    // Read nlocalpart * 3 doubles at defined prefix * 3
+    std::vector<double> vel(3 * nlocalpart);
+    mpiio_read_array<double>(fnam + ".vel", vel.data(), 3 * nlocalpart,
+                             3 * pref, MPI_DOUBLE);
+
+    for (int i = 0; i < nlocalpart; ++i)
+      for (int k = 0; k < 3; ++k)
+        local_particles[id[i]]->m.v[k] = vel[3*i+k] * time_step;
+  }
+
+  if (fields & MPIIO_OUT_BND) {
+    // 1.boff
+    // nlocalpart + 1 ints per process
+    std::vector<int> boff(nlocalpart + 1);
+    mpiio_read_array<int>(fnam + ".boff", boff.data(), nlocalpart + 1,
+                          pref + rank, MPI_INT);
+
+    nlocalbond = boff[nlocalpart];
+    // Determine the bond prefixes
+    bpref = 0;
+    MPI_Exscan(&nlocalbond, &bpref, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+    // 1.bond
+    // nlocalbonds ints per process
+    std::vector<int> bond(nlocalbond);
+    mpiio_read_array<int>(fnam + ".bond", bond.data(), nlocalbond, bpref,
+                          MPI_INT);
+
+    for (int i = 0; i < nlocalpart; ++i) {
+      int blen = boff[i+1] - boff[i];
+      IntList *il = &local_particles[id[i]]->bl;
+      realloc_intlist(il, blen);
+      memcpy(il->e, &bond[boff[i]], blen * sizeof(int));
+      il->n = blen;
+    }
+  }
+
+  if (rank == 0)
+    build_particle_node();
+  rebuild_verletlist = 1;
+  on_particle_change();
+}
+
+#endif // HAVE_MPI

--- a/src/core/mpiio.hpp
+++ b/src/core/mpiio.hpp
@@ -1,0 +1,47 @@
+/*
+  Copyright (C) 2010,2011,2012,2013,2014,2015,2016 The ESPResSo project
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+    Max-Planck-Institute for Polymer Research, Theory Group
+  
+  This file is part of ESPResSo.
+  
+  ESPResSo is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  ESPResSo is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+/** \file mpiio.hpp
+ *  Implements binary output unsing MPI-IO.
+ */
+
+#ifndef _MPIIO_HPP
+#define _MPIIO_HPP
+
+#ifdef HAVE_MPI
+/** Parallel binary output using MPI-IO. To be called by all MPI
+ * processes. Aborts ESPResSo if an error occurs.
+ *
+ * \param filename A null-terminated filename prefix.
+ * \param fields Output specifier which fields to dump.
+ */
+void mpi_mpiio_common_write(const char *filename, unsigned fields);
+
+/** Parallel binary input using MPI-IO. To be called by all MPI
+ * processes. Aborts ESPResSo if an error occurs.
+ *
+ * \param filename A null-terminated filename prefix.
+ * \param fields Specifier which fields to read.
+ */
+void mpi_mpiio_common_read(const char *filename, unsigned fields);
+
+#endif
+
+#endif

--- a/src/tcl/Makefile.am
+++ b/src/tcl/Makefile.am
@@ -83,7 +83,8 @@ libEspressoTcl_la_SOURCES = \
 	twist_stack_tcl.hpp twist_stack_tcl.cpp \
 	hydrogen_bond_tcl.hpp hydrogen_bond_tcl.cpp \
 	minimize_energy_tcl.cpp minimize_energy_tcl.hpp \
-	integrate_sd_tcl.cpp integrate_sd_tcl.hpp
+	integrate_sd_tcl.cpp integrate_sd_tcl.hpp \
+	mpiio_tcl.cpp mpiio_tcl.hpp
 
 # nonbonded potentials and forces
 libEspressoTcl_la_SOURCES += \

--- a/src/tcl/initialize_interpreter.cpp
+++ b/src/tcl/initialize_interpreter.cpp
@@ -64,6 +64,7 @@
 #include "actor/HarmonicOrientationWell_tcl.hpp"
 #include "minimize_energy_tcl.hpp"
 #include "h5mdfile_tcl.hpp"
+#include "mpiio_tcl.hpp"
 
 #ifdef TK
 #include <tk.h>
@@ -176,6 +177,8 @@ static void tcl_register_commands(Tcl_Interp* interp) {
   #ifdef H5MD
 	REGISTER_COMMAND("h5mdfile", tclcommand_h5mdfile);
   #endif
+  /* in mpiio_tcl.cpp */
+  REGISTER_COMMAND("mpiio", tclcommand_mpiio);
   /* in constraint.cpp */
   REGISTER_COMMAND("constraint", tclcommand_constraint);
   /* in external_potential.hpp */

--- a/src/tcl/mpiio_tcl.cpp
+++ b/src/tcl/mpiio_tcl.cpp
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 2010,2011,2012,2013,2014,2015,2016 The ESPResSo project
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+    Max-Planck-Institute for Polymer Research, Theory Group
+  
+  This file is part of ESPResSo.
+  
+  ESPResSo is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  ESPResSo is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+#include "mpiio_tcl.hpp"
+#include "communication.hpp"
+
+#define LEN(x) (sizeof(x) / sizeof(*(x)))
+
+/** Array describing the mapping of possible output descriptors to
+ *  internal output specifiers.
+ */
+static const struct {
+  const char *name;
+  const MPIIOOutputFields val;
+} out_desc[] = {
+  { "pos", MPIIO_OUT_POS },
+  { "v", MPIIO_OUT_VEL },
+  { "type", MPIIO_OUT_TYP },
+  { "bond", MPIIO_OUT_BND },
+};
+
+
+int tclcommand_mpiio(ClientData data, Tcl_Interp *interp,
+                     int argc, char *argv[])
+{
+  char *filename;
+  char *mode;
+  unsigned output_fields = 0;
+  bool correct_field;
+  int write;
+
+#ifdef MULTI_TIMESTEP
+  Tcl_AppendResult(interp, "MPI-IO does not support multi-timestep velocity rescaling.",
+                   (char *) NULL);
+  return (TCL_ERROR);
+#endif
+  
+  if (argc < 3) {
+    Tcl_AppendResult(interp, "wrong # args:  should be \"",
+                     argv[0], " <filename> read|write ?pos|v|types|bonds?* ...\"",
+                     (char *) NULL);
+    return (TCL_ERROR);
+  }
+  filename = argv[1];
+  // Operation mode
+  if (!strncmp(argv[2], "write", strlen(argv[2]))) {
+    write = 1;
+  } else if (!strncmp(argv[2], "read", strlen(argv[2]))) {
+    write = 0;
+  } else {
+    Tcl_AppendResult(interp, "wrong operation mode: \"", argv[2],
+                     "\"  should be \"read\" or \"write\"",
+                     (char *) NULL);
+    return (TCL_ERROR);
+  }
+  
+  argv += 3;
+  argc -= 3;
+
+  // The remaining arguments are field output specifiers.
+  // Parse them according to out_desc.
+  for (; argc > 0; argc--, argv++) {
+    correct_field = false;
+    for (size_t i = 0; i < LEN(out_desc); ++i) {
+      if (!strncmp(*argv, out_desc[i].name, strlen(*argv))) {
+        output_fields |= out_desc[i].val;
+        correct_field = true;
+        break;
+      }
+    }
+    if (!correct_field) {
+      Tcl_AppendResult(interp, "unknown output field: \"", *argv,
+                       "\"  see the user's guide for all possibilities",
+                       (char *) NULL);
+      return (TCL_ERROR);
+    }
+  }
+
+  
+  mpi_mpiio(filename, output_fields, write);
+
+  return (TCL_OK);
+}

--- a/src/tcl/mpiio_tcl.hpp
+++ b/src/tcl/mpiio_tcl.hpp
@@ -1,0 +1,50 @@
+/*
+  Copyright (C) 2010,2011,2012,2013,2014,2015,2016 The ESPResSo project
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+    Max-Planck-Institute for Polymer Research, Theory Group
+  
+  This file is part of ESPResSo.
+  
+  ESPResSo is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  
+  ESPResSo is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+/** \file mpiio.hpp
+ *  Tcl interface for MPI-IO.
+ */
+#ifndef _MPIIO_TCL_H
+#define _MPIIO_TCL_H
+
+#include "parser.hpp"
+
+/** Constants which indicate what to output. To indicate the output of
+ *  multiple fields, OR the corresponding values.
+ *
+ */
+enum MPIIOOutputFields {
+  MPIIO_OUT_POS = 1,
+  MPIIO_OUT_VEL = 2,
+  MPIIO_OUT_TYP = 4,
+  MPIIO_OUT_BND = 8,
+};
+
+/** MPI-IO Tcl command. First argument is a file name (not a Tcl channel),
+ *  second argument the direction ("read" or "write") and all further arguments
+ *  are the fields to dump, namely: "pos", "v", "types", "bonds"
+ *
+ *  This command will create several files all with the prefix "filename".
+ *
+ */   
+int tclcommand_mpiio(ClientData data, Tcl_Interp *interp,
+                     int argc, char *argv[]);
+
+#endif

--- a/tools/mpiio2blockfile.py
+++ b/tools/mpiio2blockfile.py
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2013,2014,2015,2016 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import print_function
+
+# Important: Currently, this script assumes, that all fields are dumped.
+# To support less: Read the "fields" unsigned int from 1.head.
+
+import os
+import sys
+import array
+
+if len(sys.argv) < 2:
+    print >>sys.stderr, "Prefix as second argument!"
+    raise SystemExit(1)
+
+fpref = sys.argv[1]
+headf = fpref + ".head"
+preff = fpref + ".pref"
+idf = fpref + ".id"
+typef = fpref + ".type"
+posf = fpref + ".pos"
+velf = fpref + ".vel"
+bofff = fpref + ".boff"
+bondf = fpref + ".bond"
+
+# Determine nproc, etc. at time of writing
+nproc = os.stat(preff).st_size / 4
+ntotalpart = os.stat(idf).st_size / 4
+ntotalbond = os.stat(bondf).st_size / 4
+
+# Read header - fields, n_bonded_ia, bonded_ia_params[:].nums
+fields = 0
+nbia = 0
+biaparams = array.array("i")
+with open(headf) as f:
+    afields = array.array("I")
+    afields.read(f, 1)
+    fields = afields[0]
+    anbia = array.array("i")
+    anbia.read(f, 1)
+    nbia = anbia[0]
+    biaparams.read(f, nbia)
+
+# Read prefixes
+pref = array.array("i")
+with open(preff) as f:
+    pref.read(f, nproc)
+
+# Read ids
+id = array.array("i")
+with open(idf) as f:
+    id.read(f, ntotalpart)
+
+# Read types
+type = array.array("i")
+with open(typef) as f:
+    type.read(f, ntotalpart)
+
+# Read pos
+pos = array.array("d")
+with open(posf) as f:
+    pos.read(f, 3 * ntotalpart)
+
+# Read vel
+vel = array.array("d")
+with open(velf) as f:
+    vel.read(f, 3 * ntotalpart)
+
+# Read bonds
+boff = array.array("i")
+with open(bofff) as f:
+    boff.read(f, ntotalpart + nproc)
+
+bond = array.array("i")
+with open(bondf) as f:
+    bond.read(f, ntotalbond)
+
+
+# Print particles in blockfile format
+print("{particles {id type pos v}")
+for i in xrange(ntotalpart):
+    print("\t{%i %i %r %r %r %r %r %r}" \
+        % (id[i], type[i], pos[3*i], pos[3*i+1], pos[3*i+2], \
+           vel[3*i], vel[3*i+1], vel[3*i+2]))
+print("}")
+
+# Print bonds in blockfile format
+print("{bonds")
+addend = 0 # ntotal bonds of previous processors
+for rank in xrange(nproc):
+    # The start and end indices for the boff array are determined via
+    # pref. However, there are (nlocalpart + 1) boff entries per proc.
+    start = pref[rank] + rank
+    end = rank + (pref[rank + 1] if rank < nproc - 1 else ntotalpart)
+    for pid, i in enumerate(xrange(start, end)):
+        print("\t{%i { " % id[pref[rank] + pid], end="")
+        # The start and end indices for the bond array are determined
+        # via boff. However, boff does only *locally* store prefixes,
+        # i.e. they have to be globalized by adding the total number of
+        # bonds on all ranks before this one.
+        j = addend + boff[i]
+        while j < addend + boff[i + 1]:
+            bond_num = bond[j]
+            j += 1
+            npartners = biaparams[bond_num]
+            print("{%i" % bond_num, end="")
+            for _ in xrange(npartners):
+                print(" %i" % bond[j], end="")
+                j += 1
+            print("} ", end="")
+        print("} }")
+    addend += boff[end]
+print("}")


### PR DESCRIPTION
Add the functionality to output particle ids, types, positions, velocities and bonds using MPI-IO, i.e. without gathering everything on the master node.