### PR TITLE
These assertions are bolder than Donald Trump's speeches.  You won't believe it!

### DIFF
--- a/testsuite/python/bondedInteractions.py
+++ b/testsuite/python/bondedInteractions.py
@@ -113,7 +113,6 @@ class ParticleProperties(ut.TestCase):
       test_tabulated = generateTestForBondParams(0, Tabulated, {"type": "distance", "filename":"lj1.tab"})
 
 
-
 if __name__ == "__main__":
     print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/constant_pH.py
+++ b/testsuite/python/constant_pH.py
@@ -92,7 +92,7 @@ class ReactionEnsembleTest(ut.TestCase):
         average_degree_of_association/=num_samples
         pH=ReactionEnsembleTest.pH #note you cannot calculate the pH via -log10(<NH>/volume) in the constant pH ensemble, since the volume is totally arbitrary and does not influence the average number of protons
         real_error_in_degree_of_association=abs(average_degree_of_association-ReactionEnsembleTest.ideal_degree_of_association(ReactionEnsembleTest.pH))/ReactionEnsembleTest.ideal_degree_of_association(ReactionEnsembleTest.pH)
-        self.assertTrue(real_error_in_degree_of_association<0.07, msg="Deviation to ideal titration curve for the given input parameters too large.")
+        self.assertLess(real_error_in_degree_of_association, 0.07, msg="Deviation to ideal titration curve for the given input parameters too large.")
     
 if __name__ == "__main__":
     print("Features: ", espressomd.features())

--- a/testsuite/python/correlation.py
+++ b/testsuite/python/correlation.py
@@ -50,21 +50,9 @@ class Observables(ut.TestCase):
         corr=C2.result()
         for i in range(corr.shape[0]):
             t=corr[i,0]
-            self.assertTrue(abs(corr[i,2]-t*t) <0.0001)
-            self.assertTrue(abs(corr[i,3]-4*t*t) <0.0001)
-            self.assertTrue(abs(corr[i,4]-9*t*t) <0.0001)
-
-
-
-
-
-
-
-
-
-
-
-
+            self.assertAlmostEqual(corr[i,2], t*t  , places=3)
+            self.assertAlmostEqual(corr[i,3], 4*t*t, places=3)
+            self.assertAlmostEqual(corr[i,4], 9*t*t, places=3)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -76,9 +76,9 @@ class CoulombCloudWall(ut.TestCase):
             energy_abs_diff = abs(self.S.analysis.energy(
                 self.S)["total"] - self.reference_energy)
             print(method_name, "energy difference", energy_abs_diff)
