### PR TITLE
Check if LB boundary is compiled in.

### DIFF
--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -41,7 +41,8 @@ if CONSTRAINTS == 1:
 
 from .correlators import AutoUpdateCorrelators
 from .observables import AutoUpdateObservables
-from .lbboundaries import LBBoundaries
+if LB_BOUNDARIES or LB_BOUNDARIES_GPU:
+    from .lbboundaries import LBBoundaries
 from .ekboundaries import EKBoundaries
 
 import sys
@@ -71,7 +72,8 @@ cdef class System:
     integrator = integrate.Integrator()
     if CONSTRAINTS == 1:
         constraints = Constraints()
-    lbboundaries = LBBoundaries()
+    if LB_BOUNDARIES or LB_BOUNDARIES_GPU:
+        lbboundaries = LBBoundaries()
     ekboundaries = EKBoundaries()
 
     auto_update_observables = AutoUpdateObservables()

--- a/src/python/espressomd/lbboundaries.py
+++ b/src/python/espressomd/lbboundaries.py
@@ -1,25 +1,27 @@
 from __future__ import print_function, absolute_import
 from .script_interface import ScriptInterfaceHelper
+import espressomd.code_info
 
 
-class LBBoundaries(ScriptInterfaceHelper):
-    _so_name = "LBBoundaries::LBBoundaries"
+if any(i in espressomd.code_info.features() for i in ["LB_BOUNDARIES", "LB_BOUNDARIES_GPU"]):
+    class LBBoundaries(ScriptInterfaceHelper):
+        _so_name = "LBBoundaries::LBBoundaries"
 
-    def add(self, *args, **kwargs):
-        if len(args) == 1:
-            if isinstance(args[0], LBBoundary):
-                lbboundary = args[0]
+        def add(self, *args, **kwargs):
+            if len(args) == 1:
+                if isinstance(args[0], LBBoundary):
+                    lbboundary = args[0]
+                else:
+                    raise TypeError(
+                        "Either a LBBoundary object or key-value pairs for the parameters of a LBBoundary object need to be passed.")
             else:
-                raise TypeError(
-                    "Either a LBBoundary object or key-value pairs for the parameters of a LBBoundary object need to be passed.")
-        else:
-            lbboundary = LBBoundary(**kwargs)
-        self.call_method("add", object=lbboundary)
-        return lbboundary
+                lbboundary = LBBoundary(**kwargs)
+            self.call_method("add", object=lbboundary)
+            return lbboundary
 
-    def remove(self, lbboundary):
-        self.call_method("remove", lbboundary=lbboundary)
+        def remove(self, lbboundary):
+            self.call_method("remove", lbboundary=lbboundary)
 
 
-class LBBoundary(ScriptInterfaceHelper):
-    _so_name = "LBBoundaries::LBBoundary"
+    class LBBoundary(ScriptInterfaceHelper):
+        _so_name = "LBBoundaries::LBBoundary"


### PR DESCRIPTION
Until now, the user would not recognize that the LB boundaries are not used since no error is thrown if the feature is not compiled in.
