### PR TITLE
Typos

### DIFF
--- a/doc/ug/analysis-core.tex
+++ b/doc/ug/analysis-core.tex
@@ -26,7 +26,7 @@ Analysis in the core is a new concept introduced in \es since version
 3.1.  It was motivated by the fact, that sometimes it is desirable
 that the analysis functions do more than just return a value to the
 scripting interface.  For some observables it is desirable to be
-sampled every few integrations steps. In addition, it should be
+sampled every few integration steps. In addition, it should be
 possible to pass the observable values to other functions which
 compute history-dependent quantities, such as correlation functions.
 All this should be done without the need to interrupt the integration
@@ -146,14 +146,14 @@ system:
           The particles are ordered ascending according to their ids and the 
           angular velocity/momentum is specified in the body (co-rotating) frame.
     \item \lit{com_position} \var{particle\_specifications} \opt{blocked \var{size}}\\
-          Position of the centre of mass. 
+          Position of the center of mass. 
           If \lit{blocked \var{size}} is specified,
-          the particles are subdivided into blocks of size \var{size} and the centre
+          the particles are subdivided into blocks of size \var{size} and the center
           of mass position is calculated for each block separately.
     \item \lit{com_velocity} \var{particle\_specifications} \opt{blocked \var{size}}\\
-          Velocity of the centre of mass. 
+          Velocity of the center of mass. 
           If \lit{blocked \var{size}} is specified,
-          the particles are subdivided into blocks of size \var{size} and the centre
+          the particles are subdivided into blocks of size \var{size} and the center
           of mass velocity is calculated for each block separately.
     \item \lit{com_force} \var{particle\_specifications} \opt{blocked \var{size}}\\
           Total force on the specified particles. 
@@ -205,9 +205,9 @@ system:
 % like nobody complained until now.
     \item \lit{interacts_with} \var{particle\_specifications1} \var{particle\_specifications2} \var{cutoff} \\
           For each particle belonging to \var{particle\_specifications1} 
-          the observable is unity if a neighbour of a type from 
+          the observable is unity if a neighbor of a type from 
           \var{particle\_specifications2} is found within the distance 
-          defined by the \var{cutoff}. If no such neighbour is found, the 
+          defined by the \var{cutoff}. If no such neighbor is found, the 
           observable is zero. The observable has one dimension per each 
           particle of \var{particle\_specifications_1}
     \item \lit{density_profile}  \var{particle\_specifications} \var{profile\_specifications} \\
@@ -266,7 +266,7 @@ system:
 		\var{rbins <rbins> N <Npoly> poly\_len <poly\_len>} \\
 		Computes the pair correlation of particles on a polymer chain given through
 		the \verb!id_list!, here \verb!k! is the distance (in terms of particles) between
-		the mononers on the chain for which the pair correlation is computed. This
+		the monomers on the chain for which the pair correlation is computed. This
 		is averaged over the whole chain and all the given chains. The number of
 		polymers for which this distribution is computed has to be given as
 		\verb!Npoly! and their length through \verb!poly_len!. The distribution is
@@ -280,7 +280,7 @@ system:
       \end{itemize}
 The tclcommand observable is a helpful tool, that allows to make the 
 analysis framework much more versatile, by allowing
-the evaluation of arbitrary tcl commands.
+the evaluation of arbitrary Tcl commands.
   \begin{itemize}
     \item \lit{tclcommand \var{dimQ} \var{command}} \\
         An arbitrary Tcl function that returns a list of floating point numbers of fixed size
@@ -294,7 +294,7 @@ once their autoupdate feature is enabled.
   \begin{itemize}
     \item \lit{average \var{ref}} \\
       The running average of the reference observable with id \var{ref}. 
-      It can be resetted by \lit{observable \var{no} reset}
+      It can be reset by \lit{observable \var{no} reset}
   \end{itemize}
 \subsection{Printing an observable}
 \begin{essyntax}
@@ -354,7 +354,7 @@ observable \var{id} write_checkpoint \var{filename} \opt{binary}
 Writes the current state of the observable to \lit{filename}.
 If \lit{binary} is given then it does so in binary form. This is useful
 to save the state of statful observables as the average.
-This checkpoing mechanism is not portable, rereading is only guaranteed to work
+This checkpointing mechanism is not portable, rereading is only guaranteed to work
 on the same system with the same Espresso binary.
 
 \begin{essyntax}
@@ -391,10 +391,10 @@ of types) will not be automatically reflected in the observable.
           Requests observable calculation based on all particles in the system.
     \item \lit{types} \var{ type\_list } \\
           Restricts observable calculation to a given particle type(s). The type
-	  list is a tcl list of existing particle types.
+	  list is a Tcl list of existing particle types.
     \item \lit{id} \var{ id\_list } \\
           Restricts observable calculation to a given list of particle id(s). The id 
-	  list is a tcl list of existing particle ids.
+	  list is a Tcl list of existing particle ids.
 % The following two particle specifications have not been implemented yet
 %    \item \lit{blocks} \var{ m } \\
 %          From an $n$-dimensional observable craeates an $n/m$-dimensional one by 
@@ -529,7 +529,7 @@ Its further arguments are described below.
     \item \lit{scalar_product} \\
     Scalar product of $A$ and $B$, \ie $C=\sum\limits_{i} A_i B_i$
     \item \lit{componentwise_product} \\
-    Comnponentwise product of $A$ and $B$, \ie $C_i = A_i B_i$
+    Componentwise product of $A$ and $B$, \ie $C_i = A_i B_i$
     \item \lit{square_distance_componentwise} \\
     Each component of the correlation vector is the square of the difference between the 
     corresponding components of the observables, \ie $C_i = (A_i-B_i)^2$. 
@@ -545,7 +545,7 @@ Its further arguments are described below.
     G_i(\tau) = \frac{1}{N} \Bigl< \exp \Bigl( - \frac{\Delta x_i^2(\tau) }{w_x^2} - \frac{\Delta y_i^2(\tau)}{w_y^2} - \frac{\Delta z_i^2(\tau)}{w_z^2} \Bigr) \Bigr>\,,
     \label{eq:Gtau}
     \end{equation}
-    where $\Delta x_i^2(\tau) = \bigl(x_i(0) - x_i(\tau) \bigr)^2$ is the square discplacement 
+    where $\Delta x_i^2(\tau) = \bigl(x_i(0) - x_i(\tau) \bigr)^2$ is the square displacement 
     of particle $i$ in the $x$ direction, and $w_x$ is the beam waist of the intensity profile 
     of the exciting laser beam,
     \begin{equation}
@@ -588,7 +588,7 @@ Its further arguments are described below.
   takes one of the observable values and discards the other one. This
   is safe for all observables but produces poor statistics in the
   tail. For some observables, \lit{linear} compression can be used
-  which makes an average of two neighbouring values but produces
+  which makes an average of two neighboring values but produces
   systematic errors.  Depending on the observable, the systematic
   error can be anything between harmless and disastrous. For more
   information, we recommend to read Ref.~\cite{ramirez10a} or to
@@ -629,7 +629,7 @@ system.auto_update_correlators.add(corr)
 \variant{2} correlation n_corr
 \end{essyntax}
 
-Variant \variant{1} returns a tcl list of the defined correlations
+Variant \variant{1} returns a Tcl list of the defined correlations
 including their parameters.  \todo{Maybe not all parameters are
   printed.}  
 
@@ -651,7 +651,7 @@ MSD with a correlator other than the internal.
   binary=\arg{bool}
 }
 \end{pysyntax}
