### PR TITLE
Provisionally fix dangling boost_comm

### DIFF
--- a/src/core/MpiCallbacks.cpp
+++ b/src/core/MpiCallbacks.cpp
@@ -24,12 +24,13 @@
 #include <boost/mpi.hpp>
 
 #include "MpiCallbacks.hpp"
+#include "communication.hpp"
 
 namespace Communication {
 
 void MpiCallbacks::call(int id, int par1, int par2) const {  
   /** Can only be call from master */
-  assert(m_comm.rank() == 0);
+  assert(comm().rank() == 0);
   
   /** Check if callback exists */
   if(m_callbacks.find(id) == m_callbacks.end()) {    
@@ -38,7 +39,7 @@ void MpiCallbacks::call(int id, int par1, int par2) const {
   
   int request[3]{id, par1, par2};
   /** Send request to slaves */
-  boost::mpi::broadcast(m_comm, request, 3, 0);
+  boost::mpi::broadcast(comm(), request, 3, 0);
 }
 
 void MpiCallbacks::call(func_ptr_type fp, int par1, int par2) const {
@@ -84,7 +85,7 @@ void MpiCallbacks::loop() const {
   for(;;) {
     int request[3];
     /** Communicate callback id and parameters */
-    boost::mpi::broadcast(m_comm, request, 3, 0);
+    boost::mpi::broadcast(comm(), request, 3, 0);
     /** id == 0 is loop_abort. */
     if(request[0] == LOOP_ABORT) {
       break;
@@ -99,7 +100,7 @@ namespace {
 std::unique_ptr<MpiCallbacks> m_global_callback;
 }
 
-void initialize_callbacks(boost::mpi::communicator &comm) {
+void initialize_callbacks(const boost::mpi::communicator *comm) {
   m_global_callback = std::unique_ptr<MpiCallbacks>(new MpiCallbacks(comm));
 }
 

--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -38,7 +38,7 @@ class MpiCallbacks {
   /** Type of the callback functions. */
   typedef std::function<void (int, int)> function_type;
   
-  MpiCallbacks(const boost::mpi::communicator &comm)
+  MpiCallbacks(const boost::mpi::communicator *comm)
       : m_comm(comm)
   {
     /** Add a dummy at id 0 for loop abort. */
@@ -127,6 +127,10 @@ class MpiCallbacks {
    * @brief The boost mpi communicator used by this instance
    */
   boost::mpi::communicator comm() const {
+    return *m_comm;
+  }
+
+  const boost::mpi::communicator* comm_addr() const {
     return m_comm;
   }
   
@@ -151,7 +155,7 @@ class MpiCallbacks {
   /**
    * The MPI communicator used for the callbacks.   
    */
-  boost::mpi::communicator m_comm;
+  const boost::mpi::communicator *m_comm;
   
   /**
    * Internal storage for the callback functions.
@@ -169,7 +173,7 @@ class MpiCallbacks {
  * @brief Initialize the callback singelton.
  * This sets the communicator to use.
  */
-void initialize_callbacks(boost::mpi::communicator &comm);
+void initialize_callbacks(const boost::mpi::communicator *comm);
 
 /**
  * @brief Returns a reference to the global callback class instance.

--- a/src/core/RuntimeErrorCollector.hpp
+++ b/src/core/RuntimeErrorCollector.hpp
@@ -31,7 +31,7 @@ namespace ErrorHandling {
 
 class RuntimeErrorCollector {
 public:
-  RuntimeErrorCollector(const boost::mpi::communicator &comm);
+  RuntimeErrorCollector(const boost::mpi::communicator *comm);
 
   void 
   warning(const std::string &msg,
@@ -77,7 +77,11 @@ public:
 
 private:
   std::vector<RuntimeError> m_errors;
-  boost::mpi::communicator m_comm;
+  const boost::mpi::communicator *m_comm;
+
+  boost::mpi::communicator comm() const {
+      return *m_comm;
+  }
 };
 
 } /* ErrorHandling */

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -273,8 +273,7 @@ void mpi_init(int *argc, char ***argv)
   MPI_Cart_coords(comm_cart, this_node, 3, node_pos);
 
   boost_comm = boost::mpi::communicator(comm_cart, boost::mpi::comm_attach);
-
-  Communication::initialize_callbacks(boost_comm);
+  Communication::initialize_callbacks(&boost_comm);
   
   for(int i = 0; i < slave_callbacks.size(); ++i)  {
     mpiCallbacks().add(slave_callbacks[i]);

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -69,6 +69,7 @@ extern int this_node;
 /** The total number of nodes. */
 extern int n_nodes;
 extern MPI_Comm comm_cart;
+extern boost::mpi::communicator boost_comm;
 /*@}*/
 
 /**

--- a/src/core/errorhandling.cpp
+++ b/src/core/errorhandling.cpp
@@ -82,7 +82,7 @@ void init_error_handling(Communication::MpiCallbacks &cb) {
   
   m_callbacks->add(mpi_gather_runtime_errors_slave);
   
-  runtimeErrorCollector = unique_ptr<RuntimeErrorCollector>(new RuntimeErrorCollector(m_callbacks->comm()));
+  runtimeErrorCollector = unique_ptr<RuntimeErrorCollector>(new RuntimeErrorCollector(m_callbacks->comm_addr()));
 }
 
 void _runtimeWarning(const std::string &msg, 

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -274,6 +274,7 @@ void grid_changed_n_nodes()
   MPI_Comm_free(&comm_cart);
   
   MPI_Cart_create(MPI_COMM_WORLD, 3, node_grid, per, 0, &comm_cart);
+  boost_comm = boost::mpi::communicator(comm_cart, boost::mpi::comm_attach);
 
   MPI_Comm_rank(comm_cart, &this_node);
 


### PR DESCRIPTION
This provisionally solves the problem which Tilak described in the developers
meeting: (Arbitrary) segfaults when using multiple processes. This is due to
UB.  Boost::mpi::communicator boost_comm is instantiated in communication.cpp
and copied to MpiCallbacks. However, the underlying comm_cart is later changed
in grid_changed_n_nodes (grid.hpp) which invalidates the MPI_Comm the boost
communicator points to.

This commit is a quick and dirty fix in order to get ESPResSo running, again.
It changes the MpiCallbacks class and the RuntimeErrorCollector to hold a
pointer to a boost::mpi::communicator in order to be able to change the
underlying boost_comm in grid.cpp.  With the current state, one should
absolutely NEVER copy boost_comm, because it can change. However, this problem
should definitely be fixed differently.