### PR TITLE
Fix mmm2d energy calculation

### DIFF
--- a/src/core/actor/EwaldGPU.cpp
+++ b/src/core/actor/EwaldGPU.cpp
@@ -113,7 +113,7 @@ int EwaldgpuForce::adaptive_tune(char **log, SystemInterface &s) {
 
   // Squared charge
   auto const q_sqr = std::accumulate(
-      partCfg().begin(), partCfg().end(), 0,
+      partCfg().begin(), partCfg().end(), 0.0,
       [](double q2, Particle const &p) { return q2 + p.p.q * p.p.q; });
 
   char b[3 * ES_INTEGER_SPACE + 3 * ES_DOUBLE_SPACE + 128];

--- a/src/core/mdlc_correction.cpp
+++ b/src/core/mdlc_correction.cpp
@@ -52,7 +52,7 @@ static double mu_max;
 
 void calc_mu_max() {
   mu_max = std::accumulate(
-      local_cells.particles().begin(), local_cells.particles().end(), 0,
+      local_cells.particles().begin(), local_cells.particles().end(), 0.0,
       [](double mu, Particle const &p) { return std::max(mu, p.p.dipm); });
 
   MPI_Allreduce(MPI_IN_PLACE, &mu_max, 1, MPI_DOUBLE, MPI_MAX, comm_cart);

--- a/src/core/mmm2d.cpp
+++ b/src/core/mmm2d.cpp
@@ -1797,7 +1797,7 @@ void MMM2D_self_energy() {
 
   auto parts = local_cells.particles();
   self_energy = std::accumulate(
-      parts.begin(), parts.end(), 0,
+      parts.begin(), parts.end(), 0.0,
       [seng](double sum, Particle const &p) { return sum + seng * SQR(p.p.q); });
 }
 


### PR DESCRIPTION
Fixes mmm2d energy calculation, partly #1559 .

Description of changes:
 - changed initial value to 0.0 in std::accumulate in mmm2d.cpp and mdlc_correction.cpp.
