### PR TITLE
Systemset

### DIFF
--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -39,12 +39,17 @@ setable_properties=["box_l","max_num_cells","min_num_cells",
                     "time_step","timings"]
 
 cdef class System:
+    # NOTE: every attribute has to be declared at the class level.
+    # This means that methods cannot define an attribute by using
+    # `self.new_attr = somevalue` without declaring it inside this
+    # indentation level, either as method, property or reference.
     doge = 1
     part = particle_data.ParticleList()
     non_bonded_inter = interactions.NonBondedInteractions()
     bonded_inter = interactions.BondedInteractions()
     cell_system = CellSystem()
     thermostat = Thermostat()
+    actors = None
 
     def __init__(self):
         self.actors = Actors(_system=self)

--- a/src/python/espressomd/system.py
+++ b/src/python/espressomd/system.py
@@ -13,4 +13,32 @@ class System(_system.System):
         if hasattr(self, name):
             super(System, self).__setattr__(name, value)
         else:
-            raise AttributeError("System does not have the attribute", name)
+            raise AttributeError(
+                "System does not have the attribute " + name + "."
+                + "\nIf you know what you're doing, use "
+                + "system.create_attr()"
+            )
+    
+    def create_attr(self, *args, **kwargs):
+        """
+        Circumvents the __setattr__ lock. Allows to create and set new
+        attributes to System instances.
+        For *args, it initializes an attribute with None value, if the
+        attribute does not already exist.
+        For **kwargs, it simply calls super().__setattr__.
+        """
+        for arg in args:
+            try: name = str(arg)
+            except ValueError:
+                print("Please pass either **kwargs or string *args to"
+                    + "create_attr()"
+                )
+                continue
+            
+            if hasattr(self, name):
+                print("Attribute " + name + " already exists.")
+            else:
+                super(System, self).__setattr__(name, None)
+
+        for name, value in kwargs.items():
+            super(System, self).__setattr__(name, value)

--- a/src/python/espressomd/system.py
+++ b/src/python/espressomd/system.py
@@ -7,7 +7,7 @@ from espressomd import _system
 class System(_system.System):
 
     def __init__(self):
-       _system.System.__init__(self)
+        _system.System.__init__(self)
 
     def __setattr__(self, name, value):
         if hasattr(self, name):
@@ -18,7 +18,7 @@ class System(_system.System):
                 + "\nIf you know what you're doing, use "
                 + "system.create_attr()"
             )
-    
+
     def create_attr(self, *args, **kwargs):
         """
         Circumvents the __setattr__ lock. Allows to create and set new
@@ -31,10 +31,10 @@ class System(_system.System):
             try: name = str(arg)
             except ValueError:
                 print("Please pass either **kwargs or string *args to"
-                    + "create_attr()"
-                )
+                      + "create_attr()"
+                      )
                 continue
-            
+
             if hasattr(self, name):
                 print("Attribute " + name + " already exists.")
             else:

--- a/src/python/espressomd/system.py
+++ b/src/python/espressomd/system.py
@@ -7,4 +7,10 @@ from espressomd import _system
 class System(_system.System):
 
     def __init__(self):
-        _system.System.__init__(self)
+       _system.System.__init__(self)
+
+    def __setattr__(self, name, value):
+        try: self.__getattribute__(name)
+        except AttributeError:
+            raise AttributeError("System does not have the attribute", name)
+        super(System, self).__setattr__(name, value)

--- a/src/python/espressomd/system.py
+++ b/src/python/espressomd/system.py
@@ -10,7 +10,7 @@ class System(_system.System):
        _system.System.__init__(self)
 
     def __setattr__(self, name, value):
-        try: self.__getattribute__(name)
-        except AttributeError:
+        if hasattr(self, name):
+            super(System, self).__setattr__(name, value)
+        else:
             raise AttributeError("System does not have the attribute", name)
-        super(System, self).__setattr__(name, value)


### PR DESCRIPTION
raise an exception if one tries to set a nonexisting attribute to an instance of System. This implies that methods called from System are also unable to set new attributes if these are not defined at the class level. This is to make sure that the right parameters are set and that the user is notified if a non-existing option was set.

To intentionally set nonexisting attributes, System now has the `create_attr(*args, **kwargs)` method.