### PR TITLE
Thermostat cleanup

### DIFF
--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -55,7 +55,7 @@ public:
     std::copy(std::begin(v), std::end(v), d.begin());
   }
 
-  template <typename T> explicit Vector(T const(&v)[n]) {
+  explicit Vector(Scalar const(&v)[n]) {
     std::copy(std::begin(v), std::end(v), d.begin());
   }
 
@@ -226,7 +226,8 @@ Vector<N, T> operator-(Vector<N, T> const &a, Vector<N, T> const &b) {
 template <size_t N, typename T> Vector<N, T> operator-(Vector<N, T> const &a) {
   Vector<N, T> ret;
 
-  std::transform(a.begin(), a.end(), ret.begin(), [](T const &v) { return -v; });
+  std::transform(a.begin(), a.end(), ret.begin(),
+                 [](T const &v) { return -v; });
 
   return ret;
 }
@@ -284,14 +285,12 @@ T operator*(Vector<N, T> const &a, Vector<N, T> const &b) {
 }
 
 /* Componentwise square route */
-template <size_t N, typename T> 
-Vector<N, T> sqrt(Vector<N, T> const& a) {
+template <size_t N, typename T> Vector<N, T> sqrt(Vector<N, T> const &a) {
   using std::sqrt;
   Vector<N, T> ret;
 
-  std::transform(a.begin(), a.end(), ret.begin(), [](T const& v) {
-      return sqrt(v);
-    });
+  std::transform(a.begin(), a.end(), ret.begin(),
+                 [](T const &v) { return sqrt(v); });
 
   return ret;
 }

--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -161,8 +161,9 @@ Vector<N, T> binary_op(Vector<N, T> const &a, Vector<N, T> const &b, Op op) {
 }
 
 template <size_t N, typename T, typename Op>
-void binary_op_assign(Vector<N, T> &a, Vector<N, T> const &b, Op op) {
+Vector<N, T> & binary_op_assign(Vector<N, T> &a, Vector<N, T> const &b, Op op) {
   std::transform(std::begin(a), std::end(a), std::begin(b), std::begin(a), op);
+  return a;
 }
 
 template <size_t N, typename T, typename Op>
@@ -214,7 +215,7 @@ Vector<N, T> operator+(Vector<N, T> const &a, Vector<N, T> const &b) {
 }
 
 template <size_t N, typename T>
-void operator+=(Vector<N, T> &a, Vector<N, T> const &b) {
+Vector<N, T> & operator+=(Vector<N, T> &a, Vector<N, T> const &b) {
   return detail::binary_op_assign(a, b, std::plus<T>());
 }
 
@@ -233,7 +234,7 @@ template <size_t N, typename T> Vector<N, T> operator-(Vector<N, T> const &a) {
 }
 
 template <size_t N, typename T>
-void operator-=(Vector<N, T> &a, Vector<N, T> const &b) {
+Vector<N, T> & operator-=(Vector<N, T> &a, Vector<N, T> const &b) {
   return detail::binary_op_assign(a, b, std::minus<T>());
 }
 

--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -54,11 +54,11 @@ public:
     std::copy(std::begin(v), std::end(v), d.begin());
   }
 
-  template <typename T> explicit Vector(T const (&v)[n]) {
+  template <typename T> explicit Vector(T const(&v)[n]) {
     std::copy(std::begin(v), std::end(v), d.begin());
   }
 
-  explicit Vector(std::initializer_list<Scalar> v) {
+  Vector(std::initializer_list<Scalar> v) {
     /* Convert to static_assert in C++14 */
     assert(v.size() == n);
     std::copy(std::begin(v), std::end(v), d.begin());
@@ -211,4 +211,11 @@ template <size_t N, typename T>
 Vector<N, T> operator-(Vector<N, T> const &a, Vector<N, T> const &b) {
   return detail::binary_op(a, b, std::minus<T>());
 }
+
+template <size_t N, typename T> Vector<N, T> operator-(Vector<N, T> const &a) {
+  Vector<N, T> ret{a};
+
+  std::transform(a.begin(), a.end(), a.begin(), [](T const &v) { return -v; });
+}
+
 #endif

--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -259,9 +259,11 @@ Vector<N, T> operator*(Vector<N, T> const &b, T const &a) {
   return ret;
 }
 
-template <size_t N, typename T> void operator*=(Vector<N, T> &b, T const &a) {
+template <size_t N, typename T>
+Vector<N, T> &operator*=(Vector<N, T> &b, T const &a) {
   std::transform(b.begin(), b.end(), b.begin(),
                  [a](T const &val) { return a * val; });
+  return b;
 }
 
 /* Scalar division */
@@ -274,9 +276,11 @@ Vector<N, T> operator/(Vector<N, T> const &a, T const &b) {
   return ret;
 }
 
-template <size_t N, typename T> void operator/=(Vector<N, T> &a, T const &b) {
+template <size_t N, typename T>
+Vector<N, T> &operator/=(Vector<N, T> &a, T const &b) {
   std::transform(a.begin(), a.end(), a.begin(),
                  [b](T const &val) { return val / b; });
+  return a;
 }
 
 /* Scalar product */

--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -247,7 +247,17 @@ Vector<N, T> operator*(T const &a, Vector<N, T> const &b) {
   return ret;
 }
 
-template <size_t N, typename T> void operator*=(T const &a, Vector<N, T> &b) {
+template <size_t N, typename T>
+Vector<N, T> operator*(Vector<N, T> const &b, T const &a) {
+  Vector<N, T> ret;
+
+  std::transform(b.begin(), b.end(), ret.begin(),
+                 [a](T const &val) { return a * val; });
+
+  return ret;
+}
+
+template <size_t N, typename T> void operator*=(Vector<N, T> &b, T const &a) {
   std::transform(b.begin(), b.end(), b.begin(),
                  [a](T const &val) { return a * val; });
 }
@@ -271,6 +281,19 @@ template <size_t N, typename T> void operator/=(Vector<N, T> &a, T const &b) {
 template <size_t N, typename T>
 T operator*(Vector<N, T> const &a, Vector<N, T> const &b) {
   return std::inner_product(a.begin(), a.end(), b.begin(), T{});
+}
+
+/* Componentwise square route */
+template <size_t N, typename T> 
+Vector<N, T> sqrt(Vector<N, T> const& a) {
+  using std::sqrt;
+  Vector<N, T> ret;
+
+  std::transform(a.begin(), a.end(), ret.begin(), [](T const& v) {
+      return sqrt(v);
+    });
+
+  return ret;
 }
 
 #endif

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -407,7 +407,8 @@ void mpi_bcast_event_slave(int node, int event) {
     break;
 #endif
 
-  default:;
+  default:
+    ;
   }
 }
 
@@ -2374,28 +2375,17 @@ void mpi_set_particle_temperature_slave(int pnode, int part) {
 #ifndef PARTICLE_ANISOTROPY
 void mpi_set_particle_gamma(int pnode, int part, double gamma) {
 #else
-void mpi_set_particle_gamma(int pnode, int part, double gamma[3]) {
+void mpi_set_particle_gamma(int pnode, int part, Vector3d gamma) {
 #endif
-  int j;
   mpi_call(mpi_set_particle_gamma_slave, pnode, part);
 
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-/* here the setting actually happens, if the particle belongs to the local
- * node */
-#ifndef PARTICLE_ANISOTROPY
+    /* here the setting actually happens, if the particle belongs to the local
+     * node */
     p->p.gamma = gamma;
-#else
-    for (j = 0; j < 3; j++)
-      p->p.gamma[j] = gamma[j];
-#endif
-
   } else {
-#ifndef PARTICLE_ANISOTROPY
-    MPI_Send(&gamma, 1, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
-#else
-    MPI_Send(gamma, 3, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
-#endif
+    comm_cart.send(pnode, SOME_TAG, Vector3d{gamma});
   }
 
   on_particle_change();
@@ -2404,49 +2394,31 @@ void mpi_set_particle_gamma(int pnode, int part, double gamma[3]) {
 
 void mpi_set_particle_gamma_slave(int pnode, int part) {
 #ifdef LANGEVIN_PER_PARTICLE
-  double s_buf = 0.;
-  int j;
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    MPI_Status status;
-/* here the setting happens for nonlocal nodes */
-#ifndef PARTICLE_ANISOTROPY
-    MPI_Recv(&s_buf, 1, MPI_DOUBLE, 0, SOME_TAG, comm_cart, &status);
-    p->p.gamma = s_buf;
-#else
-    MPI_Recv(p->p.gamma, 3, MPI_DOUBLE, 0, SOME_TAG, comm_cart, &status);
-#endif
+    comm_cart.recv(0, SOME_TAG, p->p.gamma);
   }
+
   on_particle_change();
 #endif
 }
 
 #if defined(LANGEVIN_PER_PARTICLE) && defined(ROTATION)
-#ifndef ROTATIONAL_INERTIA
+#ifndef PARTICLE_ANISOTROPY
 void mpi_set_particle_gamma_rot(int pnode, int part, double gamma_rot)
 #else
-void mpi_set_particle_gamma_rot(int pnode, int part, double gamma_rot[3])
+void mpi_set_particle_gamma_rot(int pnode, int part, Vector3d gamma_rot)
 #endif
 {
-  int j;
   mpi_call(mpi_set_particle_gamma_rot_slave, pnode, part);
 
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-/* here the setting actually happens, if the particle belongs to the local
- * node */
-#ifndef ROTATIONAL_INERTIA
+    /* here the setting actually happens, if the particle belongs to the local
+     * node */
     p->p.gamma_rot = gamma_rot;
-#else
-    for (j = 0; j < 3; j++)
-      p->p.gamma_rot[j] = gamma_rot[j];
-#endif
   } else {
-#ifndef ROTATIONAL_INERTIA
-    MPI_Send(&gamma_rot, 1, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
-#else
-    MPI_Send(gamma_rot, 3, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
-#endif
+    comm_cart.send(pnode, SOME_TAG, Vector3d{gamma_rot});
   }
 
   on_particle_change();
@@ -2455,19 +2427,11 @@ void mpi_set_particle_gamma_rot(int pnode, int part, double gamma_rot[3])
 
 void mpi_set_particle_gamma_rot_slave(int pnode, int part) {
 #if defined(LANGEVIN_PER_PARTICLE) && defined(ROTATION)
-  double s_buf = 0.;
-  int j;
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    MPI_Status status;
-/* here the setting happens for nonlocal nodes */
-#ifndef ROTATIONAL_INERTIA
-    MPI_Recv(&s_buf, 1, MPI_DOUBLE, 0, SOME_TAG, comm_cart, &status);
-    p->p.gamma_rot = s_buf;
-#else
-    MPI_Recv(p->p.gamma_rot, 3, MPI_DOUBLE, 0, SOME_TAG, comm_cart, &status);
-#endif
+    comm_cart.recv(pnode, SOME_TAG, p->p.gamma_rot);
   }
+
   on_particle_change();
 #endif
 }

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -493,14 +493,14 @@ void mpi_set_particle_temperature(int pnode, int part, double _T);
 #ifndef PARTICLE_ANISOTROPY
 void mpi_set_particle_gamma(int pnode, int part, double gamma);
 #else
-void mpi_set_particle_gamma(int pnode, int part, double gamma[3]);
+void mpi_set_particle_gamma(int pnode, int part, Vector3d gamma);
 #endif
 
 #ifdef ROTATION
 #ifndef ROTATIONAL_INERTIA
 void mpi_set_particle_gamma_rot(int pnode, int part, double gamma_rot);
 #else
-void mpi_set_particle_gamma_rot(int pnode, int part, double gamma_rot[3]);
+void mpi_set_particle_gamma_rot(int pnode, int part, Vector3d gamma_rot);
 #endif // ROTATIONAL_INERTIA
 #endif
 #endif // LANGEVIN_PER_PARTICLE

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -88,7 +88,7 @@ const std::unordered_map<int, Datafield> fields{{
       1}}, /* 5  from thermostat.cpp */
 #else
     {FIELD_LANGEVIN_GAMMA,
-     {langevin_gamma, Datafield::Type::DOUBLE, 3, "gamma",
+     {langevin_gamma.data(), Datafield::Type::DOUBLE, 3, "gamma",
       1}}, /* 5  from thermostat.cpp */
 #endif // PARTICLE_ANISOTROPY
     {FIELD_LEES_EDWARDS_OFFSET,
@@ -244,7 +244,7 @@ const std::unordered_map<int, Datafield> fields{{
       1}} /* 55 from thermostat.cpp */
 #else
     {FIELD_LANGEVIN_GAMMA_ROTATION,
-     {langevin_gamma_rotation, Datafield::Type::DOUBLE, 3, "gamma_rot",
+     {langevin_gamma_rotation.data(), Datafield::Type::DOUBLE, 3, "gamma_rot",
       1}} /* 55 from thermostat.cpp */
 #endif
 }};

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -776,7 +776,7 @@ int set_particle_temperature(int part, double T) {
 #ifndef PARTICLE_ANISOTROPY
 int set_particle_gamma(int part, double gamma)
 #else
-int set_particle_gamma(int part, double gamma[3])
+int set_particle_gamma(int part, Vector3d gamma)
 #endif // PARTICLE_ANISOTROPY
 {
   int pnode;
@@ -799,7 +799,7 @@ int set_particle_gamma(int part, double gamma[3])
 #ifndef ROTATIONAL_INERTIA
 int set_particle_gamma_rot(int part, double gamma_rot)
 #else
-int set_particle_gamma_rot(int part, double gamma_rot[3])
+int set_particle_gamma_rot(int part, Vector3d gamma_rot)
 #endif // ROTATIONAL_INERTIA
 {
   int pnode;
@@ -1709,7 +1709,7 @@ void pointer_to_gamma(Particle *p, double *&res) {
 #ifndef PARTICLE_ANISOTROPY
   res = &(p->p.gamma);
 #else
-  res = p->p.gamma; // array [3]
+  res = p->p.gamma.data(); // array [3]
 #endif // PARTICLE_ANISTROPY
 }
 
@@ -1718,7 +1718,7 @@ void pointer_to_gamma_rot(Particle *p, double *&res) {
 #ifndef ROTATIONAL_INERTIA
   res = &(p->p.gamma_rot);
 #else
-  res = p->p.gamma_rot; // array [3]
+  res = p->p.gamma_rot.data(); // array [3]
 #endif // ROTATIONAL_INERTIA
 }
 #endif // ROTATION

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -796,11 +796,11 @@ int set_particle_gamma(int part, Vector3d gamma)
   return ES_OK;
 }
 #ifdef ROTATION
-#ifndef ROTATIONAL_INERTIA
+#ifndef PARTICLE_ANISOTROPY
 int set_particle_gamma_rot(int part, double gamma_rot)
 #else
 int set_particle_gamma_rot(int part, Vector3d gamma_rot)
-#endif // ROTATIONAL_INERTIA
+#endif // PARTICLE_ANISOTROPY
 {
   int pnode;
 
@@ -1715,7 +1715,7 @@ void pointer_to_gamma(Particle *p, double *&res) {
 
 #ifdef ROTATION
 void pointer_to_gamma_rot(Particle *p, double *&res) {
-#ifndef ROTATIONAL_INERTIA
+#ifndef PARTICLE_ANISOTROPY
   res = &(p->p.gamma_rot);
 #else
   res = p->p.gamma_rot.data(); // array [3]

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -161,14 +161,14 @@ struct ParticleProperties {
 #ifndef PARTICLE_ANISOTROPY
   double gamma = -1.;
 #else
-  double gamma[3] = {-1., -1., -1.};
+  Vector3d gamma = {-1., -1., -1.};
 #endif // PARTICLE_ANISOTROPY
 /* Friction coefficient gamma for rotation */
 #ifdef ROTATION
-#ifndef ROTATIONAL_INERTIA
+#ifndef PARTICLE_ANISOTROPY
   double gamma_rot = -1.;
 #else
-  double gamma_rot[3] = {-1., -1., -1.};
+  Vector3d gamma_rot = {-1., -1., -1.};
 #endif // ROTATIONAL_INERTIA
 #endif // ROTATION
 #endif // LANGEVIN_PER_PARTICLE
@@ -768,13 +768,13 @@ int set_particle_temperature(int part, double T);
 #ifndef PARTICLE_ANISOTROPY
 int set_particle_gamma(int part, double gamma);
 #else
-int set_particle_gamma(int part, double gamma[3]);
+int set_particle_gamma(int part, Vector3d gamma);
 #endif
 #ifdef ROTATION
-#ifndef ROTATIONAL_INERTIA
+#ifndef PARTICLE_ANISOTROPY
 int set_particle_gamma_rot(int part, double gamma);
 #else
-int set_particle_gamma_rot(int part, double gamma[3]);
+int set_particle_gamma_rot(int part, Vector3d gamma);
 #endif
 #endif
 #endif // LANGEVIN_PER_PARTICLE

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -35,22 +35,18 @@ int thermo_switch = THERMO_OFF;
 /** Temperature */
 double temperature = 0.0;
 
-/* LANGEVIN THERMOSTAT */
-#ifndef PARTICLE_ANISOTROPY
-/* Langevin friction coefficient gamma for translation. */
-double langevin_gamma = -1.0;
-#else
-/* Langevin friction coefficient gamma for translation. */
-double langevin_gamma[3] = {-1.0,-1.0,-1.0};
-#endif // PARTICLE_ANISOTROPY
+using Thermostat::GammaType;
 
-#ifndef ROTATIONAL_INERTIA
+/* LANGEVIN THERMOSTAT */
+
+/* Langevin friction coefficient gamma for translation. */
+GammaType langevin_gamma = {-1.0,-1.0,-1.0};
 /* Friction coefficient gamma for rotation. */
-double langevin_gamma_rotation = -1.0;
-#else
-/* Friction coefficient gamma for rotation. */
-double langevin_gamma_rotation[3] = {-1.0,-1.0,-1.0};
-#endif // ROTATIONAL_INERTIA
+GammaType langevin_gamma_rotation = {-1.0,-1.0,-1.0};
+GammaType langevin_pref1;
+GammaType langevin_pref2;
+GammaType langevin_pref2_rotation;
+
 /* Langevin for translations */
 bool langevin_trans = true;
 /* Langevin for rotations */
@@ -68,36 +64,16 @@ int ghmc_nmd = 1;
 // phi parameter for partial momentum update step in GHMC
 double ghmc_phi = 0;
 
-#ifndef PARTICLE_ANISOTROPY
-double langevin_pref1, langevin_pref2;
-#else
-double langevin_pref1[3], langevin_pref2[3];
-#endif
-
-#ifndef ROTATIONAL_INERTIA
-double langevin_pref2_rotation;
-#else
-double langevin_pref2_rotation[3];
-#endif
-
 #ifdef MULTI_TIMESTEP
-  double langevin_pref1_small, langevin_pref2_small;
-  static double langevin_pref2_small_buffer;
+GammaType langevin_pref1_small, langevin_pref2_small;
+static GammaType langevin_pref2_small_buffer;
 #endif
 
 /** buffers for the work around for the correlated random values which cool the system,
     and require a magical heat up whenever reentering the integrator. */
-#ifndef PARTICLE_ANISOTROPY
-static double langevin_pref2_buffer;
-#else
-static double langevin_pref2_buffer[3];
-#endif
+static GammaType langevin_pref2_buffer;
 
-#ifndef ROTATIONAL_INERTIA
-static double langevin_pref2_rotation_buffer;
-#else
-static double langevin_pref2_rotation_buffer[3];
-#endif
+static GammaType langevin_pref2_rotation_buffer;
 
 #ifdef NPT
 double nptiso_pref1;
@@ -110,16 +86,9 @@ double nptiso_pref4;
 void thermo_init_langevin() 
 {
   int j;
-#ifndef PARTICLE_ANISOTROPY
+
   langevin_pref1 = -langevin_gamma/time_step;
   langevin_pref2 = sqrt(24.0*temperature*langevin_gamma/time_step);
-#else
-  for (j = 0; j < 3; j++) {
-    langevin_pref1[j] = -langevin_gamma[j] / time_step;
-    langevin_pref2[j] =
-        sqrt(24.0 * temperature * langevin_gamma[j] / time_step);
-}
-#endif // PARTICLE_ANISOTROPY
 
 #ifdef MULTI_TIMESTEP
   if (smaller_time_step > 0.) {

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -1,22 +1,22 @@
 /*
   Copyright (C) 2010,2012,2013,2014,2015,2016 The ESPResSo project
-  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
     Max-Planck-Institute for Polymer Research, Theory Group
-  
+
   This file is part of ESPResSo.
-  
+
   ESPResSo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   ESPResSo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file thermostat.cpp
     Implementation of \ref thermostat.hpp "thermostat.h"
@@ -37,12 +37,20 @@ double temperature = 0.0;
 
 using Thermostat::GammaType;
 
+namespace {
+  /* These functions return the sentinel value for the
+     langevin params, indicating that they have not been
+     set yet. */
+constexpr double sentinel(double) { return -1.0; }
+Vector3d sentinel(Vector3d) { return {-1.0, -1.0, -1.0}; }
+}
+
 /* LANGEVIN THERMOSTAT */
 
 /* Langevin friction coefficient gamma for translation. */
-GammaType langevin_gamma = {-1.0,-1.0,-1.0};
+GammaType langevin_gamma = sentinel(GammaType{});
 /* Friction coefficient gamma for rotation. */
-GammaType langevin_gamma_rotation = {-1.0,-1.0,-1.0};
+GammaType langevin_gamma_rotation = sentinel(GammaType{});
 GammaType langevin_pref1;
 GammaType langevin_pref2;
 GammaType langevin_pref2_rotation;
@@ -69,7 +77,8 @@ GammaType langevin_pref1_small, langevin_pref2_small;
 static GammaType langevin_pref2_small_buffer;
 #endif
 
-/** buffers for the work around for the correlated random values which cool the system,
+/** buffers for the work around for the correlated random values which cool the
+   system,
     and require a magical heat up whenever reentering the integrator. */
 static GammaType langevin_pref2_buffer;
 
@@ -82,54 +91,45 @@ double nptiso_pref3;
 double nptiso_pref4;
 #endif
 
-
-void thermo_init_langevin() 
-{
-  int j;
-
-  langevin_pref1 = -langevin_gamma/time_step;
-  langevin_pref2 = sqrt(24.0*temperature*langevin_gamma/time_step);
+void thermo_init_langevin() {
+  langevin_pref1 = -langevin_gamma / time_step;
+  langevin_pref2 = sqrt(24.0 * temperature / time_step * langevin_gamma);
+  ;
 
 #ifdef MULTI_TIMESTEP
   if (smaller_time_step > 0.) {
-    langevin_pref1_small = -langevin_gamma/smaller_time_step;
- #ifndef LANGEVIN_PER_PARTICLE
-    langevin_pref2_small = sqrt(24.0*temperature*langevin_gamma/smaller_time_step);
- #endif
+    langevin_pref1_small = -langevin_gamma / smaller_time_step;
+#ifndef LANGEVIN_PER_PARTICLE
+    langevin_pref2_small =
+        sqrt(24.0 * temperature * langevin_gamma / smaller_time_step);
+#endif
   } else {
-    langevin_pref1_small = -langevin_gamma/time_step;
- #ifndef LANGEVIN_PER_PARTICLE
-    langevin_pref2_small = sqrt(24.0*temperature*langevin_gamma/time_step);
- #endif
+    langevin_pref1_small = -langevin_gamma / time_step;
+#ifndef LANGEVIN_PER_PARTICLE
+    langevin_pref2_small =
+        sqrt(24.0 * temperature * langevin_gamma / time_step);
+#endif
   }
 #endif
 
-#ifdef ROTATION 
-#ifndef ROTATIONAL_INERTIA
-  if ( langevin_gamma_rotation < 0.0 )
-  {
+  /* If gamma_rotation is not set explicitly,
+     use the linear one. */
+  if (langevin_gamma_rotation < GammaType{}) {
     langevin_gamma_rotation = langevin_gamma;
   }
-#else
-  if (( langevin_gamma_rotation[0] < 0.0 ) || (langevin_gamma_rotation[1] < 0.0) || (langevin_gamma_rotation[2] < 0.0))
-  for ( j = 0 ; j < 3 ; j++)
-  {
-#ifdef PARTICLE_ANISOTROPY
-    langevin_gamma_rotation[j] = langevin_gamma[j];
-#else
-    langevin_gamma_rotation[j] = langevin_gamma;
-#endif // PARTICLE_ANISOTROPY
-  }
-#endif // ROTATIONAL_INERTIA
 
-#ifndef ROTATIONAL_INERTIA
-  langevin_pref2_rotation = sqrt(24.0*temperature*langevin_gamma_rotation/time_step);
-#else
-  for ( j = 0 ; j < 3 ; j++) langevin_pref2_rotation[j] = sqrt(24.0*temperature*langevin_gamma_rotation[j]/time_step);
-#endif // ROTATIONAL_INERTIA
-  THERMO_TRACE(fprintf(stderr,"%d: thermo_init_langevin: langevin_gamma_rotation=%f, langevin_pref2_rotation=%f",this_node, langevin_gamma_rotation,langevin_pref2_rotation));
+  langevin_pref2_rotation =
+      sqrt(24.0 * temperature * langevin_gamma_rotation / time_step);
+
+#ifdef ROTATION
+  THERMO_TRACE(
+      fprintf(stderr, "%d: thermo_init_langevin: langevin_gamma_rotation=%f, "
+                      "langevin_pref2_rotation=%f",
+              this_node, langevin_gamma_rotation, langevin_pref2_rotation));
 #endif
-  THERMO_TRACE(fprintf(stderr,"%d: thermo_init_langevin: langevin_pref1=%f, langevin_pref2=%f",this_node,langevin_pref1,langevin_pref2));  
+  THERMO_TRACE(fprintf(
+      stderr, "%d: thermo_init_langevin: langevin_pref1=%f, langevin_pref2=%f",
+      this_node, langevin_pref1, langevin_pref2));
 }
 
 #ifdef NPT
@@ -159,120 +159,103 @@ void thermo_init_npt_isotropic() {
 }
 #endif
 
-void thermo_init()
-{
-  if(thermo_switch == THERMO_OFF){
+void thermo_init() {
+  if (thermo_switch == THERMO_OFF) {
     return;
   }
 #ifdef INTER_DPD
-  if(thermo_switch & THERMO_INTER_DPD)  inter_dpd_init();
+  if (thermo_switch & THERMO_INTER_DPD)
+    inter_dpd_init();
 #endif
-  if(thermo_switch & THERMO_LANGEVIN ) thermo_init_langevin();
+  if (thermo_switch & THERMO_LANGEVIN)
+    thermo_init_langevin();
 #ifdef DPD
-  if(thermo_switch & THERMO_DPD) thermo_init_dpd();
+  if (thermo_switch & THERMO_DPD)
+    thermo_init_dpd();
 #endif
 #ifdef NPT
-  if(thermo_switch & THERMO_NPT_ISO)   thermo_init_npt_isotropic();
+  if (thermo_switch & THERMO_NPT_ISO)
+    thermo_init_npt_isotropic();
 #endif
 #ifdef GHMC
-  if(thermo_switch & THERMO_GHMC) thermo_init_ghmc();
+  if (thermo_switch & THERMO_GHMC)
+    thermo_init_ghmc();
 #endif
 }
 
-void thermo_heat_up()
-{
-  int j;
-  if(thermo_switch & THERMO_LANGEVIN) {
-#ifndef PARTICLE_ANISOTROPY
-    langevin_pref2_buffer          = langevin_pref2;
-    langevin_pref2 *= sqrt(3);
-#else
-    for ( j = 0 ; j < 3 ; j++)
-    {
-        langevin_pref2_buffer[j]         = langevin_pref2[j];
-        langevin_pref2[j] *= sqrt(3);
-    }
-#endif // PARTICLE_ANISOTROPY
+void langevin_heat_up() {
+  langevin_pref2_buffer = langevin_pref2;
+  langevin_pref2 *= sqrt(3);
 
-#ifndef ROTATIONAL_INERTIA
-    langevin_pref2_rotation_buffer = langevin_pref2_rotation;
-    langevin_pref2_rotation *= sqrt(3);
-#else
-    for ( j = 0 ; j < 3 ; j++)
-    {
-    	langevin_pref2_rotation_buffer[j] = langevin_pref2_rotation[j];
-    	langevin_pref2_rotation[j] *= sqrt(3);
-    }
-#endif // PARTICLE_ANISOTROPY
+  langevin_pref2_rotation_buffer = langevin_pref2_rotation;
+  langevin_pref2_rotation *= sqrt(3);
 
 #ifdef MULTI_TIMESTEP
-    langevin_pref2_small_buffer    = langevin_pref2_small;
-    langevin_pref2_small          *= sqrt(3);
-#endif
-  }
-#ifdef DPD
-  else if (thermo_switch & THERMO_DPD){dpd_heat_up();}
-#endif
-#ifdef INTER_DPD
-  else if (thermo_switch & THERMO_INTER_DPD) {inter_dpd_heat_up();}
+  langevin_pref2_small_buffer = langevin_pref2_small;
+  langevin_pref2_small *= sqrt(3);
 #endif
 }
 
-void thermo_cool_down()
-{
-  int j;
-  if(thermo_switch & THERMO_LANGEVIN) {
-#ifndef PARTICLE_ANISOTROPY
-    langevin_pref2          = langevin_pref2_buffer;
-#else
-    for ( j = 0 ; j < 3 ; j++) langevin_pref2[j] = langevin_pref2_buffer[j];
+void thermo_heat_up() {
+  if (thermo_switch & THERMO_LANGEVIN) {
+    langevin_heat_up();
+  }
+#ifdef DPD
+  if (thermo_switch & THERMO_DPD) {
+    dpd_heat_up();
+  }
 #endif
+#ifdef INTER_DPD
+  if (thermo_switch & THERMO_INTER_DPD) {
+    inter_dpd_heat_up();
+  }
+#endif
+}
 
-#ifndef ROTATIONAL_INERTIA
-    langevin_pref2_rotation = langevin_pref2_rotation_buffer;
-#else
-    for ( j = 0 ; j < 3 ; j++) langevin_pref2_rotation[j] = langevin_pref2_rotation_buffer[j];
-#endif
+void langevin_cool_down() {
+  langevin_pref2 = langevin_pref2_buffer;
+  langevin_pref2_rotation = langevin_pref2_rotation_buffer;
 
 #ifdef MULTI_TIMESTEP
-    langevin_pref2_small    = langevin_pref2_small_buffer;
-#endif
-  }
-#ifdef DPD
-  else if (thermo_switch & THERMO_DPD){dpd_cool_down();}
-#endif
-#ifdef INTER_DPD
-  else if (thermo_switch & THERMO_INTER_DPD) inter_dpd_cool_down();
+  langevin_pref2_small = langevin_pref2_small_buffer;
 #endif
 }
 
-int get_cpu_temp()
-{
+void thermo_cool_down() {
+  if (thermo_switch & THERMO_LANGEVIN) {
+    langevin_cool_down();
+  }
+#ifdef DPD
+  if (thermo_switch & THERMO_DPD) {
+    dpd_cool_down();
+  }
+#endif
+#ifdef INTER_DPD
+  if (thermo_switch & THERMO_INTER_DPD)
+    inter_dpd_cool_down();
+#endif
+}
+
+int get_cpu_temp() {
   std::ifstream f("/sys/class/thermal/thermal_zone0/temp");
   int temp;
   f >> temp;
   f.close();
-  return (temp + 273150)/1000;
+  return (temp + 273150) / 1000;
 }
 
 static int volatile cpu_temp_count = 0;
-void set_cpu_temp(int temp)
-{
-  while (temp != get_cpu_temp())
-  {
-    if (temp < get_cpu_temp())
-    {
-      //printf("Cooling down CPU from %dK to %dK\n", get_cpu_temp(), temp);
+void set_cpu_temp(int temp) {
+  while (temp != get_cpu_temp()) {
+    if (temp < get_cpu_temp()) {
+      // printf("Cooling down CPU from %dK to %dK\n", get_cpu_temp(), temp);
       // pause for 1 second to give the CPU time to cool down
       usleep(1e6);
-    }
-    else
-    {
-      //printf("Heating up CPU from %dK to %dK\n", get_cpu_temp(), temp);
+    } else {
+      // printf("Heating up CPU from %dK to %dK\n", get_cpu_temp(), temp);
       // crunch some numbers to heat up the CPU
       cpu_temp_count = 0;
-      for (int i = 0; i < 1e9; ++i)
-      {
+      for (int i = 0; i < 1e9; ++i) {
         cpu_temp_count += i;
       }
     }

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -36,6 +36,7 @@
 #include "lb.hpp"
 #include "dpd.hpp"
 #include "virtual_sites.hpp"
+#include "Vector.hpp"
 
 /** \name Thermostat switches*/
 /************************************************************/
@@ -53,6 +54,13 @@
 
 namespace Thermostat {
   auto noise = []() { return (d_random() - 0.5); };
+
+#ifdef PARTICLE_ANISOTROPY
+  using GammaType = Vector3d;
+#else
+  using GammaType = double;
+#endif
+
 }
 
 /************************************************
@@ -69,19 +77,10 @@ extern int thermo_switch;
 /** temperature. */
 extern double temperature;
 
-#ifndef PARTICLE_ANISOTROPY
 /** Langevin friction coefficient gamma. */
-extern double langevin_gamma;
-#else
-extern double langevin_gamma[3];
-#endif
-
-#ifndef ROTATIONAL_INERTIA
+extern Thermostat::GammaType langevin_gamma;
 /** Langevin friction coefficient gamma. */
-extern double langevin_gamma_rotation;
-#else
-extern double langevin_gamma_rotation[3];
-#endif
+extern Thermostat::GammaType langevin_gamma_rotation;
 
 /** Langevin for translations */
 extern bool langevin_trans;

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -1,26 +1,26 @@
 /*
   Copyright (C) 2010,2011,2012,2013,2014,2015,2016 The ESPResSo project
-  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
     Max-Planck-Institute for Polymer Research, Theory Group
-  
+
   This file is part of ESPResSo.
-  
+
   ESPResSo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   ESPResSo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifndef _THERMOSTAT_H
 #define _THERMOSTAT_H
-/** \file thermostat.hpp 
+/** \file thermostat.hpp
 
 */
 
@@ -42,25 +42,24 @@
 /************************************************************/
 /*@{*/
 
-#define THERMO_OFF        0
-#define THERMO_LANGEVIN   1
-#define THERMO_DPD        2
-#define THERMO_NPT_ISO    4
-#define THERMO_LB         8
-#define THERMO_INTER_DPD  16
-#define THERMO_GHMC       32
-#define THERMO_CPU        64
+#define THERMO_OFF 0
+#define THERMO_LANGEVIN 1
+#define THERMO_DPD 2
+#define THERMO_NPT_ISO 4
+#define THERMO_LB 8
+#define THERMO_INTER_DPD 16
+#define THERMO_GHMC 32
+#define THERMO_CPU 64
 /*@}*/
 
 namespace Thermostat {
-  auto noise = []() { return (d_random() - 0.5); };
+auto noise = []() { return (d_random() - 0.5); };
 
 #ifdef PARTICLE_ANISOTROPY
-  using GammaType = Vector3d;
+using GammaType = Vector3d;
 #else
-  using GammaType = double;
+using GammaType = double;
 #endif
-
 }
 
 /************************************************
@@ -88,9 +87,11 @@ extern bool langevin_trans;
 /** Langevin for rotations */
 extern bool langevin_rotate;
 
-/** Friction coefficient for nptiso-thermostat's inline-function friction_therm0_nptiso */
+/** Friction coefficient for nptiso-thermostat's inline-function
+ * friction_therm0_nptiso */
 extern double nptiso_gamma0;
-/** Friction coefficient for nptiso-thermostat's inline-function friction_thermV_nptiso */
+/** Friction coefficient for nptiso-thermostat's inline-function
+ * friction_thermV_nptiso */
 extern double nptiso_gammav;
 
 /** Number of NVE-MD steps in GHMC Cycle*/
@@ -102,16 +103,17 @@ extern double ghmc_phi;
  * functions
  ************************************************/
 
-
 /** initialize constants of the thermostat on
     start of integration */
 void thermo_init();
 
 /** very nasty: if we recalculate force when leaving/reentering the integrator,
     a(t) and a((t-dt)+dt) are NOT equal in the vv algorithm. The random
-    numbers are drawn twice, resulting in a different variance of the random force.
+    numbers are drawn twice, resulting in a different variance of the random
+   force.
     This is corrected by additional heat when restarting the integrator here.
-    Currently only works for the Langevin thermostat, although probably also others
+    Currently only works for the Langevin thermostat, although probably also
+   others
     are affected.
 */
 void thermo_heat_up();
@@ -125,90 +127,103 @@ int get_cpu_temp();
 void set_cpu_temp(int temp);
 
 #ifdef ROTATION
-inline void thermo_define_rotation_matrix(Particle *p, double A[9])
-{
-  double q0q0 =p->r.quat[0];
-  q0q0 *=q0q0;
+inline void thermo_define_rotation_matrix(Particle *p, double A[9]) {
+  double q0q0 = p->r.quat[0];
+  q0q0 *= q0q0;
 
-  double q1q1 =p->r.quat[1];
-  q1q1 *=q1q1;
+  double q1q1 = p->r.quat[1];
+  q1q1 *= q1q1;
 
-  double q2q2 =p->r.quat[2];
-  q2q2 *=q2q2;
+  double q2q2 = p->r.quat[2];
+  q2q2 *= q2q2;
 
-  double q3q3 =p->r.quat[3];
-  q3q3 *=q3q3;
+  double q3q3 = p->r.quat[3];
+  q3q3 *= q3q3;
 
-  A[0 + 3*0] = q0q0 + q1q1 - q2q2 - q3q3;
-  A[1 + 3*1] = q0q0 - q1q1 + q2q2 - q3q3;
-  A[2 + 3*2] = q0q0 - q1q1 - q2q2 + q3q3;
+  A[0 + 3 * 0] = q0q0 + q1q1 - q2q2 - q3q3;
+  A[1 + 3 * 1] = q0q0 - q1q1 + q2q2 - q3q3;
+  A[2 + 3 * 2] = q0q0 - q1q1 - q2q2 + q3q3;
 
-  A[0 + 3*1] = 2*(p->r.quat[1]*p->r.quat[2] + p->r.quat[0]*p->r.quat[3]);
-  A[0 + 3*2] = 2*(p->r.quat[1]*p->r.quat[3] - p->r.quat[0]*p->r.quat[2]);
-  A[1 + 3*0] = 2*(p->r.quat[1]*p->r.quat[2] - p->r.quat[0]*p->r.quat[3]);
+  A[0 + 3 * 1] =
+      2 * (p->r.quat[1] * p->r.quat[2] + p->r.quat[0] * p->r.quat[3]);
+  A[0 + 3 * 2] =
+      2 * (p->r.quat[1] * p->r.quat[3] - p->r.quat[0] * p->r.quat[2]);
+  A[1 + 3 * 0] =
+      2 * (p->r.quat[1] * p->r.quat[2] - p->r.quat[0] * p->r.quat[3]);
 
-  A[1 + 3*2] = 2*(p->r.quat[2]*p->r.quat[3] + p->r.quat[0]*p->r.quat[1]);
-  A[2 + 3*0] = 2*(p->r.quat[1]*p->r.quat[3] + p->r.quat[0]*p->r.quat[2]);
-  A[2 + 3*1] = 2*(p->r.quat[2]*p->r.quat[3] - p->r.quat[0]*p->r.quat[1]);
+  A[1 + 3 * 2] =
+      2 * (p->r.quat[2] * p->r.quat[3] + p->r.quat[0] * p->r.quat[1]);
+  A[2 + 3 * 0] =
+      2 * (p->r.quat[1] * p->r.quat[3] + p->r.quat[0] * p->r.quat[2]);
+  A[2 + 3 * 1] =
+      2 * (p->r.quat[2] * p->r.quat[3] - p->r.quat[0] * p->r.quat[1]);
 }
 
-inline void thermo_convert_forces_body_to_space(Particle *p, double *force)
-{
+inline void thermo_convert_forces_body_to_space(Particle *p, double *force) {
   double A[9];
   thermo_define_rotation_matrix(p, A);
 
-  force[0] = A[0 + 3*0]*p->f.f[0] + A[1 + 3*0]*p->f.f[1] + A[2 + 3*0]*p->f.f[2];
-  force[1] = A[0 + 3*1]*p->f.f[0] + A[1 + 3*1]*p->f.f[1] + A[2 + 3*1]*p->f.f[2];
-  force[2] = A[0 + 3*2]*p->f.f[0] + A[1 + 3*2]*p->f.f[1] + A[2 + 3*2]*p->f.f[2];
+  force[0] = A[0 + 3 * 0] * p->f.f[0] + A[1 + 3 * 0] * p->f.f[1] +
+             A[2 + 3 * 0] * p->f.f[2];
+  force[1] = A[0 + 3 * 1] * p->f.f[0] + A[1 + 3 * 1] * p->f.f[1] +
+             A[2 + 3 * 1] * p->f.f[2];
+  force[2] = A[0 + 3 * 2] * p->f.f[0] + A[1 + 3 * 2] * p->f.f[1] +
+             A[2 + 3 * 2] * p->f.f[2];
 }
 
-inline void thermo_convert_vel_space_to_body(Particle *p, double *vel_space, double *vel_body)
-{
+inline void thermo_convert_vel_space_to_body(Particle *p, double *vel_space,
+                                             double *vel_body) {
   double A[9];
   thermo_define_rotation_matrix(p, A);
 
-  vel_body[0] = A[0 + 3*0]*vel_space[0] + A[0 + 3*1]*vel_space[1] + A[0 + 3*2]*vel_space[2];
-  vel_body[1] = A[1 + 3*0]*vel_space[0] + A[1 + 3*1]*vel_space[1] + A[1 + 3*2]*vel_space[2];
-  vel_body[2] = A[2 + 3*0]*vel_space[0] + A[2 + 3*1]*vel_space[1] + A[2 + 3*2]*vel_space[2];
+  vel_body[0] = A[0 + 3 * 0] * vel_space[0] + A[0 + 3 * 1] * vel_space[1] +
+                A[0 + 3 * 2] * vel_space[2];
+  vel_body[1] = A[1 + 3 * 0] * vel_space[0] + A[1 + 3 * 1] * vel_space[1] +
+                A[1 + 3 * 2] * vel_space[2];
+  vel_body[2] = A[2 + 3 * 0] * vel_space[0] + A[2 + 3 * 1] * vel_space[1] +
+                A[2 + 3 * 2] * vel_space[2];
 }
 #endif // ROTATION
 
-/** locally defined funcion to find Vx. In case of LEES_EDWARDS, that is relative to the LE shear frame
+/** locally defined funcion to find Vx. In case of LEES_EDWARDS, that is
+   relative to the LE shear frame
     @param i      coordinate index
     @param vel    velocity vector
     @param pos    position vector
     @return       adjusted (or not) i^th velocity coordinate */
-inline double le_frameV(int i, double *vel, double *pos)
-{
+inline double le_frameV(int i, double *vel, double *pos) {
 #ifdef LEES_EDWARDS
 
-   if( i == 0 ){
-       double relY  = pos[1] * box_l_i[1] - 0.5;
-       return( vel[0] - relY * lees_edwards_rate );
-   }
+  if (i == 0) {
+    double relY = pos[1] * box_l_i[1] - 0.5;
+    return (vel[0] - relY * lees_edwards_rate);
+  }
 
 #endif
 
-   return vel[i];
+  return vel[i];
 }
 
 #ifdef NPT
-/** add velocity-dependend noise and friction for NpT-sims to the particle's velocity 
-    @param dt_vj  j-component of the velocity scaled by time_step dt 
-    @return       j-component of the noise added to the velocity, also scaled by dt (contained in prefactors) */
+/** add velocity-dependend noise and friction for NpT-sims to the particle's
+   velocity
+    @param dt_vj  j-component of the velocity scaled by time_step dt
+    @return       j-component of the noise added to the velocity, also scaled by
+   dt (contained in prefactors) */
 inline double friction_therm0_nptiso(double dt_vj) {
   extern double nptiso_pref1, nptiso_pref2;
-  if(thermo_switch & THERMO_NPT_ISO)
-    return ( nptiso_pref1*dt_vj + nptiso_pref2*Thermostat::noise() );
-  
+  if (thermo_switch & THERMO_NPT_ISO)
+    return (nptiso_pref1 * dt_vj + nptiso_pref2 * Thermostat::noise());
+
   return 0.0;
 }
 
-/** add p_diff-dependend noise and friction for NpT-sims to \ref nptiso_struct::p_diff */
+/** add p_diff-dependend noise and friction for NpT-sims to \ref
+ * nptiso_struct::p_diff */
 inline double friction_thermV_nptiso(double p_diff) {
   extern double nptiso_pref3, nptiso_pref4;
-  if(thermo_switch & THERMO_NPT_ISO)   
-    return ( nptiso_pref3*p_diff + nptiso_pref4*Thermostat::noise() );
+  if (thermo_switch & THERMO_NPT_ISO)
+    return (nptiso_pref3 * p_diff + nptiso_pref4 * Thermostat::noise());
   return 0.0;
 }
 #endif
@@ -216,15 +231,9 @@ inline double friction_thermV_nptiso(double p_diff) {
 /** overwrite the forces of a particle with
     the friction term, i.e. \f$ F_i= -\gamma v_i + \xi_i\f$.
 */
-inline void friction_thermo_langevin(Particle *p)
-{
-#ifndef PARTICLE_ANISOTROPY
-  extern double langevin_pref1, langevin_pref2;
-  double langevin_pref1_temp, langevin_pref2_temp;
-#else
-  extern double langevin_pref1[3], langevin_pref2[3];
-  double langevin_pref1_temp[3], langevin_pref2_temp[3];
-#endif
+inline void friction_thermo_langevin(Particle *p) {
+  extern Thermostat::GammaType langevin_pref1, langevin_pref2;
+  Thermostat::GammaType langevin_pref1_temp, langevin_pref2_temp;
 
   double particle_force[3] = {0.0, 0.0, 0.0};
 
@@ -238,287 +247,224 @@ inline void friction_thermo_langevin(Particle *p)
   int j;
   int aniso_flag = 1; // particle anisotropy flag
   double switch_trans = 1.0;
-  if ( langevin_trans == false )
-  {
+  if (langevin_trans == false) {
     switch_trans = 0.0;
   }
 
-  // Virtual sites related decision making
+// Virtual sites related decision making
 #ifdef VIRTUAL_SITES
 #ifndef VIRTUAL_SITES_THERMOSTAT
-      // In this case, virtual sites are NOT thermostated 
-  if (ifParticleIsVirtual(p))
-    {
-      for (j=0;j<3;j++)
-        p->f.f[j]=0;
-  
-      return;
-    }
+  // In this case, virtual sites are NOT thermostated
+  if (ifParticleIsVirtual(p)) {
+    for (j = 0; j < 3; j++)
+      p->f.f[j] = 0;
+
+    return;
+  }
 #endif /* VIRTUAL_SITES_THERMOSTAT */
 #ifdef THERMOSTAT_IGNORE_NON_VIRTUAL
-      // In this case NON-virtual particles are NOT thermostated
-  if (!ifParticleIsVirtual(p))
-    {
-      for (j=0;j<3;j++)
-        p->f.f[j]=0;
-  
-      return;
-    }
+  // In this case NON-virtual particles are NOT thermostated
+  if (!ifParticleIsVirtual(p)) {
+    for (j = 0; j < 3; j++)
+      p->f.f[j] = 0;
+
+    return;
+  }
 #endif /* THERMOSTAT_IGNORE_NON_VIRTUAL */
 #endif /* VIRTUAL_SITES */
 
   // Get velocity effective in the thermostatting
-  double velocity[3],velocity_body[3] = {0.0, 0.0, 0.0};
+  double velocity[3], velocity_body[3] = {0.0, 0.0, 0.0};
   for (int i = 0; i < 3; i++) {
     // Particle velocity
     velocity[i] = p->m.v[i];
-    #ifdef ENGINE
-      // In case of the engine feature, the velocity is relaxed
-      // towards a swimming velocity oriented parallel to the
-      // particles director
-      velocity[i] -= (p->swim.v_swim*time_step)*p->r.quatu[i];
-    #endif
-
-    // Local effective velocity for leeds-edwards boundary conditions
-    velocity[i]=le_frameV(i,velocity,p->r.p);
-  } // for
-  
-  // Determine prefactors for the friction and the noise term 
-
-  // first, set defaults
-#ifndef PARTICLE_ANISOTROPY
-  langevin_pref1_temp = langevin_pref1;
-  langevin_pref2_temp = langevin_pref2;
-#else
-  for ( j = 0 ; j < 3 ; j++)
-  {
-	  langevin_pref1_temp[j] = langevin_pref1[j];
-	  langevin_pref2_temp[j] = langevin_pref2[j];
-  }
+#ifdef ENGINE
+    // In case of the engine feature, the velocity is relaxed
+    // towards a swimming velocity oriented parallel to the
+    // particles director
+    velocity[i] -= (p->swim.v_swim * time_step) * p->r.quatu[i];
 #endif
 
-  // Override defaults if per-particle values for T and gamma are given 
-#ifdef LANGEVIN_PER_PARTICLE  
+    // Local effective velocity for leeds-edwards boundary conditions
+    velocity[i] = le_frameV(i, velocity, p->r.p);
+  } // for
+
+// Determine prefactors for the friction and the noise term
+
+// first, set defaults
+  langevin_pref1_temp = langevin_pref1;
+  langevin_pref2_temp = langevin_pref2;
+
+// Override defaults if per-particle values for T and gamma are given
+#ifdef LANGEVIN_PER_PARTICLE
   auto const constexpr langevin_temp_coeff = 24.0;
 
-#ifndef PARTICLE_ANISOTROPY
-    if(p->p.gamma >= 0.) 
-    {
-      langevin_pref1_temp = -p->p.gamma/time_step;
-      // Is a particle-specific temperature also specified?
-      if(p->p.T >= 0.)
-        langevin_pref2_temp = sqrt(langevin_temp_coeff*p->p.T*p->p.gamma/time_step);
-      else
-        // Default temperature but particle-specific gamma
-        langevin_pref2_temp = sqrt(langevin_temp_coeff*temperature*p->p.gamma/time_step);
-
-    } // particle specific gamma
-    else 
-    {
-      langevin_pref1_temp = -langevin_gamma/time_step;
-      // No particle-specific gamma, but is there particle-specific temperature
-      if(p->p.T >= 0.)
-        langevin_pref2_temp = sqrt(langevin_temp_coeff*p->p.T*langevin_gamma/time_step);
-      else
-        // Defaut values for both
-        langevin_pref2_temp = langevin_pref2;
-    }
-#else
-    for ( j = 0 ; j < 3 ; j++)
-    if(p->p.gamma[j] >= 0.)
-    {
-      langevin_pref1_temp[j] = -p->p.gamma[j]/time_step;
-      // Is a particle-specific temperature also specified?
-      if(p->p.T >= 0.)
-        langevin_pref2_temp[j] = sqrt(langevin_temp_coeff*p->p.T*p->p.gamma[j]/time_step);
-      else
-        // Default temperature but particle-specific gamma
-        langevin_pref2_temp[j] = sqrt(langevin_temp_coeff*temperature*p->p.gamma[j]/time_step);
-
-    } // particle specific gamma
+  if (p->p.gamma >= Thermostat::GammaType{}) {
+    langevin_pref1_temp = -p->p.gamma / time_step;
+    // Is a particle-specific temperature also specified?
+    if (p->p.T >= 0.)
+      langevin_pref2_temp =
+          sqrt(langevin_temp_coeff * p->p.T * p->p.gamma / time_step);
     else
-    {
-      langevin_pref1_temp[j] = -langevin_gamma[j]/time_step;
-      // No particle-specific gamma, but is there particle-specific temperature
-      if(p->p.T >= 0.)
-        langevin_pref2_temp[j] = sqrt(langevin_temp_coeff*p->p.T*langevin_gamma[j]/time_step);
-      else
-        // Defaut values for both
-        langevin_pref2_temp[j] = langevin_pref2[j];
-    }
+      // Default temperature but particle-specific gamma
+      langevin_pref2_temp =
+          sqrt(langevin_temp_coeff * temperature * p->p.gamma / time_step);
 
-#endif // PARTICLE_ANISOTROPY
+  } // particle specific gamma
+  else {
+    langevin_pref1_temp = -langevin_gamma / time_step;
+    // No particle-specific gamma, but is there particle-specific temperature
+    if (p->p.T >= 0.)
+      langevin_pref2_temp =
+          sqrt(langevin_temp_coeff * p->p.T * langevin_gamma / time_step);
+    else
+      // Defaut values for both
+      langevin_pref2_temp = langevin_pref2;
+  }
+
 #endif /* LANGEVIN_PER_PARTICLE */
 
-  // Multi-timestep handling
-  // This has to be last, as it may set the prefactors to 0.
-  #ifdef MULTI_TIMESTEP
-    if (smaller_time_step > 0.) {
-      langevin_pref1_temp *= time_step/smaller_time_step;
-      if (p->p.smaller_timestep==1 && current_time_step_is_small==1) 
-        langevin_pref2_temp *= sqrt(time_step/smaller_time_step);
-      else if (p->p.smaller_timestep != current_time_step_is_small) {
-        langevin_pref1_temp  = 0.;
-        langevin_pref2_temp  = 0.;
-      }
+// Multi-timestep handling
+// This has to be last, as it may set the prefactors to 0.
+#ifdef MULTI_TIMESTEP
+  if (smaller_time_step > 0.) {
+    langevin_pref1_temp *= time_step / smaller_time_step;
+    if (p->p.smaller_timestep == 1 && current_time_step_is_small == 1)
+      langevin_pref2_temp *= sqrt(time_step / smaller_time_step);
+    else if (p->p.smaller_timestep != current_time_step_is_small) {
+      langevin_pref1_temp = 0.;
+      langevin_pref2_temp = 0.;
     }
+  }
 #endif /* MULTI_TIMESTEP */
 
 #ifdef PARTICLE_ANISOTROPY
-    // Particle frictional isotropy check
-    aniso_flag = (langevin_pref1_temp[0] != langevin_pref1_temp[1]) || (langevin_pref1_temp[1] != langevin_pref1_temp[2]) ||
-            (langevin_pref2_temp[0] != langevin_pref2_temp[1]) || (langevin_pref2_temp[1] != langevin_pref2_temp[2]);
-    if (aniso_flag)
-            thermo_convert_vel_space_to_body(p,velocity,velocity_body);
+  // Particle frictional isotropy check
+  aniso_flag = (langevin_pref1_temp[0] != langevin_pref1_temp[1]) ||
+               (langevin_pref1_temp[1] != langevin_pref1_temp[2]) ||
+               (langevin_pref2_temp[0] != langevin_pref2_temp[1]) ||
+               (langevin_pref2_temp[1] != langevin_pref2_temp[2]);
+  if (aniso_flag)
+    thermo_convert_vel_space_to_body(p, velocity, velocity_body);
 #endif
 
   // Do the actual thermostatting
-  for ( j = 0 ; j < 3 ; j++) 
-  {
-    #ifdef EXTERNAL_FORCES
-      // If individual coordinates are fixed, set force to 0.
-      if ((p->p.ext_flag & COORD_FIXED(j)))
-        p->f.f[j] = 0;
-      else	
-    #endif
+  for (j = 0; j < 3; j++) {
+#ifdef EXTERNAL_FORCES
+    // If individual coordinates are fixed, set force to 0.
+    if ((p->p.ext_flag & COORD_FIXED(j)))
+      p->f.f[j] = 0;
+    else
+#endif
     {
-      // Apply the force
+// Apply the force
 #ifndef PARTICLE_ANISOTROPY
-      p->f.f[j] = langevin_pref1_temp*velocity[j] + switch_trans*langevin_pref2_temp*Thermostat::noise();
+      p->f.f[j] = langevin_pref1_temp * velocity[j] +
+                  switch_trans * langevin_pref2_temp * Thermostat::noise();
 #else
-      // In case of anisotropic particle: body-fixed reference frame. Otherwise: lab-fixed reference frame.
+      // In case of anisotropic particle: body-fixed reference frame. Otherwise:
+      // lab-fixed reference frame.
       if (aniso_flag)
-        p->f.f[j] = langevin_pref1_temp[j]*velocity_body[j] + switch_trans*langevin_pref2_temp[j]*Thermostat::noise();
+        p->f.f[j] = langevin_pref1_temp[j] * velocity_body[j] +
+                    switch_trans * langevin_pref2_temp[j] * Thermostat::noise();
       else
-        p->f.f[j] = langevin_pref1_temp[j]*velocity[j] + switch_trans*langevin_pref2_temp[j]*Thermostat::noise();
+        p->f.f[j] = langevin_pref1_temp[j] * velocity[j] +
+                    switch_trans * langevin_pref2_temp[j] * Thermostat::noise();
 #endif
     }
   } // END LOOP OVER ALL COMPONENTS
 
 #ifdef PARTICLE_ANISOTROPY
-  if (aniso_flag)
-  {
-      thermo_convert_forces_body_to_space(p,particle_force);
-      for ( j = 0 ; j < 3 ; j++)
-      {
+  if (aniso_flag) {
+    thermo_convert_forces_body_to_space(p, particle_force);
+    for (j = 0; j < 3; j++) {
 #ifdef EXTERNAL_FORCES
-          if (!(p->p.ext_flag & COORD_FIXED(j)))
+      if (!(p->p.ext_flag & COORD_FIXED(j)))
 #endif
-          {
-              p->f.f[j] = particle_force[j];
-          }
+      {
+        p->f.f[j] = particle_force[j];
       }
+    }
   }
 #endif // PARTICLE_ANISOTROPY
 
-  // printf("%d: %e %e %e %e %e %e\n",p->p.identity, p->f.f[0],p->f.f[1],p->f.f[2], p->m.v[0],p->m.v[1],p->m.v[2]);
-  ONEPART_TRACE(if(p->p.identity==check_id) fprintf(stderr,"%d: OPT: LANG f = (%.3e,%.3e,%.3e)\n",this_node,p->f.f[0],p->f.f[1],p->f.f[2]));
-  THERMO_TRACE(fprintf(stderr,"%d: Thermo: P %d: force=(%.3e,%.3e,%.3e)\n",this_node,p->p.identity,p->f.f[0],p->f.f[1],p->f.f[2]));
+  // printf("%d: %e %e %e %e %e %e\n",p->p.identity,
+  // p->f.f[0],p->f.f[1],p->f.f[2], p->m.v[0],p->m.v[1],p->m.v[2]);
+  ONEPART_TRACE(if (p->p.identity == check_id)
+                    fprintf(stderr, "%d: OPT: LANG f = (%.3e,%.3e,%.3e)\n",
+                            this_node, p->f.f[0], p->f.f[1], p->f.f[2]));
+  THERMO_TRACE(fprintf(stderr, "%d: Thermo: P %d: force=(%.3e,%.3e,%.3e)\n",
+                       this_node, p->p.identity, p->f.f[0], p->f.f[1],
+                       p->f.f[2]));
 }
 
 #ifdef ROTATION
-/** set the particle torques to the friction term, i.e. \f$\tau_i=-\gamma w_i + \xi_i\f$.
+/** set the particle torques to the friction term, i.e. \f$\tau_i=-\gamma w_i +
+   \xi_i\f$.
     The same friction coefficient \f$\gamma\f$ is used as that for translation.
 */
-inline void friction_thermo_langevin_rotation(Particle *p)
-{
-#ifndef ROTATIONAL_INERTIA
-  extern double langevin_pref2_rotation;
-  double langevin_pref1_temp, langevin_pref2_temp;
-#else
-  extern double langevin_pref2_rotation[3];
-  double langevin_pref1_temp[3], langevin_pref2_temp[3];
-#endif
+inline void friction_thermo_langevin_rotation(Particle *p) {
+  extern Thermostat::GammaType langevin_pref2_rotation;
+  Thermostat::GammaType langevin_pref1_temp, langevin_pref2_temp;
 
-  int j;
   double switch_rotate = 1.0;
-  if ( langevin_rotate == false )
-  {
+  if (langevin_rotate == false) {
     switch_rotate = 0.0;
   }
 
-  // first, set defaults
-#ifndef ROTATIONAL_INERTIA
   langevin_pref1_temp = langevin_gamma_rotation;
   langevin_pref2_temp = langevin_pref2_rotation;
-#else
-  for ( j = 0 ; j < 3 ; j++)
-  {
-	  langevin_pref1_temp[j] = langevin_gamma_rotation[j];
-	  langevin_pref2_temp[j] = langevin_pref2_rotation[j];
-  }
-#endif
 
-  // Override defaults if per-particle values for T and gamma are given
+// Override defaults if per-particle values for T and gamma are given
 #ifdef LANGEVIN_PER_PARTICLE
-    // If a particle-specific gamma is given
-auto const constexpr langevin_temp_coeff = 24.0;
+  // If a particle-specific gamma is given
+  auto const constexpr langevin_temp_coeff = 24.0;
 
-#ifndef ROTATIONAL_INERTIA
-    if(p->p.gamma_rot >= 0.)
-    {
-      langevin_pref1_temp = p->p.gamma_rot;
-      // Is a particle-specific temperature also specified?
-      if(p->p.T >= 0.)
-        langevin_pref2_temp = sqrt(langevin_temp_coeff*p->p.T*p->p.gamma_rot/time_step);
-      else
-        // Default temperature but particle-specific gamma
-        langevin_pref2_temp = sqrt(langevin_temp_coeff*temperature*p->p.gamma_rot/time_step);
-
-    } // particle specific gamma
+  if (p->p.gamma_rot >= Thermostat::GammaType{}) {
+    langevin_pref1_temp = p->p.gamma_rot;
+    // Is a particle-specific temperature also specified?
+    if (p->p.T >= 0.)
+      langevin_pref2_temp =
+          sqrt(langevin_temp_coeff * p->p.T * p->p.gamma_rot / time_step);
     else
-    {
-      langevin_pref1_temp = langevin_gamma_rotation;
-      // No particle-specific gamma, but is there particle-specific temperature
-      if(p->p.T >= 0.)
-        langevin_pref2_temp = sqrt(langevin_temp_coeff*p->p.T*langevin_gamma_rotation/time_step);
-      else
-        // Default values for both
-        langevin_pref2_temp = langevin_pref2_rotation;
-    }
-#else
-    for ( j = 0 ; j < 3 ; j++)
-    if(p->p.gamma_rot[j] >= 0.)
-    {
-      langevin_pref1_temp[j] = p->p.gamma_rot[j];
-      // Is a particle-specific temperature also specified?
-      if(p->p.T >= 0.)
-        langevin_pref2_temp[j] = sqrt(langevin_temp_coeff*p->p.T*p->p.gamma_rot[j]/time_step);
-      else
-        // Default temperature but particle-specific gamma
-        langevin_pref2_temp[j] = sqrt(langevin_temp_coeff*temperature*p->p.gamma_rot[j]/time_step);
+      // Default temperature but particle-specific gamma
+      langevin_pref2_temp =
+          sqrt(langevin_temp_coeff * temperature * p->p.gamma_rot / time_step);
 
-    } // particle specific gamma
+  } // particle specific gamma
+  else {
+    langevin_pref1_temp = langevin_gamma_rotation;
+    // No particle-specific gamma, but is there particle-specific temperature
+    if (p->p.T >= 0.)
+      langevin_pref2_temp = sqrt(langevin_temp_coeff * p->p.T *
+                                 langevin_gamma_rotation / time_step);
     else
-    {
-      langevin_pref1_temp[j] = langevin_gamma_rotation[j];
-      // No particle-specific gamma, but is there particle-specific temperature
-      if(p->p.T >= 0.)
-        langevin_pref2_temp[j] = sqrt(langevin_temp_coeff*p->p.T*langevin_gamma_rotation[j]/time_step);
-      else
-        // Default values for both
-        langevin_pref2_temp[j] = langevin_pref2_rotation[j];
-    }
-#endif // PARTICLE_ANISOTROPY
+      // Default values for both
+      langevin_pref2_temp = langevin_pref2_rotation;
+  }
 #endif /* LANGEVIN_PER_PARTICLE */
-
 
   // Rotational degrees of virtual sites are thermostatted,
   // so no switching here
 
-
   // Here the thermostats happens
-  for ( j = 0 ; j < 3 ; j++) 
-  {
-#ifdef ROTATIONAL_INERTIA
-    p->f.torque[j] = -langevin_pref1_temp[j]*p->m.omega[j] + switch_rotate*langevin_pref2_temp[j]*Thermostat::noise();
+  for (int j = 0; j < 3; j++) {
+#ifdef PARTICLE_ANISOTROPY
+    p->f.torque[j] =
+        -langevin_pref1_temp[j] * p->m.omega[j] +
+        switch_rotate * langevin_pref2_temp[j] * Thermostat::noise();
 #else
-    p->f.torque[j] = -langevin_pref1_temp*p->m.omega[j] + switch_rotate*langevin_pref2_temp*Thermostat::noise();
+    p->f.torque[j] = -langevin_pref1_temp * p->m.omega[j] +
+                     switch_rotate * langevin_pref2_temp * Thermostat::noise();
 #endif
   }
 
-  ONEPART_TRACE(if(p->p.identity==check_id) fprintf(stderr,"%d: OPT: LANG f = (%.3e,%.3e,%.3e)\n",this_node,p->f.f[0],p->f.f[1],p->f.f[2]));
-  THERMO_TRACE(fprintf(stderr,"%d: Thermo: P %d: force=(%.3e,%.3e,%.3e)\n",this_node,p->p.identity,p->f.f[0],p->f.f[1],p->f.f[2]));
+  ONEPART_TRACE(if (p->p.identity == check_id)
+                    fprintf(stderr, "%d: OPT: LANG f = (%.3e,%.3e,%.3e)\n",
+                            this_node, p->f.f[0], p->f.f[1], p->f.f[2]));
+  THERMO_TRACE(fprintf(stderr, "%d: Thermo: P %d: force=(%.3e,%.3e,%.3e)\n",
+                       this_node, p->p.identity, p->f.f[0], p->f.f[1],
+                       p->f.f[2]));
 }
 
 #endif // ROTATION

--- a/src/core/unit_tests/Vector_test.cpp
+++ b/src/core/unit_tests/Vector_test.cpp
@@ -124,6 +124,19 @@ BOOST_AUTO_TEST_CASE(algebraic_operators) {
 
   BOOST_CHECK(((2 * v1) == Vector<3, int>{2, 4, 6}));
   BOOST_CHECK(((v1 * 2) == Vector<3, int>{2, 4, 6}));
+
+  {
+    Vector<3, int> v1{2, 4, 6};
+    auto v2 = 2 * v1;
+    BOOST_CHECK(v2 == (v1 *= 2));
+  }
+
+  {
+    Vector<3, int> v1{2, 4, 6};
+    auto v2 = v1 / 2;
+    BOOST_CHECK(v2 == (v1 /= 2));
+  }
+
   BOOST_CHECK((sqrt(Vector<3, double>{1., 2., 3.}) ==
                Vector<3, double>{sqrt(1.), sqrt(2.), sqrt(3.)}));
 }

--- a/src/core/unit_tests/Vector_test.cpp
+++ b/src/core/unit_tests/Vector_test.cpp
@@ -125,4 +125,7 @@ BOOST_AUTO_TEST_CASE(algebraic_operators) {
   }
 
   BOOST_CHECK(((2 * v1) == Vector<3, int>{2, 4, 6}));
+  BOOST_CHECK(((v1 * 2) == Vector<3, int>{2, 4, 6}));
+  BOOST_CHECK((sqrt(Vector<3, double>{1., 2., 3.}) ==
+               Vector<3, double>{sqrt(1.), sqrt(2.), sqrt(3.)}));
 }

--- a/src/core/unit_tests/Vector_test.cpp
+++ b/src/core/unit_tests/Vector_test.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(normalize) {
   BOOST_CHECK((v.norm2() - 1.0) <= std::numeric_limits<double>::epsilon());
 }
 
-BOOST_AUTO_TEST_CASE(operators) {
+BOOST_AUTO_TEST_CASE(comparison_operators) {
   Vector<5, int> v1{1, 2, 3, 4, 5};
   Vector<5, int> v2{6, 7, 8, 9, 10};
 
@@ -99,4 +99,30 @@ BOOST_AUTO_TEST_CASE(operators) {
   BOOST_CHECK(v1 != v2);
   BOOST_CHECK(!(v1 == v2));
   BOOST_CHECK(v1 == v1);
+}
+
+BOOST_AUTO_TEST_CASE(algebraic_operators) {
+  Vector<3, int> v1{1, 2, 3};
+  Vector<3, int> v2{4, 5, 6};
+
+  BOOST_CHECK((v1 * v2) ==
+              std::inner_product(v1.begin(), v1.end(), v2.begin(), 0));
+
+  BOOST_CHECK(((v1 + v2) == Vector<3, int>{5, 7, 9}));
+  BOOST_CHECK(((v1 - v2) == Vector<3, int>{-3, -3, -3}));
+  BOOST_CHECK(((-v1) == Vector<3, int>{-1, -2, -3}));
+
+  {
+    auto v3 = v1;
+    v3 += v2;
+    BOOST_CHECK(((v1 + v2) == v3));
+  }
+
+  {
+    auto v3 = v1;
+    v3 -= v2;
+    BOOST_CHECK(((v1 - v2) == v3));
+  }
+
+  BOOST_CHECK(((2 * v1) == Vector<3, int>{2, 4, 6}));
 }

--- a/src/core/unit_tests/Vector_test.cpp
+++ b/src/core/unit_tests/Vector_test.cpp
@@ -114,14 +114,12 @@ BOOST_AUTO_TEST_CASE(algebraic_operators) {
 
   {
     auto v3 = v1;
-    v3 += v2;
-    BOOST_CHECK(((v1 + v2) == v3));
+    BOOST_CHECK((v1 + v2) == (v3 += v2));
   }
 
   {
     auto v3 = v1;
-    v3 -= v2;
-    BOOST_CHECK(((v1 - v2) == v3));
+    BOOST_CHECK((v1 - v2) == (v3 -= v2));
   }
 
   BOOST_CHECK(((2 * v1) == Vector<3, int>{2, 4, 6}));

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -26,6 +26,10 @@ from libcpp.memory cimport unique_ptr
 
 include "myconfig.pxi"
 
+cdef extern from "Vector.hpp":
+    cppclass Vector3d:
+        double & operator[](int i)
+
 # Import particle data structures and setter functions from particle_data.hpp
 
 cdef extern from "particle_data.hpp":
@@ -149,15 +153,15 @@ cdef extern from "particle_data.hpp":
         void pointer_to_temperature(particle * p, double * & res)
 
         IF PARTICLE_ANISOTROPY:
-            int set_particle_gamma(int part, double gamma[3])
+            int set_particle_gamma(int part, Vector3d gamma)
         ELSE:
             int set_particle_gamma(int part, double gamma)
 
         void pointer_to_gamma(particle * p, double * & res)
 
         IF ROTATION:
-            IF ROTATIONAL_INERTIA:
-                int set_particle_gamma_rot(int part, double gamma[3])
+            IF PARTICLE_ANISOTROPY:
+                int set_particle_gamma_rot(int part, Vector3d gamma_rot)
             ELSE:
                 int set_particle_gamma_rot(int part, double gamma)
 

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -926,7 +926,7 @@ cdef class ParticleHandle(object):
                 """
 
                 def __set__(self, _gamma):
-                    cdef double gamma[3]
+                    cdef Vector3d gamma
                     check_type_or_throw_except(
                         _gamma, 3, float, "Friction has to be 3 floats.")
                     for i in range(3):
@@ -985,7 +985,7 @@ cdef class ParticleHandle(object):
                     """
 
                     def __set__(self, _gamma_rot):
-                        cdef double gamma_rot[3]
+                        cdef Vector3d gamma_rot
                         check_type_or_throw_except(
                             _gamma_rot, 3, float, "Rotational friction has to be 3 floats.")
                         for i in range(3):


### PR DESCRIPTION
Description of changes:
 - Removed some of the confusion regarding
   ROTATIONAL_INERTIA and PARTICLE_ANISOTROPY
   in the langevin thermostat.
 - The vector gamma and gamma_rot (global or per particle if
   LANGEVIN_PER_PARTICLE) is now turned on by PARTICLE_ANISOTROPY. 
 - Made per particle gamma{_rot} and langevin_gamma{_rot} Vector3d.
