### PR TITLE
openGL Visualizer: Ignore non shape-based Constraints.

### DIFF
--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -219,7 +219,7 @@ class openGLLive(object):
 
         # Collect shapes and interaction type (for coloring) from constraints
         coll_shape_obj = collections.defaultdict(list)
-        for c in self.system.constraints.call_method('get_elements'):
+        for c in self.system.constraints:
             if type(c) == espressomd.constraints.ShapeBasedConstraint:
                 t = c.get_parameter('particle_type')
                 s = c.get_parameter('shape')

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -220,13 +220,14 @@ class openGLLive(object):
         # Collect shapes and interaction type (for coloring) from constraints
         coll_shape_obj = collections.defaultdict(list)
         for c in self.system.constraints.call_method('get_elements'):
-            t = c.get_parameter('particle_type')
-            s = c.get_parameter('shape')
-            n = s.name()
-            if n in ['Shapes::Wall', 'Shapes::Cylinder', 'Shapes::Sphere', 'Shapes::SpheroCylinder']:
-                coll_shape_obj[n].append([s, t])
-            else:
-                coll_shape_obj['Shapes::Misc'].append([s, t])
+            if type(c) == espressomd.constraints.ShapeBasedConstraint:
+                t = c.get_parameter('particle_type')
+                s = c.get_parameter('shape')
+                n = s.name()
+                if n in ['Shapes::Wall', 'Shapes::Cylinder', 'Shapes::Sphere', 'Shapes::SpheroCylinder']:
+                    coll_shape_obj[n].append([s, t])
+                else:
+                    coll_shape_obj['Shapes::Misc'].append([s, t])
 
         # TODO: get shapes from lbboundaries
         for s in coll_shape_obj['Shapes::Wall']:


### PR DESCRIPTION
Without this fix, the visualizer crashes if non ShapeBasedConstraint type constraints are part of the system
