### PR TITLE
cmake: Require CUDA minimum version 7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endforeach(func_name __PRETTY_FUNCTION__ __FUNCTION__)
 ######################################################################
 
 if (WITH_CUDA)
-  find_package(CUDA QUIET)
+  find_package(CUDA 7.0)
   if(CUDA_FOUND)
     list(APPEND LIBRARIES ${CUDA_CUFFT_LIBRARIES})
     list(APPEND LIBRARIES ${CUDA_LIBRARIES})


### PR DESCRIPTION
Fixes #1455.

Description of changes:
 - Require CUDA version 7.0 in cmake
