### PR TITLE
I can't stop reading this PR 😂

### DIFF
--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -128,10 +128,11 @@ IF ELECTROSTATICS:
             return p3m_set_mesh_offset(mesh_offset[0], mesh_offset[1], mesh_offset[2])
 
         cdef inline python_p3m_adaptive_tune():
-            cdef char * log = ""
+            cdef char * log = NULL
             cdef int response
             response = p3m_adaptive_tune(& log)
-            print(log)
+            handle_errors("Error in p3m_adaptive_tune")
+            if log.strip(): print(log)
             return response
 
         cdef inline python_p3m_set_params(p_r_cut, p_mesh, p_cao, p_alpha, p_accuracy):

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -128,7 +128,7 @@ IF ELECTROSTATICS:
             return p3m_set_mesh_offset(mesh_offset[0], mesh_offset[1], mesh_offset[2])
 
         cdef inline python_p3m_adaptive_tune():
-            cdef char * log = NULL
+            cdef char * log = ""
             cdef int response
             response = p3m_adaptive_tune(& log)
             print(log)


### PR DESCRIPTION
Fixes #1072

If the periodicity is not met, P3M immediately return an error without writing a message in the `log` variable.  Afterwards this log is printed to the screen, however, if it is the NULL pointer, it will fail because `strlen` cannot determine the length of the NULL pointer.  If we properly initialize the message to empty string, the segfault is gone and we obtain a regular Python exception.

From the documentation of [`std::strlen`](http://en.cppreference.com/w/cpp/string/byte/strlen)

> The behavior is undefined if there is no null character in the character array pointed to by str.