### PR TITLE
Fix reading/writing of blockfiles whith ROTATIONAL_INERTIA enabled (c…

### DIFF
--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -105,9 +105,9 @@ const Datafield fields[] = {
 #ifndef ROTATIONAL_INERTIA
   {&(langevin_gamma_rotation),  TYPE_DOUBLE, 1, "gamma_rot",1 },    /* 61 from thermostat.cpp */
 #else
-  {&(langevin_gamma_rotation[0]),  TYPE_DOUBLE, 1, "gamma_rot[0]",1 },    /* 61 from thermostat.cpp */
-  {&(langevin_gamma_rotation[1]),  TYPE_DOUBLE, 1, "gamma_rot[1]",1 },    /* 62 from thermostat.cpp */
-  {&(langevin_gamma_rotation[2]),  TYPE_DOUBLE, 1, "gamma_rot[2]",1 },    /* 63 from thermostat.cpp */
+  {&(langevin_gamma_rotation[0]),  TYPE_DOUBLE, 1, "gamma_rot_0",1 },    /* 61 from thermostat.cpp */
+  {&(langevin_gamma_rotation[1]),  TYPE_DOUBLE, 1, "gamma_rot_1",1 },    /* 62 from thermostat.cpp */
+  {&(langevin_gamma_rotation[2]),  TYPE_DOUBLE, 1, "gamma_rot_2",1 },    /* 63 from thermostat.cpp */
 #endif
   { NULL, 0, 0, NULL, 0 }
 };

--- a/testsuite/tcl/CMakeLists.txt
+++ b/testsuite/tcl/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(tcl_tests  analysis.tcl
                angle.tcl
+               blockfile.tcl
                bonded_coulomb.tcl
                collision-detection-angular.tcl
                collision-detection-centers.tcl

--- a/testsuite/tcl/Makefile.am
+++ b/testsuite/tcl/Makefile.am
@@ -20,6 +20,7 @@
 tests = \
 	analysis.tcl \
 	angle.tcl \
+  blockfile.tcl \
 	bonded_coulomb.tcl \
 	collision-detection-angular.tcl \
 	collision-detection-centers.tcl \

--- a/testsuite/tcl/blockfile.tcl
+++ b/testsuite/tcl/blockfile.tcl
@@ -1,0 +1,36 @@
+
+# Copyright (C) 2010,2011,2012,2013,2014,2015,2016 The ESPResSo project
+# Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+#   Max-Planck-Institute for Polymer Research, Theory Group
+#  
+# This file is part of ESPResSo.
+#  
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#  
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#  
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+#
+source "tests_common.tcl"
+
+puts "-------------------------------------------"
+puts "- Testcase blockfile running on [format %02d [setmd n_nodes]] nodes: -"
+puts "-------------------------------------------"
+
+# this test checks whether a blockfile of the setmd parameters can be written and read again
+
+setmd time_step 0.01
+setmd skin 0.4
+set f [open temp.bf w]
+blockfile $f write variable
+close $f
+set f [open temp.bf r]
+blockfile $f read variable
+


### PR DESCRIPTION
(closes #748)

* Rename the setmd variables gamma_rot[0] to gamma_rot_0, etc. Better choice, because [] have special meaning in tcl.
* Very basic test case to check that blockfile write/read of setmd variables doesn't crash