### PR TITLE
cmake: Add SCAFACOS include dir.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,6 +30,7 @@ add_dependencies(EspressoCore EspressoConfig)
 target_link_libraries(EspressoCore ${LIBRARIES} Actor ObjectInFluid ImmersedBoundary Shapes Constraints EspressoUtils Correlators Observables)
 
 if(SCAFACOS)
+  include_directories(${SCAFACOS_INCLUDE_DIRS})
   target_link_libraries(EspressoCore Scafacos)
 endif(SCAFACOS)
 


### PR DESCRIPTION
Fixes # -

Description of changes:
 - Add scafacos include dir to include dirs so that build with scafacos works if scafacos is in a non-standard location
