### PR TITLE
H5md serial output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ include(RequireCXX11)
 # Boost
 #######################################################################
 
-find_package(Boost REQUIRED mpi serialization filesystem system)
+find_package(Boost REQUIRED mpi serialization filesystem system timer chrono)
 include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ list(APPEND LIBRARIES ${Boost_LIBRARIES})
 
 if(WITH_TESTS)
   enable_testing()
-  find_package(Boost COMPONENTS unit_test_framework timer chrono) 
+  find_package(Boost COMPONENTS unit_test_framework) 
   if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     set(WITH_UNIT_TESTS ON)
     list(APPEND LIBRARIES ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ include(RequireCXX11)
 # Boost
 #######################################################################
 
-find_package(Boost REQUIRED mpi serialization filesystem system timer chrono)
+find_package(Boost REQUIRED mpi serialization filesystem system)
 include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ list(APPEND LIBRARIES ${Boost_LIBRARIES})
 
 if(WITH_TESTS)
   enable_testing()
-  find_package(Boost COMPONENTS unit_test_framework) 
+  find_package(Boost COMPONENTS unit_test_framework timer chrono) 
   if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     set(WITH_UNIT_TESTS ON)
     list(APPEND LIBRARIES ${Boost_LIBRARIES})

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -16,8 +16,14 @@ sys.cell_system.skin = 0.4
 
 for i in range(1000):
     sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
+sys.non_bonded_inter[0, 0].lennard_jones.set_params(
+		    epsilon=1, sigma=1,
+		    cutoff=2.3, shift="auto")
 sys.integrator.run(steps=10)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False)
+                    write_force=True, write_type=True, write_mass=False,write_ordered=True)
+h5_file.write()
+sys.part.add(id=1000, pos=np.random.random(3) * sys.box_l, type=23)
+sys.integrator.run(steps=1000)
 h5_file.write()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -16,8 +16,9 @@ sys.cell_system.skin = 0.4
 
 for i in range(1000):
     sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
-sys.integrator.run(steps=10)
+sys.non_bonded_inter[0, 0].lennard_jones.set_params(epsilon=1, sigma=1,cutoff=2.3, shift="auto")
+sys.integrator.run(steps=100)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False)
+                    write_force=True, write_type=True, write_mass=False, write_ordered=True)
 h5_file.write()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -16,14 +16,8 @@ sys.cell_system.skin = 0.4
 
 for i in range(1000):
     sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
-sys.non_bonded_inter[0, 0].lennard_jones.set_params(
-		    epsilon=1, sigma=1,
-		    cutoff=2.3, shift="auto")
 sys.integrator.run(steps=10)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False,write_ordered=True)
-h5_file.write()
-sys.part.add(id=1000, pos=np.random.random(3) * sys.box_l, type=23)
-sys.integrator.run(steps=1000)
+                    write_force=True, write_type=True, write_mass=False)
 h5_file.write()
 h5_file.close()

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -268,27 +268,23 @@ void File::Write(int write_dat)
     bool write_force = write_dat & W_F;
     bool write_mass = write_dat & W_MASS;
 
-    int num_particles_to_be_written;
-    int remainder=0;
-    
+    std::cout << "ordered " << m_write_ordered << std::endl;
+
     if (m_write_ordered==true) {
-    	num_particles_to_be_written=std::floor(n_part/n_nodes);
+    	int npart=max_seen_particle+1;
+    	int num_particles_to_be_written=std::floor(npart/n_nodes);
+    	int remainder=0;
     	if(this_node==n_nodes-1)
-    		remainder=n_part%num_particles_to_be_written;
-     }else{
-         /* Get the number of particles on each node. */
-        num_particles_to_be_written = cells_get_n_particles();       
-     }
+    		remainder=npart%num_particles_to_be_written;
         
