### PR TITLE
seed with 32bit ints

### DIFF
--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -245,7 +245,7 @@ cdef class System:
         for i in range(n_nodes):
             states_on_node_i = []
             for j in range(_state_size_plus_one + 1):
-                states_on_node_i.append(rng.randint(0, numeric_limits[int].max))
+                states_on_node_i.append(rng.randint(0, numeric_limits[int].max()))
             states[i] = " ".join(map(str, states_on_node_i))
         mpi_random_set_stat(states)
 

--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -245,8 +245,11 @@ cdef class System:
         for i in range(n_nodes):
             states_on_node_i = []
             for j in range(_state_size_plus_one + 1):
-                states_on_node_i.append(rng.randint(0, sys.maxint))
+                #states_on_node_i.append(rng.randint(0, sys.maxint))
+                states_on_node_i.append(rng.randint(0, 2**31-1))
+
             states[i] = " ".join(map(str, states_on_node_i))
+        print( "SETTING mpi_random_set with len: {}".format(len(states[0].split()) ))
         mpi_random_set_stat(states)
 
     property seed:
@@ -264,6 +267,7 @@ cdef class System:
                 seed_array.resize(len(_seed))
                 for i in range(len(_seed)):
                     seed_array[i] = int(_seed[i])
+                print( "SETTING mpi_random_seeds with len: {}".format(len(seed_array) ))
 
                 mpi_random_seed(n_nodes, seed_array)
             else:
@@ -283,6 +287,7 @@ cdef class System:
                 for i in range(n_nodes):
                     states[i] = " ".join(
                         map(str, rng_state[i * _state_size_plus_one:(i + 1) * _state_size_plus_one]))
+                print( "SETTING mpi_random_set with len: {}".format(len(states[0].split()) ))
                 mpi_random_set_stat(states)
             else:
                 raise ValueError("Wrong # of args: Usage: 'random_number_generator_state \"<state(1)> ... <state(n_nodes*(state_size+1))>, where each <state(i)> is an integer. The state size of the PRNG can be obtained by calling _get_PRNG_state_size().")

--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -245,11 +245,8 @@ cdef class System:
         for i in range(n_nodes):
             states_on_node_i = []
             for j in range(_state_size_plus_one + 1):
-                #states_on_node_i.append(rng.randint(0, sys.maxint))
                 states_on_node_i.append(rng.randint(0, 2**31-1))
-
             states[i] = " ".join(map(str, states_on_node_i))
-        print( "SETTING mpi_random_set with len: {}".format(len(states[0].split()) ))
         mpi_random_set_stat(states)
 
     property seed:
@@ -267,8 +264,6 @@ cdef class System:
                 seed_array.resize(len(_seed))
                 for i in range(len(_seed)):
                     seed_array[i] = int(_seed[i])
-                print( "SETTING mpi_random_seeds with len: {}".format(len(seed_array) ))
-
                 mpi_random_seed(n_nodes, seed_array)
             else:
                 raise ValueError(
@@ -287,7 +282,6 @@ cdef class System:
                 for i in range(n_nodes):
                     states[i] = " ".join(
                         map(str, rng_state[i * _state_size_plus_one:(i + 1) * _state_size_plus_one]))
-                print( "SETTING mpi_random_set with len: {}".format(len(states[0].split()) ))
                 mpi_random_set_stat(states)
             else:
                 raise ValueError("Wrong # of args: Usage: 'random_number_generator_state \"<state(1)> ... <state(n_nodes*(state_size+1))>, where each <state(i)> is an integer. The state size of the PRNG can be obtained by calling _get_PRNG_state_size().")

--- a/src/python/espressomd/_system.pyx
+++ b/src/python/espressomd/_system.pyx
@@ -245,7 +245,7 @@ cdef class System:
         for i in range(n_nodes):
             states_on_node_i = []
             for j in range(_state_size_plus_one + 1):
-                states_on_node_i.append(rng.randint(0, 2**31-1))
+                states_on_node_i.append(rng.randint(0, numeric_limits[int].max))
             states[i] = " ".join(map(str, states_on_node_i))
         mpi_random_set_stat(states)
 

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -72,3 +72,5 @@ cdef extern from "<limits>" namespace "std" nogil:
     cdef cppclass numeric_limits[T]:
         @staticmethod
         T epsilon()
+        @staticmethod
+        T max()


### PR DESCRIPTION
Fixes #1046 

Description of changes:
 - 
Use int32 instead of sys.maxint which can sometimes be 64 bits.

Seems to fix the (#1046) problem for me, my understanding is that this needs to be 32 bits anyways, see
http://www.cplusplus.com/reference/random/seed_seq/

I think there is still another issue concerning a 625 length vector, (instead of 626) but that's for another day. 





PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
