### PR TITLE
Py: Speed up the mayavi visualization for large systems

### DIFF
--- a/samples/python/visualization_bonded.py
+++ b/samples/python/visualization_bonded.py
@@ -25,12 +25,15 @@ system.non_bonded_inter[0,0].lennard_jones.set_params(
     epsilon=0, sigma=1,
     cutoff=2, shift="auto")
 system.bonded_inter[0] = HarmonicBond(k=1.0,r_0=1.0)
+system.bonded_inter[1] = HarmonicBond(k=1.0,r_0=1.0)
 
 for i in range(n_part):
   system.part.add(id=i, pos=numpy.random.random(3) * system.box_l)
 
-for i in range(n_part-1):
+for i in range(n_part/2):
   system.part[i].add_bond((system.bonded_inter[0], system.part[i+1].id))
+for i in range(n_part/2,n_part-1):
+  system.part[i].add_bond((system.bonded_inter[1], system.part[i+1].id))
 
 mayavi = visualization.mayavi_live(system)
 

--- a/src/python/espressomd/visualization.pyx
+++ b/src/python/espressomd/visualization.pyx
@@ -8,8 +8,11 @@ from espressomd.interactions cimport *
 from espressomd._system cimport *
 from libcpp.vector cimport vector
 
+cdef extern from "utils.hpp":
+    void get_mi_vector(double * res, double * a, double * b)
+
 if not "ETS_TOOLKIT" in os.environ:
-	os.environ["ETS_TOOLKIT"] = "wx"
+    os.environ["ETS_TOOLKIT"] = "wx"
 from mayavi import mlab
 from pyface.api import GUI
 from pyface.timer.api import Timer
@@ -26,181 +29,181 @@ output.SetFileName("/dev/null")
 vtk.vtkOutputWindow().SetInstance(output)
 
 cdef class mayavi_live:
-	"""This class provides live visualization using Enthought Mayavi.
-	Use the update method to push your current simulation state after
-	integrating. If you run your integrate loop in a separate thread, 
-	you can call run_gui_event_loop in your main thread to be able to
-	interact with the GUI."""
+    """This class provides live visualization using Enthought Mayavi.
+    Use the update method to push your current simulation state after
+    integrating. If you run your integrate loop in a separate thread, 
+    you can call run_gui_event_loop in your main thread to be able to
+    interact with the GUI."""
 
-	cdef object system
-	cdef object points 
-	cdef object box 
-	cdef object arrows
-	cdef object data 
-	cdef int last_N 
-	cdef int last_Nbonds 
-	cdef double last_boxl[3] 
-	cdef bool running 
-	cdef double last_T 
+    cdef object system
+    cdef object points 
+    cdef object box 
+    cdef object arrows
+    cdef object data 
+    cdef int last_N 
+    cdef int last_Nbonds 
+    cdef double last_boxl[3] 
+    cdef bool running 
+    cdef double last_T 
 
-	cdef object gui 
-	cdef object timers 
+    cdef object gui 
+    cdef object timers 
 
 
-	def __init__(self, system):
-		"""Constructor.
-		**Arguments**
+    def __init__(self, system):
+        """Constructor.
+        **Arguments**
 
-		:system: instance of espressomd.System
-		"""
-		self.system = system
+        :system: instance of espressomd.System
+        """
+        self.system = system
 
-		# objects drawn
-		self.points = mlab.quiver3d([],[],[], [],[],[], scalars=[], mode="sphere", scale_factor=1, name="Particles")
-		self.points.glyph.color_mode = 'color_by_scalar'
-		self.points.glyph.glyph_source.glyph_source.center = [0, 0, 0]
-		self.box = mlab.outline(extent=(0,0,0,0,0,0), color=(1,1,1), name="Box")
-		self.arrows = mlab.quiver3d([],[],[], [],[],[], scalars=[], mode="2ddash", scale_factor=1, name="Bonds")
-		self.arrows.glyph.color_mode = 'color_by_scalar'
+        # objects drawn
+        self.points = mlab.quiver3d([],[],[], [],[],[], scalars=[], mode="sphere", scale_factor=1, name="Particles")
+        self.points.glyph.color_mode = 'color_by_scalar'
+        self.points.glyph.glyph_source.glyph_source.center = [0, 0, 0]
+        self.box = mlab.outline(extent=(0,0,0,0,0,0), color=(1,1,1), name="Box")
+        self.arrows = mlab.quiver3d([],[],[], [],[],[], scalars=[], mode="2ddash", scale_factor=1, name="Bonds")
+        self.arrows.glyph.color_mode = 'color_by_scalar'
 
