### PR TITLE
script_interface: Make sure that parallel wrapper instances are kept …

### DIFF
--- a/src/script_interface/ParallelScriptInterface.cpp
+++ b/src/script_interface/ParallelScriptInterface.cpp
@@ -126,6 +126,16 @@ Variant ParallelScriptInterface::call_method(const std::string &name,
   return m_p->call_method(name, p);
 }
 
+Variant ParallelScriptInterface::get_parameter(std::string const &name) const {
+  auto p = m_p->get_parameter(name);
+
+  if (is_objectid(p)) {
+    return map_local_to_parallel_id(name, p);
+  } else {
+    return p;
+  }
+}
+
 std::map<std::string, Variant> ParallelScriptInterface::get_parameters() const {
   auto p = m_p->get_parameters();
 

--- a/src/script_interface/ParallelScriptInterface.cpp
+++ b/src/script_interface/ParallelScriptInterface.cpp
@@ -178,6 +178,12 @@ ParallelScriptInterface::map_parallel_to_local_id(std::string const &name,
 
     /* and return the id of the underlying object */
     return po_ptr->get_underlying_object()->id();
+  } else if (so_ptr == nullptr) {
+    /* Release the object */
+    obj_map.erase(name);
+
+    /* Return None */
+    return ObjectId();
   } else {
     throw std::runtime_error(
         "Parameters passed to Parallel entities must also be parallel.");

--- a/src/script_interface/ParallelScriptInterface.cpp
+++ b/src/script_interface/ParallelScriptInterface.cpp
@@ -83,6 +83,8 @@ void ParallelScriptInterface::set_parameter(const std::string &name,
   boost::mpi::broadcast(Communication::mpiCallbacks().comm(), d, 0);
 
   m_p->set_parameter(d.first, d.second);
+
+  collect_garbage();
 }
 
 void ParallelScriptInterface::set_parameters(const VariantMap &parameters) {
@@ -101,6 +103,8 @@ void ParallelScriptInterface::set_parameters(const VariantMap &parameters) {
   boost::mpi::broadcast(Communication::mpiCallbacks().comm(), p, 0);
 
   m_p->set_parameters(p);
+
+  collect_garbage();
 }
 
 Variant ParallelScriptInterface::call_method(const std::string &name,
@@ -143,7 +147,7 @@ ParallelScriptInterface::map_local_to_parallel_id(std::string const &name,
    * has the same id everywhere.
    */
   if (boost::get<ObjectId>(value) != ObjectId()) {
-    return obj_map.at(name);
+    return obj_map.at(name)->id();
   } else {
     return value;
   }
@@ -160,15 +164,32 @@ ParallelScriptInterface::map_parallel_to_local_id(std::string const &name,
 
   if (po_ptr != nullptr) {
     /* Store a pointer to the object */
-    obj_map[name] = po_ptr->id();
+    obj_map[name] = po_ptr;
 
     /* and return the id of the underlying object */
-    auto underlying_object = po_ptr->get_underlying_object();
-
-    return underlying_object->id();
+    return po_ptr->get_underlying_object()->id();
   } else {
     throw std::runtime_error(
         "Parameters passed to Parallel entities must also be parallel.");
+  }
+}
+
+void ParallelScriptInterface::collect_garbage() {
+  /* Removal condition, the instance is removed iff
+     its payload is not used anywhere. In this case
+     the reference count is one, because the host object
+     still holds a pointer.
+  */
+  auto pred = [](map_t::value_type const &e) -> bool {
+    return e.second->get_underlying_object().use_count() == 1;
+  };
+
+  for (auto it = obj_map.begin(); it != obj_map.end();) {
+    if (pred(*it)) {
+      obj_map.erase(it++);
+    } else {
+      ++it;
+    }
   }
 }
 

--- a/src/script_interface/ParallelScriptInterface.hpp
+++ b/src/script_interface/ParallelScriptInterface.hpp
@@ -61,6 +61,7 @@ public:
     return m_p->valid_parameters();
   }
 
+  Variant get_parameter(const std::string &name) const override;
   VariantMap get_parameters() const override;
   Variant call_method(const std::string &name,
                       const VariantMap &parameters) override;

--- a/src/script_interface/ParallelScriptInterface.hpp
+++ b/src/script_interface/ParallelScriptInterface.hpp
@@ -72,14 +72,21 @@ public:
                                    Variant const &value);
 
 private:
+  using map_t = std::map<std::string, std::shared_ptr<ParallelScriptInterface>>;
+
   void call(CallbackAction action) {
     Communication::mpiCallbacks().call(m_callback_id, static_cast<int>(action));
   }
 
+  /**
+   * @brief Remove instances that are not used by anybody but us.
+   */
+  void collect_garbage();
+
   /* Data members */
   int m_callback_id;
   std::shared_ptr<ScriptInterfaceBase> m_p;
-  std::map<std::string, ObjectId> obj_map;
+  map_t obj_map;
 };
 
 } /* namespace ScriptInterface */


### PR DESCRIPTION
…alive when their payload is still used. Fixes #968.

Fixes #968 

Description of changes:
 - When passing object parameters to the payload, the host instance keeps a shared_ptr to
   the host object of the passed object. This keeps it alive. After the call to the payload returned,
  the ref count of the payload of all stored host classes is check to see if they can be removed.

~~Arguably the should be unit tests for stuff like that, I'll look into that.~~

PR Checklist
------------
 - [x] Tests?
   - ~~Interface~~
   - [x] Core 
 - ~~Docs~~
