### PR TITLE
Extend thermostat and rotation test

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,7 +4,7 @@ file(GLOB EspressoCore_SRC
 
 if( WITH_COVERAGE )
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O1 --coverage -fprofile-arcs -ftest-coverage")
   link_libraries(gcov)
 endif()
 

--- a/src/core/correlators/Correlator.cpp
+++ b/src/core/correlators/Correlator.cpp
@@ -380,7 +380,8 @@ void Correlator::initialize() {
 
 int Correlator::get_data() {
   if (finalized) {
-     throw std::runtime_error("No data can be added after finalize() was called.");
+     runtimeErrorMsg() << "No data can be added after finalize() was called.";
+     return 0;
   }
   // We must now go through the hierarchy and make sure there is space for the new 
   // datapoint. For every hierarchy level we have to decide if it necessary to move 
@@ -615,7 +616,8 @@ int Correlator::read_data_from_file(const char * filename, bool binary){
 
 int Correlator::finalize() {
   if (finalized) {
-     throw std::runtime_error("Correlator::finalize() can only be called once.");
+     runtimeErrorMsg() << "Correlator::finalize() can only be called once.";
+     return 0;
   }
   // We must now go through the hierarchy and make sure there is space for the new 
   // datapoint. For every hierarchy level we have to decide if it necessary to move 

--- a/src/core/correlators/Correlator.cpp
+++ b/src/core/correlators/Correlator.cpp
@@ -379,6 +379,9 @@ void Correlator::initialize() {
 }
 
 int Correlator::get_data() {
+  if (finalized) {
+     throw std::runtime_error("No data can be added after finalize() was called.");
+  }
   // We must now go through the hierarchy and make sure there is space for the new 
   // datapoint. For every hierarchy level we have to decide if it necessary to move 
   // something
@@ -611,6 +614,9 @@ int Correlator::read_data_from_file(const char * filename, bool binary){
 
 
 int Correlator::finalize() {
+  if (finalized) {
+     throw std::runtime_error("Correlator::finalize() can only be called once.");
+  }
   // We must now go through the hierarchy and make sure there is space for the new 
   // datapoint. For every hierarchy level we have to decide if it necessary to move 
   // something

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -220,7 +220,7 @@ class ScriptInterfaceHelper(PScriptInterface):
             try:
                 return self.__dict__[attr]
             except KeyError:
-                raise AttributeError
+                raise AttributeError("Class "+self.__class__.__name__+" does not have an attribute "+attr)
 
     def __setattr__(self, attr, value):
         if attr in self._valid_parameters():

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -220,13 +220,13 @@ cdef class Thermostat(object):
         scalar_gamma_def = True
         scalar_gamma_rot_def = True
         IF PARTICLE_ANISOTROPY:
-            if isinstance(gamma, list):
+            if hasattr(gamma, "__iter__"):
                 scalar_gamma_def = False
             else:
                 scalar_gamma_def = True
 
         IF PARTICLE_ANISOTROPY:
-            if isinstance(gamma_rotation, list):
+            if hasattr(gamma_rotation, "__iter__"):
                 scalar_gamma_rot_def = False
             else:
                 scalar_gamma_rot_def = True

--- a/testsuite/langevin_thermostat.py
+++ b/testsuite/langevin_thermostat.py
@@ -317,6 +317,12 @@ class LangevinThermostat(ut.TestCase):
                 self.verify_diffusion(p_gamma,corr_omega,kT,eff_per_part_gamma_rot)
                 self.verify_diffusion(p_kT,corr_omega,per_part_kT,eff_gamma_rot)
                 self.verify_diffusion(p_both,corr_omega,per_part_kT,eff_per_part_gamma_rot)
+        for c in corr_vel.values():
+            s.auto_update_correlators.remove(c)
+        for c in corr_omega.values():
+            s.auto_update_correlators.remove(c)
+
+
             
 
     def verify_diffusion(self,p,corr,kT,gamma):

--- a/testsuite/langevin_thermostat.py
+++ b/testsuite/langevin_thermostat.py
@@ -23,6 +23,8 @@ import espressomd
 import numpy as np
 from espressomd.interactions import FeneBond
 from time import time
+from espressomd.correlators import Correlator
+from espressomd.observables import ParticleVelocities, ParticleAngularMomentum
 
 
 @ut.skipIf(espressomd.has_features("THERMOSTAT_IGNORE_NON_VIRTUAL"),
@@ -70,21 +72,39 @@ class LangevinThermostat(ut.TestCase):
         s = self.s
         s.part.clear()
         s.time_step = 0.1
+        
+        # Place particles
         s.part.add(pos=np.random.random((N, 3)))
+       
+        # Enable rotation if compiled in
+        if espressomd.has_features("ROTATION"): 
+            s.part[:].rotation = 1,1,1
+
         kT = 2.3
         gamma = 1.5
         s.thermostat.set_langevin(kT=kT, gamma=gamma)
+        
+        # Warmup
         s.integrator.run(100)
+
+        # Sampling
         loops = 6000
         v_stored = np.zeros((N * loops, 3))
+        omega_stored = np.zeros((N * loops, 3))
         for i in range(loops):
             s.integrator.run(2)
             v_stored[i * N:(i + 1) * N, :] = s.part[:].v
+            if espressomd.has_features("ROTATION"):
+                omega_stored[i * N:(i + 1) * N, :] = s.part[:].omega_body
+
         v_minmax = 5
         bins = 5
         error_tol = 0.01
         self.check_velocity_distribution(
             v_stored, v_minmax, bins, error_tol, kT)
+        if espressomd.has_features("ROTATION"): 
+            self.check_velocity_distribution(
+                omega_stored, v_minmax, bins, error_tol, kT)
 
     @ut.skipIf(not espressomd.has_features("LANGEVIN_PER_PARTICLE"),
                "Test requires LANGEVIN_PER_PARTICLE")
@@ -97,6 +117,9 @@ class LangevinThermostat(ut.TestCase):
         s.part.clear()
         s.time_step = 0.1
         s.part.add(pos=np.random.random((N, 3)))
+        if espressomd.has_features("ROTATION"): 
+            s.part[:].rotation = 1,1,1
+        
         kT = 2.3
         gamma = 1.5
         gamma2 = 2.3
@@ -115,6 +138,10 @@ class LangevinThermostat(ut.TestCase):
 
         v_kT = np.zeros((int(N / 2) * loops, 3))
         v_kT2 = np.zeros((int(N / 2 * loops), 3))
+        
+        if espressomd.has_features("ROTATION"): 
+            omega_kT = np.zeros((int(N / 2) * loops, 3))
+            omega_kT2 = np.zeros((int(N / 2 * loops), 3))
 
         for i in range(loops):
             s.integrator.run(2)
@@ -122,13 +149,113 @@ class LangevinThermostat(ut.TestCase):
                  :] = s.part[:int(N / 2)].v
             v_kT2[int(i * N / 2):int((i + 1) * N / 2),
                   :] = s.part[int(N / 2):].v
+           
+            if espressomd.has_features("ROTATION"):
+               omega_kT[int(i * N / 2):int((i + 1) * N / 2),
+                   :] = s.part[:int(N / 2)].omega_body
+               omega_kT2[int(i * N / 2):int((i + 1) * N / 2),
+                    :] = s.part[int(N / 2):].omega_body
         v_minmax = 5
         bins = 5
         error_tol = 0.014
         self.check_velocity_distribution(v_kT, v_minmax, bins, error_tol, kT)
         self.check_velocity_distribution(v_kT2, v_minmax, bins, error_tol, kT2)
+        
+        self.check_velocity_distribution(omega_kT, v_minmax, bins, error_tol, kT)
+        self.check_velocity_distribution(omega_kT2, v_minmax, bins, error_tol, kT2)
 
+    def test_diffusion(self):
+        """This tests rotational and translational diffusion coeff via green-kubo"""
+        s=self.s
+        s.part.clear()
 
+        gamma=2.4
+        kT=1.37
+        dt=0.1
+        s.time_step=dt
+        gamma_rot_i=0.8
+        gamma_rot_a=gamma,0.8,2.5
+        
+        p=s.part.add(pos=(0,0,0),id=0)
+        
+        # Make sure, mass doesn't change diff coeff
+        if espressomd.has_features("MASS"):
+            s.part[0].mass=0.5
+
+        
+        if espressomd.has_features("ROTATION"): 
+            s.part[0].rotation = 1,1,1
+            # Make sure rinertia does not change diff coeff
+            if espressomd.has_features("ROTATIONAL_INERTIA"): 
+                s.part[0].rinertia =0.5,1.5,1.
+            if espressomd.has_features("PARTICLE_ANISOTROPY"):
+                # particle anisotropy and rotation
+                s.thermostat.set_langevin(kT=kT,gamma=gamma,gamma_rotation=gamma_rot_a)
+            else:
+                # Rotation without particle anisotropy
+                s.thermostat.set_langevin(kT=kT,gamma=gamma,gamma_rotation=gamma_rot_i)
+        else:
+            # No rotation
+            s.thermostat.set_langevin(kT=kT,gamma=gamma)
+        
+
+        
+        s.cell_system.skin =0.4
+        s.integrator.run(500)
+        
+        # linear vel
+        vel_obs=ParticleVelocities(ids=(0,))
+        c_vel = Correlator(obs1=vel_obs, tau_lin=16, tau_max=20., dt=dt,
+            corr_operation="componentwise_product", compress1="discard1")
+        s.auto_update_correlators.add(c_vel)
+        
+        # angular vel
+        if espressomd.has_features("ROTATION"):
+            omega_obs=ParticleAngularMomentum(ids=(0,))
+            c_omega = Correlator(obs1=omega_obs, tau_lin=16, tau_max=40., dt=dt,
+                corr_operation="componentwise_product", compress1="discard1")
+            s.auto_update_correlators.add(c_omega)
+        
+        s.integrator.run(10000000)
+        
+        # Analyze linear vel
+        c_vel.finalize()
+        # Integral of vacf via Green-Kubo
+        #D= 1/3 int_0^infty <v(t_0)v(t_0+t)> dt
+        vacf=c_vel.result()
+        #Integrate w. trapez rule
+        for coord in 2,3,4:
+            I=np.trapz(vacf[:,coord],vacf[:,0])
+            ratio = I/(kT/gamma)
+            print("Ratio of measured and expected diffusion coeff from Green-Kubo:",ratio)
+            self.assertAlmostEqual(ratio,1.,delta=0.07)
+        
+        # Analyze angular el
+        if espressomd.has_features("ROTATION"):
+            c_omega.finalize()
+            # Integral of vacf via Green-Kubo
+            #D= 1/3 int_0^infty <v(t_0)v(t_0+t)> dt
+            omega_acf=c_omega.result()
+            
+            print("angular vel")
+            # No particle anisotropy
+            if not espressomd.has_features("PARTICLE_ANISOTROPY"):
+                #Integrate w. trapez rule
+                for coord in 2,3,4: 
+                    I=np.trapz(omega_acf[:,coord],omega_acf[:,0])
+                    ratio = I/(kT/gamma_rot_i)
+                    print("Ratio of measured and expected diffusion coeff from Green-Kubo:",ratio)
+                    self.assertAlmostEqual(ratio,1.,delta=0.07)
+            else:
+                # Particle anisotropy
+                #Integrate w. trapez rule
+                for coord in 2,3,4: 
+                    I=np.trapz(omega_acf[:,coord],omega_acf[:,0])
+                    ratio = I/(kT/gamma_rot_a[coord-2])
+                    print("Ratio of measured and expected diffusion coeff from Green-Kubo:",ratio)
+                    self.assertAlmostEqual(ratio,1.,delta=0.07)
+        print(s.thermostat.get_state())                    
+        
+ 
 if __name__ == "__main__":
-    print("Features: ", espressomd.features())
     ut.main()

--- a/testsuite/langevin_thermostat.py
+++ b/testsuite/langevin_thermostat.py
@@ -24,7 +24,7 @@ import numpy as np
 from espressomd.interactions import FeneBond
 from time import time
 from espressomd.correlators import Correlator
-from espressomd.observables import ParticleVelocities, ParticleAngularMomentum
+from espressomd.observables import ParticleVelocities, ParticleBodyAngularMomentum
 
 
 @ut.skipIf(espressomd.has_features("THERMOSTAT_IGNORE_NON_VIRTUAL"),
@@ -197,6 +197,7 @@ class LangevinThermostat(ut.TestCase):
         else:
             # No rotation
             s.thermostat.set_langevin(kT=kT,gamma=gamma)
+        print(s.thermostat.get_state())                    
         
 
         
@@ -211,7 +212,7 @@ class LangevinThermostat(ut.TestCase):
         
         # angular vel
         if espressomd.has_features("ROTATION"):
-            omega_obs=ParticleAngularMomentum(ids=(0,))
+            omega_obs=ParticleBodyAngularMomentum(ids=(0,))
             c_omega = Correlator(obs1=omega_obs, tau_lin=16, tau_max=40., dt=dt,
                 corr_operation="componentwise_product", compress1="discard1")
             s.auto_update_correlators.add(c_omega)
@@ -254,7 +255,6 @@ class LangevinThermostat(ut.TestCase):
                     ratio = I/(kT/gamma_rot_a[coord-2])
                     print("Ratio of measured and expected diffusion coeff from Green-Kubo:",ratio)
                     self.assertAlmostEqual(ratio,1.,delta=0.07)
-        print(s.thermostat.get_state())                    
         
  
 if __name__ == "__main__":

--- a/testsuite/langevin_thermostat.py
+++ b/testsuite/langevin_thermostat.py
@@ -25,7 +25,6 @@ from espressomd.interactions import FeneBond
 from time import time
 from espressomd.correlators import Correlator
 from espressomd.observables import ParticleVelocities, ParticleBodyAngularMomentum
-import trace 
 
 
 
@@ -333,8 +332,6 @@ class LangevinThermostat(ut.TestCase):
            kT=kT, gamma=gamma as 3 component vector.
         """
         c=corr[p]
-        print(p,kT,gamma, type(c.obs1))
-        c.finalize()
         # Integral of vacf via Green-Kubo
         #D= int_0^infty <v(t_0)v(t_0+t)> dt     (o 1/3, since we work componentwise)
         acf=c.result()

--- a/testsuite/langevin_thermostat.py
+++ b/testsuite/langevin_thermostat.py
@@ -37,6 +37,9 @@ class LangevinThermostat(ut.TestCase):
     s.cell_system.set_n_square()
     s.cell_system.skin = 0.3
     s.seed = range(s.cell_system.get_state()["n_nodes"])
+    if espressomd.has_features("PARTIAL_PERIODIC"):
+        s.periodicity = 0,0,0
+
 
     @classmethod
     def setUpClass(cls):
@@ -71,7 +74,7 @@ class LangevinThermostat(ut.TestCase):
         N = 200
         s = self.s
         s.part.clear()
-        s.time_step = 0.1
+        s.time_step = 0.02
         
         # Place particles
         s.part.add(pos=np.random.random((N, 3)))
@@ -115,7 +118,7 @@ class LangevinThermostat(ut.TestCase):
         N = 200
         s = self.s
         s.part.clear()
-        s.time_step = 0.1
+        s.time_step = 0.02
         s.part.add(pos=np.random.random((N, 3)))
         if espressomd.has_features("ROTATION"): 
             s.part[:].rotation = 1,1,1
@@ -188,7 +191,7 @@ class LangevinThermostat(ut.TestCase):
         
         # Rotational gamma
         gamma_rot_i=0.4
-        gamma_rot_a=2.5,0.7,1.4
+        gamma_rot_a=0.7,0.6,1.2
 
         # If we have langevin per particle:
         # per particle kT
@@ -197,7 +200,7 @@ class LangevinThermostat(ut.TestCase):
         per_part_gamma=1.63
         # Rotational 
         per_part_gamma_rot_i=0.6
-        per_part_gamma_rot_a=2.2,1.7,1.1
+        per_part_gamma_rot_a=0.4,0.8,1.1
 
 
         
@@ -272,17 +275,17 @@ class LangevinThermostat(ut.TestCase):
         for p in all_particles:
             # linear vel
             vel_obs[p]=ParticleVelocities(ids=(p.id,))
-            corr_vel[p] = Correlator(obs1=vel_obs[p], tau_lin=32, tau_max=4., dt=dt,
+            corr_vel[p] = Correlator(obs1=vel_obs[p], tau_lin=32, tau_max=4., dt=2*dt,
                 corr_operation="componentwise_product", compress1="discard1")
             s.auto_update_correlators.add(corr_vel[p])
             # angular vel
             if espressomd.has_features("ROTATION"):
                 omega_obs[p]=ParticleBodyAngularMomentum(ids=(p.id,))
-                corr_omega[p] = Correlator(obs1=omega_obs[p], tau_lin=16, tau_max=24, dt=dt,
+                corr_omega[p] = Correlator(obs1=omega_obs[p], tau_lin=16, tau_max=24, dt=2*dt,
                     corr_operation="componentwise_product", compress1="discard1")
                 s.auto_update_correlators.add(corr_omega[p])
         
-        s.integrator.run(2000000)
+        s.integrator.run(5000000)
 
         # Verify diffusion
         # Translation

--- a/testsuite/langevin_thermostat.py
+++ b/testsuite/langevin_thermostat.py
@@ -25,6 +25,8 @@ from espressomd.interactions import FeneBond
 from time import time
 from espressomd.correlators import Correlator
 from espressomd.observables import ParticleVelocities, ParticleBodyAngularMomentum
+import trace 
+
 
 
 @ut.skipIf(espressomd.has_features("THERMOSTAT_IGNORE_NON_VIRTUAL"),
@@ -285,7 +287,7 @@ class LangevinThermostat(ut.TestCase):
                     corr_operation="componentwise_product", compress1="discard1")
                 s.auto_update_correlators.add(corr_omega[p])
         
-        s.integrator.run(1000000)
+        s.integrator.run(800000)
         for c in corr_vel.values():
             s.auto_update_correlators.remove(c)
         for c in corr_omega.values():
@@ -331,6 +333,7 @@ class LangevinThermostat(ut.TestCase):
            kT=kT, gamma=gamma as 3 component vector.
         """
         c=corr[p]
+        print(p,kT,gamma, type(c.obs1))
         c.finalize()
         # Integral of vacf via Green-Kubo
         #D= int_0^infty <v(t_0)v(t_0+t)> dt     (o 1/3, since we work componentwise)
@@ -404,7 +407,6 @@ class LangevinThermostat(ut.TestCase):
                     self.assertAlmostEqual(s.part[0].omega_body[j],o0*np.exp(-gamma_r_a[j]/s.part[0].rinertia[j]*s.time),places=2)
                 else:
                     self.assertAlmostEqual(s.part[0].omega_body[j],o0*np.exp(-gamma_r_i/s.part[0].rinertia[j]*s.time),places=2)
-
 
 
 

--- a/testsuite/rotational_inertia.py
+++ b/testsuite/rotational_inertia.py
@@ -11,6 +11,7 @@ class RotationalInertia(ut.TestCase):
     longMessage = True
     # Handle for espresso system
     es = espressomd.System()
+    es.cell_system.skin = 0
 
     def define_rotation_matrix(self, part):
         A = np.zeros((3, 3))
@@ -40,9 +41,9 @@ class RotationalInertia(ut.TestCase):
         return self.es.part[part].omega_body[:] * \
             self.es.part[part].rinertia[:]
 
-    def test(self):
-        self.es.cell_system.skin = 0
-        self.es.part.add(pos=np.array([0.0, 0.0, 0.0]), id=0)
+    def test_stability(self):
+        self.es.part.clear()
+        self.es.part.add(pos=np.array([0.0, 0.0, 0.0]), id=0,rotation=(1,1,1))
 
         # Inertial motion around the stable and unstable axes
 
@@ -151,6 +152,29 @@ class RotationalInertia(ut.TestCase):
                         L_0_lab[k],
                         L_lab[k]))
             self.es.integrator.run(10)
+
+
+    
+    def energy(self,p):
+        return 0.5*np.dot(p.rinertia , p.omega_body**2)
+    def momentum(self,p):
+        return np.linalg.norm(p.rinertia * p.omega_body)
+
+    def test_energy_and_momentum_conservation(self):
+        es=self.es
+        es.part.clear()
+        es.thermostat.turn_off()
+        p=es.part.add(pos=(0,0,0),rinertia=(1.1,1.3,1.5),rotation=(1,1,1),omega_body=(2,1,4))
+        E0=self.energy(p)
+        m0=self.momentum(p)
+        es.time_step=0.001
+        for i in range(1000):
+            es.integrator.run(100)
+            self.assertAlmostEqual(self.energy(p),E0,places=3)
+            self.assertAlmostEqual(self.momentum(p),m0,places=3)
+
+        
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Verify diffusion coeff via Green Kubo per component for rotation and translation.
All combinations of ROTATION, MASS, RINERTIA, LANGEVIN_PER_PARTICLE and PARTICLE_ANISOTROPY should be handled.
Extended test for rotational inertia: Test momenum and energy conservation for non-isotropic inertia tensor

Further changes:
* Coverage maxset build with -O1 rather than -O0. Otherwise the tests never complete.
Correlator: Prevent double finalize() as well as get_data() after finalize().
py thermostat interface: Replace isinstance(... List) by hasattr(.., @__iter___@) so it works with tuplesp and np arrays.