-            self.assertTrue(energy_abs_diff <= self.tolerance, "Absolte energy difference " +
+            self.assertLessEqual(energy_abs_diff, self.tolerance, "Absolte energy difference " +
                             str(energy_abs_diff) + " too large for " + method_name)
-        self.assertTrue(force_abs_diff <= self.tolerance, "Asbolute force difference " +
+        self.assertLessEqual(force_abs_diff, self.tolerance, "Asbolute force difference " +
                         str(force_abs_diff) + " too large for method " + method_name)
 
     # Tests for individual methods
@@ -114,7 +114,7 @@ class CoulombCloudWall(ut.TestCase):
 
     def test_zz_deactivation(self):
         # Is the energy 0, if no methods active
-        self.assertTrue(self.S.analysis.energy(self.S)["total"] == 0.0)
+        self.assertEqual(self.S.analysis.energy(self.S)["total"], 0.0)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/coulomb_tuning.py
+++ b/testsuite/python/coulomb_tuning.py
@@ -63,7 +63,7 @@ class CoulombCloudWallTune(ut.TestCase):
 
         print(method_name, "force difference", force_abs_diff)
 
-        self.assertTrue(force_abs_diff <= self.tolerance, "Asbolute force difference " +
+        self.assertLessEqual(force_abs_diff, self.tolerance, "Asbolute force difference " +
                         str(force_abs_diff) + " too large for method " + method_name)
 
     # Tests for individual methods

--- a/testsuite/python/dawaanr-and-dds-gpu.py
+++ b/testsuite/python/dawaanr-and-dds-gpu.py
@@ -115,7 +115,7 @@ class DDSGPUTest(ut.TestCase):
                                 msg = 'Torques on particle do not match. i={0} dawaanr_t={1} ratio_dawaanr_dds_gpu*ddsgpu_t={2}'.format(i,np.array(dawaanr_t[i]), ratio_dawaanr_dds_gpu * np.array(ddsgpu_t[i])))
                 self.assertTrue(self.vectorsTheSame(np.array(dawaanr_f[i]),ratio_dawaanr_dds_gpu * np.array(ddsgpu_f[i])), \
                                 msg = 'Forces on particle do not match: i={0} dawaanr_f={1} ratio_dawaanr_dds_gpu*ddsgpu_f={2}'.format(i,np.array(dawaanr_f[i]), ratio_dawaanr_dds_gpu * np.array(ddsgpu_f[i])))
-            self.assertTrue(abs(dawaanr_e - ddsgpu_e * ratio_dawaanr_dds_gpu) <= 0.001, \
+            self.assertAlmostEqual(dawaanr_e, ddsgpu_e * ratio_dawaanr_dds_gpu, places=3, \
                             msg = 'Energies for dawaanr {0} and dds_gpu {1} do not match.'.format(dawaanr_e,ratio_dawaanr_dds_gpu * ddsgpu_e))
             
             self.es.integrator.run(steps = 0,recalc_forces = True)

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -21,8 +21,6 @@
 # reference data from direct summation. In 2d, reference data from the mdlc
 # test case is used
 
-
-
 from __future__ import print_function
 import espressomd 
 import espressomd.magnetostatics as magnetostatics
@@ -84,9 +82,9 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         tol_t=2E-3
         tol_e=1E-3
 
-        self.assertTrue(abs(err_e)<=tol_e,"Energy difference too large")
-        self.assertTrue(abs(err_t)<=tol_t,"Torque difference too large")
-        self.assertTrue(abs(err_f)<=tol_f,"Force difference too large")
+        self.assertLessEqual(abs(err_e),tol_e,"Energy difference too large")
+        self.assertLessEqual(abs(err_t),tol_t,"Torque difference too large")
+        self.assertLessEqual(abs(err_f),tol_f,"Force difference too large")
     
         s.part.clear()
         del s.actors[0]
@@ -126,9 +124,9 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         tol_t=2E-3
         tol_e=1E-3
 
-        self.assertTrue(abs(err_e)<=tol_e,"Energy difference too large")
-        self.assertTrue(abs(err_t)<=tol_t,"Torque difference too large")
-        self.assertTrue(abs(err_f)<=tol_f,"Force difference too large")
+        self.assertLessEqual(abs(err_e),tol_e,"Energy difference too large")
+        self.assertLessEqual(abs(err_t),tol_t,"Torque difference too large")
+        self.assertLessEqual(abs(err_f),tol_f,"Force difference too large")
     
         s.part.clear()
         del s.actors[0]
@@ -168,17 +166,14 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         tol_t=2E-3
         tol_e=1E-3
 
-        self.assertTrue(abs(err_e)<=tol_e,"Energy difference too large")
-        self.assertTrue(abs(err_t)<=tol_t,"Torque difference too large")
-        self.assertTrue(abs(err_f)<=tol_f,"Force difference too large")
+        self.assertLessEqual(abs(err_e),tol_e,"Energy difference too large")
+        self.assertLessEqual(abs(err_t),tol_t,"Torque difference too large")
+        self.assertLessEqual(abs(err_f),tol_f,"Force difference too large")
     
         s.part.clear()
         del s.actors[0]
     
 
-
-
-    
 if __name__ == "__main__":
     #print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/domain_decomposition.py
+++ b/testsuite/python/domain_decomposition.py
@@ -46,12 +46,12 @@ class DomainDecomposition(ut.TestCase):
         part_dist = self.S.cell_system.resort()
 
         # Check that we did not lose particles
-        self.assertTrue(sum(part_dist) == n_part)
+        self.assertEqual(sum(part_dist), n_part)
 
         # Check that we can still access all the particles
         # This basically checks if part_node and local_particles
         # is still in a valid state after the particle exchange
-        self.assertTrue(sum(self.S.part[:].type) == n_part)
+        self.assertEqual(sum(self.S.part[:].type), n_part)
 
 if __name__ == "__main__":
     print("Features: ", espressomd.features())

--- a/testsuite/python/ek_eof_one_species_x.py
+++ b/testsuite/python/ek_eof_one_species_x.py
@@ -23,8 +23,6 @@ import numpy as np
 import sys
 import math
 
-
-
 ################################################################################
 #                              Set up the System                               # 
 ################################################################################
@@ -276,14 +274,14 @@ class ek_eof_one_species_x(ut.TestCase):
     print("Pressure deviation xz component: {}".format(total_pressure_difference_xz))
 
 
-    self.assertTrue(total_density_difference < 1.5e-05,"Density accuracy not achieved")
-    self.assertTrue(total_velocity_difference < 2.0e-06,"Velocity accuracy not achieved")
-    self.assertTrue(total_pressure_difference_xx < 2.0e-05,"Pressure accuracy xx component not achieved")
-    self.assertTrue(total_pressure_difference_yy < 1.5e-07,"Pressure accuracy yy component not achieved")
-    self.assertTrue(total_pressure_difference_zz < 1.5e-07,"Pressure accuracy zz component not achieved")
-    self.assertTrue(total_pressure_difference_xy < 3.0e-10,"Pressure accuracy xy component not achieved")
-    self.assertTrue(total_pressure_difference_yz < 2.5e-10,"Pressure accuracy yz component not achieved")
-    self.assertTrue(total_pressure_difference_xz < 2.5e-05,"Pressure accuracy xz component not achieved")
+    self.assertLess(total_density_difference, 1.5e-05,"Density accuracy not achieved")
+    self.assertLess(total_velocity_difference, 2.0e-06,"Velocity accuracy not achieved")
+    self.assertLess(total_pressure_difference_xx, 2.0e-05,"Pressure accuracy xx component not achieved")
+    self.assertLess(total_pressure_difference_yy, 1.5e-07,"Pressure accuracy yy component not achieved")
+    self.assertLess(total_pressure_difference_zz, 1.5e-07,"Pressure accuracy zz component not achieved")
+    self.assertLess(total_pressure_difference_xy, 3.0e-10,"Pressure accuracy xy component not achieved")
+    self.assertLess(total_pressure_difference_yz, 2.5e-10,"Pressure accuracy yz component not achieved")
+    self.assertLess(total_pressure_difference_xz, 2.5e-05,"Pressure accuracy xz component not achieved")
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_eof_one_species_x_nonlinear.py
+++ b/testsuite/python/ek_eof_one_species_x_nonlinear.py
@@ -23,8 +23,6 @@ import numpy as np
 import sys
 import math
 
-
-
 ################################################################################
 #                              Set up the System                               # 
 ################################################################################
@@ -276,14 +274,14 @@ class ek_eof_one_species_x(ut.TestCase):
     print("Pressure deviation xz component: {}".format(total_pressure_difference_xz))
 
 
-    self.assertTrue(total_density_difference < 8.0e-06,"Density accuracy not achieved")
-    self.assertTrue(total_velocity_difference < 3.0e-06,"Velocity accuracy not achieved")
-    self.assertTrue(total_pressure_difference_xx < 6.0e-05,"Pressure accuracy xx component not achieved")
-    self.assertTrue(total_pressure_difference_yy < 8.0e-05,"Pressure accuracy yy component not achieved")
-    self.assertTrue(total_pressure_difference_zz < 8.0e-05,"Pressure accuracy zz component not achieved")
-    self.assertTrue(total_pressure_difference_xy < 1.0e-10,"Pressure accuracy xy component not achieved")
-    self.assertTrue(total_pressure_difference_yz < 1.0e-10,"Pressure accuracy yz component not achieved")
-    self.assertTrue(total_pressure_difference_xz < 2.0e-05,"Pressure accuracy xz component not achieved")
+    self.assertLess(total_density_difference, 8.0e-06,"Density accuracy not achieved")
+    self.assertLess(total_velocity_difference, 3.0e-06,"Velocity accuracy not achieved")
+    self.assertLess(total_pressure_difference_xx, 6.0e-05,"Pressure accuracy xx component not achieved")
+    self.assertLess(total_pressure_difference_yy, 8.0e-05,"Pressure accuracy yy component not achieved")
+    self.assertLess(total_pressure_difference_zz, 8.0e-05,"Pressure accuracy zz component not achieved")
+    self.assertLess(total_pressure_difference_xy, 1.0e-10,"Pressure accuracy xy component not achieved")
+    self.assertLess(total_pressure_difference_yz, 1.0e-10,"Pressure accuracy yz component not achieved")
+    self.assertLess(total_pressure_difference_xz, 2.0e-05,"Pressure accuracy xz component not achieved")
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_eof_one_species_y.py
+++ b/testsuite/python/ek_eof_one_species_y.py
@@ -23,8 +23,6 @@ import numpy as np
 import sys
 import math
 
-
-
 ################################################################################
 #                              Set up the System                               # 
 ################################################################################
@@ -274,14 +272,14 @@ class ek_eof_one_species_x(ut.TestCase):
     print("Pressure deviation yz component: {}".format(total_pressure_difference_yz))
     print("Pressure deviation xz component: {}".format(total_pressure_difference_xz))
 
-    self.assertTrue(total_density_difference < 1.5e-06,"Density accuracy not achieved")
-    self.assertTrue(total_velocity_difference < 5.0e-07,"Velocity accuracy not achieved")
-    self.assertTrue(total_pressure_difference_xx < 1.5e-07,"Pressure accuracy xx component not achieved")
-    self.assertTrue(total_pressure_difference_yy < 3.5e-05,"Pressure accuracy yy component not achieved")
-    self.assertTrue(total_pressure_difference_zz < 1.5e-07,"Pressure accuracy zz component not achieved")
-    self.assertTrue(total_pressure_difference_xy < 3.0e-06,"Pressure accuracy xy component not achieved")
-    self.assertTrue(total_pressure_difference_yz < 1.5e-09,"Pressure accuracy yz component not achieved")
-    self.assertTrue(total_pressure_difference_xz < 7.5e-10,"Pressure accuracy xz component not achieved")
+    self.assertLess(total_density_difference, 1.5e-06,"Density accuracy not achieved")
+    self.assertLess(total_velocity_difference, 5.0e-07,"Velocity accuracy not achieved")
+    self.assertLess(total_pressure_difference_xx, 1.5e-07,"Pressure accuracy xx component not achieved")
+    self.assertLess(total_pressure_difference_yy, 3.5e-05,"Pressure accuracy yy component not achieved")
+    self.assertLess(total_pressure_difference_zz, 1.5e-07,"Pressure accuracy zz component not achieved")
+    self.assertLess(total_pressure_difference_xy, 3.0e-06,"Pressure accuracy xy component not achieved")
+    self.assertLess(total_pressure_difference_yz, 1.5e-09,"Pressure accuracy yz component not achieved")
+    self.assertLess(total_pressure_difference_xz, 7.5e-10,"Pressure accuracy xz component not achieved")
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_eof_one_species_y_nonlinear.py
+++ b/testsuite/python/ek_eof_one_species_y_nonlinear.py
@@ -274,14 +274,14 @@ class ek_eof_one_species_x(ut.TestCase):
     print("Pressure deviation yz component: {}".format(total_pressure_difference_yz))
     print("Pressure deviation xz component: {}".format(total_pressure_difference_xz))
 
-    self.assertTrue(total_density_difference < 1.0e-06,"Density accuracy not achieved")
-    self.assertTrue(total_velocity_difference < 1.0e-06,"Velocity accuracy not achieved")
-    self.assertTrue(total_pressure_difference_xx < 1.0e-05,"Pressure accuracy xx component not achieved")
-    self.assertTrue(total_pressure_difference_yy < 2.5e-05,"Pressure accuracy yy component not achieved")
-    self.assertTrue(total_pressure_difference_zz < 1.0e-05,"Pressure accuracy zz component not achieved")
-    self.assertTrue(total_pressure_difference_xy < 2.0e-06,"Pressure accuracy xy component not achieved")
-    self.assertTrue(total_pressure_difference_yz < 1.0e-10,"Pressure accuracy yz component not achieved")
-    self.assertTrue(total_pressure_difference_xz < 1.0e-10,"Pressure accuracy xz component not achieved")
+    self.assertLess(total_density_difference, 1.0e-06,"Density accuracy not achieved")
+    self.assertLess(total_velocity_difference, 1.0e-06,"Velocity accuracy not achieved")
+    self.assertLess(total_pressure_difference_xx, 1.0e-05,"Pressure accuracy xx component not achieved")
+    self.assertLess(total_pressure_difference_yy, 2.5e-05,"Pressure accuracy yy component not achieved")
+    self.assertLess(total_pressure_difference_zz, 1.0e-05,"Pressure accuracy zz component not achieved")
+    self.assertLess(total_pressure_difference_xy, 2.0e-06,"Pressure accuracy xy component not achieved")
+    self.assertLess(total_pressure_difference_yz, 1.0e-10,"Pressure accuracy yz component not achieved")
+    self.assertLess(total_pressure_difference_xz, 1.0e-10,"Pressure accuracy xz component not achieved")
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_eof_one_species_z.py
+++ b/testsuite/python/ek_eof_one_species_z.py
@@ -273,15 +273,14 @@ class ek_eof_one_species_x(ut.TestCase):
     print("Pressure deviation yz component: {}".format(total_pressure_difference_yz))
     print("Pressure deviation xz component: {}".format(total_pressure_difference_xz))
 
-    self.assertTrue(total_density_difference < 1.5e-06,"Density accuracy not achieved")
-    self.assertTrue(total_velocity_difference < 3.5e-07,"Velocity accuracy not achieved")
-    self.assertTrue(total_pressure_difference_xx < 2.5e-07,"Pressure accuracy xx component not achieved")
-    self.assertTrue(total_pressure_difference_yy < 2.5e-07,"Pressure accuracy yy component not achieved")
-    self.assertTrue(total_pressure_difference_zz < 4.0e-06,"Pressure accuracy zz component not achieved")
-    self.assertTrue(total_pressure_difference_xy < 1.0e-09,"Pressure accuracy xy component not achieved")
-    self.assertTrue(total_pressure_difference_yz < 2.0e-06,"Pressure accuracy yz component not achieved")
-    self.assertTrue(total_pressure_difference_xz < 1.5e-09,"Pressure accuracy xz component not achieved")
-
+    self.assertLess(total_density_difference, 1.5e-06,"Density accuracy not achieved")
+    self.assertLess(total_velocity_difference, 3.5e-07,"Velocity accuracy not achieved")
+    self.assertLess(total_pressure_difference_xx, 2.5e-07,"Pressure accuracy xx component not achieved")
+    self.assertLess(total_pressure_difference_yy, 2.5e-07,"Pressure accuracy yy component not achieved")
+    self.assertLess(total_pressure_difference_zz, 4.0e-06,"Pressure accuracy zz component not achieved")
+    self.assertLess(total_pressure_difference_xy, 1.0e-09,"Pressure accuracy xy component not achieved")
+    self.assertLess(total_pressure_difference_yz, 2.0e-06,"Pressure accuracy yz component not achieved")
+    self.assertLess(total_pressure_difference_xz, 1.5e-09,"Pressure accuracy xz component not achieved")
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_eof_one_species_z_nonlinear.py
+++ b/testsuite/python/ek_eof_one_species_z_nonlinear.py
@@ -23,8 +23,6 @@ import numpy as np
 import sys
 import math
 
-
-
 ################################################################################
 #                              Set up the System                               # 
 ################################################################################
@@ -274,14 +272,14 @@ class ek_eof_one_species_x(ut.TestCase):
     print("Pressure deviation yz component: {}".format(total_pressure_difference_yz))
     print("Pressure deviation xz component: {}".format(total_pressure_difference_xz))
 
-    self.assertTrue(total_density_difference < 1.5e-06,"Density accuracy not achieved")
-    self.assertTrue(total_velocity_difference < 4.0e-07,"Velocity accuracy not achieved")
-    self.assertTrue(total_pressure_difference_xx < 5.0e-06,"Pressure accuracy xx component not achieved")
-    self.assertTrue(total_pressure_difference_yy < 5.0e-06,"Pressure accuracy yy component not achieved")
-    self.assertTrue(total_pressure_difference_zz < 4.0e-06,"Pressure accuracy zz component not achieved")
-    self.assertTrue(total_pressure_difference_xy < 1.0e-10,"Pressure accuracy xy component not achieved")
-    self.assertTrue(total_pressure_difference_yz < 1.5e-06,"Pressure accuracy yz component not achieved")
-    self.assertTrue(total_pressure_difference_xz < 1.0e-10,"Pressure accuracy xz component not achieved")
+    self.assertLess(total_density_difference, 1.5e-06,"Density accuracy not achieved")
+    self.assertLess(total_velocity_difference, 4.0e-07,"Velocity accuracy not achieved")
+    self.assertLess(total_pressure_difference_xx, 5.0e-06,"Pressure accuracy xx component not achieved")
+    self.assertLess(total_pressure_difference_yy, 5.0e-06,"Pressure accuracy yy component not achieved")
+    self.assertLess(total_pressure_difference_zz, 4.0e-06,"Pressure accuracy zz component not achieved")
+    self.assertLess(total_pressure_difference_xy, 1.0e-10,"Pressure accuracy xy component not achieved")
+    self.assertLess(total_pressure_difference_yz, 1.5e-06,"Pressure accuracy yz component not achieved")
+    self.assertLess(total_pressure_difference_xz, 1.0e-10,"Pressure accuracy xz component not achieved")
 
 
 if __name__ == "__main__":

--- a/testsuite/python/engine_langevin.py
+++ b/testsuite/python/engine_langevin.py
@@ -45,8 +45,10 @@ class SwimmerTest(ut.TestCase):
         delta_pos_0 = np.linalg.norm(S.part[0].pos - pos_0)
         delta_pos_1 = np.linalg.norm(S.part[1].pos - pos_1)
 
-        self.assertTrue(1.4e-3 < delta_pos_0 and delta_pos_0 < 1.6e-3)
-        self.assertTrue(4.9e-4 < delta_pos_1 and delta_pos_1 < 5.1e-4)
+        self.assertLess(1.4e-3, delta_pos_0)
+        self.assertLess(delta_pos_0, 1.6e-3)
+        self.assertLess(4.9e-4, delta_pos_1)
+        self.assertLess(delta_pos_1, 5.1e-4)
 
 if __name__ == '__main__':
     print("Features: ", espressomd.features())

--- a/testsuite/python/exclusions.py
+++ b/testsuite/python/exclusions.py
@@ -39,11 +39,11 @@ class Exclusions(ut.TestCase):
 
         self.s.part[0].add_exclusion(1)
         self.s.part[0].add_exclusion(2)
-        self.assertTrue(self.s.part[0].exclusions == [1,2])
+        self.assertEqual(self.s.part[0].exclusions, [1,2])
         self.s.part[0].delete_exclusion(1)
-        self.assertTrue(self.s.part[0].exclusions == [2])
+        self.assertEqual(self.s.part[0].exclusions, [2])
         self.s.part[0].delete_exclusion(2)
-        self.assertTrue(self.s.part[0].exclusions == [])
+        self.assertEqual(self.s.part[0].exclusions, [])
 
     def test_transfer(self):
         self.s.part.add(id=0,pos=[0,0,0],v=[1.,1.,1])
@@ -55,7 +55,7 @@ class Exclusions(ut.TestCase):
 
         for i in range(15):
             self.s.integrator.run(100)
-            self.assertTrue(self.s.part[0].exclusions==[1,2,3])
+            self.assertEqual(self.s.part[0].exclusions,[1,2,3])
 
     @ut.skipIf(not espressomd.has_features(['LENNARD_JONES']), "Skipping test")
     def test_particle_property(self):
@@ -67,7 +67,7 @@ class Exclusions(ut.TestCase):
         self.s.part.add(id=1,pos=[1,0,0],type=0)
 
         pair_energy = self.s.analysis.energy()['total']
-        self.assertTrue(pair_energy > 0.)
+        self.assertGreater(pair_energy,0.)
 
         self.s.part.add(id=2,pos=[2,0,0],type=0)
         self.assertAlmostEqual(self.s.analysis.energy()['total'], 2*pair_energy)

--- a/testsuite/python/icc.py
+++ b/testsuite/python/icc.py
@@ -69,7 +69,7 @@ class test_icc(ut.TestCase):
         induced_dipole = 0.5*(abs(QL)+abs(QR))*box_l
 
         #Result
-        assert ( abs(1-induced_dipole/testcharge_dipole) < 1e-4 )
+        self.assertAlmostEqual(1,induced_dipole/testcharge_dipole,places=4)
 
 if __name__ == "__main__":
     print("Features: ", espressomd.features())

--- a/testsuite/python/layered.py
+++ b/testsuite/python/layered.py
@@ -46,12 +46,12 @@ class Layered(ut.TestCase):
         part_dist = self.S.cell_system.resort()
 
         # Check that we did not lose particles
-        self.assertTrue(sum(part_dist) == n_part)
+        self.assertEqual(sum(part_dist), n_part)
 
         # Check that we can still access all the particles
         # This basically checks if part_node and local_particles
         # is still in a valid state after the particle exchange
-        self.assertTrue(sum(self.S.part[:].type) == n_part)
+        self.assertEqual(sum(self.S.part[:].type), n_part)
 
 if __name__ == "__main__":
     print("Features: ", espressomd.features())

--- a/testsuite/python/lb_stokes_sphere_gpu.py
+++ b/testsuite/python/lb_stokes_sphere_gpu.py
@@ -81,7 +81,7 @@ class Stokes(ut.TestCase):
         print("Measured force: f=%f" %size(force))
         stokes_force = 6*np.pi*kinematic_visc*radius*size(v)
         print("Stokes' Law says: f=%f" %stokes_force)
-        self.assertTrue(abs(1.0 - size(force)/stokes_force) <0.06)
+        self.assertLess(abs(1.0 - size(force)/stokes_force), 0.06)
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/mass-and-rinertia_per_particle.py
+++ b/testsuite/python/mass-and-rinertia_per_particle.py
@@ -86,11 +86,11 @@ class ThermoTest(ut.TestCase):
         tol = 1.25E-4
         for i in range(100):
             for k in range(3):
-                self.assertTrue(abs(self.es.part[0].v[k] - math.exp( - gamma[0] * self.es.time / mass)) <= tol and \
-                                abs(self.es.part[1].v[k] - math.exp( - gamma[1] * self.es.time / mass)) <= tol)
+                self.assertLess(abs(self.es.part[0].v[k] - math.exp( - gamma[0] * self.es.time / mass)), tol)
+                self.assertLess(abs(self.es.part[1].v[k] - math.exp( - gamma[1] * self.es.time / mass)), tol)
                 if "ROTATION" in espressomd.features():
-                    self.assertTrue(abs(self.es.part[0].omega_body[k] - math.exp( - gamma[0] * self.es.time / J[k])) <= tol and \
-                                    abs(self.es.part[1].omega_body[k] - math.exp( - gamma[1] * self.es.time / J[k])) <= tol)
+                    self.assertLess(abs(self.es.part[0].omega_body[k] - math.exp( - gamma[0] * self.es.time / J[k])), tol)
+                    self.assertLess(abs(self.es.part[1].omega_body[k] - math.exp( - gamma[1] * self.es.time / J[k])), tol)
             self.es.integrator.run(10)
 
         for i in range(len(self.es.part)):
@@ -255,13 +255,13 @@ class ThermoTest(ut.TestCase):
                 print("Deviation in rotational energy per degrees of freedom: {0} {1} {2}".format(do_vec[k,0], do_vec[k,1], do_vec[k,2]))
             print("Deviation in translational diffusion: {0} ".format(dr_norm[k]))
             
-            self.assertTrue(abs(dv[k]) <= tolerance, msg = 'Relative deviation in translational energy too large: {0}'.format(dv[k]))
+            self.assertLessEqual(abs(dv[k]), tolerance, msg = 'Relative deviation in translational energy too large: {0}'.format(dv[k]))
             if "ROTATION" in espressomd.features():
-                self.assertTrue(abs(do[k]) <= tolerance, msg = 'Relative deviation in rotational energy too large: {0}'.format(do[k]))
-                self.assertTrue(abs(do_vec[k,0]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis X is too large: {0}'.format(do_vec[k,0]))
-                self.assertTrue(abs(do_vec[k,1]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis Y is too large: {0}'.format(do_vec[k,1]))
-                self.assertTrue(abs(do_vec[k,2]) <= tolerance, msg = 'Relative deviation in rotational energy per the body axis Z is too large: {0}'.format(do_vec[k,2]))
-            self.assertTrue(abs(dr_norm[k]) <= tolerance, msg = 'Relative deviation in translational diffusion is too large: {0}'.format(dr_norm[k]))
+                self.assertLessEqual(abs(do[k]), tolerance, msg = 'Relative deviation in rotational energy too large: {0}'.format(do[k]))
+                self.assertLessEqual(abs(do_vec[k,0]), tolerance, msg = 'Relative deviation in rotational energy per the body axis X is too large: {0}'.format(do_vec[k,0]))
+                self.assertLessEqual(abs(do_vec[k,1]), tolerance, msg = 'Relative deviation in rotational energy per the body axis Y is too large: {0}'.format(do_vec[k,1]))
+                self.assertLessEqual(abs(do_vec[k,2]), tolerance, msg = 'Relative deviation in rotational energy per the body axis Z is too large: {0}'.format(do_vec[k,2]))
+            self.assertLessEqual(abs(dr_norm[k]), tolerance, msg = 'Relative deviation in translational diffusion is too large: {0}'.format(dr_norm[k]))
 
     def test(self):
         for i in range(4):

--- a/testsuite/python/minimize_energy.py
+++ b/testsuite/python/minimize_energy.py
@@ -44,11 +44,8 @@ class test_minimize_energy(ut.TestCase):
 
         energy = self.system.analysis.energy() 
 
-        assert( energy["total"] == 0 )
+        self.assertEqual(energy["total"], 0)
 
 if __name__ == "__main__":
     print("Features: ", espressomd.features())
     ut.main()
-
-
-

--- a/testsuite/python/nonBondedInteractions.py
+++ b/testsuite/python/nonBondedInteractions.py
@@ -24,7 +24,6 @@ import numpy as np
 from espressomd.interactions import *
 
 
-
 class Non_bonded_interactionsTests(ut.TestCase):
     #  def __init__(self,particleId):
     #    self.pid=particleId

--- a/testsuite/python/nsquare.py
+++ b/testsuite/python/nsquare.py
@@ -41,16 +41,16 @@ class NSquare(ut.TestCase):
         part_dist = self.S.cell_system.resort()
 
         # Check that we did not lose particles
-        self.assertTrue(sum(part_dist) == n_part)
+        self.assertEqual(sum(part_dist), n_part)
 
         # Check that the parts are evenly distributed
         for node_parts in part_dist:
-            self.assertTrue(abs(node_parts - n_part_avg) < 2)
+            self.assertLess(abs(node_parts - n_part_avg),2)
 
         # Check that we can still access all the particles
         # This basically checks if part_node and local_particles
         # is still in a valid state after the particle exchange
-        self.assertTrue(sum(self.S.part[:].type) == n_part)
+        self.assertEqual(sum(self.S.part[:].type), n_part)
 
 if __name__ == "__main__":
     print("Features: ", espressomd.features())

--- a/testsuite/python/observables.py
+++ b/testsuite/python/observables.py
@@ -28,7 +28,6 @@ from espressomd.observables import *
 
 class Observables(ut.TestCase):
 
-
     # Error tolerance when comparing arrays/tuples...
     tol = 1E-9
 
@@ -63,8 +62,6 @@ class Observables(ut.TestCase):
                 self.es.part[i].dip=random(3)
               if espressomd.has_features(["ROTATION"]):
                 self.es.part[i].omega_lab=random(3)
-
-
 
 
     def generate_test_for_pid_observable(_obs_name,_pprop_name,_agg_type=None):
@@ -106,8 +103,6 @@ class Observables(ut.TestCase):
     
     if espressomd.has_features(["DIPOLES"]):
         test_mag_dip = generate_test_for_pid_observable(MagneticDipoleMoment,"dip","sum")
-        
-
 
 
     # This is disabled as it does not currently work
@@ -141,8 +136,6 @@ class Observables(ut.TestCase):
             com_vel=sum((self.es.part[:].v.T).T,0)/len(self.es.part)
         obs_data=ComVelocity(ids=range(1000)).calculate()
         self.assertTrue(self.arraysNearlyEqual(com_vel,obs_data),"Center of mass velocity observable wrong value")
-
-
 
 
 if __name__ == "__main__":

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -97,8 +97,8 @@ class ParticleProperties(ut.TestCase):
             # It will use the state of the variables in the outer function,
             # which was there, when the outer function was called
             setattr(self.es.part[self.pid], propName, value)
-            self.assertTrue(getattr(self.es.part[
-                            self.pid], propName) == value, propName + ": value set and value gotten back differ.")
+            self.assertEqual(getattr(self.es.part[
+                            self.pid], propName), value, propName + ": value set and value gotten back differ.")
 
         return func
 
@@ -155,8 +155,9 @@ class ParticleProperties(ut.TestCase):
             self.es.part.add(id=1, pos=(0, 0, 0))
             self.es.part[1].vs_relative = (0, 5.0, (0.5, -0.5, -0.5, -0.5))
             res = self.es.part[1].vs_relative
-            self.assertTrue(res[0] == 0 and res[1] == 5.0 and
-                            self.arraysNearlyEqual(res[2], np.array((0.5, -0.5, -0.5, -0.5))), "vs_relative: " + res.__str__())
+            self.assertEqual(res[0], 0, "vs_relative: " + res.__str__())
+            self.assertEqual(res[1], 5.0, "vs_relative: " + res.__str__())
+            self.assertTrue(self.arraysNearlyEqual(res[2], np.array((0.5, -0.5, -0.5, -0.5))), "vs_relative: " + res.__str__())
 
 
 if __name__ == "__main__":

--- a/testsuite/python/reaction_ensemble.py
+++ b/testsuite/python/reaction_ensemble.py
@@ -97,24 +97,24 @@ class ReactionEnsembleTest(ut.TestCase):
         K_apparent_HA_diss=K_HA_diss*standard_pressure_in_simulation_units/temperature
         pK_a=-np.log10(K_apparent_HA_diss)
         real_error_in_degree_of_association=abs(average_degree_of_association-ReactionEnsembleTest.ideal_degree_of_association(pK_a,pH))/ReactionEnsembleTest.ideal_degree_of_association(pK_a,pH)
-        self.assertTrue(real_error_in_degree_of_association<0.07, msg="Deviation to ideal titration curve for the given input parameters too large.")
+        self.assertLess(real_error_in_degree_of_association, 0.07, msg="Deviation to ideal titration curve for the given input parameters too large.")
     
     def test_reaction_system(self):
         RE_status=ReactionEnsembleTest.RE.get_status()
         forward_reaction=RE_status["reactions"][0]
         for i in range(len(forward_reaction["reactant_types"])):
-            self.assertTrue(ReactionEnsembleTest.reactant_types[i] == forward_reaction["reactant_types"][i], msg="reactant type not set correctly.")
+            self.assertEqual(ReactionEnsembleTest.reactant_types[i], forward_reaction["reactant_types"][i], msg="reactant type not set correctly.")
         for i in range(len(forward_reaction["reactant_coefficients"])):
-            self.assertTrue(ReactionEnsembleTest.reactant_coefficients[i] == forward_reaction["reactant_coefficients"][i], msg="reactant coefficients not set correctly.")
+            self.assertEqual(ReactionEnsembleTest.reactant_coefficients[i], forward_reaction["reactant_coefficients"][i], msg="reactant coefficients not set correctly.")
         for i in range(len(forward_reaction["product_types"])):
-            self.assertTrue(ReactionEnsembleTest.product_types[i] == forward_reaction["product_types"][i], msg="product type not set correctly.")
+            self.assertEqual(ReactionEnsembleTest.product_types[i], forward_reaction["product_types"][i], msg="product type not set correctly.")
         for i in range(len(forward_reaction["product_coefficients"])):
-            self.assertTrue(ReactionEnsembleTest.product_coefficients[i] == forward_reaction["product_coefficients"][i], msg="product coefficients not set correctly.")
+            self.assertEqual(ReactionEnsembleTest.product_coefficients[i], forward_reaction["product_coefficients"][i], msg="product coefficients not set correctly.")
         
-        self.assertTrue(abs(ReactionEnsembleTest.temperature-RE_status["temperature"])<1E-9, msg="reaction ensemble temperature not set correctly.")
-        self.assertTrue(abs(ReactionEnsembleTest.exclusion_radius-RE_status["exclusion_radius"])<1E-9, msg="reaction ensemble temperature not set correctly.")
+        self.assertAlmostEqual(ReactionEnsembleTest.temperature,RE_status["temperature"],places=9,msg="reaction ensemble temperature not set correctly.")
+        self.assertAlmostEqual(ReactionEnsembleTest.exclusion_radius,RE_status["exclusion_radius"],places=9,msg="reaction ensemble temperature not set correctly.")
         
-        self.assertTrue(abs(ReactionEnsembleTest.volume-ReactionEnsembleTest.RE.get_volume())<1E-9, msg="reaction ensemble temperature not set correctly.")
+        self.assertAlmostEqual(ReactionEnsembleTest.volume,ReactionEnsembleTest.RE.get_volume(),places=9,msg="reaction ensemble temperature not set correctly.")
 
     
 if __name__ == "__main__":

--- a/testsuite/python/rigid_bond.py
+++ b/testsuite/python/rigid_bond.py
@@ -27,8 +27,6 @@ from espressomd.interactions import RigidBond
 @ut.skipIf(not espressomd.has_features("BOND_CONSTRAINT"),"Test requires BOND_CONSTRAINT feature")
 class RigidBondTest(ut.TestCase):
 
-
-
     def test(self):
         target_acc=1E-3
         tol=1.2*target_acc
@@ -52,9 +50,6 @@ class RigidBondTest(ut.TestCase):
             # Velocity projection on distance vector
             vel_proj=np.dot(s.part[i].v-s.part[i-1].v,v_d)/d
             self.assertLess(vel_proj,tol)
-
-
-
 
 
 if __name__ == "__main__":

--- a/testsuite/python/rotational_inertia.py
+++ b/testsuite/python/rotational_inertia.py
@@ -65,9 +65,9 @@ class RotationalInertia(ut.TestCase):
             L_body = self.L_body(0)
             L_lab = self.convert_vec_body_to_space(0, L_body)
             for k in range(3):
-                self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                self.assertLessEqual(abs(L_lab[k] - L_0_lab[k]), tol, \
                                 msg = 'Inertial motion around stable axis J1: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
-            self.assertTrue(abs(self.es.part[0].omega_body[1] - stable_omega) <= tol, \
+            self.assertLessEqual(abs(self.es.part[0].omega_body[1] - stable_omega), tol, \
                             msg = 'Inertial motion around stable axis J1: Deviation in omega is too large. Step {0}, coordinate 1, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[1]))
             self.es.integrator.run(10)
 
@@ -86,9 +86,9 @@ class RotationalInertia(ut.TestCase):
             L_body = self.L_body(0)
             L_lab = self.convert_vec_body_to_space(0, L_body)
             for k in range(3):
-                self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                self.assertLessEqual(abs(L_lab[k] - L_0_lab[k]), tol, \
                                 msg = 'Inertial motion around stable axis J2: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
-            self.assertTrue(abs(self.es.part[0].omega_body[2] - stable_omega) <= tol, \
+            self.assertLessEqual(abs(self.es.part[0].omega_body[2] - stable_omega), tol, \
                                 msg = 'Inertial motion around stable axis J2: Deviation in omega is too large. Step {0}, coordinate 2, expected {1}, got {2}'.format(i, stable_omega, self.es.part[0].omega_body[2]))
             self.es.integrator.run(10)
 
@@ -107,7 +107,7 @@ class RotationalInertia(ut.TestCase):
             L_body = self.L_body(0)
             L_lab = self.convert_vec_body_to_space(0, L_body)
             for k in range(3):
-                self.assertTrue(abs(L_lab[k] - L_0_lab[k]) <= tol, \
+                self.assertLessEqual(abs(L_lab[k] - L_0_lab[k]), tol, \
                                 msg = 'Inertial motion around stable axis J0: Deviation in angular momentum is too large. Step {0}, coordinate {1}, expected {2}, got {3}'.format(i, k, L_0_lab[k], L_lab[k]))
             self.es.integrator.run(10)
 

--- a/testsuite/python/scafacos_dipoles_1d_2d.py
+++ b/testsuite/python/scafacos_dipoles_1d_2d.py
@@ -1,33 +1,31 @@
 # Copyright (C) 2010,2011,2012,2013,2014,2015,2016 The ESPResSo project
 
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.   
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # This tests the scafacos p2nfft dipolar calculations by matching against
 # reference data from direct summation. In 2d, reference data from the mdlc
 # test case is used
 
-
-
 from __future__ import print_function
 import os
 import numpy as np
 import unittest as ut
-import espressomd 
+import espressomd
 import espressomd.magnetostatics as magnetostatics
 import tests_common
 
@@ -37,19 +35,19 @@ class Scafacos1d2d(ut.TestCase):
 
     def test_scafacos(self):
         rho =0.3
-        
+
         # This is only for box size calculation. The actual particle numbwe is
         # lower, because particles are removed from the mdlc gap region
         n_particle =100
-        
+
         particle_radius= 0.5
         dipole_lambda= 3.0
-        
+
         #################################################
-        
+
         box_l = pow(((4 * n_particle * 3.141592654) / (3*rho)), 1.0/3.0)*particle_radius
         skin =0.5
-        
+
         s=espressomd.System()
         # give Espresso some parameters
         s.time_step= 0.01
@@ -57,7 +55,7 @@ class Scafacos1d2d(ut.TestCase):
         s.box_l =box_l, box_l, box_l
         for dim in 2,1:
             print("Dimension",dim)
-        
+
             # Read reference data
             if dim == 2:
               file_prefix ="mdlc"
@@ -65,17 +63,17 @@ class Scafacos1d2d(ut.TestCase):
             else:
               s.periodicity =1,0,0
               file_prefix ="scafacos_dipoles_1d"
-              
+
             f = open(tests_common.abspath(file_prefix + "_reference_data_energy.dat"))
             ref_E =float(f.readline())
             f.close()
-            
-            
+
+
             # Particles
             data = np.genfromtxt(tests_common.abspath(file_prefix + "_reference_data_forces_torques.dat"))
             for p in data[:,:]:
                 s.part.add(id=int(p[0]),pos=p[1:4],dip=p[4:7])
-            
+
             if dim == 2:
                 scafacos = magnetostatics.Scafacos(bjerrum_length=1,method_name="p2nfft", method_params={"p2nfft_verbose_tuning":0,"pnfft_N":"80,80,160","pnfft_window_name":"bspline", "pnfft_m":"4","p2nfft_ignore_tolerance":"1","pnfft_diff_ik":"0","p2nfft_r_cut":"6","p2nfft_alpha":"0.8","p2nfft_epsB":"0.05"})
                 s.actors.add(scafacos)
@@ -92,36 +90,29 @@ class Scafacos1d2d(ut.TestCase):
                 else: raise Exception("This shouldn't happen.")
             s.thermostat.turn_off()
             s.integrator.run(0)
-        
-        
+
+
             # Calculate errors
-        
-        
-              
-        
+
             err_f=np.sum(np.sqrt(np.sum((s.part[:].f-data[:,7:10])**2,1)),0)/np.sqrt(data.shape[0])
             err_t=np.sum(np.sqrt(np.sum((s.part[:].torque_lab-data[:,10:13])**2,1)),0)/np.sqrt(data.shape[0])
             err_e=s.analysis.energy()["dipolar"]-ref_E
             print("Energy difference",err_e)
             print("Force difference",err_f)
             print("Torque difference",err_t)
-        
-        
-            
-            
-            
+
             tol_f=2E-3
             tol_t=2E-3
             tol_e=1E-3
 
-            self.assertTrue(abs(err_e)<=tol_e,"Energy difference too large")
-            self.assertTrue(abs(err_t)<=tol_t,"Torque difference too large")
-            self.assertTrue(abs(err_f)<=tol_f,"Force difference too large")
-        
+            self.assertLessEqual(abs(err_e),tol_e,"Energy difference too large")
+            self.assertLessEqual(abs(err_t),tol_t,"Torque difference too large")
+            self.assertLessEqual(abs(err_f),tol_f,"Force difference too large")
+
             s.part.clear()
             del s.actors[0]
-        
-        
+
+
 if __name__ == "__main__":
     #print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/python/script_interface_object_params.py
+++ b/testsuite/python/script_interface_object_params.py
@@ -18,16 +18,14 @@ class ScriptInterfaceObjectParams(ut.TestCase):
         # Does the shape parameter return the correct lcass
         self.assertEqual(c.shape.__class__,Wall)
         # Do the sciprt object match
-        self.assertTrue(c.shape==w)
+        self.assertEqual(c.shape,w)
         
         # Different shape
         c.shape=Sphere(radius=1)
         # Test class
-        self.assertTrue(c.shape.__class__==Sphere)
+        self.assertEqual(c.shape.__class__,Sphere)
         # Test parameter retrieval
-        self.assertTrue(abs(c.shape.radius-1)<=1E-8)
-
-
+        self.assertAlmostEqual(c.shape.radius,1,places=8)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/tabulated.py
+++ b/testsuite/python/tabulated.py
@@ -658,8 +658,8 @@ class Tabulated(ut.TestCase):
         totenergy = Analysis(self.system).energy()["total"]
         totpressure = Analysis(self.system).pressure()["total"]
 
-        self.assertTrue(np.abs(energy -totenergy)/totenergy < self.epsilon, "Failed. Energy difference too large") 
-        self.assertTrue(np.abs(pressure - totpressure)/totpressure < self.epsilon, "Failed. Pressure difference too large")
+        self.assertLess(np.abs(energy -totenergy)/totenergy, self.epsilon, "Failed. Energy difference too large") 
+        self.assertLess(np.abs(pressure - totpressure)/totpressure, self.epsilon, "Failed. Pressure difference too large")
 
     
     def test_tab(self):

--- a/testsuite/python/variant_conversion.py
+++ b/testsuite/python/variant_conversion.py
@@ -12,28 +12,28 @@ class test_variant_conversion(ut.TestCase):
     vt = script_interface.PScriptInterface("Testing::VariantTester")
 
     def check_type_and_value(self, stype, svalue, value):
-        assert(type(value) == stype)
-        assert(value == svalue)
+        self.assertEqual(type(value), stype)
+        self.assertEqual(value, svalue)
 
     def test_bool_return(self):
         """Check that bool return values work corrcetly,
         because they are needed for the other tests."""
-        assert(self.vt.call_method("true") == True)
-        assert(self.vt.call_method("false") == False)
+        self.assertTrue(self.vt.call_method("true"))
+        self.assertFalse(self.vt.call_method("false"))
 
     def test_flat(self):
         ret = self.vt.call_method("flat")
-        assert(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list))
         self.check_type_and_value(bool, True, ret[0])
         self.check_type_and_value(str, 'a string', ret[1])
         self.check_type_and_value(float, 3.14159, ret[2])
         self.check_type_and_value(list, [3,1,4,1,5], ret[3])
         self.check_type_and_value(list, [1.1,2.2,3.3], ret[4])
         # Empty object (ObjectId()) should map to None
-        assert(ret[5] == None)
+        self.assertEqual(ret[5], None)
         # An actual object
-        assert(isinstance(ret[6], script_interface.PScriptInterface))
-        assert(ret[6].name() == "Testing::VariantTester")
+        self.assertTrue(isinstance(ret[6], script_interface.PScriptInterface))
+        self.assertEqual(ret[6].name(), "Testing::VariantTester")
 
     def test_recu(self):
         ret = self.vt.call_method("recursive", max_level=5)
@@ -46,14 +46,14 @@ class test_variant_conversion(ut.TestCase):
         self.check_type_and_value(str, 'end', ret[2][1][1][1][1][1])
 
     def test_parameter_types(self):
-        assert(self.vt.call_method("check_parameter_type", type="bool", value=True))
-        assert(self.vt.call_method("check_parameter_type", type="int", value=42))
-        assert(self.vt.call_method("check_parameter_type", type="string", value='blub'))
-        assert(self.vt.call_method("check_parameter_type", type="double", value=12.5))
-        assert(self.vt.call_method("check_parameter_type", type="objectid", value=self.vt))
-        assert(self.vt.call_method("check_parameter_type", type="double_vector", value=[1.1, 2.2, 3.3]))
-        assert(self.vt.call_method("check_parameter_type", type="int_vector", value=[1,2,3]))
-        assert(self.vt.call_method("check_parameter_type", type="vector", value=[1,'string',True]))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="bool", value=True))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="int", value=42))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="string", value='blub'))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="double", value=12.5))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="objectid", value=self.vt))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="double_vector", value=[1.1, 2.2, 3.3]))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="int_vector", value=[1,2,3]))
+        self.assertTrue(self.vt.call_method("check_parameter_type", type="vector", value=[1,'string',True]))
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/virtual_sites_relative.py
+++ b/testsuite/python/virtual_sites_relative.py
@@ -45,7 +45,7 @@ class VirtualSites(ut.TestCase):
     
     def verify_vs(self,vs):
         """Verify vs position and (if compiled in) velocity."""
