### PR TITLE
Python 3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if (WITH_PYTHON)
   find_package(NumPy REQUIRED)
   list(APPEND LIBRARIES ${PYTHON_LIBRARY})
   execute_process(COMMAND ${PYTHON_EXECUTABLE} 
-                -c "import distutils.sysconfig as cg; print cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_EXEC_PREFIX}')"
+                -c "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_EXEC_PREFIX}'))"
                 OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif(WITH_PYTHON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ if (WITH_PYTHON)
   execute_process(COMMAND ${PYTHON_EXECUTABLE} 
                 -c "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_EXEC_PREFIX}'))"
                 OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(PYTHON_VERSION_MAJOR EQUAL 2)
+    set(CYTHON_FLAGS "-2" CACHE STRING "Flags used by the Cython compiler during all build types.")
+  else()
+    set(CYTHON_FLAGS "-3" CACHE STRING "Flags used by the Cython compiler during all build types.")
+  endif()
 endif(WITH_PYTHON)
 
 find_package(FFTW3)

--- a/maintainer/git2changelog.py
+++ b/maintainer/git2changelog.py
@@ -107,7 +107,7 @@ for line in fin:
         elif authorLine == prevAuthorLine:
             pass
         else:
-            print(("\n" + authorLine))
+            print("\n" + authorLine)
 
         # Assemble the actual commit message line(s) and limit the line length
         # to 80 characters.

--- a/samples/python/bonds-tst.py
+++ b/samples/python/bonds-tst.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import espressomd
 from espressomd.interactions import *
 
@@ -5,7 +6,7 @@ S = espressomd.System()
 h = HarmonicBond(r_0=0, k=1)
 f = FeneBond(k=1, d_r_max=1)
 f2 = FeneBond(k=2, d_r_max=1)
-print f2
+print(f2)
 
 
 S.bonded_inter[0] = h
@@ -13,23 +14,23 @@ S.bonded_inter[2] = f
 S.bonded_inter.add(f2)
 
 for b in S.bonded_inter:
-    print b
+    print(b)
 
 S.part.add(id=0, pos=(0., 0., 0.))
 S.part.add(id=1, pos=(0, 0, 0))
 S.part.add(id=2, pos=(0, 0, 0))
 
 
-print S.part[0].bonds
+print(S.part[0].bonds)
 S.part[0].add_bond((f2, 1))
 S.part[0].add_bond((0, 2))
-print S.part[0].bonds
+print(S.part[0].bonds)
 tmp = S.part[0].bonds
 S.part[0].delete_all_bonds()
-print S.part[0].bonds
+print(S.part[0].bonds)
 S.part[0].bonds = tmp
-print S.part[0].bonds
+print(S.part[0].bonds)
 S.part[0].delete_bond((h, 2))
-print S.part[0].bonds
+print(S.part[0].bonds)
 S.part[0].bonds = ((0, 1), (2, 2))
-print S.part[0].bonds
+print(S.part[0].bonds)

--- a/samples/python/cellsystem_test.py
+++ b/samples/python/cellsystem_test.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 import espressomd as es
 S = es.System()
 

--- a/samples/python/coulomb_debye_hueckel.py
+++ b/samples/python/coulomb_debye_hueckel.py
@@ -209,7 +209,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 

--- a/samples/python/debye_hueckel.py
+++ b/samples/python/debye_hueckel.py
@@ -211,7 +211,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 

--- a/samples/python/electrophoresis.py
+++ b/samples/python/electrophoresis.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 import espressomd
 from espressomd import code_info
 from espressomd import thermostat
@@ -24,7 +25,10 @@ from espressomd import interactions
 from espressomd import electrostatics
 import sys
 import numpy as np
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import os
 
 print(code_info.features())
@@ -163,7 +167,7 @@ pickle.dump(p3m,open("p3m_checkpoint","w"),-1)
 
 print("P3M parameter:\n")
 p3m_params = p3m.get_params()
-for key in p3m_params.keys():
+for key in list(p3m_params.keys()):
     print("{} = {}".format(key, p3m_params[key]))
 
 print(system.actors)
@@ -246,8 +250,8 @@ if float(np.version.version.split(".")[1]) >= 10:
 
     fit,_ = curve_fit(decay, c_length, cos_theta)
 
-    print c_length.shape, cos_theta.shape
-    print "PERSISTENCE LENGTH", fit[0]
+    print(c_length.shape, cos_theta.shape)
+    print("PERSISTENCE LENGTH", fit[0])
 
 # Plot Results
 ############################################################

--- a/samples/python/h5md_ReadFile.py
+++ b/samples/python/h5md_ReadFile.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 #  
-
+from __future__ import print_function
 import espressomd
 from espressomd import h5md
 import numpy as np

--- a/samples/python/h5md_WriteFile.py
+++ b/samples/python/h5md_WriteFile.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 #  
-
+from __future__ import print_function
 import espressomd
 from espressomd import h5md
 from espressomd.interactions import HarmonicBond

--- a/samples/python/lj_liquid.py
+++ b/samples/python/lj_liquid.py
@@ -177,7 +177,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 

--- a/samples/python/lj_liquid_distribution.py
+++ b/samples/python/lj_liquid_distribution.py
@@ -196,7 +196,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 
@@ -234,7 +234,7 @@ for i in range(0, int_n_times):
 #rescale distribution values and write out data
 distr_values /= int_n_times
 
-for i in xrange(distr_r_bins):
+for i in range(distr_r_bins):
     distr_file.write("{0}\t{1}\n".format(distr_r[i], distr_values[i]))
 distr_file.close()
 

--- a/samples/python/lj_liquid_structurefactor.py
+++ b/samples/python/lj_liquid_structurefactor.py
@@ -197,7 +197,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 
@@ -233,7 +233,7 @@ for i in range(0, int_n_times):
 # rescale structure factor values and write out data
 structurefactor_Sk /= int_n_times
 
-for i in xrange(structurefactor_bins):
+for i in range(structurefactor_bins):
     structurefactor_file.write("{0}\t{1}\n".format(
         structurefactor_k[i], structurefactor_Sk[i]))
 structurefactor_file.close()

--- a/samples/python/load_properties.py
+++ b/samples/python/load_properties.py
@@ -25,7 +25,10 @@ from espressomd import integrate
 from espressomd import electrostatics
 from espressomd import electrostatic_extensions
 import numpy
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 
 print("""
@@ -133,7 +136,7 @@ transfer_rate {0.transfer_rate}
 
 print("P3M parameters:\n")
 p3m_params = p3m.get_params()
-for key in p3m_params.keys():
+for key in list(p3m_params.keys()):
     print("{} = {}".format(key, p3m_params[key]))
 
 print(system.actors)
@@ -148,7 +151,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 

--- a/samples/python/minimal-charged-particles.py
+++ b/samples/python/minimal-charged-particles.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 import espressomd
 from espressomd import thermostat
 from espressomd import integrate
@@ -112,4 +113,4 @@ for i in range(0, int_n_times):
     integrate.integrate(int_steps)
 
     energies = system.analysis.energy()
-    print energies
+    print(energies)

--- a/samples/python/minimal-diamond.py
+++ b/samples/python/minimal-diamond.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 import espressomd
 from espressomd import thermostat
 from espressomd import integrate

--- a/samples/python/minimal-polymer.py
+++ b/samples/python/minimal-polymer.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 import espressomd
 from espressomd import thermostat
 from espressomd import integrate
@@ -55,4 +56,4 @@ for i in range(20):
     integrate.integrate(1000)
 
     energies = system.analysis.energy()
-    print energies
+    print(energies)

--- a/samples/python/minimal_random_number_generator.py
+++ b/samples/python/minimal_random_number_generator.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 import espressomd
 import numpy
 import sys
@@ -29,17 +30,17 @@ system = espressomd.System()
 
 system.seed=numpy.random.randint(low=1,high=2**31-1,size=system.n_nodes)
 # if no seed is provided espresso generates a seed
-print "seed ", system.seed
+print("seed ", system.seed)
 rng_state_read1=system.random_number_generator_state
-print "random number generator state read 1", rng_state_read1
+print("random number generator state read 1", rng_state_read1)
 
 rng_state=[]
 for i in range(len(rng_state_read1)):
 	rng_state.append(i)
 system.random_number_generator_state=rng_state
 rng_state_read2=system.random_number_generator_state
-print "random number generator state read 2", rng_state_read2
+print("random number generator state read 2", rng_state_read2)
 
 system.set_random_state_PRNG()
 rng_state_read3=system.random_number_generator_state
-print "random number generator state read 3", rng_state_read3
+print("random number generator state read 3", rng_state_read3)

--- a/samples/python/p3m.py
+++ b/samples/python/p3m.py
@@ -123,7 +123,7 @@ system.actors.add(p3m)
 
 print("\nSCRIPT--->P3M parameter:\n")
 p3m_params = p3m.get_params()
-for key in p3m_params.keys():
+for key in list(p3m_params.keys()):
     print("{} = {}".format(key, p3m_params[key]))
 
 print("\nSCRIPT--->Explicit tune call\n")
@@ -131,7 +131,7 @@ p3m._tune()
     
 print("\nSCRIPT--->P3M parameter:\n")
 p3m_params = p3m.get_params()
-for key in p3m_params.keys():
+for key in list(p3m_params.keys()):
     print("{} = {}".format(key, p3m_params[key]))
 
 # elc=electrostatic_extensions.ELC(maxPWerror=1.0,gap_size=1.0)
@@ -202,7 +202,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 

--- a/samples/python/store_properties.py
+++ b/samples/python/store_properties.py
@@ -163,7 +163,10 @@ transfer_rate {0.transfer_rate}
 
 # Pickle data
 ###########################################################
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 with open("particle_save","w") as particle_save:
     pickle.dump(system.part, particle_save, -1)

--- a/samples/python/visualization.py
+++ b/samples/python/visualization.py
@@ -176,7 +176,7 @@ lj_cap = 0
 system.non_bonded_inter.set_force_cap(lj_cap)
 print(system.non_bonded_inter[0, 0].lennard_jones)
 
-# print initial energies
+# print(initial energies)
 energies = system.analysis.energy()
 print(energies)
 

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -63,7 +63,7 @@ foreach(cython_file ${cython_SRC})
   else()
       list(APPEND cython_generated_SRC "${basename}.cpp")
       add_custom_command(OUTPUT ${basename}.cpp
-                         COMMAND ${CYTHON_EXECUTABLE}  --cplus
+                         COMMAND ${CYTHON_EXECUTABLE}  --cplus ${CYTHON_FLAGS}
                          -I ${CMAKE_CURRENT_BINARY_DIR}/_espresso
                          -I ${CMAKE_CURRENT_SOURCE_DIR}
                          -I ${CMAKE_CURRENT_SOURCE_DIR}/_espresso

--- a/src/python/espressomd/_espresso.pxd
+++ b/src/python/espressomd/_espresso.pxd
@@ -22,5 +22,6 @@
 # specific class.
 #
 
+from __future__ import print_function, absolute_import
 cdef extern from "communication.hpp":
     int mpi_bcast_parameter(int p)

--- a/src/python/espressomd/_init.pyx
+++ b/src/python/espressomd/_init.pyx
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 import sys
 
 cdef extern from "communication.hpp":

--- a/src/python/espressomd/_system.pxd
+++ b/src/python/espressomd/_system.pxd
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 import particle_data
 from libcpp.vector cimport vector

--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -16,24 +16,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 from globals cimport *
 import numpy as np
 
-cimport integrate
-import interactions
-from actors import Actors
-cimport cuda_init
-import particle_data
-import cuda_init
-import code_info
-from thermostat import Thermostat
-from cellsystem import CellSystem
-from minimize_energy import MinimizeEnergy
-from polymer import Polymer
-from analyze import Analysis
-from galilei import GalileiTransform
+from . cimport integrate
+from . import interactions
+from .actors import Actors
+from . cimport cuda_init
+from . import particle_data
+from . import cuda_init
+from . import code_info
+from .thermostat import Thermostat
+from .cellsystem import CellSystem
+from .minimize_energy import MinimizeEnergy
+from .polymer import Polymer
+from .analyze import Analysis
+from .galilei import GalileiTransform
 
 import sys
 import random #for true random numbers from os.urandom()

--- a/src/python/espressomd/actors.pxd
+++ b/src/python/espressomd/actors.pxd
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 cdef class Actor:
     cdef public _isactive
     cdef public _params

--- a/src/python/espressomd/actors.pyx
+++ b/src/python/espressomd/actors.pyx
@@ -1,5 +1,6 @@
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-from highlander import ThereCanOnlyBeOne
+from .highlander import ThereCanOnlyBeOne
 
 
 cdef class Actor:
@@ -166,9 +167,9 @@ class Actors:
             raise ThereCanOnlyBeOne(actor)
 
     def __str__(self):
-        print "Active Actors:"
+        print("Active Actors:")
         for actor in Actors.active_actors:
-            print actor
+            print(actor)
         return ""
 
     def __getitem__(self, key):

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -18,5 +18,6 @@
 #
 # For C-extern Analysis
 
+from __future__ import print_function, absolute_import
 cimport numpy as np
-from utils cimport *
+from espressomd.utils cimport *

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -17,23 +17,24 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # For C-extern Analysis
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-cimport c_analyze
-cimport utils
-cimport particle_data
-import utils
-import code_info
-import particle_data
+from . cimport c_analyze
+from . cimport utils
+from . cimport particle_data
+from . import utils
+from . import code_info
+from . import particle_data
 from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
 from libcpp.map cimport map  # import std::map as map
-from interactions import *
-from interactions cimport *
+from .interactions import *
+from espressomd.interactions cimport *
 import numpy as np
 cimport numpy as np
 from globals cimport n_configs, min_box_l
 from collections import OrderedDict
-from _system import System
+from ._system import System
 
 
 class Analysis:
@@ -727,7 +728,7 @@ class Analysis:
     
     
     def angularmomentum(self, p_type=None):
-        print "p_type = ", p_type
+        print("p_type = ", p_type)
         check_type_or_throw_except(
             p_type, 1, int,   "p_type has to be an int")
     

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -853,9 +853,9 @@ class Analysis:
             check_type_or_throw_except(avk, 1, float, "avk has to be a float")
             _Vkappa["avk"] = avk
             if (_Vkappa["avk"] <= 0.0):
+                result = _Vkappa["Vk1"] = _Vkappa["Vk2"] = _Vkappa["avk"] = 0.0
                 raise Exception(
                     "ERROR: # of averages <avk> has to be positive! Resetting values.")
-                result = _Vkappa["Vk1"] = _Vkappa["Vk2"] = _Vkappa["avk"] = 0.0
             else:
                 result = _Vkappa["Vk2"] / _Vkappa["avk"] - \
                     (_Vkappa["Vk1"] / _Vkappa["avk"])**2

--- a/src/python/espressomd/c_analyze.pxd
+++ b/src/python/espressomd/c_analyze.pxd
@@ -23,8 +23,9 @@
 #
 
 
+from __future__ import print_function, absolute_import
 cimport numpy as np
-from utils cimport *
+from espressomd.utils cimport *
 from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
 from libcpp.map cimport map  # import std::map as map

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -18,6 +18,7 @@
 #
 
 # @TODO: shouldn't these global definitions be used via global_variables?
+from __future__ import print_function, absolute_import
 cdef extern from "global.hpp":
     int FIELD_NODEGRID
 

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -16,7 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-cimport cellsystem
+from __future__ import print_function, absolute_import
+from . cimport cellsystem
 from globals cimport *
 
 cdef class CellSystem(object):

--- a/src/python/espressomd/cuda_init.pxd
+++ b/src/python/espressomd/cuda_init.pxd
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 cdef extern from "cuda_init.hpp":
     int cuda_set_device(int dev)
     int cuda_get_device()

--- a/src/python/espressomd/cuda_init.pyx
+++ b/src/python/espressomd/cuda_init.pyx
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-cimport cuda_init
+from . cimport cuda_init
 
 cdef class CudaInitHandle:
     def __init__(self):

--- a/src/python/espressomd/debye_hueckel.pxd
+++ b/src/python/espressomd/debye_hueckel.pxd
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 cdef extern from "config.hpp":

--- a/src/python/espressomd/debye_hueckel.pyx
+++ b/src/python/espressomd/debye_hueckel.pyx
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 IF ELECTROSTATICS == 1:
     def set_params(kappa, r_cut):

--- a/src/python/espressomd/diamond.pxd
+++ b/src/python/espressomd/diamond.pxd
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 cdef extern from "polymer.hpp":

--- a/src/python/espressomd/diamond.pyx
+++ b/src/python/espressomd/diamond.pyx
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 cdef class Diamond:
     def __init__(self, *args, **kwargs):

--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 from libcpp cimport bool
 import numpy as np
 

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -18,10 +18,11 @@
 #
 # Handling of electrostatics
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-from _system cimport *
-from utils cimport *
-from electrostatics cimport *
+from espressomd._system cimport *
+from espressomd.utils cimport *
+from espressomd.electrostatics cimport *
 
 IF ELECTROSTATICS and P3M:
 

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -17,10 +17,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cimport utils
+from __future__ import print_function, absolute_import
+from . cimport utils
 include "myconfig.pxi"
-cimport actors
-import actors
+from espressomd cimport actors
+from . import actors
 import numpy as np
 
 IF ELECTROSTATICS and P3M:

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -301,7 +301,9 @@ IF ELECTROSTATICS and MMM1D_GPU:
     cdef extern from "actor/Mmm1dgpuForce.hpp":
         ctypedef float mmm1dgpu_real
         cdef cppclass Mmm1dgpuForce:
-            Mmm1dgpuForce(SystemInterface &s, mmm1dgpu_real coulomb_prefactor, mmm1dgpu_real maxPWerror, mmm1dgpu_real far_switch_radius = -1, int bessel_cutoff = -1);
+            Mmm1dgpuForce(SystemInterface &s, mmm1dgpu_real coulomb_prefactor, mmm1dgpu_real maxPWerror, mmm1dgpu_real far_switch_radius, int bessel_cutoff);
+            Mmm1dgpuForce(SystemInterface &s, mmm1dgpu_real coulomb_prefactor, mmm1dgpu_real maxPWerror, mmm1dgpu_real far_switch_radius);
+            Mmm1dgpuForce(SystemInterface &s, mmm1dgpu_real coulomb_prefactor, mmm1dgpu_real maxPWerror);
             void setup(SystemInterface &s);
             void tune(SystemInterface &s, mmm1dgpu_real _maxPWerror, mmm1dgpu_real _far_switch_radius, int _bessel_cutoff);
             void set_params(mmm1dgpu_real _boxz, mmm1dgpu_real _coulomb_prefactor, mmm1dgpu_real _maxPWerror, mmm1dgpu_real _far_switch_radius, int _bessel_cutoff, bool manual = False);
@@ -314,7 +316,8 @@ IF ELECTROSTATICS and MMM1D_GPU:
             bool need_tune;
 
             int pairs;
-            mmm1dgpu_real *dev_forcePairs, *dev_energyBlocks;
+            mmm1dgpu_real *dev_forcePairs;
+            mmm1dgpu_real *dev_energyBlocks;
 
             mmm1dgpu_real coulomb_prefactor, maxPWerror, far_switch_radius;
             int bessel_cutoff;

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -18,10 +18,11 @@
 #
 # Handling of electrostatics
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-from _system cimport *
+from espressomd._system cimport *
 cimport numpy as np
-from utils cimport *
+from espressomd.utils cimport *
 
 cdef extern from "SystemInterface.hpp":
     cdef cppclass SystemInterface:
@@ -132,7 +133,7 @@ IF ELECTROSTATICS:
             cdef char * log = NULL
             cdef int response
             response = p3m_adaptive_tune(& log)
-            print log
+            print(log)
             return response
 
         cdef inline python_p3m_set_params(p_r_cut, p_mesh, p_cao, p_alpha, p_accuracy):
@@ -271,7 +272,7 @@ IF ELECTROSTATICS:
             raise ValueError("MMM1D Sanity check failed: wrong periodicity or wrong cellsystem, PRTFM")
         resp=mmm1d_tune(&log)
         if resp:
-            print log
+            print(log)
         return resp
 
 IF ELECTROSTATICS:

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -16,14 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 from cython.operator cimport dereference
 include "myconfig.pxi"
-cimport actors
-import actors
+from espressomd cimport actors
+from . import actors
 cimport globals
 import numpy as np
-from scafacos import *
-cimport scafacos
+from .scafacos import *
+from . cimport scafacos
 
 
 cdef class ElectrostaticInteraction(actors.Actor):
@@ -399,7 +400,7 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
                     "precision"], self._params["K_max"], self._params["time_calc_steps"])
             resp = self.thisptr.adaptive_tune( & self.log, dereference(self.interface))
             if resp != 0:
-                print self.log
+                print(self.log)
 
         def _set_params_in_es_core(self):
             coulomb_set_bjerrum(self._params["bjerrum_length"])
@@ -627,13 +628,13 @@ IF ELECTROSTATICS:
                 self._params["delta_mid_bot"] = -1
                 self._params["const_pot_on"] = 1
 
-            print MMM2D_set_params(self._params["maxPWerror"], self._params["far_cut"], self._params["delta_mid_top"], self._params["delta_mid_bot"], self._params["capacitor"], self._params["pot_diff"])
+            print(MMM2D_set_params(self._params["maxPWerror"], self._params["far_cut"], self._params["delta_mid_top"], self._params["delta_mid_bot"], self._params["capacitor"], self._params["pot_diff"]))
 
         def _activate_method(self):
             coulomb.method = COULOMB_MMM2D
             self._set_params_in_es_core()
             MMM2D_init()
-            print MMM2D_sanity_checks()
+            print(MMM2D_sanity_checks())
 
     IF SCAFACOS == 1:
         class Scafacos(ScafacosConnector, ElectrostaticInteraction):

--- a/src/python/espressomd/galilei.pxd
+++ b/src/python/espressomd/galilei.pxd
@@ -18,6 +18,7 @@
 #
 
 
+from __future__ import print_function, absolute_import
 cdef extern from "galilei.hpp":
 
     void local_kill_particle_motion(int rotation)

--- a/src/python/espressomd/galilei.pyx
+++ b/src/python/espressomd/galilei.pyx
@@ -17,7 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cimport galilei
+from __future__ import print_function, absolute_import
+from . cimport galilei
 
 cdef class GalileiTransform:
 

--- a/src/python/espressomd/grand_canonical.pxd
+++ b/src/python/espressomd/grand_canonical.pxd
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 cdef extern from "particle_data.hpp":
 	int init_type_array(int type)
 	int delete_particle_of_type(int type)

--- a/src/python/espressomd/grand_canonical.pyx
+++ b/src/python/espressomd/grand_canonical.pyx
@@ -16,7 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from utils cimport *
+from __future__ import print_function, absolute_import
+from espressomd.utils cimport *
 cimport globals
 from globals cimport max_seen_particle
 

--- a/src/python/espressomd/h5md.pyx
+++ b/src/python/espressomd/h5md.pyx
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import print_function, absolute_import
 import h5py
 import sys
 import numpy as np
@@ -82,7 +83,7 @@ class h5md(object):
 
         # CREATE OR OPEN DATASET
         if feature != 1:
-            print "ERROR H5: Some necessary ESPResSo features for values used in h5-file are not activated"
+            print("ERROR H5: Some necessary ESPResSo features for values used in h5-file are not activated")
             sys.exit()
         try:
             self.dataset = self.h5_file.create_dataset(
@@ -885,7 +886,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
 
             # Read value
@@ -900,13 +901,13 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
                 self.h5md.system.time = self.h5md.value_dataset[timestep]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # time
@@ -917,13 +918,13 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
                 return self.h5md.value_dataset[timestep]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # Position
@@ -934,7 +935,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -947,7 +948,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].pos = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # velocity
@@ -958,7 +959,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -970,7 +971,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].v = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # force
@@ -981,7 +982,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -993,7 +994,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].f = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # bonds
@@ -1006,13 +1007,13 @@ class h5md(object):
                 self.h5md.value_dataset_to = self.h5md.h5_file[
                     "particles/atoms/bond_to/"][datasetname]
             except:
-                print "ERROR H5: No " + "particles/atoms/bonds_from_to/" + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + "particles/atoms/bonds_from_to/" + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
                 print("ERROR H5: Reading bonds not implemented yet")
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # species
@@ -1022,7 +1023,7 @@ class h5md(object):
             try:
                 self.h5md.value_dataset = self.h5md.h5_file[groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1033,7 +1034,7 @@ class h5md(object):
                     for i in range(self.h5md.value_dataset.shape[1]):
                         self.h5md.system.part[i].type = int(self.h5md.value_dataset[timestep, i][0])
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # id
@@ -1044,7 +1045,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1057,7 +1058,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].id = int(self.h5md.value_dataset[timestep, i][0])
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
 
         def mass(self, timestep=-1, groupname="particles/atoms/mass/",
@@ -1067,7 +1068,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1080,7 +1081,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].mass = self.h5md.value_dataset[timestep, i][0]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # omega_lab
@@ -1091,7 +1092,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1104,7 +1105,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].omega_lab = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # rinertia
@@ -1115,7 +1116,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1128,7 +1129,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].rinertia = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # omega_body
@@ -1139,7 +1140,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1152,7 +1153,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].omega_body = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # torque_lab
@@ -1163,7 +1164,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1176,7 +1177,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].torque_lab = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # quat
@@ -1187,7 +1188,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1200,7 +1201,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].quat = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # charge
@@ -1211,7 +1212,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1224,7 +1225,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].q = self.h5md.value_dataset[timestep, i][0]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # virtual
@@ -1235,7 +1236,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1248,7 +1249,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].virtual = self.h5md.value_dataset[timestep, i][0]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # vs_relative
@@ -1259,7 +1260,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1272,7 +1273,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].vs_relative = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # dipole
@@ -1283,7 +1284,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1296,7 +1297,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].dip = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # dipole_magnitude
@@ -1307,7 +1308,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1320,7 +1321,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].dipm = self.h5md.value_dataset[timestep, i][0]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # external force
@@ -1331,7 +1332,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1344,7 +1345,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].ext_force = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # external force particle fix
@@ -1355,7 +1356,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1368,7 +1369,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].fix = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # external torque
@@ -1379,7 +1380,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1392,7 +1393,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].ext_torque = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # gamma
@@ -1403,7 +1404,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1416,7 +1417,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].gamma = self.h5md.value_dataset[timestep, i][0]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # temperature
@@ -1427,7 +1428,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             try:
                 if len(self.h5md.value_dataset.shape) == 2:  # time independent
@@ -1439,7 +1440,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].temp = self.h5md.value_dataset[timestep, i][0]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
         
         # rotation
@@ -1450,7 +1451,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1463,7 +1464,7 @@ class h5md(object):
                         self.h5md.system.part[
                             i].rotation = self.h5md.value_dataset[timestep, i]
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
 
     # BOX
@@ -1474,7 +1475,7 @@ class h5md(object):
                 self.h5md.value_dataset = self.h5md.h5_file[
                     groupname][datasetname]
             except:
-                print "ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting"
+                print("ERROR H5: No " + groupname + datasetname + " dataset in h5-file exisiting")
                 sys.exit()
             # Try to read value from h5-file and write to ESPResSo
             try:
@@ -1489,7 +1490,7 @@ class h5md(object):
                         box_l_temp[i] = self.h5md.value_dataset[timestep, i, i]
                     self.h5md.system.box_l = box_l_temp
             except:
-                print "ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible"
+                print("ERROR H5: Access to dataset " + groupname + datasetname + " or writing to ESPResSo not possible")
                 sys.exit()
 
         def box_boundary(

--- a/src/python/espressomd/integrate.pxd
+++ b/src/python/espressomd/integrate.pxd
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
 from libcpp cimport bool as cbool

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-from utils cimport *
+from espressomd.utils cimport *
 
 cdef int _integrate(int nSteps, int recalc_forces, int reuse_forces):
     with nogil:

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -18,10 +18,11 @@
 #
 # Handling of interactions
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-from _system cimport *
+from espressomd._system cimport *
 cimport numpy as np
-from utils cimport *
+from espressomd.utils cimport *
 
 cdef extern from "interaction_data.hpp":
     ctypedef struct ia_parameters "IA_parameters":

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 # Non-bonded interactions
 
@@ -1131,8 +1132,8 @@ class BondedInteractions:
 
         # Find the appropriate class representing such a bond
         bond_class = bonded_interaction_classes[bond_type]
-        # print bondType
-        # print "  "
+        # print(bondType)
+        # print("  ")
 
         # And return an instance of it, which refers to the bonded interaction
         # id in Espresso

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -18,6 +18,7 @@
 #
 from __future__ import print_function, absolute_import
 include "myconfig.pxi"
+from . import utils
 # Non-bonded interactions
 
 cdef class NonBondedInteraction(object):
@@ -755,7 +756,7 @@ IF TABULATED == 1:
 
         def _set_params_in_es_core(self):
             tabulated_bonded_set_params(
-                self._bond_id, self._params["type"], self._params["filename"])
+                self._bond_id, self._params["type"], utils.to_char_pointer(self._params["filename"]))
 
     cdef class TabulatedNonBonded(NonBondedInteraction):
 
@@ -787,7 +788,7 @@ IF TABULATED == 1:
                 "filename": ia_params.TAB_filename}
 
         def _set_params_in_es_core(self):
-            self.state = tabulated_set_params(self._part_types[0], self._part_types[1], self._params["filename"])
+            self.state = tabulated_set_params(self._part_types[0], self._part_types[1], utils.to_char_pointer(self._params["filename"]))
 
         def is_active(self):
             if self.state == 0:

--- a/src/python/espressomd/lb.pxd
+++ b/src/python/espressomd/lb.pxd
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 from libcpp cimport bool
 

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -24,6 +24,7 @@ from . cimport cuda_init
 from . import cuda_init
 from globals cimport *
 from copy import deepcopy
+from . import utils
 
 # Actor class
 ####################################################
@@ -150,17 +151,17 @@ IF LB_GPU or LB:
         # input/output function wrappers for whole LB fields
         ####################################################
         def print_vtk_velocity(self, path):
-            lb_lbfluid_print_vtk_velocity(path)
+            lb_lbfluid_print_vtk_velocity(utils.to_char_pointer(path))
         def print_vtk_boundary(self, path):
-            lb_lbfluid_print_vtk_boundary(path)
+            lb_lbfluid_print_vtk_boundary(utils.to_char_pointer(path))
         def print_velocity(self, path):
-            lb_lbfluid_print_velocity(path)
+            lb_lbfluid_print_velocity(utils.to_char_pointer(path))
         def print_boundary(self, path):
-            lb_lbfluid_print_boundary(path)
+            lb_lbfluid_print_boundary(utils.to_char_pointer(path))
         def save_checkpoint(self, path, binary):
-            lb_lbfluid_save_checkpoint(path, binary)
+            lb_lbfluid_save_checkpoint(utils.to_char_pointer(path), binary)
         def load_checkpoint(self, path, binary):
-            lb_lbfluid_load_checkpoint(path, binary)
+            lb_lbfluid_load_checkpoint(utils.to_char_pointer(path), binary)
         def lbnode_get_node_velocity(self, coord):
             cdef double[3] double_return
             cdef int[3] c_coord

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 import numpy as np
-from actors cimport Actor
-cimport cuda_init
-import cuda_init
+from .actors cimport Actor
+from . cimport cuda_init
+from . import cuda_init
 from globals cimport *
 from copy import deepcopy
 

--- a/src/python/espressomd/magnetostatic_extensions.pxd
+++ b/src/python/espressomd/magnetostatic_extensions.pxd
@@ -18,9 +18,10 @@
 #
 # Handling of electrostatics
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-from _system cimport *
-from utils cimport *
+from espressomd._system cimport *
+from espressomd.utils cimport *
 
 IF DIPOLES == 1:
 

--- a/src/python/espressomd/magnetostatic_extensions.pyx
+++ b/src/python/espressomd/magnetostatic_extensions.pyx
@@ -17,9 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cimport utils
+from __future__ import print_function, absolute_import
+from . cimport utils
 include "myconfig.pxi"
-from actors import Actor
+from .actors import Actor
 
 IF DIPOLES == 1:
     class MagnetostaticExtension(Actor):

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 import numpy as np
-from actors cimport Actor
+from .actors cimport Actor
 from globals cimport temperature
 
 IF DIPOLES == 1:
@@ -149,7 +150,7 @@ IF DP3M == 1:
             if resp:
                 raise Exception(
                     "failed to tune dipolar P3M parameters to required accuracy")
-            print log
+            print(log)
             self._params.update(self._get_params_from_es_core())
 
         def _activate_method(self):

--- a/src/python/espressomd/minimize_energy.pxd
+++ b/src/python/espressomd/minimize_energy.pxd
@@ -18,10 +18,11 @@
 #
 # Minimize Energy
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-from _system cimport *
+from espressomd._system cimport *
 cimport numpy as np
-from utils cimport *
+from espressomd.utils cimport *
 
 cdef extern from "minimize_energy.hpp": 
     cdef void minimize_energy_init(const double f_max, const double gamma, const int max_steps, const double max_displacement) 

--- a/src/python/espressomd/minimize_energy.pyx
+++ b/src/python/espressomd/minimize_energy.pyx
@@ -18,7 +18,8 @@
 #
 # Minimize Energy
 
-cimport minimize_energy
+from __future__ import print_function, absolute_import
+from . cimport minimize_energy
 
 cdef class MinimizeEnergy(object):
     cdef object _params

--- a/src/python/espressomd/p3m_common.pxd
+++ b/src/python/espressomd/p3m_common.pxd
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 IF P3M == 1 or DP3M == 1:

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -16,10 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from _system cimport *
+from __future__ import print_function, absolute_import
+from espressomd._system cimport *
 # Here we create something to handle particles
 cimport numpy as np
-from utils cimport *
+from espressomd.utils cimport *
 from libcpp cimport bool
 
 include "myconfig.pxi"

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -16,15 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 cimport numpy as np
 import numpy as np
-cimport utils
-from utils cimport *
-cimport particle_data
-from interactions import BondedInteraction
-from interactions import BondedInteractions
+from . cimport utils
+from espressomd.utils cimport *
+from . cimport particle_data
+from .interactions import BondedInteraction
+from .interactions import BondedInteractions
 from copy import copy
 from globals cimport max_seen_particle, time_step, smaller_time_step, box_l
 import collections

--- a/src/python/espressomd/polymer.pxd
+++ b/src/python/espressomd/polymer.pxd
@@ -18,6 +18,7 @@
 #
 
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 cdef extern from "polymer.hpp":

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -17,11 +17,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-cimport utils
-from utils cimport *
-from utils import *
-cimport polymer
+from . cimport utils
+from espressomd.utils cimport *
+from .utils import *
+from . cimport polymer
 
 cdef class Polymer(object):
     cdef object _params
@@ -35,14 +36,14 @@ cdef class Polymer(object):
 
         for k in self.required_keys():
             if k not in kwargs:
-                print k 
+                print(k)
                 raise ValueError(
                     "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__())
 
         for k in kwargs:
             self._params[k] = kwargs[k]
 
-        print self._params
+        print(self._params)
         self.validate_params()
 
         cdef double start_pos[3];

--- a/src/python/espressomd/reaction.pxd
+++ b/src/python/espressomd/reaction.pxd
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 IF CATALYTIC_REACTIONS:

--- a/src/python/espressomd/reaction.pyx
+++ b/src/python/espressomd/reaction.pyx
@@ -1,8 +1,9 @@
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
-cimport reaction
-cimport globals
-cimport utils
-from highlander import ThereCanOnlyBeOne
+from . cimport reaction
+from . cimport globals
+from . cimport utils
+from .highlander import ThereCanOnlyBeOne
 
 IF CATALYTIC_REACTIONS:
     __reaction_is_initiated = False

--- a/src/python/espressomd/scafacos.pxd
+++ b/src/python/espressomd/scafacos.pxd
@@ -1,6 +1,7 @@
 # Interface to the scafacos library. These are the methods shared between
 # dipolar and electrostatics methods
 
+from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 
 from libcpp.string cimport string

--- a/src/python/espressomd/scafacos.pyx
+++ b/src/python/espressomd/scafacos.pyx
@@ -1,4 +1,5 @@
-from actors cimport *
+from __future__ import print_function, absolute_import
+from espressomd.actors cimport *
 from libcpp.string cimport string  # import std::string
 
 include "myconfig.pxi"

--- a/src/python/espressomd/system.py
+++ b/src/python/espressomd/system.py
@@ -40,5 +40,5 @@ class System(_system.System):
             else:
                 super(System, self).__setattr__(name, None)
 
-        for name, value in kwargs.items():
+        for name, value in list(kwargs.items()):
             super(System, self).__setattr__(name, value)

--- a/src/python/espressomd/thermostat.pxd
+++ b/src/python/espressomd/thermostat.pxd
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 cdef extern from "communication.hpp":
     void mpi_bcast_parameter(int p)
 

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -16,7 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-cimport thermostat
+from __future__ import print_function, absolute_import
+from . cimport thermostat
 
 cdef class Thermostat:
 

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 import numpy as np
 cimport numpy as np
 

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function, absolute_import
 cimport numpy as np
 import numpy as np
 
@@ -44,7 +45,7 @@ cdef int_list * create_int_list_from_python_object(obj):
     alloc_intlist(il, len(obj))
     for i in range(len(obj)):
         il.e[i] = obj[i]
-        print il.e[i]
+        print(il.e[i])
     il.n = len(obj)
     return il
 

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -19,6 +19,7 @@
 from __future__ import print_function, absolute_import
 cimport numpy as np
 import numpy as np
+from cpython.version cimport PY_MAJOR_VERSION
 
 cdef extern from "stdlib.h":
     void free(void * ptr)
@@ -98,3 +99,19 @@ cdef check_range_or_except(D, name, v_min, incl_min, v_max, incl_max):
                 v_max != "inf" and ((incl_max and x > v_max) or (not incl_max and x >= v_max))):
             raise ValueError("In " + name + ": Value " + str(x) + " is out of range " + ("[" if incl_min else "]") +
                              str(v_min) + "," + str(v_max) + ("]" if incl_max else "["))
+
+def to_char_pointer(s):
+    if isinstance(s, unicode):
+        s = (<unicode>s).encode('utf8')
+    return s
+
+def to_unicode(s):
+    if type(s) is unicode:
+        return <unicode>s
+    elif PY_MAJOR_VERSION < 3 and isinstance(s, bytes):
+        # only accept byte strings in Python 2, not in Python 3
+        return (<bytes>s).decode('ascii')
+    elif isinstance(s, unicode):
+        return unicode(s)
+    else:
+        raise TypeError("Cannot convert to unicode")

--- a/src/python/espressomd/visualization.pyx
+++ b/src/python/espressomd/visualization.pyx
@@ -1,9 +1,10 @@
+from __future__ import print_function, absolute_import, division
 import numpy
 cimport numpy
 import os
 from libcpp cimport bool
 from espressomd.particle_data import ParticleHandle
-from particle_data cimport *
+from espressomd.particle_data cimport *
 from espressomd.interactions cimport *
 from espressomd._system cimport *
 from libcpp.vector cimport vector
@@ -155,7 +156,7 @@ cdef class mayavi_live:
                     k+=1
             j += 1
         assert j == self.system.n_part
-        cdef int Nbonds = bonds.size()/3
+        cdef int Nbonds = bonds.size()//3
         
         bond_coords = numpy.empty((Nbonds,7))
 

--- a/testsuite/python/bondedInteractions.py
+++ b/testsuite/python/bondedInteractions.py
@@ -112,5 +112,5 @@ class ParticleProperties(ut.TestCase):
         test_subt_lj = generateTestForBondParams(0, Subt_Lj, {"k": 5.2, "r": 3.2})
 
 if __name__ == "__main__":
-    print(("Features: ", code_info.features()))
+    print("Features: ", code_info.features())
     ut.main()

--- a/testsuite/python/bondedInteractions.py
+++ b/testsuite/python/bondedInteractions.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import espressomd._system as es
@@ -45,7 +46,7 @@ class ParticleProperties(ut.TestCase):
         if inType != outType:
             return False
 
-        for k in inParams.keys():
+        for k in list(inParams.keys()):
             if k not in outParams:
                 return False
             if outParams[k] != inParams[k]:
@@ -111,5 +112,5 @@ class ParticleProperties(ut.TestCase):
         test_subt_lj = generateTestForBondParams(0, Subt_Lj, {"k": 5.2, "r": 3.2})
 
 if __name__ == "__main__":
-    print("Features: ", code_info.features())
+    print(("Features: ", code_info.features()))
     ut.main()

--- a/testsuite/python/cellsystem.py
+++ b/testsuite/python/cellsystem.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import numpy as np
@@ -42,5 +43,5 @@ class CellSystem(ut.TestCase):
 
 
 if __name__ == "__main__":
-    print("Features: ", espressomd.features())
+    print(("Features: ", espressomd.features()))
     ut.main()

--- a/testsuite/python/cellsystem.py
+++ b/testsuite/python/cellsystem.py
@@ -43,5 +43,5 @@ class CellSystem(ut.TestCase):
 
 
 if __name__ == "__main__":
-    print(("Features: ", espressomd.features()))
+    print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import numpy as np
@@ -67,13 +68,13 @@ class CoulombCloudWall(ut.TestCase):
                 force_abs_diff += abs(np.sqrt(sum((p.f - self.forces[p.id])**2)))
             force_abs_diff /= len(self.S.part)
     
-            print method_name, "force difference", force_abs_diff
+            print(method_name, "force difference", force_abs_diff)
     
             # Energy
             if energy:
                 energy_abs_diff = abs(self.S.analysis.energy(
                     self.S)["total"] - self.reference_energy)
-                print method_name, "energy difference", energy_abs_diff
+                print(method_name, "energy difference", energy_abs_diff)
                 self.assertTrue(energy_abs_diff <= self.tolerance, "Absolte energy difference " +
                                 str(energy_abs_diff) + " too large for " + method_name)
             self.assertTrue(force_abs_diff <= self.tolerance, "Asbolute force difference " +

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -62,6 +62,6 @@ class ElectrostaticInteractionsTests(ut.TestCase):
     
     
 if __name__ == "__main__":
-    print(("Features: ", espressomd.features()))
+    print("Features: ", espressomd.features())
     ut.main()
 

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import numpy as np
@@ -61,6 +62,6 @@ class ElectrostaticInteractionsTests(ut.TestCase):
     
     
 if __name__ == "__main__":
-    print("Features: ", espressomd.features())
+    print(("Features: ", espressomd.features()))
     ut.main()
 

--- a/testsuite/python/engine_langevin.py
+++ b/testsuite/python/engine_langevin.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest as ut
 import numpy as np
 import espressomd
@@ -48,5 +49,5 @@ if "ENGINE" in espressomd.features():
             self.assertTrue(4.9e-4 < delta_pos_1 and delta_pos_1 < 5.1e-4)
 
     if __name__ == '__main__':
-        print("Features: ", espressomd.features())
+        print(("Features: ", espressomd.features()))
         ut.main()

--- a/testsuite/python/engine_langevin.py
+++ b/testsuite/python/engine_langevin.py
@@ -49,5 +49,5 @@ if "ENGINE" in espressomd.features():
             self.assertTrue(4.9e-4 < delta_pos_1 and delta_pos_1 < 5.1e-4)
 
     if __name__ == '__main__':
-        print(("Features: ", espressomd.features()))
+        print("Features: ", espressomd.features())
         ut.main()

--- a/testsuite/python/engine_lb.py
+++ b/testsuite/python/engine_lb.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest as ut
 import tests_common
 import os
@@ -62,9 +63,9 @@ if "ENGINE" in espressomd.features() and "LB" in espressomd.features():
                     lbm.print_vtk_velocity("engine_lb_tmp.vtk")
                     different, difference = tests_common.calculate_vtk_max_pointwise_difference("engine_lb.vtk", "engine_lb_tmp.vtk",tol=2.0e-7)
                     os.remove("engine_lb_tmp.vtk")
-                    print("Maximum deviation to the reference point is: {}".format(difference))
+                    print(("Maximum deviation to the reference point is: {}".format(difference)))
                     self.assertTrue( different )
 
 if __name__ == '__main__':
-    print("Features: ", espressomd.features())
+    print(("Features: ", espressomd.features()))
     ut.main()

--- a/testsuite/python/engine_lb.py
+++ b/testsuite/python/engine_lb.py
@@ -63,9 +63,9 @@ if "ENGINE" in espressomd.features() and "LB" in espressomd.features():
                     lbm.print_vtk_velocity("engine_lb_tmp.vtk")
                     different, difference = tests_common.calculate_vtk_max_pointwise_difference("engine_lb.vtk", "engine_lb_tmp.vtk",tol=2.0e-7)
                     os.remove("engine_lb_tmp.vtk")
-                    print(("Maximum deviation to the reference point is: {}".format(difference)))
+                    print("Maximum deviation to the reference point is: {}".format(difference))
                     self.assertTrue( different )
 
 if __name__ == '__main__':
-    print(("Features: ", espressomd.features()))
+    print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/ewald_gpu.py
+++ b/testsuite/python/ewald_gpu.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import espressomd
 import unittest as ut
 import numpy as np
@@ -45,5 +46,5 @@ class ewald_GPU_test(ut.TestCase):
             self.assertTrue(params_match(test_params,ewald._get_params_from_es_core()))
 
     if __name__ == "__main__":
-        print("Features: ", espressomd.features())
+        print(("Features: ", espressomd.features()))
         ut.main()

--- a/testsuite/python/ewald_gpu.py
+++ b/testsuite/python/ewald_gpu.py
@@ -46,5 +46,5 @@ class ewald_GPU_test(ut.TestCase):
             self.assertTrue(params_match(test_params,ewald._get_params_from_es_core()))
 
     if __name__ == "__main__":
-        print(("Features: ", espressomd.features()))
+        print("Features: ", espressomd.features())
         ut.main()

--- a/testsuite/python/lb_test.py
+++ b/testsuite/python/lb_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import espressomd
 import espressomd.lb
 from espressomd import integrate
@@ -7,27 +8,27 @@ S.box_l = [16, 16, 16]
 S.skin = 0.4
 S.time_step = 0.01
 
-print "Setup LB"
+print("Setup LB")
 lb = espressomd.lb.LBFluid(dens=0.5, agrid=1.0, visc=0.8, tau=0.1, fric=1, ext_force=[1e-1,2e-1,3e-1])
 
 # print "Get LB params", lb.getParams()
 
 
-print "Add LB Actor"
+print("Add LB Actor")
 S.actors.add(lb)
-print "Get LB params ", lb.get_params()
+print("Get LB params ", lb.get_params())
 lb.set_params(dens=1.0)
-print "Get LB params 2nd ", lb.get_params()
+print("Get LB params 2nd ", lb.get_params())
 #lb.set_params(gpu="yes")
 
 
-print "Place Particles"
+print("Place Particles")
 S.part.add(pos=[10,10,25])
 S.part.add(pos=[10,10,75])
 
 
-print "Integrate"
+print("Integrate")
 for i in range(0,10):
    integrate.integrate(100)
-   print "P1: " + str(S.part[0].pos)
-   print "P2: " + str(S.part[1].pos)
+   print("P1: " + str(S.part[0].pos))
+   print("P2: " + str(S.part[1].pos))

--- a/testsuite/python/lb_test_gpu.py
+++ b/testsuite/python/lb_test_gpu.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import espressomd
 import espressomd.lb
 from espressomd import integrate
@@ -7,27 +8,27 @@ S.box_l = [16, 16, 16]
 S.skin = 0.4
 S.time_step = 0.01
 
-print "Setup LB"
+print("Setup LB")
 lb = espressomd.lb.LBFluid_GPU(dens=0.5, agrid=1.0, visc=0.8, tau=0.1, fric=1, ext_force=[1e-1,2e-1,3e-1])
 
 # print "Get LB params", lb.getParams()
 
 
-print "Add LB Actor"
+print("Add LB Actor")
 S.actors.add(lb)
-print "Get LB params ", lb.get_params()
+print("Get LB params ", lb.get_params())
 lb.set_params(dens=1.0)
-print "Get LB params 2nd ", lb.get_params()
+print("Get LB params 2nd ", lb.get_params())
 #lb.set_params(gpu="yes")
 
 
-print "Place Particles"
+print("Place Particles")
 S.part.add(pos=[10,10,25])
 S.part.add(pos=[10,10,75])
 
 
-print "Integrate"
+print("Integrate")
 for i in range(0,10):
    integrate.integrate(100)
-   print "P1: " + str(S.part[0].pos)
-   print "P2: " + str(S.part[1].pos)
+   print("P1: " + str(S.part[0].pos))
+   print("P2: " + str(S.part[1].pos))

--- a/testsuite/python/magnetostaticInteractions.py
+++ b/testsuite/python/magnetostaticInteractions.py
@@ -57,5 +57,5 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
             DipolarDirectSumWithReplicaCpu, dict(prefactor=3.4, n_replica=2))
 
 if __name__ == "__main__":
-    print(("Features: ", espressomd.features()))
+    print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/magnetostaticInteractions.py
+++ b/testsuite/python/magnetostaticInteractions.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import numpy as np
@@ -56,5 +57,5 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
             DipolarDirectSumWithReplicaCpu, dict(prefactor=3.4, n_replica=2))
 
 if __name__ == "__main__":
-    print("Features: ", espressomd.features())
+    print(("Features: ", espressomd.features()))
     ut.main()

--- a/testsuite/python/minimize_energy.py
+++ b/testsuite/python/minimize_energy.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import unittest as ut
 import espressomd._system as es
@@ -42,7 +43,7 @@ class test_minimize_energy(ut.TestCase):
         assert( energy["total"] == 0 )
 
 if __name__ == "__main__":
-    print("Features: ", espressomd.features())
+    print(("Features: ", espressomd.features()))
     ut.main()
 
 

--- a/testsuite/python/minimize_energy.py
+++ b/testsuite/python/minimize_energy.py
@@ -43,7 +43,7 @@ class test_minimize_energy(ut.TestCase):
         assert( energy["total"] == 0 )
 
 if __name__ == "__main__":
-    print(("Features: ", espressomd.features()))
+    print("Features: ", espressomd.features())
     ut.main()
 
 

--- a/testsuite/python/nonBondedInteractions.py
+++ b/testsuite/python/nonBondedInteractions.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import numpy as np
@@ -37,15 +38,15 @@ class Non_bonded_interactionsTests(ut.TestCase):
         inParams.
         """
         if inType != outType:
-            print("Type mismatch:", inType, outType)
+            print(("Type mismatch:", inType, outType))
             return False
 
-        for k in inParams.keys():
+        for k in list(inParams.keys()):
             if k not in outParams:
-                print(k, "missing from returned parameters")
+                print((k, "missing from returned parameters"))
                 return False
             if outParams[k] != inParams[k]:
-                print("Mismatch in parameter ", k, inParams[k], outParams[k])
+                print(("Mismatch in parameter ", k, inParams[k], outParams[k]))
                 return False
 
         return True
@@ -123,5 +124,5 @@ class Non_bonded_interactionsTests(ut.TestCase):
 
 
 if __name__ == "__main__":
-    print("Features: ", espressomd.features())
+    print(("Features: ", espressomd.features()))
     ut.main()

--- a/testsuite/python/nonBondedInteractions.py
+++ b/testsuite/python/nonBondedInteractions.py
@@ -38,15 +38,15 @@ class Non_bonded_interactionsTests(ut.TestCase):
         inParams.
         """
         if inType != outType:
-            print(("Type mismatch:", inType, outType))
+            print("Type mismatch:", inType, outType)
             return False
 
         for k in list(inParams.keys()):
             if k not in outParams:
-                print((k, "missing from returned parameters"))
+                print(k, "missing from returned parameters")
                 return False
             if outParams[k] != inParams[k]:
-                print(("Mismatch in parameter ", k, inParams[k], outParams[k]))
+                print("Mismatch in parameter ", k, inParams[k], outParams[k])
                 return False
 
         return True
@@ -124,5 +124,5 @@ class Non_bonded_interactionsTests(ut.TestCase):
 
 
 if __name__ == "__main__":
-    print(("Features: ", espressomd.features()))
+    print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/p3m_gpu.py
+++ b/testsuite/python/p3m_gpu.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import espressomd
 import unittest as ut
 import numpy as np
@@ -45,5 +46,5 @@ if "ELECTROSTATICS" in espressomd.features() and "CUDA" in espressomd.features()
             self.assertTrue(params_match(test_params,p3m._get_params_from_es_core()))
 
 if __name__ == "__main__":
-    print("Features: ", espressomd.features())
+    print(("Features: ", espressomd.features()))
     ut.main()

--- a/testsuite/python/p3m_gpu.py
+++ b/testsuite/python/p3m_gpu.py
@@ -46,5 +46,5 @@ if "ELECTROSTATICS" in espressomd.features() and "CUDA" in espressomd.features()
             self.assertTrue(params_match(test_params,p3m._get_params_from_es_core()))
 
 if __name__ == "__main__":
-    print(("Features: ", espressomd.features()))
+    print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests particle property setters/getters
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import numpy as np

--- a/testsuite/python/tabulated.py
+++ b/testsuite/python/tabulated.py
@@ -18,6 +18,7 @@
 #
 # Tests particle property setters/getters
 
+from __future__ import print_function
 import unittest as ut
 import espressomd
 import numpy as np
@@ -664,7 +665,7 @@ class Tabulated(ut.TestCase):
         def test_tab(self):
             self.compare()
     else:
-        print "TABULATED feature inactive"
+        print("TABULATED feature inactive")
         sys.exit()
 
 

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -56,10 +56,10 @@ def params_match(inParams, outParams):
 
     for k in list(inParams.keys()):
         if k not in outParams:
-            print((k, "missing from returned parameters"))
+            print(k, "missing from returned parameters")
             return False
         if outParams[k] != inParams[k]:
-            print(("Mismatch in parameter ", k, inParams[k], outParams[k]))
+            print("Mismatch in parameter ", k, inParams[k], outParams[k])
             return False
 
     return True

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 try:
     import vtk
@@ -53,12 +54,12 @@ def params_match(inParams, outParams):
     Only check keys present in inParams.
     """
 
-    for k in inParams.keys():
+    for k in list(inParams.keys()):
         if k not in outParams:
-            print(k, "missing from returned parameters")
+            print((k, "missing from returned parameters"))
             return False
         if outParams[k] != inParams[k]:
-            print("Mismatch in parameter ", k, inParams[k], outParams[k])
+            print(("Mismatch in parameter ", k, inParams[k], outParams[k]))
             return False
 
     return True

--- a/tools/blockfile.py
+++ b/tools/blockfile.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 #
+from __future__ import print_function
 import re
 import numpy
 import sys

--- a/tools/blockfile2pickle.py
+++ b/tools/blockfile2pickle.py
@@ -19,6 +19,7 @@
 
 ### This script extracts tcl blockfiles and pickles the appropriate py class.
 
+from __future__ import print_function
 import blockfile as bf
 import espressomd
 import espressomd._system as es
@@ -41,11 +42,11 @@ def safe_str2intflt(string):
 
 # nagnagnag
 if len(argv) < 3:
-    print "Usage:  ./pypresso ./blockfile2pickle.py <blockfile> <output-prefix>"
-    print "Output: create files named <output-prefix>-<classname>.pcl in workdir"
-    print "Example output: lj_fluid-ParticleList.pcl lj_fluid-NonBondedInteractions.pcl"
-    print "Supports: particle, interaction"
-    print "Depends:  Espresso/tools/blockfile.py file in a sys.path dir"
+    print("Usage:  ./pypresso ./blockfile2pickle.py <blockfile> <output-prefix>")
+    print("Output: create files named <output-prefix>-<classname>.pcl in workdir")
+    print("Example output: lj_fluid-ParticleList.pcl lj_fluid-NonBondedInteractions.pcl")
+    print("Supports: particle, interaction")
+    print("Depends:  Espresso/tools/blockfile.py file in a sys.path dir")
 
 # initialize blockfile class from blockfile
 blocks = bf.open(argv[1])
@@ -68,27 +69,27 @@ for k in b_list:
     
     # if k is a particle block
     if k[0] == 'particles':
-        print "Particle Block found"
+        print("Particle Block found")
         if "pos" not in k[1] or "id" not in k[1]:
-            print "Error, id and/or pos missing in particle block, skipping particle"
+            print("Error, id and/or pos missing in particle block, skipping particle")
             continue # the continue statement jumps to the next iteration.
 
-        print "Particle properties found:"
-        print k[1].keys()
+        print("Particle properties found:")
+        print(list(k[1].keys()))
         # instance of the system internal particle list
         pl = ParticleList()
         # Set appropriate params foreach particle, since pl.add is so nice,
         # we just have to pass the k[1] dict.
         try: pl.add( k[1] )
         except AttributeError: 
-            print "Error, the blockfile sets a particle parameter which is not compiled in."
-            print "To properly pickle a particle, all necessary features need to be compiled."
-            print "For example, if the particle property 'q' is set, we need ELECTROSTATICS."
-            print "skipping particle"
+            print("Error, the blockfile sets a particle parameter which is not compiled in.")
+            print("To properly pickle a particle, all necessary features need to be compiled.")
+            print("For example, if the particle property 'q' is set, we need ELECTROSTATICS.")
+            print("skipping particle")
             continue
         # pickle it
         with open(argv[2] + "-ParticleList.pcl", 'w') as outfile:
-            print "Pickling ParticleList"
+            print("Pickling ParticleList")
             pickle.dump(pl, outfile, -1)
             del pl
 
@@ -98,8 +99,8 @@ for k in b_list:
         # here, the blockfile tool returns a string containing ugly escapes.
         # this means we have to do some data processing.
         if not isinstance(k[1], str):
-            print "Unexpected error, bf.blockfile did not return string for inter"
-            print "skipping interaction block"
+            print("Unexpected error, bf.blockfile did not return string for inter")
+            print("skipping interaction block")
             continue
         # split block into strings for every interaction directive and
         # get rid of unnecessary characters
@@ -109,7 +110,7 @@ for k in b_list:
         # every numeric string into an integer or float.
         # Then filter every empty string.
         # Do that for every command invocation in block.
-        k[1] = [filter(lambda x: x!='',[safe_str2intflt(word) for word in words.split(' ')]) 
+        k[1] = [[x for x in [safe_str2intflt(word) for word in words.split(' ')] if x!=''] 
                             for words in k[1]] 
 
         # We need to differentiate between Bonded and Nonbonded
@@ -135,11 +136,11 @@ for k in b_list:
                     # Here, we found lennard-jones interaction. 
                     # In this indentation level we write interaction specific
                     # parsing code.
-                    print "Found lennard-jones interaction for particles"
+                    print("Found lennard-jones interaction for particles")
                     # test whether or not there are enough arguments for
                     # the required parameters of lj
                     if n_args < 6:
-                        print "Not enough arguments for lennard-jones, skipping"
+                        print("Not enough arguments for lennard-jones, skipping")
                         continue # The continue statement jumps to the next
                                  # iteration of the innermost for-loop
                     # create input dict for the lj kwargs
@@ -153,7 +154,7 @@ for k in b_list:
                     if 7 < n_args: in_dict["offset"] = arg_list[7]
                     if 8 < n_args: in_dict["min"]    = arg_list[8]
                     if 9 < n_args: 
-                        print "Error: too many arguments for lennard-jones, skipping"
+                        print("Error: too many arguments for lennard-jones, skipping")
                         continue
                     # initialization of the interaction with nia.
                     # Also: since set_params doesn't natively support dicts as *args
@@ -163,10 +164,10 @@ for k in b_list:
                     nia_success = True # set this to true if nia actually did something
                     
                     # be nice to the user
-                    print "\nSetting up lennard-jones with the following params:"
-                    print in_dict
-                    print "for id %d and %d" %(arg_list[0], arg_list[1])
-                    print ""
+                    print("\nSetting up lennard-jones with the following params:")
+                    print(in_dict)
+                    print("for id %d and %d" %(arg_list[0], arg_list[1]))
+                    print("")
             
                 # HERE is the spot where you can implement the initialization
                 # for an individual NonBondedInteraction. One elif-statement for every
@@ -177,7 +178,7 @@ for k in b_list:
                 elif arg_list[2] == "MyNonBondedInteraction":
                     pass
                 else:
-                    print "NonBondedInteraction " + arg_list[2] + " is unknown, skipping"
+                    print("NonBondedInteraction " + arg_list[2] + " is unknown, skipping")
                     continue
         
             elif isinstance(arg_list[0], int) and isinstance(arg_list[1], str):
@@ -190,26 +191,26 @@ for k in b_list:
                     pass
                 
                 else:
-                    print "BondedInteraction" + arg_list[1] + " is unknown, skipping"
+                    print("BondedInteraction" + arg_list[1] + " is unknown, skipping")
                     continue
             else:
-                print "Unknown interaction format, skipping"
+                print("Unknown interaction format, skipping")
         
         # end of arg_list for loop
         if nia_success:
             with open(argv[2] + "-NonBondedInteractions.pcl", "w") as outfile:
                 pickle.dump(nia, outfile, -1)
-                print "pickling NonBondedInteractions"
+                print("pickling NonBondedInteractions")
             del nia, nia_success
         if bia_success:
             with open(argv[2] + "-BondedInteractions.pcl", "w") as outfile:
                 pickle.dump(bia, outfile, -1)
-                print "pickling NonBondedInteractions"
+                print("pickling NonBondedInteractions")
             del bia, bia_success
     elif k[0] == "MyBlockIdentifier":
         pass
 
     else:
-        print "blocktype " + k[0] + " unknown, skipping"
+        print("blocktype " + k[0] + " unknown, skipping")
 
 

--- a/tools/mpiio2blockfile.py
+++ b/tools/mpiio2blockfile.py
@@ -94,7 +94,7 @@ with open(bondf) as f:
 
 # Print particles in blockfile format
 print("{particles {id type pos v}")
-for i in xrange(ntotalpart):
+for i in range(ntotalpart):
     print("\t{%i %i %r %r %r %r %r %r}" \
         % (id[i], type[i], pos[3*i], pos[3*i+1], pos[3*i+2], \
            vel[3*i], vel[3*i+1], vel[3*i+2]))
@@ -103,12 +103,12 @@ print("}")
 # Print bonds in blockfile format
 print("{bonds")
 addend = 0 # ntotal bonds of previous processors
-for rank in xrange(nproc):
+for rank in range(nproc):
     # The start and end indices for the boff array are determined via
     # pref. However, there are (nlocalpart + 1) boff entries per proc.
     start = pref[rank] + rank
     end = rank + (pref[rank + 1] if rank < nproc - 1 else ntotalpart)
-    for pid, i in enumerate(xrange(start, end)):
+    for pid, i in enumerate(range(start, end)):
         print("\t{%i { " % id[pref[rank] + pid], end="")
         # The start and end indices for the bond array are determined
         # via boff. However, boff does only *locally* store prefixes,
@@ -120,7 +120,7 @@ for rank in xrange(nproc):
             j += 1
             npartners = biaparams[bond_num]
             print("{%i" % bond_num, end="")
-            for _ in xrange(npartners):
+            for _ in range(npartners):
                 print(" %i" % bond[j], end="")
                 j += 1
             print("} ", end="")

--- a/tools/trace_memory.py
+++ b/tools/trace_memory.py
@@ -71,7 +71,7 @@ for line in f:
         elif addr in allocated:
             del allocated[addr]
         else:
-            print(("\n" + addr + " freed at " + src + ", but never allocated\n"))
+            print("\n" + addr + " freed at " + src + ", but never allocated\n")
 
 print("\n")
 for (addr,info) in list(allocated.items()):


### PR DESCRIPTION
Here's Python 3.x support. Closes #780.
Adding it was pretty much trivial, but below are a few explanations to what I did:
- Default arguments inside `cdef cppclass` don't work. Instead I now declare the individual overloads.
- Changed every use of `print` to the new function syntax.
- Cython is now called with `-2` or `-3` so that the Cython code's syntax needs to match that of the Python version in use. This isn't strictly necessary as the generated C code contains `#ifdef`s so it can be used with both Python 2 and 3, but I did it anyway for the sake of consistency.
- I ran `2to3`, which fixed things like the `cPickle` module or the `xrange` builtin having been eliminated and some explicit casts to `list` being required.
- Massive changes to the imports inside the `espressomd` module were necessary due to Python 3 dropping support for implicit relative imports, see [PEP 328](https://www.python.org/dev/peps/pep-0328/). So the following replacements were necessary:

  Old|New
  ---|---
  `import x` | `from . import x`
  `from x import y` | `from .x import y`
  `cimport x` | `from . cimport x`
  `from x cimport y` | ~~`from .x cimport y`~~*  `from espressomd.x cimport y`


Once @fweik publishes the [Espresso Docker file](/fweik/espresso-docker), we should duplicate it to also build a container that contains Python 3.5 instead of Python 2.7.

By default, Python 2 will be used if available. If it is not available but Python 3 is available, that is used instead.

Could one of the Cython experts (@tobiasrau, @RudolfWeeber) have a look at this pull request to make sure that none of the changes have adverse effects? I don't see any problematic ones, but especially the relative import stuff could use a second pair of eyes.

---
\* Logically, this should work, but Cython doesn't appear to support it (yet).