### PR TITLE
ensure that automatic setting of skin value by python_integrate() is compatible with max_skin

### DIFF
--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -1238,7 +1238,7 @@ int python_integrate(int n_steps, bool recalc_forces, bool reuse_forces_par) {
           << "cannot automatically determine skin, please set it manually";
       return ES_ERROR;
     }
-    skin = 0.4 * max_cut;
+    skin = std::min(0.4 * max_cut,max_skin);
     mpi_bcast_parameter(FIELD_SKIN);
   }
 


### PR DESCRIPTION
Fixes #1219

Description of changes:
 - ensure that if the skin is not set, then the automatic setting of its value in python_integrate() does not exceed the max_skin value. Otherwise, this could lead to unexpected crashes, e.g. when p3m tuning changes the max_cut and cellsystem parameters.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