-		# state
-		self.data = None
-		self.last_N = 1
-		self.last_Nbonds = 1
-		self.last_boxl = [0,0,0]
-		self.running = False
-		self.last_T = -1
+        # state
+        self.data = None
+        self.last_N = 1
+        self.last_Nbonds = 1
+        self.last_boxl = [0,0,0]
+        self.running = False
+        self.last_T = -1
 
-		# GUI window
-		self.gui = GUI()
-		self.timers = [Timer(100, self._draw)]
+        # GUI window
+        self.gui = GUI()
+        self.timers = [Timer(100, self._draw)]
 
-	def _draw(self):
-		"""Update the Mayavi objects with new particle information.
-		This is called periodically in the GUI thread"""
-		if self.data is None:
-			return
-		
-		assert isinstance(threading.current_thread(), threading._MainThread)
+    def _draw(self):
+        """Update the Mayavi objects with new particle information.
+        This is called periodically in the GUI thread"""
+        if self.data is None:
+            return
+        
+        assert isinstance(threading.current_thread(), threading._MainThread)
 
-		f = mlab.gcf()
-		visual.set_viewer(f)
+        f = mlab.gcf()
+        visual.set_viewer(f)
 
-		coords, types, radii, N_changed, bonds, Nbonds_changed, boxl, box_changed = self.data
-		self.data = None
+        coords, types, radii, N_changed, bonds, Nbonds_changed, boxl, box_changed = self.data
+        self.data = None
 
-		if box_changed or not self.running:
-			self.box.set(bounds=(0,boxl[0], 0,boxl[1], 0,boxl[2]))
+        if box_changed or not self.running:
+            self.box.set(bounds=(0,boxl[0], 0,boxl[1], 0,boxl[2]))
 
-		if not N_changed:
-			self.points.mlab_source.set(x=coords[:,0]%boxl[0], y=coords[:,1]%boxl[1], z=coords[:,2]%boxl[2], u=radii, v=radii, w=radii, scalars=types)
-		else:
-			self.points.mlab_source.reset(x=coords[:,0]%boxl[0], y=coords[:,1]%boxl[1], z=coords[:,2]%boxl[2], u=radii, v=radii, w=radii, scalars=types)
-		if not self.running:
-			f.scene.reset_zoom()
-			self.running = True
+        if not N_changed:
+            self.points.mlab_source.set(x=coords[:,0]%boxl[0], y=coords[:,1]%boxl[1], z=coords[:,2]%boxl[2], u=radii, v=radii, w=radii, scalars=types)
+        else:
+            self.points.mlab_source.reset(x=coords[:,0]%boxl[0], y=coords[:,1]%boxl[1], z=coords[:,2]%boxl[2], u=radii, v=radii, w=radii, scalars=types)
+        if not self.running:
+            f.scene.reset_zoom()
+            self.running = True
 
-		if not Nbonds_changed:
-			if bonds.shape[0] > 0:
-				self.arrows.mlab_source.set  (x=bonds[:,0], y=bonds[:,1], z=bonds[:,2], u=bonds[:,3], v=bonds[:,4], w=bonds[:,5])
-		else:
-			self.arrows.mlab_source.reset(x=bonds[:,0], y=bonds[:,1], z=bonds[:,2], u=bonds[:,3], v=bonds[:,4], w=bonds[:,5], scalars=bonds[:,6])
+        if not Nbonds_changed:
+            if bonds.shape[0] > 0:
+                self.arrows.mlab_source.set  (x=bonds[:,0], y=bonds[:,1], z=bonds[:,2], u=bonds[:,3], v=bonds[:,4], w=bonds[:,5])
+        else:
+            self.arrows.mlab_source.reset(x=bonds[:,0], y=bonds[:,1], z=bonds[:,2], u=bonds[:,3], v=bonds[:,4], w=bonds[:,5], scalars=bonds[:,6])
 
-	def update(self):
-		"""Pull the latest particle information from Espresso.
-		This is the only function that should be called from the computation thread.
-		It does not call any Mayavi functions unless it is being called from the main (GUI) thread."""
+    def update(self):
+        """Pull the latest particle information from Espresso.
+        This is the only function that should be called from the computation thread.
+        It does not call any Mayavi functions unless it is being called from the main (GUI) thread."""
 
