### PR TITLE
Add --gdb flag to pypresso to launch Python in GDB

### DIFF
--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -13,7 +13,11 @@ if test -n "$PYTHONPATH"; then
 else
   PYTHONPATH=@PYTHON_DIR@
 fi
-
-
 export PYTHONPATH
+
+if [ "$1" = "--gdb" ]; then
+  shift
+  exec gdb -ex run --args @PYTHON_EXECUTABLE@ $@
+fi
+
 exec @PYTHON_EXECUTABLE@ $@

--- a/src/python/pypresso.in
+++ b/src/python/pypresso.in
@@ -12,4 +12,10 @@ else
     PYTHONPATH=@abs_top_builddir@
 fi
 export PYTHONPATH
+
+if [ "$1" = "--gdb" ]; then
+  shift
+  exec gdb -ex run --args @PYTHON_EXECUTABLE@ $@
+fi
+
 exec @PYTHON@ $@


### PR DESCRIPTION
@richter-t complained about the difficulty of running Espresso with Python in the debugger. This pull request adds a flag `--gdb` to pypresso to simplify that as discussed with @RudolfWeeber. Obviously, you need to set `CMAKE_BUILD_TYPE=Debug` via ccmake.