### PR TITLE
Introducing has_features

### DIFF
--- a/src/python/espressomd/__init__.py
+++ b/src/python/espressomd/__init__.py
@@ -26,3 +26,21 @@ espressomd._init.setup()
 
 from espressomd.system import System
 from espressomd.code_info import features
+
+def has_features(arg):
+    """Tests whether a list of features is a subset of the compiled-in features"""
+
+    return set(arg) < set(features())
+
+
+def missing_features(arg):
+    """Returns a list of the missing features in the argument"""
+
+    return list(set(arg) - set(features()))
+
+
+def assert_features(arg, ExceptionType = Exception):
+    """Raises an excpetion when a list of features is not a subset of the compiled-in features"""
+
+    if not has_features(arg):
+        raise ExceptionType("Missing features " + ", ".join(missing_features(arg)))


### PR DESCRIPTION
I usually do a runtime check for the existing features in ESPResSo to see if my feature is compiled in before I run the script.  So far this has been rather tedious and was verbose.  That is why I introduce `has_features`.

Additionally, I introduce `missing_features` which determines which of the features are actually not compiled in.

The user might not want to write all that code in each and every of their scripts and manually raise and exception.  That is why I introduce `assert_features` alongside which combines `has_features` and `missing_features` with an informative exception.

````python
from espressomd import assert_features, has_features, missing_features

if not has_features(["LENNARD_JONES"]):
    print("Feature LENNARD_JONES is missing")

desired_features = ["MASS", "LB_GPU", "LB_BOUNDARIES_GPU"]
if not has_features(desired_features):
    print("Missing features " + ", ".join(missing_features(desired_features)))

assert_features(desired_features)

assert_features(desired_features, ExceptionType = ImportError)
````