-		if self.last_T is not None and self.last_T == self.system.time:
-			return
-		self.last_T = self.system.time
-		
-		cdef int N = self.system.n_part
-		coords = numpy.zeros((N,3))
-		types = numpy.empty(N, dtype=int)
-		inter = NonBondedInteractions()
-		radii = numpy.empty(N)
-		cdef int i=0,j=0,k=0 
-		cdef int t 
-		cdef int partner
-		cdef particle p
-		cdef ia_parameters* ia
-		cdef vector[int] bonds
+        if self.last_T is not None and self.last_T == self.system.time:
+            return
+        self.last_T = self.system.time
+        
+        cdef int N = self.system.n_part
+        coords = numpy.zeros((N,3))
+        types = numpy.empty(N, dtype=int)
+        inter = NonBondedInteractions()
+        radii = numpy.empty(N)
+        cdef int i=0,j=0,k=0 
+        cdef int t 
+        cdef int partner
+        cdef particle p
+        cdef ia_parameters* ia
+        cdef vector[int] bonds
 
     # Using (additional) untyped variables and python constructs in the loop 
     # will slow it down considerably. 
-		for i in range(self.system.max_part+1):
-			if not particle_exists(i):
-				continue
-			get_particle_data(i,&p)
-			coords[j,:] = p.r.p
-			t = p.p.type
-			types[j] = t +1
-			radii[j] =get_ia_param(t,t).LJ_sig *0.5
+        for i in range(self.system.max_part+1):
+            if not particle_exists(i):
+                continue
+            get_particle_data(i,&p)
+            coords[j,:] = p.r.p
+            t = p.p.type
+            types[j] = t +1
+            radii[j] =get_ia_param(t,t).LJ_sig *0.5
 
-			# ITerate over bonds
-			k=0		
-			while k<p.bl.n:
-				# Bond type
-				t= p.bl.e[k]
-				k+=1
-				# Iterate over bond partners and store each connection
-				for l in range(bonded_ia_params[t].num):
-					bonds.push_back(i)
-					bonds.push_back(p.bl.e[k])
-					k+=1
-			j += 1
-		assert j == self.system.n_part
-		cdef int Nbonds = bonds.size()/2
-		
-		bond_coords = numpy.zeros((Nbonds,7))
+            # ITerate over bonds
+            k=0        
+            while k<p.bl.n:
+                # Bond type
+                t= p.bl.e[k]
+                k+=1
+                # Iterate over bond partners and store each connection
+                for l in range(bonded_ia_params[t].num):
+                    bonds.push_back(i)
+                    bonds.push_back(p.bl.e[k])
+                    k+=1
+            j += 1
+        assert j == self.system.n_part
+        cdef int Nbonds = bonds.size()/2
+        
+        bond_coords = numpy.zeros((Nbonds,7))
 
-		cdef int n
-		cdef particle p1,p2
-		cdef double bond_vec[3]
-		for n in range(Nbonds):
-			i =bonds[2*n]
-			j =bonds[2*n+1]
-			get_particle_data(i,&p1)
-			get_particle_data(j,&p2)
-			bond_coords[n,:3] = p1.r.p 
-			get_mi_vector(bond_vec,p2.r.p,p1.r.p)
-			bond_coords[n,3:6] = bond_vec
-# Not needed			bond_coords[n,6] = 0 # numeric bond IDs have been removed
+        cdef int n
+        cdef particle p1,p2
+        cdef double bond_vec[3]
+        for n in range(Nbonds):
+            i =bonds[2*n]
+            j =bonds[2*n+1]
+            get_particle_data(i,&p1)
+            get_particle_data(j,&p2)
+            bond_coords[n,:3] = p1.r.p 
+            get_mi_vector(bond_vec,p2.r.p,p1.r.p)
+            bond_coords[n,3:6] = bond_vec
+# Not needed            bond_coords[n,6] = 0 # numeric bond IDs have been removed
 
-		boxl = self.system.box_l
+        boxl = self.system.box_l
 
