### PR TITLE
changed definition of the hydrodynamic radius

### DIFF
--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -530,7 +530,7 @@ The following formula is used for the computation:
 .. math::
 
    \label{eq:Rh}
-   \frac{1}{R_{\mathrm H}} = \frac{2}{N(N-1)} \sum\limits_{i=1}^{N} \sum\limits_{j=i}^{N} \frac{1}{|\vec r_i - \vec r_j|}\,,
+   \frac{1}{R_{\mathrm H}} = \frac{2}{N(N-1)} \sum\limits_{i=1}^{N} \sum\limits_{j<i}^{N} \frac{1}{|\vec r_i - \vec r_j|}\,,
 
 The above-mentioned formula is only valid under certain assumptions. For
 more information, see Chapter 4 and equation 4.102

--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -530,12 +530,12 @@ The following formula is used for the computation:
 .. math::
 
    \label{eq:Rh}
-   \frac{1}{R_{\mathrm H}} = \frac{2}{N^2} \sum\limits_{i=1}^{N} \sum\limits_{j=i}^{N} \frac{1}{|\vec r_i - \vec r_j|}\,,
+   \frac{1}{R_{\mathrm H}} = \frac{2}{N(N-1)} \sum\limits_{i=1}^{N} \sum\limits_{j=i}^{N} \frac{1}{|\vec r_i - \vec r_j|}\,,
 
 The above-mentioned formula is only valid under certain assumptions. For
 more information, see Chapter 4 and equation 4.102
 in :cite:`doi86a`.
-Note that the hydrodynamic radius is sometimes defined in a similar fashion but with a denominator of :math:`N(N-1)` instead of :math:`N^2` in the prefactor.
+Note that the hydrodynamic radius is sometimes defined in a similar fashion but with a denominator of :math:`N^2` instead of :math:`N(N-1)` in the prefactor.
 Both versions are equivalent in the :math:`N\rightarrow \infty` limit but give numerically different values for finite polymers.
 
 

--- a/src/core/statistics_chain.cpp
+++ b/src/core/statistics_chain.cpp
@@ -197,7 +197,7 @@ void calc_rh(PartCfg & partCfg, double **_rh) {
   *_rh = rh = Utils::realloc(rh, 2 * sizeof(double));
 
   prefac = 0.5 * chain_length *
-           chain_length; /* 1/N^2 is not a normalization factor */
+           (chain_length -1 ); /* 1/N^2 is not a normalization factor */
   for (p = 0; p < chain_n_chains; p++) {
     ri = 0.0;
     for (i = chain_start + chain_length * p;
@@ -226,7 +226,7 @@ void calc_rh_av(double **_rh) {
   double dx, dy, dz, r_H = 0.0, r_H2 = 0.0, *rh = nullptr, ri = 0.0, prefac, tmp;
   *_rh = rh = Utils::realloc(rh, 2 * sizeof(double));
 
-  prefac = 0.5 * chain_length * chain_length;
+  prefac = 0.5 * chain_length * (chain_length - 1);
   for (k = 0; k < n_configs; k++) {
     for (p = 0; p < chain_n_chains; p++) {
       ri = 0.0;

--- a/testsuite/analyze_chains.py
+++ b/testsuite/analyze_chains.py
@@ -70,9 +70,9 @@ class AnalyzeChain(ut.TestCase):
             ij = np.triu_indices(len(r), k=1)
             r_ij = r[ij[0]] - r[ij[1]]
             dist = np.sqrt(np.sum(r_ij**2, axis=1))
-            rh.append(self.num_mono*self.num_mono*0.5/(np.sum(1./dist)))
+            #rh.append(self.num_mono*self.num_mono*0.5/(np.sum(1./dist)))
             # the other way do it, with the proper prefactor of N(N-1)
-            #rh.append(np.mean(1./dist))
+            rh.append(1./np.mean(1./dist))
         rh = np.array(rh)
         return np.mean(rh), np.std(rh)
 


### PR DESCRIPTION
Fixes #

Not sure if this is a good idea since it changes older behaviour.
Calculating the chain hydrodynamic radius involves finding the mean <1/r> distances.
The old prefactor of N^2 in
<img width="409" alt="old" src="https://user-images.githubusercontent.com/1529852/34053774-6745a9de-e1c8-11e7-9112-b2497580d998.png">
is now N(N-1)
<img width="516" alt="new" src="https://user-images.githubusercontent.com/1529852/34053778-6bb6072a-e1c8-11e7-8362-a4fbbc6482e4.png">

Description of changes:
 - change the prefactor in calculating the average


PR Checklist
------------
 - [x] Tests?
   - [ ] Interface
   - [x] Core 
 - [x] Docs?
