### PR TITLE
script_interface: Make ScriptInterfaceHelper forward the creation pol…

### DIFF
--- a/src/python/espressomd/correlators.py
+++ b/src/python/espressomd/correlators.py
@@ -7,7 +7,7 @@ import numpy as np
 class Correlator(ScriptInterfaceHelper):
     _so_name = "Correlators::Correlator"
     _so_bind_methods = ("update","auto_update","finalize", "dim_corr","n_results","hierarchy_depth")
-    _policy = "LOCAL"
+    _so_creation_policy = "LOCAL"
 
     def result(self):
         res=np.array(self.call_method("get_correlation"))
@@ -17,7 +17,7 @@ class Correlator(ScriptInterfaceHelper):
 @script_interface_register
 class AutoUpdateCorrelators(ScriptInterfaceHelper):
     _so_name = "Correlators::AutoUpdateCorrelators"
-    _policy = "LOCAL"
+    _so_creation_policy = "LOCAL"
 
     def add(self, *args, **kwargs):
         if len(args) == 1:

--- a/src/python/espressomd/correlators.py
+++ b/src/python/espressomd/correlators.py
@@ -7,20 +7,17 @@ import numpy as np
 class Correlator(ScriptInterfaceHelper):
     _so_name = "Correlators::Correlator"
     _so_bind_methods = ("update","auto_update","finalize", "dim_corr","n_results","hierarchy_depth")
+    _policy = "LOCAL"
 
     def result(self):
         res=np.array(self.call_method("get_correlation"))
         res=res.reshape((self.n_results(),2+self.dim_corr()))
         return res
 
-
-
-
-
-
 @script_interface_register
 class AutoUpdateCorrelators(ScriptInterfaceHelper):
     _so_name = "Correlators::AutoUpdateCorrelators"
+    _policy = "LOCAL"
 
     def add(self, *args, **kwargs):
         if len(args) == 1:

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -4,6 +4,7 @@ from .script_interface import ScriptInterfaceHelper,script_interface_register
 @script_interface_register
 class AutoUpdateObservables(ScriptInterfaceHelper):
     _so_name = "Observables::AutoUpdateObservables"
+    _policy = "LOCAL"
 
     def add(self, *args, **kwargs):
         if len(args) == 1:
@@ -24,8 +25,7 @@ class AutoUpdateObservables(ScriptInterfaceHelper):
 class Observable(ScriptInterfaceHelper):
     _so_name="Observables::Observable"
     _so_bind_methods = ("value","calculate","update","auto_write_to")
-
-
+    _policy = "LOCAL"
 
 @script_interface_register
 class ComForce(Observable):

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -4,7 +4,7 @@ from .script_interface import ScriptInterfaceHelper,script_interface_register
 @script_interface_register
 class AutoUpdateObservables(ScriptInterfaceHelper):
     _so_name = "Observables::AutoUpdateObservables"
-    _policy = "LOCAL"
+    _so_creation_policy = "LOCAL"
 
     def add(self, *args, **kwargs):
         if len(args) == 1:
@@ -25,7 +25,7 @@ class AutoUpdateObservables(ScriptInterfaceHelper):
 class Observable(ScriptInterfaceHelper):
     _so_name="Observables::Observable"
     _so_bind_methods = ("value","calculate","update","auto_write_to")
-    _policy = "LOCAL"
+    _so_creation_policy = "LOCAL"
 
 @script_interface_register
 class ComForce(Observable):

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -198,9 +198,10 @@ cdef class PScriptInterface(object):
 class ScriptInterfaceHelper(PScriptInterface):
     _so_name = None
     _so_bind_methods =()
+    _policy = "GLOBAL"
 
-    def __init__(self,**kwargs):
-        super(ScriptInterfaceHelper,self).__init__(self._so_name)
+    def __init__(self, **kwargs):
+        super(ScriptInterfaceHelper,self).__init__(self._so_name, self._policy)
         self.set_params(**kwargs)
         self.define_bound_methods()
 

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -198,10 +198,10 @@ cdef class PScriptInterface(object):
 class ScriptInterfaceHelper(PScriptInterface):
     _so_name = None
     _so_bind_methods =()
-    _policy = "GLOBAL"
+    _so_creation_policy = "GLOBAL"
 
     def __init__(self, **kwargs):
-        super(ScriptInterfaceHelper,self).__init__(self._so_name, self._policy)
+        super(ScriptInterfaceHelper,self).__init__(self._so_name, self._so_creation_policy)
         self.set_params(**kwargs)
         self.define_bound_methods()
 


### PR DESCRIPTION
…icy to PScriptInterface. Create observables and correlators only on the master as they should.

I'm not totally happy with the way this is done, but this is what we already started....

Description of changes:
 - Let objects derived from ScriptInterfaceHelper decided whether they should be created on
  all nodes, or only the caller.
- Make observabled and correlaters local.

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
