### PR TITLE
cmake build scripts for jenkins & travis

### DIFF
--- a/maintainer/jenkins/build_cmake.sh
+++ b/maintainer/jenkins/build_cmake.sh
@@ -24,10 +24,8 @@ source $DIR/common.sh
 # compiling on on proc is slow, lets use 4:
 [ -z "$build_procs" ] && build_procs=4
 # check_procs is never used...
-! $with_mpi && check_procs=1
 [ -z "$check_procs" ] && check_procs=2
 [ -z "$make_check" ] && make_check="true"
-[ -z "$with_mpi" ] && with_mpi="true"
 [ -z "$with_fftw" ] && with_fftw="true"
 [ -z "$with_tcl" ] && with_tcl="true"
 [ -z "$with_python_interface" ] && with_python_interface="false" #true in other build_cmake.sh
@@ -57,7 +55,7 @@ if ! $insource ; then
 fi
 
 outp insource srcdir builddir \
-    configure_params with_mpi with_fftw \
+    configure_params with_fftw \
     with_tcl with_python_interface myconfig check_procs with_h5md with_cuda
 
 # check indentation of python files
@@ -76,12 +74,6 @@ fi
 
 # CONFIGURE
 start "CONFIGURE"
-
-if $with_mpi; then
-    cmake_params="-DWITH_MPI=ON $cmake_params"
-else
-    cmake_params="-DWITH_MPI=OFF $cmake_params"
-fi
 
 if $with_fftw; then
     cmake_params="$cmake_params"

--- a/maintainer/jenkins/build_cmake.sh
+++ b/maintainer/jenkins/build_cmake.sh
@@ -1,0 +1,180 @@
+#!/bin/bash --login 
+# Copyright (C) 2013 Olaf Lenz
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+##############################################################################################################
+# configure.sh
+##############################################################################################################
+
+# in case the mpi path is not set properly run sth like:
+#export PATH=/usr/lib64/mpi/gcc/openmpi/bin:$PATH
+
+DIR=`dirname $0`
+source $DIR/common.sh
+
+# DEFAULTS
+[ -z "$insource" ] && insource="true"
+[ -z "$srcdir" ] && srcdir=`pwd`                                           
+[ -z "$cmake_params" ] && configure_params=""  
+[ -z "$myconfig" ] && myconfig="default"
+# compiling on on proc is slow, lets use 4:
+[ -z "$build_procs" ] && build_procs=4
+# check_procs is never used...
+! $with_mpi && check_procs=1
+[ -z "$check_procs" ] && check_procs=2
+[ -z "$make_check" ] && make_check="true"
+[ -z "$with_mpi" ] && with_mpi="true"
+[ -z "$with_fftw" ] && with_fftw="true"
+[ -z "$with_tcl" ] && with_tcl="true"
+[ -z "$with_python_interface" ] && with_python_interface="false" #true in other build_cmake.sh
+[ -z "$with_cuda" ] && with_cuda="true"
+[ -z "$with_h5md" ] && with_h5md="true"
+
+# set builddir 
+if $insource; then
+    builddir=$srcdir
+elif [ -z "$builddir" ]; then
+    builddir=$srcdir/build
+fi
+
+# create builddir if neccessary
+if ! $insource; then
+    if [ ! -d $builddir ]; then
+        echo "Creating $builddir..."
+        mkdir -p $builddir
+    fi
+fi
+
+# alternatively could probably use: 'pushd $builddir' & 'popd'?
+# and finally change into $builddir
+# pushd $builddir
+if ! $insource ; then
+    cd $builddir
+fi
+
+outp insource srcdir builddir \
+    configure_params with_mpi with_fftw \
+    with_tcl with_python_interface myconfig check_procs with_h5md with_cuda
+
+# check indentation of python files
+pep8 --filename=*.pyx,*.pxd,*.py --select=E111 $srcdir/src/python/espressomd/
+ec=$?
+if [ $ec -eq 0 ]; then
+    echo ""
+    echo "Indentation in Python files correct..."
+    echo ""
+else
+    echo ""
+    echo "Error: Python files are not indented the right way. Please use 4 spaces per indentation level!"
+    echo ""
+    exit $ec
+fi
+
+# CONFIGURE
+start "CONFIGURE"
+
+if $with_mpi; then
+    cmake_params="-DWITH_MPI=ON $cmake_params"
+else
+    cmake_params="-DWITH_MPI=OFF $cmake_params"
+fi
+
+if $with_fftw; then
+    cmake_params="$cmake_params"
+# THESE WHERE IN THE GCC SCRIPT
+#     if [ -e $FFTW_HEADER ]; then
+#         echo "Using FFTW => deleting mock $FFTW_HEADER..."
+#         rm $FFTW_HEADER
+#     fi
+else
+    cmake_params="-DCMAKE_DISABLE_FIND_PACKAGE_FFTW3=ON $cmake_params"
+#     echo "Not using FFTW => generating mock $FFTW_HEADER..."
+#     echo "#error ERROR: fftw is not really present but used somewhere." \
+#         > $FFTW_HEADER
+fi
+
+if $with_tcl; then
+    cmake_params="-DWITH_TCL=ON $cmake_params"
+else
+    cmake_params="-DWITH_TCL=OFF $cmake_params"
+fi
+
+if $with_python_interface; then
+    cmake_params="-DWITH_PYTHON=ON $cmake_params"
+else
+    cmake_params="-DWITH_PYTHON=OFF $cmake_params"
+fi
+
+if $with_cuda; then
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
+    cmake_params="-DWITH_CUDA=ON $cmake_params"
+    # if [ -e $CUDA_HEADER ]; then
+    #     echo "Using CUDA => deleting mock $CUDA_HEADER..."
+    #     rm $CUDA_HEADER
+    # fi
+else
+    cmake_params="-DWITH_CUDA=OFF $cmake_params"
+    # configure_vars="$configure_vars NVCC=/bin/false"
+    # echo "Not using CUDA => generating mock $CUDA_HEADER..."
+    # echo "#error ERROR: cuda is not really present but used somewhere." \
+    #     > $CUDA_HEADER
+fi
+
+# The CMakeLists do not seem to have this option yet:
+# if $with_h5md; then
+#     cmake_params="-DWITH_HDF5=ON $cmake_params"
+# else
+#     cmake_params="-DWITH_HDF5=OFF $cmake_params"
+# fi
+
+MYCONFIG_DIR=$srcdir/maintainer/jenkins/configs
+if [ "$myconfig" = "default" ]; then
+    echo "Using default myconfig."
+else
+    myconfig_file=$MYCONFIG_DIR/$myconfig.hpp
+    if [ ! -e "$myconfig_file" ]; then
+        echo "$myconfig_file does not exist!"
+        exit 1
+    fi
+    echo "Copying $myconfig.hpp to $builddir/myconfig.hpp..."
+    cp $myconfig_file $builddir/myconfig.hpp
+fi
+
+# Activate anaconda environment
+cmd "source activate test"
+
+cmd "cmake $cmake_params $srcdir" || exit $?
+end "CONFIGURE"
+
+# BUILD
+start "BUILD"
+
+cmd "make -j $build_procs" || exit $?
+
+end "BUILD"
+
+if $make_check; then
+    start "TEST"
+
+    cmd "make check_tcl $make_params"
+    ec=$?
+    if [ $ec != 0 ]; then   
+        cmd "cat $srcdir/testsuite/tcl/Testing/Temporary/LastTest.log"
+        exit $ec
+    fi
+
+    cmd "make check_unit_tests $make_params"
+    ec=$?
+    if [ $ec != 0 ]; then   
+        cmd "cat $srcdir/src/core/unit_tests/Testing/Temporary/LastTest.log"
+        exit $ec
+    fi
+
+    end "TEST"
+fi
+
+# popd

