### PR TITLE
Make the User guide compile again

### DIFF
--- a/doc/ug/introduction.tex
+++ b/doc/ug/introduction.tex
@@ -297,7 +297,7 @@ whole \es-script, there should be no problems.
 
 \section{Requirements}
 \label{sec:requirements}
-\index{requirements}
+\index{Installation requirements}
 
 The following libraries and tools are required to be able to compile
 and use \es:
@@ -322,8 +322,8 @@ and use \es:
 \end{description}
 
 \subsection{Installing Requirements on Ubuntu 16.04 LTS}
-\label{sec:installing_requirements}
-\index{installing_requirements}
+\label{sec:installing-requirements}
+\index{Installation requirements!Ubuntu 16.04 LTS}
 
 To make ESPResSo run on Ubuntu 16.04 LTS, its dependencies can be installed with:
 \begin{code}
@@ -335,8 +335,8 @@ Optionally the ccmake utility can be installed for easier configuration:
 \end{code}
 
 \subsection{Installing Requirements on Mac OS X}
-\label{sec:installing_requirements_mac}
-\index{installing_requirements_mac}
+\label{sec:installing-requirements-mac}
+\index{Installation requirements!Mac OS X}
 
 To make ESPResSo run on Mac OS X 10.9 or higher, its dependencies can be installed using MacPorts.
 First, download the installer package appropriate for your Mac OS X version from \url{https://www.macports.org/install.php} and install it. Then, run the following commands:


### PR DESCRIPTION
**tl;dr** Don't use underscores in `\label`.

The user guide used to not compile on the first try with an error message like this
````
! Missing \endcsname inserted.
<to be read again> 
                   \unhbox 
l.23 ... on Ubuntu 16.04 LTS}{subsection.1.5.1}{}}
````
This is due to the fact that someone used an underscore in a `\label`.  The user guide does `\usepackage[strings]{underscore}`.  This package will make the underscore an active character, such that you can conveniently type text containing underscores without having to escape them using `\_` while retaining the meaning as the subscript operator in math mode.  Unfortunately, the definition of the macro behind the active underscore is not e-TeX protected which leads to it being expanded once written to an `aux` file (which is what `\label` does).  It then tries to expand assignments somewhere deep down in the expansion chain which is not possible at this point which then leads to the error.