### PR TITLE
add reference to martys99 for quaternions integrator

### DIFF
--- a/doc/ug/otherrefs.bib
+++ b/doc/ug/otherrefs.bib
@@ -554,6 +554,17 @@ year = {2007},
   pages = {1106}
 }
 
+@article{martys99,
+  title = {Velocity Verlet algorithm for dissipative-particle-dynamics-based models of suspensions},
+  author = {Martys, Nicos S. and Mountain, Raymond D.},
+  journal = {Phys. Rev. E},
+  volume = {59},
+  issue = {3},
+  pages = {3733--3736},
+  year = {1999},
+  doi = {10.1103/PhysRevE.59.3733}
+}
+
 @ARTICLE{mehlig92,
   author = {Mehlig, B. and Heermann, D. W. and Forrest, B. M.},
   title = {Hybrid Monte Carlo method for condensed-matter systems},

--- a/doc/ug/run.tex
+++ b/doc/ug/run.tex
@@ -81,6 +81,9 @@ can be added are:
   box is assumed.
 \end{itemize}
 
+For systems with the \feature{ROTATION} feature, the integration is done using the
+quaternion-based Velocity Verlet scheme by Martys and Mountain~\cite{martys99}.
+
 \section{\texttt{time_integration}: Runtime of the integration loop}
 \newescommand[time-integration]{time_integration}
 


### PR DESCRIPTION
The source code refers to
http://ciks.cbt.nist.gov/~garbocz/dpd1/dpd.html that is actually the web
version of the (now-)cited article.

There is no corresponding issue number.

Description of changes:
 - Addition of a reference and of a comment about quaternion based-integration in the section "integrate".


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [x] Docs?
