### PR TITLE
Recursive variant

### DIFF
--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -48,7 +48,7 @@ public:
   }
 
   template <typename InputIterator>
-  Vector(InputIterator const& begin, InputIterator const& end) {
+  Vector(InputIterator const &begin, InputIterator const &end) {
     assert(std::distance(begin, end) <= n);
     std::copy(begin, end, d.begin());
   }
@@ -76,6 +76,9 @@ public:
   static constexpr size_t size() { return n; }
 
   operator std::array<Scalar, n> const &() const { return d; }
+  operator std::vector<Scalar>() const {
+    return std::vector<Scalar>(std::begin(d), std::end(d));
+  }
 
   std::vector<Scalar> as_vector() const {
     return std::vector<Scalar>(std::begin(d), std::end(d));

--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -43,12 +43,18 @@ public:
   Vector() {}
 
   template <typename Container> explicit Vector(Container const &v) {
-    assert(std::distance(std::begin(v), std::end(v)) == n);
+    assert(std::distance(std::begin(v), std::end(v)) <= n);
     std::copy(std::begin(v), std::end(v), d.begin());
   }
 
+  template <typename InputIterator>
+  Vector(InputIterator const& begin, InputIterator const& end) {
+    assert(std::distance(begin, end) <= n);
+    std::copy(begin, end, d.begin());
+  }
+
   Vector(std::initializer_list<Scalar> l) {
-    assert(l.size() == n);
+    assert(l.size() <= n);
     std::copy(std::begin(l), std::end(l), d.begin());
   }
 
@@ -68,6 +74,8 @@ public:
   const_reference back() const { return d.back(); }
 
   operator std::array<Scalar, n> const &() const { return d; }
+
+  size_t size() const { return d.size(); }
 
   std::vector<Scalar> as_vector() const {
     return std::vector<Scalar>(std::begin(d), std::end(d));

--- a/src/core/constraints.hpp
+++ b/src/core/constraints.hpp
@@ -26,7 +26,7 @@ inline void add_constraints_forces(Particle *p) {
   memcpy(pos,p->r.p,3*sizeof(double));
   memcpy(image,p->l.i,3*sizeof(int));
 
-  fold_position(p->r.p, p->l.i);
+  fold_position(pos,image);
   for (auto const &c : Constraints::constraints) {
     c->add_force(p, pos);
   }
@@ -39,9 +39,12 @@ inline void init_constraint_forces() {
 }
 
 inline void add_constraints_energy(Particle *p) {
-  int image[3];
 
-  fold_position(p->r.p, image);
+  int image[3];
+  double pos[3];
+  memcpy(pos,p->r.p,3*sizeof(double));
+  memcpy(image,p->l.i,3*sizeof(int));
+  fold_position(pos,image);
   for (auto const &c : Constraints::constraints) {
     c->add_energy(p, p->r.p, energy);
   }

--- a/src/core/correlators/Correlator.cpp
+++ b/src/core/correlators/Correlator.cpp
@@ -22,6 +22,8 @@
 #include "integrate.hpp"
 #include "utils.hpp" 
 
+#include <limits>
+
 namespace Correlators {
 
 /* global variables */
@@ -147,8 +149,8 @@ void Correlator::initialize() {
   }
 
   // Time steps and intervals
-  update_frequency = (int) floor(dt/time_step);
-  
+  update_frequency = std::floor(dt/time_step + std::numeric_limits<double>::round_error());
+
   if ( tau_lin == 1 ) { // use the default
     tau_lin=(int)ceil(tau_max/dt);
     if (tau_lin%2) tau_lin+=1;

--- a/src/core/observables/Observable.cpp
+++ b/src/core/observables/Observable.cpp
@@ -22,7 +22,6 @@
 namespace Observables {
 
 Observable::Observable() {
-  type = OBSERVABLE;
   last_update = 0;
   autoupdate = 0;
   autoupdate_dt = 0;

--- a/src/core/unit_tests/NumeratedContainer_test.cpp
+++ b/src/core/unit_tests/NumeratedContainer_test.cpp
@@ -34,6 +34,28 @@
 
 using namespace Utils;
 
+BOOST_AUTO_TEST_CASE(il_constructor) {
+  NumeratedContainer<int> container{{0, 1}, {2, 3}};
+
+  BOOST_CHECK(container.size() == 2);
+
+  /* Index 0 was in the construction set,
+     so the next free index should be 1.
+  */
+  {
+    const int next_index = container.add(5);
+    BOOST_CHECK(next_index == 1);
+  }
+
+  /* Index 2 was in the construction set,
+     so the next free index has to be 3.
+  */
+  {
+    const int next_index = container.add(5);
+    BOOST_CHECK(next_index == 3);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(index_handling) {
   NumeratedContainer<int> container;
 

--- a/src/core/unit_tests/Vector_test.cpp
+++ b/src/core/unit_tests/Vector_test.cpp
@@ -28,6 +28,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <vector>
 
 #include "../Vector.hpp"
 
@@ -36,9 +37,8 @@
   { 0, 1, 1, 7, 21, 112, 456, 2603, 13203 }
 #define TEST_NUMBERS_PARTIAL_NORM2                                             \
   { 0, 1, 2, 51, 492, 13036 }
-const int test_numbers[] = TEST_NUMBERS;
-const int test_numbers_partial_norm2[] = TEST_NUMBERS_PARTIAL_NORM2;
-const int n_test_numbers = sizeof(test_numbers) / sizeof(int);
+constexpr int test_numbers[] = TEST_NUMBERS;
+constexpr int n_test_numbers = sizeof(test_numbers) / sizeof(int);
 
 template <int n> bool il_constructor() {
   bool pass = true;
@@ -64,25 +64,23 @@ template <int n> bool default_constructor() {
 }
 
 template <int n> bool norm2() {
-  Vector<n, int> v(test_numbers);
+  Vector<n, int> v(std::begin(test_numbers), test_numbers + n);
 
-  return v.norm2() == test_numbers_partial_norm2[n - 1];
+  return v.norm2() == std::inner_product(v.begin(), v.end(), v.begin(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_constructor) {
-#ifdef HAVE_CXX11
-  BOOST_CHECK(il_constructor<1>());
-  BOOST_CHECK(il_constructor<2>());
-  BOOST_CHECK(il_constructor<3>());
-  BOOST_CHECK(il_constructor<4>());
-  BOOST_CHECK(il_constructor<5>());
-  BOOST_CHECK(il_constructor<6>());
-  BOOST_CHECK(il_constructor<7>());
-  BOOST_CHECK(il_constructor<8>());
-  BOOST_CHECK(il_constructor<9>());
-  BOOST_CHECK(il_constructor<10>());
-#endif
+BOOST_AUTO_TEST_CASE(initializer_list_constructor) {
+  Vector<n_test_numbers, int> v(TEST_NUMBERS);
 
+  BOOST_CHECK(std::equal(v.begin(), v.end(), test_numbers));
+}
+
+BOOST_AUTO_TEST_CASE(iterator_constructor) {
+  Vector<n_test_numbers, int> v(std::begin(test_numbers), std::end(test_numbers));
+  BOOST_CHECK(std::equal(v.begin(), v.end(), test_numbers));
+}
+
+BOOST_AUTO_TEST_CASE(default_constructor_test) {
   BOOST_CHECK(default_constructor<1>());
   BOOST_CHECK(default_constructor<2>());
   BOOST_CHECK(default_constructor<3>());
@@ -100,6 +98,4 @@ BOOST_AUTO_TEST_CASE(test_norm2) {
   BOOST_CHECK(norm2<2>());
   BOOST_CHECK(norm2<3>());
   BOOST_CHECK(norm2<4>());
-  BOOST_CHECK(norm2<5>());
-  BOOST_CHECK(norm2<6>());
 }

--- a/src/core/utils/NumeratedContainer.hpp
+++ b/src/core/utils/NumeratedContainer.hpp
@@ -30,7 +30,7 @@
 namespace Utils {
 
 /**
- * \brief Container for objects that are identified by a numeric id.
+ * @brief Container for objects that are identified by a numeric id.
  *
  * This class implements a container that holds T instances and references
  * them by an integral index. New elements get the lowest free index
@@ -41,9 +41,31 @@ public:
   typedef typename std::unordered_map<index_type, T>::iterator iterator;
   typedef
       typename std::unordered_map<index_type, T>::const_iterator const_iterator;
+  typedef typename std::unordered_map<index_type, T>::value_type value_type;
+
   NumeratedContainer() {
     m_free_indices.insert(0);
     m_free_indices.insert(1);
+  }
+
+  /**
+   * @brief Construct from list of key-value pairs.
+   * The keys have to be unique.
+   */
+  explicit NumeratedContainer(std::initializer_list<value_type> l)
+      : NumeratedContainer() {
+    for (auto const &e : l) {
+      m_container.insert(e);
+      /* Remove the index from the index set if it exists. */
+      m_free_indices.erase(m_free_indices.find(e.first), m_free_indices.end());
+    }
+
+    /* Refill the index set */
+    for (index_type it(0); m_free_indices.size() < 2; ++it) {
+      if (m_container.find(it) == m_container.end()) {
+        m_free_indices.insert(it);
+      }
+    }
   }
 
   /**

--- a/src/core/utils/ObjectId.hpp
+++ b/src/core/utils/ObjectId.hpp
@@ -28,6 +28,11 @@
 #include "NumeratedContainer.hpp"
 namespace Utils {
 
+/**
+ * @brief Class to automatically maintain a registry of
+ * objects. The objects are assigned an id, by which an
+ * instance can be retrieved.
+ */
 template <typename T> class AutoObjectId {
 public:
   class ObjectId {
@@ -65,14 +70,17 @@ public:
    */
   ObjectId id() const { return m_id; }
   /**
-   * @brief get instance by id.
+   * @brief get instance by id. If the id is none (ObjectId()),
+   * a nullptr is returned. If the id is unknown, an out-of-range
+   * exception is thrown.
    */
   static std::weak_ptr<T> &get_instance(ObjectId id) { return reg()[id.m_id]; }
 
 private:
   ObjectId m_id;
   static Utils::NumeratedContainer<std::weak_ptr<T>> &reg() {
-    static Utils::NumeratedContainer<std::weak_ptr<T>> m_reg;
+    static Utils::NumeratedContainer<std::weak_ptr<T>> m_reg(
+        {{ObjectId().id(), std::weak_ptr<T>()}});
 
     return m_reg;
   }

--- a/src/core/verlet.cpp
+++ b/src/core/verlet.cpp
@@ -92,10 +92,8 @@ void free_pairList(PairList *list)
   list->pair = (Particle **)Utils::realloc(list->pair, 0);
 }
 
-
 /** Returns true if the particles are to be considered for short range 
     interactions */
-
 
 void build_verlet_lists()
 {

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -64,6 +64,8 @@ cdef extern from "script_interface/ScriptInterface.hpp" namespace "ScriptInterfa
         Variant & operator = (const Variant &)
         int which()
     void transform_vectors(Variant &)
+    string get_type_label(const Variant &)
+    string get_type_label(ParameterType)
 
 cdef extern from "script_interface/ScriptInterface.hpp" namespace "boost":
     T get[T](const Variant &) except +

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -47,7 +47,7 @@ cdef extern from "script_interface/Parameter.hpp" namespace "ScriptInterface::Pa
     cdef ParameterType DOUBLE_VECTOR
     cdef ParameterType VECTOR3D
     cdef ParameterType VECTOR2D
-    cdef ParameterType OBJECT
+    cdef ParameterType OBJECTID
     cdef ParameterType VECTOR
 
 cdef extern from "script_interface/Parameter.hpp" namespace "ScriptInterface":
@@ -63,6 +63,7 @@ cdef extern from "script_interface/ScriptInterface.hpp" namespace "ScriptInterfa
         Variant(const Variant & )
         Variant & operator = (const Variant &)
         int which()
+    void transform_vectors(Variant &)
 
 cdef extern from "script_interface/ScriptInterface.hpp" namespace "boost":
     T get[T](const Variant &) except +

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -90,9 +90,9 @@ cdef extern from "script_interface/ScriptInterface.hpp" namespace "ScriptInterfa
 cdef class PScriptInterface:
     cdef shared_ptr[ScriptInterfaceBase] sip
     cdef map[string, Parameter] parameters
-    cdef Variant make_variant(self, ParameterType type, value)
     cdef set_sip(self, shared_ptr[ScriptInterfaceBase] sip)
     cdef variant_to_python_object(self, Variant value)
+    cdef Variant python_object_to_variant(self, value)
 
 cdef class PObjectId:
     cpdef ObjectId id

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -24,16 +24,6 @@ from libcpp.memory cimport shared_ptr
 from libcpp.memory cimport weak_ptr
 from libcpp cimport bool
 
-cdef extern from "Vector.hpp":
-    cdef cppclass Vector3d:
-        Vector3d()
-        Vector3d(vector[double])
-        vector[double] as_vector()
-    cdef cppclass Vector2d:
-        Vector2d()
-        Vector2d(vector[double])
-        vector[double] as_vector()
-
 cdef extern from "script_interface/Parameter.hpp" namespace "ScriptInterface":
     cdef cppclass ParameterType:
         bool operator == (const ParameterType & a, const ParameterType & b)
@@ -45,8 +35,6 @@ cdef extern from "script_interface/Parameter.hpp" namespace "ScriptInterface::Pa
     cdef ParameterType STRING
     cdef ParameterType INT_VECTOR
     cdef ParameterType DOUBLE_VECTOR
-    cdef ParameterType VECTOR3D
-    cdef ParameterType VECTOR2D
     cdef ParameterType OBJECTID
     cdef ParameterType VECTOR
 

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -79,10 +79,7 @@ cdef class PScriptInterface:
             # Map python object do id
             oid = value.id()
             return make_variant[ObjectId](oid.id)
-        # Check for iter is on purpose (instead of Sequence),
-        # because strings should be converted to strings and
-        # not to vector[int].
-        elif hasattr(value, '__iter__'):
+        elif hasattr(value, '__iter__') and not(type(value) == str):
             for e in value:
                 vec.push_back(self.python_object_to_variant(e))
             v = make_variant[vector[Variant]](vec)

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -63,7 +63,7 @@ cdef class PScriptInterface:
             if v.which() == <int> type:
                 parameters[name] = v
             else:
-                raise ValueError("Wrong type for parameter '%s'" % pname)
+                raise ValueError("Wrong type for parameter '%s': Expected %s, but got %s" % (pname, get_type_label(type), get_type_label(v)))
 
         self.sip.get().set_parameters(parameters)
 

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -93,6 +93,8 @@ cdef class PScriptInterface:
     cdef variant_to_python_object(self, Variant value):
         cdef ObjectId oid
         cdef int type = value.which()
+        cdef shared_ptr[ScriptInterfaceBase] ptr
+
         if < int > type == <int > BOOL:
             return get[bool](value)
         if < int > type == <int > INT:
@@ -113,9 +115,13 @@ cdef class PScriptInterface:
             # Get the id and build a curresponding object
             try:
                 oid = get[ObjectId](value)
-                pobj = PScriptInterface()
-                pobj.set_sip(get_instance(oid).lock())
-                return pobj
+                ptr = get_instance(oid).lock()
+                if ptr != shared_ptr[ScriptInterfaceBase]():
+                    pobj = PScriptInterface()
+                    pobj.set_sip(ptr)
+                    return pobj
+                else:
+                    return None
             except:
                 return None
 

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -35,6 +35,9 @@ cdef class PScriptInterface:
 
         return self.variant_to_python_object(self.sip.get().call_method(to_char_pointer(method), parameters))
 
+    def name(self):
+        return self.sip.get().name()
+
     def set_params(self, **kwargs):
         cdef ParameterType type
         cdef map[string, Variant] parameters

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -52,7 +52,7 @@ cdef class PScriptInterface:
                 raise ValueError("Unknown parameter %s" % name)
 
             # Check number of elements if applicable
-            if < int > type in [ < int > INT_VECTOR, < int > DOUBLE_VECTOR, < int > VECTOR2D, < int > VECTOR3D]:
+            if < int > type in [ < int > INT_VECTOR, < int > DOUBLE_VECTOR]:
                 n_elements = self.parameters[name].n_elements()
                 if n_elements!=0 and not (len(kwargs[pname]) == n_elements):
                     raise ValueError(
@@ -117,10 +117,6 @@ cdef class PScriptInterface:
             return get[vector[int]](value)
         if < int > type == <int > DOUBLE_VECTOR:
             return get[vector[double]](value)
-        if < int > type == <int > VECTOR3D:
-            return get[Vector3d](value).as_vector()
-        if < int > type == <int > VECTOR2D:
-            return get[Vector2d](value).as_vector()
         if < int > type == <int > OBJECTID:
             # Get the id and build a curresponding object
             try:

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -65,6 +65,7 @@ cdef class PScriptInterface:
         self.sip.get().set_parameters(parameters)
 
     cdef Variant python_object_to_variant(self, value):
+        cdef Variant v
         cdef vector[Variant] vec
         cdef PObjectId oid
 
@@ -81,7 +82,9 @@ cdef class PScriptInterface:
         elif hasattr(value, '__iter__'):
             for e in value:
                 vec.push_back(self.python_object_to_variant(e))
-            return make_variant[vector[Variant]](vec)
+            v = make_variant[vector[Variant]](vec)
+            transform_vectors(v)
+            return v
         elif type(value) == str:
             return make_variant[string](to_char_pointer(value))
         elif type(value) == int:
@@ -115,7 +118,7 @@ cdef class PScriptInterface:
             return get[Vector3d](value).as_vector()
         if < int > type == <int > VECTOR2D:
             return get[Vector2d](value).as_vector()
-        if < int > type == <int > OBJECT:
+        if < int > type == <int > OBJECTID:
             # Get the id and build a curresponding object
             try:
                 oid = get[ObjectId](value)

--- a/src/script_interface/ParallelScriptInterface.hpp
+++ b/src/script_interface/ParallelScriptInterface.hpp
@@ -24,7 +24,7 @@
 
 #include <utility>
 
-#include "ScriptInterface.hpp"
+#include "ScriptInterfaceBase.hpp"
 
 #include "ParallelScriptInterfaceSlave.hpp"
 #include "core/errorhandling.hpp"

--- a/src/script_interface/ParallelScriptInterface.hpp
+++ b/src/script_interface/ParallelScriptInterface.hpp
@@ -58,6 +58,7 @@ public:
   std::shared_ptr<T> m_p;
 
   ParallelScriptInterface() : m_p(ScriptInterfaceBase::make_shared<T>()) {
+
     call(static_cast<int>(CallbackAction::SET_ID));
 
     ObjectId global_id{m_p->id()};
@@ -89,7 +90,11 @@ public:
 
   Variant map_local_to_parallel_id(std::string const &name,
                                    Variant const &value) const {
-    return obj_map.at(name)->id();
+    if (boost::get<ObjectId>(value) != ObjectId()) {
+      return obj_map.at(name)->id();
+    } else {
+      return value;
+    }
   }
 
   Variant map_parallel_to_local_id(std::string const &name,

--- a/src/script_interface/ParallelScriptInterface.hpp
+++ b/src/script_interface/ParallelScriptInterface.hpp
@@ -75,7 +75,7 @@ public:
   void set_parameter(const std::string &name, const Variant &value) override {
     std::pair<std::string, Variant> d(name, Variant());
 
-    if (valid_parameters()[name].type() == ParameterType::OBJECT) {
+    if (valid_parameters()[name].type() == ParameterType::OBJECTID) {
       d = std::make_pair(name, map_parallel_to_local_id(name, value));
     } else {
       d = std::make_pair(name, value);
@@ -129,7 +129,7 @@ public:
 
     /* Unwrap the object ids */
     for (auto &it : p) {
-      if (valid_parameters()[it.first].type() == ParameterType::OBJECT) {
+      if (valid_parameters()[it.first].type() == ParameterType::OBJECTID) {
         it.second = map_parallel_to_local_id(it.first, it.second);
       }
     }
@@ -148,7 +148,7 @@ public:
 
     /* Wrap the object ids */
     for (auto &it : p) {
-      if (valid_parameters()[it.first].type() == ParameterType::OBJECT) {
+      if (valid_parameters()[it.first].type() == ParameterType::OBJECTID) {
         it.second = map_local_to_parallel_id(it.first, it.second);
       }
     }
@@ -163,7 +163,7 @@ public:
 
     /* Unwrap the object ids */
     for (auto &it : p) {
-      if (it.second.which() == static_cast<int>(ParameterType::OBJECT)) {
+      if (it.second.which() == static_cast<int>(ParameterType::OBJECTID)) {
         it.second = map_parallel_to_local_id(it.first, it.second);
       }
     }

--- a/src/script_interface/Parameter.hpp
+++ b/src/script_interface/Parameter.hpp
@@ -44,17 +44,7 @@ public:
 
   Parameter(ParameterType type, bool required)
       : m_type(type), m_required(required) {
-    switch (type) {
-    case ParameterType::VECTOR2D:
-      m_n_elements = 2;
-      break;
-    case ParameterType::VECTOR3D:
-      m_n_elements = 3;
-      break;
-    default:
-      m_n_elements = ARBITRARY_LENGTH;
-      break;
-    }
+    m_n_elements = ARBITRARY_LENGTH;
   }
 
   Parameter(ParameterType type, int n_elements, bool required)

--- a/src/script_interface/Parameter.hpp
+++ b/src/script_interface/Parameter.hpp
@@ -20,8 +20,7 @@
 #ifndef SCRIPT_INTERFACE_PARAMETERS_HPP
 #define SCRIPT_INTERFACE_PARAMETERS_HPP
 
-#include <map>
-#include <string>
+#include "Variant.hpp"
 
 namespace ScriptInterface {
 
@@ -29,18 +28,7 @@ namespace ScriptInterface {
  * Possible parameter type. Corresponds to the template parameters of @type
  * Variant.
  */
-enum class ParameterType {
-  BOOL = 0,
-  INT,
-  DOUBLE,
-  STRING,
-  INT_VECTOR,
-  DOUBLE_VECTOR,
-  VECTOR2D,
-  VECTOR3D,
-  OBJECT,
-  VECTOR
-};
+using ParameterType = VariantType;
 
 /**
  * @brief Script interface parameter.

--- a/src/script_interface/ScriptInterface.hpp
+++ b/src/script_interface/ScriptInterface.hpp
@@ -22,20 +22,18 @@
 #ifndef SCRIPT_INTERFACE_SCRIPT_INTERFACE_HPP
 #define SCRIPT_INTERFACE_SCRIPT_INTERFACE_HPP
 
-#include "initialize.hpp"
-#include "ScriptInterfaceBase.hpp"
 #include "ParallelScriptInterface.hpp"
+#include "ScriptInterfaceBase.hpp"
+#include "initialize.hpp"
 
 namespace ScriptInterface {
-  enum { NOT_SET = -1 };
+enum { NOT_SET = -1 };
 
-  inline std::shared_ptr<ScriptInterfaceBase> get_instance(Variant value) {
-    const auto id = boost::get<ObjectId>(value);
+inline std::shared_ptr<ScriptInterfaceBase> get_instance(Variant value) {
+  const auto id = boost::get<ObjectId>(value);
 
   return ScriptInterfaceBase::get_instance(id).lock();
 }
-
-
 
 } /* namespace ScriptInterface */
 

--- a/src/script_interface/ScriptInterfaceBase.hpp
+++ b/src/script_interface/ScriptInterfaceBase.hpp
@@ -32,6 +32,17 @@
 #include "Variant.hpp"
 
 namespace ScriptInterface {
+
+template <typename T> T get_value(Variant const &v) { return boost::get<T>(v); }
+
+template <> inline Vector3d get_value<Vector3d>(Variant const &v) {
+  return Vector3d(boost::get<std::vector<double>>(v));
+}
+
+template <> inline Vector2d get_value<Vector2d>(Variant const &v) {
+  return Vector2d(boost::get<std::vector<double>>(v));
+}
+
 /**
  * @brief Tries to extract a value with the type of MEMBER_NAME from the
  * Variant.
@@ -42,11 +53,10 @@ namespace ScriptInterface {
  * remove_reference ensures that this also works with member access by reference
  * for example as returned by a function.
  */
-
 #define SET_PARAMETER_HELPER(PARAMETER_NAME, MEMBER_NAME)                      \
   if (name == PARAMETER_NAME) {                                                \
     MEMBER_NAME =                                                              \
-        boost::get<std::remove_reference<decltype(MEMBER_NAME)>::type>(value); \
+        get_value<std::remove_reference<decltype(MEMBER_NAME)>::type>(value);  \
   }
 
 /**

--- a/src/script_interface/ScriptInterfaceBase.hpp
+++ b/src/script_interface/ScriptInterfaceBase.hpp
@@ -26,28 +26,12 @@
 #include <type_traits>
 #include <vector>
 
-#include <boost/variant.hpp>
-
-#include "utils/ObjectId.hpp"
 #include "utils/serialization/array.hpp"
 
 #include "Parameter.hpp"
-#include "core/Vector.hpp"
+#include "Variant.hpp"
 
 namespace ScriptInterface {
-class ScriptInterfaceBase;
-
-typedef Utils::ObjectId<ScriptInterfaceBase> ObjectId;
-
-/**
- * @brief Possible types for parameters.
- */
-
-typedef boost::make_recursive_variant<
-    bool, int, double, std::string, std::vector<int>, std::vector<double>,
-    Vector2d, Vector3d, ObjectId,
-    std::vector<boost::recursive_variant_>>::type Variant;
-
 /**
  * @brief Tries to extract a value with the type of MEMBER_NAME from the
  * Variant.

--- a/src/script_interface/ScriptInterfaceBase.hpp
+++ b/src/script_interface/ScriptInterfaceBase.hpp
@@ -43,8 +43,8 @@ typedef Utils::ObjectId<ScriptInterfaceBase> ObjectId;
  * @brief Possible types for parameters.
  */
 typedef boost::variant<bool, int, double, std::string, std::vector<int>,
-                       std::vector<double>, Vector2d, Vector3d, ObjectId>
-    Variant;
+                       std::vector<double>, Vector2d, Vector3d,
+                       ObjectId> Variant;
 
 /**
  * @brief Tries to extract a value with the type of MEMBER_NAME from the
@@ -61,16 +61,6 @@ typedef boost::variant<bool, int, double, std::string, std::vector<int>,
   if (name == PARAMETER_NAME) {                                                \
     MEMBER_NAME =                                                              \
         boost::get<std::remove_reference<decltype(MEMBER_NAME)>::type>(value); \
-  }
-
-#define SET_PARAMETER_HELPER_VECTOR3D(PARAMETER_NAME, MEMBER_NAME)             \
-  if (name == PARAMETER_NAME) {                                                \
-    MEMBER_NAME = Vector3d(boost::get<std::vector<double>>(value));            \
-  }
-
-#define SET_PARAMETER_HELPER_VECTOR2D(PARAMETER_NAME, MEMBER_NAME)             \
-  if (name == PARAMETER_NAME) {                                                \
-    MEMBER_NAME = Vector2d(boost::get<std::vector<double>>(value));            \
   }
 
 /**

--- a/src/script_interface/Variant.cpp
+++ b/src/script_interface/Variant.cpp
@@ -1,0 +1,39 @@
+#include "Variant.hpp"
+
+namespace ScriptInterface {
+const char *VariantLabels[] = {
+    "BOOL",          "INT",      "DOUBLE",  "STRING",   "INT_VECTOR",
+    "DOUBLE_VECTOR", "VECTOR2D", "VECTOR3", "OBJECTID", "VECTOR"};
+
+bool is_bool(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::BOOL);
+}
+
+bool is_int(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::INT);
+}
+
+bool is_string(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::STRING);
+}
+
+bool is_double(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::DOUBLE);
+}
+
+bool is_int_vector(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::INT_VECTOR);
+}
+
+bool is_double_vector(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::DOUBLE_VECTOR);
+}
+
+bool is_objectid(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::OBJECTID);
+}
+
+bool is_vector(Variant const &v) {
+  return v.which() == static_cast<int>(VariantType::VECTOR);
+}
+} /* namespace ScriptInterface */

--- a/src/script_interface/Variant.cpp
+++ b/src/script_interface/Variant.cpp
@@ -1,9 +1,9 @@
 #include "Variant.hpp"
 
 namespace ScriptInterface {
-static const char *VariantLabels[] = {
-    "BOOL",          "INT",      "DOUBLE",  "STRING",   "INT_VECTOR",
-    "DOUBLE_VECTOR", "VECTOR2D", "VECTOR3", "OBJECTID", "VECTOR"};
+static const char *VariantLabels[] = {"BOOL",     "INT",        "DOUBLE",
+                                      "STRING",   "INT_VECTOR", "DOUBLE_VECTOR",
+                                      "OBJECTID", "VECTOR"};
 
 std::string get_type_label(Variant const &v) {
   return std::string(VariantLabels[v.which()]);

--- a/src/script_interface/Variant.cpp
+++ b/src/script_interface/Variant.cpp
@@ -1,9 +1,17 @@
 #include "Variant.hpp"
 
 namespace ScriptInterface {
-const char *VariantLabels[] = {
+static const char *VariantLabels[] = {
     "BOOL",          "INT",      "DOUBLE",  "STRING",   "INT_VECTOR",
     "DOUBLE_VECTOR", "VECTOR2D", "VECTOR3", "OBJECTID", "VECTOR"};
+
+std::string get_type_label(Variant const &v) {
+  return std::string(VariantLabels[v.which()]);
+}
+
+std::string get_type_label(VariantType t) {
+  return std::string(VariantLabels[static_cast<int>(t)]);
+}
 
 bool is_bool(Variant const &v) {
   return v.which() == static_cast<int>(VariantType::BOOL);

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -26,8 +26,6 @@ enum class VariantType {
   STRING,
   INT_VECTOR,
   DOUBLE_VECTOR,
-  VECTOR2D,
-  VECTOR3D,
   OBJECTID,
   VECTOR
 };

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -43,6 +43,10 @@ bool is_double_vector(Variant const &v);
 bool is_objectid(Variant const &v);
 bool is_vector(Variant const &v);
 
+void transform_vectors(Variant &v);
+
+std::string print_variant_types(Variant const &v);
+
 } /* namespace ScriptInterface */
 
 #endif

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -1,0 +1,48 @@
+#ifndef SCRIPT_INTERFACE_VARIANT_HPP
+#define SCRIPT_INTERFACE_VARIANT_HPP
+
+#include <boost/variant.hpp>
+
+#include "core/Vector.hpp"
+#include "utils/ObjectId.hpp"
+
+namespace ScriptInterface {
+class ScriptInterfaceBase;
+using ObjectId = Utils::ObjectId<ScriptInterfaceBase>;
+
+/**
+ * @brief Possible types for parameters.
+ */
+
+typedef boost::make_recursive_variant<
+    bool, int, double, std::string, std::vector<int>, std::vector<double>,
+    Vector2d, Vector3d, ObjectId, std::vector<boost::recursive_variant_>>::type
+    Variant;
+
+enum class VariantType {
+  BOOL = 0,
+  INT,
+  DOUBLE,
+  STRING,
+  INT_VECTOR,
+  DOUBLE_VECTOR,
+  VECTOR2D,
+  VECTOR3D,
+  OBJECTID,
+  VECTOR
+};
+
+extern const char *VariantLabels[];
+
+bool is_bool(Variant const &v);
+bool is_int(Variant const &v);
+bool is_string(Variant const &v);
+bool is_double(Variant const &v);
+bool is_int_vector(Variant const &v);
+bool is_double_vector(Variant const &v);
+bool is_objectid(Variant const &v);
+bool is_vector(Variant const &v);
+
+} /* namespace ScriptInterface */
+
+#endif

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -16,8 +16,7 @@ using ObjectId = Utils::ObjectId<ScriptInterfaceBase>;
 
 typedef boost::make_recursive_variant<
     bool, int, double, std::string, std::vector<int>, std::vector<double>,
-    Vector2d, Vector3d, ObjectId, std::vector<boost::recursive_variant_>>::type
-    Variant;
+    ObjectId, std::vector<boost::recursive_variant_>>::type Variant;
 
 enum class VariantType {
   BOOL = 0,

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -32,7 +32,8 @@ enum class VariantType {
   VECTOR
 };
 
-extern const char *VariantLabels[];
+std::string get_type_label(Variant const &);
+std::string get_type_label(VariantType);
 
 bool is_bool(Variant const &v);
 bool is_int(Variant const &v);

--- a/src/script_interface/VariantTester.hpp
+++ b/src/script_interface/VariantTester.hpp
@@ -18,9 +18,13 @@ public:
     }
 
     if (method == "flat") {
-      return std::vector<Variant>{true, std::string("a string"), 3.14159,
+      return std::vector<Variant>{true,
+                                  std::string("a string"),
+                                  3.14159,
                                   std::vector<int>{3, 1, 4, 1, 5},
-                                  std::vector<double>{1.1, 2.2, 3.3}};
+                                  std::vector<double>{1.1, 2.2, 3.3},
+                                  ObjectId(),
+                                  this->id()};
     }
 
     if (method == "recursive") {

--- a/src/script_interface/VariantTester.hpp
+++ b/src/script_interface/VariantTester.hpp
@@ -1,0 +1,83 @@
+#include "ScriptInterface.hpp"
+
+#include <iostream>
+
+namespace ScriptInterface {
+namespace Testing {
+class VariantTester : public ScriptInterfaceBase {
+public:
+  const std::string name() const override { return "Testing::VariantTester"; }
+  Variant call_method(std::string const &method,
+                      VariantMap const &par) override {
+    if (method == "true") {
+      return true;
+    }
+
+    if (method == "false") {
+      return false;
+    }
+
+    if (method == "flat") {
+      return std::vector<Variant>{true, std::string("a string"), 3.14159,
+                                  std::vector<int>{3, 1, 4, 1, 5},
+                                  std::vector<double>{1.1, 2.2, 3.3}};
+    }
+
+    if (method == "recursive") {
+      return make_recursive_variant(0, boost::get<int>(par.at("max_level")));
+    }
+
+    if (method == "mixed") {
+      return std::vector<Variant>{1, std::string("another string"),
+                                  make_recursive_variant(0, 5)};
+    }
+
+    if (method == "check_parameter_type") {
+      auto const type = boost::get<std::string>(par.at("type"));
+
+      if (type == "bool") {
+        return is_bool(par.at("value"));
+      }
+
+      if (type == "int") {
+        return is_int(par.at("value"));
+      }
+
+      if (type == "double") {
+        return is_double(par.at("value"));
+      }
+
+      if (type == "string") {
+        return is_string(par.at("value"));
+      }
+
+      if (type == "objectid") {
+        return is_objectid(par.at("value"));
+      }
+
+      if (type == "double_vector") {
+        return is_double_vector(par.at("value"));
+      }
+
+      if (type == "int_vector") {
+        return is_int_vector(par.at("value"));
+      }
+
+      if (type == "vector") {
+        return is_vector(par.at("value"));
+      }
+    }
+
+    throw std::runtime_error("Unknown method");
+  }
+
+private:
+  Variant make_recursive_variant(int i, int max_level) const {
+    if (i < max_level)
+      return std::vector<Variant>{i, make_recursive_variant(i + 1, max_level)};
+    else
+      return std::string("end");
+  }
+};
+}
+}

--- a/src/script_interface/constraints/Constraint.hpp
+++ b/src/script_interface/constraints/Constraint.hpp
@@ -48,7 +48,7 @@ public:
     return {{"only_positive", {ParameterType::INT, true}},
             {"penetrable", {ParameterType::INT, true}},
             {"particle_type", {ParameterType::INT, true}},
-            {"shape", {ParameterType::OBJECT, true}}};
+            {"shape", {ParameterType::OBJECTID, true}}};
   }
 
   void set_parameter(std::string const &name, Variant const &value) override {

--- a/src/script_interface/constraints/Constraint.hpp
+++ b/src/script_interface/constraints/Constraint.hpp
@@ -27,15 +27,14 @@
 #include "script_interface/ScriptInterface.hpp"
 #include "script_interface/shapes/Shape.hpp"
 
-#include <memory>
-
 namespace ScriptInterface {
 namespace Constraints {
 
 class Constraint : public ScriptInterfaceBase {
 public:
-  Constraint() : m_constraint(new ::Constraints::Constraint()) {}
-  
+  Constraint()
+      : m_constraint(new ::Constraints::Constraint()), m_shape(nullptr) {}
+
   const std::string name() const override { return "Constraints::Constraint"; }
 
   VariantMap get_parameters() const override {
@@ -53,7 +52,7 @@ public:
   }
 
   void set_parameter(std::string const &name, Variant const &value) override {
-    if (name == "shape") {
+    if ((name == "shape") && (boost::get<ObjectId>(value) != ObjectId())) {
       std::shared_ptr<ScriptInterfaceBase> so_ptr =
           ScriptInterface::get_instance(value);
 

--- a/src/script_interface/correlators/Correlator.hpp
+++ b/src/script_interface/correlators/Correlator.hpp
@@ -59,8 +59,8 @@ public:
       {{"tau_lin", {ParameterType::INT, true}},
       {"tau_max", {ParameterType::DOUBLE, true}},
       {"dt", {ParameterType::DOUBLE, true}},
-      {"obs1", {ParameterType::OBJECT, true}},
-      {"obs2", {ParameterType::OBJECT, true}},
+      {"obs1", {ParameterType::OBJECTID, true}},
+      {"obs2", {ParameterType::OBJECTID, true}},
       {"compress1", {ParameterType::STRING, true}},
       {"compress2", {ParameterType::STRING, true}},
       {"corr_operation", {ParameterType::STRING, true}}};

--- a/src/script_interface/initialize.cpp
+++ b/src/script_interface/initialize.cpp
@@ -24,6 +24,8 @@
 #include "correlators/initialize.hpp" 
 #include "lbboundaries/initialize.hpp"
 
+#include "VariantTester.hpp"
+
 namespace ScriptInterface {
 void initialize() {
   Shapes::initialize();
@@ -31,6 +33,8 @@ void initialize() {
   Observables::initialize();
   Correlators::initialize();
   LBBoundaries::initialize();
+
+  ParallelScriptInterface<Testing::VariantTester>::register_new("Testing::VariantTester");
 }
 
 } /* namespace ScriptInterface */

--- a/src/script_interface/lbboundaries/LBBoundary.hpp
+++ b/src/script_interface/lbboundaries/LBBoundary.hpp
@@ -33,7 +33,7 @@ public:
             {"charge_density", {ParameterType::DOUBLE, true}},
             {"net_charge", {ParameterType::DOUBLE, true}},
 #endif
-            {"shape", {ParameterType::OBJECT, true}}};
+            {"shape", {ParameterType::OBJECTID, true}}};
   }
 
   void set_parameter(std::string const &name, Variant const &value) override {

--- a/src/script_interface/lbboundaries/LBBoundary.hpp
+++ b/src/script_interface/lbboundaries/LBBoundary.hpp
@@ -27,8 +27,8 @@ public:
   }
 
   ParameterMap valid_parameters() const override {
-    return {{"velocity", {ParameterType::VECTOR3D, true}},
-            {"force", {ParameterType::VECTOR3D, true}},
+    return {{"velocity", {ParameterType::DOUBLE_VECTOR, 3, true}},
+            {"force", {ParameterType::DOUBLE_VECTOR, 3, true}},
 #ifdef EK_BOUNDARIES
             {"charge_density", {ParameterType::DOUBLE, true}},
             {"net_charge", {ParameterType::DOUBLE, true}},

--- a/src/script_interface/shapes/Cylinder.cpp
+++ b/src/script_interface/shapes/Cylinder.cpp
@@ -28,8 +28,8 @@ namespace ScriptInterface {
 namespace Shapes {
 
 ParameterMap Cylinder::valid_parameters() const {
-  return {{"center", {ParameterType::VECTOR3D, true}},
-          {"axis", {ParameterType::VECTOR3D, true}},
+  return {{"center", {ParameterType::DOUBLE_VECTOR, 3, true}},
+          {"axis", {ParameterType::DOUBLE_VECTOR, 3, true}},
           {"direction", {ParameterType::DOUBLE, true}},
           {"radius", {ParameterType::DOUBLE, true}},
           {"length", {ParameterType::DOUBLE, true}}};

--- a/src/script_interface/shapes/Pore.cpp
+++ b/src/script_interface/shapes/Pore.cpp
@@ -28,8 +28,8 @@ namespace ScriptInterface {
 namespace Shapes {
 
 ParameterMap Pore::valid_parameters() const {
-  return {{"pos", {ParameterType::VECTOR3D, true}},
-          {"axis", {ParameterType::VECTOR3D, true}},
+  return {{"pos", {ParameterType::DOUBLE_VECTOR, 3, true}},
+          {"axis", {ParameterType::DOUBLE_VECTOR, 3, true}},
           {"rad_left", {ParameterType::DOUBLE, true}},
           {"rad_right", {ParameterType::DOUBLE, true}},
           {"smoothing_radius", {ParameterType::DOUBLE, true}},

--- a/src/script_interface/shapes/Rhomboid.cpp
+++ b/src/script_interface/shapes/Rhomboid.cpp
@@ -28,10 +28,10 @@ namespace ScriptInterface {
 namespace Shapes {
 
 ParameterMap Rhomboid::valid_parameters() const {
-  return {{"corner", {ParameterType::VECTOR3D, true}},
-          {"a", {ParameterType::VECTOR3D, true}},
-          {"b", {ParameterType::VECTOR3D, true}},
-          {"c", {ParameterType::VECTOR3D, true}},
+  return {{"corner", {ParameterType::DOUBLE_VECTOR, 3, true}},
+          {"a", {ParameterType::DOUBLE_VECTOR, 3, true}},
+          {"b", {ParameterType::DOUBLE_VECTOR, 3, true}},
+          {"c", {ParameterType::DOUBLE_VECTOR, 3, true}},
           {"direction", {ParameterType::DOUBLE, true}}};
 }
 

--- a/src/script_interface/shapes/Sphere.cpp
+++ b/src/script_interface/shapes/Sphere.cpp
@@ -28,17 +28,19 @@ namespace ScriptInterface {
 namespace Shapes {
 
 ParameterMap Sphere::valid_parameters() const {
-  return {{"center", {ParameterType::VECTOR3D, true}},
+  return {{"center", {ParameterType::DOUBLE_VECTOR, 3, true}},
           {"radius", {ParameterType::DOUBLE, true}},
-		  {"direction", {ParameterType::DOUBLE, true}}};
+          {"direction", {ParameterType::DOUBLE, true}}};
 }
 
 VariantMap Sphere::get_parameters() const {
-  return {{"center", m_sphere->pos()}, {"radius", m_sphere->rad()}, {"direction", m_sphere->direction()}};
+  return {{"center", m_sphere->pos()},
+          {"radius", m_sphere->rad()},
+          {"direction", m_sphere->direction()}};
 }
 
 void Sphere::set_parameter(const string &name,
-                         const ScriptInterface::Variant &value) {
+                           const ScriptInterface::Variant &value) {
   SET_PARAMETER_HELPER("center", m_sphere->pos());
   SET_PARAMETER_HELPER("radius", m_sphere->rad());
   SET_PARAMETER_HELPER("direction", m_sphere->direction());

--- a/src/script_interface/shapes/SpheroCylinder.cpp
+++ b/src/script_interface/shapes/SpheroCylinder.cpp
@@ -28,8 +28,8 @@ namespace ScriptInterface {
 namespace Shapes {
 
 ParameterMap SpheroCylinder::valid_parameters() const {
-  return {{"pos", {ParameterType::VECTOR3D, true}},
-          {"axis", {ParameterType::VECTOR3D, true}},
+  return {{"pos", {ParameterType::DOUBLE_VECTOR, 3, true}},
+          {"axis", {ParameterType::DOUBLE_VECTOR, 3, true}},
           {"length", {ParameterType::DOUBLE, true}},
           {"rad", {ParameterType::DOUBLE, true}}};
 }

--- a/src/script_interface/shapes/Wall.cpp
+++ b/src/script_interface/shapes/Wall.cpp
@@ -28,7 +28,7 @@ namespace ScriptInterface {
 namespace Shapes {
 
 ParameterMap Wall::valid_parameters() const {
-  return {{"normal", {ParameterType::VECTOR3D, true}},
+  return {{"normal", {ParameterType::DOUBLE_VECTOR, 3, true}},
           {"dist", {ParameterType::DOUBLE, true}}};
 }
 

--- a/src/script_interface/shapes/Wall.cpp
+++ b/src/script_interface/shapes/Wall.cpp
@@ -41,7 +41,7 @@ void Wall::set_parameter(const string &name,
   if (name == "normal") {
     /* Get the variant as vector, and explicitly construct a Vector3d
        from that. */
-    m_wall->set_normal(boost::get<Vector3d>(value));
+    m_wall->set_normal(get_value<Vector3d>(value));
   }
 
   SET_PARAMETER_HELPER("dist", m_wall->d());

--- a/testsuite/python/correlation.py
+++ b/testsuite/python/correlation.py
@@ -27,11 +27,7 @@ from espressomd.observables import *
 from espressomd.observables import *
 from espressomd.correlators import *
 
-
-
 class Observables(ut.TestCase):
-
-
     # Error tolerance when comparing arrays/tuples...
     tol = 1E-9
 
@@ -49,7 +45,7 @@ class Observables(ut.TestCase):
         s.part.add(id=0,pos=(0,0,0),v=(1,2,3))
 
         O=ParticlePositions(ids=(0,))
-        C2=Correlator(obs1=O,dt=0.01,tau_lin=10,tau_max=10,corr_operation="square_distance_componentwise")
+        C2=Correlator(obs1=O,dt=0.01,tau_lin=10,tau_max=10.0,corr_operation="square_distance_componentwise")
         s.integrator.run(1000)
         s.auto_update_correlators.add(C2)
         s.integrator.run(20000)

--- a/testsuite/python/variant_conversion.py
+++ b/testsuite/python/variant_conversion.py
@@ -1,0 +1,59 @@
+from __future__ import print_function
+import sys
+import unittest as ut
+
+from espressomd import script_interface
+
+class test_variant_conversion(ut.TestCase):
+    """
+    Test the variant conversion functions.
+    This needs the c++ helper class ScriptInterface::Testing::VariantTester.
+    """
+    vt = script_interface.PScriptInterface("Testing::VariantTester")
+
+    def check_type_and_value(self, stype, svalue, value):
+        assert(type(value) == stype)
+        assert(value == svalue)
+
+    def test_bool_return(self):
+        """Check that bool return values work corrcetly,
+        because they are needed for the other tests."""
+        assert(self.vt.call_method("true") == True)
+        assert(self.vt.call_method("false") == False)
+
+    def test_flat(self):
+        ret = self.vt.call_method("flat")
+        assert(isinstance(ret, list))
+        self.check_type_and_value(bool, True, ret[0])
+        self.check_type_and_value(str, 'a string', ret[1])
+        self.check_type_and_value(float, 3.14159, ret[2])
+        self.check_type_and_value(list, [3,1,4,1,5], ret[3])
+        self.check_type_and_value(list, [1.1,2.2,3.3], ret[4])
+        # Empty object (ObjectId()) should map to None
+        assert(ret[5] == None)
+        # An actual object
+        assert(isinstance(ret[6], script_interface.PScriptInterface))
+        assert(ret[6].name() == "Testing::VariantTester")
+
+    def test_recu(self):
+        ret = self.vt.call_method("recursive", max_level=5)
+        self.check_type_and_value(str, 'end', ret[1][1][1][1][1])
+
+    def test_mixed(self):
+        ret = self.vt.call_method("mixed")
+        self.check_type_and_value(int, 1, ret[0])
+        self.check_type_and_value(str, 'another string', ret[1])
+        self.check_type_and_value(str, 'end', ret[2][1][1][1][1][1])
+
+    def test_parameter_types(self):
+        assert(self.vt.call_method("check_parameter_type", type="bool", value=True))
+        assert(self.vt.call_method("check_parameter_type", type="int", value=42))
+        assert(self.vt.call_method("check_parameter_type", type="string", value='blub'))
+        assert(self.vt.call_method("check_parameter_type", type="double", value=12.5))
+        assert(self.vt.call_method("check_parameter_type", type="objectid", value=self.vt))
+        assert(self.vt.call_method("check_parameter_type", type="double_vector", value=[1.1, 2.2, 3.3]))
+        assert(self.vt.call_method("check_parameter_type", type="int_vector", value=[1,2,3]))
+        assert(self.vt.call_method("check_parameter_type", type="vector", value=[1,'string',True]))
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
- Made the variant type in the script interface recursive, so that functions can return structured data
- Corresponding translation functions in python
- some clean up of the ObjectId handling (needs further improvement)
- Cleanup and fix of the variant conversion

Fixes #889, #856, #855, #854,  
