### PR TITLE
Visualizer improvements + espresso logo

### DIFF
--- a/doc/sphinx/io.rst
+++ b/doc/sphinx/io.rst
@@ -431,10 +431,11 @@ window with ``start()``. See the following minimal code example::
     system.time_step = 0.01
     system.box_l = [10,10,10]
 
-    system.part.add(pos = [1,1,1]) system.part.add(pos = [9,9,9])
+    system.part.add(pos = [1,1,1]) 
+    system.part.add(pos = [9,9,9])
 
-    visualizer = visualization.mayaviLive(system) 
-    #visualizer = visualization.openGLLive(system)
+    #visualizer = visualization.mayaviLive(system) 
+    visualizer = visualization.openGLLive(system)
 
     def main_thread(): 
         while True: 
@@ -485,14 +486,29 @@ Optional keywords:
 OpenGL visualizer
 ~~~~~~~~~~~~~~~~~
 
+| :meth:`espressomd.visualization.openGLLive.run()` 
+
+To visually debug your simulation, ``run()`` can be used to conveniently start 
+an integration loop in a seperate thread once the visualizer is initialized::
+
+    import espressomd 
+    from espressomd import visualization 
+
+    system = espressomd.System() 
+    system.cell_system.skin = 0.4
+    system.time_step = 0.00001
+    system.box_l = [10,10,10]
+
+    system.part.add(pos = [1,1,1], v = [1,0,0]) 
+    system.part.add(pos = [9,9,9], v = [0,1,0])
+
+    visualizer = visualization.openGLLive(system, background_color = [1,1,1])
+    visualizer.run(1)
+
 :class:`espressomd.visualization.openGLLive()`
 
-The optional keywords in ``**kwargs`` to adjust the appearance of the visualization
-have suitable default values for most simulations. Colors for particles,
-bonds and constraints are specified by RGBA arrays, materials by an
-array for the ambient, diffuse and specular (ADS) components. To
-distinguish particle groups, arrays of RGBA or ADS entries are used,
-which are indexed circularly by the numerical particle type.
+The optional keywords in ``**kwargs`` are used to adjust the appearance of the visualization.
+The parameters have suitable default values for most simulations. 
 
 Required paramters:
     * `system`: The espressomd.System() object.
@@ -547,6 +563,28 @@ Optional keywords:
     * `spotlight_brightness`: Brightness (inverse constant attenuation) of the spotlight. 
     * `spotlight_focus`: Focus (spot exponent) for the spotlight from 0 (uniform) to 128. 
 
+Colors and Materials
+^^^^^^^^^^^^^^^^^^^^
+
+Colors for particles, bonds and constraints are specified by RGBA arrays.
+Materials by an array for the ambient, diffuse, specular and shininess (ADSS)
+components. To distinguish particle groups, arrays of RGBA or ADSS entries are
+used, which are indexed circularly by the numerical particle type::
+
+    # Particle type 0 is red, type 1 is blue (type 2 is red etc)..
+    visualizer = visualization.openGLLive(system, 
+                                          particle_coloring = 'type',
+                                          particle_type_colors = [[1, 0, 0, 1],[0, 0, 1, 1]])
+
+`particle_type_materials` lists the materials by type::
+
+    # Particle type 0 is gold, type 1 is blue (type 2 is gold again etc).
+    visualizer = visualization.openGLLive(system, 
+                                          particle_coloring = 'type',
+                                          particle_type_colors = [[1, 1, 1, 1],[0, 0, 1, 1]],
+                                          particle_type_materials = [gold, bright])
+
+Materials are stored in :attr:`espressomd.visualization.openGLLive().materials`. 
 
 Controls
 ^^^^^^^^

--- a/samples/billard.py
+++ b/samples/billard.py
@@ -65,7 +65,7 @@ def fire():
     global stopped
     if stopped:
         stopped = False
-        system.part[0].v += impulse * np.array([sin(angle),0,cos(angle)])
+        system.part[0].v = system.part[0].v + impulse * np.array([sin(angle),0,cos(angle)])
         system.part[0].fix = [0,1,0]
         system.part[0].ext_force = [0,0,0]
 

--- a/samples/espresso_logo.py
+++ b/samples/espresso_logo.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import espressomd
+from espressomd.shapes import *
 from espressomd.visualization_opengl import openGLLive
 import numpy as np
 from math import *
@@ -7,6 +8,8 @@ from math import *
 system = espressomd.System()
 box_l = 15
 system.box_l = [box_l, box_l, box_l]
+
+yoff = 3
 
 # cup
 cup_top_circ = 21
@@ -16,7 +19,7 @@ for i in range(cup_height):
     circ = cup_bot_circ + i*(cup_top_circ-cup_bot_circ)/float(cup_height-1)
     rad = circ/(2.0*np.pi)
     alpha = 2.0*np.pi/int(circ)
-    posy = 2.0+i
+    posy = yoff+i
     for j in range(int(circ)):
         posx = box_l/2.0 + rad * sin(j*alpha+(np.pi/2.0))
         posz = box_l/2.0 + rad * cos(j*alpha+(np.pi/2.0))
@@ -24,7 +27,7 @@ for i in range(cup_height):
 
 # cup bottom
 rad  = cup_bot_circ/(2.0*np.pi)
-posy = 2.0
+posy = yoff
 while (rad > 1.0):
     rad -= 0.9
     circ = 2.0*np.pi*rad
@@ -39,7 +42,7 @@ while (rad > 1.0):
 hand_rad = (cup_height-4.0)/sqrt(2.0)
 hand_circ = (1.5*np.pi*hand_rad)
 hand_xoff = (cup_bot_circ+cup_top_circ)/(4.0*np.pi)+1.2
-hand_yoff = 2.0+cup_height/2.0 -0.2
+hand_yoff = yoff+cup_height/2.0 -0.2
 alpha = 2.0*np.pi/int(4.0*hand_circ/3.0)
 beta =  sin((cup_top_circ-cup_bot_circ)/(2.0*np.pi*cup_height-1))
 beta = beta - np.pi/8.0
@@ -62,25 +65,25 @@ ci_val = -len(system.part)/float(n_ci)
 for i in range(n_saucer):
     rad = s_rad_o-i
     alpha = 2.0*np.pi/int(saucer_circ-(i*2.0*np.pi))
-    posy = 2.3 - 0.5*i
+    posy = yoff + 0.3 - 0.5*i
     for j in range(int(saucer_circ-(i*2.0*np.pi))):
         posx = box_l/2.0 + rad*sin(j*alpha)
         posz =  box_l/2.0 + rad*cos(j*alpha)
         system.part.add(pos = [posx, posy, posz], type = 1)
 
 # steam
-fene = espressomd.interactions.FeneBond(k=10.0, d_r_max=2.0, r_0=0.1)
+fene = espressomd.interactions.FeneBond(k=15.1, d_r_max=2.0, r_0=0.1)
 system.bonded_inter.add(fene)
 
-n_steam = 10
-l_steam = 10
-rad = (cup_top_circ-12.0)/(2.0*np.pi)
+n_steam = 6
+l_steam = 12
+rad = (cup_top_circ-12.5)/(2.0*np.pi)
 alpha = 2.0*np.pi/int(n_steam)
 for i in range(n_steam):
     for j in range(l_steam):
         posx = box_l/2.0 + rad*sin(i*alpha + j*0.6)
         posz = box_l/2.0 + rad*cos(i*alpha + j*0.6)
-        posy = cup_height + j * 0.1 *rad
+        posy = yoff + 2 + j * 0.1 *rad
         system.part.add(pos = [posx, posy, posz], type = 2)
         pid = len(system.part)-1
 
@@ -90,31 +93,44 @@ for i in range(n_steam):
             system.part[pid].bonds = (fene, pid-1)
 
         if j == l_steam-1:
-            system.part[pid].ext_force = [0,5.0,0]
+            system.part[pid].ext_force = [0,7.0,0]
+
+# stand
+system.constraints.add(
+        shape=Cylinder(
+        center=[box_l/2.0, 1.0, box_l/2.0], 
+        axis = [0, 1, 0], 
+        direction = 1, 
+        radius = 7.5, 
+        length = 1), particle_type = 4, penetrable = 1)
 
 
 system.time_step = 0.00022
 system.cell_system.skin = 0.4
 
-system.thermostat.set_langevin(kT=0.0, gamma=0.07)
+system.thermostat.set_langevin(kT=0.0, gamma=0.1)
 WCA_cut = 2.**(1. / 6.)
 
 lj_eps = 1.0
 lj_sig = 0.7
 lj_cut = WCA_cut * lj_sig
