### PR TITLE
Fix typo that breaks visualization of LB fluid.

### DIFF
--- a/samples/visualization_constraints.py
+++ b/samples/visualization_constraints.py
@@ -58,7 +58,7 @@ system.non_bonded_inter[0, 1].lennard_jones.set_params(
     epsilon=200.0, sigma=5.0,
     cutoff=20.0, shift="auto")
 
-system.non_bonded_inter.set_force_cap(1000.0)
+system.force_cap = 1000.0
 
 
 def main():

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -268,7 +268,7 @@ class openGLLive(object):
                               'ext_forces': [0, 0, 0] * len(self.system.part),
                               'charges': [0] * len(self.system.part)}
 
-    def updateLB(self):
+    def _updateLB(self):
         agrid = self.lb_params['agrid']
         self.lb_plane_vel = []
         ng = self.specs['LB_plane_ngrid']


### PR DESCRIPTION
For eample: `espresso/samples/visualization_poisseuille.py`

Also brings the force cap syntax in `visualization_constraints.py` sample script up to date.