-		if self.data is None:
-			self.data = coords, types, radii, (self.last_N != N), \
-			            bond_coords, (self.last_Nbonds != Nbonds), \
-			            boxl, (self.last_boxl != boxl).any()
-		else:
-			self.data = coords, types, radii, self.data[3] or (self.last_N != N), \
-			            bond_coords, self.data[5] or (self.last_Nbonds != Nbonds), \
-			            boxl, self.data[7] or (self.last_boxl != boxl).any()
-		self.last_N = N
-		self.last_Nbonds = Nbonds
-		self.last_boxl = boxl
+        if self.data is None:
+            self.data = coords, types, radii, (self.last_N != N), \
+                        bond_coords, (self.last_Nbonds != Nbonds), \
+                        boxl, (self.last_boxl != boxl).any()
+        else:
+            self.data = coords, types, radii, self.data[3] or (self.last_N != N), \
+                        bond_coords, self.data[5] or (self.last_Nbonds != Nbonds), \
+                        boxl, self.data[7] or (self.last_boxl != boxl).any()
+        self.last_N = N
+        self.last_Nbonds = Nbonds
+        self.last_boxl = boxl
 
 
-		# when drawing from the main thread, the timer never fires, but we can safely call draw ourselves
-		if isinstance(threading.current_thread(), threading._MainThread):
-			self._draw()
+        # when drawing from the main thread, the timer never fires, but we can safely call draw ourselves
+        if isinstance(threading.current_thread(), threading._MainThread):
+            self._draw()
 
-	def process_gui_events(self):
-		"""Process GUI events, e.g. mouse clicks, in the Mayavi window.
-		Call this function as often as you can to get a smooth GUI experience."""
-		assert isinstance(threading.current_thread(), threading._MainThread)
-		self.gui.process_events()
+    def process_gui_events(self):
+        """Process GUI events, e.g. mouse clicks, in the Mayavi window.
+        Call this function as often as you can to get a smooth GUI experience."""
+        assert isinstance(threading.current_thread(), threading._MainThread)
+        self.gui.process_events()
 
-	def run_gui_event_loop(self):
-		"""Start the GUI event loop.
-		This function blocks until the Mayavi window is closed.
-		So you should only use it if your Espresso simulation's integrate loop is running in a secondary thread."""
-		assert isinstance(threading.current_thread(), threading._MainThread)
-		self.gui.start_event_loop()
+    def run_gui_event_loop(self):
+        """Start the GUI event loop.
+        This function blocks until the Mayavi window is closed.
+        So you should only use it if your Espresso simulation's integrate loop is running in a secondary thread."""
+        assert isinstance(threading.current_thread(), threading._MainThread)
+        self.gui.start_event_loop()
 
-	def register_callback(self, cb, interval=1000):
-		self.timers.append(Timer(interval, cb))
+    def register_callback(self, cb, interval=1000):
+        self.timers.append(Timer(interval, cb))
 
 # TODO: constraints

--- a/src/python/espressomd/visualization.pyx
+++ b/src/python/espressomd/visualization.pyx
@@ -151,25 +151,27 @@ cdef class mayavi_live:
                 for l in range(bonded_ia_params[t].num):
                     bonds.push_back(i)
                     bonds.push_back(p.bl.e[k])
+                    bonds.push_back(t)
                     k+=1
             j += 1
         assert j == self.system.n_part
-        cdef int Nbonds = bonds.size()/2
+        cdef int Nbonds = bonds.size()/3
         
-        bond_coords = numpy.zeros((Nbonds,7))
+        bond_coords = numpy.empty((Nbonds,7))
 
         cdef int n
         cdef particle p1,p2
         cdef double bond_vec[3]
         for n in range(Nbonds):
-            i =bonds[2*n]
-            j =bonds[2*n+1]
+            i =bonds[3*n]
+            j =bonds[3*n+1]
+            t =bonds[3*n+2]
             get_particle_data(i,&p1)
             get_particle_data(j,&p2)
             bond_coords[n,:3] = p1.r.p 
             get_mi_vector(bond_vec,p2.r.p,p1.r.p)
             bond_coords[n,3:6] = bond_vec
-# Not needed            bond_coords[n,6] = 0 # numeric bond IDs have been removed
+            bond_coords[n,6] = t
 
         boxl = self.system.box_l
 


### PR DESCRIPTION
By cythonizing the inner loop in the update() method. Particle positions and bonds are accessed on the c level, avoiding python object construction.

Due to file rename .py -> .pyx, remove src/python under the build directory before recompiling.
