### PR TITLE
Fix t_random call in blockfile_read_auto_random

### DIFF
--- a/scripts/blockfile_support.tcl
+++ b/scripts/blockfile_support.tcl
@@ -415,7 +415,7 @@ proc blockfile_write_random {channel write random} {
 
 proc blockfile_read_auto_random {channel read auto} {
     set data [blockfile $channel read toend]
-    eval t_random stat [eval concat $data]
+    t_random stat [concat $data]
 
     return "random"
 }


### PR DESCRIPTION
Do not use eval here, since it unpacks the list. The read function in
random_tcl.cpp, however, expects one string.