### PR TITLE
Checking int, float against various numpy types

### DIFF
--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -35,7 +35,7 @@ cimport numpy as np
 from globals cimport n_configs, min_box_l
 from collections import OrderedDict
 from .system import System
-
+from espressomd.utils import is_valid_type
 
 class Analysis(object):
 
@@ -82,12 +82,12 @@ class Analysis(object):
             raise Exception("Both, p1 and p2 have to be specified\n" + __doc__)
         else:
             for i in range(len(p1)):
-                if not isinstance(p1[i], int):
+                if not is_valid_type(p1[i], int):
                     raise ValueError(
                         "Particle types in p1 and p2 have to be of type int: " + str(p1[i]))
 
             for i in range(len(p2)):
-                if not isinstance(p2[i], int):
+                if not is_valid_type(p2[i], int):
                     raise ValueError(
                         "Particle types in p1 and p2 have to be of type int" + str(p2[i]))
 
@@ -132,7 +132,7 @@ class Analysis(object):
         # Get position
         # If particle id specified
         if id is not None:
-            if not isinstance(id, int):
+            if not is_valid_type(id, int):
                 raise ValueError("Id has to be an integer")
             if not id in self._system.part[:].id:
                 raise ValueError("Id has to be an index of an existing particle")

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -22,6 +22,7 @@ from . cimport integrate
 from globals cimport *
 import numpy as np
 from espressomd.utils cimport handle_errors
+from espressomd.utils import is_valid_type
 
 cdef class CellSystem(object):
     def set_domain_decomposition(self, use_verlet_lists=True):
@@ -79,7 +80,7 @@ cdef class CellSystem(object):
         cell_structure.use_verlet_list = use_verlet_lists
 
         if n_layers:
-            if not isinstance(n_layers, int):
+            if not is_valid_type(n_layers, int):
                 raise ValueError("layer height should be positive")
 
             if not n_layers > 0:

--- a/src/python/espressomd/checkpointing.py
+++ b/src/python/espressomd/checkpointing.py
@@ -20,6 +20,7 @@ from __future__ import print_function, absolute_import
 
 from collections import OrderedDict
 import sys, inspect, os, re, signal
+from espressomd.utils import is_valid_type
 
 try:
     import cPickle as pickle
@@ -232,7 +233,7 @@ class Checkpointing(object):
         Writes the given signal integer signum to the signal file.
         
         """
-        if not isinstance(signum, int):
+        if not is_valid_type(signum, int):
             raise ValueError("Signal must be an integer number.")
 
         signals = self.read_signals()
@@ -249,7 +250,7 @@ class Checkpointing(object):
         Register a signal that will trigger signal_handler().
         
         """
-        if not isinstance(signum, int):
+        if not is_valid_type(signum, int):
             raise ValueError("Signal must be an integer number.")
 
         if signum in self.checkpoint_signals:

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import
 from .script_interface import ScriptInterfaceHelper, script_interface_register
+from espressomd.utils import is_valid_type
 
 
 @script_interface_register