-    double_array_3d pos(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    double_array_3d vel(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    double_array_3d f(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    int_array_3d image(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    int_array_3d id(boost::extents[1][num_particles_to_be_written+remainder][1]);
-    int_array_3d typ(boost::extents[1][num_particles_to_be_written+remainder][1]);
-    double_array_3d mass(boost::extents[1][num_particles_to_be_written+remainder][1]);
-    
-    if(m_write_ordered==true){
+        
+        double_array_3d pos(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        double_array_3d vel(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        double_array_3d f(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        int_array_3d image(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        int_array_3d id(boost::extents[1][num_particles_to_be_written+remainder][1]);
+        int_array_3d typ(boost::extents[1][num_particles_to_be_written+remainder][1]);
+        double_array_3d mass(boost::extents[1][num_particles_to_be_written+remainder][1]);
         //loop over all particles
         for(int particle_index=this_node*num_particles_to_be_written;particle_index<(this_node+1)*num_particles_to_be_written+remainder;particle_index++){
             	Particle current_particle;
@@ -327,7 +323,48 @@ void File::Write(int write_dat)
 		free_particle(&current_particle);
 
         }
-    } else {
+
+        if (n_part > m_max_n_part) {
+        	m_max_n_part = n_part;
+        }
+
+        WriteDataset(id, "particles/atoms/id");
+
+        if (write_typ)
+        {
+            WriteDataset(typ, "particles/atoms/type");
+            printf("write type%d \n", this_node);
+        }
+        if (write_mass)
+        {
+            WriteDataset(mass, "particles/atoms/mass");
+        }
+        if (write_pos)
+        {
+            WriteDataset(pos, "particles/atoms/position");
+            WriteDataset(image, "particles/atoms/image");
+            printf("write pos%d \n", this_node);
+        }
+        if (write_vel)
+        {
+            WriteDataset(vel, "particles/atoms/velocity");
+        }
+        if (write_force)
+        {
+            WriteDataset(f, "particles/atoms/force");
+            printf("write force%d \n", this_node);
+        }
+    }else{
+        /* Get the number of particles on all other nodes. */
+        int nlocalpart = cells_get_n_particles();
+        double_array_3d pos(boost::extents[1][nlocalpart][3]);
+        double_array_3d vel(boost::extents[1][nlocalpart][3]);
+        double_array_3d f(boost::extents[1][nlocalpart][3]);
+        int_array_3d image(boost::extents[1][nlocalpart][3]);
+        int_array_3d id(boost::extents[1][nlocalpart][1]);
+        int_array_3d typ(boost::extents[1][nlocalpart][1]);
+        double_array_3d mass(boost::extents[1][nlocalpart][1]);
+
         /* Prepare data for writing, loop over all local cells. */
         Cell *local_cell;
         int particle_index = 0;
@@ -376,34 +413,35 @@ void File::Write(int write_dat)
                 particle_index++;
             }
         }
-    
-    }
-    if (n_part > m_max_n_part) {
-    	m_max_n_part = n_part;
-    }
 
-    WriteDataset(id, "particles/atoms/id");
+        int n_part = max_seen_particle+1;
+        if (n_part > m_max_n_part) {
+        	m_max_n_part = n_part;
+        }
 
-    if (write_typ)
-    {
-        WriteDataset(typ, "particles/atoms/type");
-    }
-    if (write_mass)
-    {
-        WriteDataset(mass, "particles/atoms/mass");
-    }
-    if (write_pos)
-    {
-        WriteDataset(pos, "particles/atoms/position");
-        WriteDataset(image, "particles/atoms/image");
-    }
-    if (write_vel)
-    {
-        WriteDataset(vel, "particles/atoms/velocity");
-    }
-    if (write_force)
-    {
-        WriteDataset(f, "particles/atoms/force");
+        WriteDataset(id, "particles/atoms/id");
+
+        if (write_typ)
+        {
+            WriteDataset(typ, "particles/atoms/type");
+        }
+        if (write_mass)
+        {
+            WriteDataset(mass, "particles/atoms/mass");
+        }
+        if (write_pos)
+        {
+            WriteDataset(pos, "particles/atoms/position");
+            WriteDataset(image, "particles/atoms/image");
+        }
+        if (write_vel)
+        {
+            WriteDataset(vel, "particles/atoms/velocity");
+        }
+        if (write_force)
+        {
+            WriteDataset(f, "particles/atoms/force");
+        }
     }
 }
 

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -55,10 +55,14 @@ create_dims(hsize_t dim, hsize_t size, hsize_t chunk_size=0)
 #ifdef H5MD_DEBUG
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
 #endif
-    if (dim > 0)
+    if (dim == 3)
         return std::vector<hsize_t>{chunk_size, size, dim};
-    else
+    if (dim == 2)
+        return std::vector<hsize_t>{size, dim};
+    if (dim == 1)
         return std::vector<hsize_t>{size};
+    else
+        throw std::runtime_error("H5MD Error: datastets with this dimension are not implemented\n");
 }
 
 static std::vector<hsize_t> create_maxdims(hsize_t dim, hsize_t size)
@@ -140,28 +144,28 @@ void File::init_filestructure()
     hsize_t npart = static_cast<hsize_t>(n_part);
     dataset_descriptors = {
             //path, dim, size, type
-        { "particles/atoms/box/edges"     , 0, 3    , type_double },
-        { "particles/atoms/mass/value"    , 1, npart, type_double },
-        { "particles/atoms/mass/time"     , 1, 1    , type_double },
-        { "particles/atoms/mass/step"     , 1, 1    , type_int },
-        { "particles/atoms/id/value"      , 1, npart, type_int },
-        { "particles/atoms/id/time"       , 1, 1    , type_double },
-        { "particles/atoms/id/step"       , 1, 1    , type_int },
-        { "particles/atoms/type/value"    , 1, npart, type_int },
-        { "particles/atoms/type/time"     , 1, 1    , type_double },
-        { "particles/atoms/type/step"     , 1, 1    , type_int },
-        { "particles/atoms/position/value", 3, npart, type_double },
-        { "particles/atoms/position/time" , 1, 1    , type_double },
-        { "particles/atoms/position/step" , 1, 1    , type_int },
-        { "particles/atoms/velocity/value", 3, npart, type_double },
-        { "particles/atoms/velocity/time" , 1, 1    , type_double },
-        { "particles/atoms/velocity/step" , 1, 1    , type_int },
-        { "particles/atoms/force/value"   , 3, npart, type_double },
-        { "particles/atoms/force/time"    , 1, 1    , type_double },
-        { "particles/atoms/force/step"    , 1, 1    , type_int },
-        { "particles/atoms/image/value"   , 3, npart, type_int },
-        { "particles/atoms/image/time"    , 1, 1    , type_double },
-        { "particles/atoms/image/step"    , 1, 1    , type_int },
+        { "particles/atoms/box/edges"     , 1, type_double },
+        { "particles/atoms/mass/value"    , 2, type_double },
+        { "particles/atoms/mass/time"     , 1, type_double },
+        { "particles/atoms/mass/step"     , 1, type_int },
+        { "particles/atoms/id/value"      , 2, type_int },
+        { "particles/atoms/id/time"       , 1, type_double },
+        { "particles/atoms/id/step"       , 1, type_int },
+        { "particles/atoms/type/value"    , 2, type_int },
+        { "particles/atoms/type/time"     , 1, type_double },
+        { "particles/atoms/type/step"     , 1, type_int },
+        { "particles/atoms/position/value", 3, type_double },
+        { "particles/atoms/position/time" , 1, type_double },
+        { "particles/atoms/position/step" , 1, type_int },
+        { "particles/atoms/velocity/value", 3, type_double },
+        { "particles/atoms/velocity/time" , 1, type_double },
+        { "particles/atoms/velocity/step" , 1, type_int },
+        { "particles/atoms/force/value"   , 3, type_double },
+        { "particles/atoms/force/time"    , 1, type_double },
+        { "particles/atoms/force/step"    , 1, type_int },
+        { "particles/atoms/image/value"   , 3, type_int },
+        { "particles/atoms/image/time"    , 1, type_double },
+        { "particles/atoms/image/step"    , 1, type_int },
     };
 }
 
@@ -200,17 +204,19 @@ void File::create_datasets(bool only_load)
                 datasets[path] = h5xx::dataset(groups[father],
                                                basename);
             } else {
-                auto dims = create_dims(descr.dim, descr.size);
-                auto cdims = create_dims(descr.dim, descr.size, 1);
-                auto maxdims = create_maxdims(descr.dim, descr.size);
-                auto storage = h5xx::policy::storage::chunked(cdims).set(
+                int creation_size_dataset=0;
+                int chunk_size=1;
+                if(descr.dim>1){
+                    //we deal now with a particle based property
+                    chunk_size=n_part;
+                }
+                auto dims = create_dims(descr.dim, creation_size_dataset);
+                auto chunk_dims = create_dims(descr.dim, chunk_size, 1);
+                auto maxdims = create_maxdims(descr.dim, creation_size_dataset);
+                auto storage = h5xx::policy::storage::chunked(chunk_dims).set(
                         h5xx::policy::storage::fill_value(-10));
                 auto dataspace = h5xx::dataspace(dims, maxdims);
-                datasets[path] = h5xx::dataset(groups[father],
-                                               basename,
-                                               descr.type,
-                                               dataspace,
-                                               storage);
+                datasets[path] = h5xx::dataset(groups[father],basename, descr.type,dataspace,storage);
             }
         }
     }
@@ -227,7 +233,8 @@ void File::load_file(const std::string& filename)
     std::cout << "Finished opening the h5 file on node " << this_node << std::endl;
 #endif
     create_groups();
-    create_datasets(true);
+    bool only_load = true;
+    create_datasets(only_load);
 }
 
 void File::create_new_file(const std::string &filename)
