### PR TITLE
H5 md serial output on head parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ include(RequireCXX11)
 # Boost
 #######################################################################
 
-find_package(Boost REQUIRED mpi serialization filesystem system)
+find_package(Boost REQUIRED mpi serialization filesystem system timer chrono)
 include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ list(APPEND LIBRARIES ${Boost_LIBRARIES})
 
 if(WITH_TESTS)
   enable_testing()
-  find_package(Boost COMPONENTS unit_test_framework timer chrono) 
+  find_package(Boost COMPONENTS unit_test_framework) 
   if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     set(WITH_UNIT_TESTS ON)
     list(APPEND LIBRARIES ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ include(RequireCXX11)
 # Boost
 #######################################################################
 
-find_package(Boost REQUIRED mpi serialization filesystem system timer chrono)
+find_package(Boost REQUIRED mpi serialization filesystem system)
 include_directories(${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ list(APPEND LIBRARIES ${Boost_LIBRARIES})
 
 if(WITH_TESTS)
   enable_testing()
-  find_package(Boost COMPONENTS unit_test_framework) 
+  find_package(Boost COMPONENTS unit_test_framework timer chrono) 
   if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     set(WITH_UNIT_TESTS ON)
     list(APPEND LIBRARIES ${Boost_LIBRARIES})

--- a/doc/ug/io.tex
+++ b/doc/ug/io.tex
@@ -316,88 +316,7 @@ checkpointed user variables (like \var{skin}) or checkpointed \es submodules
 \section{Writing H5MD-files}
 For large amounts of data it's a good idea to store it in the hdf5 (H5MD is
 based on hdf5) file format
-(see \url{https://www.hdfgroup.org/} for details). \es currently supports
-some basic functions for writing simulation data to H5MD files.
-\subsection{\keyword{h5md_init}: Initialize a H5MD data file}
-
-\begin{essyntax}
-h5md_init \var{/where/to/store/data/file} [\var{list\_of\_p\_ids}]
-\end{essyntax}
-The \codebox{h5md_init} command initializes the H5MD file and
-creates groups and datasets according to the conventions of H5MD (see
-\url{http://nongnu.org/h5md/}). In order to safely start from a
-checkpoint the init command automatically copies the old file to a new file
-with a "tmp" suffix. The optional argument \var{list\_of\_p\_ids} can be provided. In
-this case observables are written for these particle ids only.
-
-\subsection{\keyword{h5md_write_positions}: Write particle positions to H5MD
-file}
-
-\begin{essyntax}
-h5md_write_positions
-\opt{folded}
-\end{essyntax}
-Writes the positions of all particles to the dataset which was previously 
-initialized by \texttt{h5md_init}.
-
-\subsection{\keyword{h5md_write_velocities}: Write particle velocities to H5MD
-file}
-
-\begin{essyntax}
-h5md_write_velocities
-\end{essyntax}
-Writes the velocities of all particles to the dataset which was previously 
-initialized by \texttt{h5md_init}.
-
-\begin{essyntax}
-h5md_write_forces
-\end{essyntax}
-Writes the forces of all particles to the dataset which was previously 
-initialized by \texttt{h5md_init}.
-
-\subsection{\keyword{h5md_observable1D_init}: Initialize a user-defined H5MD
-observable}
-
-\begin{essyntax}
-h5md_observable1D_init \var{name\_of\_observable}
-\end{essyntax}
-Initializes an observable dataset of a zero dimensional, but timedependent, 
-observable with given name in the H5MD file previously
-initialized by \texttt{h5md_init}.
-
-\subsection{\keyword{h5md_observable1D_write}: Write to a user-defined H5MD
-dataset}
-
-\begin{essyntax}
-h5md_observable1D_write \var{name\_of\_observable} \var{value}
-\end{essyntax}
-Writes \texttt{value} to a user-defined observable dataset with given name.
-
-
-\begin{essyntax}
-h5md_observable2D_init \var{name\_of\_observable}
-\end{essyntax}
-Initializes an observable dataset of a one dimensional, but timedependent, 
-observable with given \textit{property} of particles in Espresso in the H5MD file previously
-initialized by \texttt{h5md_init}.
-
-\subsection{\keyword{h5md_observable2D_write}: Write to a user-defined H5MD
-dataset}
-
-\begin{essyntax}
-h5md_observable2D_write \var{name\_of\_observable} \var{value}
-\end{essyntax}
-Writes \texttt{value} to a user-defined observable dataset with given name.
-
-\subsection{\keyword{h5md_close}: Close H5MD file}
-
-\begin{essyntax}
-h5md_close
-\end{essyntax}
-Closes the H5MD data file.
-
-
-\section{Writing H5MD-files with Python}
+(see \url{https://www.hdfgroup.org/} for details).
 To write data in a hdf5-file, first an object of the class \texttt{H5md} has to
 be created and linked to the respective hdf5-file. This may, for example, look
 like:
@@ -411,7 +330,7 @@ If a file with the given filename exists and has a valid H5MD structures it
 will be backed up to a file with suffix ".bak". This file will be removed by
 the close() method of the class which has to be called at the end of the
 simulation to close the file. The current implementation allows to write the
-following properties: positions, velocities, forces, types, and masses of the
+following properties: positions, velocities, forces, types, masses and charges of the
 particles. In order to write any property, you have to set the respective
 boolean flag as an option to the H5md class. Currently available:
 \begin{itemize}
@@ -419,24 +338,33 @@ boolean flag as an option to the H5md class. Currently available:
     \item write_vel
     \item write_force
     \item write_type
-    \item write_mass.
+    \item write_mass
+    \item write_charge
+    \item write_ordered
 \end{itemize}
-In simulations with varying numbers of particles (MC or reactions), the
+Connectivity Information is written out automatically if there are bonds in the system.
+Additionally you can force \es to write particle based properties ordered according to particle ids via the flag write\_ordered. Typically for particle numbers below or around $10^4$ the ordered, serial output (default) from the master node is faster since only one write access is needed. For very large particle numbers the unordered, parallel output is faster. 
+In simulations with varying numbers of particles (e.g. in the reaction ensemble), the
 size of the dataset will be adapted if the maximum number of particles
 increases but will not be decreased. Instead a negative fill value will 
-be written to the trajectory for the id. If you have a parallel simulation
-please keep in mind that the sequence of particles in general changes
+be written to the trajectory for the id. If you use unordered output please keep in mind that the sequence of particles in general changes
 from timestep to timestep. Therefore you have to always use the dataset
-for the ids to track which position/velocity/force/type/mass entry belongs
+for the ids to track which property entry belongs
 to which particle.
 To write data to the hdf5 file, simply call the H5md objects write method
 without any arguments.
 \begin{pycode}
 h5.write()
 \end{pycode}
+You can flush the h5md file via calling
+\begin{pycode}
+h5.flush()
+\end{pycode}
 After the last write call, you have to call the close() method to remove
 the backup file and to close the datasets etc.
-\section{\texttt{blockfile}: Using the structured file format}
+
+\section{\texttt{blockfile}: Using the structured file format (deprecated)}
+
 \label{sec:structured-file-format}
 \newescommand{blockfile}
 

--- a/doc/ug/setup.tex
+++ b/doc/ug/setup.tex
@@ -81,7 +81,7 @@ set:
   If one value is specified then other diagonal elements are defined
   equal to it automatically.
 \item[gamma_rot] (double \asep double[3], \ro) Rotational friction constant for the
-  Langevin thermostat. Feature \feature{ROTATIONAL_INERTIA}} requires 3
+  Langevin thermostat. Feature \feature{ROTATIONAL_INERTIA} requires 3
   values of the gamma_rot corresponding to diagonal elements of the tensor.
   If one is not specified then the translational gamma value is used.
 \item[integ_switch] (int, \ro) Internal switch which integrator to

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -15,11 +15,11 @@ sys.thermostat.set_langevin(kT=1.0, gamma=1.0)
 sys.cell_system.skin = 0.4
 
 for i in range(1000):
-    sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
+    sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23, q=-1.2)
 sys.non_bonded_inter[0, 0].lennard_jones.set_params(epsilon=1, sigma=1,cutoff=2.3, shift="auto")
 sys.integrator.run(steps=10)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False, write_ordered=True)
+                    write_force=True, write_type=True, write_mass=False, write_charge=True, write_ordered=True)
 h5_file.write()
 h5_file.flush()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -16,8 +16,14 @@ sys.cell_system.skin = 0.4
 
 for i in range(1000):
     sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
+sys.non_bonded_inter[0, 0].lennard_jones.set_params(
+		    epsilon=1, sigma=1,
+		    cutoff=2.3, shift="auto")
 sys.integrator.run(steps=10)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False)
+                    write_force=True, write_type=True, write_mass=False,write_ordered=True)
+h5_file.write()
+sys.part.add(id=1000, pos=np.random.random(3) * sys.box_l, type=23)
+sys.integrator.run(steps=1000)
 h5_file.write()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -6,6 +6,8 @@ in ESPResSo.
 import numpy as np
 import espressomd  # pylint: disable=import-error
 from espressomd.io.writer import h5md  # pylint: disable=import-error
+from espressomd import polymer
+from espressomd import interactions
 
 
 sys = espressomd.System()
@@ -14,12 +16,14 @@ sys.time_step = 0.01
 sys.thermostat.set_langevin(kT=1.0, gamma=1.0)
 sys.cell_system.skin = 0.4
 
-for i in range(1000):
-    sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23, q=-1.2)
-sys.non_bonded_inter[0, 0].lennard_jones.set_params(epsilon=1, sigma=1,cutoff=2.3, shift="auto")
-sys.integrator.run(steps=10)
+fene = interactions.FeneBond(k=10, d_r_max=2)
+sys.bonded_inter.add(fene)
+polymer.create_polymer(N_P = 5, bond_length = 1.0, MPC=50, bond=fene)
+
+sys.integrator.run(steps=0)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
                     write_force=True, write_type=True, write_mass=False, write_charge=True, write_ordered=True)
-h5_file.write()
+for i in range(1):
+	h5_file.write()
 h5_file.flush()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -9,7 +9,7 @@ from espressomd.io.writer import h5md  # pylint: disable=import-error
 
 
 sys = espressomd.System()
-sys.box_l = [10.0, 10.0, 10.0]
+sys.box_l = [100.0, 100.0, 100.0]
 sys.time_step = 0.01
 sys.thermostat.set_langevin(kT=1.0, gamma=1.0)
 sys.cell_system.skin = 0.4
@@ -17,8 +17,8 @@ sys.cell_system.skin = 0.4
 for i in range(1000):
     sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
 sys.non_bonded_inter[0, 0].lennard_jones.set_params(epsilon=1, sigma=1,cutoff=2.3, shift="auto")
-sys.integrator.run(steps=100)
+sys.integrator.run(steps=10)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False, write_ordered=False)
+                    write_force=True, write_type=True, write_mass=False, write_ordered=True)
 h5_file.write()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -21,4 +21,5 @@ sys.integrator.run(steps=10)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
                     write_force=True, write_type=True, write_mass=False, write_ordered=True)
 h5_file.write()
+h5_file.flush()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -19,6 +19,6 @@ for i in range(1000):
 sys.non_bonded_inter[0, 0].lennard_jones.set_params(epsilon=1, sigma=1,cutoff=2.3, shift="auto")
 sys.integrator.run(steps=100)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False, write_ordered=True)