-where \texttt{Observalble} is one of the many obsrvables available.
+where \texttt{Observable} is one of the many observables available.
 
 A simple example for the MSD would be
 \begin{pypresso}
@@ -749,7 +749,7 @@ used by the \lit{uwerr} command).
 \index{Multiple tau correlator}
 
 Here we briefly describe the multiple tau correlator which is implemented in \es.
-For a more detailed description and discussion of its behaviour with respect to
+For a more detailed description and discussion of its behavior with respect to
 statistical and systematic errors, please read the cited literature.
 This type of correlator has been in use for years in the analysis of
 dynamic light scattering~\cite{schatzel88a}. About a decade later it found its way
@@ -787,7 +787,7 @@ to as compression level 0. To compute the correlations for lag times
 $\tau \in [p:2(p-1)]$, the original data are first coarse-grained, so
 that $m$ values of the original data are compressed to produce a single
 data point in the higher compression level. Thus the lag time between
-the neighbouring values in the higher compression level increases
+the neighboring values in the higher compression level increases
 by a factor of $m$, while the number of stored values decreases by
 the same factor and the number of correlation operations at this level
 reduces by a factor of $m^2$. Correlations for lag times 
@@ -819,7 +819,7 @@ can be applied universally to any combination of observables and
 correlation operation. On the other hand, it reduces the
 statistical accuracy as the compression level increases.
 In many cases, the \lit{average} compression operation
-can be applied, which averages the two neighbouring values
+can be applied, which averages the two neighboring values
 and the average then enters the higher level, preserving
 almost the full statistical accuracy of the original data. 
 In general, if averaging can be safely used or not, depends on the 
@@ -839,7 +839,7 @@ discussion is presented in Ref.~\cite{ramirez10a}.
 
 \subsection{Checkpointing the correlator}
 It is possible to checkpoint the correlator. Thereby the data is written
-directly to a file. It may be usefull to write to a binary file, as this
+directly to a file. It may be useful to write to a binary file, as this
 preserves the full bit-value of the variables, whereas the text file 
 representation has a lower accuracy.
 
@@ -850,9 +850,9 @@ representation has a lower accuracy.
 
 In order to load a checkpoint, the correlator has to be initialized. Therefore
 the observable(s) have to be created. Make sure that the correlator is exactly
-initilized as it was when the checkpoint was created. If this is not
-fullfilled, and e.g. the size of an observable has changed, loading the
-checkpoint failes.
+initialized as it was when the checkpoint was created. If this is not
+fulfilled, and e.g. the size of an observable has changed, loading the
+checkpoint fails.
 \begin{essyntax}
 \variant{1} correlation \var{id} read_checkpoint_binary \var{filename}
 \variant{2} correlation \var{id} read_checkpoint_ascii \var{filename}

--- a/doc/ug/analysis.tex
+++ b/doc/ug/analysis.tex
@@ -97,9 +97,9 @@ between particles of only those types is determined.
 particle \var{pid} (variant \variant{2}), or to the coordinates
 (\var{x}, \var{y}, \var{z}) (Variant \variant{3}).
 
-\subsection{Particles in the neighbourhood}
+\subsection{Particles in the neighborhood}
 \label{analyze:nbhood}
-\analyzeindex{particles in the neighbourhood}
+\analyzeindex{particles in the neighborhood}
 
 \begin{pysyntax}
   \object{
@@ -201,12 +201,12 @@ of the currently identified properties.
 \begin{enumerate}
 \item \var{xbins} is the number of bins along the axis of rotation.
 \item \var{ybins} is the number of bins in the radial direction.
-\item The centre point (\var{centerofrotation}) of the cylinder is
+\item The center point (\var{centerofrotation}) of the cylinder is
   located in the lower cap, i.e., \var{xrange} is the height of the
-  cylinder with respect to this centre point.
+  cylinder with respect to this center point.
 \item The bins are distributed along \var{axisofrotation} starting
   from 0 (\var{centerofrotation}).
-\item The \var{thetabins} seem to average with respect to the centre
+\item The \var{thetabins} seem to average with respect to the center
   of mass of the particles in the individual bins rather than with
   respect to the central axis, which one would think is natural.
 \end{enumerate}
@@ -266,9 +266,9 @@ After knowing what the output looks like we might want to have more
 information on how to input data.
 \begin{itemize}
 \item \var{center} is a double list containing the coordinates of the
-  centre point of the cylinder.
+  center point of the cylinder.
 \item \var{direction} is a double list containing a (not necessarily
-  normalised) vector.
+  normalized) vector.
 \item \var{length} is the total length of the cylinder.
 \item \var{radius} is the radius of the cylinder.
 \item \var{bins\_axial} is the number of bins along the \var{direction}
@@ -1078,7 +1078,7 @@ defined as
 R_{\mathrm G}^2 = \frac{1}{N} \sum\limits_{i=1}^{N} \left(\vec r_i - \vec r_{\mathrm{cm}}\right)^2\,,
 \end{equation}
 where $\vec r_i$ are position vectors of individual particles constituting a molecule
-and $\vec r_{\mathrm{cm}}$ is the position vector of its centre of mass. The sum runs
+and $\vec r_{\mathrm{cm}}$ is the position vector of its center of mass. The sum runs
 over all $N$ particles comprising the molecule. For more information see
 any polymer science book, e.g.~\cite{rubinstein03a}.
 If \lit{<rg>} is used, the radius of gyration is averaged over all stored
@@ -1136,7 +1136,7 @@ configurations (see section \vref{sec:stored-configs}).
 \{ \var{idf(0)} \var{idf(1)} \dots \var{idf(chain\_length-1)} \}
 \end{code}
 The index corresponds to the number of beads between the two monomers
-considered (0 = next neighbours, 1 = one monomer in between, \dots).
+considered (0 = next neighbors, 1 = one monomer in between, \dots).
 
 \subsubsection{Internal distances II (specific monomer)}
 \analyzeindex{bond distances internal first monomer}

--- a/doc/ug/aux.tex
+++ b/doc/ug/aux.tex
@@ -17,7 +17,7 @@
 % You should have received a copy of the GNU General Public License
 % along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %
-\chapter{Auxilliary commands}
+\chapter{Auxiliary commands}
 \label{chap:aux}
 
 \todo{Missing commands: 
@@ -128,12 +128,12 @@ SPEEDOFLIGHT
 \begin{code}
 EPSILON0
 \end{code}
-Returns dielectric constant of vaccum in Coulomb\^2/(Joule meter)
+Returns dielectric constant of vacuum in Coulomb\^2/(Joule meter)
    \item
 \begin{code}
 ATOMICMASS
 \end{code}
-    Returns the atomic mass unit u in kilogramms
+    Returns the atomic mass unit u in kilograms
   \end{itemize}
  \item
   MATHEMATICAL FUNCTIONS
@@ -174,25 +174,25 @@ dist\_random <dist> [max]
 \end{code}
 returns random numbers in the interval $[0,1]$ which have a
 distribution according to the distribution function p(x) \var{dist}
-which has to be given as a tcl list containing equally spaced values
+which has to be given as a Tcl list containing equally spaced values
 of p(x). If p(x) contains values larger than 1 (default value of max)
 the maximum or any number larger than that has to be given \var{max}.
 This routine basically takes the function p(x) and places it into a
 rectangular area ([0,1],[0,max]). Then it uses to random numbers to
-specify a point in this area and checks wether it resides in the area
-under p(x). Attention: Since this is written in tcl it is probably not
+specify a point in this area and checks whether it resides in the area
+under p(x). Attention: Since this is written in Tcl it is probably not
 the fastest way to do this!
    \item
 \begin{code}
 vec\_random [len]
 \end{code}
 returns a random vector of length \var{len} (uniform distribution on a
-sphere) This is done by chosing 3 uniformly distributed random numbers
+sphere) This is done by choosing 3 uniformly distributed random numbers
 $[-1,1]$ If the length of the resulting vector is $<= 1.0$ the vector
 is taken and normalized to the desired length, otherwise the procedure