--- a/src/python/espressomd/diamond.pyx
+++ b/src/python/espressomd/diamond.pyx
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 from espressomd.utils cimport handle_errors
+from espressomd.utils import is_valid_type
 
 cdef class Diamond(object):
     """
@@ -62,22 +63,22 @@ cdef class Diamond(object):
         if(self._params[valid_keys[1]] < 0):
             raise ValueError("Bond length must be positive got: ",
                              self._params[valid_keys[1]])
-        if(self._params[valid_keys[2]] < 0 or not isinstance(self._params[valid_keys[2]], int)):
+        if(self._params[valid_keys[2]] < 0 or not is_valid_type(self._params[valid_keys[2]], int)):
             raise ValueError(
                 "Monomers per chain must be positive integer got: ", self._params[valid_keys[2]])
-        if(self._params[valid_keys[3]] < 0 or not isinstance(self._params[valid_keys[3]], int)):
+        if(self._params[valid_keys[3]] < 0 or not is_valid_type(self._params[valid_keys[3]], int)):
             raise ValueError(
                 "The number of counterions must be integer got:", self._params[valid_keys[3]])
-        if(not isinstance(self._params[valid_keys[4]], float)):
+        if(not is_valid_type(self._params[valid_keys[4]], float)):
             raise ValueError(
                 "The charge of the nodes must be double got", self._params[valid_keys[4]])
-        if(not isinstance(self._params[valid_keys[5]], float)):
+        if(not is_valid_type(self._params[valid_keys[5]], float)):
             raise ValueError(
                 "The charge of the monomers must be double got", self._params[valid_keys[5]])
-        if(not isinstance(self._params[valid_keys[6]], float)):
+        if(not is_valid_type(self._params[valid_keys[6]], float)):
             raise ValueError(
                 "The charge of the counterions must be double got", self._params[valid_keys[6]])
-        if(not isinstance(self._params[valid_keys[7]], int)):
+        if(not is_valid_type(self._params[valid_keys[7]], int)):
             raise ValueError(
                 "The distance between two charged monomers' indices must be integer ", self._params[valid_keys[7]])
         if(self._params[valid_keys[7]] == "nonet"):

--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -4,6 +4,7 @@ from .lb cimport HydrodynamicInteraction
 from .ekboundaries import EKBoundary
 from . import utils
 import numpy as np
+from espressomd.utils import is_valid_type
 
 IF ELECTROKINETICS:
     cdef class Electrokinetics(HydrodynamicInteraction):
@@ -104,12 +105,12 @@ IF ELECTROKINETICS:
         def set_density(self, species=None, density=None, node=None):
             if species == None or density == None:
                 raise ValueError("species and density has to be set.")
-            if not isinstance(int, species):
+            if not is_valid_type(species, int):
                 raise ValueError("species needs to be an integer.")
             if node == None:
                 ek_set_density(species, density)
             else:
-                if not (isinstance(list, node) or isinstance(np.ndarray, node)):
+                if not (isinstance(node, list) or isinstance(node, np.ndarray)):
                     if len(node) != 3:
                         raise ValueError("node has to be an array of length 3 of integers.")
                 ek_node_set_density(species, node[0], node[1], node[2], density)
@@ -302,7 +303,7 @@ IF ELECTROKINETICS:
 
         property density:
             def __set__(self, value):
-                if isinstance(value, float) or isinstance(value, int):
+                if is_valid_type(value, float) or is_valid_type(value, int):
                     if ek_node_set_density(self.id, self.node[0], self.node[1], self.node[2], value) != 0:
                         raise Exception("Species has not been added to EK.")
 

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -23,6 +23,7 @@ include "myconfig.pxi"
 from espressomd.system cimport *
 cimport numpy as np
 from espressomd.utils cimport *
+from espressomd.utils import is_valid_type
 
 cdef extern from "SystemInterface.hpp":
     cdef cppclass SystemInterface:
@@ -145,7 +146,7 @@ IF ELECTROSTATICS:
             cao = p_cao
             alpha = p_alpha
             accuracy = p_accuracy
-            if isinstance(p_mesh, int):
+            if is_valid_type(p_mesh, int):
                 mesh[0] = p_mesh
                 mesh[1] = p_mesh
                 mesh[2] = p_mesh
@@ -167,7 +168,7 @@ IF ELECTROSTATICS:
             alpha = p_alpha
             accuracy = p_accuracy
             n_interpol = p_n_interpol
-            if isinstance(p_mesh, int):
+            if is_valid_type(p_mesh, int):
                 mesh[0] = p_mesh
                 mesh[1] = p_mesh
                 mesh[2] = p_mesh

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -27,6 +27,7 @@ IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector 
     from . cimport scafacos
 from espressomd.utils cimport handle_errors
+from espressomd.utils import is_valid_type
 
 IF ELECTROSTATICS == 1: 
     cdef class ElectrostaticInteraction(actors.Actor):
@@ -245,7 +246,7 @@ IF P3M == 1:
             if not (self._params["r_cut"] >= 0 or self._params["r_cut"] == default_params["r_cut"]):
                 raise ValueError("P3M r_cut has to be >=0")
 
-            if not (isinstance(self._params["mesh"], int) or len(self._params["mesh"])):
+            if not (is_valid_type(self._params["mesh"], int) or len(self._params["mesh"])):
                 raise ValueError(
                     "P3M mesh has to be an integer or integer list of length 3")
 
@@ -264,7 +265,7 @@ IF P3M == 1:
             if self._params["epsilon"] == "metallic":
                 self._params = 0.0
 
-            if not (isinstance(self._params["epsilon"], float) or self._params["epsilon"] == "metallic"):
+            if not (is_valid_type(self._params["epsilon"], float) or self._params["epsilon"] == "metallic"):
                 raise ValueError("epsilon should be a double or 'metallic'")
 
             if not (self._params["inter"] == default_params["inter"] or self._params["inter"] > 0):
@@ -389,7 +390,7 @@ IF P3M == 1:
                 if not (self._params["r_cut"] >= 0 or self._params["r_cut"] == default_params["r_cut"]):
                     raise ValueError("P3M r_cut has to be >=0")
 
-                if not (isinstance(self._params["mesh"], int) or len(self._params["mesh"])):
+                if not (is_valid_type(self._params["mesh"], int) or len(self._params["mesh"])):
                     raise ValueError(
                         "P3M mesh has to be an integer or integer list of length 3")
 
@@ -408,7 +409,7 @@ IF P3M == 1:
                 # if self._params["epsilon"] == "metallic":
                 #  self._params = 0.0
 
-                if not (isinstance(self._params["epsilon"], float) or self._params["epsilon"] == "metallic"):
+                if not (is_valid_type(self._params["epsilon"], float) or self._params["epsilon"] == "metallic"):
                     raise ValueError(
                         "epsilon should be a double or 'metallic'")
 
@@ -544,7 +545,7 @@ IF ELECTROSTATICS and CUDA and EWALD_GPU:
             if self._params["bjerrum_length"] <= 0.0 and self._params["bjerrum_length"] != default_params["bjerrum_length"]:
                 raise ValueError("Bjerrum_length should be a positive double")
             if isinstance(self._params["K_max"], (list, np.ndarray)):
-                if isinstance(self._params["K_max"], int) and len(self._params["K_max"]) == 3:
+                if is_valid_type(self._params["K_max"], int) and len(self._params["K_max"]) == 3:
                     self._params["num_kx"] = self._params["K_max"][0]
                     self._params["num_ky"] = self._params["K_max"][1]
                     self._params["num_kz"] = self._params["K_max"][2]

--- a/src/python/espressomd/grand_canonical.pyx
+++ b/src/python/espressomd/grand_canonical.pyx
@@ -22,12 +22,12 @@ cimport globals
 from globals cimport max_seen_particle
 
 es_error=1
-def is_valid_type(current_type):
+def is_valid_particle_type(current_type):
     return (not (isinstance(current_type, int) or current_type < 0 or current_type > globals.n_particle_types))
 
 
 def check_valid_type(current_type):
-    if is_valid_type(current_type):
+    if is_valid_particle_type(current_type):
         raise ValueError("type", current_type, "does not exist!")
 
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -19,6 +19,7 @@
 from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 from . import utils
+from espressomd.utils import is_valid_type
 
 
 # Non-bonded interactions
@@ -42,7 +43,7 @@ cdef class NonBondedInteraction(object):
     def __init__(self, *args, **kwargs):
 
         # Interaction id as argument
-        if len(args) == 2 and isinstance(args[0], int) and isinstance(args[1], int):
+        if len(args) == 2 and is_valid_type(args[0], int) and is_valid_type(args[1], int):
             self._part_types = args
 
             # Load the parameters currently set in the Espresso core
@@ -1371,7 +1372,7 @@ class NonBondedInteractionHandle(object):
 
     def __init__(self, _type1, _type2):
         """Takes two particle types as argument"""
-        if not (isinstance(_type1, int) and isinstance(_type2, int)):
+        if not (is_valid_type(_type1, int) and is_valid_type(_type2, int)):
             raise TypeError("The particle types have to be of type integer.")
         self.type1 = _type1
         self.type2 = _type2
@@ -1417,7 +1418,7 @@ cdef class NonBondedInteractions(object):
         if not isinstance(key, tuple):
             raise ValueError(
                 "NonBondedInteractions[] expects two particle types as indices.")
-        if len(key) != 2 or (not isinstance(key[0], int)) or (not isinstance(key[1], int)):
+        if len(key) != 2 or (not is_valid_type(key[0], int)) or (not is_valid_type(key[1], int)):
             raise ValueError(
                 "NonBondedInteractions[] expects two particle types as indices.")
         return NonBondedInteractionHandle(key[0], key[1])
@@ -1464,7 +1465,7 @@ cdef class BondedInteraction(object):
 
         """
         # Interaction id as argument
