### PR TITLE
Implement iterators over cells

### DIFF
--- a/src/core/ParticleIterator.hpp
+++ b/src/core/ParticleIterator.hpp
@@ -16,6 +16,10 @@ struct ParticleIterator : public boost::iterator_facade<
     }
   }
 
+  operator Particle *() const {
+    return &((*m_cell)->part[m_part_id]);
+  }
+
 private:
   friend class boost::iterator_core_access;
 

--- a/src/core/ParticleIterator.hpp
+++ b/src/core/ParticleIterator.hpp
@@ -3,10 +3,29 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 
-template <typename BidirectionalIterator, typename Particle>
+namespace __particle_iterator_util {
+template <typename ReturnType, typename It, typename Particle>
+struct CellDeref;
+
+template <typename It, typename Particle>
+struct CellDeref<Particle&, It, Particle> {
+  static inline Particle& get_particle(It m_cell, int m_part_id) {
+    return (*m_cell)->part[m_part_id];
+  }
+};
+
+template <typename It, typename Particle>
+struct CellDeref<Particle*, It, Particle> {
+  static inline Particle* get_particle(It m_cell, int m_part_id) {
+    return &((*m_cell)->part[m_part_id]);
+  }
+};
+}
+
+template <typename BidirectionalIterator, typename Particle, typename DerefType = Particle&>
 struct ParticleIterator : public boost::iterator_facade<
-                              ParticleIterator<BidirectionalIterator, Particle>,
-                              Particle, boost::forward_traversal_tag> {
+                              ParticleIterator<BidirectionalIterator, Particle, DerefType>,
+                              Particle, boost::forward_traversal_tag, DerefType> {
   ParticleIterator(BidirectionalIterator cell, BidirectionalIterator end,
                    int part_id)
       : m_cell(cell), m_end(end), m_part_id(part_id) {
@@ -14,10 +33,6 @@ struct ParticleIterator : public boost::iterator_facade<
     if ((m_cell != m_end) && (*m_cell)->n == 0) {
       increment();
     }
-  }
-
-  operator Particle *() const {
-    return &((*m_cell)->part[m_part_id]);
   }
 
 private:
@@ -51,7 +66,11 @@ private:
     return (*m_cell == *(rhs.m_cell)) && (m_part_id == rhs.m_part_id);
   }
 
-  Particle &dereference() const { return (*m_cell)->part[m_part_id]; }
+  DerefType dereference() const {
+      return __particle_iterator_util
+                ::CellDeref<DerefType, BidirectionalIterator, Particle>
+                ::get_particle(m_cell, m_part_id);
+  }
 
   BidirectionalIterator m_cell, m_end;
   int m_part_id;

--- a/src/core/celliter.cpp
+++ b/src/core/celliter.cpp
@@ -11,8 +11,9 @@ Utils::Range<CellNeighIterator> IndexedCellProxy::hsneigh() const
                            CellNeighIterator(idx, dd.cell_inter[idx].n_neighbors));
 }
 
-CellNeighIterator::value_type CellNeighIterator::dereference() const
+void CellNeighIterator::advance(difference_type n)
 {
-  return value_type(&dd.cell_inter[cellidx].nList[i].pList);
+  i += n;
+  cp.set_cell(&dd.cell_inter[cellidx].nList[i].pList);
 }
 

--- a/src/core/celliter.cpp
+++ b/src/core/celliter.cpp
@@ -1,0 +1,18 @@
+
+#include "celliter.hpp"
+#include "cells.hpp"
+#include "domain_decomposition.hpp"
+
+Utils::Range<CellNeighIterator> IndexedCellProxy::hsneigh() const
+{
+  if (cell_structure.type != CELL_STRUCTURE_DOMDEC)
+    throw NoDomainDecompositionError();
+  return Utils::make_range(CellNeighIterator(idx, 0),
+                           CellNeighIterator(idx, dd.cell_inter[idx].n_neighbors));
+}
+
+CellNeighIterator::value_type CellNeighIterator::dereference() const
+{
+  return value_type(&dd.cell_inter[cellidx].nList[i].pList);
+}
+

--- a/src/core/celliter.cpp
+++ b/src/core/celliter.cpp
@@ -3,6 +3,11 @@
 #include "cells.hpp"
 #include "domain_decomposition.hpp"
 
