### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,42 @@
 language: cpp
 dist: trusty
-sudo: required
+sudo: false
 
 cache: 
   - apt
   - ccache
 
+addons:
+  apt:
+    sources:
+      - boost-latest 
+      - ubuntu-toolchain-r-test
+      - george-edison55-precise-backports
+    packages:
+      - ccache
+      - tcl-dev
+      - libhdf5-serial-dev 
+      - build-essential 
+      - pep8 
+      - cmake
+      - cmake-data
+      - libboost1.55-dev 
+      - libboost-test1.55-dev
+      - libopenmpi-dev
+      - openmpi-bin
+      - libfftw3-dev
+      - gcc-4.8
+      - g++-4.8
+
 before_install:
- - sudo apt-get update
- - sudo apt-get install -y tcl-dev libhdf5-serial-dev build-essential pep8 cmake libboost-dev libboost-test-dev
- - if [ "$with_mpi" != false ]; then sudo apt-get install -y libopenmpi-dev openmpi-bin; fi
- - if [ "$with_fftw" != false ]; then sudo apt-get install -y libfftw3-dev; fi
+ - if [[ ${CC} = gcc ]]; then export CC="gcc-${GVER}" CXX="g++-${GVER}"; fi
  - travis_retry wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
  - chmod +x miniconda.sh
  - bash miniconda.sh -b -p $HOME/miniconda
  - export PATH=/home/travis/miniconda/bin:$PATH
  - conda update --yes conda
+ - ln -s /usr/bin/ccache "$HOME/miniconda/bin/clang++"
+ - ln -s /usr/bin/ccache "$HOME/miniconda/bin/clang"
 
 install:
  - conda create --yes -n test python=2.7.9
@@ -24,15 +45,19 @@ install:
  - pip install codecov
 
 env:
-  - myconfig=default
-  - myconfig=maxset
-  - myconfig=maxset-gaussrandom
-  - myconfig=maxset-gaussrandomcut
-  - myconfig=molcut
-  - myconfig=rest1
-  - myconfig=rest2
-  - make_check=false myconfig=nocheck-maxset
-  - with_fftw=false with_mpi=false myconfig=maxset
+  global:
+    - CCACHE_CPP2=yes
+    - GVER=4.8
+  matrix:
+    - myconfig=default
+    - myconfig=maxset
+    - myconfig=maxset-gaussrandom
+    - myconfig=maxset-gaussrandomcut
+    - myconfig=molcut
+    - myconfig=rest1
+    - myconfig=rest2
+    - make_check=false myconfig=nocheck-maxset
+    - with_fftw=false with_mpi=false myconfig=maxset
 
 compiler:
   - gcc

--- a/maintainer/travis/build_cmake.sh
+++ b/maintainer/travis/build_cmake.sh
@@ -99,9 +99,9 @@ else
 fi
 
 if $with_fftw; then
-    cmake_params="-DWITH_FFTW=ON $cmake_params"
+    cmake_params="$cmake_params"
 else
-    cmake_params="-DWITH_FFTW=OFF $cmake_params"
+    cmake_params="-DCMAKE_DISABLE_FIND_PACKAGE_FFTW3=ON $cmake_params"
 fi
 
 if $with_tcl; then


### PR DESCRIPTION
`sudo` isn't really needed anymore, so let's switch to the container-based infrastructure.

Additionally I found a bug in `build_cmake.sh`, the `WITH_FFTW` option is gone, so let's replace it with `CMAKE_DISABLE_FIND_PACKAGE_FFTW3`, which forces cmake to not find fftw3 at all.