### PR TITLE
observable: throw if axis not z for cylindrical lb obs.

### DIFF
--- a/src/core/observables/CylindricalLBFluxDensityProfileAtParticlePositions.cpp
+++ b/src/core/observables/CylindricalLBFluxDensityProfileAtParticlePositions.cpp
@@ -50,14 +50,8 @@ operator()(PartCfg &partCfg) const {
       ppos_shifted[3 * index + 0] = ppos_shifted_tmp[0];
       ppos_shifted[3 * index + 1] = ppos_shifted_tmp[1];
       ppos_shifted[3 * index + 2] = ppos_shifted_tmp[2];
-    } else if (axis == "x") {
-      ppos_shifted[3 * index + 0] = -ppos_shifted_tmp[2];
-      ppos_shifted[3 * index + 1] = ppos_shifted_tmp[1];
-      ppos_shifted[3 * index + 2] = ppos_shifted_tmp[0];
-    } else if (axis == "y") {
-      ppos_shifted[3 * index + 0] = ppos_shifted_tmp[0];
-      ppos_shifted[3 * index + 1] = -ppos_shifted_tmp[2];
-      ppos_shifted[3 * index + 2] = ppos_shifted_tmp[1];
+    } else if (axis == "x" || axis == "y") {
+      throw std::runtime_error("'x' and 'y' axis orientation not supported!");
     }
     auto const ppos_cyl_tmp =
         Utils::transform_to_cylinder_coordinates(ppos_shifted_tmp);

--- a/src/core/observables/CylindricalLBVelocityProfileAtParticlePositions.cpp
+++ b/src/core/observables/CylindricalLBVelocityProfileAtParticlePositions.cpp
@@ -50,14 +50,8 @@ operator()(PartCfg &partCfg) const {
       ppos_shifted[3 * index + 0] = ppos_shifted_tmp[0];
       ppos_shifted[3 * index + 1] = ppos_shifted_tmp[1];
       ppos_shifted[3 * index + 2] = ppos_shifted_tmp[2];
-    } else if (axis == "x") {
-      ppos_shifted[3 * index + 0] = -ppos_shifted_tmp[2];
-      ppos_shifted[3 * index + 1] = ppos_shifted_tmp[1];
-      ppos_shifted[3 * index + 2] = ppos_shifted_tmp[0];
-    } else if (axis == "y") {
-      ppos_shifted[3 * index + 0] = ppos_shifted_tmp[0];
-      ppos_shifted[3 * index + 1] = -ppos_shifted_tmp[2];
-      ppos_shifted[3 * index + 2] = ppos_shifted_tmp[1];
+    } else if (axis == "x" || axis == "y") {
+      throw std::runtime_error("'x' and 'y' axis orientation not supported!");
     }
     auto const ppos_cyl_tmp =
         Utils::transform_to_cylinder_coordinates(ppos_shifted_tmp);

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -365,6 +365,7 @@ class CylindricalLBFluxDensityProfileAtParticlePositions(Observable):
              Position of the center of the polar coordinate system for the histogram.
     axis : :obj:`str` (``x``, ``y``, or ``z``)
            Orientation of the ``z``-axis of the polar coordinate system for the histogram.
+           .. note:: Currently only the ``z`` option is implemented!
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
     n_phi_bins : :obj:`int`
@@ -400,6 +401,7 @@ class CylindricalLBVelocityProfileAtParticlePositions(Observable):
              Position of the center of the polar coordinate system for the histogram.
     axis : :obj:`str` (``x``, ``y``, or ``z``)
            Orientation of the ``z``-axis of the polar coordinate system for the histogram.
+           .. note:: Currently only the ``z`` option is implemented!
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
     n_phi_bins : :obj:`int`

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -365,7 +365,9 @@ class CylindricalLBFluxDensityProfileAtParticlePositions(Observable):
              Position of the center of the polar coordinate system for the histogram.
     axis : :obj:`str` (``x``, ``y``, or ``z``)
            Orientation of the ``z``-axis of the polar coordinate system for the histogram.
+
            .. note:: Currently only the ``z`` option is implemented!
+
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
     n_phi_bins : :obj:`int`
@@ -401,7 +403,9 @@ class CylindricalLBVelocityProfileAtParticlePositions(Observable):
              Position of the center of the polar coordinate system for the histogram.
     axis : :obj:`str` (``x``, ``y``, or ``z``)
            Orientation of the ``z``-axis of the polar coordinate system for the histogram.
-           .. note:: Currently only the ``z`` option is implemented!
+
+          .. note:: Currently only the ``z`` option is implemented!
+
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
     n_phi_bins : :obj:`int`


### PR DESCRIPTION
Fixes #1763 

Description of changes:
 - throw error if not supported observable specs are used