### PR TITLE
Add h5py package to Dockerfiles (needed for testing h5mdcore.

### DIFF
--- a/maintainer/docker/debian/Dockerfile
+++ b/maintainer/docker/debian/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    python python-numpy python-pyvtk \
+    python python-numpy python-pyvtk python-h5py\
     tcl-dev \
     git \
     pep8 \

--- a/maintainer/docker/opensuse/Dockerfile
+++ b/maintainer/docker/opensuse/Dockerfile
@@ -7,7 +7,7 @@ RUN zypper -n --gpg-auto-import-keys refresh \
   openmpi-devel \
   fftw3-devel \
   boost-devel libboost_serialization1_54_0 libboost_mpi1_54_0  libboost_filesystem1_54_0 libboost_test1_54_0 \
-  python python-numpy python-PyVTK \
+  python python-numpy python-PyVTK python-h5py\
   tcl-devel \
   git \
   python-pep8 \

--- a/maintainer/docker/ubuntu-cuda/Dockerfile
+++ b/maintainer/docker/ubuntu-cuda/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    python python-numpy \
+    python python-numpy python-h5py \
     tcl-dev \
     git \
     pep8 \

--- a/maintainer/docker/ubuntu-cuda/Dockerfile
+++ b/maintainer/docker/ubuntu-cuda/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update && apt-get install -y \
     python-pip \
     libpython-dev \
     libhdf5-openmpi-dev \
-    libhdf5-openmpi-10:amd64 \
-    libhdf5-10:amd64 \
 && pip install cython \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*

--- a/maintainer/docker/ubuntu-python3/Dockerfile
+++ b/maintainer/docker/ubuntu-python3/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    cython3 python3 python3-numpy \
+    cython3 python3 python3-numpy python3-h5py \
     tcl-dev \
     git \
     pep8 \

--- a/maintainer/docker/ubuntu/Dockerfile
+++ b/maintainer/docker/ubuntu/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    cython python python-numpy \
+    cython python python-numpy python-h5py \
     tcl-dev \
     git \
     pep8 \


### PR DESCRIPTION
Description of changes:
 - Additional python package for h5 files in the dockerfiles
 - Removing wrong packages in ubuntu-cuda Dockerfile

Is related to PR: #745 
