### PR TITLE
utils: Enable mpi optimization for std::array

### DIFF
--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -28,7 +28,7 @@
 #include <iterator>
 #include <vector>
 
-#include <boost/serialization/array.hpp>
+#include "utils/serialization/array.hpp"
 
 template <size_t n, typename Scalar> class Vector {
 private:

--- a/src/core/utils/serialization/array.hpp
+++ b/src/core/utils/serialization/array.hpp
@@ -3,12 +3,12 @@
 
 #include <boost/version.hpp>
 
-/* New versions of boost alrady containt this
+/* New versions of boost already containt this
  * function
  * */
 #if BOOST_VERSION < 105600
-#include <boost/serialization/serialization.hpp>
 #include <array>
+#include <boost/serialization/serialization.hpp>
 
 namespace boost {
 namespace serialization {
@@ -18,9 +18,19 @@ void serialize(Archive &ar, std::array<T, N> &a, const unsigned int) {
 }
 }
 }
-
 #else
 #include <array>
 #include <boost/serialization/serialization.hpp>
+#endif
+
+/* Will be included in boost from verison 1.63 */
+#if BOOST_VERSION <= 106200
+#include <boost/mpi/datatype_fwd.hpp>
+namespace boost {
+namespace mpi {
+template <class T, std::size_t N>
+struct is_mpi_datatype<std::array<T, N>> : public is_mpi_datatype<T> {};
+} /* namespace mpi */
+} /* namespace boost */
 #endif
 #endif

--- a/src/script_interface/ParallelScriptInterfaceSlave.hpp
+++ b/src/script_interface/ParallelScriptInterfaceSlave.hpp
@@ -23,8 +23,6 @@
 #define SCRIPT_INTERFACE_PARALLEL_SCRIPT_INTERFACE_SLAVE_HPP
 
 #include <boost/mpi/collectives.hpp>
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/array.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/string.hpp>
@@ -33,6 +31,7 @@
 
 #include "core/utils/parallel/InstanceCallback.hpp"
 #include "core/utils/parallel/ParallelObject.hpp"
+#include "core/utils/serialization/array.hpp"
 
 namespace ScriptInterface {
 


### PR DESCRIPTION
Fixes: Removes unnecessary MPI communication
Description of changes:
 - Enable is_mpi_datatype for std::array<T, N> iff is_mpi_datatype<T>


