### PR TITLE
Travis: Build+test on Mac OS X and build CUDA code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,60 @@
 language: generic
-sudo: required
 
-services: docker
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=default
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=maxset
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=maxset image=ubuntu-python3
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=maxset image=debian
+    - os: osx
+      osx_image: xcode8
+      env: myconfig=maxset
+      cache:
+        directories:
+        - /usr/local/Cellar/boost
+    - os: osx
+      osx_image: xcode8
+      env: myconfig=maxset image=python3
+      cache:
+        directories:
+        - /usr/local/Cellar/boost
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=maxset-gaussrandom
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=maxset-gaussrandomcut
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=molcut
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=rest1
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=rest2
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=nocheck-maxset make_check=false
 
-env:
-  matrix:
-    - myconfig=default
-    - myconfig=maxset
-    - myconfig=maxset image=ubuntu-python3
-    - myconfig=maxset image=debian
-    - myconfig=maxset-gaussrandom
-    - myconfig=maxset-gaussrandomcut
-    - myconfig=molcut
-    - myconfig=rest1
-    - myconfig=rest2
-    - make_check=false myconfig=nocheck-maxset
 
 script:
         - maintainer/travis/build_docker.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       sudo: required
       services: docker
       env: myconfig=maxset image=debian
+    - os: linux
+      sudo: required
+      services: docker
+      env: myconfig=maxset image=ubuntu-cuda make_check=false
     - os: osx
       osx_image: xcode8
       env: myconfig=maxset

--- a/maintainer/docker/ubuntu-cuda/Dockerfile
+++ b/maintainer/docker/ubuntu-cuda/Dockerfile
@@ -1,0 +1,28 @@
+FROM nvidia/cuda:7.5-devel-ubuntu14.04
+MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+	apt-utils \
+	build-essential \
+	curl \
+	openmpi-bin \
+	libfftw3-dev \
+	libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+	python python-numpy \
+	tcl-dev \
+	git \
+	pep8 \
+	python-pyvtk \
+	python-pip \
+	libpython-dev \
+&& pip install cython \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN cd /usr/local \
+&& curl -sL https://cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
+
+RUN useradd -m espresso
+USER espresso
+WORKDIR /home/espresso
+

--- a/maintainer/travis/build_cmake.sh
+++ b/maintainer/travis/build_cmake.sh
@@ -41,7 +41,7 @@ function cmd {
 # handle environment variables
 [ -z "$insource" ] && insource="true"
 [ -z "$srcdir" ] && srcdir=`pwd`
-[ -z "$cmake_params" ] && configure_params=""
+[ -z "$cmake_params" ] && cmake_params=""
 [ -z "$with_fftw" ] && with_fftw="true"
 [ -z "$with_tcl" ] && with_tcl="true"
 [ -z "$with_python_interface" ] && with_python_interface="true"
@@ -56,7 +56,7 @@ elif [ -z "$builddir" ]; then
 fi
 
 outp insource srcdir builddir \
-    configure_params with_fftw \
+    cmake_params with_fftw \
     with_tcl with_python_interface myconfig check_procs
 
 # check indentation of python files

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -18,7 +18,8 @@ if [ -z "$image" ]; then
 fi
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-	docker run -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it espressomd/buildenv-espresso-${image} /bin/bash -c "git clone /travis && cd travis && maintainer/travis/build_cmake.sh"
+	image=espressomd/buildenv-espresso-$image
+	docker run -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it $image /bin/bash -c "git clone /travis && cd travis && maintainer/travis/build_cmake.sh"
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	brew update
 	brew upgrade

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -4,7 +4,7 @@ ENV_FILE=$(mktemp esXXXXXXX.env)
 
 cat > $ENV_FILE <<EOF
 insource=$insource
-configure_params=$configure_params
+cmake_params=$cmake_params
 with_fftw=$with_fftw
 with_tcl=$with_tcl
 with_python_interface=$with_python_interface
@@ -17,4 +17,46 @@ if [ -z "$image" ]; then
 	image=ubuntu
 fi
 
-docker run -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it espressomd/buildenv-espresso-${image} /bin/bash -c "git clone /travis && cd travis && maintainer/travis/build_cmake.sh"
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+	docker run -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it espressomd/buildenv-espresso-${image} /bin/bash -c "git clone /travis && cd travis && maintainer/travis/build_cmake.sh"
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+	brew update
+	brew upgrade
+	brew install cmake
+	case "$image" in
+		python3)
+			brew install python3
+			pip3 install cython
+			pip3 install numpy
+			pip3 install pep8
+			PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}' | awk -F . '{print $1"."$2}')
+			export cmake_params="-DPYTHON_EXECUTABLE=$(which python3) -DPYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython${PYTHON_VERSION}.dylib -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python${PYTHON_VERSION}m $cmake_params"
+		;;
+		*)
+			brew install python
+			pip install cython
+			pip install numpy
+			pip install pep8
+			export cmake_params="-DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7 $cmake_params"
+		;;
+	esac
+	brew install openmpi
+	brew install fftw
+
+	# The binary version of Boost comes without MPI support, so we have to compile it ourselves.
+	# Boost takes a long time to install, so we have Travis-CI cache it.
+	BOOST_VERSION=$(brew info --json=v1 boost | python -m json.tool | grep linked_keg | awk -F '"' '{print $4}')
+	brew unlink boost
+	brew info --json=v1 boost | python -m json.tool | grep -B 4 "\"version\": \"$BOOST_VERSION\"" | grep -q 'with-mpi' || brew uninstall boost
+	brew install boost --without-single --with-mpi &
+	BOOST_PID=$!
+	while kill -0 $BOOST_PID; do
+		# boost takes a while to compile, during which there 
+		# is no output, causing Travis-CI to abort eventually
+		echo "Boost is being built..."
+		sleep 30
+	done
+	brew link boost
+
+	maintainer/travis/build_cmake.sh
+fi

