### PR TITLE
Fix broken build due to conflict between #1100 and #1176

### DIFF
--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -1,6 +1,6 @@
 from espressomd.utils import to_char_pointer,to_str
 
-cdef class PObjectId:
+cdef class PObjectId(object):
     cpdef ObjectId id
     
     def __richcmp__(PObjectId a, PObjectId b, op):


### PR DESCRIPTION
#1176 updated all old-style classes to be new-style and enforced all classes to be new-style. #1100 introduced a new old-style class. This pull request updates the latter to be new-style as well.