### PR TITLE
Defer visualizer import errors to when visualizer is instantiated

### DIFF
--- a/src/python/espressomd/visualization.pyx
+++ b/src/python/espressomd/visualization.pyx
@@ -1,3 +1,15 @@
-from .visualizationMayavi import mayaviLive
-from .visualizationOpenGL import openGLLive
+try:
+    from .visualizationMayavi import mayaviLive
+except ImportError as e:
+    class mayaviLive:
+        def __init__(*args, **kwargs):
+            raise e
+
+try:
+    from .visualizationOpenGL import openGLLive
+except ImportError as e:
+    class openGLLive:
+        def __init__(*args, **kwargs):
+            raise e
+
 __all__ = ['mayaviLive', 'openGLLive']


### PR DESCRIPTION
@KonradBreitsprecher: Thischange  allows using one visualizer if the other's dependencies are not met. Previously, the following would fail if mayavi wasn't installed: 
```
from espressomd.visualization import openGLLive
```