### PR TITLE
Fix rotation flag getter

### DIFF
--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1030,7 +1030,7 @@ cdef class ParticleHandle(object):
                 cdef const short int * _rot = NULL
                 pointer_to_rotation( self.particle_data, _rot)
                 rot=_rot[0]
-                res=np.zeros(3)
+                res=np.zeros(3, dtype=int)
                 if rot&ROT_X: res[0]=1
                 if rot&ROT_Y: res[1]=1
                 if rot&ROT_Z: res[2]=1


### PR DESCRIPTION
Bug reported by @iammmiru while reading in checkpoints:
```
ValueError: The rotation flag has to be given as a tuple of 3 integers. -- Item 0 was of type float64
```