### PR TITLE
removed lees_edwards_offset from default setable properties

### DIFF
--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -50,7 +50,7 @@ import sys
 import random  # for true random numbers from os.urandom()
 
 setable_properties = ["box_l", "min_global_cut", "periodicity", "time",
-                      "time_step", "timings", "lees_edwards_offset"]
+                      "time_step", "timings"]
 IF LEES_EDWARDS == 1:
     setable_properties.append("lees_edwards_offset")
 


### PR DESCRIPTION
Fixes #
The property system.lees_edwards_offset was in the default list regardless of if it was FEATURED or not.

Description of changes:
 - 


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