-        if len(args) == 1 and isinstance(args[0], int):
+        if len(args) == 1 and is_valid_type(args[0], int):
             bond_id = args[0]
             # Check, if the bond in Espresso core is really defined as a FENE
             # bond
@@ -2618,7 +2619,7 @@ class BondedInteractions(object):
     from bonded_interaction_classes"""
 
     def __getitem__(self, key):
-        if not isinstance(key, int):
+        if not is_valid_type(key, int):
             raise ValueError(
                 "Index to BondedInteractions[] has to be an integer referring to a bond id")
 
@@ -2644,7 +2645,7 @@ class BondedInteractions(object):
         # Validate arguments
 
         # type of key must be int
-        if not isinstance(key, int):
+        if not is_valid_type(key, int):
             raise ValueError(
                 "Index to BondedInteractions[] has to ba an integer referring to a bond id")
 

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -28,7 +28,7 @@ from . import cuda_init
 from globals cimport *
 from copy import deepcopy
 from . import utils
-from espressomd.utils import array_locked
+from espressomd.utils import array_locked, is_valid_type
 
 # Actor class
 ####################################################
@@ -67,7 +67,7 @@ IF LB_GPU or LB:
                 if self._params["dens"] == default_params["dens"]:
                     raise Exception("LB_FLUID density not set")
                 else:
-                    if not (self._params["dens"] > 0.0 and (isinstance(self._params["dens"], float) or isinstance(self._params["dens"], int))):
+                    if not (self._params["dens"] > 0.0 and (is_valid_type(self._params["dens"], float) or is_valid_type(self._params["dens"], int))):
                         raise ValueError("Density must be one positive double")
 
         # list of valid keys for parameters
@@ -296,7 +296,7 @@ IF LB or LB_GPU:
             IF LB_GPU:
                 def __set__(self, value):
                     cdef double[3] host_velocity
-                    if all(isinstance(v, float) for v in value) and len(value) == 3:
+                    if all(is_valid_type(v, float) for v in value) and len(value) == 3:
                         host_velocity = value
                         lb_lbnode_set_u(self.node, host_velocity)
                     else:

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -26,6 +26,7 @@ IF SCAFACOS == 1:
     from . cimport scafacos
 
 from espressomd.utils cimport handle_errors
+from espressomd.utils import is_valid_type
 
 IF DIPOLES == 1:
     cdef class MagnetostaticInteraction(Actor):
@@ -136,7 +137,7 @@ IF DP3M == 1:
             if not (self._params["r_cut"] >= 0 or self._params["r_cut"] == default_params["r_cut"]):
                 raise ValueError("P3M r_cut has to be >=0")
 
-            if not (isinstance(self._params["mesh"], int) or len(self._params["mesh"])):
+            if not (is_valid_type(self._params["mesh"], int) or len(self._params["mesh"])):
                 raise ValueError(
                     "P3M mesh has to be an integer or integer list of length 3")
 
@@ -155,7 +156,7 @@ IF DP3M == 1:
             if self._params["epsilon"] == "metallic":
                 self._params["epsilon"] = 0.0
 
-            if not (isinstance(self._params["epsilon"], float) or self._params["epsilon"] == "metallic"):
+            if not (is_valid_type(self._params["epsilon"], float) or self._params["epsilon"] == "metallic"):
                 raise ValueError("epsilon should be a double or 'metallic'")
 
             if not (self._params["inter"] == default_params["inter"] or self._params["inter"] > 0):

--- a/src/python/espressomd/minimize_energy.pyx
+++ b/src/python/espressomd/minimize_energy.pyx
@@ -20,6 +20,7 @@
 
 from __future__ import print_function, absolute_import
 from . cimport minimize_energy
+from espressomd.utils import is_valid_type
 
 cdef class MinimizeEnergy(object):
     """