@@ -241,11 +248,15 @@ void File::create_new_file(const std::string &filename)
                              h5xx::file::out);
 
     create_groups();
-    create_datasets(false);
+    bool only_load = false;
+    create_datasets(only_load);
     std::vector<double> boxvec = {box_l[0], box_l[1], box_l[2]};
     h5xx::write_attribute(groups["particles/atoms/box"], "dimension", 3);
     h5xx::write_attribute(groups["particles/atoms/box"], "boundary", "periodic");
-    h5xx::write_dataset(datasets["particles/atoms/box/edges"], boxvec);
+    std::string path_edges="particles/atoms/box/edges";
+    int extent_edges = 3;
+    ExtendDataset(path_edges, extent_edges);
+    h5xx::write_dataset(datasets[path_edges], boxvec);
 }
 
 
@@ -358,41 +369,29 @@ void File::Write(int write_dat)
 }
 
 
-void File::ExtendDataset(std::string path ){
+void File::ExtendDataset(std::string path, int extent=1){
     /* Until now the h5xx does not support dataset extending, so we
        have to use the lower level hdf5 library functions. */
-        /* Get the number of particles on all other nodes. */
-    int n_part = max_seen_particle+1;
-    if (n_part > m_max_n_part) {
-    	m_max_n_part = n_part;
-    }
-    
-    auto& dataset = datasets[path + "/value"];
-    auto& time = datasets[path + "/time"];
-    auto& step = datasets[path + "/step"];
+    auto& dataset = datasets[path];
     /* Get the current dimensions of the dataspace. */
     hid_t ds = H5Dget_space(dataset.hid());
-    hsize_t dims[3], maxdims[3];
+    hsize_t rank = H5Sget_simple_extent_ndims(ds);
+    hsize_t dims[rank], maxdims[rank];
     H5Sget_simple_extent_dims(ds, dims, maxdims);
     H5Sclose(ds);
     /* Extend the dataset for another timestep. */
-    dims[0] += 1;
-    dims[1] = m_max_n_part;
+    dims[0] += extent;
+    
+    // Extend the dataset for more particles if the particle number increased
+    if(rank>1){
+        /* Get the number of particles on all other nodes. */
+        int n_part = max_seen_particle+1;
+        if (n_part > m_max_n_part) {
+        	m_max_n_part = n_part;
+        }
+        dims[1] = m_max_n_part;
+    }
     H5Dset_extent(dataset.hid(), dims); //extend all dims is collective
-    
-    /* Extend time dataset */
-    ds = H5Dget_space(time.hid());
-    H5Sget_simple_extent_dims(ds, dims, maxdims);
-    H5Sclose(ds);
-    dims[0] += 1;
-    H5Dset_extent(time.hid(), dims);
-    
-    /* Same offset, count and dims as the time dataset */
-    ds = H5Dget_space(step.hid());
-    H5Sget_simple_extent_dims(ds, dims, maxdims);
-    H5Sclose(ds);
-    dims[0] += 1;
-    H5Dset_extent(step.hid(), dims);
 }
 
 /* data is assumed to be three dimensional */
@@ -405,35 +404,43 @@ void File::WriteDataset(T &data, const std::string& path, int_array_3d id )
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
     std::cout << "Dataset: " << path << std::endl;
 #endif
-H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
-    ExtendDataset(path);
+    H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
     auto& dataset = datasets[path + "/value"];
+    ExtendDataset(path+ "/value");
     auto& time = datasets[path + "/time"];
+    ExtendDataset(path+ "/time");
     auto& step = datasets[path + "/step"];
+    ExtendDataset(path+ "/step");
 
     int num_particles_to_be_written = data.shape()[1];
     int prefix = 0;
     hid_t ds = H5Dget_space(dataset.hid());
+    hsize_t rank = H5Sget_simple_extent_ndims(ds);
     /* Get the current dimensions of the dataspace. */
-    hsize_t dims[3], maxdims[3];
+    hsize_t dims[rank], maxdims[rank];
     H5Sget_simple_extent_dims(ds, dims, maxdims);
     /* Select the region in the dataspace. */
-    hsize_t offset[3];
-    hsize_t count[3];
+    hsize_t offset[rank];
+    hsize_t count[rank];
     hid_t ds_new;
     if(m_write_ordered==false){
         ds = H5Dget_space(dataset.hid());
         //calculate offset (prefix) based on local particle number
         MPI_Exscan(&num_particles_to_be_written, &prefix, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
         offset[0]= dims[0]-1;
-        offset[1]= static_cast<hsize_t>(prefix);
-        offset[2]= 0;
         count [0] = 1;
-        count [1] = static_cast<hsize_t>(num_particles_to_be_written);
-        count [2] = data.shape()[2];
+        if(rank>1){
+            offset[1]= static_cast<hsize_t>(prefix);
+            count [1] = static_cast<hsize_t>(num_particles_to_be_written);
+        }
+        if(rank>2){
+            offset[2]= 0;
+            count [2] = data.shape()[2];
+        }
+            
         H5Sselect_hyperslab(ds, H5S_SELECT_SET, offset, NULL, count, NULL);
         /* Create a temporary dataspace. */
-        ds_new = H5Screate_simple(3, count, maxdims);
+        ds_new = H5Screate_simple(rank, count, maxdims);
         /* Finally write the data to the dataset. */
         H5Dwrite(dataset.hid(),
                  dataset.get_type(),
@@ -447,14 +454,18 @@ H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
             ds = H5Dget_space(dataset.hid());
             prefix=id[0][i][0];
             offset[0]= dims[0]-1;
-            offset[1]= static_cast<hsize_t>(prefix);
-            offset[2]= 0;
-            count[0]= 1;
-            count[1]= 1;
-            count[2]= data.shape()[2];
+            count[0]= 1; 
+            if(rank>1){
+                offset[1]= static_cast<hsize_t>(prefix);
+                count[1]= 1; 
+            }
+            if(rank>2){
+                offset[2]= 0;
+                count[2]= data.shape()[2];
+            }
             H5Sselect_hyperslab(ds, H5S_SELECT_SET, offset, NULL, count, NULL);
             /* Create a temporary dataspace. */
-            ds_new = H5Screate_simple(3, count, maxdims);
+            ds_new = H5Screate_simple(rank, count, maxdims);
             /* Finally write the data to the dataset. */
             T data_single_particle(boost::extents[1][1][3]);
             data_single_particle[0][0][0]=data[0][i][0];
@@ -468,28 +479,31 @@ H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
 
     /* Write the md time to the position -- time dataset. */
     ds = H5Dget_space(time.hid());
-    H5Sget_simple_extent_dims(ds, dims, maxdims);
+    rank = H5Sget_simple_extent_ndims(ds);
+    hsize_t dims_time[rank];
+    hsize_t maxdims_time[rank];
+    H5Sget_simple_extent_dims(ds, dims_time, maxdims_time);
 
-    hsize_t timeoffset[3] = {dims[0]-1, 0, 0};
-    hsize_t timecount[3] = {0, 0, 0};
+    hsize_t time_offset[rank];
+    time_offset[0] = dims_time[0]-1;
+    hsize_t time_count[rank];
+    time_count[0] = 0;
     /* Only master node writes time and timestep */
     if (this_node == 0)
-        timecount[0] = timecount[1] = timecount[2] = 1;
-    H5Sselect_hyperslab(ds, H5S_SELECT_SET, timeoffset, NULL, timecount, NULL);
-    ds_new = H5Screate_simple(1, timecount, maxdims);
+        time_count[0] = 1; //write 1 timestep
+    H5Sselect_hyperslab(ds, H5S_SELECT_SET, time_offset, NULL, time_count, NULL);
+    ds_new = H5Screate_simple(rank, time_count, maxdims_time);
     H5Dwrite(time.hid(),
              time.get_type(),
              ds_new,
              ds, H5P_DEFAULT,
              &sim_time);
-    H5Sclose(ds_new);
     H5Sclose(ds);
     /* Write the md step to the position -- step dataset. */
     /* Same offset, count and dims as the time dataset */
     ds = H5Dget_space(step.hid());
-    H5Sget_simple_extent_dims(ds, dims, maxdims);
-    H5Sselect_hyperslab(ds, H5S_SELECT_SET, timeoffset, NULL, timecount, NULL);
-    ds_new = H5Screate_simple(1, timecount, maxdims);
+    H5Sget_simple_extent_dims(ds, dims_time, maxdims_time);
+    H5Sselect_hyperslab(ds, H5S_SELECT_SET, time_offset, NULL, time_count, NULL);
     int sim_step_data = (int)std::round(sim_time/time_step);
     H5Dwrite(step.hid(),
              step.get_type(),

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -146,7 +146,7 @@ void File::init_filestructure()
         { "particles/atoms/id/value"      , 1, npart, type_int },
         { "particles/atoms/id/time"       , 1, 1    , type_double },
         { "particles/atoms/id/step"       , 1, 1    , type_int },
-        { "particles/atoms/type/value"    , 1, npart, type_double },
+        { "particles/atoms/type/value"    , 1, npart, type_int },
         { "particles/atoms/type/time"     , 1, 1    , type_double },
         { "particles/atoms/type/step"     , 1, 1    , type_int },
         { "particles/atoms/position/value", 3, npart, type_double },

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -84,7 +84,7 @@ void File::InitFile()
 #endif
     boost::filesystem::path script_path(m_scriptname);
     m_absolute_script_path = boost::filesystem::canonical(script_path);
-    if(!(cells_get_n_particles() > 0)) {
+    if(n_part <= 0) {
         throw std::runtime_error("Please first set up particles before initializing the H5md object.");
     }
 

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -120,9 +120,9 @@ class File
         void WriteDataset(T &data, const std::string& path, int_array_3d id);
         
         /**
-         * @brief Method that calls WriteDataset to write all datasets.
-         */        
-        void WriteAllDatasets(int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f,bool write_typ,bool write_mass,bool write_pos, bool write_vel, bool write_force);
+         * @brief create chunk dataset dimensions.
+         */  	
+	std::vector<hsize_t> create_chunk_dims(hsize_t dim, hsize_t size, hsize_t chunk_size);
 
         /**
          * @brief Method that extends datasets.

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -111,12 +111,24 @@ class File
          * @return TRUE if H5MD structure is present, FALSE else.
          */
         bool check_for_H5MD_structure(std::string const &filename);
+        
         /**
          * @brief Method that performs all the low-level stuff for writing the particle
          * positions to the dataset.
          */
         template <typename T>
-        void WriteDataset(T &data, const std::string& path);
+        void WriteDataset(T &data, const std::string& path, int_array_3d id);
+        
+        /**
+         * @brief Method that calls WriteDataset to write all datasets.
+         */        
+        void WriteAllDatasets(int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f,bool write_typ,bool write_mass,bool write_pos, bool write_vel, bool write_force);
+
+        /**
+         * @brief Method that extends datasets.
+         */            
+        void ExtendDataset(std::string path );
+        
         /*
          * @brief Method to fill the arrays that are used by WriteDataset particle by particle.
          */

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -127,7 +127,7 @@ class File
         /**
          * @brief Method that extends datasets.
          */            
-        void ExtendDataset(std::string path );
+        void ExtendDataset(std::string path, int extent);
         
         /*
          * @brief Method to fill the arrays that are used by WriteDataset particle by particle.
@@ -181,7 +181,6 @@ class File
         struct DatasetDescriptor  {
             std::string path;
             hsize_t dim;
-            hsize_t size;
             h5xx::datatype type;
         };
         std::vector<std::string> group_names;

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -118,6 +118,10 @@ class File
         template <typename T>
         void WriteDataset(T &data, const std::string& path);
         /*
+         * @brief Method to fill the arrays that are used by WriteDataset particle by particle.
+         */
+	void fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, Particle* current_particle, bool write_typ,bool write_mass,bool write_pos, bool write_vel, bool write_force );
+        /*
          * @brief Method to write the simulation script to the dataset.
          */
         void WriteScript(std::string const &filename);

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -37,6 +37,7 @@
 #include <boost/filesystem.hpp>
 #undef BOOST_NO_CXX11_SCOPED_ENUMS
 #include <h5xx/h5xx.hpp>
+#include "communication.hpp"
 
 
 extern double sim_time;
@@ -94,6 +95,8 @@ class File
         std::string &scriptname() { return m_scriptname; };
         // Returns the int that describes which data should be written to the dataset.
         int &what() { return m_what; };
+        // Returns the boolean value that describes whether data should be written to the dataset in the order of ids (possibly slower on output for many particles).
+        bool &write_ordered() {return m_write_ordered;} ;
 
     private:
         bool check_file_exists(const std::string &name)
@@ -154,6 +157,7 @@ class File
         std::string m_filename;
         std::string m_scriptname;
         int m_what;
+        bool m_write_ordered;
         std::string m_backup_filename;
         boost::filesystem::path m_absolute_script_path = "NULL";
         h5xx::file m_h5md_file;

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -345,19 +345,19 @@ void free_particle(Particle *part) {
 int updatePartCfg(int bonds_flag)
 {
   int j;
-
+printf("00001000\n");
   if(partCfg)
     return 1;
-
+printf("00002000\n");
   partCfg = (Particle*)Utils::malloc(n_part*sizeof(Particle));
   if (bonds_flag != WITH_BONDS)
     mpi_get_particles(partCfg, NULL);
   else
     mpi_get_particles(partCfg,&partCfg_bl);
-
+printf("00003000\n");
   for(j=0; j<n_part; j++)
     unfold_position(partCfg[j].r.p, partCfg[j].m.v, partCfg[j].l.i);
-
+printf("00004000\n");
   partCfgSorted = 0;
 #ifdef VIRTUAL_SITES
 

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -345,19 +345,15 @@ void free_particle(Particle *part) {
 int updatePartCfg(int bonds_flag)
 {
   int j;
-printf("00001000\n");
   if(partCfg)
     return 1;
-printf("00002000\n");
   partCfg = (Particle*)Utils::malloc(n_part*sizeof(Particle));
   if (bonds_flag != WITH_BONDS)
     mpi_get_particles(partCfg, NULL);
   else
     mpi_get_particles(partCfg,&partCfg_bl);
-printf("00003000\n");
   for(j=0; j<n_part; j++)
     unfold_position(partCfg[j].r.p, partCfg[j].m.v, partCfg[j].l.i);
-printf("00004000\n");
   partCfgSorted = 0;
 #ifdef VIRTUAL_SITES
 

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -91,6 +91,7 @@ foreach(cython_file ${cython_SRC})
                          -I ${CMAKE_CURRENT_SOURCE_DIR}/_espresso
                          ${cython_file}
                          -o ${outputpath}
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
                          DEPENDS _espresso/myconfig.pxi ${cython_file}
                                  ${cython_HEADER}
                          )

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -53,7 +53,7 @@ class H5md(object):
             elif i not in self.valid_params:
                 raise ValueError("Unknown parameter {} for H5MD writer.".format(i))
         
-        write_ordered_default=True
+        write_ordered_default=False
         self.write_ordered=kwargs.get('write_ordered',write_ordered_default)
         
         self.h5md_instance = PScriptInterface("ScriptInterface::Writer::H5mdScript")

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -30,8 +30,10 @@ class H5md(object):
                      If types should be written.
         write_mass : bool, optional
                      If masses should be written.
+        write_ordered: bool, optional
+                       If particle properties should be ordered according to ids.
         """
-        self.valid_params = ['filename',]
+        self.valid_params = ['filename','write_ordered',]
         if 'filename' not in kwargs:
             raise ValueError("'filename' parameter missing.")
         self.what = {'write_pos': 1<<0,
@@ -50,9 +52,13 @@ class H5md(object):
                     raise ValueError("{} has to be a bool value.".format(i))
             elif i not in self.valid_params:
                 raise ValueError("Unknown parameter {} for H5MD writer.".format(i))
+        
+        write_ordered_default=True
+        self.write_ordered=kwargs.get('write_ordered',write_ordered_default)
+        
         self.h5md_instance = PScriptInterface("ScriptInterface::Writer::H5mdScript")
         self.h5md_instance.set_params(filename=kwargs['filename'], what=self.what_bin,
-                                      scriptname=sys.argv[0])
+                                      scriptname=sys.argv[0], write_ordered=self.write_ordered)
         self.h5md_instance.call_method("init_file")
 
 

--- a/src/script_interface/h5md/h5md.cpp
+++ b/src/script_interface/h5md/h5md.cpp
@@ -35,7 +35,9 @@ ParameterMap H5mdScript::valid_parameters() const
 {
     return {{"filename", {ParameterType::STRING, true}},
             {"scriptname", {ParameterType::STRING, true}},
-            {"what", {ParameterType::INT, true}}};
+            {"what", {ParameterType::INT, true}},
+            {"write_ordered", {ParameterType::BOOL, true}}
+            };
 }
 
 
@@ -44,6 +46,7 @@ void H5mdScript::set_parameter(const std::string& name, const Variant& value)
     SET_PARAMETER_HELPER("filename", m_h5md->filename());
     SET_PARAMETER_HELPER("scriptname", m_h5md->scriptname());
     SET_PARAMETER_HELPER("what", m_h5md->what());
+    SET_PARAMETER_HELPER("write_ordered", m_h5md->write_ordered());
 }
 
 
@@ -51,7 +54,9 @@ VariantMap H5mdScript::get_parameters() const
 {
     return {{"filename", m_h5md->filename()},
             {"scriptname", m_h5md->scriptname()},
-            {"what", m_h5md->what()}};
+            {"what", m_h5md->what()},
+            {"write_ordered", m_h5md->write_ordered()},
+            };
 }
 
 

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -49,7 +49,7 @@ class H5mdTest(ut.TestCase):
                 self.system.part[i].ext_force = [0.1, 0.2, 0.3]
         self.system.integrator.run(steps=0)
         self.h5 = h5md.H5md(filename="test.h5", write_pos=True, write_vel=True,
-                            write_force=True, write_type=True, write_mass=True)
+                            write_force=True, write_type=True, write_mass=True, write_ordered=True)
         self.h5.write()
         self.h5.close()
         del self.h5


### PR DESCRIPTION
Description of changes:
Allows to optionally write h5md files where positions etc. are ordered according to ids. The current implementation however only works in the single process mode since it relies on the existence of the global partCfg array. Still positions/types/charges/masses/images/etc. which have a fixed order remove the need to sort the h5md content and therefore this change eases the analysis of the obtained data.