### PR TITLE
Don’t click this if you don’t want to set LB populations

### DIFF
--- a/src/core/lb.cpp
+++ b/src/core/lb.cpp
@@ -1381,7 +1381,16 @@ int lb_lbnode_get_boundary(int* ind, int* p_boundary) {
 
 int lb_lbnode_get_pop(int* ind, double* p_pop) {
     if (lattice_switch & LATTICE_LB_GPU) {
-        fprintf(stderr, "Not implemented for GPU\n");
+#ifdef LB_GPU
+      float population[19];
+
+      // c is the LB_COMPONENT for SHANCHEN (not yet interfaced)
+      int c = 0;
+      lb_lbfluid_get_population( ind, population, c );
+
+      for (int i = 0; i < LBQ; ++i)
+        p_pop[i] = population[i];
+#endif // LB_GPU
     } else {
 #ifdef LB
         index_t index;
@@ -1475,7 +1484,16 @@ int lb_lbnode_set_pi_neq(int* ind, double* pi_neq) {
 
 int lb_lbnode_set_pop(int* ind, double* p_pop) {
     if (lattice_switch & LATTICE_LB_GPU) {
-        printf("Not implemented in the LB GPU code!\n");
+#ifdef LB_GPU
+      float population[19];
+
+      for (int i = 0; i < LBQ; ++i)
+        population[i] = p_pop[i];
+
+      // c is the LB_COMPONENT for SHANCHEN (not yet interfaced)
+      int c = 0;
+      lb_lbfluid_set_population( ind, population, c );
+#endif // LB_GPU
     } else {
 #ifdef LB
         index_t index;

--- a/src/core/lbgpu.hpp
+++ b/src/core/lbgpu.hpp
@@ -311,6 +311,9 @@ void lb_lbfluid_fluid_add_momentum(float momentum[3]);
 void lb_lbfluid_calc_linear_momentum(float momentum[3], int include_particles, int include_lbfluid);
 void lb_lbfluid_particles_add_momentum(float velocity[3]);
 
+void lb_lbfluid_set_population( int[3], float[LBQ], int );
+void lb_lbfluid_get_population( int[3], float[LBQ], int );
+
 //int statistics_observable_lbgpu_radial_velocity_profile(radial_profile_data* pdata, double* A, unsigned int n_A);
 //int statistics_observable_lbgpu_velocity_profile(profile_data* pdata, double* A, unsigned int n_A);
 

--- a/src/python/espressomd/lb.pxd
+++ b/src/python/espressomd/lb.pxd
@@ -95,6 +95,7 @@ IF LB_GPU or LB:
         int lb_lbnode_get_pi(int * coord, double * double_return)
         int lb_lbnode_get_pi_neq(int * coord, double * double_return)
         int lb_lbnode_get_pop(int * coord, double * double_return)
+        int lb_lbnode_set_pop(int * coord, double * double_return)
         int lb_lbnode_get_boundary(int * coord, int * int_return)
         int lb_lbfluid_set_couple_flag(int c_couple_flag)
         int lb_lbfluid_get_couple_flag(int * c_couple_flag)

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -267,7 +267,8 @@ IF LB or LB_GPU:
                 return double_return
 
             def __set__(self, value):
-                raise Exception("Not implemented.")
+                cdef double[19] double_return = value
+                lb_lbnode_set_pop(self.node, double_return)
 
         property boundary:
             def __get__(self):

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -18,6 +18,9 @@ export PYTHONPATH
 if [ "$1" = "--gdb" ]; then
   shift
   exec gdb -ex run --args @PYTHON_FRONTEND@ $@
+elif [ "$1" = "--cuda-gdb" ]; then
+  shift
+  exec cuda-gdb -ex run --args @PYTHON_FRONTEND@ $@
 fi
 
 exec @PYTHON_FRONTEND@ $@


### PR DESCRIPTION
So far directly setting the populations on the LB lattice nodes was only possible for LB on the CPU.  This PR introduces this feature for the GPU.

Note:  Because SHANCHEN is not yet interfaced, it is not clear what the behaviour for a multi-component fluid should be.  We ensure extensibility by providing a default parameter for the fluid component, which defaults to 0 (which is the case without SHANCHEN).