### PR TITLE
Changed seeding of rng

### DIFF
--- a/samples/python/minimal_random_number_generator.py
+++ b/samples/python/minimal_random_number_generator.py
@@ -38,5 +38,5 @@ for i in range(len(rng_state_read1)):
 	rng_state.append(i)
 system.random_number_generator_state=rng_state
 rng_state_read2=system.random_number_generator_state
-print "random number generator state read 2", rng_state_read2, "should be ", rng_state
+print "random number generator state read 2", rng_state_read2,
 

--- a/samples/python/minimal_random_number_generator.py
+++ b/samples/python/minimal_random_number_generator.py
@@ -18,10 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import espressomd
-from espressomd import thermostat
-from espressomd import integrate
-from espressomd import interactions
-from espressomd import diamond
 import numpy
 import sys
 
@@ -30,17 +26,17 @@ import sys
 
 system = espressomd.System()
 
-system.time_step = 0.01
-system.skin = 0.4
-system.box_l = [100, 100, 100]
-system.thermostat.set_langevin(1.0, 1.0)
-system.cell_system.set_n_square(use_verlet_lists=False)
 
-system.non_bonded_inter[0, 0].lennard_jones.set_params(
-    epsilon=1, sigma=1,
-    cutoff=2**(1. / 6), shift="auto")
+system.seed=numpy.random.randint(low=1,high=2**31-1,size=system.n_nodes)
+# if no seed is provided espresso generates a seed
+print "seed ", system.seed
+rng_state_read1=system.random_number_generator_state
+print "random number generator state read 1", rng_state_read1
 
-fene = interactions.FeneBond(k=10, d_r_max=2)
-system.bonded_inter.add(fene)
+rng_state=[]
+for i in range(len(rng_state_read1)):
+	rng_state.append(i)
+system.random_number_generator_state=rng_state
+rng_state_read2=system.random_number_generator_state
+print "random number generator state read 2", rng_state_read2, "should be ", rng_state
 
-diamond.Diamond(a=20, bond_length=2, MPC=20)

--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -129,8 +129,9 @@ void init_random(void)
 
 void init_random_seed(int seed)
 {
-  std::seed_seq seeder{seed};
+  std::seed_seq seeder{seed}; //come up with "sane" initialization to avoid too many zeros in the internal state of the Mersenne twister
   generator.seed(seeder);
+  generator.discard(1e6); //discard the first 1e6 random number generators to warm up the Mersenne-Twister PRNG
 }
 
 } /* Random */

--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -131,7 +131,7 @@ void init_random_seed(int seed)
 {
   std::seed_seq seeder{seed}; //come up with "sane" initialization to avoid too many zeros in the internal state of the Mersenne twister
   generator.seed(seeder);
-  generator.discard(1e6); //discard the first 1e6 random number generators to warm up the Mersenne-Twister PRNG
+  generator.discard(1e6); //discard the first 1e6 random numbers to warm up the Mersenne-Twister PRNG
 }
 
 } /* Random */

--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -129,7 +129,8 @@ void init_random(void)
 
 void init_random_seed(int seed)
 {
-  generator.seed(seed);
+  std::seed_seq seeder{seed};
+  generator.seed(seeder);
 }
 
 } /* Random */

--- a/src/python/espressomd/_system.pxd
+++ b/src/python/espressomd/_system.pxd
@@ -27,4 +27,12 @@ cdef extern from "grid.hpp":
 cdef extern from "communication.hpp" namespace "Random":
         void mpi_random_seed(int cnt, vector[int] &seed)
 
+
+from libcpp.string cimport string  # import std::string as string
+from libcpp.vector cimport vector  # import std::vector as vector
+cdef extern from "random.hpp" namespace "Random":
+    string mpi_random_get_stat()
+    void mpi_random_set_stat(const vector[string] &stat)
+
+
 cdef bool skin_set

--- a/src/python/espressomd/_system.pxd
+++ b/src/python/espressomd/_system.pxd
@@ -30,6 +30,7 @@ cdef extern from "communication.hpp" namespace "Random":
 
 from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
+ctypedef vector[string] string_vec
 cdef extern from "random.hpp" namespace "Random":
     string mpi_random_get_stat()
     void mpi_random_set_stat(const vector[string] &stat)

--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -410,8 +410,10 @@ cdef class System:
         #sets the random number generator state in the core. this is of interest for deterministic checkpointing
         def __set__(self,rng_state):
             if(len(rng_state)== n_nodes*625):
-                rng_state=" ".join(map(str,rng_state))
-                mpi_random_set_stat(rng_state);
+                states=string_vec(n_nodes) 
+                for i in range(n_nodes):
+                        states[i]=" ".join(map(str,rng_state[i*625:(i+1)*625]))
+                mpi_random_set_stat(states);
             else:
                 raise ValueError("Wrong # of args: Usage: 'random_number_generator_state \"<state(1)> ... <state(n_nodes*625)>")
         def __get__(self):


### PR DESCRIPTION
According to sackoverflow this seeding procedure is suggested:
https://stackoverflow.com/questions/15509270/does-stdmt19937-require-warmup 
```
std::seed_seq seeder{seed};
generator.seed(seeder);
```
seed_seq "tries to come up with a sane initialization" (see second source). 
However this is still not enough for a good seeding, see e.g. http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0205r0.html#ref-01 or http://www.pcg-random.org/posts/cpp-seeding-surprises.html

Of course "good seeding" with only one 32bit integer cannot be done truely for the mersenne twister with its huge internal state which cannot be filled with only one 32bit integer. Maybe the most clean way to seed the mersenne twister in the core would be to provide a function set_random_seed() in the python interface which sets the state of the mersenne_twister in the core with true random numbers.