### PR TITLE
cmake: remove soversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,6 @@ project(ESPResSo)
 enable_language(CXX)
 
 set(PROJECT_VERSION "4.0-dev")
-string(REGEX REPLACE "^([1-9]+)\\.[0-9]+.*$" "\\1" SOVERSION "${PROJECT_VERSION}")
-if (NOT ${SOVERSION} MATCHES "^[1-9]+$")
-  message(FATAL_ERROR "Could not determind SOVERSION from ${PROJECT_VERSION}")
-endif (NOT ${SOVERSION} MATCHES "^[1-9]+$")
 
 ######################################################################
 # CMake internal vars
@@ -239,10 +235,6 @@ add_definitions(-DH5XX_USE_MPI)
 if (NOT DEFINED DATA)
   set(DATA "share/espresso")
 endif(NOT DEFINED DATA)
-
-if (NOT DEFINED LIBDIR)
-  set(LIBDIR "lib")
-endif(NOT DEFINED LIBDIR)
 
 if (NOT DEFINED BINDIR)
   set(BINDIR "bin")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,8 +23,7 @@ add_custom_target(EspressoConfig DEPENDS config-features.hpp config-features.cpp
 add_dependencies(EspressoConfig myconfig)
 
 add_library(EspressoCore SHARED ${EspressoCore_SRC} config-features.cpp config-version.cpp)
-set_target_properties(EspressoCore PROPERTIES SOVERSION ${SOVERSION})
-install(TARGETS EspressoCore LIBRARY DESTINATION ${LIBDIR})
+install(TARGETS EspressoCore LIBRARY DESTINATION ${PYTHON_INSTDIR})
 add_dependencies(EspressoCore EspressoConfig)
 
 target_link_libraries(EspressoCore ${LIBRARIES} Actor ObjectInFluid ImmersedBoundary Shapes Constraints EspressoUtils Correlators Observables)
@@ -44,7 +43,7 @@ if(CUDA)
   cuda_include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
   cuda_add_library(EspressoCuda SHARED ${EspressoCuda_SRC})
-  install(TARGETS EspressoCuda DESTINATION ${LIBDIR})
+  install(TARGETS EspressoCuda DESTINATION ${PYTHON_INSTDIR})
   add_dependencies(EspressoCuda EspressoConfig)
 
   set_target_properties(EspressoCuda PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/actor/CMakeLists.txt
+++ b/src/core/actor/CMakeLists.txt
@@ -1,8 +1,7 @@
 file(GLOB Actor_SRC *.cpp)
 
 add_library(Actor SHARED ${Actor_SRC})
-set_target_properties(Actor PROPERTIES SOVERSION ${SOVERSION})
-install(TARGETS Actor LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
+install(TARGETS Actor LIBRARY DESTINATION ${PYTHON_INSTDIR} ARCHIVE DESTINATION ${PYTHON_INSTDIR})
 add_dependencies(Actor EspressoConfig)
 
 set_target_properties(Actor PROPERTIES MACOSX_RPATH TRUE)
@@ -10,7 +9,7 @@ set_target_properties(Actor PROPERTIES MACOSX_RPATH TRUE)
 if(CUDA)
   file(GLOB ActorCuda_SRC *.cu)
   cuda_add_library(ActorCuda SHARED ${ActorCuda_SRC})
-  install(TARGETS ActorCuda DESTINATION ${LIBDIR})
+  install(TARGETS ActorCuda DESTINATION ${PYTHON_INSTDIR})
   add_dependencies(ActorCuda EspressoConfig)
 
   add_dependencies(Actor ActorCuda)

--- a/src/core/immersed_boundary/CMakeLists.txt
+++ b/src/core/immersed_boundary/CMakeLists.txt
@@ -1,14 +1,13 @@
 file(GLOB ImmersedBoundary_SRC *.cpp)
 add_library(ImmersedBoundary SHARED ${ImmersedBoundary_SRC})
-set_target_properties(ImmersedBoundary PROPERTIES SOVERSION ${SOVERSION})
 set_target_properties(ImmersedBoundary PROPERTIES MACOSX_RPATH TRUE)
-install(TARGETS ImmersedBoundary LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
+install(TARGETS ImmersedBoundary LIBRARY DESTINATION ${PYTHON_INSTDIR} ARCHIVE DESTINATION ${PYTHON_INSTDIR})
 add_dependencies(ImmersedBoundary EspressoConfig)
 
 if(CUDA)
   file(GLOB ImmersedBoundaryCuda_SRC *.cu)
   cuda_add_library(ImmersedBoundaryCuda SHARED ${ImmersedBoundaryCuda_SRC})
-  install(TARGETS ImmersedBoundaryCuda DESTINATION ${LIBDIR})
+  install(TARGETS ImmersedBoundaryCuda DESTINATION ${PYTHON_INSTDIR})
   add_dependencies(ImmersedBoundaryCuda EspressoConfig)
 
   set_target_properties(ImmersedBoundaryCuda PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/object-in-fluid/CMakeLists.txt
+++ b/src/core/object-in-fluid/CMakeLists.txt
@@ -1,6 +1,5 @@
 file(GLOB ObjectInFluid_SRC *.cpp)
 add_library(ObjectInFluid SHARED ${ObjectInFluid_SRC})
-set_target_properties(ObjectInFluid PROPERTIES SOVERSION ${SOVERSION})
-install(TARGETS ObjectInFluid LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
+install(TARGETS ObjectInFluid LIBRARY DESTINATION ${PYTHON_INSTDIR} ARCHIVE DESTINATION ${PYTHON_INSTDIR})
 add_dependencies(ObjectInFluid EspressoConfig)
 set_target_properties(ObjectInFluid PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/scafacos/CMakeLists.txt
+++ b/src/core/scafacos/CMakeLists.txt
@@ -2,8 +2,7 @@ include_directories(${SCAFACOS_INCLUDE_DIRS})
 
 file(GLOB Scafacos_SRC *.cpp)
 add_library(Scafacos SHARED ${Scafacos_SRC})
-set_target_properties(Scafacos PROPERTIES SOVERSION ${SOVERSION})
-install(TARGETS Scafacos DESTINATION ${LIBDIR})
+install(TARGETS Scafacos DESTINATION ${PYTHON_INSTDIR})
 add_dependencies(Scafacos EspressoConfig)
 
 target_link_libraries(Scafacos ${SCAFACOS_LDFLAGS})


### PR DESCRIPTION
Espresso is a python module now, so .so versioning is not needed
anymore. Move all libraries into python module path as well.