### PR TITLE
Fix virtual sites test for 3 procs

### DIFF
--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1939,9 +1939,11 @@ cdef class ParticleList(object):
 
         """
 
+        cdef int i
+        cdef int j
         for i in range(max_seen_particle + 1):
             for j in range(i + 1, max_seen_particle + 1, 1):
-                if not (self.exists(i) and self.exists(j)):
+                if not (particle_exists(i) and particle_exists(j)):
                     continue
                 yield (self[i], self[j])
 

--- a/testsuite/tests_common.py
+++ b/testsuite/tests_common.py
@@ -135,7 +135,7 @@ def verify_lj_forces(system, tolerance, ids_to_skip=[]):
     all_types=np.unique(system.part[:].type)
     for i in all_types:
         for j in all_types:
-            lj_params[i,j]=non_bonded_inter[i,j].lennard_jones.get_params()
+            lj_params[i,j]=non_bonded_inter[int(i),int(j)].lennard_jones.get_params()
             
 
 

--- a/testsuite/tests_common.py
+++ b/testsuite/tests_common.py
@@ -110,9 +110,9 @@ def lj_force(v_d, d, lj_params):
     Supports epsilon and cutoff."""
 
     if d >= lj_params["cutoff"]:
-        return np.array((0., 0., 0.))
+        return np.zeros(3)
 
-    return 4. * lj_params["epsilon"] * v_d / d * (-12 * d**-13 + 6 * d**-7)
+    return 4. * lj_params["epsilon"] * v_d * (-12.0 * d**-14 + 6.0 * d**-8)
 
 
 def verify_lj_forces(system, tolerance, ids_to_skip=[]):
@@ -126,23 +126,36 @@ def verify_lj_forces(system, tolerance, ids_to_skip=[]):
     for id in system.part[:].id:
         f_expected[id] = np.zeros(3)
 
+    # Cache some stuff to speed up pair loop
+    dist_vec=system.distance_vec
+    norm=np.linalg.norm
+    non_bonded_inter=system.non_bonded_inter
+    # lj parameters
+    lj_params={}
+    all_types=np.unique(system.part[:].type)
+    for i in all_types:
+        for j in all_types:
+            lj_params[i,j]=non_bonded_inter[i,j].lennard_jones.get_params()
+            
+
+
+      
+
     # Go over all pairs of particles
     for pair in system.part.pairs():
-        if pair[0].id in ids_to_skip or pair[1].id in ids_to_skip:
+        p0=pair[0]
+        p1=pair[1]
+        if p0.id in ids_to_skip or p1.id in ids_to_skip:
             continue
 
         # Distance and distance vec
-        v_d = system.distance_vec(pair[0], pair[1])
-        d = system.distance(pair[0], pair[1])
-
-        # get lj params for the type combination from system
-        lj_params = system.non_bonded_inter[pair[0].type,
-                                            pair[1].type].lennard_jones.get_params()
+        v_d = dist_vec(p0,p1)
+        d = norm(v_d)
 
         # calc and add expected lj force
-        f = lj_force(v_d, d, lj_params)
-        f_expected[pair[0].id] += f
-        f_expected[pair[1].id] -= f
+        f = lj_force(v_d, d, lj_params[p0.type,p1.type])
+        f_expected[p0.id] += f
+        f_expected[p1.id] -= f
     # Check actual forces agaisnt expected
     for id in system.part[:].id:
         if id in ids_to_skip:

--- a/testsuite/virtual_sites_relative.py
+++ b/testsuite/virtual_sites_relative.py
@@ -77,7 +77,7 @@ class VirtualSites(ut.TestCase):
 
     def test_pos_vel_forces(self):
         s = self.s
-        s.box_l = 2, 2, 2
+        s.box_l = 10,10,10
         s.part.clear()
         s.time_step = 0.008
         s.part.clear()
@@ -155,7 +155,7 @@ class VirtualSites(ut.TestCase):
           get lost or are outdated in the short range loop"""
         s = self.s
         # Parameters
-        n = 30
+        n = 90 
         phi = 0.6
         sigma = 1.
         eps = .025


### PR DESCRIPTION
Box size was too small for interaction range. Remaining errors seem to be a consequence of the unit test framework continueing with more tests after an exception.
I was forced to increase the particle number. I sped up the lj force verification by some caching toe keep the runtime of the test within reason.

Fixes #1571