-for i in range(2):
-    for j in range(i,2):
-        system.non_bonded_inter[i,j].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
+#for i in range(2):
+#    for j in range(i,2):
+#        system.non_bonded_inter[i,j].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
 visualizer = openGLLive(system, 
 						background_color = [0.2,0.2,0.3],
-                        particle_sizes = [0.6,0.7,0.3], 
-						particle_type_materials = ['bright', 'gold', 'chrome'],
+                        particle_sizes = [0.6,0.75,0.2], 
+						particle_type_materials = ['silver', 'gold', 'chrome'],
 						bond_type_materials = ['chrome'],
-                        particle_type_colors = [[0, 0, 0.8, 1], [0.8, 0, 0, 1], [0.8, 0.8, 0.8, 1]],
-                        bond_type_colors = [[0.2, 0.2, 0.2, 1], [0, 1, 1, 1], [1, 0.5, 0, 1]],
+                        particle_type_colors = [[0.2, 0.2, 0.8, 1], [0.8, 0.2, 0.2, 1], [0.8, 0.8, 0.8, 1]],
+                        bond_type_colors = [[0.2, 0.2, 0.2, 0.5]],
                         bond_type_radius = [0.1],
-                        spotlight_brightness = 1.0,
+                        constraint_type_colors = [[1,1,1,0.5]],
+                        constraint_type_materials = ['ruby'],
+                        spotlight_brightness = 4.0,
+                        spotlight_focus = 100,
+                        spotlight_angle = 60,
                         light_brightness = 1.0,
                         ext_force_arrows = False,
                         draw_axis = False,

--- a/samples/espresso_logo.py
+++ b/samples/espresso_logo.py
@@ -1,0 +1,125 @@
+from __future__ import print_function
+import espressomd
+from espressomd import thermostat
+from espressomd import integrate
+import numpy
+from threading import Thread
+from math import *
+from espressomd.visualization_opengl import *
+
+system = espressomd.System()
+box_l = 15
+system.box_l = [box_l, box_l, box_l]
+
+# cup
+cup_top_circ = 21
+cup_bot_circ = 15
+cup_height = 6
+for i in range(cup_height):
+    circ = cup_bot_circ + i*(cup_top_circ-cup_bot_circ)/float(cup_height-1)
+    rad = circ/(2.0*np.pi)
+    alpha = 2.0*np.pi/int(circ)
+    posy = 2.0+i
+    for j in range(int(circ)):
+        posx = box_l/2.0 + rad * sin(j*alpha+(np.pi/2.0))
+        posz = box_l/2.0 + rad * cos(j*alpha+(np.pi/2.0))
+        system.part.add(pos = [posx, posy, posz], type = 0)
+
+# cup bottom
+rad  = cup_bot_circ/(2.0*np.pi)
+posy = 2.0
+while (rad > 1.0):
+    rad -= 0.9
+    circ = 2.0*np.pi*rad
+    alpha = 2.0*np.pi/int(circ)
+    for j in range(int(circ)):
+        posx = box_l/2.0 + rad*sin(j*alpha+(np.pi/2.0))
+        posz = box_l/2.0 + rad*cos(j*alpha+(np.pi/2.0))
+        system.part.add(pos = [posx, posy, posz], type = 0)
+
+
+# cup handle
+hand_rad = (cup_height-4.0)/sqrt(2.0)
+hand_circ = (1.5*np.pi*hand_rad)
+hand_xoff = (cup_bot_circ+cup_top_circ)/(4.0*np.pi)+1.2
+hand_yoff = 2.0+cup_height/2.0 -0.2
+alpha = 2.0*np.pi/int(4.0*hand_circ/3.0)
+beta =  sin((cup_top_circ-cup_bot_circ)/(2.0*np.pi*cup_height-1))
+beta = beta - np.pi/8.0
+posz = (box_l/2.0)+0.5
+for i in range(int(hand_circ)):
+    posx = hand_xoff + box_l/2.0 + hand_rad*sin(i*alpha+beta)
+    posy = hand_yoff + hand_rad*cos(i*alpha+beta)
+    system.part.add(pos = [posx, posy, posz], type = 0)
+
+# saucer
+saucer_circ = 30
+s_rad_o = saucer_circ/(2.0*np.pi)
+s_rad_i = cup_bot_circ/(2.0*np.pi)
+n_saucer = int(s_rad_o-s_rad_i) + 1
+n_ci = 0
+for i in range(n_saucer):
+    n_ci += int(saucer_circ-(i*2.0*np.pi))
+
+ci_val = -len(system.part)/float(n_ci)
+for i in range(n_saucer):
+    rad = s_rad_o-i
+    alpha = 2.0*np.pi/int(saucer_circ-(i*2.0*np.pi))
+    posy = 2.3 - 0.5*i
+    for j in range(int(saucer_circ-(i*2.0*np.pi))):
+        posx = box_l/2.0 + rad*sin(j*alpha)
+        posz =  box_l/2.0 + rad*cos(j*alpha)
+        system.part.add(pos = [posx, posy, posz], type = 1)
+
+# steam
+fene = espressomd.interactions.FeneBond(k=10.0, d_r_max=2.0, r_0=0.1)
+system.bonded_inter.add(fene)
+
+n_steam = 10
+l_steam = 10
+rad = (cup_top_circ-12.0)/(2.0*np.pi)
+alpha = 2.0*np.pi/int(n_steam)
+for i in range(n_steam):
+    for j in range(l_steam):
+        posx = box_l/2.0 + rad*sin(i*alpha + j*0.6)
+        posz = box_l/2.0 + rad*cos(i*alpha + j*0.6)
+        posy = cup_height + j * 0.1 *rad
+        system.part.add(pos = [posx, posy, posz], type = 2)
+        pid = len(system.part)-1
+
+        if j == 0:
+            system.part[pid].fix = [1,1,1]
+        else:
+            system.part[pid].bonds = (fene, pid-1)
+
+        if j == l_steam-1:
+            system.part[pid].ext_force = [0,5.0,0]
+
+
+system.time_step = 0.00015
+system.cell_system.skin = 0.4
+
+system.thermostat.set_langevin(kT=0.0, gamma=0.1)
+WCA_cut = 2.**(1. / 6.)
+
+lj_eps = 1.0
+lj_sig = 0.7
+lj_cut = WCA_cut * lj_sig
+for i in range(2):
+    for j in range(i,2):
+        system.non_bonded_inter[i,j].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
+
+visualizer = openGLLive(system, 
+                        particle_sizes = [0.6,0.7,0.2], 
+                        particle_type_colors = [[0, 0, 0.8, 1], [0.8, 0, 0, 1], [0.8, 0.8, 0.8, 1], [0, 1, 1, 1], [1, 1, 1, 1], [1, 0.5, 0, 1], [0.5, 0, 1, 1]],
+                        bond_type_colors = [[0.2, 0.2, 0.2, 1], [0, 1, 1, 1], [1, 1, 1, 1], [1, 0.5, 0, 1], [0.5, 0, 1, 1]],
+                        bond_type_radius = [0.1],
+                        spotlight_brightness = 1,
+                        light_brightness = 2.0,
+                        ext_force_arrows = False,
+                        draw_axis = False,
+                        draw_box = False,
+                        drag_enabled = True )
+visualizer.run(1)
+
+

--- a/samples/espresso_logo.py
+++ b/samples/espresso_logo.py
@@ -1,11 +1,8 @@
 from __future__ import print_function
 import espressomd
-from espressomd import thermostat
-from espressomd import integrate
-import numpy
-from threading import Thread
+from espressomd.visualization_opengl import openGLLive
+import numpy as np
 from math import *
-from espressomd.visualization_opengl import *
 
 system = espressomd.System()
 box_l = 15
@@ -96,10 +93,10 @@ for i in range(n_steam):
             system.part[pid].ext_force = [0,5.0,0]
 
 
-system.time_step = 0.00015
+system.time_step = 0.00022
 system.cell_system.skin = 0.4
 
-system.thermostat.set_langevin(kT=0.0, gamma=0.1)
+system.thermostat.set_langevin(kT=0.0, gamma=0.07)
 WCA_cut = 2.**(1. / 6.)
 
 lj_eps = 1.0
@@ -110,16 +107,23 @@ for i in range(2):
         system.non_bonded_inter[i,j].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
 visualizer = openGLLive(system, 
-                        particle_sizes = [0.6,0.7,0.2], 
-                        particle_type_colors = [[0, 0, 0.8, 1], [0.8, 0, 0, 1], [0.8, 0.8, 0.8, 1], [0, 1, 1, 1], [1, 1, 1, 1], [1, 0.5, 0, 1], [0.5, 0, 1, 1]],
-                        bond_type_colors = [[0.2, 0.2, 0.2, 1], [0, 1, 1, 1], [1, 1, 1, 1], [1, 0.5, 0, 1], [0.5, 0, 1, 1]],
+						background_color = [0.2,0.2,0.3],
+                        particle_sizes = [0.6,0.7,0.3], 
+						particle_type_materials = ['bright', 'gold', 'chrome'],
+						bond_type_materials = ['chrome'],
+                        particle_type_colors = [[0, 0, 0.8, 1], [0.8, 0, 0, 1], [0.8, 0.8, 0.8, 1]],
+                        bond_type_colors = [[0.2, 0.2, 0.2, 1], [0, 1, 1, 1], [1, 0.5, 0, 1]],
                         bond_type_radius = [0.1],
-                        spotlight_brightness = 1,
-                        light_brightness = 2.0,
+                        spotlight_brightness = 1.0,
+                        light_brightness = 1.0,
                         ext_force_arrows = False,
                         draw_axis = False,
                         draw_box = False,
                         drag_enabled = True )
+
+def rotate():
+	visualizer.camera.rotateSystemXL()
+
+visualizer.registerCallback(rotate, interval = 16)
+
 visualizer.run(1)
-
-

--- a/samples/espresso_logo.py
+++ b/samples/espresso_logo.py
@@ -102,7 +102,7 @@ system.constraints.add(
         axis = [0, 1, 0], 
         direction = 1, 
         radius = 7.5, 
-        length = 1), particle_type = 4, penetrable = 1)
+        length = 1), particle_type = 0, penetrable = 1)
 
 
 system.time_step = 0.00022
@@ -114,9 +114,9 @@ WCA_cut = 2.**(1. / 6.)
 lj_eps = 1.0
 lj_sig = 0.7
 lj_cut = WCA_cut * lj_sig
