### PR TITLE
Remove unnecessary mutable specifiers

### DIFF
--- a/src/core/observables/Observable.cpp
+++ b/src/core/observables/Observable.cpp
@@ -80,7 +80,7 @@ bool Observable::writable() const
 }
 
 
-void Observable::write() const
+void Observable::write()
 {
   if ( writable() )
   {
@@ -89,7 +89,7 @@ void Observable::write() const
 }
 
 
-void Observable::do_write() const
+void Observable::do_write()
 {
   m_ofile << sim_time;
   for (auto p : last_value)

--- a/src/core/observables/Observable.hpp
+++ b/src/core/observables/Observable.hpp
@@ -44,7 +44,7 @@ class Observable {
     /* IO functions for observables */
     void set_filename(std::string const& filename, bool binary);
     bool writable() const;
-    void write() const;
+    void write();
   //void read();
     virtual int n_values() const {return 0;};
     std::vector<double> last_value;
@@ -55,9 +55,9 @@ class Observable {
     int autoupdate;
     double autoupdate_dt;
 
-    virtual void do_write() const;
+    virtual void do_write();
   //virtual void do_read();
-    std::ofstream mutable m_ofile;
+    std::ofstream m_ofile;
     std::string m_filename;
     bool        m_binary;
 };

--- a/src/script_interface/observables/PidObservable.hpp
+++ b/src/script_interface/observables/PidObservable.hpp
@@ -70,7 +70,7 @@ public:
     return m_observable;
   };
   private:
-  mutable std::shared_ptr<::Observables::PidObservable> m_observable;
+  std::shared_ptr<::Observables::PidObservable> m_observable;
 };
 
 
@@ -88,7 +88,7 @@ public: \
     return m_observable;\
   };\
   private: \
-  mutable std::shared_ptr<::Observables::obs_name> m_observable; \
+  std::shared_ptr<::Observables::obs_name> m_observable; \
 };
 
 NEW_PID_OBSERVABLE(ParticlePositions);

--- a/src/script_interface/observables/ProfileObservable.hpp
+++ b/src/script_interface/observables/ProfileObservable.hpp
@@ -98,7 +98,7 @@ public:
     return m_observable;
   };
   private:
-    mutable std::shared_ptr<::Observables::ProfileObservable> m_observable;
+    std::shared_ptr<::Observables::ProfileObservable> m_observable;
 };
 
 


### PR DESCRIPTION
It turns out that none of the `mutable` specifiers were even needed.

@RudolfWeeber 