### PR TITLE
Make the check_unit_tests target depend on EspressoConfig in order to…

### DIFF
--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Target for the unit tests
 add_custom_target(check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND})
-
+add_dependencies(check_unit_tests EspressoConfig)
 # Run unit tests on check
 add_dependencies(check check_unit_tests)
 


### PR DESCRIPTION
… have the config-features.hpp written before.