-#for i in range(2):
-#    for j in range(i,2):
-#        system.non_bonded_inter[i,j].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
+for i in range(2):
+    for j in range(i,2):
+        system.non_bonded_inter[i,j].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
 visualizer = openGLLive(system, 
 						background_color = [0.2,0.2,0.3],

--- a/samples/espresso_logo.py
+++ b/samples/espresso_logo.py
@@ -16,85 +16,86 @@ cup_top_circ = 21
 cup_bot_circ = 15
 cup_height = 6
 for i in range(cup_height):
-    circ = cup_bot_circ + i*(cup_top_circ-cup_bot_circ)/float(cup_height-1)
-    rad = circ/(2.0*np.pi)
-    alpha = 2.0*np.pi/int(circ)
-    posy = yoff+i
+    circ = cup_bot_circ + i * \
+        (cup_top_circ - cup_bot_circ) / float(cup_height - 1)
+    rad = circ / (2.0 * np.pi)
+    alpha = 2.0 * np.pi / int(circ)
+    posy = yoff + i
     for j in range(int(circ)):
-        posx = box_l/2.0 + rad * sin(j*alpha+(np.pi/2.0))
-        posz = box_l/2.0 + rad * cos(j*alpha+(np.pi/2.0))
-        system.part.add(pos = [posx, posy, posz], type = 0)
+        posx = box_l / 2.0 + rad * sin(j * alpha + (np.pi / 2.0))
+        posz = box_l / 2.0 + rad * cos(j * alpha + (np.pi / 2.0))
+        system.part.add(pos=[posx, posy, posz], type=0)
 
 # cup bottom
-rad  = cup_bot_circ/(2.0*np.pi)
+rad = cup_bot_circ / (2.0 * np.pi)
 posy = yoff
 while (rad > 1.0):
     rad -= 0.9
-    circ = 2.0*np.pi*rad
-    alpha = 2.0*np.pi/int(circ)
+    circ = 2.0 * np.pi * rad
+    alpha = 2.0 * np.pi / int(circ)
     for j in range(int(circ)):
-        posx = box_l/2.0 + rad*sin(j*alpha+(np.pi/2.0))
-        posz = box_l/2.0 + rad*cos(j*alpha+(np.pi/2.0))
-        system.part.add(pos = [posx, posy, posz], type = 0)
+        posx = box_l / 2.0 + rad * sin(j * alpha + (np.pi / 2.0))
+        posz = box_l / 2.0 + rad * cos(j * alpha + (np.pi / 2.0))
+        system.part.add(pos=[posx, posy, posz], type=0)
 
 
 # cup handle
-hand_rad = (cup_height-4.0)/sqrt(2.0)
-hand_circ = (1.5*np.pi*hand_rad)
-hand_xoff = (cup_bot_circ+cup_top_circ)/(4.0*np.pi)+1.2
-hand_yoff = yoff+cup_height/2.0 -0.2
-alpha = 2.0*np.pi/int(4.0*hand_circ/3.0)
-beta =  sin((cup_top_circ-cup_bot_circ)/(2.0*np.pi*cup_height-1))
-beta = beta - np.pi/8.0
-posz = (box_l/2.0)+0.5
+hand_rad = (cup_height - 4.0) / sqrt(2.0)
+hand_circ = (1.5 * np.pi * hand_rad)
+hand_xoff = (cup_bot_circ + cup_top_circ) / (4.0 * np.pi) + 1.2
+hand_yoff = yoff + cup_height / 2.0 - 0.2
+alpha = 2.0 * np.pi / int(4.0 * hand_circ / 3.0)
+beta = sin((cup_top_circ - cup_bot_circ) / (2.0 * np.pi * cup_height - 1))
+beta = beta - np.pi / 8.0
+posz = (box_l / 2.0) + 0.5
 for i in range(int(hand_circ)):
-    posx = hand_xoff + box_l/2.0 + hand_rad*sin(i*alpha+beta)
-    posy = hand_yoff + hand_rad*cos(i*alpha+beta)
-    system.part.add(pos = [posx, posy, posz], type = 0)
+    posx = hand_xoff + box_l / 2.0 + hand_rad * sin(i * alpha + beta)
+    posy = hand_yoff + hand_rad * cos(i * alpha + beta)
+    system.part.add(pos=[posx, posy, posz], type=0)
 
 # saucer
 saucer_circ = 30
-s_rad_o = saucer_circ/(2.0*np.pi)
-s_rad_i = cup_bot_circ/(2.0*np.pi)
-n_saucer = int(s_rad_o-s_rad_i) + 1
+s_rad_o = saucer_circ / (2.0 * np.pi)
+s_rad_i = cup_bot_circ / (2.0 * np.pi)
+n_saucer = int(s_rad_o - s_rad_i) + 1
 n_ci = 0
 for i in range(n_saucer):
-    n_ci += int(saucer_circ-(i*2.0*np.pi))
+    n_ci += int(saucer_circ - (i * 2.0 * np.pi))
 
-ci_val = -len(system.part)/float(n_ci)
+ci_val = -len(system.part) / float(n_ci)
 for i in range(n_saucer):
-    rad = s_rad_o-i
-    alpha = 2.0*np.pi/int(saucer_circ-(i*2.0*np.pi))
-    posy = yoff + 0.3 - 0.5*i
-    for j in range(int(saucer_circ-(i*2.0*np.pi))):
-        posx = box_l/2.0 + rad*sin(j*alpha)
-        posz =  box_l/2.0 + rad*cos(j*alpha)
-        system.part.add(pos = [posx, posy, posz], type = 1)
+    rad = s_rad_o - i
+    alpha = 2.0 * np.pi / int(saucer_circ - (i * 2.0 * np.pi))
+    posy = yoff + 0.3 - 0.5 * i
+    for j in range(int(saucer_circ - (i * 2.0 * np.pi))):
+        posx = box_l / 2.0 + rad * sin(j * alpha)
+        posz = box_l / 2.0 + rad * cos(j * alpha)
+        system.part.add(pos=[posx, posy, posz], type=1)
 
 # python
 n_pbody = 12
 posy = 3.5
-posz = box_l/2.0 
+posz = box_l / 2.0
 diam = 0.8
 mass = 0.01
 fl = -1
 harm = espressomd.interactions.HarmonicBond(
-            k=400.0, r_0=diam, r_cut=5.0)
+    k=400.0, r_0=diam, r_cut=5.0)
 system.bonded_inter.add(harm)
 
 for i in range(n_pbody):
-    posx = i*diam
-    system.part.add(pos = [posx, posy, posz], type = 2, mass = mass)
-    pid = len(system.part)-1
+    posx = i * diam
+    system.part.add(pos=[posx, posy, posz], type=2, mass=mass)
+    pid = len(system.part) - 1
     if i > 0:
-        system.part[pid].bonds = (harm, pid-1)
+        system.part[pid].bonds = (harm, pid - 1)
     if i % 3 == 0:
-       fl *= -1
-       system.part[pid].ext_force = [0,fl*40*mass,0]
+        fl *= -1
+        system.part[pid].ext_force = [0, fl * 40 * mass, 0]
     if i >= n_pbody - 3:
-       system.part[pid].ext_force = [50.0*mass,0,0]
+        system.part[pid].ext_force = [50.0 * mass, 0, 0]
     elif i == 0:
-       system.part[pid].ext_force = [-20*mass,0,0]
+        system.part[pid].ext_force = [-20 * mass, 0, 0]
 
 
 # steam
@@ -103,34 +104,33 @@ system.bonded_inter.add(fene)
 
 n_steam = 6
 l_steam = 12
-rad = (cup_top_circ-12.5)/(2.0*np.pi)
-alpha = 2.0*np.pi/int(n_steam)
+rad = (cup_top_circ - 12.5) / (2.0 * np.pi)
+alpha = 2.0 * np.pi / int(n_steam)
 for i in range(n_steam):
     for j in range(l_steam):
-        posx = box_l/2.0 + rad*sin(i*alpha + j*0.6)
-        posz = box_l/2.0 + rad*cos(i*alpha + j*0.6)
-        posy = yoff + 2 + j * 0.1 *rad
-        system.part.add(pos = [posx, posy, posz], type = 3)
-        pid = len(system.part)-1
+        posx = box_l / 2.0 + rad * sin(i * alpha + j * 0.6)
+        posz = box_l / 2.0 + rad * cos(i * alpha + j * 0.6)
+        posy = yoff + 2 + j * 0.1 * rad
+        system.part.add(pos=[posx, posy, posz], type=3)
+        pid = len(system.part) - 1
 
         if j == 0:
-            system.part[pid].fix = [1,1,1]
+            system.part[pid].fix = [1, 1, 1]
         else:
-            system.part[pid].bonds = (fene, pid-1)
+            system.part[pid].bonds = (fene, pid - 1)
 
-        if j == l_steam-1:
-            system.part[pid].ext_force = [0,7.0,0]
-
+        if j == l_steam - 1:
+            system.part[pid].ext_force = [0, 7.0, 0]
 
 
 # stand
 system.constraints.add(
-        shape=Cylinder(
-        center=[box_l/2.0, 1.0, box_l/2.0], 
-        axis = [0, 1, 0], 
-        direction = 1, 
-        radius = 7.5, 
-        length = 1), particle_type = 0, penetrable = 1)
+    shape=Cylinder(
+        center=[box_l / 2.0, 1.0, box_l / 2.0],
+            axis=[0, 1, 0],
+            direction=1,
+            radius=7.5,
+            length=1), particle_type=0, penetrable=1)
 
 
 system.time_step = 0.00022
@@ -143,38 +143,46 @@ lj_eps = 1.0
 lj_sig = 0.7
 lj_cut = WCA_cut * lj_sig
 for i in range(2):
