### PR TITLE
I fixed the User Guide with this simple trick ...

### DIFF
--- a/doc/ug/setup.tex
+++ b/doc/ug/setup.tex
@@ -161,7 +161,7 @@ set:
 
 
 \section{Setting global variables in Python}
-\label{sec:glob_vars_python}
+\label{sec:glob-vars-python}
 In analogy to the TCL interface global system variables can be read and 
 set in Python simply by accessing the attribute of the corresponding \es 
 Python object. Those variables that are already available in the Python 


### PR DESCRIPTION
As already laid out in #875 you should not use the underscore letter in `\label`.  This is because the `underscore` package makes the underscore an active character which breaks inside `\label`.  As I have already explained in the previous pull request the underscore wreaks havoc when used within `\label`.  It is ill-advised to use underscore characters in `\label` names.  Therefore, when your cursor reside in the curly braces belonging to a `\label` commands please do not press the underscore key on your keyboard.  If you are typing a `\label` in the User Guide the underscore symbol is not to be used.

## Don't use underscores in `\label` names, use a hyphen instead!