### PR TITLE
Have you seen anyone with a semicolon tattoo? Here's what it's about.

### DIFF
--- a/doc/misc/common.tex
+++ b/doc/misc/common.tex
@@ -42,7 +42,6 @@
         box_l,
         cellsystem,
         CellSystem,
-        code_info,
         COORDS_ALL_FIXED,
         COORDS_FIX_MASK,
         COORD_FIXED,

--- a/doc/sphinx/inter.rst
+++ b/doc/sphinx/inter.rst
@@ -1354,7 +1354,7 @@ Required paramters:
 
 For this feature to work, you need to have the ``fftw3`` library
 installed on your system. In , you can check if it is compiled in by
-checking for the feature ``FFTW`` with ``espressomd.code_info.features()``
+checking for the feature ``FFTW`` with ``espressomd.features()``
 P3M requires full periodicity (1 1 1). Make sure that you know the relevance of the
 P3M parameters before using P3M! If you are not sure, read the following
 references

--- a/doc/tutorials/python/01-lennard_jones/01-lennard_jones.tex
+++ b/doc/tutorials/python/01-lennard_jones/01-lennard_jones.tex
@@ -96,7 +96,7 @@ pagesize,                       % set the pagesize in a DVI document
 \lstset{numbers=left, numberstyle=\tiny, numbersep=5pt, showspaces=false, showstringspaces=false,postbreak=\space, breakindent=5pt, breaklines}
 \lstset{language=python, keywordstyle=\color{blue}\bfseries ,emphstyle=\color{green}, commentstyle=\color{red}\itshape }
 \lstset{keywordsprefix=setmd}
-\lstset{keywords=[6]{thermostat,part,inter,integrate,rescale_velocities,code_info,save_sim,writepdb,analyze,uwerr}}
+\lstset{keywords=[6]{thermostat,part,inter,integrate,rescale_velocities,save_sim,writepdb,analyze,uwerr}}
 
 \newtheorem{task}{Task}
 
@@ -367,7 +367,6 @@ First, we include necessary modules with \lstinline|import|.
 \begin{pypresso}
 from __future__ import print_function
 import espressomd
-from espressomd import code_info
 
 import os 
 import numpy as np
@@ -378,7 +377,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 \end{pypresso}\vspace{0,2cm}
 

--- a/doc/tutorials/python/01-lennard_jones/scripts/lj_tutorial.py
+++ b/doc/tutorials/python/01-lennard_jones/scripts/lj_tutorial.py
@@ -18,7 +18,6 @@
 #
 from __future__ import print_function
 import espressomd
-from espressomd import code_info
 
 import os 
 import numpy as np
@@ -29,7 +28,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 # System parameters
 #############################################################

--- a/doc/tutorials/python/01-lennard_jones/scripts/msd.py
+++ b/doc/tutorials/python/01-lennard_jones/scripts/msd.py
@@ -35,7 +35,6 @@
 # 1. Setup and equilibrate LJ liquid
 from __future__ import print_function
 import espressomd
-from espressomd import code_info
 
 import cPickle as pickle
 import os 

--- a/doc/tutorials/python/01-lennard_jones/scripts/two-component-visualization.py
+++ b/doc/tutorials/python/01-lennard_jones/scripts/two-component-visualization.py
@@ -27,7 +27,6 @@
 # 1. Setup and equilibrate LJ liquid
 from __future__ import print_function
 import espressomd
-from espressomd import code_info
 
 import os 
 import numpy as np

--- a/doc/tutorials/python/01-lennard_jones/scripts/two-component.py
+++ b/doc/tutorials/python/01-lennard_jones/scripts/two-component.py
@@ -27,7 +27,6 @@
 # 1. Setup and equilibrate LJ liquid
 from __future__ import print_function
 import espressomd
-from espressomd import code_info
 
 import os 
 import numpy as np

--- a/doc/tutorials/python/04-lattice_boltzmann/04-lattice_boltzmann.tex
+++ b/doc/tutorials/python/04-lattice_boltzmann/04-lattice_boltzmann.tex
@@ -342,7 +342,7 @@ final]{scrartcl}
 %\lstset{numbers=left, numberstyle=\tiny, numbersep=5pt, showspaces=false, showstringspaces=false,postbreak=\space, breakindent=5pt, breaklines}
 %\lstset{language=tcl, keywordstyle=\color{blue}\bfseries ,emphstyle=\color{green}, commentstyle=\color{red}\itshape }
 %\lstset{keywordsprefix=setmd}
-%\lstset{keywords=[6]{thermostat,part,inter,integrate,rescale_velocities,code_info,save_sim,writepdb,analyze,uwerr, lbnode, lb_boundary, lbfluid, constraint}}
+%\lstset{keywords=[6]{thermostat,part,inter,integrate,rescale_velocities,save_sim,writepdb,analyze,uwerr, lbnode, lb_boundary, lbfluid, constraint}}
 
 \include{common}
 \newtheorem{task}{Task}

--- a/doc/tutorials/python/07-electrokinetics/07-electrokinetics.tex
+++ b/doc/tutorials/python/07-electrokinetics/07-electrokinetics.tex
@@ -341,7 +341,7 @@ final]{scrartcl}
 %\lstset{numbers=left, numberstyle=\tiny, numbersep=5pt, showspaces=false, showstringspaces=false,postbreak=\space, breakindent=5pt, breaklines}
 %\lstset{basicstyle=\ttfamily,keywordstyle=\color{blue}\bfseries,emphstyle=\color{green}, commentstyle=\color{red}\itshape,columns=fullflexible }
 \lstset{keywordsprefix=setmd}
-\lstset{keywords=[6]{thermostat,part,inter,integrate,rescale_velocities,code_info,save_sim,writepdb,analyze,uwerr, lbnode, lb_boundary, lbfluid, constraint,electrokinetics}}
+\lstset{keywords=[6]{thermostat,part,inter,integrate,rescale_velocities,save_sim,writepdb,analyze,uwerr, lbnode, lb_boundary, lbfluid, constraint,electrokinetics}}
 
 
 %Python

--- a/samples/python/billard.py
+++ b/samples/python/billard.py
@@ -2,7 +2,6 @@
 
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 from espressomd import analyze
 from espressomd import integrate
 from espressomd import electrostatics

--- a/samples/python/coulomb_debye_hueckel.py
+++ b/samples/python/coulomb_debye_hueckel.py
@@ -19,7 +19,6 @@
 from __future__ import print_function
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 from espressomd import electrostatics
 import numpy
 
@@ -29,7 +28,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/samples/python/debye_hueckel.py
+++ b/samples/python/debye_hueckel.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import espressomd._system as es
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 from espressomd import electrostatics
 import numpy
 
@@ -30,7 +29,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/samples/python/electrophoresis.py
+++ b/samples/python/electrophoresis.py
@@ -18,7 +18,6 @@
 #
 from __future__ import print_function
 import espressomd
-from espressomd import code_info
 from espressomd import thermostat
 from espressomd import interactions
 from espressomd import electrostatics
@@ -30,7 +29,7 @@ except ImportError:
     import pickle
 import os
 
-print(code_info.features())
+print(espressomd.features())
 
 # Seed
 #############################################################

--- a/samples/python/lbf.py
+++ b/samples/python/lbf.py
@@ -19,7 +19,6 @@
 from __future__ import print_function
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 from espressomd import lb
 import numpy as np
 
@@ -29,7 +28,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 
 system = espressomd.System()

