### PR TITLE
Fix total non-bonded energy.

### DIFF
--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -717,7 +717,8 @@ class Analysis(object):
             for j in range(c_analyze.n_particle_types):
                 #      if checkIfParticlesInteract(i, j):
                 e["non_bonded", i, j] = c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
-                total_non_bonded += c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
+                if i <= j:
+                    total_non_bonded += c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
     #        total_intra +=c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
     #        e["non_bonded_intra",i,j] =c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
     #        e["nonBondedInter",i,j] =c_analyze.obsstat_nonbonded_inter(&c_analyze.total_energy_non_bonded, i, j)[0]

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -37,17 +37,18 @@ from collections import OrderedDict
 from .system import System
 from espressomd.utils import is_valid_type
 
+
 class Analysis(object):
 
     _systemp = None
 
-    def __init__(self,system):
-        if not isinstance(system,System):
+    def __init__(self, system):
+        if not isinstance(system, System):
             raise TypeError("An instance of System is required as argument")
-        self._system=system            
+        self._system = system
 
     #
-    # Append configs    
+    # Append configs
     #
 
     def append(self):
@@ -55,7 +56,8 @@ class Analysis(object):
         if c_analyze.n_part == 0:
             raise Exception("No particles to append!")
         if (c_analyze.n_configs > 0) and (c_analyze.n_part_conf != c_analyze.n_part):
-            raise Exception("All configurations stored must have the same length")
+            raise Exception(
+                "All configurations stored must have the same length")
 
         c_analyze.analyze_append(c_analyze.partCfg())
 
@@ -100,7 +102,6 @@ class Analysis(object):
     # Distance to particle or point
     #
 
-
     def dist_to(self, id=None, pos=None):
         """
         Calculates the distance to a point or particle.
@@ -120,10 +121,12 @@ class Analysis(object):
         """
 
         if id is None and pos is None:
-            raise Exception("Either id or pos have to be specified\n" + __doc__)
+            raise Exception(
+                "Either id or pos have to be specified\n" + __doc__)
 
         if (id is not None) and (pos is not None):
-            raise Exception("Only one of id or pos may be specified\n" + __doc__)
+            raise Exception(
+                "Only one of id or pos may be specified\n" + __doc__)
 
         cdef double cpos[3]
         if len(self._system.part) == 0:
@@ -135,7 +138,8 @@ class Analysis(object):
             if not is_valid_type(id, int):
                 raise ValueError("Id has to be an integer")
             if not id in self._system.part[:].id:
-                raise ValueError("Id has to be an index of an existing particle")
+                raise ValueError(
+                    "Id has to be an index of an existing particle")
             _pos = self._system.part[id].pos
             for i in range(3):
                 cpos[i] = _pos[i]
@@ -149,7 +153,6 @@ class Analysis(object):
     #
     # Analyze Linear Momentum
     #
-
 
     def analyze_linear_momentum(self, include_particles=True, include_lbfluid=True):
         """
@@ -172,11 +175,9 @@ class Analysis(object):
         """
         return c_analyze.calc_linear_momentum(include_particles, include_lbfluid)
 
-
     #
     # Analyze center of mass
     #
-
 
     def center_of_mass(self, part_type=None):
         """
@@ -195,11 +196,9 @@ class Analysis(object):
         """
         return c_analyze.centerofmass(c_analyze.partCfg(), part_type)
 
-
     # get all particles in neighborhood r_catch of pos and return their ids
     # in il. plane can be used to specify the distance in the xy, xz or yz
     # plane
-
 
     def nbhood(self, pos=None, r_catch=None, plane='3d'):
         """
@@ -249,7 +248,7 @@ class Analysis(object):
 
         ids = c_analyze.nbhood(c_analyze.partCfg(), c_pos, r_catch, planedims)
 
-        return create_nparray_from_int_list(&ids)
+        return create_nparray_from_int_list(& ids)
 
     def cylindrical_average(self, center=None, axis=None,
                             length=None, radius=None,
@@ -282,7 +281,6 @@ class Analysis(object):
             Note that the columns `density`, `v_radial` and `v_axial` appear for each type indicated in `types` in the same order.
 
         """