-is repeated until succes. On average the procedure needs 5.739 random
+is repeated until success. On average the procedure needs 5.739 random
 numbers per vector. (This is probably not the most efficient way, but
-it works!) Ask your favorit mathematician for a proof!
+it works!) Ask your favorite mathematician for a proof!
    \item
 \begin{code}
 phivec\_random <v> <phi> [len]
@@ -206,7 +206,7 @@ phivec\_random <v> <phi> [len]
   either denote the particle identity (then the particle position is
   extracted with the The part command command) or the particle
   position directly When the optional \var{box} parameter for minimum
-  image conventions is omited the functions use the the \codebox{setmd
+  image conventions is omitted the functions use the \codebox{setmd
     box\_l} command.
   \begin{itemize}
    \item
@@ -285,7 +285,7 @@ from \var{p3} which builds a bond angle \var{phi} (default=random) for
  \item
   VECTOR OPERATIONS
 
-  A vector \var{v} is a tcl list of numbers with an arbitrary length
+  A vector \var{v} is a Tcl list of numbers with an arbitrary length
   Some functions are provided only for three dimensional vectors.
   corresponding functions contain 3d at the end of the name.
   \begin{itemize}
@@ -348,7 +348,7 @@ create\_dihedral\_vec <v1> <v2> <theta> [phi] [len]
 \end{code}
 create last vector of a dihedral (\var{v1}, \var{v2}, res) with
 dihedral angle \var{theta} and bond angle (\var{v2}, res) \var{phi}
-and length \var{len} (default 1.0). If \var{phi} is ommited or set to
+and length \var{len} (default 1.0). If \var{phi} is omitted or set to
 rnd then \var{phi} is assigned a random value between 0 and 2 Pi.
   \end{itemize}
  \item
@@ -358,7 +358,7 @@ rnd then \var{phi} is assigned a random value between 0 and 2 Pi.
 \begin{code}
 average <list>
 \end{code}
-    Returns the avarage of the provided \var{list}
+    Returns the average of the provided \var{list}
    \item
 \begin{code}
 list\_add\_value <list> <val>
@@ -373,8 +373,8 @@ flatten <list>
 \begin{code}
 list\_contains <list> <val>
 \end{code}
-Checks wether \var{list} contains \var{val}. returns the number of
-occurences of \var{val} in \var{list}.
+Checks whether \var{list} contains \var{val}. Returns the number of
+occurrences of \var{val} in \var{list}.
   \end{itemize}
  \item
   REGRESSION
@@ -383,7 +383,7 @@ occurences of \var{val} in \var{list}.
 \begin{code}
 LinRegression <l>
 \end{code}
-where \var{l} is a listof pairs of points \verb!{ {$x1 $y1} {$x2 $y2} ...} !. 
+where \var{l} is a list of pairs of points \verb!{ {$x1 $y1} {$x2 $y2} ...} !. 
 \verb!LinRegression! returns the least-square linear fit $ax+b$ and 
 the standard errors $\sigma_a$ and $\sigma_b$.
    \item
@@ -402,7 +402,7 @@ covariance $\mathrm{cov}(a,b)$ and $\chi$.
 \label{ssec:trandom}
 \begin{itemize}
  \item
-   Without further arguments (tcl only),
+   Without further arguments (Tcl only),
 \begin{code}
 t\_random
 \end{code}
@@ -410,10 +410,10 @@ t\_random
 returns a random double between 0 and 1 using the standard C++ Mersenne twister random number generator. For drawing random numbers in python please use the numpy random number generator. 
  \item
 \begin{code}
-t\_random int <n> (tcl only)
+t\_random int <n> (Tcl only)
 \end{code}
   returns a random integer between 0 and n-1. For python please use the numpy random number generator.
- \item Note that the best practice in initilizing the random number generator is to randomly set its internal state. This is \textit{attempted} by seeding the random number generator however the state space of the random number generator is typically much bigger than than a single random number. Therefore C++ cannot do miracles during the seeding with only one random number and cannot come up with more randomness. In the python interface Espresso provides the function
+ \item Note that the best practice in initializing the random number generator is to randomly set its internal state. This is \textit{attempted} by seeding the random number generator however the state space of the random number generator is typically much bigger than than a single random number. Therefore C++ cannot do miracles during the seeding with only one random number and cannot come up with more randomness. In the python interface Espresso provides the function
 \begin{pypresso}
 system = espressomd.System()
 system.set_random_state_PRNG()
@@ -435,7 +435,7 @@ t_random stat
 system = espressomd.System()
 print(system.random_number_generator_state)
 \end{pypresso} 
- \item Alternatively to setting the full state of the random number generator one can also only set a seed and hope for sane initilization of the random number generator state. The following command sets the seeds to the new values respectively, re-initializing the
+ \item Alternatively to setting the full state of the random number generator one can also only set a seed and hope for sane initialization of the random number generator state. The following command sets the seeds to the new values respectively, re-initializing the
 random number generators on each node
 \begin{code}
 t\_random seed <seed(0)> ... <seed(n\_nodes-1)>
@@ -472,7 +472,7 @@ code\_info
 provides information on the version, compilation status and the debug
 status of the used code. It is highly recommended to store this
 information with your simulation data in order to maintain the
-reproducibility of your results.  Exemplaric output:
+reproducibility of your results.  Exemplary output:
 \begin{tclcode}
 ESPRESSO: v1.5.Beta (Neelix), Last Change: 23.01.2004
 { Compilation status { PARTIAL_PERIODIC } { ELECTROSTATICS }

--- a/doc/ug/electrokinetics.tex
+++ b/doc/ug/electrokinetics.tex
@@ -424,7 +424,7 @@ LB fluid is compressible and the sum of the fluxes of the three species is not e
 zero in the frame co-moving with the advective fluid velocity. It is therefore debatable
 whether it is necessary to impose Eq.~\eqref{eq:ek-mass-balance}, since the EK algorithm
 itself does not conserve mass density. However, we strived to be as accurate as
-possible and in future versions of the EK algorithm the lack of incompressiblity will 
+possible and in future versions of the EK algorithm the lack of incompressibility will 
 be addressed. 
 
 The reaction is specified by the second term on the right-hand side of 

--- a/doc/ug/examples.tex
+++ b/doc/ug/examples.tex
@@ -46,7 +46,7 @@ as samples how to use \es{}.
 %  quite some time to finish.
 \item[pe\_solution.tcl] Polyelectrolyte solution under poor solvent
   condition. Test case for comparison with data produced by polysim9
-  from M.Deserno. Note that the equilibration of this system takes
+  from M.~Deserno. Note that the equilibration of this system takes
   roughly $15000 \tau$.
 \item[pe\_analyze.tcl] Example for doing the analysis after the actual
   simulation run (offline analysis). Calculates the integrated ion

--- a/doc/ug/features.tex
+++ b/doc/ug/features.tex
@@ -113,14 +113,14 @@ Features can be activated in the configuration header
 \item \newfeature{COLLISION\_DETECTION} Allows particles to be bound on collision. See section \ref{sec:collision}
 \item \newfeature{OLD\_RW\_VERSION} This switches back to the old,
   \emph{wrong} random walk code of the polymer. Only use this if you
-  rely on the old behaviour and \emph{know what you are doing}.
+  rely on the old behavior and \emph{know what you are doing}.
 \item \newfeature{H5MD} Allows to write data to H5MD formatted hdf5 files.
 \end{itemize}
 
 In addition, there are switches that enable additional features in the
 integrator or thermostat:
 \begin{itemize}
-\item \newfeature{NEMD} Enables the non-equilbrium (shear) MD support
+\item \newfeature{NEMD} Enables the non-equilibrium (shear) MD support
   (see section \vref{sec:NEMD}).
 \item \newfeature{NPT} Enables an on--the--fly NPT integration scheme
   (see section \vref{ssec:NPTthermostat}).
@@ -195,7 +195,7 @@ Some of the short range interactions have additional features:
 \end{itemize}
 
 If you want to use bond-angle potentials (see section
-\vref{sec:angle}), you need the followig features.
+\vref{sec:angle}), you need the following features.
 \begin{itemize}
 \item \newfeature{BOND\_ANGLE}
 \item \newfeature{BOND\_ANGLEDIST}
@@ -265,7 +265,7 @@ looking directly at the code.
   when exiting unexpectedly.
 \item \newfeature{MPI\_CORE} Causes \es{} to try this even with MPI errors.
 \item \newfeature{SD_DEBUG} Causes \es{} to check more things in the Stokesian
-  Dynamics code. If \var{warnings} is larger 1, SD prints more informations.
+  Dynamics code. If \var{warnings} is larger 1, SD prints more information.
 \end{itemize}
 
 %%% Local Variables: 

--- a/doc/ug/firststeps.tex
+++ b/doc/ug/firststeps.tex
@@ -85,7 +85,7 @@ OpenMPI, you can use
 \begin{code}
 mpirun -n \var{n\_nodes} Espresso \var{script}
 \end{code}
-where \var{n\_nodes} is the number of prcessors to be used.
+where \var{n\_nodes} is the number of processors to be used.
 
 
 \section{Running \es}

--- a/doc/ug/installation.tex
+++ b/doc/ug/installation.tex
@@ -64,7 +64,7 @@ for as many platforms as you want.
 \paragraph{Example}
 When the source directory is \codebox{srcdir} (\ie the files where
 unpacked to this directory), then the user can create a build directory
-\codebox{build} below that path by calling the \codebox{mkdir srcdir/build}. In the build direcotry cmake is to be executed, followed by a call of make. None of the files in the source directory is ever modified when by the build process.
+\codebox{build} below that path by calling the \codebox{mkdir srcdir/build}. In the build directory cmake is to be executed, followed by a call of make. None of the files in the source directory is ever modified when by the build process.
 \begin{code}
 cd build
 cmake srcdir
@@ -75,7 +75,7 @@ Afterwards Espresso can be run via calling Espresso from the command line.
 \subsection{ccmake}
 Optionally and for easier use the curses interface to cmake can be used to configure ESPResSo interactively. 
 \paragraph{Example}
-Alternatively to the previous example instead of \codebox{cmake}, the \codebox{ccmake} executable is called in the build direcotry to configure ESPResSo previous to its compilation followed by a call of make:
+Alternatively to the previous example instead of \codebox{cmake}, the \codebox{ccmake} executable is called in the build directory to configure ESPResSo previous to its compilation followed by a call of make:
 \begin{code}
 cd build
 ccmake srcdir
@@ -92,7 +92,7 @@ Fig.~\ref{fig:ccmake} shows the interactive ccmake UI.
 
 
 \subsection{Options and Variables}
-The behaviour of \codebox{cmake} can be
+The behavior of \codebox{cmake} can be
 controlled by the means of options and variables in the CMakeLists.txt file. Also options are defined there.
 The following options are available:
 \begin{description}
@@ -104,7 +104,7 @@ The following options are available:
 	\item WITH_SCAFACOS: Build with Scafacos support
 	\item WITH_VALGRIND_INSTRUMENTATION: Build with valgrind instrumentation markers
 \end{description}
-When the value in the CMakeLists.txt file is set to ON the corresponding option is created if the value of the opition is set to OFF the corresponding option is not created. 
+When the value in the CMakeLists.txt file is set to ON the corresponding option is created if the value of the option is set to OFF the corresponding option is not created. 
 These options can also be modified by calling cmake with the command line argument -D:
 \begin{code}
 cmake -D WITH_TCL=OFF srcdir 
@@ -130,10 +130,10 @@ following targets are available:
   run can be controlled by means of the variable \texttt{tests}, which
   processor numbers are to be used can be controlled via the variable
   \texttt{processors}. Note that depending on your MPI installation,
-  MPI jobs can only be run in the queueing system, so that \es{} will
+  MPI jobs can only be run in the queuing system, so that \es{} will
   not run from the command line. In that case, you may not be able to
   run the testsuite, or you have to directly submit the testsuite script
-  \verb!testsuite/test.sh! to the queueing system.\\
+  \verb!testsuite/test.sh! to the queuing system.\\
   \textbf{Example:} \verb!make check tests="madelung.tcl" processors="1 2"!\\
   will run the test \texttt{madlung.tcl} on one and two processors.
 \item[\texttt{clean}] Deletes all files that were created during the
@@ -203,7 +203,7 @@ mpiexec -n \var{n\_nodes} Espresso [\var{tcl\_script} [\var{args}]]
 \end{code}
 where \var{n\_nodes} denotes the number of MPI nodes to be used.
 However, note that depending on your MPI installation, MPI jobs can
-only be run in a queueing system, so that \es will not run from the
+only be run in a queuing system, so that \es will not run from the
 command line. Also, older installations sometimes require ``-np''
 instead of ``-n'' or ``mpirun'' instead of ``mpiexec''. 
 

--- a/doc/ug/inter.tex
+++ b/doc/ug/inter.tex
@@ -198,7 +198,7 @@ A special case of the Lennard--Jones potential is the
 Weeks--Chandler--Andersen (WCA) potential, which one obtains by
 putting the cutoff into the minimum, \ie choosing
 $\var{r_\mathrm{cut}}=2^\frac{1}{6}\var{\sigma}$. The WCA potential is
-purely repulsive, and is often used to mimick hard sphere repulsion.
+purely repulsive, and is often used to mimic hard sphere repulsion.
 
 
 When coupling particles to a Shan-Chen fluid, if the \lit{affinity} interaction is set, the Lennard-Jones potential is multiplied by the function 
@@ -227,7 +227,7 @@ if both particles are in a region rich in the second component,
 then $\phi\simeq-1$, and  $A(r)\simeq 1$, so that the potential
 will be very close to the full LJ one. If the cutoff has been set
 large enough, the particle will experience the attractive part of
-the potential, mimiking the effective attraction induced by the bad
+the potential, mimicking the effective attraction induced by the bad
 solvent.
 
 
@@ -577,7 +577,7 @@ undefined.
   \end{features}
 \end{essyntax}
 This defines an interaction according to the Gaussian potential 
-between particles of the typers \var{type1} and \var{type2}.  The
+between particles of the types \var{type1} and \var{type2}.  The
 Gaussian potential is defined by
 \begin{equation}
   V(r) = 
@@ -1168,12 +1168,12 @@ stretching force between A and B is calculated using
 Here, \var{n_{AB}} is the unit vector pointing from \var{A} to \var{B}, \var{k_s} 
 is the constant for nonlinear stretching, \var{k_{slin}} 
 is the constant for linear stretching, $\lambda_{AB} = \var{L_{AB}}/\var{L_{AB}^0}$, and 
-$\kappa$ is a nonlinear function that resembles neo-Hookean behaviour
+$\kappa$ is a nonlinear function that resembles neo-Hookean behavior
 \begin{equation}
 \kappa(\lambda_{AB}) = \frac{\lambda_{AB}^{0.5} + \lambda_{AB}^{-2.5}}
 {\lambda_{AB} + \lambda_{AB}^{-3}}.
 \end{equation}
-Typicaly, one wants either nonlinear or linear behaviour and therefore one of $k_s, k_{slin}$ is zero. But the interaction will work with both constants non-zero. 
+Typically, one wants either nonlinear or linear behavior and therefore one of $k_s, k_{slin}$ is zero. But the interaction will work with both constants non-zero. 
 \begin{center}
   \includegraphics[width=8cm]{figures/stretching.png}
 \end{center}
@@ -1196,7 +1196,7 @@ Typicaly, one wants either nonlinear or linear behaviour and therefore one of $k
 
 \subsubsection*{Bending}
 The tendency of an elastic object to maintain the resting shape is achieved by 
-prescribing the preferred angles between the neighbouring triangles of the mesh. 
+prescribing the preferred angles between the neighboring triangles of the mesh. 
 
 Denote the angle between two triangles in the resting shape by $\theta^0$. For 
 closed immersed objects, one always has to set the inner angle. The deviation 
@@ -1426,7 +1426,7 @@ For the potential acting between the three particles three variants are possible
   \begin{equation}
     V(\alpha) = K \left[1 - \cos(\phi - \phi0)\right]
   \end{equation}
-  Around $\phi_0$, this potenial is close to a harmonic one (both are
+  Around $\phi_0$, this potential is close to a harmonic one (both are
   $1/2(\phi-\phi_0)^2$ in leading order), but it is periodic and smooth for all
   angles $\phi$.
 \item Cosine square bond angle potential \variant{3}:\\
@@ -1456,7 +1456,7 @@ dihedral potential is given by
 \begin{equation}
   V(\phi) = \var{K}\left[1 - \cos(\var{n}\phi - \var{p})\right],
 \end{equation}
-where \var{n} is the multiplicity of the potential (number of minimas)
+where \var{n} is the multiplicity of the potential (number of minima)
 and can take any integer value (typically from 1 to 6), $p$ is a phase
 parameter and \var{K} is the bending constant of the potential. $\phi$
 is the dihedral angle between the particles defined by the particle
@@ -1610,8 +1610,8 @@ To simplify this, \es{} provides a function to automatically tune the
 algorithm.  Note that for this function to work properly, your system
 should already contain an initial configuration of charges and the
 correct initial box size. Also note that both provided tuning
-algorithms work very well on homogenous charge distributions, but
-might not achieve the requested precision for highly inhomogenous or
+algorithms work very well on homogeneous charge distributions, but
+might not achieve the requested precision for highly inhomogeneous or
 symmetric systems. For example, because of the nature of the P3M
 algorithm, systems are problematic where most charges are placed in
 one plane, one small region, or on a regular grid.
@@ -1856,7 +1856,7 @@ fluctuations in energy.
 
 For $\kappa = 0$, this corresponds to the plain coulomb potential.
 
-The second variant combines the coulomb interaction for charges that are closer than $r_0$ with the Debye-Hueckel approximation for charges that are further apart than $r_1$ in a continous way. The used potential is 
+The second variant combines the coulomb interaction for charges that are closer than $r_0$ with the Debye-Hueckel approximation for charges that are further apart than $r_1$ in a continuous way. The used potential is 
 
 \begin{equation}
   U(r)^{C-DHC} = 
@@ -1868,7 +1868,7 @@ The second variant combines the coulomb interaction for charges that are closer 
   \end{cases}
 \end{equation}
 
-The parameter $\alpha$ that controlls the transition from Coulomb- to Debye-H\"uckel potential should be chosen such that the force is continous.
+The parameter $\alpha$ that controls the transition from Coulomb- to Debye-H\"uckel potential should be chosen such that the force is continuous.
 
 \subsection{MMM2D}
 \index{MMM2D method|mainindex}
@@ -2133,7 +2133,7 @@ The main error of the MEMD algorithm stems from the lattice
 interpolation and is proportional to the lattice size in three
 dimensions, which means $\Delta_\text{lattice} \propto a^3$.
 
-Without derivation here, the algorithmis error is proportional to
+Without derivation here, the algorithms error is proportional to
 $1/c^2$, where $c$ is the adjustable speed of light. From the
 stability criterion, this yields
 
@@ -2295,9 +2295,9 @@ Scafacos can be used as Coulomb solver for the system.
 	\end{features}
 \end{pysyntax}
 Here \var{method} is a scafacos method as returned by \texttt{scafacos_methods}. 
-\texttt{tolerance_field} sets the desisired rms accuracy for the electric field if supported by the method.
+\texttt{tolerance_field} sets the desired rms accuracy for the electric field if supported by the method.
 \var{parameters} is a list of parameters as described by the Scafacos manual. If parameters of the solver
-are not set, and the method supports it, the open parameteres are tuned.
+are not set, and the method supports it, the open parameters are tuned.
 To use the \texttt{ewald} solver from scafacos as electrostatics solver for your system, set its cutoff
 to $1.5$ and tune the other parameters for an accuracy of $10^{-3}$, use the command
 \begin{tclcode}
@@ -2375,7 +2375,7 @@ slab~\cite{ballenegger09a}. Therefore, under normal circumstance, you
 will probably want to disable the neutralization using
 \opt{noneutralization}. This corresponds then to a formal
 regularization of the forces and energies~\cite{ballenegger09a}. Also,
-if you add neutralizing walls explicitely as constraints, you have to
+if you add neutralizing walls explicitly as constraints, you have to
 disable the neutralization.
 
 The dielectric contrast features work exactly the same as for MMM2D,
@@ -2435,7 +2435,7 @@ allows to specify the accuracy of the iteration. It corresponds to the
 maximum relative change of any of the interface particle's
 charge. After \var{max\_iterations} the iteration stops anyways. The
 dielectric constant in bulk, i.~e. outside the dielectric walls is
-specified by \var{eps\_out}. A homogenous electric field can be added
+specified by \var{eps\_out}. A homogeneous electric field can be added
 to the calculation of dielectric boundary forces by specifying it in
 the parameter \var{ext\_field}.
 
@@ -2505,7 +2505,7 @@ with these interactions as efficiently as possible, but almost all of
 them require some knowledge to use them properly.  Uneducated use can
 result in completely unphysical simulations.
 
-The commands above work as their couterparts for the electrostatic
+The commands above work as their counterparts for the electrostatic
 interactions (see section \vref{sec:coulomb}).  Variant \variant{1}
 disables dipolar interactions.  Variant \variant{2} returns the
 current parameters of the dipolar interaction as a Tcl-list using the
@@ -2569,7 +2569,7 @@ Note that dipolar P3M does not work with non-cubic boxes.
 \end{essyntax}
 
 Tuning dipolar P3M works exactly as tuning Coulomb P3M.  Therefore,
-for details on how to tune the algorothm, refer to the documentation
+for details on how to tune the algorithm, refer to the documentation
 of Coulomb P3M (see section \vref{ssec:tunep3m}).
 
 For the magnetic case, the expressions of the error estimate are given
@@ -2591,7 +2591,7 @@ Like ELC but applied to the case of magnetic dipoles, but here the
 accuracy is the one you wish for computing the energy.
 \var{far_cutoff} is set to a value that, assuming all dipoles to be as
 larger as the largest of the dipoles in the system, the error for the
-energy would be smaller thant the value given by accuracy. At this
+energy would be smaller than the value given by accuracy. At this
 moment you cannot compute the accuracy for the forces, or torques,
 nonetheless, usually you will have an error for forces and torques
 smaller than for energies. Thus, the error for the energies is an
@@ -2690,9 +2690,9 @@ That a method is listed there, does not imply that it supports dipolar calculati
   \end{features}
 \end{essyntax}
 Here \var{method} is a scafacos method as returned by \texttt{scafacos_methods}. 
-\texttt{tolerance_field} sets the desisired rms accuracy for the electric field if supported by the method.
+\texttt{tolerance_field} sets the desired rms accuracy for the electric field if supported by the method.
 \var{parameters} is a list of parameters as described by the Scafacos manual. If parameters of the solver
-are not set, and the method supports it, the open parameteres are tuned.
+are not set, and the method supports it, the open parameters are tuned.
 For details of the various methods and their parameters please refer to the Scafacos manual.
 Note that the \texttt{SCAFACOS} feature is only available if you build with cmake. You need
 to build Scafacos as a shared library.

--- a/doc/ug/internal.tex
+++ b/doc/ug/internal.tex
@@ -31,22 +31,22 @@
 Since basically all major parts of the main MD integration have to
 access the particle data, efficient access to the particle data is
 crucial for a fast MD code. Therefore the particle data needs some
-more elaborate organisation, which will be presented here. A particle
+more elaborate organization, which will be presented here. A particle
 itself is represented by a structure (Particle) consisting of several
 substructures (e. g. ParticlePosition, ParticleForce or
 ParticleProperties), which in turn represent basic physical properties
-such as position, force or charge. The particles are organised in one
+such as position, force or charge. The particles are organized in one
 or more particle lists on each node, called Cell cells. The cells are
 arranged by several possible systems, the cellsystems as described
 above. A cell system defines a way the particles are stored in \es{},
 i. e. how they are distributed onto the processor nodes and how they
-are organised on each of them. Moreover a cell system also defines
+are organized on each of them. Moreover a cell system also defines
 procedures to efficiently calculate the force, energy and pressure for
-the short ranged interactions, since these can be heavily optimised
+the short ranged interactions, since these can be heavily optimized
 depending on the cell system. For example, the domain decomposition
 cellsystem allows an order N interactions evaluation.
 
-Technically, a cell is organised as a dynamically growing array, not
+Technically, a cell is organized as a dynamically growing array, not
 as a list. This ensures that the data of all particles in a cell is
 stored contiguously in the memory. The particle data is accessed
 transparently through a set of methods common to all cell systems,
@@ -68,11 +68,11 @@ cells along the first coordinate, allowing for a small skin of 0.05.
 If one chooses only 6 boxes in the first coordinate, the skin depth
 increases to 0.467. In this example we assume that the number of cells
 in the first coordinate was chosen to be 6 and that the cells are
-cubic. \es{} would then organise the cells on each node in a $6\times
-12\times 12$ cell grid embedded at the centre of a $8\times 14 \times
+cubic. \es{} would then org anise the cells on each node in a $6\times
+12\times 12$ cell grid embedded at the center of a $8\times 14 \times
 14$ grid. The additional cells around the cells containing the
 particles represent the ghost shell in which the information of the
-ghost particles from the neighbouring nodes is stored. Therefore the
+ghost particles from the neighboring nodes is stored. Therefore the
 particle information stored on each node resides in 1568 particle
 lists of which 864 cells contain particles assigned to the node, the
 rest contain information of particles from other nodes.a
@@ -97,17 +97,17 @@ around 200MHz. Modern double data rate (DDR) RAM transfers up to
 3.2GB/s at this clock speed (at each edge of the clock signal 8 bytes
 are transferred). But in addition to the data transfer speed, DDR RAM
 has some latency for fetching the data, which can be up to 50ns in the
-worst case. Memory is organised internally in pages or rows of
+worst case. Memory is organized internally in pages or rows of
 typically 8KB size. The full $2\times 200$ MHz data rate can only be
 achieved if the access is within the same memory page (page hit),
 otherwise some latency has to be added (page miss). The actual latency
-depends on some other aspects of the memory organisation which will
+depends on some other aspects of the memory organization which will
 not be discussed here, but the penalty is at least 10ns, resulting in
 an effective memory transfer rate of only 800MB/s. To remedy this,
 modern processors have a small amount of low latency memory directly
 attached to the processor, the cache.
 
-The processor cache is organised in different levels. The level 1 (L1)
+The processor cache is organized in different levels. The level 1 (L1)
 cache is built directly into the processor core, has no latency and
 delivers the data immediately on demand, but has only a small size of
 around 128KB. This is important since modern processors can issue
@@ -120,12 +120,12 @@ In a typical implementation of the link cell scheme the order of the
 particles is fairly random, determined e. g. by the order in which the
 particles are set up or have been communicated across the processor
 boundaries. The force loop therefore accesses the particle array in
-arbitrary order, resulting in a lot of unfavourable page misses. In
-the memory organisation of \es{}, the particles are accessed in a
+arbitrary order, resulting in a lot of unfavorable page misses. In
+the memory organization of \es{}, the particles are accessed in a
 virtually linear order. Because the force calculation goes through the
 cells in a linear fashion, all accesses to a single cell occur close
 in time, for the force calculation of the cell itself as well as for
-its neighbours. Using the domain decomposition cell scheme, two cell
+its neighbors. Using the domain decomposition cell scheme, two cell
 layers have to be kept in the processor cache. For 10000 particles and
 a typical cell grid size of 20, these two cell layers consume roughly
 200 KBytes, which nearly fits into the L2 cache. Therefore every cell

--- a/doc/ug/introduction.tex
+++ b/doc/ug/introduction.tex
@@ -195,7 +195,7 @@ The simulation engine is written in C and C++ for the sake
 of computational efficiency. The steering or control
 level is interfaced to the kernel via an interpreter 
 of the Tcl and Python scripting languages.
-Please be aware that th TCL interface is going to be removed soon and new simulations should use Python as scripting language.
+Please be aware that the Tcl interface is going to be removed soon and new simulations should use Python as scripting language.
 
 The kernel performs all computationally demanding tasks. Before all,
 integration of Newton's equations of motion, including calculation of
@@ -206,16 +206,16 @@ modularized so that basic functions are accessed via a set of
 well-defined lean interfaces, hiding the details of the complex
 numerical algorithms.
 
-The scripting interface (Python or Tcl) are used to setup the system (particles, boundary onditions, interactions, ...), control the simulation, run analysis, and store and load results.
-The user has at hand the full rl3sibili5y and functionality of the scripting language. For instance, it is possible to use the SciPy package for analysis and PyPlot for plotting.
+The scripting interface (Python or Tcl) are used to setup the system (particles, boundary conditions, interactions, ...), control the simulation, run analysis, and store and load results.
+The user has at hand the full reliability and functionality of the scripting language. For instance, it is possible to use the SciPy package for analysis and PyPlot for plotting.
 With a certain overhead in efficiency, it can also be
 used to reject/accept new configurations in combined MD/MC schemes. In
 principle, any parameter which is accessible from the scripting level can be
 changed at any moment of runtime.  In this way methods like
 thermodynamic integration become readily accessible.
 
-The focus of the user guide is documenting the scripting interfacce, its
-behaviour and use in the simulation. It only describes certain
+The focus of the user guide is documenting the scripting interface, its
+behavior and use in the simulation. It only describes certain
 technical details of implementation which are necessary for
 understanding how the script interface works.  Technical documentation of the
 code and program structure is contained in the Developers' guide (see

--- a/doc/ug/io.tex
+++ b/doc/ug/io.tex
@@ -87,7 +87,7 @@ see the \texttt{lbfluid} command for further details.
 
 \section{(Almost) generic checkpointing in Python}
 Referring to the previous section, generic checkpointing poses difficulties 
-in many ways. Fortunatelly, the Python checkpointing module presented in 
+in many ways. Fortunately, the Python checkpointing module presented in 
 this section provides a comfortable workflow for an almost generic 
 checkpointing.
 
@@ -687,7 +687,7 @@ The files produced by this command are (assumed \var{filename} is
 
 Currently, these files have to be read by exactly the same number of MPI
 processes that was used to dump them, otherwise an error is
-signalled. Also, the same type of machine (endianess, byte order) has to
+signaled. Also, the same type of machine (endianess, byte order) has to
 be used. Otherwise only garbage will be read. The read command replaces
 the particles, i.e. all previous existent particles will be
 \textit{deleted}.
@@ -935,7 +935,7 @@ method uses the internal box length and topology information from
 espresso. If you wish to shift particles prior to folding then supply
 the optional shift information. \var{shift} should be a three member
 tcl list consisting of x, y, and z shifts respectively and each number
-should be a floating point (ie with decimal point).
+should be a floating point (i.e. with decimal point).
 
 \subsection{\lit{readpdb}: Reading the coordinates and interactions}
 \newescommand{readpdb}
@@ -983,7 +983,7 @@ The command returns the number of particles that were successfully added.
 
 Reading bonded interactions and dihedrals is currently not supported.
 
-\section{Online-visualisation with VMD}
+\section{Online-visualization with VMD}
 \label{sec:IMD}
 \index{IMD}
 
@@ -1129,7 +1129,7 @@ which allows to quickly find the line causing the error.
 However, some errors can only be detected after changing the internal
 structures, so that \es is left in a state such that integration is
 not possible without massive fixes by the users. Especially errors
-occuring on nodes other than the primary node fall under this
+occurring on nodes other than the primary node fall under this
 condition, for example a broken bond or illegal parameter
 combinations.
 
@@ -1141,7 +1141,7 @@ message of the form
 \end{code}
 is returned. Following possibly a normal Tcl error message, after the
 background keyword all severe errors are listed node by node,
-preceeded by the node number. A special error is \lit{<consent>},
+preceded by the node number. A special error is \lit{<consent>},
 which means that one of the slave nodes found exactly the same errors
 as the master node. This happens mainly during the initialization of
 the integrate, \eg if the time step is not set. In this case the error
@@ -1154,7 +1154,7 @@ parts of the internal data also had to be changed to allow \es to
 continue, so you should really know what you do if you try and catch
 these errors.
 
-\section{Online-visualisation with Mayavi or OpenGL}
+\section{Online-visualization with Mayavi or OpenGL}
 \label{sec:visualizer}
 \index{Visualization}
 
@@ -1180,7 +1180,7 @@ setup and equilibration process.
 
 The recommended usage of both tools is similar: Create the visualizer of your
 choice and pass it the \lstinline{espressomd.System()} object. Then write your
-integration loop in a seperate function, which is started in a non-blocking
+integration loop in a separate function, which is started in a non-blocking
 thread. Whenever needed, call \lstinline{update()} to synchronize the renderer
 with your system. Finally start the blocking visualization window with
 \lstinline{start()}. See the following minimal code example:
@@ -1238,7 +1238,7 @@ Starts the blocking visualizer window.
 }
 \end{pysyntax}
 
-Synchonizes system and visualizer, handles keyboard events for openGLLive. 
+Synchronizes system and visualizer, handles keyboard events for openGLLive. 
 
 \begin{pysyntax}
   \object{

--- a/doc/ug/lb.tex
+++ b/doc/ug/lb.tex
@@ -103,7 +103,7 @@ The parameters \var{dens} and \var{visc} set up the density and
 (kinematic) viscosity of the LB fluid in (usual) MD units.  Internally the LB
 implementation works with a different set of units: all lengths are
 expressed in \var{agrid}, all times in \var{tau} and so on.  Therefore
-changing \var{agrid} and \var{tau}, might change the behaviour of the
+changing \var{agrid} and \var{tau}, might change the behavior of the
 LB fluid, \eg at boundaries, due to characteristics of the LBM
 itself. It should also be noted that the LB nodes are located at 0.5, 1.5, 2.5,
 etc (in terms of \var{agrid}).  This has important implications for the
@@ -143,7 +143,7 @@ of the options \lit{dens}, \lit{visc}, \lit{bulk_viscosity}, \lit{friction},
 they are set to the default values. The three elements of the
 coupling matrix can be supplied with the option \lit{sc_coupling},
 and the mobility coefficient can be
-specified with the option \lit{mobility}. By default no copuling is activated,
+specified with the option \lit{mobility}. By default no coupling is activated,
 and the relaxation parameter associated to the mobility is zero, corresponding
 to an infinite value for \lit{mobility}. Additional details are given in
 \ref{sec:shanchen} and \ref{sec:scmd-coupling}.
@@ -151,7 +151,7 @@ to an infinite value for \lit{mobility}. Additional details are given in
 \begin{essyntax}
   lbfluid print_interpolated_velocity \var{x} \var{y} \var{z}
 \end{essyntax}
-This variant returns the velocity at point in countinous space. 
+This variant returns the velocity at point in continuous space. 
 This can make it easier to calculate flow profiles independent of
 the lattice constant.
 
@@ -169,7 +169,7 @@ be taken when using the binary format as the format of doubles can depend
 on both the computer being used as well as the compiler. One thing that one
 needs to be aware of is that loading the checkpoint also requires the used to
 reuse the old forces. This is necessary since the coupling force between the
-paricles and the fluid has already been applied to the fluid. Failing to reuse
+particles and the fluid has already been applied to the fluid. Failing to reuse
 the old forces breaks momentum conservation, which is in general a problem. It
 is particularly problematic for bulk simulations as the system as a whole
 acquires a drift of the center of mass, causing errors in the calculation of
@@ -199,7 +199,7 @@ implementation the force can alternatively be interpolated using a three point
 scheme which couples the particles to the nearest 27 LB nodes.  This can be
 called using ``lbfluid \lit{couple} 3pt'' and is described in D\"{u}nweg and
 Ladd by equation 301\cite{duenweg08a}. Note that the three point coupling
-scheme is incompatible with the Shan Chen Lattice Boltmann.  The frictional
+scheme is incompatible with the Shan Chen Lattice Boltzmann.  The frictional
 force tends to decrease the relative velocity between the fluid and the
 particle whereas the random forces are chosen so large that the average kinetic
 energy per particle corresponds to the given temperature, according to a
@@ -212,7 +212,7 @@ nonconserved modes, including the pressure tensor, fluctuate correctly
 according to the given temperature and the relaxation parameters. All
 fluctuations can be switched off by setting the temperature to 0.
 
-Regarind the unit of the temperature, please refer to
+Regarding the unit of the temperature, please refer to
 Section~\ref{sec:units}.
 
 \section{The Shan Chen bicomponent fluid\label{sec:shanchen}}
@@ -240,7 +240,7 @@ also for the momentum modes, since they are not conserved quantities in the
 Shan-Chen method, by using the option \lit{mobility}. The mobility transport
 coefficient expresses the propensity of the two components to mutually diffuse,
 and, differently from other transport coefficients, only one value is needed,
-as it carachterizes the mixture as a whole. When thermal fluctuations are
+as it characterizes the mixture as a whole. When thermal fluctuations are
 switched on, a random noise is added, in addition, also to the momentum modes.
 Differently from the other modes, a correlated noise is added to the momentum
 ones, in order to preserve the \emph{total} momentum. 
@@ -262,7 +262,7 @@ the fluid (baricentric) velocity, $\rho=\sum_\zeta\rho_\zeta$ is
 the total density, and $p=\sum_{\zeta} p_{\zeta}=\sum_{\zeta} c_s^2
 \rho_{\zeta}$ is the internal pressure of the mixture ($c_s$ being
 the sound speed). Two fluctuating terms $\hat{{\vec{\sigma}}}$ and
-$\hat{{\vec{\xi}}}_{\zeta}$ are associated, respectivelu, to the
+$\hat{{\vec{\xi}}}_{\zeta}$ are associated, respectively, to the
 diffusive current ${\vec{D}}_{\zeta}$ and to the viscous stress
 tensor ${\vec{\Pi}}$.
 
@@ -322,7 +322,7 @@ around a particle.  The particle property \lit{solvation}
 (Chap.~\ref{chap:part}) sets the coupling constants
 $\lambda_A$,$\kappa_A$,$\lambda_B$ and $\kappa_B$, where $A$ and $B$
 denote the first and second fluid component, respectively.  A complete
-description of the copuling scheme can be found in \cite{sega13c}.
+description of the coupling scheme can be found in \cite{sega13c}.
 
 \section{SC component-dependent interactions between particles}
 \label{sec:scmd-affinity}
@@ -422,7 +422,7 @@ mayavi2\footnote{http://code.enthought.com/projects/mayavi/}. Otherwise gnuplot
 readable data will be 
 exported. If you plan to use paraview for visualization, note that also the 
 particle positions can be exported in the VTK format \ref{sec:writevtk}.
-\variant{2} allows you to only output part of the flow field by specifiying an
+\variant{2} allows you to only output part of the flow field by specifying an
 axis aligned bounding box through the coordinates of two of its corners. This
 bounding box can be used to output a slice of the flow field. As an example,
 executing \texttt{lbfluid print vtk velocity 0 0 5 10 10 5 filename} will
@@ -447,7 +447,7 @@ or external) boundaries.
 
 The \lit{lbboundary} command syntax is very close to the
 \lit{constraint} syntax, as usually one wants the hydrodynamic
-boundary conditions to be shaped similarily to the MD
+boundary conditions to be shaped similarly to the MD
 boundaries. Currently the shapes mentioned above are available and
 their syntax exactly follows the syntax of the constraint command. For
 example
@@ -476,7 +476,7 @@ viscosity. This can \eg be seen when using the sample script
 The bounce back boundary conditions allow to set velocity at a boundary to a nonzero
 value. This allows to create shear flow and boundaries moving relative to 
 each other. This could be a fixed sphere in a channel moving at a finite speed -- 
-corresponding to the galilei-transform of a moving sphere in a fixed channel.
+corresponding to the Galilei-transform of a moving sphere in a fixed channel.
 The velocity boundary conditions are implemented according to \cite{succi01a}
 eq.~12.58. Using this implementation as a blueprint for the boundary treatment 
 an implementation of the Ladd-Coupling should be relatively straightforward.
@@ -525,7 +525,7 @@ activated.
 \end{essyntax}
 
 If the feature \lit{LB_ELECTROHYDRODYNAMICS} is activated, the
-(non-GPU) Lattice Boltzmann Code can be used to implicitely model
+(non-GPU) Lattice Boltzmann Code can be used to implicitly model
 surrounding salt ions in an external electric field by having the
 charged particles create flow.
 

--- a/src/core/observables/Observable.hpp
+++ b/src/core/observables/Observable.hpp
@@ -36,7 +36,7 @@ class Observable {
     int update();
     int calculate();
     virtual int actual_calculate() {
-      throw std::runtime_error("Observable did not override actual_caucluate()\n");
+      throw std::runtime_error("Observable did not override actual_calculate()\n");
     }; 
     virtual int actual_update() {};
 

--- a/src/script_interface/README.org
+++ b/src/script_interface/README.org
@@ -1,24 +1,24 @@
 * Script Interface
 ** Purpose
 The generic script interface should make common tasks like setting and getting parameters from objects easier.
-It provides facilities to set parameters on datastructures on all nodes, and call methods on all nodes.
+It provides facilities to set parameters on data structures on all nodes, and call methods on all nodes.
 
 ** Steps to add a new class for parameter setting.
 1. Create file for a new class implementation in src/script_interface/<namespace>/.
 2. #include "ScriptInterface.hpp"
-3. Create a new class that derieves from ScriptInterfaceBase
+3. Create a new class that derives from ScriptInterfaceBase
 4. Implement the required functions (get_parameters(), set_parameter(), name(), valid_parameters()).
-   - name() shoud return the full name for the class
-   - optionally add implmentations for get_parameter() and set_parameters() and call_method()
+   - name() should return the full name for the class
+   - optionally add implementations for get_parameter() and set_parameters() and call_method()
    - valid_parameters() should return a list of all accepted parameters. ParameterMap is an associative
      array of parameter names and their corresponding description. For a list of supported parameter
      types see src/script_interface/Parameter.hpp. A compact form for this implementation uses curled braces
      initialization as shown in the HelloWorld example and e.g. in Wall.hpp.
-   - get_parameters() should return a map of parameters. Again, curled brace init can be used for a shor notation.
+   - get_parameters() should return a map of parameters. Again, curled brace init can be used for a short notation.
    - set_parameter() should set the named parameter.
 
 5. Add the new class to the initialization functions
-   - if they dont exist add initialize.{hpp, cpp} to src/script_interface/<namespace>/
+   - if they don't exist add initialize.{hpp, cpp} to src/script_interface/<namespace>/
    - if it does not exist add a function initialize (c.f. src/script_interface/shapes/initialize.{hpp,cpp})
    - include the header for your new class
    - Register the class, use
@@ -91,7 +91,7 @@ For a more elaborate example that creates a c++ class have a look at src/script_
 
 ** Variant
 The implementation uses a specialization of boost::variant to hand over parameters and return values of different types.
-It currently supports the type bool, int, double, string, vector<int>, vector<double> and object. THe lattter means that
+It currently supports the type bool, int, double, string, vector<int>, vector<double> and object. The latter means that
 this parameter is an other script object.
 
 In c++ the variants can simply assigned a value of any supported type. To get the value back it hast to be fetched via
@@ -109,7 +109,7 @@ Example:
 #+END_SRC
 
 To reduce boiler plate there exists a macro SET_PARAMETER_HELPER(NAME, MEMBER) is to be used in the set_parameter implementation.
-It gets the value of the variant variable called value and assings it to MEMBER if name == NAME. Member can allso be a reference,
+It gets the value of the variant variable called value and assigns it to MEMBER if name == NAME. Member can also be a reference,
 so that the helper can be used with setters.
 
 With the macro the set_parameter function of the example class could read


### PR DESCRIPTION
Corrects  typos, and, in the files touched, consistently uses AE instead of BE -- since it is also used in the code base.
