### PR TITLE
Even click-bate PR writers are surprised by this little hack.

### DIFF
--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -15,21 +15,19 @@ find_program(SPHINX_API_DOC_EXE NAMES sphinx-apidoc sphinx-apidoc-${PYTHON_VERSI
     DOC "Sphinx api-doc executable."
 )
 
-if( Sphinx_FIND_VERSION )
+if(SPHINX_FIND_VERSION)
   execute_process(COMMAND "${SPHINX_EXECUTABLE}" --version
                   OUTPUT_VARIABLE QUERY_VERSION
                   RESULT_VARIABLE QUERY_VERSION_RESULT
                   ERROR_QUIET)
-  if( NOT QUERY_VERSION_RESULT )
+  if(NOT QUERY_VERSION_RESULT)
     string(REGEX MATCH "[0-9.]+" AVAILABLE_VERSION "${QUERY_VERSION}")
-    if( "${Sphinx_FIND_VERSION}" VERSION_GREATER "${AVAILABLE_VERSION}" )
-      message(FATAL_ERROR "Sphinx version ${Sphinx_FIND_VERSION} requested but only ${AVAILABLE_VERSION} found!")
-    endif( )
   endif( )
 endif( )
 
 find_package_handle_standard_args(Sphinx DEFAULT_MSG
-    SPHINX_EXECUTABLE
+    REQUIRED_VARS SPHINX_EXECUTABLE SPHINX_API_DOC_EXE
+    VERSION_VAR AVAILABLE_VERSION
 )
  
 mark_as_advanced(SPHINX_EXECUTABLE)


### PR DESCRIPTION
sphinx: remove FATAL_ERROR from FindSphinx.