### PR TITLE
visualization of velocities and forces

### DIFF
--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -23,57 +23,121 @@ class openGLLive(object):
     Use the update method to push your current simulation state after
     integrating. Modify the appearance with a list of keywords.
     Timed callbacks can be registered via the registerCallback method.
-    Keyboad callbacks via  keyboardManager.registerButton()."""
+    Keyboad callbacks via  keyboardManager.registerButton().
 
+    Attributes
+    ----------
+
+    system : instance of :attr:`espressomd.System`
+    window_size : array_like :obj:`int`, optional
+                  Size of the visualizer window in pixels.
+    name : :obj:`str`, optional
+           The name of the visualizer window.
+    background_color : array_like :obj:`int`, optional
+                       RGB of the background.
+    periodic_images : array_like :obj:`int`, optional
+                      Periodic repetitions on both sides of the box in xyzdirection.
+    draw_box : :obj:`bool`, optional
+               Draw wireframe boundaries.
+    draw_axis : :obj:`bool`, optional
+                Draws xyz system axes.
+    quality_particles : :obj:`int`, optional
+                        The number of subdivisions for particle spheres.
+    quality_bonds : :obj:`int`, optional
+                    The number of subdivisions for cylindrical bonds.
+    quality_arrows : :obj:`int`, optional
+                     The number of subdivisions for external force arrows.
+    quality_constraints : :obj:`int`, optional
+                          The number of subdivisions for primitive constraints.
+    close_cut_distance : :obj:`float`, optional
+                         The distance from the viewer to the near clipping plane.
+    far_cut_distance : :obj:`float`, optional
+                       The distance from the viewer to the far clipping plane.
+    camera_position : :obj:`str` or array_like :obj:`float`, optional
+                      Initial camera position. ``auto`` (default) for shiftet position in z-direction.
+    camera_target : :obj:`str` or array_like :obj:`float`, optional
+                    Initial camera target. ``auto`` (default) to look towards the system center.
+    camera_right : array_like :obj:`float`, optional
+                   Camera right vector in system coordinates. Default is [1, 0, 0]
+    particle_sizes : :obj:`str` or array_like :obj:`float` or callable, optional
+                     auto (default): The Lennard-Jones sigma value of the
+                     self-interaction is used for the particle diameter.
+                     callable: A lambda function with one argument. Internally,
+                     the numerical particle type is passed to the lambda
+                     function to determine the particle radius.  list: A list
+                     of particle radii, indexed by the particle type.
+    particle_coloring : :obj:`str`, optional
+                        auto (default): Colors of charged particles are
+                        specified by particle_charge_colors, neutral particles
+                        by particle_type_colors. charge: Minimum and maximum
+                        charge of all particles is determined by the
+                        visualizer. All particles are colored by a linear
+                        interpolation of the two colors given by
+                        particle_charge_colors according to their charge. type:
+                        Particle colors are specified by particle_type_colors,
+                        indexed by their numerical particle type.
+    particle_type_colors : array_like :obj:`float`, optional
+                           Colors for particle types.
+    particle_type_materials : :obj:`str`, optional
+                              Materials of the particle types.
+    particle_charge_colors : array_like :obj:`float`, optional
+                             Two colors for min/max charged particles.
+    draw_constraints : :obj:`bool`, optional
+                       Enables constraint visualization. For simple constraints
+                       (planes, spheres and cylinders), OpenGL primitives are
+                       used. Otherwise, visualization by rasterization is used.
+    rasterize_pointsize : :obj:`float`, optional
+                          Point size for the rasterization dots.
+    rasterize_resolution : :obj:`float`, optional
+                           Accuracy of the rasterization.
+    quality_constraints : :obj:`int`, optional
+                          The number of subdivisions for primitive constraints.
+    constraint_type_colors : array_like :obj:`float`, optional
+                             Colors of the constaints by type.
+    constraint_type_materials : array_like :obj:`str`, optional 
+                                Materials of the constraints by type.
+    draw_bonds : :obj:`bool`, optional
+                 Enables bond visualization.
+    bond_type_radius : array_like :obj:`float`, optional
+                       Radii of bonds by type.
+    bond_type_colors : array_like :obj:`float`, optional
+                       Color of bonds by type.
+    bond_type_materials : array_like :obj:`float`, optional
+                          Materials of bonds by type.
+    ext_force_arrows : :obj:`bool`, optional
+                       Enables external force visualization.
+    ext_force_arrows_scale : :obj:`float`, optional
+                             Scale factor for external force arrows.
+    drag_enabled : :obj:`bool`, optional
+                   Enables mouse-controlled particles dragging (Default: False)
+    drag_force : :obj:`bool`, optional
+                 Factor for particle dragging
+    light_pos : array_like :obj:`float`, optional
+                If auto (default) is used, the light is placed dynamically in
+                the particle barycenter of the system. Otherwise, a fixed
+                coordinate can be set.
+    light_colors : array_like :obj:`float`, optional
+                   Three lists to specify ambient, diffuse and specular light colors.
+    light_brightness : :obj:`float`, optional
+                       Brightness (inverse constant attenuation) of the light.
+    light_size : :obj:`float`, optional
+                 Size (inverse linear attenuation) of the light. If auto
+                 (default) is used, the light size will be set to a reasonable
+                 value according to the box size at start.
+    spotlight_enabled : :obj:`bool`, optional
+                        If set to True (default), it enables a spotlight on the
+                        camera position pointing in look direction.
+    spotlight_colors : array_like :obj:`float`, optional
+                       Three lists to specify ambient, diffuse and specular spotlight colors.
+    spotlight_angle : :obj:`float`, optional
+                      The spread angle of the spotlight in degrees (from 0 to 90).
+    spotlight_brightness : :obj:`float`, optional
+                           Brightness (inverse constant attenuation) of the spotlight.
+    spotlight_focus : :obj:`float`, optional
+                      Focus (spot exponent) for the spotlight from 0 (uniform) to 128.
+
+    """
     def __init__(self, system, **kwargs):
