### PR TITLE
Uncomment pep8 check in build script.

### DIFF
--- a/maintainer/travis/build_cmake.sh
+++ b/maintainer/travis/build_cmake.sh
@@ -60,7 +60,7 @@ outp insource srcdir builddir \
     with_tcl with_python_interface myconfig check_procs
 
 # check indentation of python files
-#pep8 --filename=*.pyx,*.pxd,*.py --select=E111 $srcdir/src/python/espressomd/
+pep8 --filename=*.pyx,*.pxd,*.py --select=E111 $srcdir/src/python/espressomd/
 ec=$?
 if [ $ec -eq 0 ]; then
     echo ""


### PR DESCRIPTION
Fixes #922

Description of changes:
 - Uncommenting pep8 python file checks