### PR TITLE
pickle: only pickle the mass if its compiled in.

### DIFF
--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1236,6 +1236,8 @@ cdef class ParticleList:
         for i in ["director", "dip", "id"]:
             if i in pickle_attr:
                 pickle_attr.remove(i)
+        IF MASS == 0:
+            pickle_attr.remove("mass")
         odict = {}
         key_list = [p.id for p in self]
         for particle_number in key_list:


### PR DESCRIPTION
Description of changes:
 - if the mass feature is not compiled in the mass atribute is removed from the __getstate__ method otherwise the __setstate__ method would try to set the mass which is not supported.