### PR TITLE
Add custom mapping for particle visualization.

### DIFF
--- a/src/python/espressomd/visualizationMayavi.pyx
+++ b/src/python/espressomd/visualizationMayavi.pyx
@@ -36,6 +36,7 @@ cdef class mayaviLive:
     interact with the GUI."""
 
     cdef object system
+    cdef object mapping
     cdef object points 
     cdef object box 
     cdef object arrows
@@ -50,13 +51,15 @@ cdef class mayaviLive:
     cdef object timers 
 
 
-    def __init__(self, system):
+    def __init__(self, system, mapping=None):
         """Constructor.
         **Arguments**
 
         :system: instance of espressomd.System
+        :mapping: (optional) function which maps particle types to radii
         """
         self.system = system
+        self.mapping = mapping
 
         # objects drawn
         self.points = mlab.quiver3d([],[],[], [],[],[], scalars=[], mode="sphere", scale_factor=1, name="Particles")
@@ -139,7 +142,10 @@ cdef class mayaviLive:
             coords[j,:] = p.r.p
             t = p.p.type
             types[j] = t +1
-            radii[j] =get_ia_param(t,t).LJ_sig *0.5
+            if self.mapping is None:
+                radii[j] = get_ia_param(t,t).LJ_sig *0.5
+            else:
+                radii[j] = self.mapping(t)
 
             # ITerate over bonds
             k=0        

--- a/src/python/espressomd/visualizationMayavi.pyx
+++ b/src/python/espressomd/visualizationMayavi.pyx
@@ -36,7 +36,7 @@ cdef class mayaviLive:
     interact with the GUI."""
 
     cdef object system
-    cdef object mapping
+    cdef object particle_sizes
     cdef object points 
     cdef object box 
     cdef object arrows
@@ -51,15 +51,15 @@ cdef class mayaviLive:
     cdef object timers 
 
 
-    def __init__(self, system, mapping=None):
+    def __init__(self, system, particle_sizes='auto'):
         """Constructor.
         **Arguments**
 
         :system: instance of espressomd.System
-        :mapping: (optional) function which maps particle types to radii
+        :particle_sizes: (optional) function, list, or dict, which maps particle types to radii
         """
         self.system = system
-        self.mapping = mapping
+        self.particle_sizes = particle_sizes
 
         # objects drawn
         self.points = mlab.quiver3d([],[],[], [],[],[], scalars=[], mode="sphere", scale_factor=1, name="Particles")
@@ -80,6 +80,30 @@ cdef class mayaviLive:
         # GUI window
         self.gui = GUI()
         self.timers = [Timer(100, self._draw)]
+
+    def _determine_radius(self, t):
+        """Determine radius of particle type t for visualization."""
+        def radius_from_lj(t):
+            radius = 0.
+            try:
+                radius = 0.5 * get_ia_param(t,t).LJ_sig
+            except:
+                radius = 0.
+            if radius == 0:
+                radius = 0.5  # fallback value
+            return radius
+
+        radius = 0.
+        try:
+            if self.particle_sizes is 'auto':
+                radius = radius_from_lj(t)
+            elif callable(self.particle_sizes):
+                radius = self.particle_sizes(t)
+            else:
+                radius = self.particle_sizes[t]
+        except:
+            radius = radius_from_lj(t)
+        return radius
 
     def _draw(self):
         """Update the Mayavi objects with new particle information.
@@ -142,23 +166,20 @@ cdef class mayaviLive:
             coords[j,:] = p.r.p
             t = p.p.type
             types[j] = t +1
-            if self.mapping is None:
-                radii[j] = get_ia_param(t,t).LJ_sig *0.5
-            else:
-                radii[j] = self.mapping(t)
+            radii[j] = self._determine_radius(t)
 
-            # ITerate over bonds
-            k=0        
+            # Iterate over bonds
+            k = 0        
             while k<p.bl.n:
                 # Bond type
-                t= p.bl.e[k]
-                k+=1
+                t = p.bl.e[k]
+                k += 1
                 # Iterate over bond partners and store each connection
                 for l in range(bonded_ia_params[t].num):
                     bonds.push_back(i)
                     bonds.push_back(p.bl.e[k])
                     bonds.push_back(t)
-                    k+=1
+                    k += 1
             j += 1
         assert j == len(self.system.part)
         cdef int Nbonds = bonds.size()//3
@@ -169,9 +190,9 @@ cdef class mayaviLive:
         cdef particle p1,p2
         cdef double bond_vec[3]
         for n in range(Nbonds):
-            i =bonds[3*n]
-            j =bonds[3*n+1]
-            t =bonds[3*n+2]
+            i = bonds[3*n]
+            j = bonds[3*n+1]
+            t = bonds[3*n+2]
             get_particle_data(i,&p1)
             get_particle_data(j,&p2)
             bond_coords[n,:3] = p1.r.p 


### PR DESCRIPTION
Usually, particles are visualized according to their Lennard-Jones radius.  This is a slight drawback because this requires a LJ interaction of particles with the same type.  If this is not desirable for physical reasons these particles cannot be visualized.  Therefore we overload the visualizer in such a way that the user can define a custom mapping function from type to particle radius.  If this overload is not used it defaults to the previous behavior.

Example:  Set the radius for all particles (all types) to 0.5
````
visualizer = visualization.mayaviLive(system, lambda x: 0.5)
````