-        """
-        Parameters
-        ----------
-
-        :system: instance of espressomd.System
-        :window\_size: Size of the visualizer window in pixels.
-        :name: The name of the visualizer window.
-        :background\_color: RGB of the background.
-        :periodic\_images: Periodic repetitions on both sides of the box in xyzdirection.
-        :draw\_box: Draw wireframe boundaries.
-        :draw\_axis: Draws xyz system axes.
-        :quality\_particles: The number of subdivisions for particle spheres.
-        :quality\_bonds: The number of subdivisions for cylindrical bonds.
-        :quality\_arrows: The number of subdivisions for external force arrows.
-        :quality\_constraints: The number of subdivisions for primitive constraints.
-        :close\_cut\_distance: The distance from the viewer to the near clipping plane.
-        :far\_cut\_distance: The distance from the viewer to the far clipping plane.
-        :camera\_position: Initial camera position. auto (default) for shiftet position in z-direction.
-        :camera\_target: Initial camera target. auto (default) to look towards the system center.
-        :camera\_right: Camera right vector in system coordinates. Default is [1, 0, 0]
-        :particle\_sizes: auto (default): The Lennard-Jones sigma value of the self-interaction is used for the particle diameter. callable: A lambda function with one argument. Internally, the numerical particle type is passed to the lambda function to determine the particle radius.  list: A list of particle radii, indexed by the particle type.
-        :particle\_coloring: auto (default): Colors of charged particles are specified by particle\_charge\_colors, neutral particles by particle\_type\_colors. charge: Minimum and maximum charge of all particles is determined by the visualizer. All particles are colored by a linear interpolation of the two colors given by particle\_charge\_colors according to their charge. type: Particle colors are specified by particle\_type\_colors, indexed by their numerical particle type.
-        :particle\_type\_colors: Colors for particle types.
-        :particle\_type\_materials: Materials of the particle types.
-        :particle\_charge\_colors: Two colors for min/max charged particles.
-        :draw\_constraints: Enables constraint visualization. For simple constraints (planes, spheres and cylinders), OpenGL primitives are used. Otherwise, visualization by rasterization is used.
-        :rasterize\_pointsize: Point size for the rasterization dots.
-        :rasterize\_resolution: Accuracy of the rasterization.
-        :quality\_constraints: The number of subdivisions for primitive constraints.
-        :constraint\_type\_colors: Colors of the constaints by type.
-        :constraint\_type\_materials: Materials of the constraints by type.
-        :draw\_bonds: Enables bond visualization.
-        :bond\_type\_radius: Radii of bonds by type.
-        :bond\_type\_colors: Color of bonds by type.
-        :bond\_type\_materials: Materials of bonds by type.
-        :ext\_force\_arrows: Enables external force visualization.
-        :ext\_force\_arrows\_scale: Scale factor for external force arrows.
-        :drag\_enabled: Enables mouse-controlled particles dragging (Default: False)
-        :drag\_force: Factor for particle dragging
-        :light\_pos: If auto (default) is used, the light is placed dynamically in the particle barycenter of the system. Otherwise, a fixed coordinate can be set.
-        :light\_colors: Three lists to specify ambient, diffuse and specular light colors.
-        :light\_brightness: Brightness (inverse constant attenuation) of the light.
-        :light\_size: Size (inverse linear attenuation) of the light. If auto (default) is used, the light size will be set to a reasonable value according to the box size at start.
-        :spotlight\_enabled: If set to True (default), it enables a spotlight on the camera position pointing in look direction.
-        :spotlight\_colors: Three lists to specify ambient, diffuse and specular spotlight colors.
-        :spotlight\_angle: The spread angle of the spotlight in degrees (from 0 to 90).
-        :spotlight\_brightness: Brightness (inverse constant attenuation) of the spotlight.
-        :spotlight\_focus: Focus (spot exponent) for the spotlight from 0 (uniform) to 128."""
 
         # MATERIALS
         self.materials = {


### PR DESCRIPTION
 - Possibility to draw arrows for particle forces, external forces and velocites
- Type specific colors and scales for the arrows

```
import espressomd
from espressomd.visualization_opengl import openGLLive
import numpy as np

system = espressomd.System()
system.time_step = 0.00001
system.cell_system.skin = 0.4
system.box_l = [10,10,10] 

system.thermostat.set_langevin(kT=0.1, gamma=1.0)

for i in range(10):
    system.part.add(pos = 10.0*np.random.random(3), v = 1.0 * np.random.random(3), ext_force = np.random.random(3))
    system.part.add(pos = 10.0*np.random.random(3),type = 1, v = 1.0 * np.random.random(3), ext_force = np.random.random(3))
    
visualizer = openGLLive(system,
                        velocity_arrows=True,
                        velocity_arrows_scale = [1.8],
                        velocity_arrows_type_colors = [[1,0,0,1],[0,1,0,1]],
                        force_arrows=True, 
                        force_arrows_scale = [0.01],
                        force_arrows_type_colors = [[1,1,0,1],[0,0,1,1]],
                        ext_force_arrows=True, 
                        ext_force_arrows_scale = [1.0],
                        ext_force_arrows_type_colors = [[0,1,1,1], [1,0,1,1]],
                        arrows_radius = 0.1)
visualizer.run(1)                                                   
```                                                                                                     
![image](https://user-images.githubusercontent.com/3974659/34045666-2c2c7eae-e1aa-11e7-8a5b-eb153f6615c3.png)