-        self.assertTrue(vs.virtual==1)
+        self.assertEqual(vs.virtual,1)
 
         vs_r=vs.vs_relative
 
@@ -56,16 +56,16 @@ class VirtualSites(ut.TestCase):
         d=self.s.distance(rel,vs)
         v_d=self.s.distance_vec(rel,vs)
         # Check distance
-        self.assertTrue(abs(d-vs_r[1])<1E-6)
+        self.assertAlmostEqual(d,vs_r[1],places=6)
 
         # check velocity
         if not espressomd.has_features("VIRTUAL_SITES_NO_VELOCITY"):
-            self.assertTrue(np.linalg.norm(vs.v -rel.v -np.cross(rel.omega_lab,v_d))<=1E-6)
+            self.assertLessEqual(np.linalg.norm(vs.v -rel.v -np.cross(rel.omega_lab,v_d)),1E-6)
 
         # Check position
-        self.assertTrue(np.linalg.norm(
+        self.assertLess(np.linalg.norm(
           v_d -vs_r[1]*self.director_from_quaternion(
-          self.multiply_quaternions(rel.quat,vs_r[2])))<1E-6)
+          self.multiply_quaternions(rel.quat,vs_r[2]))),1E-6)
 
     def test_pos_vel_forces(self):
         s=self.s
