### PR TITLE
Electromagnetic constraints feature

### DIFF
--- a/src/core/constraints/Constraint.cpp
+++ b/src/core/constraints/Constraint.cpp
@@ -6,6 +6,7 @@
 #include "errorhandling.hpp"
 #include "forces_inline.hpp"
 #include "interaction_data.hpp"
+#include "particle_data.hpp"
 
 namespace Constraints {
 
@@ -58,6 +59,7 @@ void Constraint::reflect_particle(Particle *p, const double *distance_vector,
 void Constraint::add_force(Particle *p, double *folded_pos) {
   double dist, vec[3], force[3], torque1[3], torque2[3];
   Particle part_rep;
+  Vector3d vec_dip({0., 0., 0.}), vec_field({0., 0., 0.}), torque_3d({0., 0., 0.});
   part_rep.p.type = m_type;
 
   IA_parameters *ia_params = get_ia_param(p->p.type, part_rep.p.type);
@@ -65,8 +67,9 @@ void Constraint::add_force(Particle *p, double *folded_pos) {
   dist = 0.;
   for (int j = 0; j < 3; j++) {
     force[j] = 0;
+    vec_field[j] = 0;
 #ifdef ROTATION
-    torque1[j] = torque2[j] = 0;
+    torque1[j] = torque2[j] = torque_3d[j] = 0;
 #endif
   }
 
@@ -97,9 +100,25 @@ void Constraint::add_force(Particle *p, double *folded_pos) {
       }
     }
   }
+
   for (int j = 0; j < 3; j++) {
+      if (dist) vec_field[j] = vec[j] / dist;
+#ifdef DIPOLES
+      vec_dip[j] = p->r.dip[j];
+#endif
+  }
+
+#ifdef DIPOLES
+  torque_3d = vec_dip.cross(vec_dip,vec_field);
+#endif
+
+  for (int j = 0; j < 3; j++) {
+    force[j] += m_ext_electric_field * p->p.q * vec_field[j]; // The constraint electrostatic interaction with particles
     p->f.f[j] += force[j];
     m_local_force[j] -= force[j];
+#ifdef DIPOLES
+    torque1[j] += m_ext_magn_field * torque_3d[j];  // The constraint magnetostatic interaction with particles
+#endif
 #ifdef ROTATION
     p->f.torque[j] += torque1[j];
     part_rep.f.torque[j] += torque2[j];
@@ -114,6 +133,7 @@ void Constraint::add_energy(Particle *p, double *folded_pos,
   double nonbonded_en = 0.0;
   Particle part_rep;
   part_rep.p.type = m_type;
+  Vector3d vec_dip, vec_field;
 
   ia_params = get_ia_param(p->p.type, part_rep.p.type);
 
@@ -133,6 +153,20 @@ void Constraint::add_energy(Particle *p, double *folded_pos,
                         << " violated by particle " << p->p.identity;
     }
   }
+
+  for (int j = 0; j < 3; j++) {
+      vec_field[j] = 0;
+      if (dist) vec_field[j] = vec[j] / dist;
+#ifdef DIPOLES
+      vec_dip[j] = p->r.dip[j];
+#endif
+  }
+// The constraint electromagnetic interaction with particles
+#ifdef DIPOLES
+  nonbonded_en += - m_ext_magn_field * vec_field.dot(vec_dip);
+#endif
+  nonbonded_en += - m_ext_electric_field * dist * p->p.q;
+
   if (part_rep.p.type >= 0)
     *obsstat_nonbonded(&energy, p->p.type, part_rep.p.type) += nonbonded_en;
 }

--- a/src/core/constraints/Constraint.hpp
+++ b/src/core/constraints/Constraint.hpp
@@ -16,7 +16,8 @@ public:
   Constraint()
       : m_shape(std::make_shared<Shapes::NoWhere>()),
         m_reflection_type(ReflectionType::NONE), m_penetrable(false),
-        m_only_positive(false), m_tuneable_slip(0), m_type(-1) {
+        m_only_positive(false), m_tuneable_slip(0),
+        m_ext_electric_field(0), m_ext_magn_field(0), m_type(-1){
     reset_force();
   }
 
@@ -41,6 +42,8 @@ public:
   void reset_force() { m_local_force = Vector3d{0, 0, 0}; }
   int &only_positive() { return m_only_positive; }
   int &penetrable() { return m_penetrable; }
+  double &ext_electric_field() { return m_ext_electric_field; }
+  double &ext_magn_field() { return m_ext_magn_field; }
   int &type() { return m_type; }
   Vector3d total_force() const;
 
@@ -56,6 +59,8 @@ private:
   int m_penetrable;
   int m_only_positive;
   int m_tuneable_slip;
+  double m_ext_electric_field;
+  double m_ext_magn_field;
   int m_type;
   Vector3d m_local_force;
 };

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -52,5 +52,15 @@ class Constraint(ScriptInterfaceHelper):
       constraint.
     shape : object
       One of the shapes from :mod:`espressomd.shapes`
+    ext_electric_field : double
+      External electric field magnitude along the
+      constraint shape surface normal direction.
+      This feature is currently precisely implemented
+      for the :mod:`espressomd.shapes.Wall` only.
+    ext_magn_field : double
+      External magnetic field magnitude along the
+      constraint shape surface normal direction.
+      This feature is currently precisely implemented
+      for the :mod:`espressomd.shapes.Wall` only.
     """
     _so_name = "Constraints::Constraint"

--- a/src/script_interface/constraints/Constraint.hpp
+++ b/src/script_interface/constraints/Constraint.hpp
@@ -41,14 +41,18 @@ public:
     return {{"only_positive", m_constraint->only_positive()},
             {"penetrable", m_constraint->penetrable()},
             {"particle_type", m_constraint->type()},
-            {"shape", (m_shape != nullptr) ? m_shape->id() : ObjectId()}};
+            {"shape", (m_shape != nullptr) ? m_shape->id() : ObjectId()},
+            {"ext_electric_field", m_constraint->ext_electric_field()},
+            {"ext_magn_field", m_constraint->ext_magn_field()}};
   }
 
   ParameterMap valid_parameters() const override {
     return {{"only_positive", {ParameterType::INT, true}},
             {"penetrable", {ParameterType::INT, true}},
             {"particle_type", {ParameterType::INT, true}},
-            {"shape", {ParameterType::OBJECTID, true}}};
+            {"shape", {ParameterType::OBJECTID, true}},
+            {"ext_electric_field", {ParameterType::DOUBLE, true}},
+            {"ext_magn_field", {ParameterType::DOUBLE, true}}};
   }
 
   void set_parameter(std::string const &name, Variant const &value) override {
@@ -63,6 +67,8 @@ public:
     SET_PARAMETER_HELPER("only_positive", m_constraint->only_positive());
     SET_PARAMETER_HELPER("penetrable", m_constraint->penetrable());
     SET_PARAMETER_HELPER("particle_type", m_constraint->type());
+    SET_PARAMETER_HELPER("ext_electric_field", m_constraint->ext_electric_field());
+    SET_PARAMETER_HELPER("ext_magn_field", m_constraint->ext_magn_field());
   }
 
   Variant call_method(std::string const &name, VariantMap const &) override {

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -2,6 +2,7 @@ set(py_tests  bondedInteractions.py
               cellsystem.py
               coulomb_cloud_wall.py
               correlation.py
+              electromagnetic_constraints.py
               electrostaticInteractions.py
               engine_langevin.py
               engine_lb.py

--- a/testsuite/python/electromagnetic_constraints.py
+++ b/testsuite/python/electromagnetic_constraints.py
@@ -1,0 +1,126 @@
+from __future__ import print_function
+import unittest as ut
+import numpy as np
+from numpy.random import random
+import espressomd
+import math
+from espressomd.interactions import *
+from espressomd.magnetostatics import *
+from espressomd.electrostatics import *
+from espressomd.shapes import *
+from espressomd.constraints import Constraint
+
+if "MASS" in espressomd.features() and "ROTATIONAL_INERTIA" in espressomd.features() \
+and "DIPOLES" in espressomd.features() and "PARTIAL_PERIODIC" in espressomd.features() \
+and "CONSTRAINTS" in espressomd.features() and "ELECTROSTATICS" in espressomd.features() :
+    class ESMSDriftTest(ut.TestCase):
+        longMessage = True
+        # Handle for espresso system
+        es = espressomd.System()
+        n_nodes = 0
+
+        def run_test_case(self):
+            box = 1000
+            self.es.box_l = [box, box, box]
+            self.es.time_step = 7E-3
+            self.es.cell_system.set_layered(n_layers = int(math.ceil(25.0 / self.n_nodes)))
+            n = 9
+            gamma0 = 7.984
+            kT = 2.64
+            self.es.periodicity = [1, 1, 0]
+            self.es.cell_system.skin = 0
+            self.es.thermostat.set_langevin(kT = kT, gamma = gamma0)
+            J = np.array([4.384, 4.384, 4.384])
+            mass = 3.847
+            B_mag = 10.0
+            q = 1.0
+            sigma = 5.0 / (2.0 * np.pi)
+            
+            # This structure has the center of mass zc
+            zc = box / 2.0 + 7 / 3.0
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0, box / 2.0]),id = 0)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0, box / 2.0 + 2.0]),id = 1)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0, box / 2.0 + 4.0]),id = 2)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0 + 2.0, box / 2.0 + 1.0]),id = 3)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0 + 2.0, box / 2.0 + 3.0]),id = 4)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0 + 2.0, box / 2.0 + 5.0]),id = 5)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0 + 4.0, box / 2.0]),id = 6)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0 + 4.0, box / 2.0 + 2.0]),id = 7)
+            self.es.part.add(pos = np.array([box / 2.0, box / 2.0 + 4.0, box / 2.0 + 4.0]),id = 8)
+            
+            for p in range(n):
+                theta = np.pi * random()
+                phi = 2 * np.pi * random()
+                self.es.part[p].type = 0
+                self.es.part[p].mass = mass
+                self.es.part[p].q = q
+                self.es.part[p].dip = np.array([0.0, 0.0, 1.0])
+                self.es.part[p].rinertia = J
+                self.es.part[p].v = np.zeros((3))
+                self.es.part[p].omega_body = np.zeros((3))
+
+            #Interactions
+            dds_cpu = DipolarDirectSumCpu(bjerrum_length = 20.0 / kT)
+            self.es.actors.add(dds_cpu)
+            mmm2d = MMM2D(bjerrum_length = 1.0 / kT, maxPWerror = 1E-6)
+            self.es.actors.add(mmm2d)
+            wall1 = Wall(normal = [0.0, 0.0, 1.0], dist = 0.02 * box)
+            constraint1 = Constraint(shape = wall1, only_positive = 0, particle_type = 2, penetrable = 1, ext_electric_field = 0.0, ext_magn_field = B_mag)
+            wall2 = Wall(normal = [0.0, 0.0, 1.0], dist = 0.03 * box)
+            constraint2 = Constraint(shape = wall2, only_positive = 0, particle_type = 2, penetrable = 0, ext_electric_field = 0.0, ext_magn_field = 0.0)
+            wall3 = Wall(normal = [0.0, 0.0, 1.0], dist = 0.01 * box)
+            constraint3 = Constraint(shape = wall3, only_positive = 0, particle_type = 2, penetrable = 1, ext_electric_field = 2.0 * np.pi * sigma, ext_magn_field = 0.0)
+            self.es.constraints.add(constraint1)
+            self.es.constraints.add(constraint2)
+            self.es.constraints.add(constraint3)
+            
+            sig = 5.0 / 6.0
+            cut = 1.4 * 1.12246 * sig
+            eps = 5
+            shift = 0.25 * eps
+            self.es.non_bonded_inter[0, 0].lennard_jones.set_params(
+                epsilon=eps, sigma=sig,
+                cutoff=cut, shift=0.25 * eps)
+
+            sig = 5.0 / 6.0
+            cut = 0.4 * 1.12246 * sig
+            eps = 5
+            shift = 0.25 * eps
+            self.es.non_bonded_inter[0, 2].lennard_jones.set_params(
+                epsilon=eps, sigma=sig,
+                cutoff=cut, shift=0.25 * eps)
+
+            q_tot = q * n
+            F = 2 * np.pi * sigma * q_tot
+            gamma_tot = gamma0 * n
+            mass_tot = mass * n
+            
+            self.es.time = 0.0
+            
+            for i in range(600):
+                self.es.integrator.run(10)
+
+            # The aggregate macroscopic parameters
+            # Center of mass Z component
+            pos_c_z = 0
+
+            for p in range(n):
+                pos_c_z += self.es.part[p].pos[2]
+            
+            t = self.es.time
+            pos_c_z = pos_c_z / n - box / 2.0
+            pos_c_z_exp = (F /  gamma_tot**2) * (mass_tot * (math.exp(- gamma_tot * t / mass_tot) - 1) + gamma_tot * t) + 7 / 3.0
+            
+            tol = 0.2
+            self.assertTrue(abs(pos_c_z - pos_c_z_exp) / pos_c_z_exp <= tol, msg = 'Z-drift deviation is too large: {0} vs the expected value {1}'.format(pos_c_z,pos_c_z_exp))
+
+        def test(self):
+            self.n_nodes = self.es.cell_system.get_state()["n_nodes"]
+            print("----------------------------------------------------------------")
+            print("- Testcase esms-driven-aggregate-drift.py running on {0} nodes -".format(self.n_nodes))
+            print("----------------------------------------------------------------")
+            self.run_test_case()
+
+if __name__ == '__main__':
+    print("Features: ", espressomd.features())
+    ut.main()


### PR DESCRIPTION
Description of changes:
 - External electric and magnetic field have been added via constraints. Previously (in the `Tcl Espresso`), similar functionality was available via `constraint ext_magn_field Bx By Bz`;
- The functionality is physically fully correct only for a `Wall` constraint. For other shapes, the present feature is introducing external fields normal to the closest constraint surface in a correspondent vicinity. Corresponding "Warning" has been added to the Python file. Even though such field spatial distribution has no physical sense (for a non-`Wall` case) it can be useful for tests of complex field geometries (based on `Shape`s complexity and their arbitrary spatial combination) or in cases of some specific physical models;
- Other option: to introduce this feature via the `Wall` class with a zero function in a `Shape` virtual method for other shapes. However, this approach contradicts to present architecture: field and energy are calculated by the `Constraint`, not by `Shape`, cause shape, after all, is just an abstract shape. Please, provide your feedback: how external electric and magnetic field should be applied in current Espresso architecture? Maybe some `ExternalField` class should be defined fully separate to `Constraint` and `Shape` and introduced additionally to fields, energies and torques?
- Suggested test validates electric and magnetic constraints in a real physical task with DDS CPU + MMM2D inter-particle interactions and external field which drives the particles aggregate. The test finally validates that particles aggregate drift as a single entity;
- If overall approach will be approved then I will supplement docs to this pull request for a user guiding; 

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
