### PR TITLE
Merge this PR and ESPResSo will never be the same again

### DIFF
--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -128,6 +128,28 @@ public:
   }
 };
 
+
+// type checking using SFINAE
+
+namespace traits {
+
+template < typename T >
+struct is_vector
+{
+  static constexpr const bool value = false;
+};
+
+template < size_t n, typename Scalar >
+struct is_vector < Vector < n, Scalar > >
+{
+  static constexpr const bool value = true;
+};
+
+} // namespace traits
+
+
+// Useful typedefs
+
 typedef Vector<3, double> Vector3d;
 typedef Vector<2, double> Vector2d;
 

--- a/src/script_interface/ScriptInterfaceBase.hpp
+++ b/src/script_interface/ScriptInterfaceBase.hpp
@@ -31,14 +31,15 @@
 
 namespace ScriptInterface {
 
-template <typename T> T get_value(Variant const &v) { return boost::get<T>(v); }
+template < typename T >
+typename std::enable_if<!traits::is_vector<T>::value, T>::type
+get_value(Variant const& v) { return boost::get<T>(v); }
 
-template <> inline Vector3d get_value<Vector3d>(Variant const &v) {
-  return Vector3d(boost::get<std::vector<double>>(v));
-}
-
-template <> inline Vector2d get_value<Vector2d>(Variant const &v) {
-  return Vector2d(boost::get<std::vector<double>>(v));
+template < typename T >
+inline typename std::enable_if<traits::is_vector<T>::value, T>::type
+get_value(Variant const& v)
+{
+  return T(boost::get<std::vector<double>>(v));
 }
 
 /**


### PR DESCRIPTION
Instead of having separate specializations for `Vector2d`, `Vector3d`, etc. in `ScriptInterfaceBase.hpp` this PR proposes template overloads based on [SFINAE](http://en.cppreference.com/w/cpp/language/sfinae) which choose a different implementation at compile time for *all* instantiations of the `Vector` class template.