### PR TITLE
core: Fixed h5md bond writing.

### DIFF
--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include "h5md_core.hpp"
+#include "core/interaction_data.hpp"
 
 namespace Writer {
 namespace H5md {
@@ -356,15 +357,24 @@ void File::fill_arrays_for_h5md_write_with_particle_property(
 
   if (!m_already_wrote_bonds) {
     int nbonds_local = bond.shape()[1];
-    for (int i = 1; i < current_particle.bl.n; i = i + 2) {
-      bond.resize(boost::extents[1][nbonds_local + 1][2]);
-      bond[0][nbonds_local][0] = current_particle.p.identity;
-      bond[0][nbonds_local][1] = current_particle.bl.e[i];
+    for (auto it = current_particle.bl.begin();
+         it != current_particle.bl.end();) {
+
+      auto const n_partners = bonded_ia_params[*it++].num;
+
+      if (1 == n_partners) {
+        bond.resize(boost::extents[1][nbonds_local + 1][2]);
+        bond[0][nbonds_local][0] = current_particle.p.identity;
+        bond[0][nbonds_local][1] = *it++;
+        nbonds_local++;
+      } else {
+        it += n_partners;
+      }
     }
   }
 }
 
-  void File::Write(int write_dat, PartCfg & partCfg) {
+void File::Write(int write_dat, PartCfg &partCfg) {
 #ifdef H5MD_DEBUG
   std::cout << "Called " << __func__ << " on node " << this_node << std::endl;
 #endif


### PR DESCRIPTION
Fixes #1303.

Description of changes:
 - Correctly parse bond lists

Bonds with more than 1 partner are ignored, this would need a larger refactoring.