--- a/maintainer/jenkins/configure.sh
+++ b/maintainer/jenkins/configure.sh
@@ -15,12 +15,11 @@ start "CONFIGURE"
 [ -z "$configure_params" ] && configure_params=""
 [ -z "$configure_vars" ] && configure_vars=""
 [ -z "$with_cuda" ] && with_cuda="true"
-[ -z "$with_mpi" ] && with_mpi="true"
 [ -z "$with_fftw" ] && with_fftw="true"
 [ -z "$with_tcl" ] && with_tcl="true"
 [ -z "$with_python_interface" ] && with_python_interface="false"
 [ -z "$with_h5md" ] && with_h5md="true"
-outp configure_params configure_vars with_cuda with_mpi with_fftw \
+outp configure_params configure_vars with_cuda with_fftw \
     with_tcl with_python_interface with_h5md
 
 # change into build dir
@@ -28,12 +27,6 @@ pushd $builddir
 
 # set up configure params
 configure_params="--enable-silent-rules $configure_params"
-
-if $with_mpi; then
-    configure_params="--with-mpi $configure_params"
-else
-    configure_params="--without-mpi $configure_params"
-fi
 
 if $with_h5md; then
     configure_params="--with-h5md $configure_params"

--- a/maintainer/travis/build.sh
+++ b/maintainer/travis/build.sh
@@ -43,12 +43,10 @@ function cmd {
 [ -z "$srcdir" ] && srcdir=`pwd`
 [ -z "$configure_params" ] && configure_params=""
 [ -z "$configure_vars" ] && configure_vars=""
-[ -z "$with_mpi" ] && with_mpi="true"
 [ -z "$with_fftw" ] && with_fftw="true"
 [ -z "$with_tcl" ] && with_tcl="true"
 [ -z "$with_python_interface" ] && with_python_interface="true"
 [ -z "$myconfig" ] && myconfig="default"
-! $with_mpi && check_procs=1
 [ -z "$check_procs" ] && check_procs=4
 [ -z "$make_check" ] && make_check="true"
 
@@ -59,7 +57,7 @@ elif [ -z "$builddir" ]; then
 fi
 
 outp insource srcdir builddir \
-    configure_params configure_vars with_mpi with_fftw \
+    configure_params configure_vars with_fftw \
     with_tcl with_python_interface myconfig check_procs
 
 # check indentation of python files
@@ -96,13 +94,6 @@ fi
 start "CONFIGURE"
 if $with_coverage ; then
     configure_params="CPPFLAGS=\"-coverage -O0\" CXXFLAGS=\"-coverage -O0\" $configure_params"
-fi
-
-if $with_mpi; then
-    configure_params="--with-mpi $configure_params"
-    configure_vars="CXX=mpic++"
-else
-    configure_params="--without-mpi $configure_params"
 fi
 
 FFTW_HEADER=$srcdir/src/core/fftw3.h

--- a/maintainer/travis/build_cmake.sh
+++ b/maintainer/travis/build_cmake.sh
@@ -88,9 +88,7 @@ fi
 
 # CONFIGURE
 start "CONFIGURE"
-if $with_coverage ; then
-    cmake_params="-DCPPFLAGS=\"-coverage -O0\" -DCXXFLAGS=\"-coverage -O0\" -DPYTHON_LIBRARY=/home/travis/miniconda/envs/test/lib/libpython2.7.so.1.0 $cmake_params"
-fi
+cmake_params="-DPYTHON_LIBRARY=/home/travis/miniconda/envs/test/lib/libpython2.7.so.1.0 $cmake_params"
 
 if $with_mpi; then
     cmake_params="-DWITH_MPI=ON $cmake_params"
@@ -138,31 +136,26 @@ end "CONFIGURE"
 # BUILD
 start "BUILD"
 
-cmd "make" || exit $?
+cmd "make -j $check_procs" || exit $?
 
 end "BUILD"
 
-# CHECK	cat $srcdir/testsuite/python/Testing/Temporary/LastTest.log
 if $make_check; then
     start "TEST"
 
-    cmd "make check_tcl $make_params"
+    cmd "make check_tcl"
     ec=$?
     if [ $ec != 0 ]; then	
-        cat $srcdir/testsuite/Testing/Temporary/LastTest.log
+        cmd "cat $srcdir/testsuite/tcl/Testing/Temporary/LastTest.log"
         exit $ec
     fi
 
-    cmd "make check_unit_tests $make_params"
+    cmd "make check_unit_tests"
     ec=$?
     if [ $ec != 0 ]; then	
-        cat $srcdir/testsuite/Testing/Temporary/LastTest.log
+        cmd "cat $srcdir/src/core/unit_tests/Testing/Temporary/LastTest.log"
         exit $ec
     fi
 
     end "TEST"
 fi
-
-for i in `find . -name  "*.gcno"` ; do
-    (cd `dirname $i` ; gcov `basename $i` > coverage.log 2>&1 )
-done

--- a/maintainer/travis/build_cmake.sh
+++ b/maintainer/travis/build_cmake.sh
@@ -42,12 +42,10 @@ function cmd {
 [ -z "$insource" ] && insource="true"
 [ -z "$srcdir" ] && srcdir=`pwd`
 [ -z "$cmake_params" ] && configure_params=""
-[ -z "$with_mpi" ] && with_mpi="true"
 [ -z "$with_fftw" ] && with_fftw="true"
 [ -z "$with_tcl" ] && with_tcl="true"
 [ -z "$with_python_interface" ] && with_python_interface="true"
 [ -z "$myconfig" ] && myconfig="default"
-! $with_mpi && check_procs=1
 [ -z "$check_procs" ] && check_procs=2
 [ -z "$make_check" ] && make_check="true"
 
@@ -58,7 +56,7 @@ elif [ -z "$builddir" ]; then
 fi
 
 outp insource srcdir builddir \
-    configure_params with_mpi with_fftw \
+    configure_params with_fftw \
     with_tcl with_python_interface myconfig check_procs
 
 # check indentation of python files
@@ -89,12 +87,6 @@ fi
 # CONFIGURE
 start "CONFIGURE"
 cmake_params="-DPYTHON_LIBRARY=/home/travis/miniconda/envs/test/lib/libpython2.7.so.1.0 $cmake_params"
-
-if $with_mpi; then
-    cmake_params="-DWITH_MPI=ON $cmake_params"
-else
-    cmake_params="-DWITH_MPI=OFF $cmake_params"
-fi
 
 if $with_fftw; then
     cmake_params="$cmake_params"


### PR DESCRIPTION
Added a `build_cmake.sh` to jenkins: Some options for `WITH_HFD5` and `WITH_FFTW` options in the `CMakeLists.txt` would eventually be nice here.
Sligthly modified the one for travis: `$check_progs` is now used