@@ -81,7 +82,7 @@ cdef class MinimizeEnergy(object):
         if self._params["gamma"] < 0:
             raise ValueError(
                 "gamma has to be a positive floating point number")
-        if self._params["max_steps"] < 0 or not isinstance(self._params["max_steps"], int):
+        if self._params["max_steps"] < 0 or not is_valid_type(self._params["max_steps"], int):
             raise ValueError(
                 "max_steps has to be a positive integer")
         if self._params["max_displacement"] < 0:

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -31,8 +31,7 @@ from globals cimport max_seen_particle, time_step, smaller_time_step, box_l, n_p
 import collections
 import functools
 import types
-from espressomd.utils import nesting_level
-from espressomd.utils import array_locked
+from espressomd.utils import nesting_level, array_locked, is_valid_type
 
 PARTICLE_EXT_FORCE = 1
 
@@ -98,7 +97,7 @@ cdef class ParticleHandle(object):
 
         def __set__(self, _type):
 
-            if isinstance(_type, int) and _type >= 0:
+            if is_valid_type(_type, int) and _type >= 0:
                 if set_particle_type(self.id, _type) == 1:
                     raise Exception("Set particle position first.")
             else:
@@ -125,7 +124,7 @@ cdef class ParticleHandle(object):
         """
 
         def __set__(self, _mol_id):
-            if isinstance(_mol_id, int) and _mol_id >= 0:
+            if is_valid_type(_mol_id, int) and _mol_id >= 0:
                 if set_particle_mol_id(self.id, _mol_id) == 1:
                     raise Exception("Set particle position first.")
             else:
@@ -629,7 +628,7 @@ cdef class ParticleHandle(object):
             """
 
             def __set__(self, _v):
