### PR TITLE
cmake: require version 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(ESPResSo)
 


### PR DESCRIPTION
since #749 with the use of the command `target_compile_definitions` we require 3.0