### PR TITLE
Py: Front-end to constraints based on script interface

### DIFF
--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -1,0 +1,25 @@
+from __future__ import print_function, absolute_import
+from .script_interface import ScriptInterfaceHelper
+
+
+class Constraints(ScriptInterfaceHelper):
+    _so_name = "Constraints::Constraints"
+
+    def add(self, *args, **kwargs):
+        if len(args) == 1:
+            if isinstance(args[0], Constraint):
+                constraint = args[0]
+            else:
+                raise TypeError(
+                    "Either a Constraint object or key-value pairs for the parameters of a Constraint object need to be passed.")
+        else:
+            constraint = Constraint(**kwargs)
+        self.call_method("add", constraint=constraint)
+        return constraint
+
+    def remove(self, constraint):
+        self.call_method("remove", constraint=constraint)
+
+
+class Constraint(ScriptInterfaceHelper):
+    _so_name = "Constraints::Constraint"

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -56,7 +56,7 @@ cdef class PScriptInterface:
         return self.variant_to_python_object(self.sip.get().call_method(method, parameters))
 
 
-    def set_parameters(self, **kwargs):
+    def set_params(self, **kwargs):
         cdef ParameterType type
         cdef map[string, Variant] parameters
 
@@ -118,10 +118,21 @@ cdef class PScriptInterface:
         cdef Variant value = self.sip.get().get_parameter(name)
         return self.variant_to_python_object(value)
 
-    def get_parameters(self):
+    def get_params(self):
         odict = {}
         for pair in self.parameters:
             odict[pair.first] = self.get_parameter(pair.first)
         return odict
+
+class ScriptInterfaceHelper(PScriptInterface):
+
+    _so_name = None
+
+    def __init__(self,**kwargs):
+        super(ScriptInterfaceHelper,self).__init__(self._so_name)
+        self.set_params(**kwargs)
+
+    
+
 
 initialize()

--- a/src/python/espressomd/shapes.pxd
+++ b/src/python/espressomd/shapes.pxd
@@ -1,5 +1,0 @@
-from script_interface import *
-from script_interface cimport *
-
-cdef class PWall(PScriptInterface):
-    pass

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -1,0 +1,41 @@
+from .script_interface import ScriptInterfaceHelper
+
+
+class Cylinder(ScriptInterfaceHelper):
+    _so_name = "Shapes::Cylinder"
+
+
+class HollowCone(ScriptInterfaceHelper):
+    _so_name = "Shapes::HollowCone"
+
+
+class NoWhere(ScriptInterfaceHelper):
+    _so_name = "Shapes::NoWhere"
+
+
+class Maze(ScriptInterfaceHelper):
+    _so_name = "Shapes::Maze"
+
+
+class Pore(ScriptInterfaceHelper):
+    _so_name = "Shapes::Pore"
+
+
+class Rhomboid(ScriptInterfaceHelper):
+    _so_name = "Shapes::Rhomboid"
+
+
+class SlitPore(ScriptInterfaceHelper):
+    _so_name = "Shapes::SlitPore"
+
+
+class Shere(ScriptInterfaceHelper):
+    _so_name = "Shapes::Sphere"
+
+
+class SheroCylinder(ScriptInterfaceHelper):
+    _so_name = "Shapes::SpheroCylinder"
+
+
+class Wall(ScriptInterfaceHelper):
+    _so_name = "Shapes::Wall"

--- a/src/python/espressomd/shapes.pyx
+++ b/src/python/espressomd/shapes.pyx
@@ -1,4 +1,0 @@
-
-cdef class PWall(PScriptInterface):
-    def __init__(self):
-        super(PWall, self).__init__("Shapes::Wall")

--- a/src/script_interface/constraints/Constraint.hpp
+++ b/src/script_interface/constraints/Constraint.hpp
@@ -41,7 +41,7 @@ public:
   VariantMap get_parameters() const override {
     return {{"only_positive", m_constraint->only_positive()},
             {"penetrable", m_constraint->penetrable()},
-            {"type", m_constraint->type()},
+            {"particle_type", m_constraint->type()},
             {"shape",
              (m_shape != nullptr) ? m_shape->id() : ScriptInterface::NOT_SET}};
   }
@@ -49,7 +49,7 @@ public:
   ParameterMap valid_parameters() const override {
     return {{"only_positive", {ParameterType::INT, true}},
             {"penetrable", {ParameterType::INT, true}},
-            {"type", {ParameterType::INT, true}},
+            {"particle_type", {ParameterType::INT, true}},
             {"shape", {ParameterType::OBJECT, true}}};
   }
 
@@ -74,7 +74,7 @@ public:
 
     SET_PARAMETER_HELPER("only_positive", m_constraint->only_positive());
     SET_PARAMETER_HELPER("penetrable", m_constraint->penetrable());
-    SET_PARAMETER_HELPER("type", m_constraint->type());
+    SET_PARAMETER_HELPER("particle_type", m_constraint->type());
   }
 
   std::shared_ptr<::Constraints::Constraint> constraint() {


### PR DESCRIPTION
* Adds ScriptInterfaceHelper-class wich allows to define
  py objects which will instanciate as a given base class of PScriptInterface
  class Wall(ScriptInterfaceHelper):
     _so_name="Shapes::Wall"

* Adds Constraints class with add and remove methods

* Added py Constraint base class
* Added py Shape classes
* makes naming "params" consistent with rest of py interface

Usage example:
from espresomd.shapes import Wall
c=system.constraints.add(
    shape=Wall(normal=[1,1,1],distance=1),particle_type=1)
print c.get_params()

This is still a preliminary solution.