### PR TITLE
maintainer: Make unit_tests obey TEST_NP

### DIFF
--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Build tests only when testing
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL ON)
-  
+
 # Target for the unit tests
 add_custom_target(check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
 
@@ -35,6 +35,12 @@ function(UNIT_TEST)
 
   # If NUM_PROC is given, set up MPI parallel test case
   if( TEST_NUM_PROC )
+    if(DEFINED TEST_NP)
+      if(${TEST_NUM_PROC} GREATER ${TEST_NP})
+        set(TEST_NUM_PROC ${TEST_NP})
+      endif()
+    endif()
+
     add_test(${TEST_NAME} ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${TEST_NUM_PROC} ${TEST_NAME})
   else( )
     add_test(${TEST_NAME} ${TEST_NAME})


### PR DESCRIPTION
Force 2 test procs on unit tests to make them work with the  new osx images on travis.
