### PR TITLE
random: Initialize PRNG with random number from system.

### DIFF
--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -127,7 +127,7 @@ string mpi_random_get_stat() {
 
 void init_random(void) {
   /** Set the initial seed */
-  init_random_seed(1 + this_node);
+  init_random_seed(std::random_device()());
 
   /** Register callbacks */
   mpiCallbacks().add(mpi_random_seed_slave);
@@ -135,11 +135,13 @@ void init_random(void) {
   mpiCallbacks().add(mpi_random_get_stat_slave);
 }
 
-void init_random_seed(int seed)
-{
-  std::seed_seq seeder{seed}; //come up with "sane" initialization to avoid too many zeros in the internal state of the Mersenne twister
+void init_random_seed(int seed) {
+  std::seed_seq seeder{seed}; // come up with "sane" initialization to avoid too
+                              // many zeros in the internal state of the
+                              // Mersenne twister
   generator.seed(seeder);
-  generator.discard(1e6); //discard the first 1e6 random numbers to warm up the Mersenne-Twister PRNG
+  generator.discard(1e6); // discard the first 1e6 random numbers to warm up the
+                          // Mersenne-Twister PRNG
 }
 
 } /* Random */

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -1,28 +1,28 @@
 /*
   Copyright (C) 2010,2012,2013,2014,2015,2016 The ESPResSo project
 
-  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
     Max-Planck-Institute for Polymer Research, Theory Group
-  
+
   This file is part of ESPResSo.
-  
+
   ESPResSo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   ESPResSo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifndef RANDOM_H
 #define RANDOM_H
 
-/** \file random.hpp 
+/** \file random.hpp
 
     A random generator
 */
@@ -78,51 +78,55 @@ void init_random_seed(int seed);
 } /* Random */
 
 /**
- * @brief Draws a random real number from the uniform distribution in the range [0,1)
+ * @brief Draws a random real number from the uniform distribution in the range
+ * [0,1)
 */
 
 inline double d_random() {
   using namespace Random;
-  return uniform_real_distribution(generator); 
+  return uniform_real_distribution(generator);
 }
 
 /**
- * @brief draws a random integer from the uniform distribution in the range [0,maxint-1]
+ * @brief draws a random integer from the uniform distribution in the range
+ * [0,maxint-1]
  *
  * @param maxint range.
  */
-inline int i_random(int maxint){
+inline int i_random(int maxint) {
   using namespace Random;
-  std::uniform_int_distribution<int> uniform_int_dist(0, maxint-1);
+  std::uniform_int_distribution<int> uniform_int_dist(0, maxint - 1);
   return uniform_int_dist(generator);
 }
 
 /**
- * @brief draws a random number from the normal distribution with mean 0 and variance 1.
+ * @brief draws a random number from the normal distribution with mean 0 and
+ * variance 1.
  */
-inline double gaussian_random(void){
+inline double gaussian_random(void) {
   using namespace Random;
   return normal_distribution(generator);
 }
 
-
 /**
  * @brief Generator for cutoff Gaussian random numbers.
  *
- * Generates a Gaussian random number and generates a number between -2 sigma and 2 sigma in the form of a Gaussian with standard deviation sigma=1.118591404 resulting in 
+ * Generates a Gaussian random number and generates a number between -2 sigma
+ * and 2 sigma in the form of a Gaussian with standard deviation
+ * sigma=1.118591404 resulting in
  * an actual standard deviation of 1.
  *
  * @return Gaussian random number.
  */
-inline double gaussian_random_cut(void){
+inline double gaussian_random_cut(void) {
   using namespace Random;
-  const double random_number=1.042267973*normal_distribution(generator);
-  
-  if ( fabs(random_number) > 2*1.042267973 ) {
-    if ( random_number > 0 ) {
-      return 2*1.042267973;
+  const double random_number = 1.042267973 * normal_distribution(generator);
+
+  if (fabs(random_number) > 2 * 1.042267973) {
+    if (random_number > 0) {
+      return 2 * 1.042267973;
     } else {
-      return -2*1.042267973;
+      return -2 * 1.042267973;
     }
   }
   return random_number;


### PR DESCRIPTION
Due to popular demand and against my better judgement, initialize
the PRNG with std::random_device.

Fixes nothing

Description of changes:
 - Initialize PRNG with true random number from std::random_device.
- clang-format

PR Checklist
------------
 - [ ] Tests? Very hard to test, details are implementation specific.
