### PR TITLE
Update Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ sudo: required
 
 services: docker
 
-before_install:
-        - docker pull espressomd/travis-build:latest
-
-
 env:
   matrix:
     - myconfig=default
     - myconfig=maxset
+    - myconfig=maxset image=ubuntu-python3
+    - myconfig=maxset image=debian
     - myconfig=maxset-gaussrandom
     - myconfig=maxset-gaussrandomcut
     - myconfig=molcut

--- a/maintainer/docker/debian/Dockerfile
+++ b/maintainer/docker/debian/Dockerfile
@@ -1,21 +1,23 @@
 FROM debian:jessie
 MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update
-RUN apt-get install -y apt-utils
-RUN apt-get install -y cmake 
-RUN apt-get install -y build-essential
-RUN apt-get install -y clang
-RUN apt-get install -y openmpi-bin
-RUN apt-get install -y libfftw3-dev
-RUN apt-get install -y libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev
-RUN apt-get install -y python python-numpy python-pyvtk
-RUN apt-get install -y tcl-dev
-RUN apt-get install -y git
-RUN apt-get install -y pep8
-RUN apt-get install -y python-pip
-RUN apt-get install -y libpython-dev
-RUN pip install cython
+RUN apt-get update && apt-get install -y \
+	apt-utils \
+	cmake \
+	build-essential \
+	clang \
+	openmpi-bin \
+	libfftw3-dev \
+	libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+	python python-numpy python-pyvtk \
+	tcl-dev \
+	git \
+	pep8 \
+	python-pip \
+	libpython-dev \
+&& pip install cython \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m espresso
 USER espresso

--- a/maintainer/docker/opensuse/Dockerfile
+++ b/maintainer/docker/opensuse/Dockerfile
@@ -1,0 +1,19 @@
+FROM opensuse:42.1
+MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
+RUN zypper -n --gpg-auto-import-keys refresh \
+&& zypper -n --gpg-auto-import-keys install \
+  patterns-openSUSE-devel_C_C++ \
+  cmake \
+  openmpi-devel \
+  fftw3-devel \
+  boost-devel libboost_serialization1_54_0 libboost_mpi1_54_0  libboost_filesystem1_54_0 libboost_test1_54_0 \
+  python python-numpy python-PyVTK \
+  tcl-devel \
+  git \
+  python-pep8 \
+  python-pip \
+  libpython-devel
+
+RUN useradd -m espresso
+USER espresso
+WORKDIR /home/espresso

--- a/maintainer/docker/ubuntu-python3/Dockerfile
+++ b/maintainer/docker/ubuntu-python3/Dockerfile
@@ -8,11 +8,10 @@ RUN apt-get update && apt-get install -y \
 	openmpi-bin \
 	libfftw3-dev \
 	libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-	cython python python-numpy \
+	cython3 python3 python3-numpy \
 	tcl-dev \
 	git \
 	pep8 \
-	python-pyvtk \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -13,4 +13,8 @@ check_procs=$check_procs
 make_check=$make_check
 EOF
 
-docker run -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it espressomd/travis-build /bin/bash -c "git clone /travis && cd travis && maintainer/travis/build_cmake.sh"
+if [ -z "$image" ]; then
+	image=ubuntu
+fi
+
+docker run -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it espressomd/buildenv-espresso-${image} /bin/bash -c "git clone /travis && cd travis && maintainer/travis/build_cmake.sh"


### PR DESCRIPTION
After @fweik added the Dockerfiles in #822, I connected Docker Hub to my Github account and made sure that automatic building works. As each `RUN` line causes one image layer to be created, I merged all commands into one to reflect accepted Docker best practices (there's a maximum number of layers that you can have in an image, somewhere around 40).

I also duplicated the Ubuntu Dockerfile to create one that contains Python 3.

---
On a related note: Can you set up the auto-builds on [Docker Hub](https://hub.docker.com)? Go to Create, Create Automated Build, link your Github account, and select the espressomd/espresso repository. Name the repository _espresso-buildenv-debian_ and click Create. In Build Settings, set the Dockerfile Location to _/maintainer/docker/debian/Dockerfile_. Repeat the same for Ubuntu and for the Python3 dockerfiles.

Once you have done that, please update _.travis-ci.yml_ so that it builds on all three Docker images instead of the one we are currently using.