### PR TITLE
Fix CUDA on Ubuntu 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ if (WITH_CUDA)
     endif()
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode=arch=compute_20,code=sm_20 -gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_50,code=sm_50")
     list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
+    list(APPEND CUDA_NVCC_FLAGS "-D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES")
     SET(CUDA_PROPAGATE_HOST_FLAGS OFF)
 
     if (APPLE)


### PR DESCRIPTION
Building Espresso on Ubuntu 16.04 (CUDA 7.5.17, GCC 5.4.0) fails with `identifier "__builtin_ia32_mwaitx" is undefined`. This pull request fixes that.