### PR TITLE
Testsuite: Try to make Coulomb mixed periodicity more robust

### DIFF
--- a/testsuite/coulomb_mixed_periodicity.py
+++ b/testsuite/coulomb_mixed_periodicity.py
@@ -39,8 +39,8 @@ class CoulombMixedPeriodicity(ut.TestCase):
     buf_node_grid = S.cell_system.node_grid
     S.thermostat.turn_off()
     forces = {}
-    tolerance_force = 1E-3
-    tolerance_energy = 1.5E-3
+    tolerance_force = 5E-4
+    tolerance_energy = 1.8E-3
     generate_data=False
 
     # Reference energy from MMM2D
@@ -113,10 +113,10 @@ class CoulombMixedPeriodicity(ut.TestCase):
             self.S.periodicity=1,1,1
             self.S.box_l = (10, 10, 10)
 
-            p3m=el.P3M(bjerrum_length=1, accuracy = 1e-6)
+            p3m=el.P3M(bjerrum_length=1, accuracy = 1e-6,mesh=(64,64,64))
             
             self.S.actors.add(p3m)
-            elc=el_ext.ELC(maxPWerror=1E-4,gap_size=1)
+            elc=el_ext.ELC(maxPWerror=1E-6,gap_size=1)
             self.S.actors.add(elc)
             self.S.integrator.run(0)
             self.compare("elc", energy=True)


### PR DESCRIPTION
* Increase energy tolerance to 1.8E-3 (from 1.5)
* Fix mesh for p3m elc to 64
* decrease force tolerance to 5E-4 (from 1E-3)

As I understand it, the test is non-deterministic due to the tuning.
Under some conditions, parameters seem to be selected which decrease the elc energy accuracy below the tolerance.

Fixes #1705
