### PR TITLE
Top ten reasons why you should be parsing PDB.

### DIFF
--- a/src/core/PdbParser.cpp
+++ b/src/core/PdbParser.cpp
@@ -48,7 +48,7 @@ namespace PdbParser {
     return bb;
   }
 
-  bool PdbParser::parse_pdb_file(string filename) { 
+  bool PdbParser::parse_pdb_file(string const &filename) {
     ifstream file;
     string tmp;
     pdb_atom a;
@@ -76,7 +76,7 @@ namespace PdbParser {
     return true; 
   }
 
-  bool PdbParser::parse_itp_file(string filename) { 
+  bool PdbParser::parse_itp_file(string const &filename) {
     ifstream file(filename.c_str());
     string tmp, buf;
     itp_atom atom;
@@ -180,7 +180,7 @@ namespace PdbParser {
     return true; 
   }
 
-  bool PdbParser::parse_file(string pdb_filename, string itp_filename) {
+  bool PdbParser::parse_file(string const &pdb_filename, string const &itp_filename) {
     return parse_pdb_file(pdb_filename) && parse_itp_file(itp_filename);
   }
 

--- a/src/core/PdbParser.hpp
+++ b/src/core/PdbParser.hpp
@@ -58,9 +58,9 @@ namespace PdbParser {
 
   class PdbParser {
   public:
-    bool parse_pdb_file(std::string filename);
-    bool parse_itp_file(std::string filename);
-    bool parse_file(std::string pdb_filename, std::string itp_filename);
+    bool parse_pdb_file(std::string const &filename);
+    bool parse_itp_file(std::string const &filename);
+    bool parse_file(std::string const &pdb_filename, std::string const &itp_filename);
     BoundingBox calc_bounding_box() const;
     std::vector<pdb_atom> pdb_atoms;
     std::map<int, itp_atom> itp_atoms;

--- a/src/core/readpdb.cpp
+++ b/src/core/readpdb.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <cmath>
 #include <set>
+#include <string>
 
 #ifdef READPDB_DEBUG
 #define READPDB_TRACE(A) A
@@ -139,14 +140,14 @@ static int add_particles(PdbParser::PdbParser &parser, int first_id, int default
   return id - first_id;
 }
 
-int pdb_add_particles_from_file(char *pdb_file, int first_id, int type, std::vector<PdbLJInteraction> &ljInteractions, double lj_rel_cutoff,
-				char *itp_file, int first_type, bool fit, bool lj_internal, bool lj_diagonal) {
+int pdb_add_particles_from_file(std::string const &pdb_file, int first_id, int type, std::vector<PdbLJInteraction> &ljInteractions, double lj_rel_cutoff,
+				std::string const &itp_file, int first_type, bool fit, bool lj_internal, bool lj_diagonal) {
   int n_part;
   PdbParser::PdbParser parser;
   if(!parser.parse_pdb_file(pdb_file))
     return 0;
 
-  if(itp_file) {
+  if(!itp_file.empty()) {
     if(!parser.parse_itp_file(itp_file))
       return 0;
   }

--- a/src/core/readpdb.hpp
+++ b/src/core/readpdb.hpp
@@ -21,6 +21,8 @@
 #ifndef __READ_PDB_HPP
 #define __READ_PDB_HPP
 
+#include <string>
+
 #include "PdbParser.hpp"
 #include "particle_data.hpp"
 
@@ -40,6 +42,6 @@ struct PdbLJInteraction {
     @return Number of particles that were added.
  */
 
-int pdb_add_particles_from_file(char *pdb_file, int first_id, int type, std::vector<PdbLJInteraction> &ljInteractions, double lj_rel_cutoff=2.5,
-				char *itp_file=NULL, int first_type=0, bool fit = false, bool lj_internal = false, bool lj_diagonal = false);
+int pdb_add_particles_from_file(std::string const &pdb_file, int first_id, int type, std::vector<PdbLJInteraction> &ljInteractions, double lj_rel_cutoff=2.5,
+				std::string const &itp_file="", int first_type=0, bool fit = false, bool lj_internal = false, bool lj_diagonal = false);
 #endif

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -23,6 +23,7 @@ cimport numpy as np
 from espressomd.utils cimport *
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
+from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 include "myconfig.pxi"
@@ -244,9 +245,8 @@ cdef extern from "readpdb.hpp":
         double epsilon
         double sigma
 
-    cdef int pdb_add_particles_from_file(char *pdb_file, int first_id,
-				int type, vector[PdbLJInteraction]&
-				ljInteractions, double lj_rel_cutoff,
-				char *itp_file, int first_type, bool
-				fit, bool lj_internal, bool
-				lj_diagonal)
+    cdef int pdb_add_particles_from_file(const string & pdb_file, int first_id,
+                                         int type, vector[PdbLJInteraction] &ljInteractions,
+                                         double lj_rel_cutoff, const string & itp_file,
+                                         int first_type, bool fit, bool lj_internal,
+                                         bool lj_diagonal)

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -23,6 +23,7 @@ cimport numpy as np
 from espressomd.utils cimport *
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
+from libcpp.vector cimport vector
 
 include "myconfig.pxi"
 
@@ -236,3 +237,16 @@ cdef class _ParticleSliceImpl:
 cdef extern from "grid.hpp":
     cdef void fold_position(double *, int*)
     void unfold_position(double pos[3], int image_box[3]) 
+
+cdef extern from "readpdb.hpp":
+    ctypedef struct PdbLJInteraction:
+        int other_type
+        double epsilon
+        double sigma
+
+    cdef int pdb_add_particles_from_file(char *pdb_file, int first_id,
+				int type, vector[PdbLJInteraction]&
+				ljInteractions, double lj_rel_cutoff,
+				char *itp_file, int first_type, bool
+				fit, bool lj_internal, bool
+				lj_diagonal)

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1934,10 +1934,8 @@ cdef class ParticleList(object):
         for i in range(0,N/3):
             push_ljia(i)
 
-        pdb_n_part = pdb_add_particles_from_file(utils.to_char_pointer(pdb_file),
-                                                 first_id, type, ljinteractions, lj_rel_cutoff,
-                                                 utils.to_char_pointer(itp_file),
-                                                 first_type, rescale_box, lj_internal, lj_diagonal)
+        pdb_n_part = pdb_add_particles_from_file(pdb_file, first_id, type, ljinteractions, lj_rel_cutoff,
+                                                 itp_file, first_type, rescale_box, lj_internal, lj_diagonal)
 
         if pdb_n_part == 0:
             raise Exception("Could not parse pdb file")


### PR DESCRIPTION
```python
import espressomd
system = espressomd.System()
system.part.(pdb_file="ortho_dimer.pdb", type=0, first_id=0)
```
Fixes #1438