### PR TITLE
Fix SpheroCylinder.

### DIFF
--- a/src/core/shapes/Cylinder.cpp
+++ b/src/core/shapes/Cylinder.cpp
@@ -53,10 +53,10 @@ int Cylinder::calculate_dist(const double *ppos, double *dist,
   d_par = fabs(d_par);
 
   if (m_direction == -1) {
-    /*apply force towards inside cylinder */
+    /* apply force towards inside cylinder */
     d_per = m_rad - d_per;
     d_par = half_length - d_par;
-    if (d_per < d_par) {
+    if (d_per < d_par or m_open) {
       *dist = d_per;
       for (int i = 0; i < 3; i++) {
         vec[i] = -d_per_vec[i] * d_per / (m_rad - d_per);
@@ -68,7 +68,7 @@ int Cylinder::calculate_dist(const double *ppos, double *dist,
       }
     }
   } else {
-    /*apply force towards outside cylinder */
+    /* apply force towards outside cylinder */
     d_per = d_per - m_rad;
     d_par = d_par - half_length;
     if (d_par < 0) {

--- a/src/core/shapes/Cylinder.hpp
+++ b/src/core/shapes/Cylinder.hpp
@@ -30,7 +30,7 @@ class Cylinder : public Shape {
 public:
   Cylinder()
       : m_pos({0.0, 0.0, 0.0}), m_axis({0.0, 0.0, 0.0}), m_length(0.0),
-        m_direction(1.0), m_rad(0) {}
+        m_direction(1.0), m_rad(0), m_open(false) {}
   int calculate_dist(const double *ppos, double *dist,
                      double *vec) const override;
 
@@ -44,14 +44,16 @@ public:
 protected:
   /** center of the cylinder. */
   Vector3d m_pos;
-  /** Axis of the cylinder .*/
+  /** Axis of the cylinder. */
   Vector3d m_axis;
   /** cylinder radius. */
   double m_rad;
   /** cylinder length. */
   double m_length;
-  /** cylinder direction. (+1 outside -1 inside interaction direction)*/
+  /** cylinder direction. (+1 outside -1 inside interaction direction) */
   double m_direction;
+  /** ignore bottom and top cap of cylinder */
+  bool m_open;
 };
 };
 

--- a/src/core/shapes/SpheroCylinder.cpp
+++ b/src/core/shapes/SpheroCylinder.cpp
@@ -37,11 +37,11 @@ int SpheroCylinder::calculate_dist(const double *ppos, double *dist,
     d += ppos_local[i] * m_axis[i];
   }
 
-  if (abs(d) >= m_length) {
+  if (abs(d) >= 0.5*m_length) {
     *dist = 0.0;
 
     for (i = 0; i < 3; i++) {
-      vec[i] = ppos_local[i] - m_length * m_axis[i] * Utils::sgn<double>(d);
+      vec[i] = ppos_local[i] - 0.5*m_length * m_axis[i] * Utils::sgn<double>(d);
       *dist += vec[i] * vec[i];
     }
 

--- a/src/core/shapes/SpheroCylinder.hpp
+++ b/src/core/shapes/SpheroCylinder.hpp
@@ -28,7 +28,7 @@
 namespace Shapes {
 class SpheroCylinder : public Cylinder {
 public:
-  SpheroCylinder() : Cylinder(){};
+  SpheroCylinder() : Cylinder() { m_open = true; };
   int calculate_dist(const double *ppos, double *dist,
                      double *vec) const override;
 };

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -191,7 +191,7 @@ class SpheroCylinder(ScriptInterfaceHelper):
        Radius of the cylinder.
 
     length : float
-      Length of the cylinder.
+      Length of the cylinder (not including the caps).
     """
     _so_name = "Shapes::SpheroCylinder"
 

--- a/src/python/espressomd/visualizationOpenGL.pyx
+++ b/src/python/espressomd/visualizationOpenGL.pyx
@@ -926,7 +926,6 @@ def drawCylinder(posA, posB, radius, color, material, quality, draw_caps = False
 def drawSpheroCylinder(posA, posB, radius, color, material, quality):
     setSolidMaterial(color[0], color[1], color[2], color[3], material[0], material[1], material[2])
     glPushMatrix()
-    print("drawing with {}, {}, {}".format(posA, posB, radius))
     quadric = gluNewQuadric()
 
     d = posB - posA

--- a/src/python/espressomd/visualizationOpenGL.pyx
+++ b/src/python/espressomd/visualizationOpenGL.pyx
@@ -231,7 +231,7 @@ class openGLLive(object):
         for s in coll_shape_obj['Shapes::Cylinder']:
             pos = np.array(s[0].get_parameter('center'))
             a = np.array(s[0].get_parameter('axis'))
-            l = 2.0*s[0].get_parameter('length')
+            l = s[0].get_parameter('length')
             r = s[0].get_parameter('radius')
             self.shapes['Shapes::Cylinder'].append([pos - a*l*0.5, pos + a*l*0.5, r, s[1]])
 

--- a/src/python/espressomd/visualizationOpenGL.pyx
+++ b/src/python/espressomd/visualizationOpenGL.pyx
@@ -216,7 +216,7 @@ class openGLLive(object):
             t = c.get_parameter('particle_type')
             s = c.get_parameter('shape')
             n = s.name()
-            if n in ['Shapes::Wall','Shapes::Cylinder','Shapes::Sphere']:
+            if n in ['Shapes::Wall','Shapes::Cylinder','Shapes::Sphere','Shapes::SpheroCylinder']:
                 coll_shape_obj[n].append([s,t])
             else:
                 coll_shape_obj['Shapes::Misc'].append([s,t])
@@ -239,6 +239,13 @@ class openGLLive(object):
             pos = np.array(s[0].get_parameter('center'))
             r = s[0].get_parameter('radius')
             self.shapes['Shapes::Sphere'].append([pos, r, s[1]])
+
+        for s in coll_shape_obj['Shapes::SpheroCylinder']:
+            pos = np.array(s[0].get_parameter('center'))
+            a = np.array(s[0].get_parameter('axis'))
+            l = s[0].get_parameter('length')
+            r = s[0].get_parameter('radius')
+            self.shapes['Shapes::SpheroCylinder'].append([pos - a*l*0.5, pos + a*l*0.5, r, s[1]])
 
         for s in coll_shape_obj['Shapes::Misc']:
             self.shapes['Shapes::Misc'].append([self.rasterizeBruteForce(s[0]), s[1]])
@@ -315,6 +322,9 @@ class openGLLive(object):
 
         for s in self.shapes['Shapes::Sphere']:
             drawSphere(s[0], s[1], self.modulo_indexing(self.specs['constraint_type_colors'],s[2]), self.modulo_indexing(self.specs['constraint_type_materials'],s[2]), self.specs['quality_constraints'])
+
+        for s in self.shapes['Shapes::SpheroCylinder']:
+            drawSpheroCylinder(s[0],s[1],s[2], self.modulo_indexing(self.specs['constraint_type_colors'],s[3]), self.modulo_indexing(self.specs['constraint_type_materials'],s[3]), self.specs['quality_constraints'])
 
         for i in range(6):
             glDisable(GL_CLIP_PLANE0+i)
@@ -910,6 +920,46 @@ def drawCylinder(posA, posB, radius, color, material, quality, draw_caps = False
 #glTranslatef(d[0], d[1], d[2])
         glTranslatef(0,0,v)
         gluDisk(quadric, 0, radius, quality, quality) 
+
+    glPopMatrix()
+
+def drawSpheroCylinder(posA, posB, radius, color, material, quality):
+    setSolidMaterial(color[0], color[1], color[2], color[3], material[0], material[1], material[2])
+    glPushMatrix()
+    print("drawing with {}, {}, {}".format(posA, posB, radius))
+    quadric = gluNewQuadric()
+
+    d = posB - posA
+    if d[2] == 0.0:
+        d[2]=0.0001
+
+    v = np.linalg.norm(d)
+    if v == 0:
+        ax = 57.2957795
+    else:
+        ax = 57.2957795 * acos(d[2] / v)
+
+    if d[2] < 0.0:
+        ax = -ax
+    rx = -d[1] * d[2]
+    ry = d[0] * d[2]
+    length = np.linalg.norm(d)
+    glTranslatef(posA[0], posA[1], posA[2])
+    glRotatef(ax, rx, ry, 0.0)
+
+    # First hemispherical cap
+    glEnable(GL_CLIP_PLANE0)
+    glClipPlane(GL_CLIP_PLANE0, (0,0,-1,0))
+    gluSphere(quadric, radius, quality, quality)
+    glDisable(GL_CLIP_PLANE0)
+    # Cylinder
+    gluCylinder(quadric, radius, radius, length, quality, quality)
+    # Second hemispherical cap
+    glTranslatef(0,0,v)
+    glEnable(GL_CLIP_PLANE0)
+    glClipPlane(GL_CLIP_PLANE0, (0,0,1,0))
+    gluSphere(quadric, radius, quality, quality)
+    glDisable(GL_CLIP_PLANE0)
 
     glPopMatrix()
 

--- a/src/script_interface/shapes/SpheroCylinder.hpp
+++ b/src/script_interface/shapes/SpheroCylinder.hpp
@@ -31,10 +31,11 @@ namespace Shapes {
 class SpheroCylinder : public Shape {
 public:
   SpheroCylinder() : m_spherocylinder(new ::Shapes::SpheroCylinder()) {
-    add_parameters({{"pos", m_spherocylinder->pos()},
+    add_parameters({{"center", m_spherocylinder->pos()},
                     {"axis", m_spherocylinder->axis()},
+                    {"direction", m_spherocylinder->direction()},
                     {"length", m_spherocylinder->length()},
-                    {"rad", m_spherocylinder->rad()}});
+                    {"radius", m_spherocylinder->rad()}});
   }
 
   const std::string name() const override { return "Shapes::SpheroCylinder"; }


### PR DESCRIPTION
Description of changes:
 - Parameters of the SpheroCylinder shape can now be set via the promised keywords.
 - Member `direction` of SpheroCylinder can be set and setting `direction=-1` actually yields the expected result. The SpheroCylinder inherits from the Cylinder shape, which had no option to ignore the top and bottom caps. The caps thus also appeared inside the SpheroCylinder, dividing the cylinder part and the hemispherical cap parts. Fixed by this PR.
 - Adds the shape visualization of SpheroCylinders to the openGL visualizer.