### PR TITLE
You won’t believe why my simulation failed.

### DIFF
--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -114,6 +114,8 @@ def to_str(s):
         return unicode(s)
     else:
         return s
+
+
 cdef handle_errors(msg):
     errors = mpi_gather_runtime_errors()
     for err in errors:
@@ -123,6 +125,3 @@ cdef handle_errors(msg):
     # Cast because cython does not support typed enums completely
         if <int> err.level() == <int> ERROR:
             raise Exception(msg)
-
-    if not errors.empty() :
-        raise Exception(msg)


### PR DESCRIPTION
`handle_errors` gets all the runtime errors from the core and propagates them to the Python level, converting them to proper Python exceptions.  However, the last branch of the code
````
if not errors.empty() :		
    raise Exception(msg)
````
does not check whether the error is an actual error or only a warning.  This leads to funny problems with the LB.  In the first step LB has to recalculate all the coupling forces for obvious reasons.  This is signalled as a RuntimeWarning.  If one now calls another routine which calls `handle_errors` (e.g. `analysis.energy`) this RuntimeWarning will be caught and converted into an exception due to this last branch.  I don’t think this is intended and therefore I removed this branch.  If the error is of class RuntimeError and exception will still be raised, so the chief feature is retained.