### PR TITLE
Fix Python include path detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,13 +107,14 @@ if (WITH_CUDA)
   endif(CUDA_FOUND)
 endif(WITH_CUDA)
 
-find_package(PythonInterp 2)
+find_package(PythonInterp)
 
 if (WITH_PYTHON)
   find_package(Cython 0.23 REQUIRED)
-  find_package(PythonLibs REQUIRED)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE}
+                -c "import distutils.sysconfig as cg; print(cg.get_python_inc())"
+                OUTPUT_VARIABLE PYTHON_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
   find_package(NumPy REQUIRED)
-  list(APPEND LIBRARIES ${PYTHON_LIBRARY})
   execute_process(COMMAND ${PYTHON_EXECUTABLE} 
                 -c "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_EXEC_PREFIX}'))"
                 OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -31,14 +31,13 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 			pip3 install numpy
 			pip3 install pep8
 			PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}' | awk -F . '{print $1"."$2}')
-			export cmake_params="-DPYTHON_EXECUTABLE=$(which python3) -DPYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython${PYTHON_VERSION}.dylib -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python${PYTHON_VERSION}m $cmake_params"
+			export cmake_params="-DPYTHON_EXECUTABLE=$(which python3) $cmake_params"
 		;;
 		*)
 			brew install python
 			pip install cython
 			pip install numpy
 			pip install pep8
-			export cmake_params="-DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7 $cmake_params"
 		;;
 	esac
 	brew install openmpi


### PR DESCRIPTION
FindPythonLibs.cmake appears to be broken, even more so in older CMake versions. There are many situations where it uses libraries and headers that don't match the interpreter used. This pull request uses `distutils.sysconfig` to directly obtain the header path from Python.

We don't need the library path because we are not embedding a Python interpreter into a C++ program, we are only creating a Python module. We did link the library before, but it's not necessary and not even considered good practice.

Closes #869.