### PR TITLE
Make calc_rg work in the python interface

### DIFF
--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -571,7 +571,7 @@ class Analysis:
     
     def calc_rg(self, chain_start=None, number_of_chains=None, chain_length=None):
         cdef double * rg = NULL
-        self.check_topology(system, chain_start, number_of_chains, chain_length)
+        self.check_topology(chain_start, number_of_chains, chain_length)
         c_analyze.calc_rg( & rg)
         tuple_rg = (rg[0], rg[1], rg[2])
         free(rg)


### PR DESCRIPTION
Calling the method `espressomd.System.analysis.calc_rg()` failed, since it internally tried to call   `check_topology()` with the undefined parameter `system`.

