### PR TITLE
cmake: Don't automatically switch to Debug builds if coverage is on.

### DIFF
--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -24,7 +24,7 @@ fi
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 	image=espressomd/espresso-$image:latest
-	sudo docker run $ci_env -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it $image /bin/bash -c "cp -r /travis .; cd travis && maintainer/travis/build_cmake.sh" || exit 1
+	docker run $ci_env -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it $image /bin/bash -c "cp -r /travis .; cd travis && maintainer/travis/build_cmake.sh" || exit 1
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	brew install cmake || brew upgrade cmake
 	case "$image" in

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -24,7 +24,7 @@ fi
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 	image=espressomd/espresso-$image:latest
-	docker run $ci_env -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it $image /bin/bash -c "cp -r /travis .; cd travis && maintainer/travis/build_cmake.sh" || exit 1
+	sudo docker run $ci_env -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it $image /bin/bash -c "cp -r /travis .; cd travis && maintainer/travis/build_cmake.sh" || exit 1
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	brew install cmake || brew upgrade cmake
 	case "$image" in

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,7 +3,6 @@ file(GLOB EspressoCore_SRC
           )
 
 if( WITH_COVERAGE )
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Og --coverage -fprofile-arcs -ftest-coverage")
   link_libraries(gcov)
 endif()

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -13,14 +13,13 @@ set(EspressoScriptInterface_SRC
 )
 
 if(H5MD)
-    list(APPEND EspressoScriptInterface_SRC 
+    list(APPEND EspressoScriptInterface_SRC
         "${CMAKE_CURRENT_SOURCE_DIR}/h5md/initialize.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/h5md/h5md.cpp"
         )
     endif(H5MD)
 
 if( WITH_COVERAGE )
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
   link_libraries(gcov)
 endif()


### PR DESCRIPTION
Fixes #1596.

Description of changes:
 - Don't automatically switch to BUILD_TYPE Debug if coverage is on. Hence CUDA
  is not build with device debug symbols, and the upstream bug is not hit.