-    for j in range(i,2):
-        system.non_bonded_inter[i,j].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
+    for j in range(i, 2):
+        system.non_bonded_inter[i, j].lennard_jones.set_params(
+            epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
 lj_eps = 1.0
 lj_sig = 1.0
 lj_cut = WCA_cut * lj_sig
 for i in range(3):
-    system.non_bonded_inter[i,2].lennard_jones.set_params(epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
+    system.non_bonded_inter[i, 2].lennard_jones.set_params(
+        epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
-visualizer = openGLLive(system, 
-						background_color = [0.2, 0.2, 0.3],
-                        camera_position = [box_l/2.0, box_l/4.0, 20*3],
-                        particle_sizes = [0.6, 0.75, 0.9, 0.2], 
-						particle_type_materials = ['silver', 'gold', 'greenplastic', 'chrome'],
-                        particle_type_colors = [[0.2, 0.2, 0.8, 1], [0.8, 0.2, 0.2, 1], [1, 1, 1, 1], [0.8, 0.8, 0.8, 1]],
-						bond_type_materials = ['chrome'],
-                        bond_type_colors = [[0.2, 0.2, 0.2, 0.5]],
-                        bond_type_radius = [0.1],
-                        constraint_type_colors = [[1, 1, 1, 0.5]],
-                        constraint_type_materials = ['ruby'],
-                        spotlight_brightness = 5.0,
-                        spotlight_focus = 100,
-                        spotlight_angle = 60,
-                        light_brightness = 1.0,
-                        ext_force_arrows = False,
-                        draw_axis = False,
-                        draw_box = False,
-                        drag_enabled = True )
+visualizer = openGLLive(system,
+                        background_color=[
+                        0.2, 0.2, 0.3],
+                        camera_position=[box_l / 2.0, box_l / 4.0, 20 * 3],
+                        particle_sizes=[0.6, 0.75, 0.9, 0.2],
+                        particle_type_materials=[
+                        'silver', 'gold', 'greenplastic', 'chrome'],
+                        particle_type_colors=[[0.2, 0.2, 0.8, 1], [
+                            0.8, 0.2, 0.2, 1], [
+                                1, 1, 1, 1], [0.8, 0.8, 0.8, 1]],
+                        bond_type_materials=[
+                        'chrome'],
+                        bond_type_colors=[[0.2, 0.2, 0.2, 0.5]],
+                        bond_type_radius=[0.1],
+                        constraint_type_colors=[[1, 1, 1, 0.5]],
+                        constraint_type_materials=['ruby'],
+                        spotlight_brightness=5.0,
+                        spotlight_focus=100,
+                        spotlight_angle=60,
+                        light_brightness=1.0,
+                        ext_force_arrows=False,
+                        draw_axis=False,
+                        draw_box=False,
+                        drag_enabled=True)
+
 
 def rotate():
-	visualizer.camera.rotateSystemXL()
+    visualizer.camera.rotateSystemXL()
 
-#visualizer.registerCallback(rotate, interval = 16)
+# visualizer.registerCallback(rotate, interval = 16)
 
 visualizer.run(1)

--- a/samples/visualization_mmm2d.py
+++ b/samples/visualization_mmm2d.py
@@ -15,7 +15,7 @@ box_l = 20
 system.box_l = [box_l, box_l, box_l]
 system.time_step = 0.02
 system.cell_system.skin = 0.4
-system.cell_system.set_layered(n_layers=5)
+system.cell_system.set_layered(n_layers=5,use_verlet_lists = False)
 system.periodicity = [1, 1, 0]
 
 qion = 1
@@ -40,7 +40,7 @@ print("After Minimization: E_total=", energy['total'])
 
 system.thermostat.set_langevin(kT=0.1, gamma=1.0)
 
-mmm2d = electrostatics.MMM2D(bjerrum_length = 100.0, maxPWerror = 1e-3, const_pot_on = 1, pot_diff = 50.0)
+mmm2d = electrostatics.MMM2D(bjerrum_length = 100.0, maxPWerror = 1e-3, const_pot = 1, pot_diff = 50.0)
 system.actors.add(mmm2d)
 
 def main():

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -72,6 +72,39 @@ class openGLLive(object):
         :spotlight\_angle: The spread angle of the spotlight in degrees (from 0 to 90).
         :spotlight\_brightness: Brightness (inverse constant attenuation) of the spotlight. 
         :spotlight\_focus: Focus (spot exponent) for the spotlight from 0 (uniform) to 128."""
+        
+
+        # MATERIALS
+        self.materials = {
+            'bright':       [[0.9,0.9,0.9],[1.0,1.0,1.0],[0.8,0.8,0.8],0.6],
+            'medium':       [[0.6,0.6,0.6],[0.8,0.8,0.8],[0.2,0.2,0.2],0.5],
+            'dark':         [[0.4,0.4,0.4],[0.5,0.5,0.5],[0.1,0.1,0.1],0.4],
+            'bluerubber':   [[0,0,0.05],[0.4,0.4,0.5],[0.04,0.04,0.7],0.078125],
+            'redrubber':    [[0.05,0,0],[0.5,0.4,0.4],[0.7,0.04,0.04],0.078125],
+            'yellowrubber': [[0.05,0.05,0],[0.5,0.5,0.4],[0.7,0.7,0.04],0.078125],
+            'greenrubber':  [[0,0.05,0],[0.4,0.5,0.4],[0.04,0.7,0.04],0.078125],
+            'whiterubber':  [[0.05,0.05,0.05],[0.5,0.5,0.5],[0.7,0.7,0.7],0.078125],
+            'cyanrubber':   [[0,0.05,0.05],[0.4,0.5,0.5],[0.04,0.7,0.7],0.078125],
+            'blackrubber':  [[0.02,0.02,0.02],[0.01,0.01,0.01],[0.4,0.4,0.4],0.078125],
+            'emerald':      [[0.0215,0.1745,0.0215],[0.07568,0.61424,0.07568],[0.633,0.727811,0.633],0.6],
+            'jade':         [[0.135,0.2225,0.1575],[0.54,0.89,0.63],[0.316228,0.316228,0.316228],0.1],
+            'obsidian':     [[0.05375,0.05,0.06625],[0.18275,0.17,0.22525],[0.332741,0.328634,0.346435],0.3],
+            'pearl':        [[0.25,0.20725,0.20725],[1,0.829,0.829],[0.296648,0.296648,0.296648],0.088],
+            'ruby':         [[0.1745,0.01175,0.01175],[0.61424,0.04136,0.04136],[0.727811,0.626959,0.626959],0.6],
+            'turquoise':    [[0.1,0.18725,0.1745],[0.396,0.74151,0.69102],[0.297254,0.30829,0.306678],0.1],
+            'brass':        [[0.329412,0.223529,0.027451],[0.780392,0.568627,0.113725],[0.992157,0.941176,0.807843],0.21794872],
+            'bronze':       [[0.2125,0.1275,0.054],[0.714,0.4284,0.18144],[0.393548,0.271906,0.166721],0.2],
+            'chrome':       [[0.25,0.25,0.25],[0.4,0.4,0.4],[0.774597,0.774597,0.774597],0.6],
+            'copper':       [[0.19125,0.0735,0.0225],[0.7038,0.27048,0.0828],[0.256777,0.137622,0.086014],0.1],
+            'gold':         [[0.24725,0.1995,0.0745],[0.75164,0.60648,0.22648],[0.628281,0.555802,0.366065],0.4],
+            'silver':       [[0.19225,0.19225,0.19225],[0.50754,0.50754,0.50754],[0.508273,0.508273,0.508273],0.4],
+            'blackplastic': [[0,0,0],[0.01,0.01,0.01],[0.5,0.5,0.5],0.25],
+            'cyanplastic':  [[0,0.1,0.06],[0,0.50980392,0.50980392],[0.50196078,0.50196078,0.50196078],0.25],
+            'greenplastic': [[0,0,0],[0.1,0.35,0.1],[0.45,0.55,0.45],0.25],
+            'redplastic':   [[0,0,0],[0.5,0,0],[0.7,0.6,0.6],0.25],
+            'whiteplastic': [[0,0,0],[0.55,0.55,0.55],[0.7,0.7,0.7],0.25],
+            'yellowplastic':[[0,0,0],[0.5,0.5,0],[0.6,0.6,0.5],0.25]}
+
 
         # DEFAULT PROPERTIES
         self.specs = {
@@ -82,7 +115,7 @@ class openGLLive(object):
             'periodic_images': [0, 0, 0],
             'draw_box': True,
             'draw_axis': True,
-            'quality_particles': 16,
+            'quality_particles': 20,
             'quality_bonds': 16,
             'quality_arrows': 16,
             'quality_constraints': 32,
@@ -91,24 +124,23 @@ class openGLLive(object):
             'camera_position': 'auto',
             'camera_target': 'auto',
             'camera_right': [1.0, 0.0, 0.0],
-            #'camera_rotation':	   		  [3.55, -0.4],
 
             'particle_coloring': 'auto',
             'particle_sizes': 'auto',
             'particle_type_colors': [[1, 1, 0, 1], [1, 0, 1, 1], [0, 0, 1, 1], [0, 1, 1, 1], [1, 1, 1, 1], [1, 0.5, 0, 1], [0.5, 0, 1, 1]],
-            'particle_type_materials': [[0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1]],
+            'particle_type_materials': ['medium'],
             'particle_charge_colors': [[1, 0, 0, 1], [0, 1, 0, 1]],
 
             'draw_constraints': True,
             'rasterize_pointsize': 10,
             'rasterize_resolution': 75.0,
             'constraint_type_colors': [[0.5, 0.5, 0.5, 0.9], [0, 0.5, 0.5, 0.9], [0.5, 0, 0.5, 0.9], [0.5, 0.5, 0, 0.9], [0, 0, 0.5, 0.9], [0.5, 0, 0, 0.9]],
-            'constraint_type_materials': [[0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1]],
+            'constraint_type_materials': ['medium'],
 
             'draw_bonds': True,
             'bond_type_radius': [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
             'bond_type_colors': [[1, 1, 1, 1], [1, 0, 1, 1], [0, 0, 1, 1], [0, 1, 1, 1], [1, 1, 0, 1], [1, 0.5, 0, 1], [0.5, 0, 1, 1]],
-            'bond_type_materials': [[0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1], [0.6, 1, 0.1]],
+            'bond_type_materials': ['medium'],
 
             'ext_force_arrows': True,
             'ext_force_arrows_scale': [1, 1, 1, 1, 1, 1, 1],
@@ -133,6 +165,7 @@ class openGLLive(object):
             'drag_enabled': False,
             'drag_force': 3.0
         }
+
 
         # OVERWRITE WITH USER PROPERTIES
         for key in kwargs:
@@ -420,9 +453,9 @@ class openGLLive(object):
         if self.specs['draw_axis']:
             axis_fac = 0.2
             axis_r = np.min(self.system.box_l)/50.0
-            _drawArrow([0,0,0], [self.system.box_l[0] * axis_fac, 0, 0], axis_r, [1, 0, 0, 1], self.specs['quality_arrows'])
-            _drawArrow([0,0,0], [0, self.system.box_l[2] * axis_fac, 0], axis_r, [0, 1, 0, 1], self.specs['quality_arrows'])
-            _drawArrow([0,0,0], [0, 0, self.system.box_l[2] * axis_fac], axis_r, [0, 0, 1, 1], self.specs['quality_arrows'])
+            _drawArrow([0,0,0], [self.system.box_l[0] * axis_fac, 0, 0], axis_r, [1, 0, 0, 1], self.materials['chrome'], self.specs['quality_arrows'])
+            _drawArrow([0,0,0], [0, self.system.box_l[2] * axis_fac, 0], axis_r, [0, 1, 0, 1], self.materials['chrome'], self.specs['quality_arrows'])
+            _drawArrow([0,0,0], [0, 0, self.system.box_l[2] * axis_fac], axis_r, [0, 0, 1, 1], self.materials['chrome'], self.specs['quality_arrows'])
 
         self._drawSystemParticles()
 
@@ -443,28 +476,28 @@ class openGLLive(object):
             glClipPlane(GL_CLIP_PLANE0 + i, self.box_eqn[i])
 
         for s in self.shapes['Shapes::Sphere']:
-            _drawSphere(s[0], s[1], self._modulo_indexing(self.specs['constraint_type_colors'], s[2]), self._modulo_indexing(
-                self.specs['constraint_type_materials'], s[2]), self.specs['quality_constraints'])
+            _drawSphere(s[0], s[1], self._modulo_indexing(self.specs['constraint_type_colors'], s[2]), self.materials[self._modulo_indexing(
+                self.specs['constraint_type_materials'], s[2])], self.specs['quality_constraints'])
 
         for s in self.shapes['Shapes::SpheroCylinder']:
             _drawSpheroCylinder(
                 s[0], s[1], s[2], self._modulo_indexing(
                     self.specs['constraint_type_colors'], s[3]),
-                               self._modulo_indexing(self.specs['constraint_type_materials'], s[3]), self.specs['quality_constraints'])
+                               self.materials[self._modulo_indexing(self.specs['constraint_type_materials'], s[3])], self.specs['quality_constraints'])
 
         for s in self.shapes['Shapes::Wall']:
             _drawPlane(
                 s[0], self._modulo_indexing(
                     self.specs['constraint_type_colors'], s[1]),
-                      self._modulo_indexing(self.specs['constraint_type_materials'], s[1]))
+                      self.materials[self._modulo_indexing(self.specs['constraint_type_materials'], s[1])])
 
         for s in self.shapes['Shapes::Cylinder']:
-            _drawCylinder(s[0], s[1], s[2], self._modulo_indexing(self.specs['constraint_type_colors'], s[3]), self._modulo_indexing(
-                self.specs['constraint_type_materials'], s[3]), self.specs['quality_constraints'], True)
+            _drawCylinder(s[0], s[1], s[2], self._modulo_indexing(self.specs['constraint_type_colors'], s[3]), self.materials[self._modulo_indexing(
+                self.specs['constraint_type_materials'], s[3])], self.specs['quality_constraints'], True)
 
         for s in self.shapes['Shapes::Misc']:
             _drawPoints(s[0], self.specs['rasterize_pointsize'],  self._modulo_indexing(
-                self.specs['constraint_type_colors'], s[1]), self._modulo_indexing(self.specs['constraint_type_materials'], s[1]))
+                self.specs['constraint_type_colors'], s[1]), self.materials[self._modulo_indexing(self.specs['constraint_type_materials'], s[1])])
 
         for i in range(6):
             glDisable(GL_CLIP_PLANE0 + i)
@@ -503,8 +536,8 @@ class openGLLive(object):
 
             radius = self._determine_radius(ptype)
 
-            material = self._modulo_indexing(
-                self.specs['particle_type_materials'], ptype)
+            m = self._modulo_indexing(self.specs['particle_type_materials'], ptype)
+            material = self.materials[m]
 
             if self.specs['particle_coloring'] == 'id':
                 color = self._IdToColorf(pid)
@@ -541,7 +574,7 @@ class openGLLive(object):
                                 self.specs['ext_force_arrows_scale'], ptype)
                         if sc > 0:
                             _drawArrow(pos, np.array(ext_f) * sc, 0.25 *
-                                      sc, [1, 1, 1, 1], self.specs['quality_arrows'])
+                                      sc, [1, 1, 1, 1], self.materials['chrome'], self.specs['quality_arrows'])
 
     def _drawBonds(self):
         coords = self.particles['coords']
@@ -550,7 +583,7 @@ class openGLLive(object):
         box_l2_sqr = pow(b2, 2.0)
         for b in self.bonds:
             col = self._modulo_indexing(self.specs['bond_type_colors'], b[2])
-            mat = self._modulo_indexing(self.specs['bond_type_materials'], b[2])
+            mat = self.materials[self._modulo_indexing(self.specs['bond_type_materials'], b[2])]
             radius = self._modulo_indexing(self.specs['bond_type_radius'], b[2])
             d = coords[b[0]] - coords[b[1]]
             bondLen_sqr = d[0] * d[0] + d[1] * d[1] + d[2] * d[2]
@@ -614,7 +647,7 @@ class openGLLive(object):
             p = lbl[0]
             v = lbl[1]
             c = np.linalg.norm(v)
-            _drawArrow(p, v * self.specs['LB_vel_scale'], self.lb_arrow_radius, [1,1,1,1], 16)
+            _drawArrow(p, v * self.specs['LB_vel_scale'], self.lb_arrow_radius, [1,1,1,1], self.materials['chrome'], 16)
         
     # USE MODULO IF THERE ARE MORE PARTICLE TYPES THAN TYPE DEFINITIONS FOR
     # COLORS, MATERIALS ETC..
@@ -1022,17 +1055,17 @@ class openGLLive(object):
 # OPENGL DRAW WRAPPERS
 
 
-def _setSolidMaterial(r, g, b, a=1.0, ambient=0.6, diffuse=1.0, specular=0.1):
+def _setSolidMaterial(r, g, b, a=1.0, ambient=[0.6,0.6,0.6], diffuse=[1.0,1.0,1.0], specular=[0.1,0.1,0.1], shininess = 0.4):
     glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT,  [
-                 ambient * r, ambient * g, ambient * g, a])
+                 ambient[0] * r, ambient[1] * g, ambient[2] * g, a])
     glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, [
-                 diffuse * r, diffuse * g, diffuse * b, a])
+                 diffuse[0] * r, diffuse[1] * g, diffuse[2] * b, a])
     glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, [
-                 specular * r, specular * g, specular * g, a])
-    glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, 50)
+                 specular[0] * r, specular[1] * g, specular[2] * g, a])
+    glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, int(shininess * 128))
 
 def _drawBox(p0, s, color):
-    _setSolidMaterial(color[0], color[1], color[2], 1, 2, 1)
+    _setSolidMaterial(color[0], color[1], color[2])
     glPushMatrix()
     glTranslatef(p0[0], p0[1], p0[2])
     glBegin(GL_LINE_LOOP)
@@ -1064,8 +1097,7 @@ def _drawBox(p0, s, color):
 def _drawSphere(pos, radius, color, material, quality):
     glPushMatrix()
     glTranslatef(pos[0], pos[1], pos[2])
-    _setSolidMaterial(color[0], color[1], color[2], color[
-                     3], material[0], material[1], material[2])
+    _setSolidMaterial(color[0], color[1], color[2], color[3], material[0], material[1], material[2], material[3])
     glutSolidSphere(radius, quality, quality)
     glPopMatrix()
 
@@ -1080,7 +1112,7 @@ def _redrawSphere(pos, radius, quality):
 def _drawPlane(edges, color, material):
 
     _setSolidMaterial(color[0], color[1], color[2], color[
-                     3], material[0], material[1], material[2])
+                     3], material[0], material[1], material[2], material[3])
 
     glBegin(GL_QUADS)
     for e in edges:
@@ -1103,7 +1135,7 @@ def _drawTriangles(triangles, color, material):
         color = np.random.random(3).tolist()
         color.append(1)
         _setSolidMaterial(color[0], color[1], color[2],
-                         color[3], material[0], material[1], material[2])
+                         color[3], material[0], material[1], material[2], material[3])
         for p in t:
             glVertex3f(p[0], p[1], p[2])
     glEnd()
@@ -1111,7 +1143,7 @@ def _drawTriangles(triangles, color, material):
 
 def _drawPoints(points, pointsize, color, material):
     _setSolidMaterial(color[0], color[1], color[2], color[3],
-                     material[0], material[1], material[2])
+                     material[0], material[1], material[2], material[3])
     glEnable(GL_POINT_SMOOTH)
 
     glPointSize(pointsize)
@@ -1123,7 +1155,7 @@ def _drawPoints(points, pointsize, color, material):
 
 def _drawCylinder(posA, posB, radius, color, material, quality, draw_caps=False):
     _setSolidMaterial(color[0], color[1], color[2], color[3],
-                     material[0], material[1], material[2])
+                     material[0], material[1], material[2], material[3])
     glPushMatrix()
     quadric = gluNewQuadric()
 
@@ -1163,7 +1195,7 @@ def _rotationHelper(d):
 
 def _drawSpheroCylinder(posA, posB, radius, color, material, quality):
     _setSolidMaterial(color[0], color[1], color[
-                     2], color[3], material[0], material[1], material[2])
+                     2], color[3], material[0], material[1], material[2], material[3])
     glPushMatrix()
     quadric = gluNewQuadric()
 
@@ -1202,10 +1234,10 @@ def _drawSpheroCylinder(posA, posB, radius, color, material, quality):
     glPopMatrix()
 
 
-def _drawArrow(pos, d, radius, color, quality):
+def _drawArrow(pos, d, radius, color, material, quality):
     pos2 = np.array(pos) + np.array(d)
 
-    _drawCylinder(pos, pos2, radius, color,[0.6,1.0,0.1], quality)
+    _drawCylinder(pos, pos2, radius, color, material, quality)
     
     ax, rx, ry = _rotationHelper(d)
 

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -16,7 +16,9 @@ include "myconfig.pxi"
 
 from copy import deepcopy
 
+
 class openGLLive(object):
+
     """This class provides live visualization using pyOpenGL.
     Use the update method to push your current simulation state after
     integrating. Modify the appearance with a list of keywords.
@@ -41,9 +43,9 @@ class openGLLive(object):
         :quality\_constraints: The number of subdivisions for primitive constraints.
         :close\_cut\_distance: The distance from the viewer to the near clipping plane.
         :far\_cut\_distance: The distance from the viewer to the far clipping plane.
-        :camera\_position: Initial camera position. auto (default) for shiftet position in z-direction. 
+        :camera\_position: Initial camera position. auto (default) for shiftet position in z-direction.
         :camera\_target: Initial camera target. auto (default) to look towards the system center.
-        :camera\_right: Camera right vector in system coordinates. Default is [1, 0, 0] 
+        :camera\_right: Camera right vector in system coordinates. Default is [1, 0, 0]
         :particle\_sizes: auto (default): The Lennard-Jones sigma value of the self-interaction is used for the particle diameter. callable: A lambda function with one argument. Internally, the numerical particle type is passed to the lambda function to determine the particle radius.  list: A list of particle radii, indexed by the particle type.
         :particle\_coloring: auto (default): Colors of charged particles are specified by particle\_charge\_colors, neutral particles by particle\_type\_colors. charge: Minimum and maximum charge of all particles is determined by the visualizer. All particles are colored by a linear interpolation of the two colors given by particle\_charge\_colors according to their charge. type: Particle colors are specified by particle\_type\_colors, indexed by their numerical particle type.
         :particle\_type\_colors: Colors for particle types.
@@ -65,46 +67,44 @@ class openGLLive(object):
         :drag\_force: Factor for particle dragging
         :light\_pos: If auto (default) is used, the light is placed dynamically in the particle barycenter of the system. Otherwise, a fixed coordinate can be set.
         :light\_colors: Three lists to specify ambient, diffuse and specular light colors.
-        :light\_brightness: Brightness (inverse constant attenuation) of the light. 
+        :light\_brightness: Brightness (inverse constant attenuation) of the light.
         :light\_size: Size (inverse linear attenuation) of the light. If auto (default) is used, the light size will be set to a reasonable value according to the box size at start.
         :spotlight\_enabled: If set to True (default), it enables a spotlight on the camera position pointing in look direction.
         :spotlight\_colors: Three lists to specify ambient, diffuse and specular spotlight colors.
         :spotlight\_angle: The spread angle of the spotlight in degrees (from 0 to 90).
-        :spotlight\_brightness: Brightness (inverse constant attenuation) of the spotlight. 
+        :spotlight\_brightness: Brightness (inverse constant attenuation) of the spotlight.
         :spotlight\_focus: Focus (spot exponent) for the spotlight from 0 (uniform) to 128."""
-        
 
         # MATERIALS
         self.materials = {
-            'bright':       [[0.9,0.9,0.9],[1.0,1.0,1.0],[0.8,0.8,0.8],0.6],
-            'medium':       [[0.6,0.6,0.6],[0.8,0.8,0.8],[0.2,0.2,0.2],0.5],
-            'dark':         [[0.4,0.4,0.4],[0.5,0.5,0.5],[0.1,0.1,0.1],0.4],
-            'bluerubber':   [[0,0,0.05],[0.4,0.4,0.5],[0.04,0.04,0.7],0.078125],
-            'redrubber':    [[0.05,0,0],[0.5,0.4,0.4],[0.7,0.04,0.04],0.078125],
-            'yellowrubber': [[0.05,0.05,0],[0.5,0.5,0.4],[0.7,0.7,0.04],0.078125],
-            'greenrubber':  [[0,0.05,0],[0.4,0.5,0.4],[0.04,0.7,0.04],0.078125],
-            'whiterubber':  [[0.05,0.05,0.05],[0.5,0.5,0.5],[0.7,0.7,0.7],0.078125],
-            'cyanrubber':   [[0,0.05,0.05],[0.4,0.5,0.5],[0.04,0.7,0.7],0.078125],
-            'blackrubber':  [[0.02,0.02,0.02],[0.01,0.01,0.01],[0.4,0.4,0.4],0.078125],
-            'emerald':      [[0.0215,0.1745,0.0215],[0.07568,0.61424,0.07568],[0.633,0.727811,0.633],0.6],
-            'jade':         [[0.135,0.2225,0.1575],[0.54,0.89,0.63],[0.316228,0.316228,0.316228],0.1],
-            'obsidian':     [[0.05375,0.05,0.06625],[0.18275,0.17,0.22525],[0.332741,0.328634,0.346435],0.3],
-            'pearl':        [[0.25,0.20725,0.20725],[1,0.829,0.829],[0.296648,0.296648,0.296648],0.088],
-            'ruby':         [[0.1745,0.01175,0.01175],[0.61424,0.04136,0.04136],[0.727811,0.626959,0.626959],0.6],
-            'turquoise':    [[0.1,0.18725,0.1745],[0.396,0.74151,0.69102],[0.297254,0.30829,0.306678],0.1],
-            'brass':        [[0.329412,0.223529,0.027451],[0.780392,0.568627,0.113725],[0.992157,0.941176,0.807843],0.21794872],
-            'bronze':       [[0.2125,0.1275,0.054],[0.714,0.4284,0.18144],[0.393548,0.271906,0.166721],0.2],
-            'chrome':       [[0.25,0.25,0.25],[0.4,0.4,0.4],[0.774597,0.774597,0.774597],0.6],
-            'copper':       [[0.19125,0.0735,0.0225],[0.7038,0.27048,0.0828],[0.256777,0.137622,0.086014],0.1],
-            'gold':         [[0.24725,0.1995,0.0745],[0.75164,0.60648,0.22648],[0.628281,0.555802,0.366065],0.4],
-            'silver':       [[0.19225,0.19225,0.19225],[0.50754,0.50754,0.50754],[0.508273,0.508273,0.508273],0.4],
-            'blackplastic': [[0,0,0],[0.01,0.01,0.01],[0.5,0.5,0.5],0.25],
-            'cyanplastic':  [[0,0.1,0.06],[0,0.50980392,0.50980392],[0.50196078,0.50196078,0.50196078],0.25],
-            'greenplastic': [[0,0,0],[0.1,0.35,0.1],[0.45,0.55,0.45],0.25],
-            'redplastic':   [[0,0,0],[0.5,0,0],[0.7,0.6,0.6],0.25],
-            'whiteplastic': [[0,0,0],[0.55,0.55,0.55],[0.7,0.7,0.7],0.25],
-            'yellowplastic':[[0,0,0],[0.5,0.5,0],[0.6,0.6,0.5],0.25]}
-
+            'bright':       [[0.9, 0.9, 0.9], [1.0, 1.0, 1.0], [0.8, 0.8, 0.8], 0.6],
+            'medium':       [[0.6, 0.6, 0.6], [0.8, 0.8, 0.8], [0.2, 0.2, 0.2], 0.5],
+            'dark':         [[0.4, 0.4, 0.4], [0.5, 0.5, 0.5], [0.1, 0.1, 0.1], 0.4],
+            'bluerubber':   [[0, 0, 0.05], [0.4, 0.4, 0.5], [0.04, 0.04, 0.7], 0.078125],
+            'redrubber':    [[0.05, 0, 0], [0.5, 0.4, 0.4], [0.7, 0.04, 0.04], 0.078125],
+            'yellowrubber': [[0.05, 0.05, 0], [0.5, 0.5, 0.4], [0.7, 0.7, 0.04], 0.078125],
+            'greenrubber':  [[0, 0.05, 0], [0.4, 0.5, 0.4], [0.04, 0.7, 0.04], 0.078125],
+            'whiterubber':  [[0.05, 0.05, 0.05], [0.5, 0.5, 0.5], [0.7, 0.7, 0.7], 0.078125],
+            'cyanrubber':   [[0, 0.05, 0.05], [0.4, 0.5, 0.5], [0.04, 0.7, 0.7], 0.078125],
+            'blackrubber':  [[0.02, 0.02, 0.02], [0.01, 0.01, 0.01], [0.4, 0.4, 0.4], 0.078125],
+            'emerald':      [[0.0215, 0.1745, 0.0215], [0.07568, 0.61424, 0.07568], [0.633, 0.727811, 0.633], 0.6],
+            'jade':         [[0.135, 0.2225, 0.1575], [0.54, 0.89, 0.63], [0.316228, 0.316228, 0.316228], 0.1],
+            'obsidian':     [[0.05375, 0.05, 0.06625], [0.18275, 0.17, 0.22525], [0.332741, 0.328634, 0.346435], 0.3],
+            'pearl':        [[0.25, 0.20725, 0.20725], [1, 0.829, 0.829], [0.296648, 0.296648, 0.296648], 0.088],
+            'ruby':         [[0.1745, 0.01175, 0.01175], [0.61424, 0.04136, 0.04136], [0.727811, 0.626959, 0.626959], 0.6],
+            'turquoise':    [[0.1, 0.18725, 0.1745], [0.396, 0.74151, 0.69102], [0.297254, 0.30829, 0.306678], 0.1],
+            'brass':        [[0.329412, 0.223529, 0.027451], [0.780392, 0.568627, 0.113725], [0.992157, 0.941176, 0.807843], 0.21794872],
+            'bronze':       [[0.2125, 0.1275, 0.054], [0.714, 0.4284, 0.18144], [0.393548, 0.271906, 0.166721], 0.2],
+            'chrome':       [[0.25, 0.25, 0.25], [0.4, 0.4, 0.4], [0.774597, 0.774597, 0.774597], 0.6],
+            'copper':       [[0.19125, 0.0735, 0.0225], [0.7038, 0.27048, 0.0828], [0.256777, 0.137622, 0.086014], 0.1],
+            'gold':         [[0.24725, 0.1995, 0.0745], [0.75164, 0.60648, 0.22648], [0.628281, 0.555802, 0.366065], 0.4],
+            'silver':       [[0.19225, 0.19225, 0.19225], [0.50754, 0.50754, 0.50754], [0.508273, 0.508273, 0.508273], 0.4],
+            'blackplastic': [[0, 0, 0], [0.01, 0.01, 0.01], [0.5, 0.5, 0.5], 0.25],
+            'cyanplastic':  [[0, 0.1, 0.06], [0, 0.50980392, 0.50980392], [0.50196078, 0.50196078, 0.50196078], 0.25],
+            'greenplastic': [[0, 0, 0], [0.1, 0.35, 0.1], [0.45, 0.55, 0.45], 0.25],
+            'redplastic':   [[0, 0, 0], [0.5, 0, 0], [0.7, 0.6, 0.6], 0.25],
+            'whiteplastic': [[0, 0, 0], [0.55, 0.55, 0.55], [0.7, 0.7, 0.7], 0.25],
+            'yellowplastic': [[0, 0, 0], [0.5, 0.5, 0], [0.6, 0.6, 0.5], 0.25]}
 
         # DEFAULT PROPERTIES
         self.specs = {
@@ -166,7 +166,6 @@ class openGLLive(object):
             'drag_force': 3.0
         }
 
-
         # OVERWRITE WITH USER PROPERTIES
         for key in kwargs:
             if key not in self.specs:
@@ -195,7 +194,7 @@ class openGLLive(object):
 
         self.timers.append((int(interval), cb))
 
-    def run(self, integ_steps = 1):
+    def run(self, integ_steps=1):
         """Convenience method wiwith a simple integration thread.
         """
 
@@ -300,11 +299,10 @@ class openGLLive(object):
                     self.triggerResetParticleDrag = False
                     self.dragId = -1
 
-        # Escape was pressed: wait for ES to finish, then call sys exit from main thread
+        # Escape was pressed: wait for ES to finish, then call sys exit from
+        # main thread
         if self.quit_savely:
             os._exit(1)
-
-
 
     # GET THE PARTICLE DATA
     def _updateParticles(self):
@@ -424,7 +422,7 @@ class openGLLive(object):
                 for k in range(int(res[2])):
                     p = np.array([i, j, k]) * sp
                     dist, vec = shape.call_method(
-                            "calc_distance", position=p.tolist())
+                        "calc_distance", position=p.tolist())
                     if not np.isnan(vec).any() and not np.isnan(dist) and abs(dist) < sp:
                         points.append((p - vec).tolist())
         return points
@@ -449,13 +447,16 @@ class openGLLive(object):
             self._drawLBVel()
         if self.specs['draw_box']:
             self._drawSystemBox()
-       
+
         if self.specs['draw_axis']:
             axis_fac = 0.2
-            axis_r = np.min(self.system.box_l)/50.0
-            _drawArrow([0,0,0], [self.system.box_l[0] * axis_fac, 0, 0], axis_r, [1, 0, 0, 1], self.materials['chrome'], self.specs['quality_arrows'])
-            _drawArrow([0,0,0], [0, self.system.box_l[2] * axis_fac, 0], axis_r, [0, 1, 0, 1], self.materials['chrome'], self.specs['quality_arrows'])
-            _drawArrow([0,0,0], [0, 0, self.system.box_l[2] * axis_fac], axis_r, [0, 0, 1, 1], self.materials['chrome'], self.specs['quality_arrows'])
+            axis_r = np.min(self.system.box_l) / 50.0
+            _drawArrow([0, 0, 0], [self.system.box_l[0] * axis_fac, 0, 0], axis_r, [
+                       1, 0, 0, 1], self.materials['chrome'], self.specs['quality_arrows'])
+            _drawArrow([0, 0, 0], [0, self.system.box_l[2] * axis_fac, 0], axis_r, [
+                       0, 1, 0, 1], self.materials['chrome'], self.specs['quality_arrows'])
+            _drawArrow([0, 0, 0], [0, 0, self.system.box_l[2] * axis_fac], axis_r, [
+                       0, 0, 1, 1], self.materials['chrome'], self.specs['quality_arrows'])
 
         self._drawSystemParticles()
 
@@ -536,7 +537,8 @@ class openGLLive(object):
 
             radius = self._determine_radius(ptype)
 
-            m = self._modulo_indexing(self.specs['particle_type_materials'], ptype)
+            m = self._modulo_indexing(
+                self.specs['particle_type_materials'], ptype)
             material = self.materials[m]
 
             if self.specs['particle_coloring'] == 'id':
@@ -556,7 +558,7 @@ class openGLLive(object):
                     self.specs['particle_type_colors'], ptype)
 
             _drawSphere(pos, radius, color, material,
-                       self.specs['quality_particles'])
+                        self.specs['quality_particles'])
             for imx in range(-self.specs['periodic_images'][0], self.specs['periodic_images'][0] + 1):
                 for imy in range(-self.specs['periodic_images'][1], self.specs['periodic_images'][1] + 1):
                     for imz in range(-self.specs['periodic_images'][2], self.specs['periodic_images'][2] + 1):
@@ -574,7 +576,7 @@ class openGLLive(object):
                                 self.specs['ext_force_arrows_scale'], ptype)
                         if sc > 0:
                             _drawArrow(pos, np.array(ext_f) * sc, 0.25 *
-                                      sc, [1, 1, 1, 1], self.materials['chrome'], self.specs['quality_arrows'])
+                                       sc, [1, 1, 1, 1], self.materials['chrome'], self.specs['quality_arrows'])
 
     def _drawBonds(self):
         coords = self.particles['coords']
@@ -583,21 +585,23 @@ class openGLLive(object):
         box_l2_sqr = pow(b2, 2.0)
         for b in self.bonds:
             col = self._modulo_indexing(self.specs['bond_type_colors'], b[2])
-            mat = self.materials[self._modulo_indexing(self.specs['bond_type_materials'], b[2])]
-            radius = self._modulo_indexing(self.specs['bond_type_radius'], b[2])
+            mat = self.materials[self._modulo_indexing(
+                self.specs['bond_type_materials'], b[2])]
+            radius = self._modulo_indexing(
+                self.specs['bond_type_radius'], b[2])
             d = coords[b[0]] - coords[b[1]]
             bondLen_sqr = d[0] * d[0] + d[1] * d[1] + d[2] * d[2]
 
             if bondLen_sqr < box_l2_sqr:
                 _drawCylinder(coords[b[0]], coords[b[1]], radius,
-                             col, mat, self.specs['quality_bonds'])
+                              col, mat, self.specs['quality_bonds'])
                 for imx in range(-self.specs['periodic_images'][0], self.specs['periodic_images'][0] + 1):
                     for imy in range(-self.specs['periodic_images'][1], self.specs['periodic_images'][1] + 1):
                         for imz in range(-self.specs['periodic_images'][2], self.specs['periodic_images'][2] + 1):
                             if imx != 0 or imy != 0 or imz != 0:
                                 im = np.array([imx, imy, imz])
                                 _drawCylinder(coords[b[0]] + im * self.imPos[dim], coords[b[1]] +
-                                             im * self.imPos[dim], radius, col, mat, self.specs['quality_bonds'])
+                                              im * self.imPos[dim], radius, col, mat, self.specs['quality_bonds'])
             else:
                 l = coords[b[0]] - coords[b[1]]
                 l0 = coords[b[0]]
@@ -618,9 +622,9 @@ class openGLLive(object):
                         if hits >= 2:
                             break
                 _drawCylinder(coords[b[0]], s0, radius, col,
-                             mat, self.specs['quality_bonds'])
+                              mat, self.specs['quality_bonds'])
                 _drawCylinder(coords[b[1]], s1, radius, col,
-                             mat, self.specs['quality_bonds'])
+                              mat, self.specs['quality_bonds'])
 
                 for imx in range(-self.specs['periodic_images'][0], self.specs['periodic_images'][0] + 1):
                     for imy in range(-self.specs['periodic_images'][1], self.specs['periodic_images'][1] + 1):
@@ -628,9 +632,9 @@ class openGLLive(object):
                             if imx != 0 or imy != 0 or imz != 0:
                                 im = np.array([imx, imy, imz])
                                 _drawCylinder(coords[b[0]] + im * self.imPos[dim], s0 + im *
-                                             self.imPos[dim], radius, col, mat, self.specs['quality_bonds'])
+                                              self.imPos[dim], radius, col, mat, self.specs['quality_bonds'])
                                 _drawCylinder(coords[b[1]] + im * self.imPos[dim], s1 + im *
-                                             self.imPos[dim], radius, col, mat, self.specs['quality_bonds'])
+                                              self.imPos[dim], radius, col, mat, self.specs['quality_bonds'])
 
     # HELPER TO DRAW PERIODIC BONDS
     def _isInsideBox(self, p):
@@ -647,8 +651,9 @@ class openGLLive(object):
             p = lbl[0]
             v = lbl[1]
             c = np.linalg.norm(v)
-            _drawArrow(p, v * self.specs['LB_vel_scale'], self.lb_arrow_radius, [1,1,1,1], self.materials['chrome'], 16)
-        
+            _drawArrow(p, v * self.specs['LB_vel_scale'], self.lb_arrow_radius, [
+                       1, 1, 1, 1], self.materials['chrome'], 16)
+
     # USE MODULO IF THERE ARE MORE PARTICLE TYPES THAN TYPE DEFINITIONS FOR
     # COLORS, MATERIALS ETC..
     def _modulo_indexing(self, l, t):
@@ -677,18 +682,17 @@ class openGLLive(object):
         def display():
             if self.hasParticleData:
                 glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-                #glLoadIdentity()
-
+                # glLoadIdentity()
 
                 glLoadMatrixf(self.camera.modelview)
-                #self.camera.rotateSystem3()
-                #self.camera.glLookAt()
+                # self.camera.rotateSystem3()
+                # self.camera.glLookAt()
 
                 if self.updateLightPos:
                     self._setLightPos()
                     self.updateLightPos = False
 
-                #self.camera.rotateSystem()
+                # self.camera.rotateSystem()
 
                 self._draw()
 
@@ -714,7 +718,7 @@ class openGLLive(object):
         def motion(x, y):
             self.mouseManager._mouseMove(x, y)
             return
-        
+
         def idleUpdate():
             return
 
@@ -847,14 +851,15 @@ class openGLLive(object):
             self.lb_plane_b1 *= np.array(self.system.box_l)
             self.lb_plane_b2 *= np.array(self.system.box_l)
             self.lb_plane_p = np.array(pn) * self.specs['LB_plane_dist']
-            self.lb_arrow_radius = self.system.box_l[self.specs['LB_plane_axis']]*0.005
-            
+            self.lb_arrow_radius = self.system.box_l[
+                self.specs['LB_plane_axis']] * 0.005
+
             self.lb_min_vel = np.array([-1e-6] * 3)
             self.lb_max_vel = np.array([1e-6] * 3)
             self.lb_vel_range = self.lb_max_vel - self.lb_min_vel
             self.lb_min_dens = np.array([0] * 3)
             self.lb_max_dens = np.array([0] * 3)
-            
+
             self._updateLB()
 
         self.elapsedTime = 0
@@ -929,7 +934,7 @@ class openGLLive(object):
         self.keyboardManager.registerButton(KeyboardButtonEvent(
             'g', KeyboardFireEvent.Hold, self.camera.moveBackward, True))
 
-    # CALLED ON ESCAPE PRESSED. TRIGGERS sys.exit() after ES is done 
+    # CALLED ON ESCAPE PRESSED. TRIGGERS sys.exit() after ES is done
     def _quit(self):
         self.quit_savely = True
 
@@ -941,15 +946,13 @@ class openGLLive(object):
                       self.smooth_light_pos[0], self.smooth_light_pos[1], self.smooth_light_pos[2], 0.6])
 
         self._setCameraSpotlight()
-       
 
     def _setCameraSpotlight(self):
-        #p = np.linalg.norm(self.camera.state_pos) * self.camera.state_target
+        # p = np.linalg.norm(self.camera.state_pos) * self.camera.state_target
         p = self.camera.camPos
         fp = [p[0], p[1], p[2], 1]
         glLightfv(GL_LIGHT1, GL_POSITION, fp)
         glLightfv(GL_LIGHT1, GL_SPOT_DIRECTION, self.camera.state_target)
-
 
     def _triggerLightPosUpdate(self):
         self.updateLightPos = True
@@ -959,7 +962,7 @@ class openGLLive(object):
         box_diag = np.linalg.norm(b)
         box_center = b * 0.5
         if self.specs['camera_position'] == 'auto':
-            cp = [box_center[0], box_center[1], b[2]*3]
+            cp = [box_center[0], box_center[1], b[2] * 3]
         else:
             cp = self.specs['camera_position']
 
@@ -967,10 +970,11 @@ class openGLLive(object):
             ct = box_center
         else:
             ct = self.specs['camera_target']
-        
+
         cr = np.array(self.specs['camera_right'])
 
-        self.camera = _Camera(camPos=np.array(cp), camTarget=ct, camRight=cr, moveSpeed=0.5 * box_diag / 17.0,  center=box_center, updateLights=self._triggerLightPosUpdate)
+        self.camera = _Camera(camPos=np.array(cp), camTarget=ct, camRight=cr, moveSpeed=0.5 *
+                              box_diag / 17.0,  center=box_center, updateLights=self._triggerLightPosUpdate)
         self.smooth_light_pos = np.copy(box_center)
         self.smooth_light_posV = np.array([0.0, 0.0, 0.0])
         self.particle_COM = np.copy(box_center)
@@ -982,8 +986,8 @@ class openGLLive(object):
         glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH)
         glutInitWindowSize(self.specs['window_size'][
                            0], self.specs['window_size'][1])
-        
-        #glutCreateWindow(bytes(self.specs['name'], encoding='ascii'))
+
+        # glutCreateWindow(bytes(self.specs['name'], encoding='ascii'))
         glutCreateWindow(b"ESPResSo visualization")
 
         glClearColor(self.specs['background_color'][0], self.specs[
@@ -993,7 +997,7 @@ class openGLLive(object):
 
         glEnable(GL_BLEND)
 
-        #glEnable(GL_CULL_FACE)
+        # glEnable(GL_CULL_FACE)
 
         glLineWidth(2.0)
         glutIgnoreKeyRepeat(1)
@@ -1055,7 +1059,7 @@ class openGLLive(object):
 # OPENGL DRAW WRAPPERS
 
 
-def _setSolidMaterial(r, g, b, a=1.0, ambient=[0.6,0.6,0.6], diffuse=[1.0,1.0,1.0], specular=[0.1,0.1,0.1], shininess = 0.4):
+def _setSolidMaterial(r, g, b, a=1.0, ambient=[0.6, 0.6, 0.6], diffuse=[1.0, 1.0, 1.0], specular=[0.1, 0.1, 0.1], shininess=0.4):
     glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT,  [
                  ambient[0] * r, ambient[1] * g, ambient[2] * g, a])
     glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, [
@@ -1063,6 +1067,7 @@ def _setSolidMaterial(r, g, b, a=1.0, ambient=[0.6,0.6,0.6], diffuse=[1.0,1.0,1.
     glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, [
                  specular[0] * r, specular[1] * g, specular[2] * g, a])
     glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, int(shininess * 128))
+
 
 def _drawBox(p0, s, color):
     _setSolidMaterial(color[0], color[1], color[2])
@@ -1097,7 +1102,8 @@ def _drawBox(p0, s, color):
 def _drawSphere(pos, radius, color, material, quality):
     glPushMatrix()
     glTranslatef(pos[0], pos[1], pos[2])
-    _setSolidMaterial(color[0], color[1], color[2], color[3], material[0], material[1], material[2], material[3])
+    _setSolidMaterial(color[0], color[1], color[2], color[
+                      3], material[0], material[1], material[2], material[3])
     glutSolidSphere(radius, quality, quality)
     glPopMatrix()
 
@@ -1112,7 +1118,7 @@ def _redrawSphere(pos, radius, quality):
 def _drawPlane(edges, color, material):
 
     _setSolidMaterial(color[0], color[1], color[2], color[
-                     3], material[0], material[1], material[2], material[3])
+        3], material[0], material[1], material[2], material[3])
 
     glBegin(GL_QUADS)
     for e in edges:
@@ -1127,6 +1133,7 @@ def _drawCube(pos, size, color, alpha):
     glutSolidCube(size)
     glPopMatrix()
 
+
 def _drawTriangles(triangles, color, material):
     np.random.seed(1)
 
@@ -1135,7 +1142,7 @@ def _drawTriangles(triangles, color, material):
         color = np.random.random(3).tolist()
         color.append(1)
         _setSolidMaterial(color[0], color[1], color[2],
-                         color[3], material[0], material[1], material[2], material[3])
+                          color[3], material[0], material[1], material[2], material[3])
         for p in t:
             glVertex3f(p[0], p[1], p[2])
     glEnd()
@@ -1143,7 +1150,7 @@ def _drawTriangles(triangles, color, material):
 
 def _drawPoints(points, pointsize, color, material):
     _setSolidMaterial(color[0], color[1], color[2], color[3],
-                     material[0], material[1], material[2], material[3])
+                      material[0], material[1], material[2], material[3])
     glEnable(GL_POINT_SMOOTH)
 
     glPointSize(pointsize)
@@ -1155,7 +1162,7 @@ def _drawPoints(points, pointsize, color, material):
 
 def _drawCylinder(posA, posB, radius, color, material, quality, draw_caps=False):
     _setSolidMaterial(color[0], color[1], color[2], color[3],
-                     material[0], material[1], material[2], material[3])
+                      material[0], material[1], material[2], material[3])
     glPushMatrix()
     quadric = gluNewQuadric()
 
@@ -1164,8 +1171,8 @@ def _drawCylinder(posA, posB, radius, color, material, quality, draw_caps=False)
     # angle,t,length = calcAngle(d)
     length = np.linalg.norm(d)
     glTranslatef(posA[0], posA[1], posA[2])
-    
-    ax,rx,ry = _rotationHelper(d)
+
+    ax, rx, ry = _rotationHelper(d)
     glRotatef(ax, rx, ry, 0.0)
     gluCylinder(quadric, radius, radius, length, quality, quality)
 
@@ -1175,6 +1182,7 @@ def _drawCylinder(posA, posB, radius, color, material, quality, draw_caps=False)
         gluDisk(quadric, 0, radius, quality, quality)
 
     glPopMatrix()
+
 
 def _rotationHelper(d):
     if d[2] == 0.0:
@@ -1193,9 +1201,10 @@ def _rotationHelper(d):
 
     return ax, rx, ry
 
+
 def _drawSpheroCylinder(posA, posB, radius, color, material, quality):
     _setSolidMaterial(color[0], color[1], color[
-                     2], color[3], material[0], material[1], material[2], material[3])
+        2], color[3], material[0], material[1], material[2], material[3])
     glPushMatrix()
     quadric = gluNewQuadric()
 
@@ -1238,7 +1247,7 @@ def _drawArrow(pos, d, radius, color, material, quality):
     pos2 = np.array(pos) + np.array(d)
 
     _drawCylinder(pos, pos2, radius, color, material, quality)
-    
+
     ax, rx, ry = _rotationHelper(d)
 
     glPushMatrix()
@@ -1250,6 +1259,7 @@ def _drawArrow(pos, d, radius, color, material, quality):
 
 # MOUSE EVENT MANAGER
 class MouseFireEvent(object):
+
     """Event type of mouse button used for mouse callbacks.
 
     """
@@ -1261,6 +1271,7 @@ class MouseFireEvent(object):
 
 
 class MouseButtonEvent(object):
+
     """Mouse event used for mouse callbacks. Stores button and callback.
 
     """
@@ -1273,6 +1284,7 @@ class MouseButtonEvent(object):
 
 
 class MouseManager(object):
+
     """Handles mouse callbacks.
 
     """
@@ -1332,6 +1344,7 @@ class MouseManager(object):
 
 
 class KeyboardFireEvent(object):
+
     """Event type of button used for keyboard callbacks.
 
     """
@@ -1342,6 +1355,7 @@ class KeyboardFireEvent(object):
 
 
 class KeyboardButtonEvent(object):
+
     """Keyboard event used for keyboard callbacks. Stores button, event type and callback.
 
     """
@@ -1354,6 +1368,7 @@ class KeyboardButtonEvent(object):
 
 
 class KeyboardManager(object):
+
     """Handles keyboard callbacks.
 
     """
@@ -1421,31 +1436,31 @@ class KeyboardManager(object):
 
 class _Camera(object):
 
-    def __init__(self, camPos=np.array([0, 0, 1]), camTarget=np.array([0, 0, 0]), camRight=np.array([1.0,0.0,0.0]), moveSpeed=0.5, rotSpeed=0.001, globalRotSpeed=3.0, center=np.array([0, 0, 0]), updateLights=None):
+    def __init__(self, camPos=np.array([0, 0, 1]), camTarget=np.array([0, 0, 0]), camRight=np.array([1.0, 0.0, 0.0]), moveSpeed=0.5, rotSpeed=0.001, globalRotSpeed=3.0, center=np.array([0, 0, 0]), updateLights=None):
         self.moveSpeed = moveSpeed
         self.lookSpeed = rotSpeed
         self.globalRotSpeed = globalRotSpeed
 
         self.center = center
         self.updateLights = updateLights
-        
+
         self.modelview = np.identity(4, np.float32)
 
-        t = camPos-camTarget
+        t = camPos - camTarget
         r = np.linalg.norm(t)
 
-        self.state_target = -t / r 
+        self.state_target = -t / r
         self.state_right = camRight / np.linalg.norm(camRight)
         self.state_up = np.cross(self.state_right, self.state_target)
 
-        self.state_pos = np.array([0,0,r])
-        
+        self.state_pos = np.array([0, 0, r])
+
         self.update_modelview()
 
     def moveForward(self):
         self.state_pos[2] += self.moveSpeed
         self.update_modelview()
-    
+
     def moveBackward(self):
         self.state_pos[2] -= self.moveSpeed
         self.update_modelview()
@@ -1483,7 +1498,6 @@ class _Camera(object):
 
     def rotateSystemZR(self):
         self.rotateCameraV(-0.01 * self.globalRotSpeed)
-
 
     def rotateCamera(self, mousePos, mousePosOld, mouseButtonState):
         dm = mousePos - mousePosOld
@@ -1589,6 +1603,7 @@ class _Camera(object):
 
 
 class _Quaternion:
+
     def __init__(self, x, y, z, w):
         self.array = np.array([x, y, z, w], np.float32)
 
@@ -1600,14 +1615,18 @@ class _Quaternion:
 
     def mult_v(self, v):
         w = - (self[0] * v[0]) - (self[1] * v[1]) - (self[2] * v[2])
-        x =   (self[3] * v[0]) + (self[1] * v[2]) - (self[2] * v[1])
-        y =   (self[3] * v[1]) + (self[2] * v[0]) - (self[0] * v[2])
-        z =   (self[3] * v[2]) + (self[0] * v[1]) - (self[1] * v[0])
+        x = (self[3] * v[0]) + (self[1] * v[2]) - (self[2] * v[1])
+        y = (self[3] * v[1]) + (self[2] * v[0]) - (self[0] * v[2])
+        z = (self[3] * v[2]) + (self[0] * v[1]) - (self[1] * v[0])
         return _Quaternion(x, y, z, w)
 
     def mult_q(self, q):
-        w = - (self[3] * q[3]) - (self[0] * q[0]) - (self[1] * q[1]) - (self[2] * q[2])
-        x =   (self[0] * q[3]) + (self[3] * q[0]) + (self[1] * q[2]) - (self[2] * q[1])
-        y =   (self[1] * q[3]) + (self[3] * q[1]) + (self[2] * q[0]) - (self[0] * q[2])
-        z =   (self[2] * q[3]) + (self[3] * q[2]) + (self[0] * q[1]) - (self[1] * q[0])
+        w = - (self[3] * q[3]) - (self[0] * q[0]) - \
+            (self[1] * q[1]) - (self[2] * q[2])
+        x =   (self[0] * q[3]) + (self[3] * q[0]) + \
+            (self[1] * q[2]) - (self[2] * q[1])
+        y = (self[1] * q[3]) + (self[3] * q[1]) + (
+            self[2] * q[0]) - (self[0] * q[2])
+        z = (self[2] * q[3]) + (self[3] * q[2]) + (
+            self[0] * q[1]) - (self[1] * q[0])
         return _Quaternion(x, y, z, w)


### PR DESCRIPTION
Fixes #1656, #1684 

Some opengl visualizer improvements:
    - Exit the visualizer and running espresso with ESC
    - Convenience method `visualizer.run(integ_steps)` that runs an integration loop + visualizer
    - OpenGL materials

Added es logo script:
![es_logo_v3](https://user-images.githubusercontent.com/3974659/33886137-e00b3f80-df45-11e7-9cff-b689d694dea7.gif)
