### PR TITLE
Dynamic properties for ParticleSlice

### DIFF
--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -227,7 +227,7 @@ cdef class ParticleHandle(object):
     cdef int update_particle_data(self) except -1
 
 
-cdef class ParticleSlice:
+cdef class ParticleSliceImpl:
 
     cdef particle particle_data
     cdef int update_particle_data(self, id) except -1

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -227,7 +227,7 @@ cdef class ParticleHandle(object):
     cdef int update_particle_data(self) except -1
 
 
-cdef class ParticleSliceImpl:
+cdef class _ParticleSliceImpl:
 
     cdef particle particle_data
     cdef int update_particle_data(self, id) except -1

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1430,9 +1430,9 @@ cdef class ParticleSlice:
         pl = ParticleList()
         for i in self.id_selection:
             if pl.exists(i):
-                res += str(pl[i]) + "\n"
-        # Remove final newline
-        return res[:-1]
+                res += str(pl[i]) + ", "
+        # Remove final comma
+        return "ParticleSlice([" + res[:-2] + "])"
 
     def update(self, P):
         if "id" in P:
@@ -1625,7 +1625,7 @@ cdef class ParticleList:
                 yield self[i]
 
     def exists(self, idx):
-        if isinstance(idx, int):
+        if isinstance(idx, int) or issubclass(type(idx), np.integer):
             return particle_exists(idx)
         if isinstance(idx, slice) or isinstance(idx, tuple) or isinstance(idx, list) or isinstance(idx, np.ndarray):
             tf_array = np.zeros(len(idx), dtype=np.bool)
@@ -1640,9 +1640,9 @@ cdef class ParticleList:
         res = ""
         for i in range(max_seen_particle + 1):
             if self.exists(i):
