### PR TITLE
Tune skin and steepest descent

### DIFF
--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -40,3 +40,8 @@ cdef extern from "layered.hpp":
 
 cdef extern from "grid.hpp":
     int node_grid[3]
+
+
+
+cdef extern from "tuning.hpp":
+    cdef void c_tune_skin "tune_skin" (double min, double max, double tol, int steps)

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -201,4 +201,22 @@ cdef class CellSystem(object):
         def __get__(self):
             return skin
 
+    def tune_skin(self,min_skin=None,max_skin=None,tol=None,int_steps=None):
+        """Tunes the skin by measuring the integration time and bisecting over the
+           given range of skins. The best skin is set in the simulation core.
 
+           Parameters
+           -----------
+           'min_skin': float
+             Minimum skin to test
+           'max_skin': float
+             Maximum skin
+           'tol': float
+             Accuracy in skin to tune to
+           'int_steps": int
+             Integration steps to time
+
+           Returns the final skin
+        """
+        c_tune_skin(min_skin, max_skin, tol, int_steps)
+        return self.skin

--- a/src/python/espressomd/integrate.pxd
+++ b/src/python/espressomd/integrate.pxd
@@ -51,9 +51,11 @@ cdef extern from "errorhandling.hpp" namespace "ErrorHandling":
     cdef vector[RuntimeError]mpi_gather_runtime_errors()
 
 cdef extern from "minimize_energy.hpp":
-    cbool minimize_energy();
     void minimize_energy_init(const double f_max, const double gamma, const int max_steps, const double max_displacement);
-    cbool steepest_descent_step();
+cdef extern from "communication.hpp":
+    int mpi_minimize_energy() 
+
+
 
 # cdef class Integrator:
 #     cdef public _method

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -64,7 +64,7 @@ cdef class Integrator(object):
                                  self._steepest_descent_params["gamma"],
                                  steps,
                                  self._steepest_descent_params["max_displacement"])
-            minimize_energy()
+            mpi_minimize_energy()
 
     def set_steepest_descent(self, *args, **kwargs):
         """


### PR DESCRIPTION
This adds Python support for tune_skin() and fixes the steepest descent mode of the Python Integrator class, so that it does not freeze in parallel simulations.
The code called minimize_energy() rather than mpi_minimize_energy()