### PR TITLE
Fix for MPI+P3MGPU

### DIFF
--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -385,9 +385,6 @@ IF P3M == 1:
 
             def validate_params(self):
                 default_params = self.default_params()
-                #if not (self._params["bjerrum_length"] > 0.0):
-                #    raise ValueError(
-                #        "Bjerrum_length should be a positive double")
 
                 if not (self._params["r_cut"] >= 0 or self._params["r_cut"] == default_params["r_cut"]):
                     raise ValueError("P3M r_cut has to be >=0")

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -385,9 +385,9 @@ IF P3M == 1:
 
             def validate_params(self):
                 default_params = self.default_params()
-                if not (self._params["bjerrum_length"] > 0.0):
-                    raise ValueError(
-                        "Bjerrum_length should be a positive double")
+                #if not (self._params["bjerrum_length"] > 0.0):
+                #    raise ValueError(
+                #        "Bjerrum_length should be a positive double")
 
                 if not (self._params["r_cut"] >= 0 or self._params["r_cut"] == default_params["r_cut"]):
                     raise ValueError("P3M r_cut has to be >=0")
@@ -457,7 +457,7 @@ IF P3M == 1:
                 self._params.update(self._get_params_from_es_core())
 
             def _activate_method(self):
-                #self._set_params_in_es_core()
+                python_p3m_gpu_init(self._params)
                 coulomb.method = COULOMB_P3M_GPU
                 if self._params["tune"]:
                     self._tune()


### PR DESCRIPTION
Fixes #1451

- Added call of p3mgpu init function in activate method of p3mgpu.
- For p3mgpu, negative bjerrum length is now allowed. 

