### PR TITLE
Py: Make particle slicing work wit non-consecutive particle numbering

### DIFF
--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -901,7 +901,6 @@ cdef class ParticleSlice:
         id_list = np.arange(max_seen_particle + 1)
         self.id_selection = id_list[slice_]
         mask =np.empty(len(self.id_selection),dtype=np.bool)
-        mask==True
         cdef int i
         for i in range(len(self.id_selection)-1,-1,-1):
             mask[i]= particle_exists(i)

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -59,7 +59,7 @@ cdef class ParticleHandle:
         utils.realloc_intlist(& (self.particle_data.bl), 0)
 
         if get_particle_data(self.id, & self.particle_data):
-            raise Exception("Error updating particle data")
+            raise Exception("Error updating particle data for id "+str(self.id))
         else:
             return 0
 
@@ -900,6 +900,14 @@ cdef class ParticleSlice:
     def __cinit__(self, slice_):
         id_list = np.arange(max_seen_particle + 1)
         self.id_selection = id_list[slice_]
+        mask =np.empty(len(self.id_selection),dtype=np.bool)
+        mask==True
+        cdef int i
+        for i in range(len(self.id_selection)-1,-1,-1):
+            mask[i]= particle_exists(i)
+        self.id_selection=self.id_selection[mask]
+
+
 
     cdef int update_particle_data(self, id) except -1:
         utils.realloc_intlist(& (self.particle_data.bl), 0)


### PR DESCRIPTION
Particle creation is still explicit, i.e.
part[:].pos=0,0,0
only acts on existing particles.
