### PR TITLE
Travis has two cores.  Why don't we use them?

### DIFF
--- a/maintainer/travis/build_cmake.sh
+++ b/maintainer/travis/build_cmake.sh
@@ -117,21 +117,21 @@ end "CONFIGURE"
 # BUILD
 start "BUILD"
 
-cmd "make" || exit $?
+cmd "make -j2" || exit $?
 
 end "BUILD"
 
 if $make_check; then
     start "TEST"
 
-    cmd "make check_python $make_params"
+    cmd "make -j2 check_python $make_params"
     ec=$?
     if [ $ec != 0 ]; then	
         cmd "cat $srcdir/testsuite/python/Testing/Temporary/LastTest.log"
         exit $ec
     fi
 
-    cmd "make check_unit_tests $make_params"
+    cmd "make -j2 check_unit_tests $make_params"
     ec=$?
     if [ $ec != 0 ]; then	
         cmd "cat $srcdir/src/core/unit_tests/Testing/Temporary/LastTest.log"


### PR DESCRIPTION
This gives a speedup of several minutes for the builds.  Compare [Build 1722][1722] with [Build 1723][1723]:

| Build 1722    | Build 1723    |
|---------------|---------------|
| 8 min 33 sec  | 7 min 27 sec  |
| 10 min 53 sec | 7 min 57 sec  |
| 10 min 13 sec | 8 min 2 sec   |
| 10 min 21 sec | 8 min 42 sec  |
| 15 min 11 sec | 12 min 11 sec |
| 30 min 52 sec | 17 min 35 sec |
| 39 min 2 sec  | 18 min 7 sec  |
| 9 min 26 sec  | 7 min 59 sec  |
| 9 min 8 sec   | 8 min         |
| 9 min 57 sec  | 7 min 53 sec  |
| 8 min 1 sec   | 7 min 9 sec   |
| 9 min 44 sec  | 6 min 54 sec  |
| 8 min 57 sec  | 7 min 2 sec   |

[1722]: https://travis-ci.org/espressomd/espresso/builds/202585126
[1723]: https://travis-ci.org/espressomd/espresso/builds/202601995