### PR TITLE
script_interface: Accept ints for double parameters.

### DIFF
--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -58,6 +58,15 @@ cdef class PScriptInterface:
                     raise ValueError(
                         "Value of %s expected to be %i elements" % (name, n_elements))
 
+            # We accept floats for ints (but not the other way round)
+            if <int> type == <int> DOUBLE and isinstance(kwargs[pname], int):
+                kwargs[pname] = float(kwargs[pname])
+            # We already know that the argument is an iterable of the correct length
+            elif <int> type == <int> DOUBLE_VECTOR:
+                for i in range(len(kwargs[pname])):
+                    if isinstance(kwargs[pname][i], int):
+                        kwargs[pname][i] = float(kwargs[pname][i])
+
             v = self.python_object_to_variant(kwargs[pname])
 
             if v.which() == <int> type:


### PR DESCRIPTION
Fixes #935 

Description of changes:
 - Implicitly convert ints to double when setting parameters


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?

