### PR TITLE
dissto(id) now ignores own ID from particle list

### DIFF
--- a/doc/sphinx/part.rst
+++ b/doc/sphinx/part.rst
@@ -37,7 +37,7 @@ It is also possible to add several particles at once:::
 
 Furthermore, the :meth:`espressomd.particle_data.ParticleList.add` method returns the added particle(s):::
 
-    tracer=system.part.add(poa=(0,0,0))
+    tracer=system.part.add(pos=(0,0,0))
     print(tracer.pos)
 
 Note that the instance of :class:`espressomd.particle_data.ParticleHandle` returned by :meth:`espressomd.particle_data.ParticleList.add` are handles for the live particles in the simulation, rather than offline copies. Changing their properties will affect the simulation.
@@ -46,18 +46,22 @@ Note that the instance of :class:`espressomd.particle_data.ParticleHandle` retur
 Accessing particle properties
 -----------------------------
 
-Particle properties can be accessed like a class
-member. To access property ``PROPERTY`` of the particle with id ``ID``::
+Particle properties can be accessed like a class member.
 
-    system.part[<ID>].<PROPERTY>
+To access property ``PROPERTY`` of the particle with index ``INDEX``::
 
-For example, to print the current position of the particle with id 0 in the system, call::
+    system.part[<INDEX>].<PROPERTY>
+
+For example, to print the current position of the particle with index 0 in the system, call::
 
     print(system.part[0].pos)
 
 Similarly, the position can be set::
 
     system.part[0].pos=(1,2.5,3)
+    system.part[0].id=4
+
+Note that the index and the property ID are not necessasirly the same.
 
 Interacting with groups of particles
 ------------------------------------
@@ -67,7 +71,7 @@ The :class:`espressomd.particle_data.ParticleList` support slicing similarly to 
     print(sysstem.part[:].pos)
     system.part[:].q=0
 
-To access particles with ids ranging from 0 to 9, use::
+To access particles with indices ranging from 0 to 9, use::
     
     system.party[0:10].pos
 
@@ -79,7 +83,7 @@ Deleting particles
 ------------------
 
 Particles can be easily deleted in Python using particle ids or ranges of particle ids.
-For example, to delete all particles with particle id greater than 10, run::
+For example, to delete all particles with particle index greater than 10, run::
 
     >>> system.part[10:].remove()
 
@@ -99,7 +103,7 @@ You can iterate over all particles or over a subset of particles as follows::
 
 You can iterate over all pairs of particles using::
     
-    for pair in system.part.paris():
+    for pair in system.part.pairs():
         print(pair[1].id,pair[2].id)
 
         

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -108,7 +108,7 @@ class Analysis(object):
 
     def distto(self, id=None, pos=None):
         """
-        Calculates the minimum distance to a point or particle.
+        Calculates the distance to a point or particle.
 
         Parameters
         ----------

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -139,13 +139,16 @@ class Analysis(object):
         if id != None:
             if not isinstance(id, int):
                 raise ValueError("Id has to be an integer")
+            if id >= len(self._system.part):
+                raise ValueError("Id has to be an index of an existing particle")
             _pos = self._system.part[id].pos
             for i in range(3):
                 cpos[i] = _pos[i]
+            _id = id
         else:
             for i in range(3):
                 cpos[i] = pos[i]
-                _id = -1
+            _id = -1
         return c_analyze.distto(c_analyze.partCfg(), cpos, _id)
 
     #

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -139,7 +139,7 @@ class Analysis(object):
         if id != None:
             if not isinstance(id, int):
                 raise ValueError("Id has to be an integer")
-            if id >= len(self._system.part):
+            if not id in self._system.part[:].id:
                 raise ValueError("Id has to be an index of an existing particle")
             _pos = self._system.part[id].pos
             for i in range(3):

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -108,7 +108,7 @@ class Analysis(object):
 
     def distto(self, id=None, pos=None):
         """
-        Calculates the distance to a point or particle.
+        Calculates the minimum distance to a point or particle.
 
         Parameters
         ----------

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -803,9 +803,9 @@ cdef class ParticleHandle(object):
             arguments it is possible to fix motion in x, y, or z coordinates
             independently. For example::
 
-                part[<ID>].fix = [0, 0, 1]
+                part[<INDEX>].fix = [0, 0, 1]
 
-            will fix motion for particle with id ``ID`` only in z.
+            will fix motion for particle with index ``INDEX`` only in z.
 
             .. note::
                This needs the feature EXTERNAL_FORCES.


### PR DESCRIPTION
Fixes 
distto(id) always returns a distance of 0,
this was due to checking ID with all others (including ID), thus always zero minimum distance.

Description of changes:
 - found a bug, fixed it.
 - doc string describes a bit better what it does


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
