### PR TITLE
Rotational inertia Tcl test port to Python

### DIFF
--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -13,6 +13,7 @@ set(py_tests  bondedInteractions.py
               observables.py
               p3m_gpu.py
               particle.py
+              rotational_inertia.py
               lbgpu_remove_total_momentum.py
               tabulated.py
 )

--- a/testsuite/python/rotational_inertia.py
+++ b/testsuite/python/rotational_inertia.py
@@ -1,0 +1,127 @@
+from __future__ import print_function
+import unittest as ut
+import numpy as np
+import espressomd
+import math
+
+if "MASS" in espressomd.features() and "ROTATIONAL_INERTIA" in espressomd.features():
+    class ThermoTest(ut.TestCase):
+        longMessage = True
+        # Handle for espresso system
+        es = espressomd.System()
+
+        def define_rotation_matrix(self, part):
+            A = np.zeros((3,3))
+            quat = self.es.part[part].quat
+            quatu = self.es.part[part].director
+            qq = np.power(quat,2)
+            
+            A[0,0] = qq[0] + qq[1] - qq[2] - qq[3]
+            A[1,1] = qq[0] - qq[1] + qq[2] - qq[3]
+            A[2,2] = qq[0] - qq[1] - qq[2] + qq[3]
+            
+            A[0,1] = 2 * (quat[1] * quat[2] + quat[0] * quat[3])
+            A[0,2] = 2 * (quat[1] * quat[3] - quat[0] * quat[2])
+            A[1,0] = 2 * (quat[1] * quat[2] - quat[0] * quat[3])
+            
+            A[1,2] = 2 * (quat[2] * quat[3] + quat[0] * quat[1])
+            A[2,0] = 2 * (quat[1] * quat[3] + quat[0] * quat[2])
+            A[2,1] = 2 * (quat[2] * quat[3] - quat[0] * quat[1])
+            
+            return A
+
+        def convert_vec_body_to_space(self, part, vec):
+            vec_lab = np.zeros((3))
+            A = self.define_rotation_matrix(part)
+            vec_lab[:] = A[0,:] * vec[0] + A[1,:] * vec[1] + A[2,:] * vec[2]
+            return vec_lab
+            
+        # Angular momentum
+        def L_body(self, part):
+            L_body_return = np.zeros((3))
+            L_body_return = self.es.part[part].omega_body[:] * self.es.part[part].rinertia[:]
+            return L_body_return
+            
+        def test(self):
+            self.es.cell_system.skin = 0
+            self.es.part.add(pos=np.array([0.0, 0.0, 0.0]),id=0)
+            
+            #Inertial motion around the stable and unstable axes
+            
+            self.es.thermostat.turn_off()
+            
+            tol = 4E-3
+            T = np.zeros((3))
+            # Anisotropic inertial moment. Stable axes correspond to J[1] and J[2].
+            # The unstable axis corresponds to J[0]. These values relation is J[1] < J[0] < J[2].
+            J = np.array([5,0.5,18.5])
+            
+            # Validation of J[1] stability
+            # ----------------------------
+            self.es.time_step = 0.0006
+            # Stable omega component should be larger than other components.
+            stable_omega = 57.65
+            self.es.part[0].omega_body=np.array([0.15, stable_omega, -0.043])
+            self.es.part[0].rinertia = J[:]
+            self.es.part[0].ext_torque = T[:]
+            
+            # Angular momentum
+            L_0_body = np.zeros((3))
+            L_0_body = self.L_body(0)
+            L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
+            
+            for i in range(100):
+                L_body = self.L_body(0)
+                L_lab = self.convert_vec_body_to_space(0, L_body)
+                for k in range(3):
+                    self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                                    msg = 'Inertial motion around stable axis J1: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
+                self.assertTrue(abs(self.es.part[0].omega_body[1] - stable_omega) <= tol, \
+                                msg = 'Inertial motion around stable axis J1: Deviation in omega is too large. Step {0}, coordinate 1, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[1]))
+                self.es.integrator.run(10)
+                
+            # Validation of J[2] stability
+            # ----------------------------
+            self.es.time_step = 0.01
+            # Stable omega component should be larger than other components.
+            stable_omega = 3.2
+            self.es.part[0].omega_body=np.array([0.011, -0.043, stable_omega])
+            self.es.part[0].rinertia = J[:]
+            self.es.part[0].ext_torque = T[:]
+            
+            L_0_body = self.L_body(0)
+            L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
+            
+            for i in range(100):
+                L_body = self.L_body(0)
+                L_lab = self.convert_vec_body_to_space(0, L_body)
+                for k in range(3):
+                    self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                                    msg = 'Inertial motion around stable axis J2: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
+                self.assertTrue(abs(self.es.part[0].omega_body[2] - stable_omega) <= tol, \
+                                    msg = 'Inertial motion around stable axis J2: Deviation in omega is too large. Step {0}, coordinate 2, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[2]))
+                self.es.integrator.run(10)
+                
+            # Validation of J[0]
+            # ------------------
+            self.es.time_step = 0.001
+            # Unstable omega component should be larger than other components.
+            unstable_omega = 5.76
+            self.es.part[0].omega_body=np.array([unstable_omega, -0.043, 0.15])
+            self.es.part[0].rinertia = J[:]
+            self.es.part[0].ext_torque = T[:]
+            
+            L_0_body = self.L_body(0)
+            L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
+            
+            for i in range(100):
+                L_body = self.L_body(0)
+                L_lab = self.convert_vec_body_to_space(0, L_body)
+                for k in range(3):
+                    self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                                    msg = 'Inertial motion around stable axis J0: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
+                self.es.integrator.run(10)
+            
+if __name__ == '__main__':
+    print("Features: ", espressomd.features())
+    ut.main()


### PR DESCRIPTION
Just a port of the `rotational_inertia.tcl`.
- no random parameters (stability)
- no notable performance impact: `Ran 1 test in 0.040s`

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