+                    write_force=True, write_type=True, write_mass=False, write_ordered=False)
 h5_file.write()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -16,8 +16,9 @@ sys.cell_system.skin = 0.4
 
 for i in range(1000):
     sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
-sys.integrator.run(steps=10)
+sys.non_bonded_inter[0, 0].lennard_jones.set_params(epsilon=1, sigma=1,cutoff=2.3, shift="auto")
+sys.integrator.run(steps=100)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False)
+                    write_force=True, write_type=True, write_mass=False, write_ordered=True)
 h5_file.write()
 h5_file.close()

--- a/samples/python/h5md.py
+++ b/samples/python/h5md.py
@@ -16,14 +16,8 @@ sys.cell_system.skin = 0.4
 
 for i in range(1000):
     sys.part.add(id=i, pos=np.random.random(3) * sys.box_l, type=23)
-sys.non_bonded_inter[0, 0].lennard_jones.set_params(
-		    epsilon=1, sigma=1,
-		    cutoff=2.3, shift="auto")
 sys.integrator.run(steps=10)
 h5_file = h5md.H5md(filename="sample.h5", write_pos=True, write_vel=True,
-                    write_force=True, write_type=True, write_mass=False,write_ordered=True)
-h5_file.write()
-sys.part.add(id=1000, pos=np.random.random(3) * sys.box_l, type=23)
-sys.integrator.run(steps=1000)
+                    write_force=True, write_type=True, write_mass=False)
 h5_file.write()
 h5_file.close()

--- a/samples/python/minimal-polymer.py
+++ b/samples/python/minimal-polymer.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import espressomd
 from espressomd import thermostat
 from espressomd import interactions
+from espressomd import polymer
 import numpy
 
 # System parameters
@@ -43,8 +44,7 @@ system.non_bonded_inter[0, 0].lennard_jones.set_params(
 fene = interactions.FeneBond(k=10, d_r_max=2)
 system.bonded_inter.add(fene)
 
-poly = system.polymer
-poly(N_P = 1, bond_length = 1.0, MPC=50, bond_id=0)
+polymer.create_polymer(N_P = 1, bond_length = 1.0, MPC=50, bond=fene)
 
 
 #############################################################

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -137,7 +137,7 @@ void File::InitFile()
             m_backup_filename = m_filename + ".bak";
             if (this_node == 0) backup_file(m_filename, m_backup_filename);
             load_file(m_filename);
-            m_already_wrote_bonds=true;
+            m_already_wrote_bonds = true;
         } else {
             throw incompatible_h5mdfile();
         }
