### PR TITLE
Extend default myconfig

### DIFF
--- a/src/core/myconfig-default.hpp
+++ b/src/core/myconfig-default.hpp
@@ -28,6 +28,7 @@
 /* global features */
 #define PARTIAL_PERIODIC
 #define ELECTROSTATICS
+#define EWALD_GPU
 #define EXTERNAL_FORCES
 #define CONSTRAINTS
 #define MASS
@@ -35,6 +36,8 @@
 #define COMFORCE
 #define COMFIXED
 #define NPT
+#define COLLISION_DETECTION
+#define LANGEVIN_PER_PARTICLE
 
 /* potentials */
 #define TABULATED
@@ -46,6 +49,18 @@
 #define BUCKINGHAM
 #define SOFT_SPHERE
 #define BOND_ANGLE
+#define GAUSSIAN
+#define HERTZIAN
+#define BOND_VIRTUAL
 
-#define MPI_CORE
-#define FORCE_CORE
+// Lattice Boltzmann
+#define LB
+#define LB_BOUNDARIES
+#define LB_BOUNDARIES_GPU
+#define LB_GPU
+
+// Electrokinetics
+#define ELECTROKINETICS
+#define EK_BOUNDARIES
+#define EK_ELECTROSTATIC_COUPLING
+

--- a/src/core/myconfig-default.hpp
+++ b/src/core/myconfig-default.hpp
@@ -28,7 +28,9 @@
 /* global features */
 #define PARTIAL_PERIODIC
 #define ELECTROSTATICS
-#define EWALD_GPU
+#ifdef CUDA
+  #define EWALD_GPU
+#endif
 #define EXTERNAL_FORCES
 #define CONSTRAINTS
 #define MASS
@@ -56,11 +58,15 @@
 // Lattice Boltzmann
 #define LB
 #define LB_BOUNDARIES
-#define LB_BOUNDARIES_GPU
-#define LB_GPU
+#ifdef CUDA
+  #define LB_GPU
+  #define LB_BOUNDARIES_GPU
+#endif  
 
 // Electrokinetics
-#define ELECTROKINETICS
-#define EK_BOUNDARIES
-#define EK_ELECTROSTATIC_COUPLING
+#ifdef CUDA
+  #define ELECTROKINETICS
+  #define EK_BOUNDARIES
+  #define EK_ELECTROSTATIC_COUPLING
+#endif
 

--- a/src/features.def
+++ b/src/features.def
@@ -99,13 +99,6 @@ SHANCHEN                        implies LB_GPU
 SHANCHEN                        requires not ELECTROKINETICS
 
 /* Stokesian-Dynamics features */
-BD
-SD                              requires CUDA
-SD                              requires ARPACK
-SD                              implies BD
-SD_FF_ONLY                      requires SD
-SD_USE_FLOAT                    requires SD
-SD_NOT_PERIODIC                 requires SD
 
 /* Interaction features */
 TABULATED
@@ -176,7 +169,6 @@ GHOSTS_HAVE_BONDS               notest
 
 /* Debugging */
 ADDITIONAL_CHECKS
-ASYNC_BARRIER
 
 ESIF_DEBUG
 COMM_DEBUG
@@ -212,8 +204,6 @@ SD_DEBUG
 CUDA_DEBUG
 H5MD_DEBUG
 
-MPI_CORE
-FORCE_CORE
 
 /* Single particle debugging */
 ONEPART_DEBUG
@@ -224,6 +214,5 @@ ONEPART_DEBUG
 # Switches that are set by configure or gcc, not to be set manually
 CUDA external
 FFTW external
-TK   external
 H5MD external
 SCAFACOS external

--- a/testsuite/lb.py
+++ b/testsuite/lb.py
@@ -66,7 +66,9 @@ class LBTest(ut.TestCase):
             pos = particle[3:6]
             f = particle[9:]
             v = particle[6:9]
-            self.system.part.add(id=int(id), pos=pos, v=v, type=int(typ), rotation=[1,1,1])
+            p=self.system.part.add(id=int(id), pos=pos, v=v, type=int(typ))
+            if espressomd.has_features("ROTATION"): 
+                p.rotation=[1,1,1]
 
         self.n_col_part = len(self.system.part)
 

--- a/testsuite/lb_gpu.py
+++ b/testsuite/lb_gpu.py
@@ -62,7 +62,9 @@ class lb_test(ut.TestCase):
             pos = particle[3:6]
             f = particle[9:]
             v = particle[6:9]
-            system.part.add(id=int(id), pos=pos, v=v, type=int(typ), rotation=[1,1,1])
+            p=system.part.add(id=int(id), pos=pos, v=v, type=int(typ))
+            if espressomd.has_features("ROTATION"):
+                p.rotation=1,1,1
 
         n_col_part=len(system.part)
 


### PR DESCRIPTION
This adds features to myconfig-default.hpp that should not strongly impact performance, as announced in #1286.
Furthermore, features that don't exist in the code are removed from features.def (Brownian, Stokesian dynamics, TK)
Fixes lb and lb_gpu tests without ROTATION.

I omitted the following
Probably being removed:
#define BOND_ANGLEDIST
#define BOND_ANGLEDIST_HARMONIC
#define BOND_ENDANGLEDIST
#define BOND_ENDANGLEDIST_HARMONIC

No Python support yet
#define GHMC

Rarely used:
#define LB_ELECTROHYDRODYNAMICS
Unclear if it results in change of default behaviour
#define LJGEN_SOFTCORE

Fixes #1286 