@@ -78,7 +78,7 @@ class VirtualSites(ut.TestCase):
 
         # Check setting of min_global_cut
         s.min_global_cut=0.23
-        self.assertEquals(s.min_global_cut,0.23)
+        self.assertEqual(s.min_global_cut,0.23)
 
         # Place central particle + 3 vs
         s.part.add(pos=(0.5,0.5,0.5),id=1,quat=(1,0,0,0),omega_lab=(1,2,3))
@@ -96,7 +96,7 @@ class VirtualSites(ut.TestCase):
             # id
             self.assertEqual(vs_r[0],1)
             #distance
-            self.assertTrue(abs(vs_r[1]-s.distance(s.part[1],s.part[cur_id]))<=1E-6)
+            self.assertAlmostEqual(vs_r[1], s.distance(s.part[1],s.part[cur_id]), places=6)
             cur_id+=1
 
         # Move central particle and Check vs placement
@@ -129,14 +129,14 @@ class VirtualSites(ut.TestCase):
     
     
         # Expected force = sum of the forces on the vs
-        self.assertTrue(np.linalg.norm(f-f2-f3)<1E-6)
+        self.assertLess(np.linalg.norm(f-f2-f3),1E-6)
     
         # Expected torque
         # Radial components of forces on a rigid body add to the torque
         t_exp=np.cross(s.distance_vec(s.part[1],s.part[2]),f2)
         t_exp+=np.cross(s.distance_vec(s.part[1],s.part[3]),f3)
         # Check
-        self.assertTrue(np.linalg.norm(t_exp-t)<=1E-6)
+        self.assertLessEqual(np.linalg.norm(t_exp-t),1E-6)
     
     def run_test_lj(self):
         """This fills the system with vs-based dumbells, adds a lj potential


### PR DESCRIPTION
It occurred to me that a lot of testcases were using the `assertTrue` function for comparisons, like
```python
self.assertTrue(a == b)
```
This of course works but in case of failure this only produces the absolutely meaningless error message
```
AssertionError: False is not true
```
without telling you what the values to be compared actually were.  This makes debugging kind of tedious and especially you cannot quickly compare the values you got locally to what, e.g., Travis CI got.

Therefore I went over all the testcases and revised many of the assertions for easier understanding.  For more info on available assertions, please see the [`unittest.TestCase` documentation](https://docs.python.org/3.6/library/unittest.html#test-cases).