@@ -201,7 +201,7 @@ void File::create_datasets(bool only_load)
         } else {
             int creation_size_dataset = 0; //creation size of all datasets is 0. Make sure to call ExtendDataset before writing to dataset
             int chunk_size = 1;
-            if(descr.dim>1){
+            if(descr.dim > 1){
                 //we deal now with a particle based property, change chunk. Important for IO performance!
                 chunk_size=n_part;
             }
@@ -222,8 +222,8 @@ void File::create_datasets(bool only_load)
 
 void File::create_links_for_time_and_step_datasets(){
     H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
-    std::string path_time="particles/atoms/id/time";
-    std::string path_step="particles/atoms/id/step";
+    std::string path_time = "particles/atoms/id/time";
+    std::string path_step = "particles/atoms/id/step";
     H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/image/time", H5P_DEFAULT, H5P_DEFAULT );
     H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/image/step", H5P_DEFAULT, H5P_DEFAULT );
     H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/force/time", H5P_DEFAULT, H5P_DEFAULT );
@@ -334,16 +334,16 @@ void File::fill_arrays_for_h5md_write_with_particle_property(int particle_index,
     }
     if (write_charge){
         #ifdef ELECTROSTATICS
-        charge[0][particle_index][0]=current_particle->p.q;
+        charge[0][particle_index][0] = current_particle->p.q;
         #endif        
     }
 
     if (!m_already_wrote_bonds) {
-        int nbonds_local=bond.shape()[1];
-        for(int i=1; i<current_particle->bl.n;i=i+2){
+        int nbonds_local = bond.shape()[1];
+        for(int i = 1; i< current_particle->bl.n;i = i+2){
             bond.resize(boost::extents[1][nbonds_local+1][2]);
-        bond[0][nbonds_local][0]=current_particle->p.identity;
-        bond[0][nbonds_local][1]=current_particle->bl.e[i];
+        bond[0][nbonds_local][0] = current_particle->p.identity;
+        bond[0][nbonds_local][1] = current_particle->bl.e[i];
         }
     }
 
@@ -356,12 +356,12 @@ void File::Write(int write_dat)
 #endif
     int num_particles_to_be_written=0;
     if(m_write_ordered == true && this_node == 0)
-        num_particles_to_be_written=n_part;
+        num_particles_to_be_written = n_part;
     else if (m_write_ordered == true && this_node != 0)
-        num_particles_to_be_written=0;
+        num_particles_to_be_written = 0;
     else if (m_write_ordered == false)
-        num_particles_to_be_written=cells_get_n_particles();
-    if(m_write_ordered == true && this_node !=0)
+        num_particles_to_be_written = cells_get_n_particles();
+    if(m_write_ordered == true && this_node != 0)
         return ;
     
     bool write_typ = write_dat & W_TYPE;
@@ -380,15 +380,15 @@ void File::Write(int write_dat)
     double_array_3d mass(boost::extents[1][num_particles_to_be_written][1]);
     double_array_3d charge(boost::extents[1][num_particles_to_be_written][1]);
     double_array_3d time(boost::extents[1][1][1]);
-    time[0][0][0]=sim_time;
+    time[0][0][0] = sim_time;
     int_array_3d step(boost::extents[1][1][1]);
-    step[0][0][0]=(int)std::round(sim_time/time_step);
+    step[0][0][0] = (int)std::round(sim_time/time_step);
     int_array_3d bond(boost::extents[0][0][0]);
 
     if (m_write_ordered == true) {
         if( this_node == 0 ){
             //loop over all particles
-            for(int particle_index=0;particle_index<n_part;particle_index++){
+            for(int particle_index=0;particle_index < n_part;particle_index++){
                 Particle current_particle;
                 get_particle_data(particle_index, &current_particle); //this function only works when run with one process
                 fill_arrays_for_h5md_write_with_particle_property(particle_index, id, typ, mass, pos, image, vel, f, charge, &current_particle, write_dat, bond);
@@ -419,14 +419,14 @@ void File::Write(int write_dat)
     int prefix = 0;
     //calculate prefix for write of the current process
     MPI_Exscan(&num_particles_to_be_written, &prefix, 1, MPI_INT, MPI_SUM, m_hdf5_comm);
-    hid_t ds=H5Dget_space(datasets["particles/atoms/id/value"].hid());
+    hid_t ds = H5Dget_space(datasets["particles/atoms/id/value"].hid());
     hsize_t dims_id[2], maxdims_id[2];
     H5Sget_simple_extent_dims(ds, dims_id, maxdims_id);
     H5Sclose(ds);
 
-    hsize_t offset_1d[1]={dims_id[0]};
-    hsize_t offset_2d[2]={dims_id[0], (hsize_t) prefix};
-    hsize_t offset_3d[3]={dims_id[0], (hsize_t) prefix, 0};
+    hsize_t offset_1d[1] = {dims_id[0]};
+    hsize_t offset_2d[2] = {dims_id[0], (hsize_t) prefix};
+    hsize_t offset_3d[3] = {dims_id[0], (hsize_t) prefix, 0};
     
     hsize_t count_1d[1]={1};
     hsize_t count_2d[2]={1, (hsize_t) num_particles_to_be_written};
@@ -434,33 +434,33 @@ void File::Write(int write_dat)
     
     //calculate the change of the extent for fluctuating particle numbers
     int n_part = max_seen_particle+1;
-    int old_max_n_part=std::max(m_max_n_part, (int) dims_id[1]); // check that dataset is not shrinked: take into account previous dimension, if we append to an already existing dataset
+    int old_max_n_part = std::max(m_max_n_part, (int) dims_id[1]); // check that dataset is not shrinked: take into account previous dimension, if we append to an already existing dataset
     if (n_part > old_max_n_part) {
         m_max_n_part = n_part; 
     }else{
-        m_max_n_part=old_max_n_part;
+        m_max_n_part = old_max_n_part;
     }
-    int extent_particle_number=m_max_n_part-old_max_n_part;
+    int extent_particle_number = m_max_n_part-old_max_n_part;
     
-    int change_extent_1d[1]={1};
-    int change_extent_2d[2]={1, extent_particle_number};
-    int change_extent_3d[3]={1, extent_particle_number, 0};
+    int change_extent_1d[1] = {1};
+    int change_extent_2d[2] = {1, extent_particle_number};
+    int change_extent_3d[3] = {1, extent_particle_number, 0};
 
 
     if (! m_already_wrote_bonds) {
         //communicate the total number of bonds to all processes since extending is a collective hdf5 function
-        int nbonds_local=bond.shape()[1];
-        int nbonds_total=nbonds_local;
-        int prefix_bonds=0;
-        if(m_write_ordered!=true){
+        int nbonds_local = bond.shape()[1];
+        int nbonds_total = nbonds_local;
+        int prefix_bonds = 0;
+        if(m_write_ordered != true){
             MPI_Exscan(&nbonds_local, &prefix_bonds, 1, MPI_INT, MPI_SUM, m_hdf5_comm);
             MPI_Allreduce(&nbonds_local, &nbonds_total, 1, MPI_INT, MPI_SUM, m_hdf5_comm);
         }
-        hsize_t offset_bonds[2]={(hsize_t) prefix_bonds, 0};
-        hsize_t count_bonds[2]={(hsize_t) nbonds_local, 2};
-        int change_extent_bonds[2]={nbonds_total, 2};
+        hsize_t offset_bonds[2] = {(hsize_t) prefix_bonds, 0};
+        hsize_t count_bonds[2] = {(hsize_t) nbonds_local, 2};
+        int change_extent_bonds[2] = {nbonds_total, 2};
         WriteDataset(bond, "connectivity/atoms", change_extent_bonds, offset_bonds, count_bonds);
-        m_already_wrote_bonds=true;
+        m_already_wrote_bonds = true;
     }
 
 
@@ -507,9 +507,9 @@ void File::ExtendDataset(std::string path, int* change_extent){
     hsize_t dims[rank], maxdims[rank];
     H5Sget_simple_extent_dims(ds, dims, maxdims);
     H5Sclose(ds);
-    /* Extend the dataset for another timestep (extent=1) */
-    for(int i=0; i<rank; i++){
-        dims[i]+=change_extent[i];
+    /* Extend the dataset for another timestep (extent = 1) */
+    for(int i = 0; i < rank; i++){
+        dims[i] += change_extent[i];
     }
     H5Dset_extent(dataset.hid(), dims); //extend all dims is collective
 }
@@ -529,8 +529,8 @@ void File::WriteDataset(T &data, const std::string& path, int* change_extent, hs
     hid_t ds = H5Dget_space(dataset.hid());
     hsize_t rank = H5Sget_simple_extent_ndims(ds);
     hsize_t maxdims[rank];
-    for(int i=0;i<rank;i++){
-        maxdims[i]=H5S_UNLIMITED;
+    for(int i = 0;i<rank;i++){
+        maxdims[i] = H5S_UNLIMITED;
     }
     H5Sselect_hyperslab(ds, H5S_SELECT_SET, offset, NULL, count, NULL);
     /* Create a temporary dataspace. */
@@ -586,8 +586,8 @@ void File::WriteScript(std::string const &filename)
 }
 
 void File::Flush(){
-        if(m_write_ordered==true){
-            if(this_node==0)
+        if(m_write_ordered == true){
+            if(this_node == 0)
                 H5Fflush(m_h5md_file.hid(),H5F_SCOPE_GLOBAL);
         }else
              H5Fflush(m_h5md_file.hid(),H5F_SCOPE_GLOBAL);

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -173,26 +173,14 @@ void File::init_filestructure()
             //path, dim, type
         { "particles/atoms/box/edges"     , 1, type_double },
         { "particles/atoms/mass/value"    , 2, type_double },
-        { "particles/atoms/mass/time"     , 1, type_double },
-        { "particles/atoms/mass/step"     , 1, type_int },
         { "particles/atoms/id/value"      , 2, type_int },
         { "particles/atoms/id/time"       , 1, type_double },
         { "particles/atoms/id/step"       , 1, type_int },
         { "particles/atoms/type/value"    , 2, type_int },
-        { "particles/atoms/type/time"     , 1, type_double },
-        { "particles/atoms/type/step"     , 1, type_int },
         { "particles/atoms/position/value", 3, type_double },
-        { "particles/atoms/position/time" , 1, type_double },
-        { "particles/atoms/position/step" , 1, type_int },
         { "particles/atoms/velocity/value", 3, type_double },
-        { "particles/atoms/velocity/time" , 1, type_double },
-        { "particles/atoms/velocity/step" , 1, type_int },
         { "particles/atoms/force/value"   , 3, type_double },
-        { "particles/atoms/force/time"    , 1, type_double },
-        { "particles/atoms/force/step"    , 1, type_int },
         { "particles/atoms/image/value"   , 3, type_int },
-        { "particles/atoms/image/time"    , 1, type_double },
-        { "particles/atoms/image/step"    , 1, type_int },
     };
 }
 
@@ -247,6 +235,26 @@ void File::create_datasets(bool only_load)
             }
         }
     }
+    create_links_for_time_and_step_datasets();
+}
+
+void File::create_links_for_time_and_step_datasets(){
+	H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
+	std::string path_time="particles/atoms/id/time";
+	std::string path_step="particles/atoms/id/step";
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/image/time", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/image/step", H5P_DEFAULT, H5P_DEFAULT );
+	
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/force/time", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/force/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/time", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/position/time", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/position/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/type/time", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/type/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/mass/time", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/mass/step", H5P_DEFAULT, H5P_DEFAULT );
 }
 
 void File::load_file(const std::string& filename)
@@ -402,35 +410,23 @@ void File::Write(int write_dat)
     if (write_typ)
     {
         WriteDataset(typ, "particles/atoms/type/value");
-        WriteDataset(time, "particles/atoms/type/time");
-        WriteDataset(step, "particles/atoms/type/step");
     }
     if (write_mass)
     {
         WriteDataset(mass, "particles/atoms/mass/value");
-        WriteDataset(time, "particles/atoms/mass/time");
-        WriteDataset(step, "particles/atoms/mass/step");
     }
     if (write_pos)
     {
         WriteDataset(pos, "particles/atoms/position/value");
-        WriteDataset(time, "particles/atoms/position/time");
-        WriteDataset(step, "particles/atoms/position/step");
         WriteDataset(image, "particles/atoms/image/value");
-        WriteDataset(time, "particles/atoms/image/time");
-        WriteDataset(step, "particles/atoms/image/step");
     }
     if (write_vel)
     {
         WriteDataset(vel, "particles/atoms/velocity/value");
-        WriteDataset(time, "particles/atoms/velocity/time");
-        WriteDataset(step, "particles/atoms/velocity/step");
     }
     if (write_force)
     {
         WriteDataset(f, "particles/atoms/force/value");
-        WriteDataset(time, "particles/atoms/force/time");
-        WriteDataset(step, "particles/atoms/force/step");
     }
 
 }

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -423,9 +423,9 @@ void File::ExtendDataset(std::string path, int extent=1){
     // Extend the dataset for more particles if the particle number increased
     if(rank>1){
         /* Get the number of particles on all other nodes. */
-        int n_part = max_seen_particle+1;
+        int n_part = std::max((int) dims[1],max_seen_particle+1); //take into account previous dimension, if we append to an already existing dataset
         if (n_part > m_max_n_part) {
-        	m_max_n_part = n_part;
+        	m_max_n_part = n_part; 
         }
         dims[1] = m_max_n_part;
     }

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -268,27 +268,23 @@ void File::Write(int write_dat)
     bool write_force = write_dat & W_F;
     bool write_mass = write_dat & W_MASS;
 
-    int num_particles_to_be_written;
-    int remainder=0;
-    
+    std::cout << "ordered " << m_write_ordered << std::endl;
+
     if (m_write_ordered==true) {
-    	num_particles_to_be_written=std::floor(n_part/n_nodes);
+    	int npart=max_seen_particle+1;
+    	int num_particles_to_be_written=std::floor(npart/n_nodes);
+    	int remainder=0;
     	if(this_node==n_nodes-1)
-    		remainder=n_part%num_particles_to_be_written;
-     }else{
-         /* Get the number of particles on each node. */
-        num_particles_to_be_written = cells_get_n_particles();       
-     }
+    		remainder=npart%num_particles_to_be_written;
         
-    double_array_3d pos(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    double_array_3d vel(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    double_array_3d f(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    int_array_3d image(boost::extents[1][num_particles_to_be_written+remainder][3]);
-    int_array_3d id(boost::extents[1][num_particles_to_be_written+remainder][1]);
-    int_array_3d typ(boost::extents[1][num_particles_to_be_written+remainder][1]);
-    double_array_3d mass(boost::extents[1][num_particles_to_be_written+remainder][1]);
-    
-    if(m_write_ordered==true){
+        
+        double_array_3d pos(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        double_array_3d vel(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        double_array_3d f(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        int_array_3d image(boost::extents[1][num_particles_to_be_written+remainder][3]);
+        int_array_3d id(boost::extents[1][num_particles_to_be_written+remainder][1]);
+        int_array_3d typ(boost::extents[1][num_particles_to_be_written+remainder][1]);
+        double_array_3d mass(boost::extents[1][num_particles_to_be_written+remainder][1]);
         //loop over all particles
         for(int particle_index=this_node*num_particles_to_be_written;particle_index<(this_node+1)*num_particles_to_be_written+remainder;particle_index++){
             	Particle current_particle;
@@ -327,7 +323,48 @@ void File::Write(int write_dat)
 		free_particle(&current_particle);
 
         }
-    } else {
+
+        if (n_part > m_max_n_part) {
+        	m_max_n_part = n_part;
+        }
+
+        WriteDataset(id, "particles/atoms/id");
+
+        if (write_typ)
+        {
+            WriteDataset(typ, "particles/atoms/type");
+            printf("write type%d \n", this_node);
+        }
+        if (write_mass)
+        {
+            WriteDataset(mass, "particles/atoms/mass");
+        }
+        if (write_pos)
+        {
+            WriteDataset(pos, "particles/atoms/position");
+            WriteDataset(image, "particles/atoms/image");
+            printf("write pos%d \n", this_node);
+        }
+        if (write_vel)
+        {
+            WriteDataset(vel, "particles/atoms/velocity");
+        }
+        if (write_force)
+        {
+            WriteDataset(f, "particles/atoms/force");
+            printf("write force%d \n", this_node);
+        }
+    }else{
+        /* Get the number of particles on all other nodes. */
+        int nlocalpart = cells_get_n_particles();
+        double_array_3d pos(boost::extents[1][nlocalpart][3]);
+        double_array_3d vel(boost::extents[1][nlocalpart][3]);
+        double_array_3d f(boost::extents[1][nlocalpart][3]);
+        int_array_3d image(boost::extents[1][nlocalpart][3]);
+        int_array_3d id(boost::extents[1][nlocalpart][1]);
+        int_array_3d typ(boost::extents[1][nlocalpart][1]);
+        double_array_3d mass(boost::extents[1][nlocalpart][1]);
+
         /* Prepare data for writing, loop over all local cells. */
         Cell *local_cell;
         int particle_index = 0;
@@ -376,34 +413,35 @@ void File::Write(int write_dat)
                 particle_index++;
             }
         }
-    
-    }
-    if (n_part > m_max_n_part) {
-    	m_max_n_part = n_part;
-    }
 
-    WriteDataset(id, "particles/atoms/id");
+        int n_part = max_seen_particle+1;
+        if (n_part > m_max_n_part) {
+        	m_max_n_part = n_part;
+        }
 
-    if (write_typ)
-    {
-        WriteDataset(typ, "particles/atoms/type");
-    }
-    if (write_mass)
-    {
-        WriteDataset(mass, "particles/atoms/mass");
-    }
-    if (write_pos)
-    {
-        WriteDataset(pos, "particles/atoms/position");
-        WriteDataset(image, "particles/atoms/image");
-    }
-    if (write_vel)
-    {
-        WriteDataset(vel, "particles/atoms/velocity");
-    }
-    if (write_force)
-    {
-        WriteDataset(f, "particles/atoms/force");
+        WriteDataset(id, "particles/atoms/id");
+
+        if (write_typ)
+        {
+            WriteDataset(typ, "particles/atoms/type");
+        }
+        if (write_mass)
+        {
+            WriteDataset(mass, "particles/atoms/mass");
+        }
+        if (write_pos)
+        {
+            WriteDataset(pos, "particles/atoms/position");
+            WriteDataset(image, "particles/atoms/image");
+        }
+        if (write_vel)
+        {
+            WriteDataset(vel, "particles/atoms/velocity");
+        }
+        if (write_force)
+        {
+            WriteDataset(f, "particles/atoms/force");
+        }
     }
 }
 

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -182,6 +182,7 @@ void File::init_filestructure()
         { "particles/atoms/velocity/value", 3, type_double },
         { "particles/atoms/force/value"   , 3, type_double },
         { "particles/atoms/image/value"   , 3, type_int },
+        { "connectivity/atoms"   , 1, type_int },
     };
 }
 
@@ -263,6 +264,8 @@ void File::create_new_file(const std::string &filename)
 
     bool only_load = false;
     create_datasets(only_load);
+
+    //write box information
     std::vector<double> boxvec = {box_l[0], box_l[1], box_l[2]};
     auto group = h5xx::group(m_h5md_file,  "particles/atoms/box");
     h5xx::write_attribute(group, "dimension", 3);
@@ -271,6 +274,7 @@ void File::create_new_file(const std::string &filename)
     int extent_edges = 3; //for three entries for cuboid box box_l_x, box_l_y, box_l_z
     ExtendDataset(path_edges, extent_edges);
     h5xx::write_dataset(datasets[path_edges], boxvec);
+
 }
 
 
@@ -326,7 +330,9 @@ void File::fill_arrays_for_h5md_write_with_particle_property(int particle_index,
             f[0][particle_index][2] = current_particle->f.f[2] * fac;
         }
         if (write_charge){
+            #ifdef ELECTROSTATICS
             charge[0][particle_index][0]=current_particle->p.q;
+            #endif        
         }
 
 }
@@ -420,7 +426,9 @@ void File::Write(int write_dat)
         WriteDataset(f, "particles/atoms/force/value");
     }
     if (write_charge){
+        #ifdef ELECTROSTATICS
         WriteDataset(charge, "particles/atoms/charge/value");
+        #endif
     }
 
 }

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -243,18 +243,18 @@ void File::create_links_for_time_and_step_datasets(){
 	std::string path_time="particles/atoms/id/time";
 	std::string path_step="particles/atoms/id/step";
 	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/image/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/image/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/image/step", H5P_DEFAULT, H5P_DEFAULT );
 	
 	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/force/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/force/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/force/step", H5P_DEFAULT, H5P_DEFAULT );
 	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/step", H5P_DEFAULT, H5P_DEFAULT );
 	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/position/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/position/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/position/step", H5P_DEFAULT, H5P_DEFAULT );
 	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/type/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/type/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/type/step", H5P_DEFAULT, H5P_DEFAULT );
 	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/mass/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/mass/step", H5P_DEFAULT, H5P_DEFAULT );
+	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/mass/step", H5P_DEFAULT, H5P_DEFAULT );
 }
 
 void File::load_file(const std::string& filename)

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -108,11 +108,11 @@ void File::InitFile()
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
 #endif
     //use a seperate mpi communicator if we want to write out ordered data. This is in order to avoid  blocking by collective functions
-    if(m_write_ordered ==true)
+    if(m_write_ordered == true)
         MPI_Comm_split(MPI_COMM_WORLD, this_node, 0, &MPI_H5MD_COMM); 
     else
         MPI_H5MD_COMM=MPI_COMM_WORLD;
-    if(m_write_ordered== true and this_node!=0)
+    if(m_write_ordered == true and this_node !=0)
         return;
     if(n_part <= 0) {
         throw std::runtime_error("Please first set up particles before initializing the H5md object."); //this is important since n_part is used for chunking
@@ -123,7 +123,7 @@ void File::InitFile()
     bool fileexists = check_file_exists(m_filename);
     /* Perform a barrier synchronization. Otherwise one process might already
      * create the file while another still checks for its existence. */
-    if(m_write_ordered==false)
+    if(m_write_ordered == false)
         MPI_Barrier(MPI_H5MD_COMM);
     if (fileexists) {
         if (check_for_H5MD_structure(m_filename)) {
@@ -219,10 +219,10 @@ void File::create_datasets(bool only_load)
                 datasets[path] = h5xx::dataset(groups[father],
                                                basename);
             } else {
-                int creation_size_dataset=0; //creation size of all datasets is 0. Make sure to call ExtendDataset before writing to dataset
-                int chunk_size=1;
+                int creation_size_dataset = 0; //creation size of all datasets is 0. Make sure to call ExtendDataset before writing to dataset
+                int chunk_size = 1;
                 if(descr.dim>1){
-                    //we deal now with a particle based property
+                    //we deal now with a particle based property, change chunk. Important for IO performance!
                     chunk_size=n_part;
                 }
                 auto dims = create_dims(descr.dim, creation_size_dataset);
@@ -288,7 +288,7 @@ void File::create_new_file(const std::string &filename)
     std::vector<double> boxvec = {box_l[0], box_l[1], box_l[2]};
     h5xx::write_attribute(groups["particles/atoms/box"], "dimension", 3);
     h5xx::write_attribute(groups["particles/atoms/box"], "boundary", "periodic");
-    std::string path_edges="particles/atoms/box/edges";
+    std::string path_edges = "particles/atoms/box/edges";
     int extent_edges = 3; //for three entries for cuboid box box_l_x, box_l_y, box_l_z
     ExtendDataset(path_edges, extent_edges);
     h5xx::write_dataset(datasets[path_edges], boxvec);
@@ -311,7 +311,7 @@ void File::fill_arrays_for_h5md_write_with_particle_property(int particle_index,
 #endif
 	        id[0][particle_index][0] = current_particle->p.identity;
             if (write_typ)
-                typ[0][particle_index][0] =current_particle->p.type;
+                typ[0][particle_index][0] = current_particle->p.type;
             if (write_mass)
                 mass[0][particle_index][0] = current_particle->p.mass;
             /* store folded particle positions. */
@@ -348,11 +348,11 @@ void File::Write(int write_dat)
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
 #endif
     int num_particles_to_be_written;
-    if(m_write_ordered==true && this_node==0)
+    if(m_write_ordered == true && this_node == 0)
         num_particles_to_be_written=n_part;
     else if(m_write_ordered == true && this_node !=0)
         return ;
-    else if (m_write_ordered ==false)
+    else if (m_write_ordered == false)
         num_particles_to_be_written=cells_get_n_particles();
     
     bool write_typ = write_dat & W_TYPE;
@@ -373,8 +373,8 @@ void File::Write(int write_dat)
     int_array_3d step(boost::extents[1][1][1]);
     step[0][0][0]=(int)std::round(sim_time/time_step);
 
-    if (m_write_ordered==true) {
-        if( this_node ==0){ 
+    if (m_write_ordered == true) {
+        if( this_node == 0 ){ 
             //loop over all particles
             for(int particle_index=0;particle_index<n_part;particle_index++){
                 Particle current_particle;

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -526,6 +526,9 @@ void File::WriteScript(std::string const &filename)
     H5Fclose(file_id);
 }
 
+void File::Flush(){
+	H5Fflush(m_h5md_file.hid(),H5F_SCOPE_GLOBAL);
+}
 
 bool File::check_for_H5MD_structure(std::string const &filename)
 {

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -146,7 +146,7 @@ void File::init_filestructure()
         { "particles/atoms/id/value"      , 1, npart, type_int },
         { "particles/atoms/id/time"       , 1, 1    , type_double },
         { "particles/atoms/id/step"       , 1, 1    , type_int },
-        { "particles/atoms/type/value"    , 1, npart, type_double },
+        { "particles/atoms/type/value"    , 1, npart, type_int },
         { "particles/atoms/type/time"     , 1, 1    , type_double },
         { "particles/atoms/type/step"     , 1, 1    , type_int },
         { "particles/atoms/position/value", 3, npart, type_double },

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -84,7 +84,7 @@ void File::InitFile()
 #endif
     boost::filesystem::path script_path(m_scriptname);
     m_absolute_script_path = boost::filesystem::canonical(script_path);
-    if(!(cells_get_n_particles() > 0)) {
+    if(n_part <= 0) {
         throw std::runtime_error("Please first set up particles before initializing the H5md object.");
     }
 

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -50,15 +50,15 @@ static void backup_file(const std::string &from, const std::string& to)
 }
 
 static std::vector<hsize_t>
-create_dims(hsize_t dim, hsize_t size, hsize_t chunk_size=0)
+create_dims(hsize_t dim, hsize_t size)
 {
 #ifdef H5MD_DEBUG
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
 #endif
     if (dim == 3)
-        return std::vector<hsize_t>{chunk_size, size, dim};
+        return std::vector<hsize_t>{size, size, dim};
     if (dim == 2)
-        return std::vector<hsize_t>{size, dim};
+        return std::vector<hsize_t>{size, size};
     if (dim == 1)
         return std::vector<hsize_t>{size};
     else
@@ -72,14 +72,14 @@ File::create_chunk_dims(hsize_t dim, hsize_t size, hsize_t chunk_size)
 #ifdef H5MD_DEBUG
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
 #endif
-	if (dim == 3)
-	    return std::vector<hsize_t>{chunk_size, size, dim};
-	if (dim == 2)
-	    return std::vector<hsize_t>{chunk_size, size};
-	if (dim == 1)
-	    return std::vector<hsize_t>{size};
-	else
-	    throw std::runtime_error("H5MD Error: datastets with this dimension are not implemented\n");
+    if (dim == 3)
+        return std::vector<hsize_t>{chunk_size, size, dim};
+    if (dim == 2)
+        return std::vector<hsize_t>{chunk_size, size};
+    if (dim == 1)
+        return std::vector<hsize_t>{size};
+    else
+        throw std::runtime_error("H5MD Error: datastets with this dimension are not implemented\n");
 
 }
 static std::vector<hsize_t> create_maxdims(hsize_t dim)
@@ -112,6 +112,9 @@ void File::InitFile()
         MPI_Comm_split(MPI_COMM_WORLD, this_node, 0, &m_hdf5_comm); 
     else
         m_hdf5_comm=MPI_COMM_WORLD;
+    if(m_write_ordered == true && this_node !=0)
+        return ;
+
     if(n_part <= 0) {
         throw std::runtime_error("Please first set up particles before initializing the H5md object."); //this is important since n_part is used for chunking
     }
@@ -134,6 +137,7 @@ void File::InitFile()
             m_backup_filename = m_filename + ".bak";
             if (this_node == 0) backup_file(m_filename, m_backup_filename);
             load_file(m_filename);
+            m_already_wrote_bonds=true;
         } else {
             throw incompatible_h5mdfile();
         }
@@ -180,7 +184,7 @@ void File::init_filestructure()
         { "particles/atoms/velocity/value", 3, type_double },
         { "particles/atoms/force/value"   , 3, type_double },
         { "particles/atoms/image/value"   , 3, type_int },
-        { "connectivity/atoms"   		  , 2, type_int },
+        { "connectivity/atoms"            , 2, type_int },
     };
 }
 
@@ -217,23 +221,23 @@ void File::create_datasets(bool only_load)
 }
 
 void File::create_links_for_time_and_step_datasets(){
-	H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
-	std::string path_time="particles/atoms/id/time";
-	std::string path_step="particles/atoms/id/step";
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/image/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/image/step", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/force/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/force/step", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/step", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/position/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/position/step", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/type/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/type/step", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/mass/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/mass/step", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/charge/time", H5P_DEFAULT, H5P_DEFAULT );
-	H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/charge/step", H5P_DEFAULT, H5P_DEFAULT );
+    H5Eset_auto(H5E_DEFAULT, (H5E_auto_t) H5Eprint, stderr);
+    std::string path_time="particles/atoms/id/time";
+    std::string path_step="particles/atoms/id/step";
+    H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/image/time", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/image/step", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/force/time", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/force/step", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/time", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/velocity/step", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/position/time", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/position/step", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/type/time", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/type/step", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/mass/time", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/mass/step", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_time.c_str(), m_h5md_file.hid(), "particles/atoms/charge/time", H5P_DEFAULT, H5P_DEFAULT );
+    H5Lcreate_hard( m_h5md_file.hid(), path_step.c_str(), m_h5md_file.hid(), "particles/atoms/charge/step", H5P_DEFAULT, H5P_DEFAULT );
 }
 
 void File::load_file(const std::string& filename)
@@ -262,69 +266,17 @@ void File::create_new_file(const std::string &filename)
 
     bool only_load = false;
     create_datasets(only_load);
-	
-	//write time independent datasets
+    
+    //write time independent datasets
     //write box information
     std::vector<double> boxvec = {box_l[0], box_l[1], box_l[2]};
     auto group = h5xx::group(m_h5md_file,  "particles/atoms/box");
     h5xx::write_attribute(group, "dimension", 3);
     h5xx::write_attribute(group, "boundary", "periodic");
     std::string path_edges = "particles/atoms/box/edges";
-    int extent_edges = 3; //for three entries for cuboid box box_l_x, box_l_y, box_l_z
-    ExtendDataset(path_edges, extent_edges);
+    int change_extent_box = 3; //for three entries for cuboid box box_l_x, box_l_y, box_l_z
+    ExtendDataset(path_edges, &change_extent_box);
     h5xx::write_dataset(datasets[path_edges], boxvec);
-
-	//writing bonds is only implemented here for bonds between two particles, use this as number of columns
-	int_array_3d bond(boost::extents[1][0][2]);
-    /* loop over all local cells. */
-    Cell *local_cell;
-    int num_bonds_local=0;
-    //loop over all particles
-    for (int cell_id = 0; cell_id < local_cells.n; ++cell_id)
-    {
-        local_cell = local_cells.cell[cell_id];
-        for (int local_part_id = 0;
-             local_part_id < local_cell->n; ++local_part_id)
-        {
-            auto & current_particle = local_cell->part[local_part_id];
-            for(int i=1; i<current_particle.bl.n;i=i+2){
-            	num_bonds_local+=1;
-            	bond.resize(boost::extents[1][num_bonds_local][2]);
-				bond[0][num_bonds_local-1][0]=current_particle.p.identity;
-				bond[0][num_bonds_local-1][1]=current_particle.bl.e[i];
-				
-			}
-        }
-    }
-    int nbonds_total;
-    MPI_Allreduce(&num_bonds_local, &nbonds_total, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-    std::string path="connectivity/atoms";
-    ExtendDataset(path, nbonds_total, 2);
-    
-    int prefix=0;
-    MPI_Exscan(&num_bonds_local, &prefix, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-    auto& dataset = datasets[path];
-	/* Get the current dimensions of the dataspace. */
-	int rank =2;
-	hsize_t offset[rank];
-	offset[0]=prefix;
-	offset[1]=0;
-	hsize_t count[rank];
-	count[0]=num_bonds_local;
-	count[1]=2;
-	hid_t ds = H5Dget_space(dataset.hid());
-    H5Sselect_hyperslab(ds, H5S_SELECT_SET, offset, NULL, count, NULL);
-	/* Create a temporary dataspace. */
-	hsize_t dims[rank], maxdims[rank];
-	H5Sget_simple_extent_dims(ds, dims, maxdims);
-	hid_t ds_new = H5Screate_simple(rank, count, maxdims);        
-	H5Dwrite(dataset.hid(),
-	         dataset.get_type(),
-	         ds_new,
-	         ds, H5P_DEFAULT,
-	         bond.origin());
-	H5Sclose(ds_new);
-	H5Sclose(ds);
 
 }
 
@@ -338,7 +290,7 @@ void File::Close()
 }
 
 
-void File::fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, double_array_3d& charge, Particle* current_particle, int write_dat ){
+void File::fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, double_array_3d& charge, Particle* current_particle, int write_dat, int_array_3d& bond){
 #ifdef H5MD_DEBUG
     /* Turn on hdf5 error messages */
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
@@ -350,41 +302,50 @@ void File::fill_arrays_for_h5md_write_with_particle_property(int particle_index,
     bool write_mass = write_dat & W_MASS;
     bool write_charge = write_dat & W_CHARGE;
 
-        id[0][particle_index][0] = current_particle->p.identity;
-        if (write_typ)
-            typ[0][particle_index][0] = current_particle->p.type;
-        if (write_mass)
-            mass[0][particle_index][0] = current_particle->p.mass;
-        /* store folded particle positions. */
-        if (write_pos)
-        {
-            pos[0][particle_index][0] = current_particle->r.p[0];
-            pos[0][particle_index][1] = current_particle->r.p[1];
-            pos[0][particle_index][2] = current_particle->r.p[2];
-            image[0][particle_index][0] = current_particle->l.i[0];
-            image[0][particle_index][1] = current_particle->l.i[1];
-            image[0][particle_index][2] = current_particle->l.i[2];
+    id[0][particle_index][0] = current_particle->p.identity;
+    if (write_typ)
+        typ[0][particle_index][0] = current_particle->p.type;
+    if (write_mass)
+        mass[0][particle_index][0] = current_particle->p.mass;
+    /* store folded particle positions. */
+    if (write_pos)
+    {
+        pos[0][particle_index][0] = current_particle->r.p[0];
+        pos[0][particle_index][1] = current_particle->r.p[1];
+        pos[0][particle_index][2] = current_particle->r.p[2];
+        image[0][particle_index][0] = current_particle->l.i[0];
+        image[0][particle_index][1] = current_particle->l.i[1];
+        image[0][particle_index][2] = current_particle->l.i[2];
+    }
+    if (write_vel)
+    {
+        vel[0][particle_index][0] = current_particle->m.v[0] / time_step;
+        vel[0][particle_index][1] = current_particle->m.v[1] / time_step;
+        vel[0][particle_index][2] = current_particle->m.v[2] / time_step;
+    }
+    if (write_force)
+    {
+        /* Scale the stored force with m/(0.5*dt**2.0) to get a real 
+         * world force. */
+        double fac = current_particle->p.mass / (0.5 * time_step * time_step);
+        f[0][particle_index][0] = current_particle->f.f[0] * fac;
+        f[0][particle_index][1] = current_particle->f.f[1] * fac;
+        f[0][particle_index][2] = current_particle->f.f[2] * fac;
+    }
+    if (write_charge){
+        #ifdef ELECTROSTATICS
+        charge[0][particle_index][0]=current_particle->p.q;
+        #endif        
+    }
+
+    if (!m_already_wrote_bonds) {
+        int nbonds_local=bond.shape()[1];
+        for(int i=1; i<current_particle->bl.n;i=i+2){
+            bond.resize(boost::extents[1][nbonds_local+1][2]);
+        bond[0][nbonds_local][0]=current_particle->p.identity;
+        bond[0][nbonds_local][1]=current_particle->bl.e[i];
         }
-        if (write_vel)
-        {
-            vel[0][particle_index][0] = current_particle->m.v[0] / time_step;
-            vel[0][particle_index][1] = current_particle->m.v[1] / time_step;
-            vel[0][particle_index][2] = current_particle->m.v[2] / time_step;
-        }
-        if (write_force)
-        {
-            /* Scale the stored force with m/(0.5*dt**2.0) to get a real 
-             * world force. */
-            double fac = current_particle->p.mass / (0.5 * time_step * time_step);
-            f[0][particle_index][0] = current_particle->f.f[0] * fac;
-            f[0][particle_index][1] = current_particle->f.f[1] * fac;
-            f[0][particle_index][2] = current_particle->f.f[2] * fac;
-        }
-        if (write_charge){
-            #ifdef ELECTROSTATICS
-            charge[0][particle_index][0]=current_particle->p.q;
-            #endif        
-        }
+    }
 
 }
 
@@ -393,13 +354,15 @@ void File::Write(int write_dat)
 #ifdef H5MD_DEBUG
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
 #endif
-    int num_particles_to_be_written;
+    int num_particles_to_be_written=0;
     if(m_write_ordered == true && this_node == 0)
         num_particles_to_be_written=n_part;
-    else if(m_write_ordered == true && this_node !=0)
-        return ;
+    else if (m_write_ordered == true && this_node != 0)
+        num_particles_to_be_written=0;
     else if (m_write_ordered == false)
         num_particles_to_be_written=cells_get_n_particles();
+    if(m_write_ordered == true && this_node !=0)
+        return ;
     
     bool write_typ = write_dat & W_TYPE;
     bool write_pos = write_dat & W_POS;
@@ -420,15 +383,16 @@ void File::Write(int write_dat)
     time[0][0][0]=sim_time;
     int_array_3d step(boost::extents[1][1][1]);
     step[0][0][0]=(int)std::round(sim_time/time_step);
+    int_array_3d bond(boost::extents[0][0][0]);
 
     if (m_write_ordered == true) {
-        if( this_node == 0 ){ 
+        if( this_node == 0 ){
             //loop over all particles
             for(int particle_index=0;particle_index<n_part;particle_index++){
                 Particle current_particle;
-	        	get_particle_data(particle_index, &current_particle); //this function only works when run with one process
-                fill_arrays_for_h5md_write_with_particle_property(particle_index, id, typ, mass, pos, image, vel, f, charge, &current_particle, write_dat );
-	            free_particle(&current_particle);
+                get_particle_data(particle_index, &current_particle); //this function only works when run with one process
+                fill_arrays_for_h5md_write_with_particle_property(particle_index, id, typ, mass, pos, image, vel, f, charge, &current_particle, write_dat, bond);
+                free_particle(&current_particle);
             }
         }
 
@@ -445,47 +409,95 @@ void File::Write(int write_dat)
                  local_part_id < local_cell->n; ++local_part_id)
             {
                 auto & current_particle = local_cell->part[local_part_id];
-                fill_arrays_for_h5md_write_with_particle_property(particle_index, id, typ, mass, pos, image, vel, f, charge, &current_particle, write_dat );
+                fill_arrays_for_h5md_write_with_particle_property(particle_index, id, typ, mass, pos, image, vel, f, charge, &current_particle, write_dat, bond);
                 particle_index++;
             }
         }
     }
 
-    WriteDataset(id, "particles/atoms/id/value");
-    WriteDataset(time, "particles/atoms/id/time");
-    WriteDataset(step, "particles/atoms/id/step");
+    // calculate count and offset
+    int prefix = 0;
+    //calculate prefix for write of the current process
+    MPI_Exscan(&num_particles_to_be_written, &prefix, 1, MPI_INT, MPI_SUM, m_hdf5_comm);
+    hid_t ds=H5Dget_space(datasets["particles/atoms/id/value"].hid());
+    hsize_t dims_id[2], maxdims_id[2];
+    H5Sget_simple_extent_dims(ds, dims_id, maxdims_id);
+    H5Sclose(ds);
+
+    hsize_t offset_1d[1]={dims_id[0]};
+    hsize_t offset_2d[2]={dims_id[0], (hsize_t) prefix};
+    hsize_t offset_3d[3]={dims_id[0], (hsize_t) prefix, 0};
+    
+    hsize_t count_1d[1]={1};
+    hsize_t count_2d[2]={1, (hsize_t) num_particles_to_be_written};
+    hsize_t count_3d[3]={1, (hsize_t) num_particles_to_be_written, 3};
+    
+    //calculate the change of the extent for fluctuating particle numbers
+    int n_part = max_seen_particle+1;
+    int old_max_n_part=std::max(m_max_n_part, (int) dims_id[1]); // check that dataset is not shrinked: take into account previous dimension, if we append to an already existing dataset
+    if (n_part > old_max_n_part) {
+        m_max_n_part = n_part; 
+    }else{
+        m_max_n_part=old_max_n_part;
+    }
+    int extent_particle_number=m_max_n_part-old_max_n_part;
+    
+    int change_extent_1d[1]={1};
+    int change_extent_2d[2]={1, extent_particle_number};
+    int change_extent_3d[3]={1, extent_particle_number, 0};
+
+
+    if (! m_already_wrote_bonds) {
+        //communicate the total number of bonds to all processes since extending is a collective hdf5 function
+        int nbonds_local=bond.shape()[1];
+        int nbonds_total=nbonds_local;
+        int prefix_bonds=0;
+        if(m_write_ordered!=true){
+            MPI_Exscan(&nbonds_local, &prefix_bonds, 1, MPI_INT, MPI_SUM, m_hdf5_comm);
+            MPI_Allreduce(&nbonds_local, &nbonds_total, 1, MPI_INT, MPI_SUM, m_hdf5_comm);
+        }
+        hsize_t offset_bonds[2]={(hsize_t) prefix_bonds, 0};
+        hsize_t count_bonds[2]={(hsize_t) nbonds_local, 2};
+        int change_extent_bonds[2]={nbonds_total, 2};
+        WriteDataset(bond, "connectivity/atoms", change_extent_bonds, offset_bonds, count_bonds);
+        m_already_wrote_bonds=true;
+    }
+
+
+    WriteDataset(id, "particles/atoms/id/value", change_extent_2d, offset_2d, count_2d);
+    WriteDataset(time, "particles/atoms/id/time", change_extent_1d, offset_1d, count_1d);
+    WriteDataset(step, "particles/atoms/id/step", change_extent_1d, offset_1d, count_1d);
 
     if (write_typ)
     {
-        WriteDataset(typ, "particles/atoms/type/value");
+        WriteDataset(typ, "particles/atoms/type/value", change_extent_2d, offset_2d, count_2d);
     }
     if (write_mass)
     {
-        WriteDataset(mass, "particles/atoms/mass/value");
+        WriteDataset(mass, "particles/atoms/mass/value", change_extent_2d, offset_2d, count_2d);
     }
     if (write_pos)
     {
-        WriteDataset(pos, "particles/atoms/position/value");
-        WriteDataset(image, "particles/atoms/image/value");
+        WriteDataset(pos, "particles/atoms/position/value", change_extent_3d, offset_3d, count_3d);
+        WriteDataset(image, "particles/atoms/image/value", change_extent_3d, offset_3d, count_3d);
     }
     if (write_vel)
     {
-        WriteDataset(vel, "particles/atoms/velocity/value");
+        WriteDataset(vel, "particles/atoms/velocity/value", change_extent_3d, offset_3d, count_3d);
     }
     if (write_force)
     {
-        WriteDataset(f, "particles/atoms/force/value");
+        WriteDataset(f, "particles/atoms/force/value", change_extent_3d, offset_3d, count_3d);
     }
     if (write_charge){
         #ifdef ELECTROSTATICS
-        WriteDataset(charge, "particles/atoms/charge/value");
+        WriteDataset(charge, "particles/atoms/charge/value", change_extent_2d, offset_2d, count_2d);
         #endif
     }
 
 }
 
-
-void File::ExtendDataset(std::string path, int extent_1, int extent_2){
+void File::ExtendDataset(std::string path, int* change_extent){
     /* Until now the h5xx does not support dataset extending, so we
        have to use the lower level hdf5 library functions. */
     auto& dataset = datasets[path];
@@ -496,25 +508,15 @@ void File::ExtendDataset(std::string path, int extent_1, int extent_2){
     H5Sget_simple_extent_dims(ds, dims, maxdims);
     H5Sclose(ds);
     /* Extend the dataset for another timestep (extent=1) */
-    dims[0] += extent_1;
-    if(extent_2!=-10)
-        dims[1] = extent_2;
-    
-    // Extend the dataset for more particles if the particle number increased
-    if(rank>1 && extent_2 ==-10){
-        /* Get the number of particles on all other nodes. */
-        int n_part = std::max((int) dims[1],max_seen_particle+1); //take into account previous dimension, if we append to an already existing dataset
-        if (n_part > m_max_n_part) {
-        	m_max_n_part = n_part; 
-        }
-        dims[1] = m_max_n_part;
+    for(int i=0; i<rank; i++){
+        dims[i]+=change_extent[i];
     }
     H5Dset_extent(dataset.hid(), dims); //extend all dims is collective
 }
 
 /* data is assumed to be three dimensional */
 template <typename T>
-void File::WriteDataset(T &data, const std::string& path)
+void File::WriteDataset(T &data, const std::string& path, int* change_extent, hsize_t* offset, hsize_t* count)
 {
 #ifdef H5MD_DEBUG
     /* Turn on hdf5 error messages */
@@ -522,40 +524,17 @@ void File::WriteDataset(T &data, const std::string& path)
     std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
     std::cout << "Dataset: " << path << std::endl;
 #endif
+    ExtendDataset(path, change_extent);
     auto& dataset = datasets[path];
-    ExtendDataset(path);
-
-    int num_particles_to_be_written = data.shape()[1];
-    int prefix = 0;
-    //calculate prefix for write of the current process
-    MPI_Exscan(&num_particles_to_be_written, &prefix, 1, MPI_INT, MPI_SUM, m_hdf5_comm);
     hid_t ds = H5Dget_space(dataset.hid());
     hsize_t rank = H5Sget_simple_extent_ndims(ds);
-    /* Get the current dimensions of the dataspace. */
-    hsize_t dims[rank], maxdims[rank];
-    H5Sget_simple_extent_dims(ds, dims, maxdims);
-    H5Sclose(ds);
-    /* Select the region in the dataspace. */
-    hsize_t offset[rank];
-    hsize_t count[rank];
-    hid_t ds_new;
-    ds = H5Dget_space(dataset.hid());
-    offset[0]= dims[0]-1; //offset for time (-1 since hdf5 counts from 0 onwards)
-    count [0] = 1; //count for time
-    if(rank>1){
-        //particle based offset and count
-        offset[1]= static_cast<hsize_t>(prefix);
-        count [1] = static_cast<hsize_t>(num_particles_to_be_written);
-     }
-    if(rank>2){
-        //coordinate based offset and count
-        offset[2]= 0;
-        count [2] = data.shape()[2];
+    hsize_t maxdims[rank];
+    for(int i=0;i<rank;i++){
+        maxdims[i]=H5S_UNLIMITED;
     }
-            
     H5Sselect_hyperslab(ds, H5S_SELECT_SET, offset, NULL, count, NULL);
     /* Create a temporary dataspace. */
-    ds_new = H5Screate_simple(rank, count, maxdims);
+    hid_t ds_new = H5Screate_simple(rank, count, maxdims);
     /* Finally write the data to the dataset. */
     H5Dwrite(dataset.hid(),
              dataset.get_type(),
@@ -594,7 +573,7 @@ void File::WriteScript(std::string const &filename)
     space = H5Screate_simple(1, dims, NULL);
     /* Create the dataset. */
     hid_t link_crt_plist = H5Pcreate(H5P_LINK_CREATE);
-    H5Pset_create_intermediate_group(link_crt_plist, true);	// Set flag for intermediate group creation
+    H5Pset_create_intermediate_group(link_crt_plist, true); // Set flag for intermediate group creation
     dset = H5Dcreate(file_id, "parameters/files/script", dtype, space, link_crt_plist, H5P_DEFAULT, H5P_DEFAULT);
     /* Write data from buffer to dataset. */
     if (this_node == 0)
@@ -607,11 +586,11 @@ void File::WriteScript(std::string const &filename)
 }
 
 void File::Flush(){
-	if(m_write_ordered==true){
-		if(this_node==0)
-			H5Fflush(m_h5md_file.hid(),H5F_SCOPE_GLOBAL);
-	} else
-		H5Fflush(m_h5md_file.hid(),H5F_SCOPE_GLOBAL);
+        if(m_write_ordered==true){
+            if(this_node==0)
+                H5Fflush(m_h5md_file.hid(),H5F_SCOPE_GLOBAL);
+        }else
+             H5Fflush(m_h5md_file.hid(),H5F_SCOPE_GLOBAL);
 }
 
 bool File::check_for_H5MD_structure(std::string const &filename)

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -111,7 +111,7 @@ class File
          * @param filename The Name of the hdf5-file to check.
          * @return TRUE if H5MD structure is present, FALSE else.
          */
-        bool check_for_H5MD_structure(std::string const &filename);   
+        bool check_for_H5MD_structure(std::string const &filename);
         /**
          * @brief Method that performs all the low-level stuff for writing the particle
          * positions to the dataset.

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -111,13 +111,24 @@ class File
          * @param filename The Name of the hdf5-file to check.
          * @return TRUE if H5MD structure is present, FALSE else.
          */
-        bool check_for_H5MD_structure(std::string const &filename);
+        bool check_for_H5MD_structure(std::string const &filename);   
         /**
          * @brief Method that performs all the low-level stuff for writing the particle
          * positions to the dataset.
          */
         template <typename T>
         void WriteDataset(T &data, const std::string& path);
+
+        /**
+         * @brief Method that extends datasets.
+         */            
+        void ExtendDataset(std::string path, int extent);
+        
+         /**
+         * @brief Method that returns chunk dimensions.
+         */  
+        std::vector<hsize_t> create_chunk_dims(hsize_t dim, hsize_t size, hsize_t chunk_size);
+        
         /*
          * @brief Method to fill the arrays that are used by WriteDataset particle by particle.
          */
@@ -170,7 +181,6 @@ class File
         struct DatasetDescriptor  {
             std::string path;
             hsize_t dim;
-            hsize_t size;
             h5xx::datatype type;
         };
         std::vector<std::string> group_names;

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -99,6 +99,7 @@ class File
         bool &write_ordered() {return m_write_ordered;} ;
 
     private:
+    	MPI_Comm MPI_H5MD_COMM;
         bool check_file_exists(const std::string &name)
         {
             std::ifstream f(name.c_str());

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -97,6 +97,10 @@ class File
         int &what() { return m_what; };
         // Returns the boolean value that describes whether data should be written to the dataset in the order of ids (possibly slower on output for many particles).
         bool &write_ordered() {return m_write_ordered;} ;
+        /**
+         * @brief Method to force flush to h5md file.
+         */
+        void Flush();
 
     private:
     	MPI_Comm m_hdf5_comm;

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -118,6 +118,10 @@ class File
         template <typename T>
         void WriteDataset(T &data, const std::string& path);
         /*
+         * @brief Method to fill the arrays that are used by WriteDataset particle by particle.
+         */
+	void fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, Particle* current_particle, bool write_typ,bool write_mass,bool write_pos, bool write_vel, bool write_force );
+        /*
          * @brief Method to write the simulation script to the dataset.
          */
         void WriteScript(std::string const &filename);

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -37,6 +37,7 @@
 #include <boost/filesystem.hpp>
 #undef BOOST_NO_CXX11_SCOPED_ENUMS
 #include <h5xx/h5xx.hpp>
+#include "communication.hpp"
 
 
 extern double sim_time;
@@ -94,6 +95,8 @@ class File
         std::string &scriptname() { return m_scriptname; };
         // Returns the int that describes which data should be written to the dataset.
         int &what() { return m_what; };
+        // Returns the boolean value that describes whether data should be written to the dataset in the order of ids (possibly slower on output for many particles).
+        bool &write_ordered() {return m_write_ordered;} ;
 
     private:
         bool check_file_exists(const std::string &name)
@@ -154,6 +157,7 @@ class File
         std::string m_filename;
         std::string m_scriptname;
         int m_what;
+        bool m_write_ordered;
         std::string m_backup_filename;
         boost::filesystem::path m_absolute_script_path = "NULL";
         h5xx::file m_h5md_file;

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -105,7 +105,9 @@ class File
 
     private:
     	MPI_Comm m_hdf5_comm;
-        bool check_file_exists(const std::string &name)
+	bool m_already_wrote_bonds=false;
+        
+	bool check_file_exists(const std::string &name)
         {
             std::ifstream f(name.c_str());
             return f.good();
@@ -122,12 +124,12 @@ class File
          * positions to the dataset.
          */
         template <typename T>
-        void WriteDataset(T &data, const std::string& path);
+        void WriteDataset(T &data, const std::string& path, int* change_extent, hsize_t* offset, hsize_t* count);
 
         /**
-         * @brief Method that extends datasets.
+         * @brief Method that extends datasets by the given extent.
          */            
-        void ExtendDataset(std::string path, int extent_1=1, int extent_2=-10);
+        void ExtendDataset(std::string path, int* change_extent);
         
          /**
          * @brief Method that returns chunk dimensions.
@@ -137,7 +139,7 @@ class File
         /*
          * @brief Method to fill the arrays that are used by WriteDataset particle by particle.
          */
-	void fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, double_array_3d& charge, Particle* current_particle, int write_dat);
+	void fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, double_array_3d& charge, Particle* current_particle, int write_dat, int_array_3d& bond);
         /*
          * @brief Method to write the simulation script to the dataset.
          */

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -160,6 +160,11 @@ class File
          * @param only_load Set this to true if you want to append to an existing file.
          */
         void create_datasets(bool only_load);
+        
+        /**
+         * @brief Links the time and step datasets to of all properties to the time and step dataset of the id property. All properties are written at the same time.
+         */
+	void create_links_for_time_and_step_datasets();
 
         /**
          * @brief Creates the necessary HDF5 groups.

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -99,7 +99,7 @@ class File
         bool &write_ordered() {return m_write_ordered;} ;
 
     private:
-    	MPI_Comm MPI_H5MD_COMM;
+    	MPI_Comm m_hdf5_comm;
         bool check_file_exists(const std::string &name)
         {
             std::ifstream f(name.c_str());
@@ -151,7 +151,7 @@ class File
         void load_file(const std::string& filename);
 
         /**
-         * @brief Initializes the necessary data to create the groups and datsets.
+         * @brief Initializes the necessary data to create the datsets and attributes.
          */
         void init_filestructure();
 
@@ -165,11 +165,6 @@ class File
          * @brief Links the time and step datasets to of all properties to the time and step dataset of the id property. All properties are written at the same time.
          */
 	void create_links_for_time_and_step_datasets();
-
-        /**
-         * @brief Creates the necessary HDF5 groups.
-         */
-        void create_groups();
 
         /**
          * Member variables.
@@ -190,7 +185,6 @@ class File
         };
         std::vector<std::string> group_names;
         std::vector<DatasetDescriptor> dataset_descriptors;
-        std::unordered_map<std::string, h5xx::group> groups;
         std::unordered_map<std::string, h5xx::dataset> datasets;
 };
 

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -127,7 +127,7 @@ class File
         /**
          * @brief Method that extends datasets.
          */            
-        void ExtendDataset(std::string path, int extent);
+        void ExtendDataset(std::string path, int extent_1=1, int extent_2=-10);
         
          /**
          * @brief Method that returns chunk dimensions.

--- a/src/core/io/writer/h5md/h5md_core.hpp
+++ b/src/core/io/writer/h5md/h5md_core.hpp
@@ -78,7 +78,8 @@ class File
                          W_V    = 1 << 1,
                          W_F    = 1 << 2,
                          W_TYPE = 1 << 3,
-                         W_MASS = 1 << 4 };
+                         W_MASS = 1 << 4,
+                         W_CHARGE= 1 << 5};
         /**
          * @brief General method to write to the datasets which calls more specific write methods.
          * @param Boolean values for position, velocity, force and mass.
@@ -136,7 +137,7 @@ class File
         /*
          * @brief Method to fill the arrays that are used by WriteDataset particle by particle.
          */
-	void fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, Particle* current_particle, bool write_typ,bool write_mass,bool write_pos, bool write_vel, bool write_force );
+	void fill_arrays_for_h5md_write_with_particle_property(int particle_index, int_array_3d& id, int_array_3d& typ, double_array_3d& mass, double_array_3d& pos, int_array_3d& image, double_array_3d& vel, double_array_3d& f, double_array_3d& charge, Particle* current_particle, int write_dat);
         /*
          * @brief Method to write the simulation script to the dataset.
          */

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -345,19 +345,19 @@ void free_particle(Particle *part) {
 int updatePartCfg(int bonds_flag)
 {
   int j;
-
+printf("00001000\n");
   if(partCfg)
     return 1;
-
+printf("00002000\n");
   partCfg = (Particle*)Utils::malloc(n_part*sizeof(Particle));
   if (bonds_flag != WITH_BONDS)
     mpi_get_particles(partCfg, NULL);
   else
     mpi_get_particles(partCfg,&partCfg_bl);
-
+printf("00003000\n");
   for(j=0; j<n_part; j++)
     unfold_position(partCfg[j].r.p, partCfg[j].m.v, partCfg[j].l.i);
-
+printf("00004000\n");
   partCfgSorted = 0;
 #ifdef VIRTUAL_SITES
 

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -345,19 +345,15 @@ void free_particle(Particle *part) {
 int updatePartCfg(int bonds_flag)
 {
   int j;
-printf("00001000\n");
   if(partCfg)
     return 1;
-printf("00002000\n");
   partCfg = (Particle*)Utils::malloc(n_part*sizeof(Particle));
   if (bonds_flag != WITH_BONDS)
     mpi_get_particles(partCfg, NULL);
   else
     mpi_get_particles(partCfg,&partCfg_bl);
-printf("00003000\n");
   for(j=0; j<n_part; j++)
     unfold_position(partCfg[j].r.p, partCfg[j].m.v, partCfg[j].l.i);
-printf("00004000\n");
   partCfgSorted = 0;
 #ifdef VIRTUAL_SITES
 

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -91,6 +91,7 @@ foreach(cython_file ${cython_SRC})
                          -I ${CMAKE_CURRENT_SOURCE_DIR}/_espresso
                          ${cython_file}
                          -o ${outputpath}
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
                          DEPENDS _espresso/myconfig.pxi ${cython_file}
                                  ${cython_HEADER}
                          )

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -33,7 +33,7 @@ class H5md(object):
         write_ordered: bool, optional
                        If particle properties should be ordered according to ids.
         """
-        self.valid_params = ['filename','write_ordered',]
+        self.valid_params = ['filename', 'write_ordered',]
         if 'filename' not in kwargs:
             raise ValueError("'filename' parameter missing.")
         self.what = {'write_pos': 1<<0,
@@ -54,7 +54,7 @@ class H5md(object):
                 raise ValueError("Unknown parameter {} for H5MD writer.".format(i))
         
         write_ordered_default=False
-        self.write_ordered=kwargs.get('write_ordered',write_ordered_default)
+        self.write_ordered=kwargs.get('write_ordered', write_ordered_default)
         
         self.h5md_instance = PScriptInterface("ScriptInterface::Writer::H5mdScript")
         self.h5md_instance.set_params(filename=kwargs['filename'], what=self.what_bin,

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -53,7 +53,7 @@ class H5md(object):
             elif i not in self.valid_params:
                 raise ValueError("Unknown parameter {} for H5MD writer.".format(i))
         
-        write_ordered_default=True
+        write_ordered_default=False
         self.write_ordered=kwargs.get('write_ordered',write_ordered_default)
         
         self.h5md_instance = PScriptInterface("ScriptInterface::Writer::H5mdScript")

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -53,7 +53,7 @@ class H5md(object):
             elif i not in self.valid_params:
                 raise ValueError("Unknown parameter {} for H5MD writer.".format(i))
         
-        write_ordered_default=False
+        write_ordered_default=True
         self.write_ordered=kwargs.get('write_ordered', write_ordered_default)
         
         self.h5md_instance = PScriptInterface("ScriptInterface::Writer::H5mdScript")

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -30,8 +30,10 @@ class H5md(object):
                      If types should be written.
         write_mass : bool, optional
                      If masses should be written.
+        write_ordered: bool, optional
+                       If particle properties should be ordered according to ids.
         """
-        self.valid_params = ['filename',]
+        self.valid_params = ['filename','write_ordered',]
         if 'filename' not in kwargs:
             raise ValueError("'filename' parameter missing.")
         self.what = {'write_pos': 1<<0,
@@ -50,9 +52,13 @@ class H5md(object):
                     raise ValueError("{} has to be a bool value.".format(i))
             elif i not in self.valid_params:
                 raise ValueError("Unknown parameter {} for H5MD writer.".format(i))
+        
+        write_ordered_default=True
+        self.write_ordered=kwargs.get('write_ordered',write_ordered_default)
+        
         self.h5md_instance = PScriptInterface("ScriptInterface::Writer::H5mdScript")
         self.h5md_instance.set_params(filename=kwargs['filename'], what=self.what_bin,
-                                      scriptname=sys.argv[0])
+                                      scriptname=sys.argv[0], write_ordered=self.write_ordered)
         self.h5md_instance.call_method("init_file")
 
 

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -30,17 +30,20 @@ class H5md(object):
                      If types should be written.
         write_mass : bool, optional
                      If masses should be written.
+        write_charge : bool, opional
+                       If charges should be written.
         write_ordered: bool, optional
                        If particle properties should be ordered according to ids.
         """
-        self.valid_params = ['filename', 'write_ordered',]
+        self.valid_params = ['filename', "write_ordered"]
         if 'filename' not in kwargs:
             raise ValueError("'filename' parameter missing.")
         self.what = {'write_pos': 1<<0,
                      'write_vel': 1<<1,
                      'write_force': 1<<2,
                      'write_type': 1<<3,
-                     'write_mass': 1<<4}
+                     'write_mass': 1<<4,
+                     'write_charge': 1<<5}
         self.valid_params.append(self.what.keys())
         self.what_bin = 0
         for i, j in iteritems(kwargs):
@@ -74,10 +77,9 @@ class H5md(object):
         self.h5md_instance.call_method("write")
 
     def flush(self):
-        """Calls the H5md write method.
+        """Calls the H5md flush method.
         """
         self.h5md_instance.call_method("flush")
-
 
     def close(self):
         """Close the H5md file.

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -73,6 +73,11 @@ class H5md(object):
         """
         self.h5md_instance.call_method("write")
 
+    def flush(self):
+        """Calls the H5md write method.
+        """
+        self.h5md_instance.call_method("flush")
+
 
     def close(self):
         """Close the H5md file.

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -1,9 +1,12 @@
 from espressomd.utils import to_char_pointer
 
 cdef class PScriptInterface:
-    def __init__(self, name=None):
+    def __init__(self, name=None, policy="GLOBAL"):
         if name:
-            self.sip = make_shared(to_char_pointer(name), GLOBAL)
+            if(policy=="GLOBAL"):
+                self.sip = make_shared(to_char_pointer(name), GLOBAL)
+            else:
+                self.sip = make_shared(to_char_pointer(name), LOCAL)
             self.parameters = self.sip.get().valid_parameters()
         else:
             self.sip = shared_ptr[ScriptInterfaceBase]()

--- a/src/script_interface/h5md/h5md.cpp
+++ b/src/script_interface/h5md/h5md.cpp
@@ -64,6 +64,7 @@ Variant H5mdScript::call_method(const std::string& name, const VariantMap& param
 {
     if (name == "init_file") m_h5md->InitFile();
     else if (name == "write") m_h5md->Write(m_h5md->what());
+    else if (name == "flush") m_h5md->Flush();
     else if (name == "close") m_h5md->Close();
     return {};
 }

--- a/src/script_interface/h5md/h5md.cpp
+++ b/src/script_interface/h5md/h5md.cpp
@@ -35,7 +35,9 @@ ParameterMap H5mdScript::valid_parameters() const
 {
     return {{"filename", {ParameterType::STRING, true}},
             {"scriptname", {ParameterType::STRING, true}},
-            {"what", {ParameterType::INT, true}}};
+            {"what", {ParameterType::INT, true}},
+            {"write_ordered", {ParameterType::BOOL, true}}
+            };
 }
 
 
@@ -44,6 +46,7 @@ void H5mdScript::set_parameter(const std::string& name, const Variant& value)
     SET_PARAMETER_HELPER("filename", m_h5md->filename());
     SET_PARAMETER_HELPER("scriptname", m_h5md->scriptname());
     SET_PARAMETER_HELPER("what", m_h5md->what());
+    SET_PARAMETER_HELPER("write_ordered", m_h5md->write_ordered());
 }
 
 
@@ -51,7 +54,9 @@ VariantMap H5mdScript::get_parameters() const
 {
     return {{"filename", m_h5md->filename()},
             {"scriptname", m_h5md->scriptname()},
-            {"what", m_h5md->what()}};
+            {"what", m_h5md->what()},
+            {"write_ordered", m_h5md->write_ordered()},
+            };
 }
 
 

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -26,58 +26,35 @@ import espressomd  # pylint: disable=import-error
 import h5py  # h5py has to be imported *after* espressomd (MPI)
 
 
-@ut.skipIf('H5MD' not in espressomd.code_info.features(),
-           "H5MD not compiled in, can not check functionality.")
-class H5mdTest(ut.TestCase):
-    """Test the core implementation of writing hdf5 files."""
-    @classmethod
-    def setUpClass(self):
-        """Prepare a testsystem."""
-        from espressomd.io.writer import h5md  # pylint: disable=import-error
-        self.system = espressomd.System()
-        self.system.box_l = [20.0, 20.0, 20.0]
-        self.system.cell_system.skin = 0.4
-        self.system.time_step = 0.01
-        for i in range(10):
-            self.system.part.add(id=i, pos=np.array([float(i),
-                                                     float(i),
-                                                     float(i)]),
-                                 v=np.array([1.0, 2.0, 3.0]), type=23)
-            if 'MASS' in espressomd.code_info.features():
-                self.system.part[i].mass = 2.3
-            if 'EXTERNAL_FORCE' in espressomd.code_info.features():
-                self.system.part[i].ext_force = [0.1, 0.2, 0.3]
-        self.system.integrator.run(steps=0)
-        self.h5 = h5md.H5md(filename="test.h5", write_pos=True, write_vel=True,
-                            write_force=True, write_type=True, write_mass=True)
-        self.h5.write()
-        self.h5.close()
-        del self.h5
-        self.py_file = h5py.File("test.h5", 'r')
-        self.py_pos = self.py_file['particles/atoms/position/value']
-        self.py_vel = self.py_file['particles/atoms/velocity/value']
-        self.py_f = self.py_file['particles/atoms/force/value']
-        self.py_type = self.py_file['particles/atoms/type/value']
-        self.py_mass = self.py_file['particles/atoms/mass/value']
-        self.py_id = self.py_file['particles/atoms/id/value']
-
-    @classmethod
-    def tearDownClass(self):
-        os.remove("test.h5")
+class CommonTests(object):
+    system = espressomd.System()
+    system.box_l = [20.0, 20.0, 20.0]
+    system.cell_system.skin = 0.4
+    system.time_step = 0.01
+    for i in range(10):
+        system.part.add(id=i, pos=np.array([float(i),
+                                            float(i),
+                                            float(i)]),
+                        v=np.array([1.0, 2.0, 3.0]), type=23)
+        if 'MASS' in espressomd.code_info.features():
+            system.part[i].mass = 2.3
+        if 'EXTERNAL_FORCE' in espressomd.code_info.features():
+            system.part[i].ext_force = [0.1, 0.2, 0.3]
+    system.integrator.run(steps=0)
 
     def test_pos(self):
         """Test if positions have been written properly."""
         self.assertTrue(np.allclose(
             np.array([(float(i), float(i), float(i)) for i in range(10)]),
             np.array([x for (y, x) in sorted(zip(self.py_id, self.py_pos))])),
-                        msg="Positions not written correctly by H5md!")
+            msg="Positions not written correctly by H5md!")
 
     def test_vel(self):
         """Test if velocities have been written properly."""
         self.assertTrue(np.allclose(
             np.array([[1.0, 2.0, 3.0] for i in range(10)]),
             np.array([x for (y, x) in sorted(zip(self.py_id, self.py_vel))])),
-                        msg="Velocities not written correctly by H5md!")
+            msg="Velocities not written correctly by H5md!")
 
     @ut.skipIf('EXTERNAL_FORCE' not in espressomd.code_info.features(),
                "EXTERNAL_FORCE not compiled in, can not check writing forces.")
@@ -86,9 +63,72 @@ class H5mdTest(ut.TestCase):
         self.assertTrue(np.allclose(
             np.array([[0.1, 0.2, 0.3] for i in range(10)]),
             np.array([x for (y, x) in sorted(zip(self.py_id, self.py_f))])),
-                        msg="Forces not written correctly by H5md!")
+            msg="Forces not written correctly by H5md!")
+
+
+@ut.skipIf('H5MD' not in espressomd.code_info.features(),
+           "H5MD not compiled in, can not check functionality.")
+class H5mdTestOrdered(ut.TestCase, CommonTests):
+    """Test the core implementation of writing hdf5 files."""
+    @classmethod
+    def tearDownClass(cls):
+        os.remove("test.h5")
+
+    @classmethod
+    def setUpClass(cls):
+        write_ordered = True
+        """Prepare a testsystem."""
+        from espressomd.io.writer import h5md  # pylint: disable=import-error
+        cls.h5 = h5md.H5md(filename="test.h5", write_pos=True, write_vel=True,
+                           write_force=True, write_type=True, write_mass=True,
+                           write_ordered=write_ordered)
+        cls.h5.write()
+        cls.h5.close()
+        del cls.h5
+        cls.py_file = h5py.File("test.h5", 'r')
+        cls.py_pos = cls.py_file['particles/atoms/position/value']
+        cls.py_vel = cls.py_file['particles/atoms/velocity/value']
+        cls.py_f = cls.py_file['particles/atoms/force/value']
+        cls.py_type = cls.py_file['particles/atoms/type/value']
+        cls.py_mass = cls.py_file['particles/atoms/mass/value']
+        cls.py_id = cls.py_file['particles/atoms/id/value']
+
+    def test_ids(self):
+        """Test if ids have been written properly."""
+        self.assertTrue(np.allclose(
+            np.array(range(10)),
+            self.py_id),
+            msg="ids correctly ordered and written by H5md!")
+
+
+class H5mdTestUnordered(ut.TestCase, CommonTests):
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove("test.h5")
+
+    @classmethod
+    def setUpClass(cls):
+        write_ordered = False
+        """Prepare a testsystem."""
+        from espressomd.io.writer import h5md  # pylint: disable=import-error
+        cls.h5 = h5md.H5md(filename="test.h5", write_pos=True, write_vel=True,
+                           write_force=True, write_type=True, write_mass=True,
+                           write_ordered=False)
+        cls.h5.write()
+        cls.h5.close()
+        del cls.h5
+        cls.py_file = h5py.File("test.h5", 'r')
+        cls.py_pos = cls.py_file['particles/atoms/position/value']
+        cls.py_vel = cls.py_file['particles/atoms/velocity/value']
+        cls.py_f = cls.py_file['particles/atoms/force/value']
+        cls.py_type = cls.py_file['particles/atoms/type/value']
+        cls.py_mass = cls.py_file['particles/atoms/mass/value']
+        cls.py_id = cls.py_file['particles/atoms/id/value']
 
 
 if __name__ == "__main__":
-    suite = ut.TestLoader().loadTestsFromTestCase(H5mdTest)
+    suite = ut.TestLoader().loadTestsFromTestCase(H5mdTestUnordered)
+    ut.TextTestRunner(verbosity=2).run(suite)
+    suite = ut.TestLoader().loadTestsFromTestCase(H5mdTestOrdered)
     ut.TextTestRunner(verbosity=2).run(suite)

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -25,13 +25,13 @@ import numpy as np
 import espressomd  # pylint: disable=import-error
 import h5py  # h5py has to be imported *after* espressomd (MPI)
 
-
+npart=25
 class CommonTests(object):
     system = espressomd.System()
-    system.box_l = [20.0, 20.0, 20.0]
+    system.box_l = [npart, npart, npart] #avoid particles to be set outside of the main box, otherwise particle positions are folded in the core when writing out and we cannot directly compare positions in the dataset and where particles were set. One would need to unfold the positions of the hdf5 file.
     system.cell_system.skin = 0.4
     system.time_step = 0.01
-    for i in range(10):
+    for i in range(npart):
         system.part.add(id=i, pos=np.array([float(i),
                                             float(i),
                                             float(i)]),
@@ -45,14 +45,14 @@ class CommonTests(object):
     def test_pos(self):
         """Test if positions have been written properly."""
         self.assertTrue(np.allclose(
-            np.array([(float(i), float(i), float(i)) for i in range(10)]),
+            np.array([(float(i), float(i), float(i)) for i in range(npart)]),
             np.array([x for (y, x) in sorted(zip(self.py_id, self.py_pos))])),
             msg="Positions not written correctly by H5md!")
 
     def test_vel(self):
         """Test if velocities have been written properly."""
         self.assertTrue(np.allclose(
-            np.array([[1.0, 2.0, 3.0] for i in range(10)]),
+            np.array([[1.0, 2.0, 3.0] for i in range(npart)]),
             np.array([x for (y, x) in sorted(zip(self.py_id, self.py_vel))])),
             msg="Velocities not written correctly by H5md!")
 
@@ -61,7 +61,7 @@ class CommonTests(object):
     def test_f(self):
         """Test if forces have been written properly."""
         self.assertTrue(np.allclose(
-            np.array([[0.1, 0.2, 0.3] for i in range(10)]),
+            np.array([[0.1, 0.2, 0.3] for i in range(npart)]),
             np.array([x for (y, x) in sorted(zip(self.py_id, self.py_f))])),
             msg="Forces not written correctly by H5md!")
 
@@ -96,7 +96,7 @@ class H5mdTestOrdered(ut.TestCase, CommonTests):
     def test_ids(self):
         """Test if ids have been written properly."""
         self.assertTrue(np.allclose(
-            np.array(range(10)),
+            np.array(range(npart)),
             self.py_id),
             msg="ids correctly ordered and written by H5md!")
 


### PR DESCRIPTION
I made H5MD output standard conform (the dimensionality of the datasets that were written was in some cases wrong). Further I added fast ordered output for h5md from the master node only. In the case of having tons of particles the output might be faster with the option write_ordered=false which performs writing in parallel on all nodes, however data is not sorted according to ids.