### PR TITLE
Bugfix Vkappa (Python Interface)

### DIFF
--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -845,8 +845,10 @@ def Vkappa(system=None, mode=None, Vk1=None, Vk2=None, avk=None):
             raise Exception(
                 "ERROR: # of averages <avk> has to be positive! Resetting values.")
             result = _Vkappa["Vk1"] = _Vkappa["Vk2"] = _Vkappa["avk"] = 0.0
-        result = _Vkappa["Vk2"] / _Vkappa["avk"] - \
-            (_Vkappa["Vk1"] / _Vkappa["avk"])**2
+        else:
+            result = _Vkappa["Vk2"] / _Vkappa["avk"] - \
+                (_Vkappa["Vk1"] / _Vkappa["avk"])**2
+        return result
     else:
         raise Exception("ERROR: Unknown mode.")
     # else: # <- WTF?  Why is there a second `else'?
@@ -854,5 +856,5 @@ def Vkappa(system=None, mode=None, Vk1=None, Vk2=None, avk=None):
     #    _Vkappa["Vk2"] += (system.box_l[0] * system.box_l[1] * system.box_l[2])**2
     #    _Vkappa["avk"] += 1.0
     #    result = _Vkappa["Vk2"] / _Vkappa["avk"] - (_Vkappa["Vk1"] / _Vkappa["avk"])**2
-
-    return result
+    #
+    # return result

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -851,10 +851,3 @@ def Vkappa(system=None, mode=None, Vk1=None, Vk2=None, avk=None):
         return result
     else:
         raise Exception("ERROR: Unknown mode.")
-    # else: # <- WTF?  Why is there a second `else'?
-    #    _Vkappa["Vk1"] += system.box_l[0] * system.box_l[1] * system.box_l[2]
-    #    _Vkappa["Vk2"] += (system.box_l[0] * system.box_l[1] * system.box_l[2])**2
-    #    _Vkappa["avk"] += 1.0
-    #    result = _Vkappa["Vk2"] / _Vkappa["avk"] - (_Vkappa["Vk1"] / _Vkappa["avk"])**2
-    #
-    # return result


### PR DESCRIPTION
Wrongly commented out code caused error when calling analyze.Vkappa(system, 'reset')