### PR TITLE
Remove boost::mpi dependency in CUDA code

### DIFF
--- a/src/core/EspressoSystemInterface_cuda.cu
+++ b/src/core/EspressoSystemInterface_cuda.cu
@@ -21,6 +21,10 @@
 #include "cuda_interface.hpp"
 #include "cuda_utils.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 // These functions will split the paritlce data structure into individual arrays for each property
 
 // Position and charge

--- a/src/core/actor/DipolarDirectSum_cuda.cu
+++ b/src/core/actor/DipolarDirectSum_cuda.cu
@@ -9,6 +9,10 @@
 #include "cuda_utils.hpp"
 #include <stdio.h>
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 
 //This needs to be done in the .cu file too!!!!!
 typedef float dds_float ;

--- a/src/core/actor/HarmonicOrientationWell_cuda.cu
+++ b/src/core/actor/HarmonicOrientationWell_cuda.cu
@@ -21,6 +21,10 @@
 #include "cuda_utils.hpp"
 #include <stdio.h>
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 __global__ void HarmonicOrientationWell_kernel(float x, float y, float z, float k,
 				     int n, float *quatu, float *torque) {
 

--- a/src/core/actor/HarmonicWell_cuda.cu
+++ b/src/core/actor/HarmonicWell_cuda.cu
@@ -21,6 +21,10 @@
 #include "cuda_utils.hpp"
 #include <stdio.h>
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 __global__ void HarmonicWell_kernel(float x, float y, float z, float k,
 				     int n, float *pos, float *f) {
 

--- a/src/core/actor/Mmm1dgpuForce_cuda.cu
+++ b/src/core/actor/Mmm1dgpuForce_cuda.cu
@@ -19,6 +19,10 @@
 #include "actor/Mmm1dgpuForce.hpp"
 #include "cuda_utils.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 #ifdef MMM1D_GPU
 
 // the code is mostly multi-GPU capable, but Espresso is not yet

--- a/src/core/cuda_init_cuda.cu
+++ b/src/core/cuda_init_cuda.cu
@@ -22,6 +22,10 @@
 #include "cuda_init.hpp"
 #include "cuda_utils.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 
 #ifdef CUDA
 

--- a/src/core/electrokinetics_cuda.cu
+++ b/src/core/electrokinetics_cuda.cu
@@ -32,7 +32,6 @@
 #include <thrust/functional.h>
 #include <thrust/device_ptr.h>
 
-#include "constraints.hpp"
 #include "cuda_interface.hpp"
 #include "cuda_utils.hpp"
 #include "electrokinetics.hpp"
@@ -40,6 +39,10 @@
 #include "fd-electrostatics.hpp"
 #include "lb-boundaries.hpp"
 #include "lbgpu.hpp"
+
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
 
   /* TODO: get rid of this code duplication with lb-boundaries.h by solving the
            cuda-mpi incompatibility */

--- a/src/core/fd-electrostatics_cuda.cu
+++ b/src/core/fd-electrostatics_cuda.cu
@@ -8,6 +8,10 @@
 //#include <cuda_interface.hpp>
 #include <cstdio>
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 __global__ void createGreensfcn();
 __global__ void multiplyGreensfcn(cufftComplex *charge_potential);
 

--- a/src/core/immersed_boundary/ibm_cuda.cu
+++ b/src/core/immersed_boundary/ibm_cuda.cu
@@ -16,6 +16,10 @@
 #include "immersed_boundary/ibm_main.hpp"
 #include "immersed_boundary/ibm_cuda_interface.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 // ****** Kernel functions for internal use ********
 __global__ void ResetLBForces_Kernel(LB_node_force_gpu node_f, const LB_parameters_gpu *const paraP);
 __global__ void ParticleVelocitiesFromLB_Kernel(LB_nodes_gpu n_curr, const IBM_CUDA_ParticleDataInput *const particles_input, IBM_CUDA_ParticleDataOutput *const particles_output, LB_node_force_gpu node_f, const float *const lb_boundary_velocity, const LB_parameters_gpu *const para);

--- a/src/core/integrate_sd_cuda.cu
+++ b/src/core/integrate_sd_cuda.cu
@@ -47,6 +47,10 @@
 //#include "errorhandling.hpp"
 #include "global.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 
 // global variables for usage in this file
 cublasHandle_t     cublas    = NULL;

--- a/src/core/integrate_sd_cuda_debug.cu
+++ b/src/core/integrate_sd_cuda_debug.cu
@@ -33,6 +33,10 @@
 //#include "errorhandling.hpp"
 #include "cuda_utils.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 
 /* *************************************************************************************************************** *
  * ********************************************    DEBUGING & TESTs   ******************************************** *

--- a/src/core/integrate_sd_cuda_device.cu
+++ b/src/core/integrate_sd_cuda_device.cu
@@ -22,6 +22,10 @@
 #include "integrate_sd_cuda.hpp"
 #include "integrate_sd_cuda_device.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 #ifdef SD
 
 /* *************************************************************************************************************** *

--- a/src/core/integrate_sd_cuda_kernel.cu
+++ b/src/core/integrate_sd_cuda_kernel.cu
@@ -29,6 +29,10 @@
 #include "integrate_sd_cuda.hpp"
 #include "integrate_sd_cuda_device.cu"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 #ifdef SD
 
 /* *************************************************************************************************************** *

--- a/src/core/integrate_sd_matrix.cu
+++ b/src/core/integrate_sd_matrix.cu
@@ -33,6 +33,10 @@
 
 #include <openssl/md5.h>
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 /// constructor for wave part
 /// _ldd_short : ldd_short of the matrix
 wavepart::wavepart(int _ldd_short):ldd_short(_ldd_short){

--- a/src/core/lb-boundaries.hpp
+++ b/src/core/lb-boundaries.hpp
@@ -38,7 +38,6 @@
 #ifndef LB_BOUNDARIES_H
 #define LB_BOUNDARIES_H
 
-#include "constraints.hpp"
 #include "utils.hpp"
 
 #if defined(LB_BOUNDARIES) || defined(LB_BOUNDARIES_GPU)

--- a/src/core/lbgpu_cuda.cu
+++ b/src/core/lbgpu_cuda.cu
@@ -36,6 +36,10 @@
 #include "cuda_interface.hpp"
 #include "cuda_utils.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 #if (!defined(FLATNOISE) && !defined(GAUSSRANDOMCUT) && !defined(GAUSSRANDOM))
 #define FLATNOISE
 #endif

--- a/src/core/p3m_gpu_cuda.cu
+++ b/src/core/p3m_gpu_cuda.cu
@@ -47,6 +47,10 @@
 #include "EspressoSystemInterface.hpp"
 #include "interaction_data.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 struct P3MGpuData {
   /** Charge mesh */
   CUFFT_TYPE_COMPLEX *charge_mesh;

--- a/src/core/p3m_gpu_error_cuda.cu
+++ b/src/core/p3m_gpu_error_cuda.cu
@@ -8,6 +8,10 @@
 
 #include "p3m_gpu_common.hpp"
 
+#if defined(OMPI_MPI_H) || defined(_MPI_H)
+#error CU-file includes mpi.h! This should not happen!
+#endif
+
 /** @TODO: Extend to hight order. This comes from some 1/sin expansion in Hockney/Eastwood */
 
 template<int cao>


### PR DESCRIPTION
@fweik @RudolfWeeber @trau @rempferg 

_constraints.hpp_ included, by means of a very long dependency chain, _boost/mpi/communicator.hpp_.