### PR TITLE
Checkpointing NonBondedInteractions

### DIFF
--- a/samples/python/load_properties.py
+++ b/samples/python/load_properties.py
@@ -59,6 +59,13 @@ system = espressomd.System()
 with open("system_save", "r") as system_save:
     pickle.load(system_save)
 
+with open("nonBondedInter_save", "r") as bond_save:
+    pickle.load(bond_save)
+
+print("Non-bonded interactions from checkpoint:")
+print(system.non_bonded_inter[0, 0].lennard_jones.get_params())
+
+
 # Integration parameters
 #############################################################
 thermostat.Thermostat().set_langevin(1.0, 1.0)
@@ -78,12 +85,16 @@ int_n_times = 10
 #############################################################
 # Interaction setup
 #############################################################
-system.non_bonded_inter[0, 0].lennard_jones.set_params(
-    epsilon=lj_eps, sigma=lj_sig,
-    cutoff=lj_cut, shift="auto")
-system.non_bonded_inter.set_force_cap(lj_cap)
 
-print(system.non_bonded_inter[0, 0].lennard_jones.get_params())
+if not system.non_bonded_inter[0, 0].lennard_jones.is_active():
+    system.non_bonded_inter[0, 0].lennard_jones.set_params(
+        epsilon=lj_eps, sigma=lj_sig,
+        cutoff=lj_cut, shift="auto")
+    system.non_bonded_inter.set_force_cap(lj_cap)
+    print("Reset Lennard-Jones Interactions to:")
+    print(system.non_bonded_inter[0, 0].lennard_jones.get_params())
+
+exit()
 
 # Import of particle properties and P3M parameters
 #############################################################

--- a/samples/python/load_properties.py
+++ b/samples/python/load_properties.py
@@ -65,6 +65,9 @@ with open("nonBondedInter_save", "r") as bond_save:
 print("Non-bonded interactions from checkpoint:")
 print(system.non_bonded_inter[0, 0].lennard_jones.get_params())
 
+print("Force cap from checkpoint:")
+print(system.non_bonded_inter.get_force_cap())
+
 
 # Integration parameters
 #############################################################

--- a/samples/python/store_properties.py
+++ b/samples/python/store_properties.py
@@ -174,5 +174,8 @@ with open("p3m_save","w") as p3m_save:
 with open("system_save","w") as system_save:
     pickle.dump(system, system_save, -1)
 
+with open("nonBondedInter_save", "w") as bond_save:
+    pickle.dump(system.non_bonded_inter, bond_save, -1)
+
 # terminate program
 print("\nFinished.")

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -116,8 +116,7 @@ cdef class NonBondedInteraction(object):
         #update interaction dict when user sets interaction
         if self._part_types[0] not in self.user_interactions:
             self.user_interactions[self._part_types[0]] = {}
-        if self._part_types[1] not in self.user_interactions[self._part_types[0]]:
-            self.user_interactions[self._part_types[0]][self._part_types[1]] = {}
+        self.user_interactions[self._part_types[0]][self._part_types[1]] = {}
         new_params = self.get_params()
         for p_key in new_params:
             self.user_interactions[self._part_types[0]][self._part_types[1]][p_key] = new_params[p_key]

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -367,9 +367,12 @@ cdef class NonBondedInteractions:
     
     def __getstate__(self):
         odict = NonBondedInteractionHandle(-1,-1).lennard_jones.user_interactions #contains info about ALL nonbonded interactions
+        odict['force_cap'] = self.get_force_cap()
         return odict
     
     def __setstate__(self, odict):
+        self.set_force_cap(odict['force_cap'])
+        del odict['force_cap']
         for _type1 in odict:
             for _type2 in odict[_type1]:
                 attrs = dir(NonBondedInteractionHandle(_type1, _type2))

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -23,6 +23,9 @@ cdef class NonBondedInteraction(object):
 
     cdef public object _part_types
     cdef object _params
+    
+    #init dict to access all user defined nonbonded-inters via user_interactions[type1][type2][parameter]
+    user_interactions = {}
 
     def __init__(self, *args, **kwargs):
         """Represents an instance of a non-bonded interaction, such as lennard jones
@@ -109,6 +112,16 @@ cdef class NonBondedInteraction(object):
 
         if self._part_types[0] >= 0 and self._part_types[1] >= 0:
             self._set_params_in_es_core()
+        
+        #update interaction dict when user sets interaction
+        if self._part_types[0] not in self.user_interactions:
+            self.user_interactions[self._part_types[0]] = {}
+        if self._part_types[1] not in self.user_interactions[self._part_types[0]]:
+            self.user_interactions[self._part_types[0]][self._part_types[1]] = {}
+        new_params = self.get_params()
+        for p_key in new_params:
+            self.user_interactions[self._part_types[0]][self._part_types[1]][p_key] = new_params[p_key]
+        self.user_interactions[self._part_types[0]][self._part_types[1]]['type_name'] = self.type_name()
 
     def validate_params(self):
         return True
@@ -351,6 +364,30 @@ cdef class NonBondedInteractions:
 
     def get_force_cap(self):
         return force_cap
+    
+    def __getstate__(self):
+        odict = NonBondedInteractionHandle(-1,-1).lennard_jones.user_interactions #contains info about ALL nonbonded interactions
+        return odict
+    
+    def __setstate__(self, odict):
+        for _type1 in odict:
+            for _type2 in odict[_type1]:
+                attrs = dir(NonBondedInteractionHandle(_type1, _type2))
+                for a in attrs:
+                    attr_ref = getattr(NonBondedInteractionHandle(_type1, _type2), a)
+                    type_name_ref = getattr(attr_ref, "type_name", None)
+                    if callable(type_name_ref) and type_name_ref() == odict[_type1][_type2]['type_name']:
+                        inter_instance = attr_ref #found nonbonded inter, e.g. LennardJonesInteraction(_type1, _type2)
+                        break
+                    else:
+                        continue
+                    
+                #inter_instance = getattr(NonBondedInteractionHandle(_type1, _type2), odict['type_name'])
+                del odict[_type1][_type2]['type_name']
+                print odict[_type1][_type2], inter_instance.__class__.__name__
+                inter_instance.set_params(**odict[_type1][_type2])
+    
+    
 
 
 cdef class BondedInteraction(object):

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -382,12 +382,8 @@ cdef class NonBondedInteractions:
                     else:
                         continue
                     
-                #inter_instance = getattr(NonBondedInteractionHandle(_type1, _type2), odict['type_name'])
                 del odict[_type1][_type2]['type_name']
-                print odict[_type1][_type2], inter_instance.__class__.__name__
-                inter_instance.set_params(**odict[_type1][_type2])
-    
-    
+                inter_instance.set_params(**odict[_type1][_type2])    
 
 
 cdef class BondedInteraction(object):


### PR DESCRIPTION
With this implementation all non-bonded interactions can be checkpointed via pickle.dump and pickle.load of system.non_bonded_inter:
* checkpointing of all nonbonded-inters set by "set_params()"
* checkpointing of forcecap
* sample script: extended store_properties.py and load_properties.py
