### PR TITLE
Require CMake 3.0 or higher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(ESPResSo)
 


### PR DESCRIPTION
CMake 2.8 does not have the `CMAKE_CXX_COMPILER_VERSION` variable, therefore the C++11 compiler flags are not set versions before 3.0.

This problem was observed by @AlexanderWeyman.