### PR TITLE
added check for existence of all particles (proposed by peter)

### DIFF
--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -634,15 +634,10 @@ class Analysis(object):
             number_of_chains, 1, int, "number_of_chains=int is a required argument")
         check_type_or_throw_except(
             chain_length, 1, int, "chain_length=int is a required argument")
-        if chain_start < 0:
-            raise ValueError('chain_start must be greater than zero')
-        if chain_length < 0:
-            raise ValueError('chain_length must be greater than zero')
-        if number_of_chains < 0:
-            raise ValueError('number_of_chains must be greater than zero')
-        if chain_start + chain_length * number_of_chains > len(self._system.part):
-            raise ValueError(
-                'start+number_of_chains*chain_length cannot be greater than the total number of particles.')
+        id_min=chain_start; id_max=chain_start + chain_length * number_of_chains;
+        for i in range(id_min,id_max):
+            if (not self._system.part.exists(i)):
+                raise ValueError('particle with id {0:.0f} does not exist\ncannot perform analysis on the range chain_start={1:.0f}, n_chains={2:.0f}, chain_length={3:.0f}\nplease provide a contiguous range of particle ids'.format(i,chain_start,number_of_chains,chain_length));
         c_analyze.chain_start = chain_start
         c_analyze.chain_n_chains = number_of_chains
         c_analyze.chain_length = chain_length


### PR DESCRIPTION
Add checks for analysis routines: checks whether all particles exist. The changes introduce a more descriptive error message.

Description of changes:
 - Check whether all particles in the given id range exist. This is expected by some analysis routines. (Changes were proposed by Peter)

Before the following example script would throw an error which is not very descriptive:

````python
import espressomd as es 
from espressomd import analyze 
import numpy as np
system=es.System() 
system.box_l=[10,10,10] 
system.time_step=06.1 
system.cell_system.skin=0.4 
for i in range(100):
    system.part.add(id=i,pos=np.random.random(3))
re=system.analysis.calc_re(chain_start=0,number_of_chains=1,chain_length=len(system.part))
print(re)
system.part[1].remove()
re=system.analysis.calc_re(chain_start=0,number_of_chains=1,chain_length=2)
print(re)
````