-                res += str(self[i]) + "\n"
-        # Remove final newline
-        return res[:-1]
+                res += str(self[i]) + ", "
+        # Remove final comma
+        return "ParticleList([" + res[:-2] + "])"
 
     def writevtk(self, fname, types='all'):
         """

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1557,10 +1557,20 @@ for attribute_name in particle_attributes:
 
     def geta(particle_slice, attribute):
         """Getter function that copies attribute from every member of particle_slice into an array."""
-        values = []
-        for i in particle_slice.id_selection:
-            values.append(getattr(ParticleHandle(i), attribute))
-        return np.array(values)
+        N = len(particle_slice.id_selection)
+        if N == 0:
+            return np.empty(0, dtype=type(None))
+
+        target = getattr(ParticleHandle(particle_slice.id_selection[0]), attribute) # get first slice member to determine its type
+        if type(target) is np.ndarray: # vectorial quantity
+            target_type = target.dtype
+        else: # scalar quantity
+            target_type = type(target)
+
+        values = np.empty((N,) + np.shape(target), dtype=target_type)
+        for i in range(N):
+            values[i] = getattr(ParticleHandle(particle_slice.id_selection[i]), attribute)
+        return values
 
     # synthesize a new property
     new_property = property(functools.partial(geta, attribute=attribute_name), functools.partial(seta, attribute=attribute_name), doc=getattr(ParticleHandle, attribute_name).__doc__)

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -61,7 +61,7 @@ cdef check_type_or_throw_except(x, n, t, msg):
         if hasattr(x, "__getitem__"):
             for i in range(len(x)):
                 if not isinstance(x[i], t):
-                    if not (t == float and isinstance(x[i], int)):
+                    if not (t == float and isinstance(x[i], int)) and not (t == int and issubclass(type(x[i]), np.integer)):
                         raise ValueError(
                             msg + " -- Item " + str(i) + " was of type " + type(x[i]).__name__)
         else:
@@ -71,7 +71,7 @@ cdef check_type_or_throw_except(x, n, t, msg):
     else:
         # N=1 and a single value
         if not isinstance(x, t):
-            if not (t == float and isinstance(x, int)):
+            if not (t == float and isinstance(x, int)) and not (t == int and issubclass(type(x), np.integer)):
                 raise ValueError(msg + " -- Got an " + type(x).__name__)
 
 

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -15,6 +15,7 @@ set(py_tests  bondedInteractions.py
               observables.py
               p3m_gpu.py
               particle.py
+              particle_slice.py
               rotational_inertia.py
               lbgpu_remove_total_momentum.py
               tabulated.py

--- a/testsuite/python/observables.py
+++ b/testsuite/python/observables.py
@@ -104,16 +104,15 @@ class Observables(ut.TestCase):
 
     com_force =generate_test_for_pid_observable(ComForce,"f","sum")
     
-    # Disabled untile ParticleSlice.dip is implemented
-    #if espressomd.has_features(["DIPOLES"]):
-        #test_mag_dip =generate_test_for_pid_observable(MagneticDipoleMoment,"dip","sum")
+    if espressomd.has_features(["DIPOLES"]):
+        test_mag_dip = generate_test_for_pid_observable(MagneticDipoleMoment,"dip","sum")
         
 
 
 
-    # This is disabled until ParticleSlice.omega_body is implemented
+    # This is disabled as it does not currently work
     #if espressomd.has_features(["ROTATION"]):
-       #test_omega_body= generate_test_for_pid_observable(ParticleBodyVelocities,"omega_body") 
+    #    test_omega_body = generate_test_for_pid_observable(ParticleBodyVelocities,"omega_body")
 
     def test_stress_tensor(self):
        s=self.es.analysis.stress_tensor()["total"].reshape(9)

--- a/testsuite/python/particle_slice.py
+++ b/testsuite/python/particle_slice.py
@@ -1,0 +1,42 @@
+from __future__ import print_function
+import unittest as ut
+import espressomd
+import numpy as np
+
+class ParticleSlice(ut.TestCase):
+
+	state = [[0,0,0], [0,0,1]]
+	system = espressomd.System()
+
+	system.part.add(pos=[0,0,0])
+	system.part.add(pos=[0,0,1], fix=state[1])
+	assert np.array_equal(system.part[0].fix, state[0])
+	assert np.array_equal(system.part[1].fix, state[1])
+	assert np.array_equal(system.part[:].fix, state)
+
+	def test_1_set_different_values(self):
+		self.state[0] = [1,0,0]
+		self.state[1] = [1,0,0]
+		self.system.part[:].fix = self.state
+		assert np.array_equal(self.system.part[:].fix, self.state)
+
+	def test_2_set_same_value(self):
+		self.state[0] = [0,1,0]
+		self.state[1] = [0,1,0]
+		self.system.part[:].fix = self.state[1]
+		assert np.array_equal(self.system.part[:].fix, self.state)
+
+	def test_3_set_one_value(self):
+		self.state[1] = [0,0,1]
+		self.system.part[1:].fix = self.state[1]
+		assert np.array_equal(self.system.part[:].fix, self.state)
+
+	def test_4_str(self):
+		self.assertEqual( repr(self.system.part[0].pos), repr(np.array([0.0,0.0,0.0])) )
+		self.assertEqual( repr(self.system.part[:].pos), repr(np.array([[0.0,0.0,0.0], [0.0,0.0,1.0]])) )
+		self.assertEqual( repr(self.system.part[0].fix), repr(np.array([0,1,0])) )
+		self.assertEqual( repr(self.system.part[:].fix), repr([np.array([0,1,0]), np.array([0,0,1])]) )
+
+
+if __name__ == "__main__":
+    ut.main()

--- a/testsuite/python/particle_slice.py
+++ b/testsuite/python/particle_slice.py
@@ -1,42 +1,67 @@
 from __future__ import print_function
 import unittest as ut
 import espressomd
+from espressomd import has_features
 import numpy as np
 
-class ParticleSlice(ut.TestCase):
+class ParticleSliceTest(ut.TestCase):
 
 	state = [[0,0,0], [0,0,1]]
 	system = espressomd.System()
 
-	system.part.add(pos=[0,0,0])
-	system.part.add(pos=[0,0,1], fix=state[1])
-	assert np.array_equal(system.part[0].fix, state[0])
-	assert np.array_equal(system.part[1].fix, state[1])
-	assert np.array_equal(system.part[:].fix, state)
+	def __init__(self, *args, **kwargs):
+		super(ParticleSliceTest, self).__init__(*args, **kwargs)
+		self.system.part.clear()
+		self.system.part.add(pos=[0,0,0])
+		if has_features(["EXTERNAL_FORCES"]):
+			self.system.part.add(pos=[0,0,1], fix=self.state[1])
+			self.assertTrue( np.array_equal(self.system.part[0].fix, self.state[0]) )
+			self.assertTrue( np.array_equal(self.system.part[1].fix, self.state[1]) )
+			self.assertTrue( np.array_equal(self.system.part[:].fix, self.state) )
 
+	@ut.skipIf(not has_features(["EXTERNAL_FORCES"]),"Features not available, skipping test!")
 	def test_1_set_different_values(self):
 		self.state[0] = [1,0,0]
 		self.state[1] = [1,0,0]
 		self.system.part[:].fix = self.state
-		assert np.array_equal(self.system.part[:].fix, self.state)
+		self.assertTrue( np.array_equal(self.system.part[:].fix, self.state) )
 
+	@ut.skipIf(not has_features(["EXTERNAL_FORCES"]),"Features not available, skipping test!")
 	def test_2_set_same_value(self):
 		self.state[0] = [0,1,0]
 		self.state[1] = [0,1,0]
 		self.system.part[:].fix = self.state[1]
-		assert np.array_equal(self.system.part[:].fix, self.state)
+		self.assertTrue( np.array_equal(self.system.part[:].fix, self.state) )
 
+	@ut.skipIf(not has_features(["EXTERNAL_FORCES"]),"Features not available, skipping test!")
 	def test_3_set_one_value(self):
 		self.state[1] = [0,0,1]
 		self.system.part[1:].fix = self.state[1]
-		assert np.array_equal(self.system.part[:].fix, self.state)
+		self.assertTrue( np.array_equal(self.system.part[:].fix, self.state) )
 
+	@ut.skipIf(not has_features(["EXTERNAL_FORCES"]),"Features not available, skipping test!")
 	def test_4_str(self):
-		self.assertEqual( repr(self.system.part[0].pos), repr(np.array([0.0,0.0,0.0])) )
-		self.assertEqual( repr(self.system.part[:].pos), repr(np.array([[0.0,0.0,0.0], [0.0,0.0,1.0]])) )
 		self.assertEqual( repr(self.system.part[0].fix), repr(np.array([0,1,0])) )
-		self.assertEqual( repr(self.system.part[:].fix), repr([np.array([0,1,0]), np.array([0,0,1])]) )
+		self.assertEqual( repr(self.system.part[:].fix), repr(np.array([[0,1,0], [0,0,1]])) )
 
+	def test_pos_str(self):
+		self.assertEqual( repr(self.system.part[0].pos), repr(np.array([0.0,0.0,0.0])) )
+		if (len(self.system.part)) > 1:
+			self.assertEqual( repr(self.system.part[:].pos), repr(np.array([[0.0,0.0,0.0], [0.0,0.0,1.0]])) )
+
+	@ut.skipIf(not has_features(["ELECTROSTATICS"]),"Features not available, skipping test!")
+	def test_scalar(self):
+		self.system.part[:1].q = 1.3
+		self.assertEqual(self.system.part[0].q, 1.3)
+		self.system.part[:].q = 2.0
+		self.assertEqual(self.system.part[0].q, 2)
+		self.assertEqual(self.system.part[1].q, 2)
+		self.system.part[:].q = 3
+		self.assertEqual(self.system.part[0].q, 3)
+		self.assertEqual(self.system.part[1].q, 3)
+		self.system.part[:].q = [-1,1.0]
+		self.assertEqual(self.system.part[0].q, -1)
+		self.assertEqual(self.system.part[1].q, 1)
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/particle_slice.py
+++ b/testsuite/python/particle_slice.py
@@ -18,6 +18,9 @@ class ParticleSliceTest(ut.TestCase):
 			self.assertTrue( np.array_equal(self.system.part[0].fix, self.state[0]) )
 			self.assertTrue( np.array_equal(self.system.part[1].fix, self.state[1]) )
 			self.assertTrue( np.array_equal(self.system.part[:].fix, self.state) )
+		xs = self.system.part[:].pos
+		for i in range(len(xs)):
+			self.assertTrue( np.array_equal(xs[i], self.system.part[i].pos) )
 
 	@ut.skipIf(not has_features(["EXTERNAL_FORCES"]),"Features not available, skipping test!")
 	def test_1_set_different_values(self):
@@ -62,6 +65,12 @@ class ParticleSliceTest(ut.TestCase):
 		self.system.part[:].q = [-1,1.0]
 		self.assertEqual(self.system.part[0].q, -1)
 		self.assertEqual(self.system.part[1].q, 1)
+		qs = self.system.part[:].q
+		self.assertEqual(qs[0], -1)
+		self.assertEqual(qs[1], 1)
+
+	def test_empty(self):
+		self.assertTrue( np.array_equal(self.system.part[0:0].pos, np.empty(0)) )
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
Fixes #958.

@RudolfWeeber @fweik @hmenke

Any properties that are not defined for `ParticleSlice` are automatically drawn from `ParticleHandle`, including docstrings. To the setter, one can either provide one value that is set on all particles or a list of values where the order corresponds to that of the slice members.

This turned out to be surprisingly difficult:
- One cannot use `setattr` to add stuff to Cython classes, so I ended up wrapping the Cython class into a Python class that has all the autogenerated properties.
- The wrapping cannot be done in the loop I added to the end of particle_data.pyx. I had to introduce a class that holds the attribute name as a member. If I generated the functions directly in the loop (i.e. capturing the loop variable), the attribute name a setter/getter was operating on would vary in a non-deterministic fashion (seems like some kind of reference counting bug in Python itself...).

Further improvements made along the way:
 - Fix `ParticleSlice.__str__`, which previously didn't return anything as `int` is not the same as `numpy.int64`.
-  Improve `ParticleSlice.__str__` and `ParticleList.__str__` so that the representations look like Numpy arrays or Python lists. Previously there were newlines and the name was missing.
- Improve `utils.check_type_or_throw_except` so that it also allows `numpy.int64` where `int` is requested.


PR Checklist
------------
 - [x] Tests?
   - [x] Interface
   - [x] Core 
