### PR TITLE
doc: switch from numpydoc to napolean extension

### DIFF
--- a/doc/sphinx/README.rst
+++ b/doc/sphinx/README.rst
@@ -9,10 +9,6 @@ How to get started with SPHINX
 
     pip2 install sphinxcontrib-bibtex --user --upgrade
 
-#. Install the numpydoc extension to Sphinx::
-
-    pip2 install numpydoc --user --upgrade
-
 #. Compile the ``sphinx`` target in your build directory (that can take some time
    since we depend on finishing the build of the interface)::
 

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -38,7 +38,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinxcontrib.bibtex',
-    'numpydoc'
+    'sphinx.ext.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -298,7 +298,6 @@ texinfo_documents = [
 
 # Supress warning if html is build
 # http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
-numpydoc_show_class_members = False
 autodoc_mock_imports = ['featuredefs', 'mayavi', 'pyface.api', 'tvtk.tools', 'vtk', 'MDAnalysis']
 autodoc_default_flags = ['members',
                          'show-inheritance', 'undoc-members']

--- a/doc/sphinx/dg.rst
+++ b/doc/sphinx/dg.rst
@@ -136,7 +136,7 @@ Documentation
 The documentation of |es| consists of four parts:
 
   -  The users' guide and developers' guide are located in ``doc/sphinx``, and make use of the Sphinx Python package
-  -  In-code documentation for the Python interface is located in the various files in src/python/espressomd and also makes use of the Sphinx Python package. We also make use of the extensions in the numpydoc package and use the NumPy documentation style.
+  -  In-code documentation for the Python interface is located in the various files in src/python/espressomd and also makes use of the Sphinx Python package. We make use of the napolean extension and use the NumPy documentation style.
   -  In-code documentation of the C++ core is located in the .cpp and .hpp files in ``/src/core`` and its sub-directories and makes use of Doxygen.
 
 

--- a/doc/sphinx/zrefs.bib
+++ b/doc/sphinx/zrefs.bib
@@ -438,24 +438,6 @@ pages = {1305--1320}
   timestamp = {2007.08.29}
 }
 
-@ARTICLE{hofling11a,
-  author = {F. H\"{o}fling and Karl-Ulrich Bamberg and Thomas Franosch},
-  title = {Anomalous transport resolved in space and time by fluorescence correlation
-	spectroscopy},
-  journal = {Soft Matter},
-  year = {2011},
-  volume = {7},
-  pages = {1358},
-  number = { },
-  month = { },
-  note = { },
-  abstract = { },
-  file = {hofling2011.pdf:hofling2011.pdf:PDF},
-  keywords = { },
-  owner = {kosovan},
-  timestamp = {2012.02.17}
-}
-
 @ARTICLE{horowitz91,
   author = {Alan M. Horowitz},
   title = {A generalized guided Monte Carlo algorithm},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 sphinx>=1.5.2
 sphinxcontrib-bibtex>=0.3.5
-numpydoc>=0.4
 MDAnalysis>=0.16

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1742,7 +1742,7 @@ cdef class ParticleList(object):
 
         Parameters
         ----------
-        add() takes either a dictionary or a bunch of keyword args.
+        Either a dictionary or a bunch of keyword args.
 
         Returns
         -------


### PR DESCRIPTION
Description of changes:
 - remove numpydoc dependency by using napolean extension to sphinx which is part of sphinx since version 1.3