+CellNeighIterator::CellNeighIterator(int cellidx, int i):
+    cellidx(cellidx), i(i), cp(&dd.cell_inter[cellidx].nList[i].pList)
+{}
+
+
 Utils::Range<CellNeighIterator> IndexedCellProxy::hsneigh() const
 {
   if (cell_structure.type != CELL_STRUCTURE_DOMDEC)

--- a/src/core/celliter.hpp
+++ b/src/core/celliter.hpp
@@ -1,0 +1,233 @@
+
+#ifndef CORE_CELLITER_H_INCLUDED
+#define CORE_CELLITER_H_INCLUDED
+
+#include <utility>
+#include "utils/Range.hpp"
+#include "ParticleIterator.hpp"
+#include "particle_data.hpp"
+
+typedef ParticleList Cell; // Same as in cells.hpp (in order not to introduce
+                           // cyclic dependencies)
+
+/** Encapsulates a Cell.
+ * This is a helper class to iterate over cells and the particles in them.
+ * This class does not take ownership of the encapsulated cell. Warning:
+ * Changes to the underlying cells (e.g. local_cells) array might invalidate
+ * CellProxies.
+ */
+struct CellProxy {
+  struct NoDomainDecompositionError {};
+
+  /** Constructor.
+   * \param c Double pointer to cell
+   */
+  CellProxy(Cell **c): c(c) {}
+
+  /** Returns a pointer to the cell.
+   */
+  Cell* cellptr() const { return *c; }
+  /** Returns a reference to the cell.
+   */
+  Cell& cell() const { return **c; }
+
+  using CellParticleIterator = ParticleIterator<Cell **, Particle>;
+  /** Returns a begin iterator to the particles of the encapsulated cell.
+   */
+  CellParticleIterator pbegin() const {
+    return CellParticleIterator(c, c + 1, 0);
+  }
+
+  /** Returns an end iterator to the particles of the encapsulated cell.
+   */
+  CellParticleIterator pend() const {
+    return CellParticleIterator(c + 1, c + 1, 0);
+  }
+
+  /** Returns a range object to iterate over particles of the encapsulates cell.
+   * Can be used in range-based for loops.
+   */
+  Utils::Range<CellParticleIterator> particles() const {
+    return Utils::make_range(pbegin(), pend());
+  }
+
+  operator Cell*() const { return cellptr(); }
+  operator Cell&() const { return cell(); }
+
+  bool operator==(const CellProxy& other) const {
+    return cellptr() == other.cellptr();
+  }
+
+  bool operator!=(const CellProxy& other) const {
+    return !(*this == other);
+  }
+
+private:
+  Cell **c;
+};
+
+/** Iterator over dd.cell_inter.
+ * dd.cell_inter[cellidx].nList[i].cell_ind is an index to "cells" and
+ * not to local_cells, so it cannot be used to index dd.cell_inter, again.
+ * Therefore, this iterator returns only CellProxies and not Indexed ones.
+ */
+struct CellNeighIterator: public boost::iterator_facade<
+                                   CellNeighIterator,
+                                   CellProxy,
+                                   boost::random_access_traversal_tag,
+                                   CellProxy> // Returns value, not reference
+{
+  /** Constructor
+   * \param cellidx Index of the center
+   * \poaram i Index of the neighbor
+   */
+  CellNeighIterator(int cellidx, int i): cellidx(cellidx), i(i) {}
+
+  struct DifferentBaseCellError {};
+
+private:
+  const int cellidx;
+  int i;
+
+  friend class boost::iterator_core_access;
+
+  value_type dereference() const;
+
+  bool equal(const CellNeighIterator& other) const {
+    return cellidx == other.cellidx && i == other.i;
+  }
+
+  void increment() { advance(1); }
+  void decrement() { advance(-1); }
+  void advance(difference_type n) { i += n; }
+
+  difference_type distance_to(const CellNeighIterator& other) const {
+    if (cellidx != other.cellidx)
+      throw DifferentBaseCellError();
+    return i - other.i;
+  }
+};
+
+/** Encapsulates a Cell.
+ * This is a helper class to iterate over cells, the particles in them and
+ * their neighborhood. A plain Cell* isn't enough since dd.cell_inter is
+ * accessed via a cell index. Therefore, this class not only keeps track of a
+ * Cell** but also its index. This class does not take ownership of the
+ * encapsulated cell. Warning: Changes to the underlying cells (e.g.
+ * local_cells) array might invalidate CellProxies.
+ */
+struct IndexedCellProxy {
+  struct NoDomainDecompositionError {};
+
+  /** Constructor.
+   * \param c Double pointer to cell
+   * \param idx Index of that cell
+   */
+  IndexedCellProxy(Cell **c, int idx): c(c), idx(idx) {}
+
+  /** Returns a pointer to the cell.
+   */
+  Cell* cellptr() const { return *c; }
+  /** Returns a reference to the cell.
+   */
+  Cell& cell() const { return **c; }
+  /** Returns the cell index.
+   */
+  int cellidx() const { return idx; }
+
+  using IdxPtrPair = std::pair<int, Cell*>;
+  /** Returns a pair (cell**, index)
+   */
+  IdxPtrPair idxptrpair() const { return std::make_pair(cellidx(), cellptr()); }
+
+  using CellParticleIterator = ParticleIterator<Cell **, Particle>;
+  /** Returns a begin iterator to the particles of the encapsulated cell.
+   */
+  CellParticleIterator pbegin() const {
+    return CellParticleIterator(c, c + 1, 0);
+  }
+
+  /** Returns an end iterator to the particles of the encapsulated cell.
+   */
+  CellParticleIterator pend() const {
+    return CellParticleIterator(c + 1, c + 1, 0);
+  }
+
+  /** Returns a range object to iterate over particles of the encapsulates cell.
+   * Can be used in range-based for loops.
+   */
+  Utils::Range<CellParticleIterator> particles() const {
+    return Utils::make_range(pbegin(), pend());
+  }
+
+  /** Returns a range object to iterate over neighbor cells (half-shell).
+   * Can be used in range-based for loops.
+   * DO NOT use this for ghost cells.
+   */
+  Utils::Range<CellNeighIterator> hsneigh() const;
+
+  operator Cell*() const { return cellptr(); }
+  operator Cell&() const { return cell(); }
+  operator int() const { return cellidx(); }
+  operator IdxPtrPair() const { return idxptrpair(); }
+
+  bool operator==(const IndexedCellProxy& other) const {
+    return cellptr() == other.cellptr();
+  }
+
+  bool operator!=(const IndexedCellProxy& other) const {
+    return !(*this == other);
+  }
+
+private:
+  Cell **c;
+  int idx;
+};
+
+
+/** Iterator over cells. Do not use this class directly, use local_cells.cells().
+ *
+ */
+struct CellIterator: public boost::iterator_facade<
+                              CellIterator,
+                              IndexedCellProxy,
+                              boost::random_access_traversal_tag,
+                              IndexedCellProxy> // Returns value, not reference
+{
+  typedef IndexedCellProxy value_type;
+
+  /** Constructor
+   * \param cells cells array to iterate over (local_cells.cell or ghost_cells.cell)
+   * \param i Iteration index
+   */
+  CellIterator(Cell **cells, int i): cells(cells), i(i) {}
+
+private:
+  Cell **cells;
+  int i;
+
+  friend class boost::iterator_core_access;
+
+  value_type dereference() const {
+    return value_type(&cells[i], i);
+  }
+
+  bool equal(const CellIterator& other) const { return i == other.i; }
+  void increment() { advance(1); }
+  void decrement() { advance(-1); }
+  void advance(difference_type n) { i += n; }
+
+  difference_type distance_to(const CellIterator& other) const {
+    return i - other.i;
+  }
+};
+
+inline bool operator==(const IndexedCellProxy& a, const CellProxy& b) {
+  return a.cellptr() == b.cellptr();
+}
+
+inline bool operator!=(const IndexedCellProxy& a, const CellProxy& b) {
+  return !(a == b);
+}
+
+#endif

--- a/src/core/celliter.hpp
+++ b/src/core/celliter.hpp
@@ -55,7 +55,10 @@ struct CellProxy {
   /** Returns a begin iterator to the particles of the encapsulated cell.
    */
   CellParticlePtrIterator pptrbegin(int begin_idx = 0) const {
-    return CellParticlePtrIterator(c, c + 1, begin_idx);
+    if (begin_idx >= cell().n)
+      return CellParticlePtrIterator(c + 1, c + 1, 0);
+    else
+      return CellParticlePtrIterator(c, c + 1, begin_idx);
   }
 
   /** Returns an end iterator to the particles of the encapsulated cell.

--- a/src/core/celliter.hpp
+++ b/src/core/celliter.hpp
@@ -103,14 +103,14 @@ struct CellNeighIterator: public boost::iterator_facade<
    * \param cellidx Index of the center
    * \poaram i Index of the neighbor
    */
-  CellNeighIterator(int cellidx, int i): cp(nullptr), cellidx(cellidx), i(i) {}
+  CellNeighIterator(int cellidx, int i);
 
   struct DifferentBaseCellError {};
 
 private:
-  CellProxy cp;
   const int cellidx;
   int i;
+  CellProxy cp;
 
   friend class boost::iterator_core_access;
 
@@ -245,12 +245,12 @@ struct CellIterator: public boost::iterator_facade<
    * \param cells cells array to iterate over (local_cells.cell or ghost_cells.cell)
    * \param i Iteration index
    */
-  CellIterator(Cell **cells, int i): icp(nullptr, -1), cells(cells), i(i) {}
+  CellIterator(Cell **cells, int i): cells(cells), i(i), icp(&cells[i], i) {}
 
 private:
-  IndexedCellProxy icp;
   Cell **cells;
   int i;
+  IndexedCellProxy icp;
 
   friend class boost::iterator_core_access;
 

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -68,6 +68,8 @@
 #include "particle_data.hpp"
 #include "utils/Range.hpp"
 #include "verlet.hpp"
+#include "celliter.hpp"
+
 
 /** \name Cell Structure */
 /** Flag telling which cell structure is used at the moment. */
@@ -124,6 +126,10 @@ struct CellPList {
   Utils::Range<CellParticleIterator> particles() const {
     return Utils::make_range(CellParticleIterator(cell, cell + n, 0),
                              CellParticleIterator(cell + n, cell + n, 0));
+  }
+
+  Utils::Range<CellIterator> cells() const {
+    return Utils::make_range(CellIterator(cell, 0), CellIterator(cell, n));
   }
 
   Cell **cell;


### PR DESCRIPTION
Following up the ParticleIterator, I implemented an iterator over cells and cell neighborhood. They are supposed to abstract away loops over local_cells and dd.cell_inter. Since these kinds of loops are everywhere in the code, an abstraction is definitely useful. Implemented features are:
- CellProxy and IndexedCellProxy encapsulate cells (and their indices in local_cells)
  and allow to iterate over the particles in a cell.
- CellNeighIterator provides an iterator over dd.cell_inter.
- CellIterator iterates over local_cells or ghost_cells.
- Extend ParticleIterator to be able to sell it as a Particle*

As an example, I show how calc_link_cell() could be transformed (which assumes another function ParticleIterator::start_after which is trivial to implement, just copy m_part_id and increment it once):
```
void new_calc_link_cell()
{
  for (auto c1: local_cells.cells()) {
    for (auto c2: c1.hsneigh()) {
      for (auto p1 = c1.pbegin(); p1 != c1.pend(); p1++) {
        auto p2 = c2.pbegin();

        if (c1 == c2) {
          // Within cell itself: bonded forces
          add_single_particle_force(p1);
          if (rebuild_verletlist)
            std::copy(p1->r.p, p1->r.p + 3, p1->l.p_old);

          // Half-Shell within a cell itself
          p2.start_after(p1);
        }
        for (; p2 != c2.pend(); p2++) {
#ifdef EXCLUSIONS
          if (do_nonbonded(p1, p2))
#endif
          {
            double vec21[3];
            double dist2 = distance2vec(p1->r.p, p2->r.p, vec21);
            add_non_bonded_pair_force(p1, p2, vec21, sqrt(dist2), dist2);
          }
        }
      }
    }
  }
  rebuild_verletlist = 0;
}
```

Using these abstractions to change calc_link_cell is probably not a good idea before measuring what the cost of them are. Runtime uncritical code could definitely benefit from abstractions.

Things which can (and should) be improved:
- CellProxy and IndexedCellProxy: Two classes are needed because for neighbors cells we don't have an index to local_cells
- Currently, CellPList::cells() allows to call hsneigh() on ghost_cells which is not desirable.
- ...