### PR TITLE
Make get_mi_vector faster

### DIFF
--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -62,6 +62,7 @@ int boundary[6] = {0, 0, 0, 0, 0, 0};
 int periodic = 7;
 
 double box_l[3] = {1, 1, 1};
+double half_box_l[3] = {.5, .5, .5};
 double box_l_i[3] = {1, 1, 1};
 double min_box_l;
 double local_box_l[3] = {1, 1, 1};
@@ -262,6 +263,7 @@ void grid_changed_box_l() {
     my_left[i] = node_pos[i] * local_box_l[i];
     my_right[i] = (node_pos[i] + 1) * local_box_l[i];
     box_l_i[i] = 1 / box_l[i];
+    half_box_l[i] = 0.5 * box_l[i];
   }
 
   calc_minimal_box_dimensions();

--- a/src/core/grid.hpp
+++ b/src/core/grid.hpp
@@ -82,6 +82,8 @@ extern int periodic;
 
 /** Simulation box dimensions. */
 extern double box_l[3];
+/** Half the box dimensions. Used for get_mi_vector. */
+extern double half_box_l[3];
 /** 1 / box dimensions. */
 extern double box_l_i[3];
 /** Smallest simulation box dimension (\ref box_l).
@@ -191,7 +193,7 @@ template <typename T, typename U, typename V>
 inline void get_mi_vector(T &res, U const &a, V const &b) {
   for (int i = 0; i < 3; i++) {
     res[i] = a[i] - b[i];
-    if (PERIODIC(i))
+    if (std::fabs(res[i]) > half_box_l[i] && PERIODIC(i))
       res[i] -= dround(res[i] * box_l_i[i]) * box_l[i];
   }
 }


### PR DESCRIPTION
Description of changes:
 - Determine if folding is necessary before doing so.
 - With this check the overhead compared to distance2vec is minimal if no folding is required: one AND instruction for the fabs and one compare instruction for each dimension.

Timings for a simple NVE ensemble of 8000 particles on my laptop with cellsystem domain_decomposition:
I replaced the used distance function in short_range_loop.hpp:
 - EuclideanDistance: 16.48s
 - MinimalImageDistance with *old* get_mi_vector: 28.86s
 - MinimalImageDistance with *new* get_mi_vector: 18.50s


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