-                if isinstance(_v, int):
+                if is_valid_type(_v, int):
                     if set_particle_virtual(self.id, _v) == 1:
                         raise Exception("Set particle position first.")
                 else:
@@ -669,7 +668,7 @@ cdef class ParticleHandle(object):
                 for i in range(4):
                     _q[i] = q[i]
 
-                if isinstance(_relto, int) and isinstance(_dist, float) and all(isinstance(fq,float) for fq in q):
+                if is_valid_type(_relto, int) and is_valid_type(_dist, float) and all(is_valid_type(fq,float) for fq in q):
                     if set_particle_vs_relative(self.id, _relto, _dist, _q) == 1:
                         raise Exception("Set particle position first.")
                 else:
@@ -1355,7 +1354,7 @@ cdef class ParticleHandle(object):
 
         # Bond type or numerical bond id
         if not isinstance(bond[0], BondedInteraction):
-            if isinstance(bond[0], int):
+            if is_valid_type(bond[0], int):
                 bond[0] = BondedInteractions()[bond[0]]
             else:
                 raise Exception(
@@ -1378,7 +1377,7 @@ cdef class ParticleHandle(object):
 
         # Type check on partners
         for i in range(1, len(bond)):
-            if not isinstance(bond[i], int):
+            if not is_valid_type(bond[i], int):
                 if not isinstance(bond[i], ParticleHandle):
                     raise ValueError(
                         "Bond partners have to be of type integer or ParticleHandle.")
@@ -1821,7 +1820,7 @@ cdef class ParticleList(object):
                 yield self[i]
 
     def exists(self, idx):
-        if isinstance(idx, int) or issubclass(type(idx), np.integer):
+        if is_valid_type(idx, int):
             return particle_exists(idx)
         if isinstance(idx, slice) or isinstance(idx, tuple) or isinstance(idx, list) or isinstance(idx, np.ndarray):
             tf_array = np.zeros(len(idx), dtype=np.bool)

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -21,6 +21,7 @@ from __future__ import print_function, absolute_import
 include "myconfig.pxi"
 from . cimport polymer
 import numpy as np
+from espressomd.utils import is_valid_type
 
 def validate_params(_params, default):
     if _params["N_P"] <= 0:
@@ -38,7 +39,7 @@ def validate_params(_params, default):
     if not isinstance(_params["start_pos"], np.ndarray) or len(_params["start_pos"]) != 3:
         raise ValueError(
                 "start_pos has to be an numpy array with 3 Elements" )
-    if not isinstance(_params["mode"], int):
+    if not is_valid_type(_params["mode"], int):
         raise ValueError(
                 "mode has to be a positive Integer" )
     if _params["shield"] < 0 and default["shield"] != _params["shield"]:
@@ -47,7 +48,7 @@ def validate_params(_params, default):
     if _params["max_tries"] < 0 and default["max_tries"] != _params["max_tries"]:
         raise ValueError(
                 "max_tries has to be a positive Integer")
-    if not isinstance(_params["val_poly"], float) and default["val_poly"] != _params["val_poly"]:
+    if not is_valid_type(_params["val_poly"], float) and default["val_poly"] != _params["val_poly"]:
         raise ValueError(
                 "val_poly has to be a float")
     if _params["charge_distance"] < 0:

--- a/src/python/espressomd/reaction.pyx
+++ b/src/python/espressomd/reaction.pyx
@@ -4,6 +4,7 @@ cimport globals
 from . cimport reaction
 from . cimport utils
 from .highlander import ThereCanOnlyBeOne
+from espressomd.utils import is_valid_type
 
 IF CATALYTIC_REACTIONS:
     __reaction_is_initiated = False
@@ -49,17 +50,17 @@ IF CATALYTIC_REACTIONS:
         """
 
         def validate_params(self):
-            if not isinstance(self._params["product_type"], int):
+            if not is_valid_type(self._params["product_type"], int):
                 raise ValueError("product_type has to be an int")
-            if not isinstance(self._params["reactant_type"], int):
+            if not is_valid_type(self._params["reactant_type"], int):
                 raise ValueError("reactant_type has to be an int")
-            if not isinstance(self._params["catalyzer_type"], int):
+            if not is_valid_type(self._params["catalyzer_type"], int):
                 raise ValueError("catalyzer_type has to be an int")
-            if not isinstance(self._params["ct_range"], float):
+            if not is_valid_type(self._params["ct_range"], float):
                 raise ValueError("ct_range has to be a float")
-            if not isinstance(self._params["ct_rate"], float):
+            if not is_valid_type(self._params["ct_rate"], float):
                 raise ValueError("ct_rate has to be a float")
-            if not isinstance(self._params["eq_rate"], float):
+            if not is_valid_type(self._params["eq_rate"], float):
                 raise ValueError("eq_rate has to be a float")
             if not isinstance(self._params["react_once"], bool):
                 raise ValueError("react_once has to be a bool")

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -1,5 +1,6 @@
 from espressomd.utils import to_char_pointer,to_str
 import numpy as np
+from espressomd.utils import is_valid_type
 
 cdef class PObjectId(object):
     cdef ObjectId id
@@ -88,12 +89,12 @@ cdef class PScriptInterface(object):
                         "Value of %s expected to be %i elements" % (name, n_elements))
 
             # We accept floats for ints (but not the other way round)
-            if <int> type == <int> DOUBLE and isinstance(kwargs[pname], int):
+            if <int> type == <int> DOUBLE and is_valid_type(kwargs[pname], int):
                 kwargs[pname] = float(kwargs[pname])
             # We already know that the argument is an iterable of the correct length
             elif <int> type == <int> DOUBLE_VECTOR:
                 for i in range(len(kwargs[pname])):
-                    if isinstance(kwargs[pname][i], int):
+                    if is_valid_type(kwargs[pname][i], int):
                         kwargs[pname][i] = float(kwargs[pname][i])
 
             v = self.python_object_to_variant(kwargs[pname])

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -47,7 +47,7 @@ if LB_BOUNDARIES or LB_BOUNDARIES_GPU:
     from .lbboundaries import LBBoundaries
 from .ekboundaries import EKBoundaries
 from .comfixed import ComFixed
-from espressomd.utils import array_locked
+from espressomd.utils import array_locked, is_valid_type
 
 import sys
 import random  # for true random numbers from os.urandom()
@@ -320,7 +320,7 @@ cdef class System(object):
         def __set__(self, _seed):
             cdef vector[int] seed_array
             self.__seed = _seed
-            if(isinstance(_seed, int) and n_nodes == 1):
+            if(is_valid_type(_seed, int) and n_nodes == 1):
                 seed_array.resize(1)
                 seed_array[0] = int(_seed)
                 mpi_random_seed(0, seed_array)
@@ -363,7 +363,7 @@ cdef class System(object):
         # defines the lees edwards offset
             def __set__(self, double _lees_edwards_offset):
 
-                if isinstance(_lees_edwards_offset, float):
+                if is_valid_type(_lees_edwards_offset, float):
                     global lees_edwards_offset
                     lees_edwards_offset = _lees_edwards_offset
                     #new_offset = _lees_edwards_offset

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -328,5 +328,5 @@ def is_valid_type(value, t):
     elif t == float:
         return isinstance(value, (float, np.float16, np.float32, np.float64, np.float128, np.longdouble))
     else:
-        raise Exception("Invalid type check.")
+        return isinstance(value, t)
 

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -85,7 +85,7 @@ cdef check_type_or_throw_except(x, n, t, msg):
         if hasattr(x, "__getitem__"):
             for i in range(len(x)):
                 if not isinstance(x[i], t):
-                    if not ((t == float and isinstance(x[i], int))
+                    if not ((t == float and is_valid_type(x[i], int))
                       or (t == float and issubclass(type(x[i]), np.integer))) \
                       and not (t == int and issubclass(type(x[i]), np.integer)):
                         raise ValueError(
@@ -97,7 +97,7 @@ cdef check_type_or_throw_except(x, n, t, msg):
     else:
         # N=1 and a single value
         if not isinstance(x, t):
-            if not (t == float and isinstance(x, int)) and not (t == int and issubclass(type(x), np.integer)):
+            if not (t == float and is_valid_type(x, int)) and not (t == int and issubclass(type(x), np.integer)):
                 raise ValueError(msg + " -- Got an " + type(x).__name__)
 
 
@@ -317,3 +317,16 @@ def nesting_level(obj):
 
     return max_level + 1
  
+def is_valid_type(value, t):
+    """
+    Extended checks for numpy int and float types.
+
+    """
+
+    if t == int:
+        return isinstance(value, (int, np.integer, np.long))
+    elif t == float:
+        return isinstance(value, (float, np.float16, np.float32, np.float64, np.float128, np.longdouble))
+    else:
+        raise Exception("Invalid type check.")
+


### PR DESCRIPTION
Fixes #1630

Added helper function:
```
def is_valid_type(value, t):
    if t == int:
        return isinstance(value, (int, np.integer, np.long))
    elif t == float:
        return isinstance(value, (float, np.float16, np.float32, np.float64, np.float128, np.longdouble))
```
Replaced all instances of `isinstance(.. , int)` and `isinstance(.. ,float)` with `is_valid_type`.

int returns true for:
- int      
- np.short    
- np.long     
- np.longlong 
- np.int   
- np.int_  
- np.intc  
- np.intp  
- np.int8  
- np.int16 
- np.int32 
- np.int64 
- np.uint8 
- np.uint16
- np.uint32
- np.uint64

float returns true for:
- float        
- np.float     
- np.float_    
- np.float16   
- np.float32   
- np.float64   
- np.float128  
- np.double    
- np.longdouble