--- a/samples/python/lj_liquid.py
+++ b/samples/python/lj_liquid.py
@@ -19,7 +19,6 @@
 from __future__ import print_function
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 import numpy
 
 print("""
@@ -28,7 +27,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/samples/python/lj_liquid_distribution.py
+++ b/samples/python/lj_liquid_distribution.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import espressomd._system as es
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 import numpy
 
 print("""
@@ -29,7 +28,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/samples/python/lj_liquid_structurefactor.py
+++ b/samples/python/lj_liquid_structurefactor.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import espressomd._system as es
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 from espressomd import analyze
 import numpy
 
@@ -30,7 +29,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/samples/python/load_properties.py
+++ b/samples/python/load_properties.py
@@ -19,7 +19,6 @@
 from __future__ import print_function
 import espressomd._system as es
 import espressomd
-from espressomd import code_info
 from espressomd import electrostatics
 from espressomd import electrostatic_extensions
 import numpy
@@ -35,7 +34,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/samples/python/p3m.py
+++ b/samples/python/p3m.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import espressomd._system as es
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 from espressomd import electrostatics
 from espressomd import electrostatic_extensions
 import numpy
@@ -31,7 +30,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/samples/python/slice_input.py
+++ b/samples/python/slice_input.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import espressomd._system as es
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 import numpy as np
 
 print("""
@@ -29,7 +28,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 
@@ -85,12 +84,12 @@ print("F\n%s"%system.part[:].f)
 system.part[:2].f=[[3,4,5],[4,5,6]]
 print("F_NEW\n%s"%system.part[:].f)
 
-if "MASS" in code_info.features():
+if espressomd.has_features(["MASS"]):
     print("MASS\n%s"%system.part[:].mass)
     system.part[:2].mass=[2,3]
     print("MASS_NEW\n%s"%system.part[:].mass)
 
-if "ELECTROSTATICS" in code_info.features():
+if espressomd.has_features(["ELECTROSTATICS"]):
     print("Q\n%s"%system.part[:].q)
     system.part[::2].q=np.ones(n_part/2)
     system.part[1::2].q=-np.ones(n_part/2)

--- a/samples/python/store_properties.py
+++ b/samples/python/store_properties.py
@@ -19,7 +19,6 @@
 from __future__ import print_function
 import espressomd._system as es
 import espressomd
-from espressomd import code_info
 from espressomd import electrostatics
 from espressomd import electrostatic_extensions
 import numpy
@@ -30,9 +29,8 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
-if not "ELECTROSTATICS" in code_info.features():
-    raise Exception("Sample script requires ELECTROSTATICS")
+print(espressomd.features())
+espressomd.assert_features(["ELECTROSTATICS"])
 
 dev = "cpu"
 

--- a/samples/python/visualization.py
+++ b/samples/python/visualization.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import espressomd._system as es
 import espressomd
 from espressomd import thermostat
-from espressomd import code_info
 from espressomd import integrate
 from espressomd import visualization
 import numpy
@@ -33,7 +32,7 @@ print("""
 =======================================================
 
 Program Information:""")
-print(code_info.features())
+print(espressomd.features())
 
 dev = "cpu"
 

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -111,7 +111,7 @@ cdef class Integrator:
             If this optional parameter is true, a cubic box is assumed.
         """
 
-        if "NPT" in espressomd.code_info.features():
+        if "NPT" not in espressomd.code_info.features():
             raise Exception("NPT is not compiled in")
         check_type_or_throw_except(
             ext_pressure, 1, float, "NPT parameter ext_pressure must be a float")

--- a/testsuite/python/bondedInteractions.py
+++ b/testsuite/python/bondedInteractions.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import unittest as ut
 import espressomd
 import espressomd._system as es
-from espressomd import code_info
 import numpy as np
 from espressomd.interactions import *
 
@@ -92,7 +91,7 @@ class ParticleProperties(ut.TestCase):
     test_harmonic2 = generateTestForBondParams(
         0, HarmonicBond, {"r_0": 1.1, "k": 5.2, "r_cut": 1.3})
 
-    if "ROTATION" in code_info.features():
+    if espressomd.has_features(["ROTATION"]):
         test_harmonic_dumbbell = generateTestForBondParams(
             0, HarmonicDumbbellBond, {"k1": 1.1, "k2": 2.2, "r_0": 1.5})
         test_harmonic_dumbbell2 = generateTestForBondParams(
@@ -101,21 +100,21 @@ class ParticleProperties(ut.TestCase):
     test_dihedral = generateTestForBondParams(
         0, Dihedral, {"mult": 3.0, "bend": 5.2, "phase": 3.})
     
-    if "BOND_ANGLE" in espressomd.features():
+    if espressomd.has_features(["BOND_ANGLE"]):
         test_angle_harm = generateTestForBondParams(
             0, Angle_Harmonic, {"bend": 5.2, "phi0": 3.2})
         test_angle_cos = generateTestForBondParams(
             0, Angle_Cosine, {"bend": 5.2, "phi0": 3.2})
         test_angle_cossquare = generateTestForBondParams(
             0, Angle_Cossquare, {"bend": 5.2, "phi0": 0.})
-    if "LENNARD_JONES" in espressomd.features():
+    if espressomd.has_features(["LENNARD_JONES"]):
         test_subt_lj = generateTestForBondParams(0, Subt_Lj, {"k": 5.2, "r": 3.2})
 
-    if "TABULATED" in espressomd.features():
+    if espressomd.has_features(["TABULATED"]):
       test_tabulated = generateTestForBondParams(0, Tabulated, {"type": "distance", "filename":"lj1.tab"})
 
 
 
 if __name__ == "__main__":
-    print("Features: ", code_info.features())
+    print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -13,8 +13,8 @@ import espressomd
 from espressomd import interactions
 from espressomd.shapes import Wall
 
-@ut.skipIf(not set(["CONSTRAINTS", "LENNARD_JONES"]) < set(espressomd.features()),
-        "Features not available, skipping test!")
+@ut.skipIf(not espressomd.has_features(["CONSTRAINTS", "LENNARD_JONES"]),
+           "Features not available, skipping test!")
 class ShapeBasedConstraintTest(ut.TestCase):
 
     def prepare(self, S):

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -25,94 +25,94 @@ import numpy as np
 from espressomd.electrostatics import *
 from espressomd import scafacos
 
-
+@ut.skipIf(not espressomd.has_features(["ELECTROSTATICS"]),
+           "Features not available, skipping test!")
 class CoulombCloudWall(ut.TestCase):
-    if "ELECTROSTATICS" in espressomd.features():
-        """This compares p3m, p3m_gpu, scafacos_p3m and scafacos_p2nfft 
-           electrostatic forces and energy against stored data."""
-        S = espressomd.System()
-        forces = {}
-        tolerance = 1E-3
+    """This compares p3m, p3m_gpu, scafacos_p3m and scafacos_p2nfft 
+       electrostatic forces and energy against stored data."""
+    S = espressomd.System()
+    forces = {}
+    tolerance = 1E-3
 
-        # Reference energy from p3m in the tcl test case
-        reference_energy = 148.94229549
+    # Reference energy from p3m in the tcl test case
+    reference_energy = 148.94229549
 
-        def setUp(self):
-            self.S.box_l = (10, 10, 10)
-            self.S.time_step = 0.01
-            self.S.cell_system.skin = 0.4
+    def setUp(self):
+        self.S.box_l = (10, 10, 10)
+        self.S.time_step = 0.01
+        self.S.cell_system.skin = 0.4
 
-            #  Clear actors that might be left from prev tests
-            if len(self.S.actors):
-                del self.S.actors[0]
-            self.S.part.clear()
-            data = np.genfromtxt("data/coulomb_cloud_wall_system.data")
+        #  Clear actors that might be left from prev tests
+        if len(self.S.actors):
+            del self.S.actors[0]
+        self.S.part.clear()
+        data = np.genfromtxt("data/coulomb_cloud_wall_system.data")
 
-            # Add particles to system and store reference forces in hash
-            # Input format: id pos q f
-            for particle in data:
-                id = particle[0]
-                pos = particle[1:4]
-                q = particle[4]
-                f = particle[5:]
-                self.S.part.add(id=int(id), pos=pos, q=q)
-                self.forces[id] = f
+        # Add particles to system and store reference forces in hash
+        # Input format: id pos q f
+        for particle in data:
+            id = particle[0]
+            pos = particle[1:4]
+            q = particle[4]
+            f = particle[5:]
+            self.S.part.add(id=int(id), pos=pos, q=q)
+            self.forces[id] = f
 
-        def compare(self, method_name, energy=True):
-            # Compare forces and energy now in the system to stored ones
+    def compare(self, method_name, energy=True):
+        # Compare forces and energy now in the system to stored ones
 
-            # Force
-            force_abs_diff = 0.
-            for p in self.S.part:
-                force_abs_diff += abs(np.sqrt(sum((p.f - self.forces[p.id])**2)))
-            force_abs_diff /= len(self.S.part)
+        # Force
+        force_abs_diff = 0.
+        for p in self.S.part:
+            force_abs_diff += abs(np.sqrt(sum((p.f - self.forces[p.id])**2)))
+        force_abs_diff /= len(self.S.part)
 
-            print(method_name, "force difference", force_abs_diff)
+        print(method_name, "force difference", force_abs_diff)
 
-            # Energy
-            if energy:
-                energy_abs_diff = abs(self.S.analysis.energy(
-                    self.S)["total"] - self.reference_energy)
-                print(method_name, "energy difference", energy_abs_diff)
-                self.assertTrue(energy_abs_diff <= self.tolerance, "Absolte energy difference " +
-                                str(energy_abs_diff) + " too large for " + method_name)
-            self.assertTrue(force_abs_diff <= self.tolerance, "Asbolute force difference " +
-                            str(force_abs_diff) + " too large for method " + method_name)
+        # Energy
+        if energy:
+            energy_abs_diff = abs(self.S.analysis.energy(
+                self.S)["total"] - self.reference_energy)
+            print(method_name, "energy difference", energy_abs_diff)
+            self.assertTrue(energy_abs_diff <= self.tolerance, "Absolte energy difference " +
+                            str(energy_abs_diff) + " too large for " + method_name)
+        self.assertTrue(force_abs_diff <= self.tolerance, "Asbolute force difference " +
+                        str(force_abs_diff) + " too large for method " + method_name)
 
-        # Tests for individual methods
+    # Tests for individual methods
 
-        if "P3M" in espressomd.features():
-            def test_p3m(self):
-                self.S.actors.add(P3M(bjerrum_length=1, r_cut=1.001, accuracy = 1e-3,
+    if espressomd.has_features(["P3M"]):
+        def test_p3m(self):
+            self.S.actors.add(P3M(bjerrum_length=1, r_cut=1.001, accuracy = 1e-3,
+                                  mesh=64, cao=7, alpha=2.70746, tune=False))
+            self.S.integrator.run(0)
+            self.compare("p3m", energy=True)
+
+    if espressomd.has_features(["ELECTROSTATICS", "CUDA"]):
+        def test_p3m_gpu(self):
+            self.S.actors.add(P3M_GPU(bjerrum_length=1, r_cut=1.001, accuracy = 1e-3,
                                       mesh=64, cao=7, alpha=2.70746, tune=False))
+            self.S.integrator.run(0)
+            self.compare("p3m_gpu", energy=False)
+
+    if espressomd.has_features(["SCAFACOS"]):
+        if "p3m" in scafacos.available_methods():
+            def test_scafacos_p3m(self):
+                self.S.actors.add(Scafacos(bjerrum_length=1, method_name="p3m", method_params={
+                                  "p3m_r_cut": 1.001, "p3m_grid": 64, "p3m_cao": 7, "p3m_alpha": 2.70746}))
                 self.S.integrator.run(0)
-                self.compare("p3m", energy=True)
+                self.compare("scafacos_p3m", energy=True)
 
-        if "ELECTROSTATICS" in espressomd.features() and "CUDA" in espressomd.features():
-            def test_p3m_gpu(self):
-                self.S.actors.add(P3M_GPU(bjerrum_length=1, r_cut=1.001, accuracy = 1e-3,
-                                          mesh=64, cao=7, alpha=2.70746, tune=False))
+        if "p2nfft" in scafacos.available_methods():
+            def test_scafacos_p2nfft(self):
+                self.S.actors.add(Scafacos(bjerrum_length=1, method_name="p2nfft", method_params={
+                                  "p2nfft_r_cut": 1.001, "tolerance_field": 1E-4}))
                 self.S.integrator.run(0)
-                self.compare("p3m_gpu", energy=False)
+                self.compare("scafacos_p2nfft", energy=True)
 
-        if "SCAFACOS" in espressomd.features():
-            if "p3m" in scafacos.available_methods():
-                def test_scafacos_p3m(self):
-                    self.S.actors.add(Scafacos(bjerrum_length=1, method_name="p3m", method_params={
-                                      "p3m_r_cut": 1.001, "p3m_grid": 64, "p3m_cao": 7, "p3m_alpha": 2.70746}))
-                    self.S.integrator.run(0)
-                    self.compare("scafacos_p3m", energy=True)
-
-            if "p2nfft" in scafacos.available_methods():
-                def test_scafacos_p2nfft(self):
-                    self.S.actors.add(Scafacos(bjerrum_length=1, method_name="p2nfft", method_params={
-                                      "p2nfft_r_cut": 1.001, "tolerance_field": 1E-4}))
-                    self.S.integrator.run(0)
-                    self.compare("scafacos_p2nfft", energy=True)
-
-        def test_zz_deactivation(self):
-            # Is the energy 0, if no methods active
-            self.assertTrue(self.S.analysis.energy(self.S)["total"] == 0.0)
+    def test_zz_deactivation(self):
+        # Is the energy 0, if no methods active
+        self.assertTrue(self.S.analysis.energy(self.S)["total"] == 0.0)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -24,20 +24,22 @@ from espressomd.electrostatics import *
 from tests_common import *
 
 
+@ut.skipIf(not espressomd.has_features(["ELECTROSTATICS"]),
+           "Features not available, skipping test!")
 class ElectrostaticInteractionsTests(ut.TestCase):
-    if "ELECTROSTATICS" in espressomd.features():
-        # Handle to espresso system
-        system = espressomd.System()
-        
-        def setUp(self):
-            self.system.box_l = 10, 10, 10
-            if not self.system.part.exists(0):
-                self.system.part.add(id=0, pos=(2.0, 2.0, 2.0), q=1)
-            if not self.system.part.exists(1):
-                self.system.part.add(id=1, pos=(8.0, 8.0, 8.0), q=-1)
-            print("ut.TestCase setUp")
+    # Handle to espresso system
+    system = espressomd.System()
     
-         
+    def setUp(self):
+        self.system.box_l = 10, 10, 10
+        if not self.system.part.exists(0):
+            self.system.part.add(id=0, pos=(2.0, 2.0, 2.0), q=1)
+        if not self.system.part.exists(1):
+            self.system.part.add(id=1, pos=(8.0, 8.0, 8.0), q=-1)
+        print("ut.TestCase setUp")
+
+
+    if espressomd.has_features(["P3M"]):
         test_P3M = generate_test_for_class(system, P3M, dict(bjerrum_length=1.0,
                                                                      epsilon=0.0,
                                                                      r_cut=2.4,
@@ -46,18 +48,18 @@ class ElectrostaticInteractionsTests(ut.TestCase):
                                                                      alpha=12,
                                                                      accuracy=0.01,
                                                                      tune=False))
-    
-        if "COULOMB_DEBYE_HUECKEL" in espressomd.features():
-            test_CDH = generate_test_for_class(system, CDH, dict(bjerrum_length=1.0,
-                                                                         kappa=2.3,
-                                                                         r_cut=2,
-                                                                         r0=1,
-                                                                         r1=1.9,
-                                                                         eps_int=0.8,
-                                                                         eps_ext=1,
-                                                                         alpha=2))
-    
-    
+
+    if espressomd.has_features(["COULOMB_DEBYE_HUECKEL"]):
+        test_CDH = generate_test_for_class(system, CDH, dict(bjerrum_length=1.0,
+                                                                     kappa=2.3,
+                                                                     r_cut=2,
+                                                                     r0=1,
+                                                                     r1=1.9,
+                                                                     eps_int=0.8,
+                                                                     eps_ext=1,
+                                                                     alpha=2))
+
+
 if __name__ == "__main__":
     print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/engine_langevin.py
+++ b/testsuite/python/engine_langevin.py
@@ -4,49 +4,50 @@ import numpy as np
 import espressomd
 
 
-if "ENGINE" in espressomd.features():
-    class SwimmerTest(ut.TestCase):
-        def test(self):
-            boxl = 12
-            sampsteps = 2000
-            tstep = 0.01
+@ut.skipIf(not espressomd.has_features(["ENGINE"]),
+           "Features not available, skipping test!")
+class SwimmerTest(ut.TestCase):
+    def test(self):
+        boxl = 12
+        sampsteps = 2000
+        tstep = 0.01
 
-            v_swim = 0.3
-            f_swim = 0.1
-            temp = 0.0
-            gamma = 1.0
+        v_swim = 0.3
+        f_swim = 0.1
+        temp = 0.0
+        gamma = 1.0
 
-            pos_0 = np.array([boxl/2., boxl/2., 1.*boxl/3.])
-            pos_1 = np.array([boxl/2., boxl/2., 2.*boxl/3.])
+        pos_0 = np.array([boxl/2., boxl/2., 1.*boxl/3.])
+        pos_1 = np.array([boxl/2., boxl/2., 2.*boxl/3.])
 
-            def z_f(t,z0):
-                return f_swim/gamma*(-1./gamma + t + (1./gamma)*np.exp(-gamma*t))+z0
+        def z_f(t,z0):
+            return f_swim/gamma*(-1./gamma + t + (1./gamma)*np.exp(-gamma*t))+z0
 
-            def z_v(t,z0):
-                return v_swim*(-1./gamma + t + (1./gamma)*np.exp(-gamma*t))+z0
+        def z_v(t,z0):
+            return v_swim*(-1./gamma + t + (1./gamma)*np.exp(-gamma*t))+z0
 
-            S = espressomd.System()
+        S = espressomd.System()
 
-            S.box_l = [boxl, boxl, boxl]
-            S.cell_system.skin = 0.1
-            S.time_step = tstep
+        S.box_l = [boxl, boxl, boxl]
+        S.cell_system.skin = 0.1
+        S.time_step = tstep
 
-            S.part.add(id=0, pos=pos_0, swimming={"v_swim": v_swim})
-            S.part.add(id=1, pos=pos_1, swimming={"f_swim": f_swim})
+        S.part.add(id=0, pos=pos_0, swimming={"v_swim": v_swim})
+        S.part.add(id=1, pos=pos_1, swimming={"f_swim": f_swim})
 
-            S.thermostat.set_langevin(kT=temp, gamma=gamma)
+        S.thermostat.set_langevin(kT=temp, gamma=gamma)
 
-            S.integrator.run(sampsteps)
+        S.integrator.run(sampsteps)
 
-            pos_0[2] = z_v(S.time, pos_0[2])
-            pos_1[2] = z_f(S.time, pos_1[2])
+        pos_0[2] = z_v(S.time, pos_0[2])
+        pos_1[2] = z_f(S.time, pos_1[2])
 
-            delta_pos_0 = np.linalg.norm(S.part[0].pos - pos_0)
-            delta_pos_1 = np.linalg.norm(S.part[1].pos - pos_1)
+        delta_pos_0 = np.linalg.norm(S.part[0].pos - pos_0)
+        delta_pos_1 = np.linalg.norm(S.part[1].pos - pos_1)
 
-            self.assertTrue(1.4e-3 < delta_pos_0 and delta_pos_0 < 1.6e-3)
-            self.assertTrue(4.9e-4 < delta_pos_1 and delta_pos_1 < 5.1e-4)
+        self.assertTrue(1.4e-3 < delta_pos_0 and delta_pos_0 < 1.6e-3)
+        self.assertTrue(4.9e-4 < delta_pos_1 and delta_pos_1 < 5.1e-4)
 
-    if __name__ == '__main__':
-        print("Features: ", espressomd.features())
-        ut.main()
+if __name__ == '__main__':
+    print("Features: ", espressomd.features())
+    ut.main()

--- a/testsuite/python/engine_lb.py
+++ b/testsuite/python/engine_lb.py
@@ -14,10 +14,8 @@ except ImportError:
     print("Module \"vtk\" not available, skipping test!")
     exit()
 
-if not set(["ENGINE", "LB"]) < set(espressomd.features()):
-    print("Features not available, skipping test!")
-    exit()
-
+@ut.skipIf(not espressomd.has_features(["ENGINE", "LB"]),
+           "Features not available, skipping test!")
 class SwimmerTest(ut.TestCase):
     def prepare(self,S):
         boxl  = 12

--- a/testsuite/python/engine_lbgpu.py
+++ b/testsuite/python/engine_lbgpu.py
@@ -14,10 +14,8 @@ except ImportError:
     print("Module \"vtk\" not available, skipping test!")
     exit()
 
-if not set(["ENGINE", "LB_GPU"]) < set(espressomd.features()):
-    print("Features not available, skipping test!")
-    exit()
-
+@ut.skipIf(not espressomd.has_features(["ENGINE", "LB_GPU"]),
+           "Features not available, skipping test!")
 class SwimmerTest(ut.TestCase):
     def prepare(self,S):
         boxl  = 12

--- a/testsuite/python/ewald_gpu.py
+++ b/testsuite/python/ewald_gpu.py
@@ -23,28 +23,29 @@ import unittest as ut
 import numpy as np
 from tests_common import *
 
+@ut.skipIf(not espressomd.has_features(["ELECTROSTATICS","CUDA","EWALD_GPU"]),
+           "Features not available, skipping test!")
 class ewald_GPU_test(ut.TestCase):
-    if "ELECTROSTATICS" in espressomd.features() and "CUDA" in espressomd.features() and "EWALD_GPU" in espressomd.features():
+    def runTest(self):
         from espressomd.electrostatics import EwaldGpu
 
-        def runTest(self):
-            es = espressomd.System()
-            test_params = {}
-            test_params["bjerrum_length"] = 2
-            test_params["num_kx"] = 2
-            test_params["num_ky"] = 2
-            test_params["num_kz"] = 2
-            test_params["K_max"] = 10
-            test_params["time_calc_steps"] = 100
-            test_params["rcut"] = 0.9
-            test_params["accuracy"] = 1e-1
-            test_params["precision"] = 1e-2
-            test_params["alpha"] = 3.5
-    
-            ewald = EwaldGpu(**test_params)
-            es.actors.add(ewald)
-            self.assertTrue(params_match(test_params,ewald._get_params_from_es_core()))
+        es = espressomd.System()
+        test_params = {}
+        test_params["bjerrum_length"] = 2
+        test_params["num_kx"] = 2
+        test_params["num_ky"] = 2
+        test_params["num_kz"] = 2
+        test_params["K_max"] = 10
+        test_params["time_calc_steps"] = 100
+        test_params["rcut"] = 0.9
+        test_params["accuracy"] = 1e-1
+        test_params["precision"] = 1e-2
+        test_params["alpha"] = 3.5
 
-    if __name__ == "__main__":
-        print("Features: ", espressomd.features())
-        ut.main()
+        ewald = EwaldGpu(**test_params)
+        es.actors.add(ewald)
+        self.assertTrue(params_match(test_params,ewald._get_params_from_es_core()))
+
+if __name__ == "__main__":
+    print("Features: ", espressomd.features())
+    ut.main()

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -48,9 +48,9 @@ class CommonTests(ut.TestCase):
                                             float(i),
                                             float(i)]),
                         v=np.array([1.0, 2.0, 3.0]), type=23)
-        if 'MASS' in espressomd.code_info.features():
+        if espressomd.has_features(['MASS']):
             system.part[i].mass = 2.3
-        if 'EXTERNAL_FORCE' in espressomd.code_info.features():
+        if espressomd.has_features(['EXTERNAL_FORCE']):
             system.part[i].ext_force = [0.1, 0.2, 0.3]
     system.integrator.run(steps=0)
 
@@ -68,7 +68,7 @@ class CommonTests(ut.TestCase):
             np.array([x for (_, x) in sorted(zip(self.py_id, self.py_vel))])),
                         msg="Velocities not written correctly by H5md!")
 
