### PR TITLE
Relative import behaviour changed in Cython 0.25

### DIFF
--- a/src/python/espressomd/reaction.pyx
+++ b/src/python/espressomd/reaction.pyx
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import
 include "myconfig.pxi"
+cimport globals
 from . cimport reaction
-from . cimport globals
 from . cimport utils
 from .highlander import ThereCanOnlyBeOne
 


### PR DESCRIPTION
Homebrew now ships version 0.25 of Cython.  There the behaviour of relative imports has changed which leads to an error when generating C++ code.  This commit merely replaces the offending line.