### PR TITLE
h5md: Make sure coords are folded.

### DIFF
--- a/src/core/grid.hpp
+++ b/src/core/grid.hpp
@@ -306,6 +306,10 @@ template <typename Particle> Vector3d folded_position(Particle const &p) {
   return pos;
 }
 
+inline void fold_position(Vector3d &pos, Vector<3, int> &image_box) {
+  fold_position(pos.data(), image_box.data());
+}
+
 /** unfold coordinates to physical position.
     \param pos the position
     \param pos the velocity

--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -322,13 +322,18 @@ void File::fill_arrays_for_h5md_write_with_particle_property(
     mass[0][particle_index][0] = current_particle.p.mass;
   /* store folded particle positions. */
   if (write_pos) {
-    pos[0][particle_index][0] = current_particle.r.p[0];
-    pos[0][particle_index][1] = current_particle.r.p[1];
-    pos[0][particle_index][2] = current_particle.r.p[2];
-    image[0][particle_index][0] = current_particle.l.i[0];
-    image[0][particle_index][1] = current_particle.l.i[1];
-    image[0][particle_index][2] = current_particle.l.i[2];
+    Vector3d p{{current_particle.r.p}};
+    Vector<3, int> i{{current_particle.l.i}};
+    fold_position(p, i);
+
+    pos[0][particle_index][0] = p[0];
+    pos[0][particle_index][1] = p[1];
+    pos[0][particle_index][2] = p[2];
+    image[0][particle_index][0] = i[0];
+    image[0][particle_index][1] = i[1];
+    image[0][particle_index][2] = i[2];
   }
+
   if (write_vel) {
     vel[0][particle_index][0] = current_particle.m.v[0] / time_step;
     vel[0][particle_index][1] = current_particle.m.v[1] / time_step;


### PR DESCRIPTION
Fixes #1437 

Description of changes:
 - Always write folded positions in h5md writer.