--- a/src/core/immersed_boundary/CMakeLists.txt
+++ b/src/core/immersed_boundary/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB ImmersedBoundary_SRC *.cpp)
 add_library(ImmersedBoundary SHARED ${ImmersedBoundary_SRC})
 set_target_properties(ImmersedBoundary PROPERTIES SOVERSION ${SOVERSION})
+set_target_properties(ImmersedBoundary PROPERTIES MACOSX_RPATH TRUE)
 install(TARGETS ImmersedBoundary LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
 add_dependencies(ImmersedBoundary EspressoConfig)
 

--- a/src/core/unit_tests/RunningAverage_test.cpp
+++ b/src/core/unit_tests/RunningAverage_test.cpp
@@ -68,11 +68,11 @@ BOOST_AUTO_TEST_CASE(simple_variance_check) {
   avg.add_sample(5.0);
 
   /** Var should be <x**2> - <x>**2 = (0**2 + 5.0**2) / 2. - 2.5**2 = 12.5 - 6.25 = 6.25 */
-  BOOST_CHECK(std::abs(avg.avg() - 2.5) <= std::numeric_limits<double>::epsilon());
-  BOOST_CHECK(std::abs(avg.var() - 6.25) <= std::numeric_limits<double>::epsilon());
+  BOOST_CHECK(std::fabs(avg.avg() - 2.5) <= std::numeric_limits<double>::epsilon());
+  BOOST_CHECK(std::fabs(avg.var() - 6.25) <= std::numeric_limits<double>::epsilon());
 
   /** Standard deviation should be sqrt(var()) */
-  BOOST_CHECK(std::abs(avg.sig() - std::sqrt(avg.var())) <= std::numeric_limits<double>::epsilon());
+  BOOST_CHECK(std::fabs(avg.sig() - std::sqrt(avg.var())) <= std::numeric_limits<double>::epsilon());
 }
 
 BOOST_AUTO_TEST_CASE(mean_and_variance) {
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(mean_and_variance) {
                                         std::end(RandomSequence::values),
                                         0.0) / sample_size;
 
-  BOOST_CHECK(std::abs(running_average.avg() - m_mean) <= 1e-12);
+  BOOST_CHECK(std::fabs(running_average.avg() - m_mean) <= 1e-12);
 
   /** Directly calculate the variance from the data */
   double m_var = 0.0;
@@ -99,5 +99,5 @@ BOOST_AUTO_TEST_CASE(mean_and_variance) {
   }
   m_var /= sample_size;
 
-  BOOST_CHECK(std::abs(running_average.var() - m_var) <= 1e-12);  
+  BOOST_CHECK(std::fabs(running_average.var() - m_var) <= 1e-12);  
 }

--- a/src/core/utils/statistics/RunningAverage.hpp
+++ b/src/core/utils/statistics/RunningAverage.hpp
@@ -22,6 +22,8 @@
 #ifndef __RUNING_AVERAGE_HPP
 #define __RUNING_AVERAGE_HPP
 
+#include <cmath>
+
 namespace Utils {
 namespace Statistics {
 

--- a/src/tcl/CMakeLists.txt
+++ b/src/tcl/CMakeLists.txt
@@ -16,6 +16,7 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/scripts DESTINATION ${DATA})
 
 add_library(EspressoTcl SHARED ${Espresso_SRC})
 set_target_properties(EspressoTcl PROPERTIES SOVERSION ${SOVERSION})
+set_target_properties(EspressoTcl PROPERTIES MACOSX_RPATH TRUE)
 add_dependencies(EspressoTcl EspressoConfig)
 install(TARGETS EspressoTcl DESTINATION ${LIBDIR})
 


### PR DESCRIPTION
This pull request adds the following build environments to Travis:
- Mac OS X 10.11 with LLVM 3.8 and Python 2.7
- Mac OS X 10.11 with LLVM 3.8 and Python 3
- Ubuntu 14.04 with GCC 4.8 and CUDA 7.5

@fweik will need to add ` maintainer/docker/ubuntu-cuda/Dockerfile` to the Espresso Docker Hub as `buildenv-espresso-ubuntu-cuda` before the CUDA build will work.

We obviously can't test CUDA code on Travis, but compiling it should help spot the biggest problems already. #851 would have never occurred if we had automatically built the CUDA code.