### PR TITLE
Use RANDOM_DEBUG instead of RANDOM_TRACE

### DIFF
--- a/src/tcl/random_tcl.cpp
+++ b/src/tcl/random_tcl.cpp
@@ -149,7 +149,7 @@ int tclcommand_t_random (ClientData data, Tcl_Interp *interp, int argc, char **a
       }
     }
 
-#ifdef RANDOM_TRACE
+#ifdef RANDOM_DEBUG
     printf("Got "); 
         
     for(int i=0;i<n_nodes;i++) 


### PR DESCRIPTION
RANDOM_TRACE is always defined (see debug.hpp), so use RANDOM_DEBUG here.