### PR TITLE
travis: Disabled OSX tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,18 @@ matrix:
       sudo: required
       services: docker
       env: myconfig=maxset image=ubuntu-cuda make_check=false
-    - os: osx
-      osx_image: xcode8
-      env: myconfig=maxset
-      cache:
-        directories:
-        - /usr/local/Cellar/boost
-    - os: osx
-      osx_image: xcode8
-      env: myconfig=maxset image=python3
-      cache:
-        directories:
-        - /usr/local/Cellar/boost
+#    - os: osx
+#      osx_image: xcode8
+#      env: myconfig=maxset
+#      cache:
+#        directories:
+#        - /usr/local/Cellar/boost
+#    - os: osx
+#      osx_image: xcode8
+#      env: myconfig=maxset image=python3
+#      cache:
+#        directories:
+#        - /usr/local/Cellar/boost
     - os: linux
       sudo: required
       services: docker


### PR DESCRIPTION
The false positives are annoying. They can be re-enabled when the boost build on osx is fixed.