-
 
         # Check the input types
         check_type_or_throw_except(
@@ -335,8 +333,10 @@ class Analysis(object):
                         (index_radial * index_radial + 2 * index_radial) * \
                         binwd_radial * binwd_radial * c_length
 
-                buffer[index_axial + bins_axial * index_radial, 0] = index_radial
-                buffer[index_axial + bins_axial * index_radial, 1] = index_axial
+                buffer[index_axial + bins_axial *
+                       index_radial, 0] = index_radial
+                buffer[index_axial + bins_axial *
+                       index_radial, 1] = index_axial
                 buffer[index_axial + bins_axial * index_radial, 2] = pos_radial
                 buffer[index_axial + bins_axial * index_radial, 3] = pos_axial
                 buffer[index_axial + bins_axial * index_radial, 4] = binvolume
@@ -352,11 +352,11 @@ class Analysis(object):
     #
     def pressure(self, v_comp=False):
         """Calculates the pressure.
-        
+
         Returns
         -------
         A dictionary with the following keys:
-         
+
         * "total", total pressure
         * "ideal", ideal pressure
         * "bonded" , total bonded pressure
@@ -368,12 +368,12 @@ class Analysis(object):
         * "coulomb", Maxwell stress, how it is calculated depends on the method
         * "dipolar", TODO
         * "virtual_sites", Stress contribution due to virtual sites
-        
+
         """
-        v_comp=int(v_comp)
-        
+        v_comp = int(v_comp)
+
         check_type_or_throw_except(v_comp, 1, int, "v_comp must be a boolean")
-    
+
         # Dict to store the results
         p = OrderedDict()
 
@@ -400,8 +400,8 @@ class Analysis(object):
         total_bonded = 0
         for i in range(c_analyze.n_bonded_ia):
             if (bonded_ia_params[i].type != 0):
-                p["bonded", i] = c_analyze.obsstat_bonded(& c_analyze.total_pressure, i)[0]
-                total_bonded += c_analyze.obsstat_bonded( & c_analyze.total_pressure, i)[0]
+                p["bonded", i] = c_analyze.obsstat_bonded( & c_analyze.total_pressure, i)[0]
+                total_bonded += c_analyze.obsstat_bonded(& c_analyze.total_pressure, i)[0]
         p["bonded"] = total_bonded
 
         # Non-Bonded interactions, total as well as intra and inter molecular
@@ -414,14 +414,14 @@ class Analysis(object):
         total_non_bonded = 0
 
         for i in range(c_analyze.n_particle_types):
-            for j in range(i,c_analyze.n_particle_types):
+            for j in range(i, c_analyze.n_particle_types):
                 #      if checkIfParticlesInteract(i, j):
-                p["non_bonded", i, j] = c_analyze.obsstat_nonbonded(& c_analyze.total_pressure, i, j)[0]
-                total_non_bonded += c_analyze.obsstat_nonbonded(& c_analyze.total_pressure, i, j)[0]
-                total_intra += c_analyze.obsstat_nonbonded_intra(& c_analyze.total_pressure_non_bonded, i, j)[0]
-                p["non_bonded_intra", i, j] = c_analyze.obsstat_nonbonded_intra(& c_analyze.total_pressure_non_bonded, i, j)[0]
-                p["non_bonded_inter", i, j] = c_analyze.obsstat_nonbonded_inter(& c_analyze.total_pressure_non_bonded, i, j)[0]
-                total_inter += c_analyze.obsstat_nonbonded_inter(& c_analyze.total_pressure_non_bonded, i, j)[0]
+                p["non_bonded", i, j] = c_analyze.obsstat_nonbonded( & c_analyze.total_pressure, i, j)[0]
+                total_non_bonded += c_analyze.obsstat_nonbonded( & c_analyze.total_pressure, i, j)[0]
+                total_intra += c_analyze.obsstat_nonbonded_intra( & c_analyze.total_pressure_non_bonded, i, j)[0]
+                p["non_bonded_intra", i, j] = c_analyze.obsstat_nonbonded_intra( & c_analyze.total_pressure_non_bonded, i, j)[0]
+                p["non_bonded_inter", i, j] = c_analyze.obsstat_nonbonded_inter( & c_analyze.total_pressure_non_bonded, i, j)[0]
+                total_inter += c_analyze.obsstat_nonbonded_inter( & c_analyze.total_pressure_non_bonded, i, j)[0]
         p["non_bonded_intra"] = total_intra
         p["non_bonded_inter"] = total_inter
         p["non_bonded"] = total_non_bonded
@@ -446,23 +446,22 @@ class Analysis(object):
 
         # virtual sites
         IF VIRTUAL_SITES == 1:
-            p_vs=0.
+            p_vs = 0.
             for i in range(c_analyze.total_pressure.n_virtual_sites):
-                p_vs +=  c_analyze.total_pressure.virtual_sites[i]
-                p["virtual_sites",i] = c_analyze.total_pressure.virtual_sites[0]
+                p_vs += c_analyze.total_pressure.virtual_sites[i]
+                p["virtual_sites", i] = c_analyze.total_pressure.virtual_sites[0]
             if c_analyze.total_pressure.n_virtual_sites:
                 p["virtual_sites"] = p_vs
 
         return p
 
-
     def stress_tensor(self, v_comp=False):
         """Calculates the stress tensor
-        
+
         Returns
         -------
         a dictionary with the following keys:
-         
+
         * "total", total stress tensor
         * "ideal", ideal stress tensor
         * "bonded" , total bonded stress tensor
@@ -474,10 +473,10 @@ class Analysis(object):
         * "coulomb", Maxwell stress tensor, how it is calculated depends on the method
         * "dipolar", TODO
         * "virtual_sites", Stress tensor contribution for virtual sites
-        
+
         """
-        v_comp=int(v_comp)
-        
+        v_comp = int(v_comp)
+
         check_type_or_throw_except(v_comp, 1, int, "v_comp must be a boolean")
 
         # Dict to store the results
@@ -494,22 +493,22 @@ class Analysis(object):
         tmp = np.zeros(9)
         for i in range(9):
             for k in range(c_analyze.total_p_tensor.data.n // 9):
-                tmp[i] += c_analyze.total_p_tensor.data.e[9*k + i]
+                tmp[i] += c_analyze.total_p_tensor.data.e[9 * k + i]
 
-        p["total"] = tmp.reshape((3,3))
+        p["total"] = tmp.reshape((3, 3))
 
         # Ideal
         p["ideal"] = create_nparray_from_double_array(
             c_analyze.total_p_tensor.data.e, 9)
-        p["ideal"] = p["ideal"].reshape((3,3))
+        p["ideal"] = p["ideal"].reshape((3, 3))
 
         # Bonded
         total_bonded = np.zeros((3, 3))
         for i in range(c_analyze.n_bonded_ia):
             if (bonded_ia_params[i].type != 0):
-                p["bonded", i] = np.reshape( create_nparray_from_double_array(
-                  c_analyze.obsstat_bonded(&c_analyze.total_p_tensor, i), 9),
-                  (3, 3) )
+                p["bonded", i] = np.reshape(create_nparray_from_double_array(
+                    c_analyze.obsstat_bonded( & c_analyze.total_p_tensor, i), 9),
+                    (3, 3))
                 total_bonded += p["bonded", i]
         p["bonded"] = total_bonded
 
@@ -520,23 +519,23 @@ class Analysis(object):
         total_non_bonded_inter = np.zeros((3, 3))
 
         for i in range(c_analyze.n_particle_types):
-            for j in range(i,c_analyze.n_particle_types):
+            for j in range(i, c_analyze.n_particle_types):
                 #      if checkIfParticlesInteract(i, j):
                 p["non_bonded", i, j] = np.reshape(
-                  create_nparray_from_double_array(c_analyze.obsstat_nonbonded(
-                    &c_analyze.total_p_tensor, i, j), 9), (3, 3) )
+                    create_nparray_from_double_array(c_analyze.obsstat_nonbonded(
+                        & c_analyze.total_p_tensor, i, j), 9), (3, 3))
                 total_non_bonded += p["non_bonded", i, j]
 
                 p["non_bonded_intra", i, j] = np.reshape(
-                  create_nparray_from_double_array(
-                    c_analyze.obsstat_nonbonded_intra(
-                      &c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3) )
+                    create_nparray_from_double_array(
+                        c_analyze.obsstat_nonbonded_intra(
+                            & c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
                 total_non_bonded_intra += p["non_bonded_intra", i, j]
 
                 p["non_bonded_inter", i, j] = np.reshape(
-                  create_nparray_from_double_array(
-                    c_analyze.obsstat_nonbonded_inter(
-                      &c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3) )
+                    create_nparray_from_double_array(
+                        c_analyze.obsstat_nonbonded_inter(
+                            & c_analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
                 total_non_bonded_inter += p["non_bonded_inter", i, j]
 
         p["non_bonded_intra"] = total_non_bonded_intra
@@ -549,7 +548,7 @@ class Analysis(object):
             for i in range(c_analyze.total_p_tensor.n_coulomb):
                 p["coulomb", i] = np.reshape(
                     create_nparray_from_double_array(
-                      c_analyze.total_p_tensor.coulomb, 9), (3, 3) )
+                        c_analyze.total_p_tensor.coulomb, 9), (3, 3))
                 total_coulomb = p["coulomb", i]
             p["coulomb"] = total_coulomb
 
@@ -559,23 +558,22 @@ class Analysis(object):
             for i in range(c_analyze.total_p_tensor.n_dipolar):
                 p["dipolar", i] = np.reshape(
                     create_nparray_from_double_array(
-                      c_analyze.total_p_tensor.dipolar, 9), (3, 3) )
+                        c_analyze.total_p_tensor.dipolar, 9), (3, 3))
                 total_dipolar = p["dipolar", i]
             p["dipolar"] = total_dipolar
 
         # virtual sites
         IF VIRTUAL_SITES_RELATIVE == 1:
-            total_vs = np.zeros((3,3))
+            total_vs = np.zeros((3, 3))
             for i in range(c_analyze.total_p_tensor.n_virtual_sites):
                 p["virtual_sites", i] = np.reshape(
                     create_nparray_from_double_array(
-                      c_analyze.total_p_tensor.virtual_sites +9*i, 9), (3, 3) )
+                        c_analyze.total_p_tensor.virtual_sites + 9 * i, 9), (3, 3))
                 total_vs += p["virtual_sites", i]
             if c_analyze.total_p_tensor.n_virtual_sites:
                 p["virtual_sites"] = total_vs
 
         return p
-
 
     def local_stress_tensor(self, periodicity=(1, 1, 1), range_start=(0.0, 0.0, 0.0), stress_range=(1.0, 1.0, 1.0), bins=(1, 1, 1)):
         """local_stress_tensor(periodicity=(1, 1, 1), range_start=(0.0, 0.0, 0.0), stress_range=(1.0, 1.0, 1.0), bins=(1, 1, 1))
@@ -630,7 +628,6 @@ class Analysis(object):
             c_range_start[i] = range_start[i]
             c_stress_range[i] = stress_range[i]
 
-
         local_stress_tensor.resize(n_bins, double_list(9, 0.0))
 
         if c_analyze.analyze_local_stress_tensor(c_periodicity, c_range_start, c_stress_range, c_bins, local_stress_tensor.data()):
@@ -643,16 +640,16 @@ class Analysis(object):
                 for k in range(bins[2]):
                     for l in range(3):
                         for m in range(3):
-                            lst_ind = i * bins[1]* bins[2] + j * bins[2] + k
+                            lst_ind = i * bins[1] * bins[2] + j * bins[2] + k
                             t_ind = l * 3 + m
-                            stress_tensor[i, j, k, l, m] = local_stress_tensor[lst_ind][t_ind]
+                            stress_tensor[i, j, k, l,
+                                          m] = local_stress_tensor[lst_ind][t_ind]
 
         return stress_tensor
 
     #
     # Energy analysis
     #
-
 
     def energy(self):
         """Calculate the systems energy.
@@ -678,7 +675,7 @@ class Analysis(object):
         e = OrderedDict()
 
         if c_analyze.total_energy.init_status == 0:
-            c_analyze.init_energies( & c_analyze.total_energy)
+            c_analyze.init_energies(& c_analyze.total_energy)
             c_analyze.master_energy_calc()
             handle_errors("calc_long_range_energies failed")
 
@@ -700,8 +697,8 @@ class Analysis(object):
         total_bonded = 0
         for i in range(c_analyze.n_bonded_ia):
             if (bonded_ia_params[i].type != BONDED_IA_NONE):
-                e["bonded", i] = c_analyze.obsstat_bonded(& c_analyze.total_energy, i)[0]
-                total_bonded += c_analyze.obsstat_bonded( & c_analyze.total_energy, i)[0]
+                e["bonded", i] = c_analyze.obsstat_bonded( & c_analyze.total_energy, i)[0]
+                total_bonded += c_analyze.obsstat_bonded(& c_analyze.total_energy, i)[0]
         e["bonded"] = total_bonded
 
         # Non-Bonded interactions, total as well as intra and inter molecular
@@ -716,9 +713,9 @@ class Analysis(object):
         for i in range(c_analyze.n_particle_types):
             for j in range(c_analyze.n_particle_types):
                 #      if checkIfParticlesInteract(i, j):
-                e["non_bonded", i, j] = c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
+                e["non_bonded", i, j] = c_analyze.obsstat_nonbonded( & c_analyze.total_energy, i, j)[0]
                 if i <= j:
-                    total_non_bonded += c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
+                    total_non_bonded += c_analyze.obsstat_nonbonded( & c_analyze.total_energy, i, j)[0]
     #        total_intra +=c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
     #        e["non_bonded_intra",i,j] =c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
     #        e["nonBondedInter",i,j] =c_analyze.obsstat_nonbonded_inter(&c_analyze.total_energy_non_bonded, i, j)[0]
@@ -747,13 +744,12 @@ class Analysis(object):
 
         return e
 
-
     def calc_re(self, chain_start=None, number_of_chains=None, chain_length=None):
         """
         Calculates the Mean end-to-end distance of chains and its
         standard deviation, as well as Mean Square end-to-end distance of
         chains and its standard deviation.
-        
+
         This requires that a set of chains of equal length which start with the
         particle with particle number ``chain_start`` and are consecutively
         numbered, the last particle in that topology has id number
@@ -770,7 +766,7 @@ class Analysis(object):
                            Number of chains contained in the range.
         chain_length : :obj:`int`
                        The length of every chain.
-        
+
         Returns            
         -------
         array_like : :obj:`float`
@@ -787,13 +783,12 @@ class Analysis(object):
         free(re)
         return tuple_re
 
-
     def calc_rg(self, chain_start=None, number_of_chains=None, chain_length=None):
         """
         Calculates the mean radius of gyration of chains and its standard deviation,
         as well as the mean square radius of gyration of chains and its
         standard deviation.
-        
+
         This requires that a set of chains of equal length which start with the
         particle with particle number ``chain_start`` and are consecutively
         numbered, the last particle in that topology has id number
@@ -806,7 +801,7 @@ class Analysis(object):
                            Number of chains contained in the range.
         chain_length : :obj:`int`.
                        The length of every chain.
-        
+
         Returns            
         -------
         array_like : :obj:`float`
@@ -823,11 +818,10 @@ class Analysis(object):
         free(rg)
         return tuple_rg
 
-
     def calc_rh(self, chain_start=None, number_of_chains=None, chain_length=None):
         """
         Calculates the hydrodynamic mean radius of chains and its standard deviation.
-        
+
         This requires that a set of chains of equal length which start with the
         particle with particle number `chain_start` and are consecutively
         numbered (the last particle in that topology has id number :
@@ -841,7 +835,7 @@ class Analysis(object):
                            Number of chains contained in the range.
         chain_length : :obj:`int`.
                        The length of every chain.
-        
+
         Returns            
         -------
         array_like
@@ -857,7 +851,6 @@ class Analysis(object):
         free(rh)
         return tuple_rh
 
-
     def check_topology(self, chain_start=None, number_of_chains=None, chain_length=None):
         check_type_or_throw_except(
             chain_start, 1, int, "chain_start=int is a required argument")
@@ -865,10 +858,12 @@ class Analysis(object):
             number_of_chains, 1, int, "number_of_chains=int is a required argument")
         check_type_or_throw_except(
             chain_length, 1, int, "chain_length=int is a required argument")
-        id_min=chain_start; id_max=chain_start + chain_length * number_of_chains;
-        for i in range(id_min,id_max):
+        id_min = chain_start
+        id_max = chain_start + chain_length * number_of_chains
+        for i in range(id_min, id_max):
             if (not self._system.part.exists(i)):
-                raise ValueError('particle with id {0:.0f} does not exist\ncannot perform analysis on the range chain_start={1:.0f}, n_chains={2:.0f}, chain_length={3:.0f}\nplease provide a contiguous range of particle ids'.format(i,chain_start,number_of_chains,chain_length));
+                raise ValueError('particle with id {0:.0f} does not exist\ncannot perform analysis on the range chain_start={1:.0f}, n_chains={2:.0f}, chain_length={3:.0f}\nplease provide a contiguous range of particle ids'.format(
+                    i, chain_start, number_of_chains, chain_length));
         c_analyze.chain_start = chain_start
         c_analyze.chain_n_chains = number_of_chains
         c_analyze.chain_length = chain_length
@@ -876,7 +871,6 @@ class Analysis(object):
     #
     # Structure factor
     #
-
 
     def structure_factor(self, sf_types=None, sf_order=None):
         """
@@ -903,7 +897,8 @@ class Analysis(object):
 
         if (sf_types is None) or (not hasattr(sf_types, '__iter__')):
             raise ValueError("sf_types has to be a list!")
-        check_type_or_throw_except(sf_order, 1, int, "sf_order has to be an int!")
+        check_type_or_throw_except(
+            sf_order, 1, int, "sf_order has to be an int!")
 
         cdef double * sf
         p_types = create_int_list_from_python_object(sf_types)
@@ -915,7 +910,6 @@ class Analysis(object):
     #
     # RDF
     #
-
 
     def rdf(self, rdf_type=None, type_list_a=None, type_list_b=None,
             r_min=0.0, r_max=None, r_bins=100, n_conf=None):
@@ -977,7 +971,8 @@ class Analysis(object):
         cdef vector[int] p2_types = type_list_b
 
         if rdf_type == 'rdf':
-            c_analyze.calc_rdf(c_analyze.partCfg(), p1_types, p2_types, r_min, r_max, r_bins, rdf)
+            c_analyze.calc_rdf(c_analyze.partCfg(), p1_types,
+                               p2_types, r_min, r_max, r_bins, rdf)
         elif rdf_type == '<rdf>':
             c_analyze.calc_rdf_av(c_analyze.partCfg(), p1_types, p2_types, r_min,
                                   r_max, r_bins, rdf, n_conf)
@@ -997,7 +992,6 @@ class Analysis(object):
     #
     # distribution
     #
-
 
     def distribution(self, type_list_a=None, type_list_b=None,
                      r_min=0.0, r_max=None, r_bins=100, log_flag=0, int_flag=0):
@@ -1056,10 +1050,11 @@ class Analysis(object):
         p1_types = create_int_list_from_python_object(type_list_a)
         p2_types = create_int_list_from_python_object(type_list_b)
 
-        c_analyze.calc_part_distribution(c_analyze.partCfg(),p1_types.e, p1_types.n, p2_types.e, p2_types.n,
+        c_analyze.calc_part_distribution(c_analyze.partCfg(), p1_types.e, p1_types.n, p2_types.e, p2_types.n,
                                          r_min, r_max, r_bins, log_flag, & low, distribution)
 
-        np_distribution = create_nparray_from_double_array(distribution, r_bins)
+        np_distribution = create_nparray_from_double_array(
+            distribution, r_bins)
 
         free(distribution)
 
@@ -1086,7 +1081,6 @@ class Analysis(object):
     # angularmomentum
     #
 
-
     def angular_momentum(self, p_type=None):
         print("p_type = ", p_type)
         check_type_or_throw_except(
@@ -1095,14 +1089,13 @@ class Analysis(object):
         cdef double[3] com
         cdef int p1 = p_type
 
-        c_analyze.angularmomentum(c_analyze.partCfg(),p1, com)
+        c_analyze.angularmomentum(c_analyze.partCfg(), p1, com)
 
         return np.array([com[0], com[1], com[2]])
 
     #
     # gyration_tensor
     #
-
 
     def gyration_tensor(self, p_type=None):
         """
@@ -1124,20 +1117,20 @@ class Analysis(object):
         * "eva1", eigenvalue 1 of the gyration tensor and its corresponding eigenvector.
         * "eva2", eigenvalue 2 of the gyration tensor and its corresponding eigenvector.
         The eigenvalues are sorted in descending order.
-      
+
         """
 
-        
         cdef vector[double] gt
 
         if p_type is not None:
-            check_type_or_throw_except(p_type, 1, int, "p_type has to be an int")
+            check_type_or_throw_except(
+                p_type, 1, int, "p_type has to be an int")
             if (p_type < 0 or p_type >= c_analyze.n_particle_types):
                 raise ValueError("Particle type", p_type, "does not exist!")
         else:
             p_type = -1
 
-        c_analyze.calc_gyration_tensor(c_analyze.partCfg(),p_type, gt)
+        c_analyze.calc_gyration_tensor(c_analyze.partCfg(), p_type, gt)
 
         return {"Rg^2": gt[3],
                 "shape": [gt[4], gt[5], gt[6]],
@@ -1148,7 +1141,6 @@ class Analysis(object):
     #
     # momentofinertiamatrix
     #
-
 
     def moment_of_inertia_matrix(self, p_type=None):
         """
@@ -1163,32 +1155,33 @@ class Analysis(object):
         -------
         array_like
             3x3 moment of inertia matrix.
-      
+
         """
 
         cdef double[9] MofImatrix
 
         if p_type is None:
-            raise ValueError("The p_type keyword argument must be provided (particle type)")
+            raise ValueError(
+                "The p_type keyword argument must be provided (particle type)")
         check_type_or_throw_except(p_type, 1, int, "p_type has to be an int")
         if (p_type < 0 or p_type >= c_analyze.n_particle_types):
             raise ValueError("Particle type", p_type, "does not exist!")
-        
-        c_analyze.momentofinertiamatrix(c_analyze.partCfg(), p_type, MofImatrix)
+
+        c_analyze.momentofinertiamatrix(
+            c_analyze.partCfg(), p_type, MofImatrix)
 
         MofImatrix_np = np.empty((9))
         for i in range(9):
             MofImatrix_np[i] = MofImatrix[i]
 
-        return MofImatrix_np.reshape((3,3))
+        return MofImatrix_np.reshape((3, 3))
 
     #
     # rdfchain
     #
 
-
     def rdf_chain(self, r_min=None, r_max=None, r_bins=None,
-                 chain_start=None, number_of_chains=None, chain_length=None):
+                  chain_start=None, number_of_chains=None, chain_length=None):
         """
         Returns three radial distribution functions (rdf) for the chains.  The
         first rdf is calculated for monomers belonging to different chains, the
@@ -1196,10 +1189,10 @@ class Analysis(object):
         is the distribution of the closest distances between the chains (the
         shortest monomer-monomer distances).  The result is normalized by the
         spherical bin shell, the total number of pairs and the system volume.
-        
+
         The distance range is given by `r_min` and `r_max` and it is divided
         into `r_bins` equidistant bins.
-        
+
         This requires that a set of chains of equal length which start with the
         particle with particle number `chain_start` and are consecutively
         numbered (the last particle in that topology has id number :
@@ -1219,7 +1212,7 @@ class Analysis(object):
                            Number of chains contained in the range.
         chain_length : :obj:`int`.
                        The length of every chain.
-        
+
         Returns            
         -------
         array_like
@@ -1228,7 +1221,7 @@ class Analysis(object):
             [2] is the second rdf: from the centers of mass of the chains,
             [3] is the third rdf: from the shortest monomer-monomer distances.
 
-        """        
+        """
         cdef double * f1
         cdef double * f2
         cdef double * f3
@@ -1238,18 +1231,19 @@ class Analysis(object):
         check_type_or_throw_except(r_bins, 1, int, "r_bins has to be an int")
 
         self.check_topology(chain_start=chain_start,
-                       number_of_chains=number_of_chains, chain_length=chain_length)
+                            number_of_chains=number_of_chains, chain_length=chain_length)
 
         if (c_analyze.chain_n_chains == 0 or chain_length == 0):
             raise Exception("The chain topology has not been set")
         if (r_bins <= 0):
-            raise Exception("Nothing to be done - choose <r_bins> greater zero!")
+            raise Exception(
+                "Nothing to be done - choose <r_bins> greater zero!")
         if (r_min < 0.):
             raise Exception("<r_min> has to be positive")
         if (r_max <= r_min):
             raise Exception("<r_max> has to be larger than <r_min>")
 
-        c_analyze.analyze_rdfchain(c_analyze.partCfg(),r_min, r_max, r_bins, & f1, & f2, & f3)
+        c_analyze.analyze_rdfchain(c_analyze.partCfg(), r_min, r_max, r_bins, & f1, & f2, & f3)
 
         rdfchain = np.empty((r_bins, 4))
         bin_width = (r_max - r_min) / float(r_bins)
@@ -1273,7 +1267,6 @@ class Analysis(object):
         "avk": 0.0
     }
 
-
     def v_kappa(self, mode=None, Vk1=None, Vk2=None, avk=None):
         """
         .. todo:: Looks to be incomplete
@@ -1290,9 +1283,9 @@ class Analysis(object):
               Volume squared.
         avk : :obj:`float`
               Number of averages.
-      
+
         """
-        
+
         check_type_or_throw_except(mode, 1, str, "mode has to be a string")
 
         if (mode == "reset"):

--- a/testsuite/analyze_energy.py
+++ b/testsuite/analyze_energy.py
@@ -7,7 +7,6 @@ from espressomd.interactions import HarmonicBond
 
 
 @ut.skipIf(not espressomd.has_features("LENNARD_JONES"), "Skipped because LENNARD_JONES turned off.")
-
 class AnalyzeEnergy(ut.TestCase):
     system = espressomd.System()
     harmonic = HarmonicBond(r_0=0.0, k=3)
@@ -21,6 +20,9 @@ class AnalyzeEnergy(ut.TestCase):
         self.system.non_bonded_inter[0, 0].lennard_jones.set_params(
             epsilon=1.0, sigma=1.0,
             cutoff=2**(1. / 6.), shift="auto")
+        self.system.non_bonded_inter[0, 1].lennard_jones.set_params(
+            epsilon=1.0, sigma=1.0,
+            cutoff=2**(1. / 6.), shift="auto")
         self.system.non_bonded_inter[1, 1].lennard_jones.set_params(
             epsilon=1.0, sigma=1.0,
             cutoff=2**(1. / 6.), shift="auto")
@@ -28,7 +30,6 @@ class AnalyzeEnergy(ut.TestCase):
         self.system.part.add(id=1, pos=[5, 2, 2], type=0)
         self.system.thermostat.set_langevin(kT=0., gamma=1.)
         self.system.bonded_inter.add(self.harmonic)
-
 
     def test_kinetic(self):
         self.system.part[0].pos = [1, 2, 2]
@@ -51,7 +52,6 @@ class AnalyzeEnergy(ut.TestCase):
         self.system.part[0].v = [0, 0, 0]
         self.system.part[1].v = [0, 0, 0]
 
-
     def test_non_bonded(self):
         self.system.part[0].pos = [1, 2, 2]
         self.system.part[1].pos = [2, 2, 2]
@@ -61,13 +61,18 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["bonded"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
         # add another pair of particles
-        self.system.part.add(id=2, pos=[1, 5, 5], type=1)
-        self.system.part.add(id=3, pos=[2, 5, 5], type=1)
+        self.system.part.add(id=2, pos=[3, 2, 2], type=1)
+        self.system.part.add(id=3, pos=[4, 2, 2], type=1)
         energy = self.system.analysis.energy()
-        self.assertAlmostEqual(energy["total"], 2., delta=1e-7)
+        self.assertAlmostEqual(energy["total"], 3., delta=1e-7)
         self.assertAlmostEqual(energy["kinetic"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 0., delta=1e-7)
-        self.assertAlmostEqual(energy["non_bonded"], 2., delta=1e-7)
+        self.assertAlmostEqual(energy["non_bonded"], 3., delta=1e-7)
+        self.assertAlmostEqual(
+            energy["non_bonded", 0, 1], energy["non_bonded", 1, 0], delta=1e-7)
+        self.assertAlmostEqual(energy["non_bonded", 0, 0]
+                               + energy["non_bonded", 0, 1]
+                               + energy["non_bonded", 1, 1], energy["total"], delta=1e-7)
         self.system.part[2].remove()
         self.system.part[3].remove()
 
@@ -118,10 +123,11 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["bonded"], 3., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
         # add another pair of particles
-        self.system.part.add(id=2, pos=[1, 5, 5], type=1 )
+        self.system.part.add(id=2, pos=[1, 5, 5], type=1)
         self.system.part.add(id=3, pos=[2, 5, 5], type=1)
         energy = self.system.analysis.energy()
-        self.assertAlmostEqual(energy["total"], 50. + 3 + (1. + 1.), delta=1e-7)
+        self.assertAlmostEqual(
+            energy["total"], 50. + 3 + (1. + 1.), delta=1e-7)
         self.assertAlmostEqual(energy["kinetic"], 50., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 3., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1. + 1., delta=1e-7)
@@ -129,8 +135,8 @@ class AnalyzeEnergy(ut.TestCase):
         self.system.part[3].remove()
         self.system.part[0].delete_all_bonds()
 
-
     features = ["ELECTROSTATICS", "P3M"]
+
     @ut.skipIf(not espressomd.has_features(*features),
                "Missing features: " + ", ".join(espressomd.missing_features(*features)))
     def test_electrostatics(self):
@@ -143,7 +149,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.system.part[1].q = -1
         p3m = electrostatics.P3M(prefactor=1.0,
                                  accuracy=9.910945054074526e-08,
-                                 mesh=[22,22,22],
+                                 mesh=[22, 22, 22],
                                  cao=7,
                                  r_cut=8.906249999999998,
                                  alpha=0.387611049779351,


### PR DESCRIPTION
When analyzing the total non-bonded energy (via `system.analysis.energy()`), the non-bonded energy contribution between types _i_ and _j_ (_i_ != _j_) are added twice.
This PR fixes that.

Sample:
```python
import espressomd
from espressomd.shapes import Wall

system = espressomd.System()
system.box_l = [10, 10, 10]
system.time_step = 0.01
system.cell_system.skin = 0.4

system.non_bonded_inter[0, 1].lennard_jones.set_params(epsilon=1, sigma=1, cutoff=5, shift="auto")
system.non_bonded_inter[1, 1].lennard_jones.set_params(epsilon=1, sigma=1, cutoff=5, shift="auto")

system.constraints.add(shape=wall, particle_type=0)
system.part.add(pos=[3,0,0], type=1)
system.part.add(pos=[3,2,0], type=1)                                                                                                    
system.integrator.run(0)

print(system.analysis.energy())
```
Output without fix:
```
OrderedDict([('total', -0.1845703125), ('kinetic', 0.0), ('bonded', 0.0), (('non_bonded', 0, 0), 0.0), (('non_bonded', 0, 1), -0.123046875), (('non_bonded', 1, 0), -0.123046875), (('non_bonded', 1, 1), -0.0615234375), ('non_bonded', -0.3076171875), ('coulomb', 0.0), (('dipolar', 0), 0.0), ('dipolar', 0.0)])
```
where `non_bonded > total`!

Fixed, as expected:
```
OrderedDict([('total', -0.1845703125), ('kinetic', 0.0), ('bonded', 0.0), (('non_bonded', 0, 0), 0.0), (('non_bonded', 0, 1), -0.123046875), (('non_bonded', 1, 0), -0.123046875), (('non_bonded', 1, 1), -0.0615234375), ('non_bonded', -0.1845703125), ('coulomb', 0.0), (('dipolar', 0), 0.0), ('dipolar', 0.0)])
```