-    @ut.skipIf('EXTERNAL_FORCE' not in espressomd.code_info.features(),
+    @ut.skipIf(not espressomd.has_features(['EXTERNAL_FORCE']),
                "EXTERNAL_FORCE not compiled in, can not check writing forces.")
     def test_f(self):
         """Test if forces have been written properly."""
@@ -78,7 +78,7 @@ class CommonTests(ut.TestCase):
                         msg="Forces not written correctly by H5md!")
 
 
-@ut.skipIf('H5MD' not in espressomd.code_info.features(),
+@ut.skipIf(not espressomd.has_features(['H5MD']),
            "H5MD not compiled in, can not check functionality.")
 class H5mdTestOrdered(CommonTests):
     """

--- a/testsuite/python/lbgpu_remove_total_momentum.py
+++ b/testsuite/python/lbgpu_remove_total_momentum.py
@@ -5,38 +5,39 @@ import espressomd.analyze
 import espressomd.lb
 import numpy as np
 
-if "LB_GPU" in espressomd.features():
-    class RemoveTotalMomentumTest(ut.TestCase):
-        def test(self):
-            dt    = 0.01
-            skin  = 0.1
-            agrid = 1.0
-            fric  = 20.0
-            visc  = 1.0
-            dens  = 1.0
+@ut.skipIf(not espressomd.has_features(["LB_GPU"]),
+           "Features not available, skipping test!")
+class RemoveTotalMomentumTest(ut.TestCase):
+    def test(self):
+        dt    = 0.01
+        skin  = 0.1
+        agrid = 1.0
+        fric  = 20.0
+        visc  = 1.0
+        dens  = 1.0
 
-            s = espressomd.System()
-            s.box_l = [10,10,10]
-            s.time_step = dt
-            s.cell_system.skin = skin
+        s = espressomd.System()
+        s.box_l = [10,10,10]
+        s.time_step = dt
+        s.cell_system.skin = skin
 
-            for i in range(100):
-                r = s.box_l*np.random.random(3)
-                v = [0.,0.,1.]
-                s.part.add(pos=r,v=v)
+        for i in range(100):
+            r = s.box_l*np.random.random(3)
+            v = [0.,0.,1.]
+            s.part.add(pos=r,v=v)
 
-            lbf = espressomd.lb.LBFluid_GPU(
-                agrid=agrid, fric=fric, dens=dens, visc=visc, tau=dt)
+        lbf = espressomd.lb.LBFluid_GPU(
+            agrid=agrid, fric=fric, dens=dens, visc=visc, tau=dt)
 
-            s.actors.add(lbf)
+        s.actors.add(lbf)
 
-            s.integrator.run(300)
+        s.integrator.run(300)
 
-            lbf.remove_total_momentum()
+        lbf.remove_total_momentum()
 
-            p = np.array(s.analysis.analyze_linear_momentum())
+        p = np.array(s.analysis.analyze_linear_momentum())
 
-            self.assertTrue( np.all( np.abs(p) < 1e-3 ) )
+        self.assertTrue( np.all( np.abs(p) < 1e-3 ) )
 
 if __name__ == "__main__":
     #print("Features: ", espressomd.features())

--- a/testsuite/python/magnetostaticInteractions.py
+++ b/testsuite/python/magnetostaticInteractions.py
@@ -37,7 +37,7 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
         if not self.system.part.exists(1):
             self.system.part.add(id=1, pos=(0, 0, 0), dip=(7.3, 6.1, -4))
 
-    if "DP3M" in espressomd.features():
+    if espressomd.has_features(["DP3M"]):
         test_DP3M = generate_test_for_class(system, DipolarP3M, dict(prefactor=1.0,
                                                                              epsilon=0.0,
                                                                              inter=1000,
@@ -49,7 +49,7 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
                                                                              accuracy=0.01,
                                                                              tune=False))
 
-    if "DIPOLAR_DIRECT_SUM" in espressomd.features():
+    if espressomd.has_features(["DIPOLAR_DIRECT_SUM"]):
         test_DdsCpu = generate_test_for_class(system,
             DipolarDirectSumCpu, dict(prefactor=3.4))
         test_DdsRCpu = generate_test_for_class(system,

--- a/testsuite/python/mass-and-rinertia_per_particle.py
+++ b/testsuite/python/mass-and-rinertia_per_particle.py
@@ -5,205 +5,206 @@ from numpy.random import random
 import espressomd
 import math
 
-if "MASS" in espressomd.features() and "ROTATIONAL_INERTIA" in espressomd.features() and "LANGEVIN_PER_PARTICLE" in espressomd.features():
-    class ThermoTest(ut.TestCase):
-        longMessage = True
-        # Handle for espresso system
-        es = espressomd.System()
+@ut.skipIf(not espressomd.has_features(["MASS","ROTATIONAL_INERTIA","LANGEVIN_PER_PARTICLE"]),
+           "Features not available, skipping test!")
+class ThermoTest(ut.TestCase):
+    longMessage = True
+    # Handle for espresso system
+    es = espressomd.System()
 
-        def run_test_case(self, test_case):
-            gamma = np.array([1.0, 1.0])
-            
-            # Decelleration
-            self.es.time_step = 0.007
-            self.es.thermostat.set_langevin(kT=0.0, gamma=gamma[0])
-            self.es.cell_system.skin = 0
-            self.es.cell_system.set_n_square(use_verlet_lists=True)
-            J = [10.0, 10.0, 10.0]
-            
-            for i in range(len(self.es.part)):
-                self.es.part[i].delete()
+    def run_test_case(self, test_case):
+        gamma = np.array([1.0, 1.0])
 
-            for i in range(2):
-                self.es.part.add(pos=np.array([0.0, 0.0, 0.0]),id=i)
-                self.es.part[i].omega_body=np.array([1.0, 1.0, 1.0])
-                self.es.part[i].rinertia=np.array(J)
+        # Decelleration
+        self.es.time_step = 0.007
+        self.es.thermostat.set_langevin(kT=0.0, gamma=gamma[0])
+        self.es.cell_system.skin = 0
+        self.es.cell_system.set_n_square(use_verlet_lists=True)
+        J = [10.0, 10.0, 10.0]
 
-            print("\n")
-            
-            if test_case == 0:
-                print("------------------------------------------------")
-                print("Test " + str(test_case) +": no particle specific values")
-                print("------------------------------------------------")
-                gamma[1] = gamma[0]
-                
-            if test_case == 1:
-                print("------------------------------------------------")
-                print("Test " + str(test_case) +": particle specific gamma but not temperature")
-                print("------------------------------------------------")
-                self.es.part[0].gamma_rot = np.array([gamma[0], gamma[0], gamma[0]])
-                self.es.part[1].gamma_rot = np.array([gamma[1], gamma[1], gamma[1]])
-                
-            if test_case == 2:
-                print("------------------------------------------------")
-                print("Test " + str(test_case) +": particle specific temperature but not gamma")
-                print("------------------------------------------------")
-                self.es.part[0].temp = 0.0
-                self.es.part[1].temp = 0.0
-                gamma[1] = gamma[0]
-                
-            if test_case == 3:
-                print("------------------------------------------------")
-                print("Test " + str(test_case) +": both particle specific gamma and temperature")
-                print("------------------------------------------------")
-                self.es.part[0].temp = 0.0
-                self.es.part[1].temp = 0.0
-                self.es.part[0].gamma_rot = np.array([gamma[0], gamma[0], gamma[0]])
-                self.es.part[1].gamma_rot = np.array([gamma[1], gamma[1], gamma[1]])
+        for i in range(len(self.es.part)):
+            self.es.part[i].delete()
 
-            self.es.time = 0.0
-            
-            tol = 0.01
-            for i in range(100):
-                for k in range(3):
-                    self.assertTrue(abs(self.es.part[0].omega_body[k] - math.exp( - gamma[0]*self.es.time / J[k])) <= tol and \
-                                    abs(self.es.part[1].omega_body[k] - math.exp( - gamma[1]*self.es.time / J[k])) <= tol)
-                self.es.integrator.run(10)
+        for i in range(2):
+            self.es.part.add(pos=np.array([0.0, 0.0, 0.0]),id=i)
+            self.es.part[i].omega_body=np.array([1.0, 1.0, 1.0])
+            self.es.part[i].rinertia=np.array(J)
 
-            for i in range(len(self.es.part)):
-                self.es.part[i].delete()
+        print("\n")
 
-            # thermalization
-            # Checks if every degree of freedom has 1/2 kT of energy, even when
-            # mass and inertia tensor are active
-            
-            # 2 different langevin parameters for particles
-            gamma = np.array((0.2 + random(2)) * 20)
-            temp = np.array([2.5, 2.0])
-            # gamma_rot matrix: [2 types of particless] x [3 dimensions X Y Z]
-            gamma_rot = np.zeros((2,3))
+        if test_case == 0:
+            print("------------------------------------------------")
+            print("Test " + str(test_case) +": no particle specific values")
+            print("------------------------------------------------")
+            gamma[1] = gamma[0]
+
+        if test_case == 1:
+            print("------------------------------------------------")
+            print("Test " + str(test_case) +": particle specific gamma but not temperature")
+            print("------------------------------------------------")
+            self.es.part[0].gamma_rot = np.array([gamma[0], gamma[0], gamma[0]])
+            self.es.part[1].gamma_rot = np.array([gamma[1], gamma[1], gamma[1]])
+
+        if test_case == 2:
+            print("------------------------------------------------")
+            print("Test " + str(test_case) +": particle specific temperature but not gamma")
+            print("------------------------------------------------")
+            self.es.part[0].temp = 0.0
+            self.es.part[1].temp = 0.0
+            gamma[1] = gamma[0]
+
+        if test_case == 3:
+            print("------------------------------------------------")
+            print("Test " + str(test_case) +": both particle specific gamma and temperature")
+            print("------------------------------------------------")
+            self.es.part[0].temp = 0.0
+            self.es.part[1].temp = 0.0
+            self.es.part[0].gamma_rot = np.array([gamma[0], gamma[0], gamma[0]])
+            self.es.part[1].gamma_rot = np.array([gamma[1], gamma[1], gamma[1]])
+
+        self.es.time = 0.0
+
+        tol = 0.01
+        for i in range(100):
+            for k in range(3):
+                self.assertTrue(abs(self.es.part[0].omega_body[k] - math.exp( - gamma[0]*self.es.time / J[k])) <= tol and \
+                                abs(self.es.part[1].omega_body[k] - math.exp( - gamma[1]*self.es.time / J[k])) <= tol)
+            self.es.integrator.run(10)
+
+        for i in range(len(self.es.part)):
+            self.es.part[i].delete()
+
+        # thermalization
+        # Checks if every degree of freedom has 1/2 kT of energy, even when
+        # mass and inertia tensor are active
+
+        # 2 different langevin parameters for particles
+        gamma = np.array((0.2 + random(2)) * 20)
+        temp = np.array([2.5, 2.0])
+        # gamma_rot matrix: [2 types of particless] x [3 dimensions X Y Z]
+        gamma_rot = np.zeros((2,3))
+        for k in range(2):
+            gamma_rot[k,:] = np.array((0.2 + random(3)) * 20)
+
+        box = 10.0
+        self.es.box_l = [box, box, box]
+        kT = 1.5
+        gamma_global = 1.0
+
+        if test_case == 2 or test_case == 3:
+            halfkT = temp / 2.0
+        else:
+            halfkT = np.array([kT, kT]) / 2.0
+
+        if test_case == 1 or test_case == 3:
+            gamma_tr = gamma
+        else:
+            gamma_tr = np.array([gamma_global, gamma_global])
+
+        # translational diffusion
+        D_tr = 2.0 * halfkT / gamma_tr
+
+        self.es.thermostat.set_langevin(kT=kT, gamma=gamma_global)
+
+        # no need to rebuild Verlet lists, avoid it
+        self.es.cell_system.skin = 1.0
+        self.es.time_step = 0.008
+        n = 200
+        mass = (0.2 + random()) * 7.0
+        J = np.array((0.2 + random(3)) * 7.0)
+
+        for i in range(n):
             for k in range(2):
-                gamma_rot[k,:] = np.array((0.2 + random(3)) * 20)
+                ind = i + k * n
+                part_pos = np.array(random(3) * box)
+                part_v = np.array([0.0, 0.0, 0.0])
+                part_omega_body = np.array([0.0, 0.0, 0.0])
+                self.es.part.add(id = ind, mass = mass, rinertia = J, pos = part_pos, v = part_v, omega_body = part_omega_body)
+                if test_case == 1:
+                    self.es.part[ind].gamma = np.array([gamma[k],gamma[k],gamma[k]])
+                    self.es.part[ind].gamma_rot = gamma_rot[k,:]
+                if test_case == 2:
+                    self.es.part[ind].temp = temp[k]
+                if test_case == 3:
+                    self.es.part[ind].gamma = np.array([gamma[k],gamma[k],gamma[k]])
+                    self.es.part[ind].gamma_rot = gamma_rot[k,:]
+                    self.es.part[ind].temp = temp[k]
 
-            box = 10.0
-            self.es.box_l = [box, box, box]
-            kT = 1.5
-            gamma_global = 1.0
-            
-            if test_case == 2 or test_case == 3:
-                halfkT = temp / 2.0
-            else:
-                halfkT = np.array([kT, kT]) / 2.0
-            
-            if test_case == 1 or test_case == 3:
-                gamma_tr = gamma
-            else:
-                gamma_tr = np.array([gamma_global, gamma_global])
-            
-            # translational diffusion
-            D_tr = 2.0 * halfkT / gamma_tr
+        # matrices: [2 types of particless] x [3 dimensions X Y Z]
+        # velocity^2, omega^2, position^2
+        v2 = np.zeros((2,3))
+        o2 = np.zeros((2,3))
+        dr2 = np.zeros((2,3))
+        dr_norm = np.array([0.0, 0.0])
+        sigma2_tr = np.array([0.0, 0.0])
 
-            self.es.thermostat.set_langevin(kT=kT, gamma=gamma_global)
-            
-            # no need to rebuild Verlet lists, avoid it
-            self.es.cell_system.skin = 1.0
-            self.es.time_step = 0.008
-            n = 200
-            mass = (0.2 + random()) * 7.0
-            J = np.array((0.2 + random(3)) * 7.0)
+        pos0 = np.zeros((2 * n, 3))
+        for p in range(n):
+            for k in range(2):
+                ind = p + k * n
+                pos0[ind,:] = self.es.part[ind].pos
 
-            for i in range(n):
-                for k in range(2):
-                    ind = i + k * n
-                    part_pos = np.array(random(3) * box)
-                    part_v = np.array([0.0, 0.0, 0.0])
-                    part_omega_body = np.array([0.0, 0.0, 0.0])
-                    self.es.part.add(id = ind, mass = mass, rinertia = J, pos = part_pos, v = part_v, omega_body = part_omega_body)
-                    if test_case == 1:
-                        self.es.part[ind].gamma = np.array([gamma[k],gamma[k],gamma[k]])
-                        self.es.part[ind].gamma_rot = gamma_rot[k,:]
-                    if test_case == 2:
-                        self.es.part[ind].temp = temp[k]
-                    if test_case == 3:
-                        self.es.part[ind].gamma = np.array([gamma[k],gamma[k],gamma[k]])
-                        self.es.part[ind].gamma_rot = gamma_rot[k,:]
-                        self.es.part[ind].temp = temp[k]
+        loops = 100
+        print("Thermalizing...")
+        therm_steps = 1200
+        self.es.integrator.run(therm_steps)
+        print("Measuring...")
 
-            # matrices: [2 types of particless] x [3 dimensions X Y Z]
-            # velocity^2, omega^2, position^2
-            v2 = np.zeros((2,3))
-            o2 = np.zeros((2,3))
-            dr2 = np.zeros((2,3))
-            dr_norm = np.array([0.0, 0.0])
-            sigma2_tr = np.array([0.0, 0.0])
-            
-            pos0 = np.zeros((2 * n, 3))
+        int_steps = 100
+        for i in range(loops):
+            self.es.integrator.run(int_steps)
+            # Get kinetic energy in each degree of freedom for all particles
             for p in range(n):
                 for k in range(2):
                     ind = p + k * n
-                    pos0[ind,:] = self.es.part[ind].pos
-            
-            loops = 100
-            print("Thermalizing...")
-            therm_steps = 1200
-            self.es.integrator.run(therm_steps)
-            print("Measuring...")
-            
-            int_steps = 100
-            for i in range(loops):
-                self.es.integrator.run(int_steps)
-                # Get kinetic energy in each degree of freedom for all particles
-                for p in range(n):
-                    for k in range(2):
-                        ind = p + k * n
-                        v = self.es.part[ind].v
-                        o = self.es.part[ind].omega_body
-                        pos = self.es.part[ind].pos
-                        o2[k,:] = o2[k,:] + np.power(o[:], 2)
-                        v2[k,:] = v2[k,:] + np.power(v[:], 2)
-                        dr2[k,:] = np.power((pos[:] - pos0[ind,:]), 2)
-                        dt0 = mass / gamma_tr[k]
-                        dt = (int_steps * (i + 1) + therm_steps) * self.es.time_step
-                        # translational diffusion variance: after a closed-form integration of the Langevin EOM
-                        sigma2_tr[k] = D_tr[k] * (6 * dt + 3 * dt0 * (- 3 + 4 * math.exp(- dt / dt0) - math.exp( - 2 * dt / dt0)))
-                        dr_norm[k] = dr_norm[k] + (sum(dr2[k,:]) - sigma2_tr[k]) / sigma2_tr[k]
-                        
-            tolerance = 0.15
-            Ev = 0.5 * mass * v2 / (n * loops)
-            Eo = 0.5 * J * o2 / (n * loops)
-            dv = np.zeros((2))
-            do = np.zeros((2))
-            do_vec = np.zeros((2,3))
-            for k in range(2):
-                dv[k] = sum(Ev[k,:]) / (3 * halfkT[k]) - 1.0
-                do[k] = sum(Eo[k,:]) / (3 * halfkT[k]) - 1.0
-                do_vec[k,:] = Eo[k,:] / halfkT[k] - 1.0
-            dr_norm = dr_norm / (n * loops)
-            for k in range(2):
-                print("\n")
-                print("k = " + str(k))
-                print("mass = " + str(mass))
-                print("gamma_tr = " + str(gamma_tr[k]))
-                print("Moment of inertia principal components: = " + str(J))
-                print("1/2 kT = " + str(halfkT[k]))
-                print("Translational energy: {0} {1} {2}".format(Ev[k,0], Ev[k,1], Ev[k,2]))
-                print("Rotational energy: {0} {1} {2}".format(Eo[k,0], Eo[k,1], Eo[k,2]))
+                    v = self.es.part[ind].v
+                    o = self.es.part[ind].omega_body
+                    pos = self.es.part[ind].pos
+                    o2[k,:] = o2[k,:] + np.power(o[:], 2)
+                    v2[k,:] = v2[k,:] + np.power(v[:], 2)
+                    dr2[k,:] = np.power((pos[:] - pos0[ind,:]), 2)
+                    dt0 = mass / gamma_tr[k]
+                    dt = (int_steps * (i + 1) + therm_steps) * self.es.time_step
+                    # translational diffusion variance: after a closed-form integration of the Langevin EOM
+                    sigma2_tr[k] = D_tr[k] * (6 * dt + 3 * dt0 * (- 3 + 4 * math.exp(- dt / dt0) - math.exp( - 2 * dt / dt0)))
+                    dr_norm[k] = dr_norm[k] + (sum(dr2[k,:]) - sigma2_tr[k]) / sigma2_tr[k]
 
-                print("Deviation in translational energy: " + str(dv[k]))
-                print("Deviation in rotational energy: " + str(do[k]))
-                print("Deviation in rotational energy per degrees of freedom: {0} {1} {2}".format(do_vec[k,0], do_vec[k,1], do_vec[k,2]))
-                print("Deviation in translational diffusion: " + str(dr_norm[k]))
-                
-                self.assertTrue(abs(dv[k]) <= tolerance, msg = 'Relative deviation in translational energy too large: {0}'.format(dv[k]))
-                self.assertTrue(abs(do[k]) <= tolerance, msg = 'Relative deviation in rotational energy too large: {0}'.format(do[k]))
-                self.assertTrue(abs(do_vec[k,0]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis X is too large: {0}'.format(do_vec[k,0]))
-                self.assertTrue(abs(do_vec[k,1]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis Y is too large: {0}'.format(do_vec[k,1]))
-                self.assertTrue(abs(do_vec[k,2]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis Z is too large: {0}'.format(do_vec[k,2]))
-                self.assertTrue(abs(dr_norm[k]) <= tolerance, msg = 'Relative deviation in translational diffusion too large: {0}'.format(dr_norm[k]))
+        tolerance = 0.15
+        Ev = 0.5 * mass * v2 / (n * loops)
+        Eo = 0.5 * J * o2 / (n * loops)
+        dv = np.zeros((2))
+        do = np.zeros((2))
+        do_vec = np.zeros((2,3))
+        for k in range(2):
+            dv[k] = sum(Ev[k,:]) / (3 * halfkT[k]) - 1.0
+            do[k] = sum(Eo[k,:]) / (3 * halfkT[k]) - 1.0
+            do_vec[k,:] = Eo[k,:] / halfkT[k] - 1.0
+        dr_norm = dr_norm / (n * loops)
+        for k in range(2):
+            print("\n")
+            print("k = " + str(k))
+            print("mass = " + str(mass))
+            print("gamma_tr = " + str(gamma_tr[k]))
+            print("Moment of inertia principal components: = " + str(J))
+            print("1/2 kT = " + str(halfkT[k]))
+            print("Translational energy: {0} {1} {2}".format(Ev[k,0], Ev[k,1], Ev[k,2]))
+            print("Rotational energy: {0} {1} {2}".format(Eo[k,0], Eo[k,1], Eo[k,2]))
 
-        def test(self):
-            for i in range(4):
-                self.run_test_case(i)
+            print("Deviation in translational energy: " + str(dv[k]))
+            print("Deviation in rotational energy: " + str(do[k]))
+            print("Deviation in rotational energy per degrees of freedom: {0} {1} {2}".format(do_vec[k,0], do_vec[k,1], do_vec[k,2]))
+            print("Deviation in translational diffusion: " + str(dr_norm[k]))
+
+            self.assertTrue(abs(dv[k]) <= tolerance, msg = 'Relative deviation in translational energy too large: {0}'.format(dv[k]))
+            self.assertTrue(abs(do[k]) <= tolerance, msg = 'Relative deviation in rotational energy too large: {0}'.format(do[k]))
+            self.assertTrue(abs(do_vec[k,0]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis X is too large: {0}'.format(do_vec[k,0]))
+            self.assertTrue(abs(do_vec[k,1]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis Y is too large: {0}'.format(do_vec[k,1]))
+            self.assertTrue(abs(do_vec[k,2]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis Z is too large: {0}'.format(do_vec[k,2]))
+            self.assertTrue(abs(dr_norm[k]) <= tolerance, msg = 'Relative deviation in translational diffusion too large: {0}'.format(dr_norm[k]))
+
+    def test(self):
+        for i in range(4):
+            self.run_test_case(i)
 
 if __name__ == '__main__':
     print("Features: ", espressomd.features())

--- a/testsuite/python/nonBondedInteractions.py
+++ b/testsuite/python/nonBondedInteractions.py
@@ -84,7 +84,7 @@ class Non_bonded_interactionsTests(ut.TestCase):
 
         return func
 
-    if "LENNARD_JONES" in espressomd.features():
+    if espressomd.has_features(["LENNARD_JONES"]):
         test_lj1 = generateTestForNon_bonded_interaction(
             0, 0, LennardJonesInteraction,
             {"epsilon": 1., "sigma": 2., "cutoff": 3.,
@@ -101,7 +101,7 @@ class Non_bonded_interactionsTests(ut.TestCase):
             "shift": 4.1, "offset": 5.1, "min": 7.1},
             "lennard_jones")
 
-    if "LENNARD_JONES_GENERIC" in espressomd.features():
+    if espressomd.has_features(["LENNARD_JONES_GENERIC"]):
         test_ljgen1 = generateTestForNon_bonded_interaction(
             0, 0, GenericLennardJonesInteraction,
             {"epsilon": 1., "sigma": 2., "cutoff": 3., "shift": 4., "offset": 5.,

--- a/testsuite/python/observables.py
+++ b/testsuite/python/observables.py
@@ -57,11 +57,11 @@ class Observables(ut.TestCase):
         if not len(self.es.part):
             for i in range(1000):
               self.es.part.add(pos=random(3),v=random(3),id=i)
-              if "MASS" in espressomd.features():
+              if espressomd.has_features(["MASS"]):
                 self.es.part[i].mass=random()
-              if "DIPOLES" in espressomd.features():
+              if espressomd.has_features(["DIPOLES"]):
                 self.es.part[i].dip=random(3)
-              if "ROTATION" in espressomd.features():
+              if espressomd.has_features(["ROTATION"]):
                 self.es.part[i].omega_lab=random(3)
 
 
@@ -105,14 +105,14 @@ class Observables(ut.TestCase):
     com_force =generate_test_for_pid_observable(ComForce,"f","sum")
     
     # Disabled untile ParticleSlice.dip is implemented
-    #if "DIPOLES" in espressomd.features():
+    #if espressomd.has_features(["DIPOLES"]):
         #test_mag_dip =generate_test_for_pid_observable(MagneticDipoleMoment,"dip","sum")
         
 
 
 
     # This is disabled until ParticleSlice.omega_body is implemented
-    #if "ROTATION" in espressomd.features():
+    #if espressomd.has_features(["ROTATION"]):
        #test_omega_body= generate_test_for_pid_observable(ParticleBodyVelocities,"omega_body") 
 
     def test_stress_tensor(self):
@@ -127,7 +127,7 @@ class Observables(ut.TestCase):
        self.assertTrue(self.arraysNearlyEqual(s,obs_data),"Stress tensor from analysis and observable StressTensorAcf did not agree")
 
     def test_com_position(self):
-        if "MASS" in espressomd.features():
+        if espressomd.has_features(["MASS"]):
             com=sum((self.es.part[:].mass*self.es.part[:].pos.T).T,0)/sum(self.es.part[:].mass)
         else:
             com=sum((self.es.part[:].pos.T).T,0)/len(self.es.part)
@@ -136,7 +136,7 @@ class Observables(ut.TestCase):
         self.assertTrue(self.arraysNearlyEqual(com,obs_data),"Center of mass observable wrong value")
     
     def test_com_velocity(self):
-        if "MASS" in espressomd.features():
+        if espressomd.has_features(["MASS"]):
             com_vel=sum((self.es.part[:].mass*self.es.part[:].v.T).T,0)/sum(self.es.part[:].mass)
         else:
             com_vel=sum((self.es.part[:].v.T).T,0)/len(self.es.part)

--- a/testsuite/python/p3m_gpu.py
+++ b/testsuite/python/p3m_gpu.py
@@ -23,25 +23,26 @@ import unittest as ut
 import numpy as np
 from tests_common import *
 
-if "ELECTROSTATICS" in espressomd.features() and "CUDA" in espressomd.features():
-    from espressomd.electrostatics import P3M_GPU
+@ut.skipIf(not espressomd.has_features(["ELECTROSTATICS","CUDA"]),
+           "Features not available, skipping test!")
+class P3M_GPU_test(ut.TestCase):
+    def runTest(self):
+        from espressomd.electrostatics import P3M_GPU
 
-    class P3M_GPU_test(ut.TestCase):
-        def runTest(self):
-            es = espressomd.System()
-            test_params = {}
-            test_params["bjerrum_length"] = 2
-            test_params["cao"] = 2
-            test_params["r_cut"] = 0.9
-            test_params["accuracy"] = 1e-1
-            test_params["mesh"] = [10, 10, 10]
-            test_params["epsilon"] = 20.0
-            test_params["alpha"] = 1.1
-            test_params["tune"] = False
-    
-            p3m = P3M_GPU(**test_params)
-            es.actors.add(p3m)
-            self.assertTrue(params_match(test_params,p3m._get_params_from_es_core()))
+        es = espressomd.System()
+        test_params = {}
+        test_params["bjerrum_length"] = 2
+        test_params["cao"] = 2
+        test_params["r_cut"] = 0.9
+        test_params["accuracy"] = 1e-1
+        test_params["mesh"] = [10, 10, 10]
+        test_params["epsilon"] = 20.0
+        test_params["alpha"] = 1.1
+        test_params["tune"] = False
+
+        p3m = P3M_GPU(**test_params)
+        es.actors.add(p3m)
+        self.assertTrue(params_match(test_params,p3m._get_params_from_es_core()))
 
 if __name__ == "__main__":
     print("Features: ", espressomd.features())

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -111,10 +111,10 @@ class ParticleProperties(ut.TestCase):
     test_bonds_property = generateTestForScalarProperty(
         "bonds", ((f1, 1), (f2, 2)))
 
-    if "MASS" in espressomd.features():
+    if espressomd.has_features(["MASS"]):
         test_mass = generateTestForScalarProperty("mass", 1.3)
 
-    if "ROTATION" in espressomd.features():
+    if espressomd.has_features(["ROTATION"]):
         test_omega_lab = generateTestForVectorProperty(
             "omega_lab", np.array([4., 2., 1.]))
         test_omega_body = generateTestForVectorProperty(
@@ -125,31 +125,31 @@ class ParticleProperties(ut.TestCase):
         test_quat = generateTestForVectorProperty(
             "quat", np.array([0.5, 0.5, 0.5, 0.5]))
 
-        if "LANGEVIN_PER_PARTICLE" in espressomd.features():
-            if "PARTICLE_ANISOTROPY" in espressomd.features():
+        if espressomd.has_features(["LANGEVIN_PER_PARTICLE"]):
+            if espressomd.has_features(["PARTICLE_ANISOTROPY"]):
                 test_gamma = generateTestForVectorProperty(
                 "gamma", np.array([2., 9., 0.23]))
             else:
                 test_gamma = generateTestForScalarProperty("gamma", 17.3)
                 
-            if "ROTATIONAL_INERTIA" in espressomd.features():
+            if espressomd.has_features(["ROTATIONAL_INERTIA"]):
                 test_gamma_rot = generateTestForVectorProperty(
                 "gamma_rot", np.array([5., 10., 0.33]))
             else:
                 test_gamma_rot = generateTestForScalarProperty("gamma_rot", 14.23)
 #    test_director=generateTestForVectorProperty("director",np.array([0.5,0.4,0.3]))
 
-    if "ELECTROSTATICS" in espressomd.features():
+    if espressomd.has_features(["ELECTROSTATICS"]):
         test_charge = generateTestForScalarProperty("q", -19.7)
 
-    if "DIPOLES" in espressomd.features():
+    if espressomd.has_features(["DIPOLES"]):
         test_dip = generateTestForVectorProperty(
             "dip", np.array([0.5, -0.5, 3]))
         test_dipm = generateTestForScalarProperty("dipm", -9.7)
 
-    if "VIRTUAL_SITES" in espressomd.features():
+    if espressomd.has_features(["VIRTUAL_SITES"]):
         test_virtual = generateTestForScalarProperty("virtual", 1)
-    if "VIRTUAL_SITES_RELATIVE" in espressomd.features():
+    if espressomd.has_features(["VIRTUAL_SITES_RELATIVE"]):
         def test_zz_vs_relative(self):
             self.es.part.add(id=0, pos=(0, 0, 0))
             self.es.part.add(id=1, pos=(0, 0, 0))

--- a/testsuite/python/rotational_inertia.py
+++ b/testsuite/python/rotational_inertia.py
@@ -4,112 +4,113 @@ import numpy as np
 import espressomd
 import math
 
-if "MASS" in espressomd.features() and "ROTATIONAL_INERTIA" in espressomd.features():
-    class ThermoTest(ut.TestCase):
-        longMessage = True
-        # Handle for espresso system
-        es = espressomd.System()
+@ut.skipIf(not espressomd.has_features(["MASS","ROTATIONAL_INERTIA"]),
+           "Features not available, skipping test!")
+class ThermoTest(ut.TestCase):
+    longMessage = True
+    # Handle for espresso system
+    es = espressomd.System()
 
-        def define_rotation_matrix(self, part):
-            A = np.zeros((3,3))
-            quat = self.es.part[part].quat
-            qq = np.power(quat,2)
-            
-            A[0,0] = qq[0] + qq[1] - qq[2] - qq[3]
-            A[1,1] = qq[0] - qq[1] + qq[2] - qq[3]
-            A[2,2] = qq[0] - qq[1] - qq[2] + qq[3]
-            
-            A[0,1] = 2 * (quat[1] * quat[2] + quat[0] * quat[3])
-            A[0,2] = 2 * (quat[1] * quat[3] - quat[0] * quat[2])
-            A[1,0] = 2 * (quat[1] * quat[2] - quat[0] * quat[3])
-            
-            A[1,2] = 2 * (quat[2] * quat[3] + quat[0] * quat[1])
-            A[2,0] = 2 * (quat[1] * quat[3] + quat[0] * quat[2])
-            A[2,1] = 2 * (quat[2] * quat[3] - quat[0] * quat[1])
-            
-            return A
-        
-        def convert_vec_body_to_space(self, part, vec):
-            A = self.define_rotation_matrix(part)
-            return np.dot(A.transpose(), vec)
-        
+    def define_rotation_matrix(self, part):
+        A = np.zeros((3,3))
+        quat = self.es.part[part].quat
+        qq = np.power(quat,2)
+
+        A[0,0] = qq[0] + qq[1] - qq[2] - qq[3]
+        A[1,1] = qq[0] - qq[1] + qq[2] - qq[3]
+        A[2,2] = qq[0] - qq[1] - qq[2] + qq[3]
+
+        A[0,1] = 2 * (quat[1] * quat[2] + quat[0] * quat[3])
+        A[0,2] = 2 * (quat[1] * quat[3] - quat[0] * quat[2])
+        A[1,0] = 2 * (quat[1] * quat[2] - quat[0] * quat[3])
+
+        A[1,2] = 2 * (quat[2] * quat[3] + quat[0] * quat[1])
+        A[2,0] = 2 * (quat[1] * quat[3] + quat[0] * quat[2])
+        A[2,1] = 2 * (quat[2] * quat[3] - quat[0] * quat[1])
+
+        return A
+
+    def convert_vec_body_to_space(self, part, vec):
+        A = self.define_rotation_matrix(part)
+        return np.dot(A.transpose(), vec)
+
+    # Angular momentum
+    def L_body(self, part):
+        return self.es.part[part].omega_body[:] * self.es.part[part].rinertia[:]
+
+    def test(self):
+        self.es.cell_system.skin = 0
+        self.es.part.add(pos=np.array([0.0, 0.0, 0.0]),id=0)
+
+        #Inertial motion around the stable and unstable axes
+
+        tol = 4E-3
+        # Anisotropic inertial moment. Stable axes correspond to J[1] and J[2].
+        # The unstable axis corresponds to J[0]. These values relation is J[1] < J[0] < J[2].
+        J = np.array([5,0.5,18.5])
+
+        # Validation of J[1] stability
+        # ----------------------------
+        self.es.time_step = 0.0006
+        # Stable omega component should be larger than other components.
+        stable_omega = 57.65
+        self.es.part[0].omega_body=np.array([0.15, stable_omega, -0.043])
+        self.es.part[0].rinertia = J[:]
+
         # Angular momentum
-        def L_body(self, part):
-            return self.es.part[part].omega_body[:] * self.es.part[part].rinertia[:]
-            
-        def test(self):
-            self.es.cell_system.skin = 0
-            self.es.part.add(pos=np.array([0.0, 0.0, 0.0]),id=0)
-            
-            #Inertial motion around the stable and unstable axes
-            
-            tol = 4E-3
-            # Anisotropic inertial moment. Stable axes correspond to J[1] and J[2].
-            # The unstable axis corresponds to J[0]. These values relation is J[1] < J[0] < J[2].
-            J = np.array([5,0.5,18.5])
-            
-            # Validation of J[1] stability
-            # ----------------------------
-            self.es.time_step = 0.0006
-            # Stable omega component should be larger than other components.
-            stable_omega = 57.65
-            self.es.part[0].omega_body=np.array([0.15, stable_omega, -0.043])
-            self.es.part[0].rinertia = J[:]
-            
-            # Angular momentum
-            L_0_body = self.L_body(0)
-            L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
-            
-            for i in range(100):
-                L_body = self.L_body(0)
-                L_lab = self.convert_vec_body_to_space(0, L_body)
-                for k in range(3):
-                    self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
-                                    msg = 'Inertial motion around stable axis J1: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
-                self.assertTrue(abs(self.es.part[0].omega_body[1] - stable_omega) <= tol, \
-                                msg = 'Inertial motion around stable axis J1: Deviation in omega is too large. Step {0}, coordinate 1, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[1]))
-                self.es.integrator.run(10)
-                
-            # Validation of J[2] stability
-            # ----------------------------
-            self.es.time_step = 0.01
-            # Stable omega component should be larger than other components.
-            stable_omega = 3.2
-            self.es.part[0].omega_body=np.array([0.011, -0.043, stable_omega])
-            self.es.part[0].rinertia = J[:]
-            
-            L_0_body = self.L_body(0)
-            L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
-            
-            for i in range(100):
-                L_body = self.L_body(0)
-                L_lab = self.convert_vec_body_to_space(0, L_body)
-                for k in range(3):
-                    self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
-                                    msg = 'Inertial motion around stable axis J2: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
-                self.assertTrue(abs(self.es.part[0].omega_body[2] - stable_omega) <= tol, \
-                                    msg = 'Inertial motion around stable axis J2: Deviation in omega is too large. Step {0}, coordinate 2, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[2]))
-                self.es.integrator.run(10)
-                
-            # Validation of J[0]
-            # ------------------
-            self.es.time_step = 0.001
-            # Unstable omega component should be larger than other components.
-            unstable_omega = 5.76
-            self.es.part[0].omega_body=np.array([unstable_omega, -0.043, 0.15])
-            self.es.part[0].rinertia = J[:]
-            
-            L_0_body = self.L_body(0)
-            L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
-            
-            for i in range(100):
-                L_body = self.L_body(0)
-                L_lab = self.convert_vec_body_to_space(0, L_body)
-                for k in range(3):
-                    self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
-                                    msg = 'Inertial motion around stable axis J0: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
-                self.es.integrator.run(10)
-            
+        L_0_body = self.L_body(0)
+        L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
+
+        for i in range(100):
+            L_body = self.L_body(0)
+            L_lab = self.convert_vec_body_to_space(0, L_body)
+            for k in range(3):
+                self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                                msg = 'Inertial motion around stable axis J1: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
+            self.assertTrue(abs(self.es.part[0].omega_body[1] - stable_omega) <= tol, \
+                            msg = 'Inertial motion around stable axis J1: Deviation in omega is too large. Step {0}, coordinate 1, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[1]))
+            self.es.integrator.run(10)
+
+        # Validation of J[2] stability
+        # ----------------------------
+        self.es.time_step = 0.01
+        # Stable omega component should be larger than other components.
+        stable_omega = 3.2
+        self.es.part[0].omega_body=np.array([0.011, -0.043, stable_omega])
+        self.es.part[0].rinertia = J[:]
+
+        L_0_body = self.L_body(0)
+        L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
+
+        for i in range(100):
+            L_body = self.L_body(0)
+            L_lab = self.convert_vec_body_to_space(0, L_body)
+            for k in range(3):
+                self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                                msg = 'Inertial motion around stable axis J2: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
+            self.assertTrue(abs(self.es.part[0].omega_body[2] - stable_omega) <= tol, \
+                                msg = 'Inertial motion around stable axis J2: Deviation in omega is too large. Step {0}, coordinate 2, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[2]))
+            self.es.integrator.run(10)
+
+        # Validation of J[0]
+        # ------------------
+        self.es.time_step = 0.001
+        # Unstable omega component should be larger than other components.
+        unstable_omega = 5.76
+        self.es.part[0].omega_body=np.array([unstable_omega, -0.043, 0.15])
+        self.es.part[0].rinertia = J[:]
+
+        L_0_body = self.L_body(0)
+        L_0_lab = self.convert_vec_body_to_space(0, L_0_body)
+
+        for i in range(100):
+            L_body = self.L_body(0)
+            L_lab = self.convert_vec_body_to_space(0, L_body)
+            for k in range(3):
+                self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                                msg = 'Inertial motion around stable axis J0: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
+            self.es.integrator.run(10)
+
 if __name__ == '__main__':
     print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/tabulated.py
+++ b/testsuite/python/tabulated.py
@@ -27,6 +27,8 @@ from espressomd.analyze import *
 import espressomd
 import sys
 
+@ut.skipIf(not espressomd.has_features(["TABULATED"]),
+           "Features not available, skipping test!")
 class Tabulated(ut.TestCase):
     """ Checks the tabulated non bonded interactions """
 
@@ -660,12 +662,8 @@ class Tabulated(ut.TestCase):
         self.assertTrue(np.abs(pressure - totpressure)/totpressure < self.epsilon, "Failed. Pressure difference too large")
 
     
-    if "TABULATED" in espressomd.features():
-        def test_tab(self):
-            self.compare()
-    else:
-        print("TABULATED feature inactive")
-        sys.exit()
+    def test_tab(self):
+        self.compare()
 
 
 if __name__ == "__main__" :


### PR DESCRIPTION
# Remove references to code_info

PR #1088 introduced `has_features` and some companion commands.  These are available directly from `espressomd`.  To make the interface more unified this PR removes all references to the `code_info` module from the samples, testsuite, and documentation.  Basically, we replace all instances of
````python
espressomd.code_info.features()
````
with
````python
espressomd.features()
````

# Heavy use of the new `has_features`

In the testsuite people were often checking for features with
````python
if "SOMEFEATURE" in espressomd.features():
````
The new `has_features` allows for more mnemonic code:
````python
if espressomd.has_features(["SOMEFEATURE"]):
````

# Conditionally skipping testcases

It used to be common practice in the testsuite to hide the whole test class defintion behind an `if` statement à la
````python
if "SOMEFEATURE" in espressomd.features():
    class SomeFeatureTest(ut.TestCase):
````
This is bad practice and the Python unit test module actually offers a decorator to handle this case.  Therefore all testcases were ported to this new syntax.
````python
@ut.skipIf(not espressomd.has_features(["SOMEFEATURE"]),
           "Features not available, skipping test!")
class SomeFeatureTest(ut.TestCase):
````
As a bonus this saves us one level of indentation.

---

The title of this PR was generated using the [Buzzfeed & Upworthy Clickbait Headline Generator](http://www.contentforest.com/copywriting-tools/clickbait-headline-generator).