### PR TITLE
Particle copy fix

### DIFF
--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -44,8 +44,8 @@
 
 ActorList energyActors;
 
-Observable_stat energy = {0, {NULL,0,0}, 0,0,0};
-Observable_stat total_energy = {0, {NULL,0,0}, 0,0,0};
+Observable_stat energy = {0, {}, 0,0,0};
+Observable_stat total_energy = {0, {}, 0,0,0};
 
 /************************************************************/
 

--- a/src/core/mmm2d.cpp
+++ b/src/core/mmm2d.cpp
@@ -104,12 +104,12 @@ char const *mmm2d_errors[] = {
 static double part_error;
 
 /** cutoffs for the bessel sum */
-static IntList besselCutoff = {NULL, 0, 0};
+static IntList besselCutoff;
 
 /** cutoffs for the complex sum */
 static int  complexCutoff[COMPLEX_STEP + 1];
 /** bernoulli numbers divided by n */
-static DoubleList  bon = {NULL, 0, 0};
+static DoubleList  bon;
 
 /** inverse box dimensions */
 /*@{*/

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -2142,13 +2142,6 @@ void pointer_to_rotation(Particle *p, short int *&res) {
 }
 #endif
 
-#ifdef EXCLUSIONS
-void pointer_to_exclusions(Particle *p, int *&res1, int *&res2) {
-  res1 = &(p->el.n);
-  res2 = p->el.e;
-}
-#endif
-
 #ifdef ENGINE
 void pointer_to_swimming(Particle *p, ParticleParametersSwimming *&swim) {
   swim = &(p->swim);

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -340,6 +340,8 @@ struct Particle {
       easily from the bonded_ia_params entry for the type. */
   IntList bl;
 
+  IntList &bonds() { return bl; }
+
   IntList &exclusions() {
 #ifdef EXCLUSIONS
     return el;

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -340,8 +340,17 @@ struct Particle {
       easily from the bonded_ia_params entry for the type. */
   IntList bl;
 
+  IntList &exclusions() {
 #ifdef EXCLUSIONS
-  /** list of particles, with which this particle has no nonbonded interactions
+    return el;
+#endif
+
+    throw std::runtime_error{"Exclusions not enabled."};
+  }
+
+#ifdef EXCLUSIONS
+  /** list of particles, with which this particle has no nonbonded
+   * interactions
    */
   IntList el;
 #endif
@@ -1035,10 +1044,6 @@ void pointer_to_gamma_rot(Particle *p, double *&res);
 
 #ifdef ROTATION_PER_PARTICLE
 void pointer_to_rotation(Particle *p, short int *&res);
-#endif
-
-#ifdef EXCLUSIONS
-void pointer_to_exclusions(Particle *p, int *&res1, int *&res2);
 #endif
 
 #ifdef ENGINE

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -320,6 +320,34 @@ struct Particle {
     return identity() != rhs.identity();
   }
 
+  /**
+   * @brief Return a copy of the particle with
+   *        only the fixed size parts.
+   *
+   * This creates a copy of the particle with
+   * only the parts than can be copied w/o heap
+   * allocation, e.g. w/o bonds and exlusions.
+   * This is more efficient if these parts are
+   * not actually needed.
+   */
+  Particle flat_copy() const {
+    Particle ret{};
+
+    ret.p = p;
+    ret.r = r;
+    ret.m = m;
+    ret.f = f;
+    ret.l = l;
+#ifdef LB
+    ret.lc = lc;
+#endif
+#ifdef ENGINE
+    ret.swim = swim;
+#endif
+
+    return ret;
+  }
+
   ///
   ParticleProperties p;
   ///
@@ -341,6 +369,7 @@ struct Particle {
   IntList bl;
 
   IntList &bonds() { return bl; }
+  IntList const &bonds() const { return bl; }
 
   IntList &exclusions() {
 #ifdef EXCLUSIONS

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -309,20 +309,6 @@ typedef struct {
 
 /** Struct holding all information for one particle. */
 struct Particle {
-  Particle() {
-    init_intlist(&bl);
-#ifdef EXCLUSIONS
-    init_intlist(&el);
-#endif
-  }
-
-  ~Particle() {
-    bl.resize(0);
-#ifdef EXCLUSIONS
-    el.resize(0);
-#endif
-  }
-
   int &identity() { return p.identity; }
   int const &identity() const { return p.identity; }
 

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -30,17 +30,17 @@
 #include "layered.hpp"
 #include "virtual_sites_relative.hpp" 
 
-Observable_stat virials  = {0, {NULL,0,0}, 0,0,0,0,0};
-Observable_stat total_pressure = {0, {NULL,0,0}, 0,0,0,0,0};
-Observable_stat p_tensor = {0, {NULL,0,0},0,0,0,0,0};
-Observable_stat total_p_tensor = {0, {NULL,0,0},0,0,0,0,0};
+Observable_stat virials  = {0, {}, 0,0,0,0,0};
+Observable_stat total_pressure = {0, {}, 0,0,0,0,0};
+Observable_stat p_tensor = {0, {},0,0,0,0,0};
+Observable_stat total_p_tensor = {0, {},0,0,0,0,0};
 
 /* Observables used in the calculation of intra- and inter- molecular
    non-bonded contributions to pressure and to stress tensor */
-Observable_stat_non_bonded virials_non_bonded  = {0, {NULL,0,0}, 0,0,0};
-Observable_stat_non_bonded total_pressure_non_bonded = {0, {NULL,0,0}, 0,0,0};
-Observable_stat_non_bonded p_tensor_non_bonded = {0, {NULL,0,0},0,0,0};
-Observable_stat_non_bonded total_p_tensor_non_bonded = {0, {NULL,0,0},0,0,0};
+Observable_stat_non_bonded virials_non_bonded  = {0, {}, 0,0,0};
+Observable_stat_non_bonded total_pressure_non_bonded = {0, {}, 0,0,0};
+Observable_stat_non_bonded p_tensor_non_bonded = {0, {},0,0,0};
+Observable_stat_non_bonded total_p_tensor_non_bonded = {0, {},0,0,0};
 
 nptiso_struct   nptiso   = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,{0.0,0.0,0.0},{0.0,0.0,0.0},1, 0 ,{NPTGEOM_XDIR, NPTGEOM_YDIR, NPTGEOM_ZDIR},0,0,0};
 

--- a/src/core/specfunc.cpp
+++ b/src/core/specfunc.cpp
@@ -89,7 +89,7 @@ static double bk0_data[11] = {
    0.00000000000000013744,
    0.00000000000000000035
 };
-static Polynom bk0_cs = { bk0_data, 11, 11 };
+static Polynom bk0_cs{bk0_data};
 
 static double ak0_data[17] = {
   2.5 -0.07643947903327941,
@@ -110,7 +110,7 @@ static double ak0_data[17] = {
   -0.00000000000000033,
    0.00000000000000005
 };
-static Polynom ak0_cs = { ak0_data, 16, 16 };
+static Polynom ak0_cs{ak0_data};
 
 static double ak02_data[14] = {
   2.5 -0.01201869826307592,
@@ -128,7 +128,7 @@ static double ak02_data[14] = {
    0.00000000000000020,
   -0.00000000000000002
 };
-static Polynom ak02_cs = { ak02_data, 13, 13 };
+static Polynom ak02_cs{ak02_data};
 
 /* based on SLATEC besi0 */
 
@@ -168,7 +168,7 @@ static double bi0_data[12] = {
    .00000000000000053339,
    .00000000000000000245
 };
-static Polynom bi0_cs = { bi0_data, 12, 12 };
+static Polynom bi0_cs{bi0_data};
 
 static double ai0_data[21] = {
   .75 +.07575994494023796, 
@@ -193,7 +193,7 @@ static double ai0_data[21] = {
   -.00000000000000071,
    .00000000000000007
 };
-static Polynom ai0_cs = { ai0_data, 21, 21 };
+static Polynom ai0_cs{ai0_data};
 
 static double ai02_data[22] = {
   .75 +.05449041101410882,
@@ -219,7 +219,7 @@ static double ai02_data[22] = {
   -.00000000000000027,
    .00000000000000003
 };
-static Polynom ai02_cs = { ai02_data, 22, 22 };
+static Polynom ai02_cs{ai02_data};
 
 /* based on SLATEC besk1(), besk1e() */
 
@@ -258,7 +258,7 @@ static double bk1_data[11] = {
   -0.0000000000000000070
 };
 
-static Polynom bk1_cs = { bk1_data, 11, 11 };
+static Polynom bk1_cs{bk1_data};
 
 static double ak1_data[17] = {
   2.5 +0.27443134069738830, 
@@ -279,7 +279,7 @@ static double ak1_data[17] = {
    0.00000000000000038,
   -0.00000000000000006
 };
-static Polynom ak1_cs = { ak1_data, 17, 17 };
+static Polynom ak1_cs{ak1_data};
 
 static double ak12_data[14] = {
   2.5 +0.06379308343739001,
@@ -297,7 +297,7 @@ static double ak12_data[14] = {
   -0.00000000000000022,
    0.00000000000000002
 };
-static Polynom ak12_cs = { ak12_data, 14, 14 };
+static Polynom ak12_cs{ak12_data};
 
 /* based on SLATEC besi1(), besi1e() */
 
@@ -335,7 +335,7 @@ static double bi1_data[11] = {
    0.000000000000004741,
    0.000000000000000024
 };
-static Polynom bi1_cs = { bi1_data, 11, 11 };
+static Polynom bi1_cs{bi1_data};
 
 static double ai1_data[21] = {
   .75 -0.02846744181881479,
@@ -360,7 +360,7 @@ static double ai1_data[21] = {
    0.00000000000000071,
   -0.00000000000000006
 };
-static Polynom ai1_cs = { ai1_data, 21, 21 };
+static Polynom ai1_cs{ai1_data};
 
 static double ai12_data[22] = {
   .75 +0.02857623501828014,
@@ -386,7 +386,7 @@ static double ai12_data[22] = {
    0.00000000000000028,
   -0.00000000000000003
 };
-static Polynom ai12_cs = { ai12_data, 22, 22 };
+static Polynom ai12_cs{ai12_data};
 
 /************************************************
  * chebychev expansions

--- a/src/core/statistics_wallstuff.cpp
+++ b/src/core/statistics_wallstuff.cpp
@@ -24,7 +24,7 @@
 #include "partCfg.hpp"
 
 // list of the currently specified box boundaries
-DoubleList wallstuff_boundaries = { NULL, 0 };
+DoubleList wallstuff_boundaries;
 // the boxes with the particle identities
 IntList *wallstuff_part_in_bin = NULL;
 

--- a/src/core/unit_tests/ParticleCache_test.cpp
+++ b/src/core/unit_tests/ParticleCache_test.cpp
@@ -22,8 +22,8 @@
  *
 */
 
-#include <vector>
 #include <random>
+#include <vector>
 
 #include <boost/mpi.hpp>
 #include <boost/serialization/access.hpp>
@@ -45,6 +45,11 @@ public:
   Particle(int id) : Testing::Particle(id) {}
 
   IntList bl;
+
+  IntList &bonds() { return bl; }
+  IntList const &bonds() const { return bl; }
+
+  Particle flat_copy() const { return Particle(m_id); }
 
   template <typename Archive> void serialize(Archive &ar, unsigned int) {
     ar &m_id;
@@ -104,7 +109,9 @@ BOOST_AUTO_TEST_CASE(update) {
     local_parts.emplace_back(rank * n_part + i);
   }
 
-  auto get_parts = [&local_parts]() -> Particles const& { return local_parts; };
+  auto get_parts = [&local_parts]() -> Particles const & {
+    return local_parts;
+  };
   ParticleCache<decltype(get_parts)> part_cfg(get_parts);
 
   if (rank == 0) {
@@ -140,7 +147,9 @@ BOOST_AUTO_TEST_CASE(update_with_bonds) {
     std::fill(part.bl.begin(), part.bl.end(), id);
   }
 
-  auto get_parts = [&local_parts]() -> Particles const& { return local_parts; };
+  auto get_parts = [&local_parts]() -> Particles const & {
+    return local_parts;
+  };
   ParticleCache<decltype(get_parts)> part_cfg(get_parts);
 
   if (rank == 0) {
@@ -173,7 +182,9 @@ BOOST_AUTO_TEST_CASE(iterators) {
     local_parts.emplace_back(rank * n_part + i);
   }
 
-  auto get_parts = [&local_parts]() -> Particles const& { return local_parts; };
+  auto get_parts = [&local_parts]() -> Particles const & {
+    return local_parts;
+  };
   ParticleCache<decltype(get_parts)> part_cfg(get_parts);
 
   if (rank == 0) {

--- a/src/core/unit_tests/ParticleCache_test.cpp
+++ b/src/core/unit_tests/ParticleCache_test.cpp
@@ -135,10 +135,8 @@ BOOST_AUTO_TEST_CASE(update_with_bonds) {
     local_parts.emplace_back(id);
     auto const bond_length = bond_lengths[id % bond_lengths.size()];
     auto &part = local_parts.back();
-    part.bl.e = nullptr;
-    part.bl.max = 0;
     part.bl.resize(bond_length);
-    part.bl.n = bond_length;
+
     std::fill(part.bl.begin(), part.bl.end(), id);
   }
 

--- a/src/core/utils/List.hpp
+++ b/src/core/utils/List.hpp
@@ -56,6 +56,7 @@ public:
   size_type size() const { return n; }
   bool empty() const { n == 0; }
   size_type capacity() const { return max; }
+  void clear() { resize(0); }
 
 private:
   /**

--- a/src/core/utils/List.hpp
+++ b/src/core/utils/List.hpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <limits>
 #include <type_traits>
+#include <iterator>
+#include <algorithm>
 
 #include "memory.hpp"
 

--- a/src/core/utils/List.hpp
+++ b/src/core/utils/List.hpp
@@ -1,31 +1,74 @@
 #ifndef CORE_UTILS_LIST_HPP
 #define CORE_UTILS_LIST_HPP
 
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
 #include "memory.hpp"
 
 namespace Utils {
-
 /** List.
     Use the functions specified in list operations. */
 template <typename T> struct List {
+  static_assert(std::is_pod<T>::value, "");
+
+  using size_type = uint32_t;
+
+  List() : e{nullptr}, n{0}, max{0} {}
+  explicit List(size_type size) : List() { resize(n = size); }
+  ~List() { resize(0); }
+
+  template <size_t N> explicit List(T (&array)[N]) : List(N) {
+    std::copy(std::begin(array), std::end(array), begin());
+  }
+
+private:
+  void copy(List const &rhs) {
+    resize(rhs.n);
+    std::copy(rhs.begin(), rhs.end(), begin());
+  }
+
+  void move(List &&rhs) {
+    using std::swap;
+    swap(n, rhs.n);
+    swap(max, rhs.max);
+    swap(e, rhs.e);
+  }
+
+public:
+  List(List const &rhs) : List() { copy(rhs); }
+  List(List &&rhs) : List() { move(std::move(rhs)); }
+  List &operator=(List const &rhs) {
+    copy(rhs);
+    return *this;
+  }
+  List &operator=(List &&rhs) {
+    move(std::move(rhs));
+    return *this;
+  }
+
   T *begin() { return e; }
   T const *begin() const { return e; }
   T *end() { return e + n; }
   T const *end() const { return e + n; }
-  int size() const { return n; }
-  void resize(int size) {
+  size_type size() const { return n; }
+  void resize(size_type size) {
     if (size != this->max) {
       this->max = size;
-      this->e = Utils::realloc(this->e, sizeof(int) * this->max);
+      this->e = Utils::realloc(this->e, sizeof(T) * this->max);
     }
   }
+
+  size_type max_size() const { return std::numeric_limits<size_type>::max(); }
+
   /** Dynamically allocated field. */
   T *e;
   /** number of used elements in the field. */
-  int n;
+  size_type n;
   /** allocated size of the field. This value is ONLY changed
       in the routines specified in list operations ! */
-  int max;
+  size_type max;
 };
 
 } /* namespace Utils */

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -61,6 +61,7 @@ cdef extern from "particle_data.hpp":
         particle_force f
         particle_local l
         int_list bl
+        int_list exclusions() except +
 
     IF ENGINE:
         IF LB or LB_GPU:
@@ -185,8 +186,6 @@ cdef extern from "particle_data.hpp":
 
     IF EXCLUSIONS:
         int change_exclusion(int part, int part2, int _delete)
-        void pointer_to_exclusions(particle * p, int * & res1, int * & res2)
-
         void remove_all_exclusions()
 
     IF ENGINE:

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1124,12 +1124,11 @@ cdef class ParticleHandle(object):
 
             def __get__(self):
                 self.update_particle_data()
-                cdef int * num_partners = NULL
-                cdef int * partners = NULL
+                cdef int_list exclusions = self.particle_data.get()[0].exclusions()
+
                 py_partners = []
-                pointer_to_exclusions(self.particle_data.get(), num_partners, partners)
-                for i in range(num_partners[0]):
-                    py_partners.append(partners[i])
+                for i in range(exclusions.n):
+                    py_partners.append(exclusions.e[i])
                 return np.array(py_partners)
 
         def add_exclusion(self, *_partners):

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -31,11 +31,11 @@ cdef extern from "stdlib.h":
 cdef extern from "utils.hpp":
     ctypedef struct int_list "IntList":
         int * e
-        int n
+        unsigned n
 
     ctypedef struct double_list "DoubleList":
         double * e
-        int n
+        unsigned n
 
     cdef void init_intlist(int_list * il)
     cdef void alloc_intlist(int_list * il, int size)


### PR DESCRIPTION
Fixes segfaults with partCfg under some circumstances.

Description of changes:
 - move/ (deep) copy for Utils::List
 - Particle::flat_copy() that copies Particles w/o bonds and exclusions
 - Some adjustments to ParticleCache to keep the particles in a valid (read destructible) state if they do not 
   carry bonds/exclusions.
 - Removed fcs_acf from the correlator because it was broken (and affected by the changes on List)
 - Some fixes to Utils::List
 - Getter Particle::exclusions() that may show a way to get rid of all the pointer_to_... stuff (will throw if the 
   feature is not enabled.)