### PR TITLE
testsuite: removed skip return code from cmake

### DIFF
--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -17,7 +17,6 @@ add_custom_target(python_tests
 foreach(testfile ${py_tests})
   get_filename_component(basename ${testfile} NAME_WE)
   add_test(${basename} ${CMAKE_BINARY_DIR}/pypresso ${testfile})
-  set_tests_properties(${basename} PROPERTIES SKIP_RETURN_CODE 42)
 endforeach(testfile ${py_tests})
 
 add_custom_target(check_python COMMAND ${CMAKE_CTEST_COMMAND})

--- a/testsuite/tcl/CMakeLists.txt
+++ b/testsuite/tcl/CMakeLists.txt
@@ -122,7 +122,6 @@ if(WITH_TCL)
     else()
       add_test(${basename} ${TEST_EXECUTABLE} ${testfile})
     endif()
-    set_tests_properties(${basename} PROPERTIES SKIP_RETURN_CODE 42)
   endforeach(testfile ${tcl_tests})
   add_custom_target(check_tcl COMMAND ${CMAKE_CTEST_COMMAND}
     DEPENDS Espresso tcl_tests)


### PR DESCRIPTION
We already agreed upon not using this feature a long time ago, as it marks skipped tests as failed. This was the reason we introduced the wrapper script for tests.

Needs to be removed because it's a feature of cmake 3.x, we require 2.8 as minimum.