### PR TITLE
Minor fixes for build system and compiling on Mac

### DIFF
--- a/cmake/MyConfig.cmake
+++ b/cmake/MyConfig.cmake
@@ -33,9 +33,7 @@ else()
     set(MYCONFIG_FILE ${CMAKE_SOURCE_DIR}/src/core/myconfig-default.hpp)
   endif()
 endif()
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/src/core/myconfig-final.hpp
-  COMMAND ${CMAKE_COMMAND} -E copy ${MYCONFIG_FILE} ${CMAKE_BINARY_DIR}/src/core/myconfig-final.hpp
-  DEPENDS ${MYCONFIG_FILE})
+configure_file(${MYCONFIG_FILE} ${CMAKE_BINARY_DIR}/src/core/myconfig-final.hpp COPYONLY)
 add_custom_target(myconfig DEPENDS ${CMAKE_BINARY_DIR}/src/core/myconfig-final.hpp)
 message(STATUS "Config file: ${MYCONFIG_FILE}")
 # Clear variable, otherwise cmake must be run by hand to detect myconfig

--- a/src/core/electrokinetics_pdb_parse.hpp
+++ b/src/core/electrokinetics_pdb_parse.hpp
@@ -22,7 +22,7 @@
 
 #include "electrokinetics.hpp"
 
-#ifdef ELECTROKINETICS
+#ifdef EK_BOUNDARIES
 
 extern float* pdb_charge_lattice;
 extern int* pdb_boundary_lattice;

--- a/src/core/tab.cpp
+++ b/src/core/tab.cpp
@@ -160,7 +160,7 @@ int tabulated_bonded_set_params(int bond_type, TabulatedBondedInteraction tab_ty
   */
   if(tab_type == TAB_BOND_ANGLE ) {
     if( bonded_ia_params[bond_type].p.tab.minval != 0.0 || 
-	abs(bonded_ia_params[bond_type].p.tab.maxval-PI) > 1e-5 ) {
+	std::abs(bonded_ia_params[bond_type].p.tab.maxval-PI) > 1e-5 ) {
       fclose(fp);
       return 6;
     }
@@ -169,7 +169,7 @@ int tabulated_bonded_set_params(int bond_type, TabulatedBondedInteraction tab_ty
   /* check interval for angle and dihedral potentials */
   if(tab_type == TAB_BOND_DIHEDRAL ) {
     if( bonded_ia_params[bond_type].p.tab.minval != 0.0 || 
-	abs(bonded_ia_params[bond_type].p.tab.maxval-(2*PI)) > 1e-5 ) {
+	std::abs(bonded_ia_params[bond_type].p.tab.maxval-(2*PI)) > 1e-5 ) {
       fclose(fp);
       return 6;
     }

--- a/src/core/unit_tests/RunningAverage_test.cpp
+++ b/src/core/unit_tests/RunningAverage_test.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <limits>
 #include <algorithm>
+#include <numeric>
 
 #define BOOST_TEST_MODULE RunningAverage test
 #include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
- Use `configure_file` so that myconfig.hpp is copied at `make`-time and not just `cmake`-time
- Fix an `ifdef` mismatch between .cpp and .hpp file
- make the C++ code more standard-conforming

These changes were originally contained in #564, but it makes more sense to have them in a separate pull request.