### PR TITLE
fix stress tensor components python

### DIFF
--- a/samples/lj-demo.py
+++ b/samples/lj-demo.py
@@ -462,7 +462,7 @@ def main_loop():
         plt1_x_data[-plot_max_data_len + 1:], system.time)
     if show_real_system_temperature:
         plt1_y_data = numpy.append(plt1_y_data[-plot_max_data_len + 1:], 2. / (
-            3. * len(system.part)) * system.analysis.energy()["ideal"])
+            3. * len(system.part)) * system.analysis.energy()["kinetic"])
     else:
         plt1_y_data = numpy.append(
             plt1_y_data[-plot_max_data_len + 1:], (system.part[:].v**2).sum())
@@ -539,8 +539,8 @@ def calculate_kinetic_energy():
         tmp_kin_energy += 1. / 2. * numpy.linalg.norm(system.part[i].v)**2.0
 
     print("tmp_kin_energy={}".format(tmp_kin_energy))
-    print("system.analysis.energy()['ideal']={}".format(
-        system.analysis.energy(system)["ideal"]))
+    print("system.analysis.energy()['kinetic']={}".format(
+        system.analysis.energy(system)["kinetic"]))
 
 
 def rotate_scene():

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -66,7 +66,7 @@ class Analysis(object):
     #
 
     def min_dist2(self, p1, p2):
-        """Minimal distance between two points p1 and p2.
+        """Minimal distance between two three dimensional coordinates p1 and p2.
 
         Parameters
         ----------

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -65,6 +65,21 @@ class Analysis(object):
     # Minimal distance between particles
     #
 
+    def min_dist2(self, p1, p2):
+        """Minimal distance between two points p1 and p2.
+
+        Parameters
+        ----------
+        p1, p2 
+    
+        """
+        cdef double p1c[3]
+        cdef double p2c[3]
+        for i in range(3):
+            p1c[i]=p1[i]
+            p2c[i]=p2[i]
+        return c_analyze.min_distance2(p1c, p2c)
+
     def min_dist(self, p1='default', p2='default'):
         """Minimal distance between two sets of particles.
 
@@ -93,9 +108,9 @@ class Analysis(object):
                     raise ValueError(
                         "Particle types in p1 and p2 have to be of type int" + str(p2[i]))
 
+
             set1 = create_int_list_from_python_object(p1)
             set2 = create_int_list_from_python_object(p2)
-
         return c_analyze.mindist(c_analyze.partCfg(), set1, set2)
 
     #
@@ -358,7 +373,7 @@ class Analysis(object):
         A dictionary with the following keys:
 
         * "total", total pressure
-        * "ideal", ideal pressure
+        * "kinetic", kinetic pressure
         * "bonded" , total bonded pressure
         * "bonded", bond_type , bonded pressure which arises from the given bond_type
         * "nonbonded", total nonbonded pressure
@@ -392,8 +407,8 @@ class Analysis(object):
 
         p["total"] = tmp
 
-        # Ideal
-        p["ideal"] = c_analyze.total_pressure.data.e[0]
+        # kinetic
+        p["kinetic"] = c_analyze.total_pressure.data.e[0]
 
         # Bonded
         cdef double total_bonded
@@ -463,7 +478,7 @@ class Analysis(object):
         a dictionary with the following keys:
 
         * "total", total stress tensor
-        * "ideal", ideal stress tensor
+        * "kinetic", kinetic stress tensor
         * "bonded" , total bonded stress tensor
         * "{bonded, bond_type}" , bonded stress tensor which arises from the given bond_type
         * "nonbonded", total nonbonded stress tensor
@@ -497,10 +512,10 @@ class Analysis(object):
 
         p["total"] = tmp.reshape((3, 3))
 
-        # Ideal
-        p["ideal"] = create_nparray_from_double_array(
+        # kinetic
+        p["kinetic"] = create_nparray_from_double_array(
             c_analyze.total_p_tensor.data.e, 9)
-        p["ideal"] = p["ideal"].reshape((3, 3))
+        p["kinetic"] = p["kinetic"].reshape((3, 3))
 
         # Bonded
         total_bonded = np.zeros((3, 3))
@@ -548,7 +563,7 @@ class Analysis(object):
             for i in range(c_analyze.total_p_tensor.n_coulomb):
                 p["coulomb", i] = np.reshape(
                     create_nparray_from_double_array(
-                        c_analyze.total_p_tensor.coulomb, 9), (3, 3))
+                        c_analyze.total_p_tensor.coulomb+9*i, 9), (3, 3))
                 total_coulomb = p["coulomb", i]
             p["coulomb"] = total_coulomb
 
@@ -558,7 +573,7 @@ class Analysis(object):
             for i in range(c_analyze.total_p_tensor.n_dipolar):
                 p["dipolar", i] = np.reshape(
                     create_nparray_from_double_array(
-                        c_analyze.total_p_tensor.dipolar, 9), (3, 3))
+                        c_analyze.total_p_tensor.dipolar+9*i, 9), (3, 3))
                 total_dipolar = p["dipolar", i]
             p["dipolar"] = total_dipolar
 

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -559,22 +559,22 @@ class Analysis(object):
 
         # Electrostatics
         IF ELECTROSTATICS == 1:
-            total_coulomb = np.zeros(9)
+            total_coulomb = np.zeros((3,3))
             for i in range(c_analyze.total_p_tensor.n_coulomb):
                 p["coulomb", i] = np.reshape(
                     create_nparray_from_double_array(
                         c_analyze.total_p_tensor.coulomb+9*i, 9), (3, 3))
-                total_coulomb = p["coulomb", i]
+                total_coulomb += p["coulomb", i]
             p["coulomb"] = total_coulomb
 
         # Dipoles
         IF DIPOLES == 1:
-            total_dipolar = np.zeros(9)
+            total_dipolar = np.zeros((3,3))
             for i in range(c_analyze.total_p_tensor.n_dipolar):
                 p["dipolar", i] = np.reshape(
                     create_nparray_from_double_array(
                         c_analyze.total_p_tensor.dipolar+9*i, 9), (3, 3))
-                total_dipolar = p["dipolar", i]
+                total_dipolar += p["dipolar", i]
             p["dipolar"] = total_dipolar
 
         # virtual sites

--- a/src/python/espressomd/c_analyze.pxd
+++ b/src/python/espressomd/c_analyze.pxd
@@ -61,6 +61,7 @@ cdef extern from "statistics.hpp":
     ctypedef struct Observable_stat_non_bonded:
         pass
     cdef double mindist(PartCfg &, const int_list & set1, const int_list & set2)
+    cdef double min_distance2(double pos1[3], double pos2[3])
     cdef int_list nbhood(PartCfg &, double pos[3], double r_catch, int planedims[3])
     cdef double distto(PartCfg &, double pos[3], int pid)
     cdef double * obsstat_bonded(Observable_stat * stat, int j)

--- a/testsuite/stress.py
+++ b/testsuite/stress.py
@@ -14,7 +14,7 @@ import numpy as np
 tol = 1.0e-13
 
 # analytical result for convective stress
-def stress_ideal(vel, box_l):
+def stress_kinetic(vel, box_l):
   return np.einsum('ij,ik->jk', vel, vel) / box_l**3
 
 # analytical result for stress originating from bond force
@@ -106,7 +106,7 @@ class stress_test(ut.TestCase):
     pos = system.part[:].pos
     vel = system.part[:].v
 
-    sim_stress_ideal = system.analysis.stress_tensor()['ideal']
+    sim_stress_kinetic = system.analysis.stress_tensor()['kinetic']
     sim_stress_bonded = system.analysis.stress_tensor()['bonded']
     sim_stress_bonded_harmonic = system.analysis.stress_tensor()['bonded', len(system.bonded_inter)-1]
     sim_stress_nonbonded = system.analysis.stress_tensor()['non_bonded']
@@ -115,7 +115,7 @@ class stress_test(ut.TestCase):
     sim_stress_nonbonded_intra = system.analysis.stress_tensor()['non_bonded_intra']
     sim_stress_nonbonded_intra00 = system.analysis.stress_tensor()['non_bonded_intra', 0, 0]
     sim_stress_total = system.analysis.stress_tensor()['total']
-    sim_pressure_ideal = system.analysis.pressure()['ideal']
+    sim_pressure_kinetic = system.analysis.pressure()['kinetic']
     sim_pressure_bonded = system.analysis.pressure()['bonded']
     sim_pressure_bonded_harmonic = system.analysis.pressure()['bonded', len(system.bonded_inter)-1]
     sim_pressure_nonbonded = system.analysis.pressure()['non_bonded']
@@ -125,28 +125,28 @@ class stress_test(ut.TestCase):
     sim_pressure_nonbonded_intra00 = system.analysis.pressure()['non_bonded_intra', 0, 0]
     sim_pressure_total = system.analysis.pressure()['total']
 
-    anal_stress_ideal = stress_ideal(vel, box_l)
+    anal_stress_kinetic = stress_kinetic(vel, box_l)
     anal_stress_bonded = stress_bonded(pos, box_l)
     anal_stress_nonbonded = stress_nonbonded(system.part.pairs(), box_l)
     anal_stress_nonbonded_inter = stress_nonbonded_inter(system.part.pairs(), box_l)
     anal_stress_nonbonded_intra = stress_nonbonded_intra(system.part.pairs(), box_l)
-    anal_stress_total = anal_stress_ideal + anal_stress_bonded + anal_stress_nonbonded
-    anal_pressure_ideal = np.einsum('ii', anal_stress_ideal)/3.0
+    anal_stress_total = anal_stress_kinetic + anal_stress_bonded + anal_stress_nonbonded
+    anal_pressure_kinetic = np.einsum('ii', anal_stress_kinetic)/3.0
     anal_pressure_bonded = np.einsum('ii', anal_stress_bonded)/3.0
     anal_pressure_nonbonded = np.einsum('ii', anal_stress_nonbonded)/3.0
     anal_pressure_nonbonded_inter = np.einsum('ii', anal_stress_nonbonded_inter)/3.0
     anal_pressure_nonbonded_intra = np.einsum('ii', anal_stress_nonbonded_intra)/3.0
-    anal_pressure_total = anal_pressure_ideal + anal_pressure_bonded + anal_pressure_nonbonded
+    anal_pressure_total = anal_pressure_kinetic + anal_pressure_bonded + anal_pressure_nonbonded
 
     print('particle positions')
     print(pos)
     print('particle velocities')
     print(vel)
 
-    print('\nsimulated ideal pressure=')
-    print(sim_pressure_ideal)
-    print('analytical ideal pressure=')
-    print(anal_pressure_ideal)
+    print('\nsimulated kinetic pressure=')
+    print(sim_pressure_kinetic)
+    print('analytical kinetic pressure=')
+    print(anal_pressure_kinetic)
 
     print('\nsimulated bonded pressure=')
     print(sim_pressure_bonded)
@@ -188,10 +188,10 @@ class stress_test(ut.TestCase):
     print('analytic total pressure=')
     print(anal_pressure_total)
 
-    print('\nsimulated ideal stress=')
-    print(sim_stress_ideal)
-    print('analytic ideal stress=')
-    print(anal_stress_ideal)
+    print('\nsimulated kinetic stress=')
+    print(sim_stress_kinetic)
+    print('analytic kinetic stress=')
+    print(anal_stress_kinetic)
 
     print('\nsimulated bonded stress=')
     print(sim_stress_bonded)
@@ -235,7 +235,7 @@ class stress_test(ut.TestCase):
 
     system.part.clear()
 
-    self.assertTrue(np.max(np.abs(sim_stress_ideal-anal_stress_ideal)) < tol, 'ideal stress does not match analytical result')
+    self.assertTrue(np.max(np.abs(sim_stress_kinetic-anal_stress_kinetic)) < tol, 'kinetic stress does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_bonded-anal_stress_bonded)) < tol, 'bonded stress does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_bonded_harmonic-anal_stress_bonded)) < tol, 'bonded stress harmonic bond does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_nonbonded-anal_stress_nonbonded)) < tol, 'non-bonded stress does not match analytical result')
@@ -244,7 +244,7 @@ class stress_test(ut.TestCase):
     self.assertTrue(np.max(np.abs(sim_stress_nonbonded_intra-anal_stress_nonbonded_intra)) < tol, 'non-bonded intramolecular stress does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_nonbonded_intra00-anal_stress_nonbonded_intra)) < tol, 'non-bonded intramolecular stress molecule 0 does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_total-anal_stress_total)) < tol, 'total stress does not match analytical result')
-    self.assertTrue(np.abs(sim_pressure_ideal-anal_pressure_ideal) < tol, 'ideal pressure does not match analytical result')
+    self.assertTrue(np.abs(sim_pressure_kinetic-anal_pressure_kinetic) < tol, 'kinetic pressure does not match analytical result')
     self.assertTrue(np.abs(sim_pressure_bonded-anal_pressure_bonded) < tol, 'bonded pressure does not match analytical result')
     self.assertTrue(np.abs(sim_pressure_bonded_harmonic-anal_pressure_bonded) < tol, 'bonded pressure harmonic bond does not match analytical result')
     self.assertTrue(np.abs(sim_pressure_nonbonded-anal_pressure_nonbonded) < tol, 'non-bonded pressure does not match analytical result')
@@ -300,7 +300,7 @@ class stress_lees_edwards_test(ut.TestCase):
     pos = system.part[:].pos
     vel = system.part[:].v
 
-    sim_stress_ideal = system.analysis.stress_tensor()['ideal']
+    sim_stress_kinetic = system.analysis.stress_tensor()['kinetic']
     sim_stress_bonded = system.analysis.stress_tensor()['bonded']
     sim_stress_bonded_harmonic = system.analysis.stress_tensor()['bonded', len(system.bonded_inter)-1]
     sim_stress_nonbonded = system.analysis.stress_tensor()['non_bonded']
@@ -309,7 +309,7 @@ class stress_lees_edwards_test(ut.TestCase):
     sim_stress_nonbonded_intra = system.analysis.stress_tensor()['non_bonded_intra']
     sim_stress_nonbonded_intra00 = system.analysis.stress_tensor()['non_bonded_intra', 0, 0]
     sim_stress_total = system.analysis.stress_tensor()['total']
-    sim_pressure_ideal = system.analysis.pressure()['ideal']
+    sim_pressure_kinetic = system.analysis.pressure()['kinetic']
     sim_pressure_bonded = system.analysis.pressure()['bonded']
     sim_pressure_bonded_harmonic = system.analysis.pressure()['bonded', len(system.bonded_inter)-1]
     sim_pressure_nonbonded = system.analysis.pressure()['non_bonded']
@@ -319,18 +319,18 @@ class stress_lees_edwards_test(ut.TestCase):
     sim_pressure_nonbonded_intra00 = system.analysis.pressure()['non_bonded_intra', 0, 0]
     sim_pressure_total = system.analysis.pressure()['total']
 
-    anal_stress_ideal = stress_ideal(vel, box_l)
+    anal_stress_kinetic = stress_kinetic(vel, box_l)
     anal_stress_bonded = stress_bonded(pos, box_l)
     anal_stress_nonbonded = stress_nonbonded(system.part.pairs(), box_l)
     anal_stress_nonbonded_inter = stress_nonbonded_inter(system.part.pairs(), box_l)
     anal_stress_nonbonded_intra = stress_nonbonded_intra(system.part.pairs(), box_l)
-    anal_stress_total = anal_stress_ideal + anal_stress_bonded + anal_stress_nonbonded
-    anal_pressure_ideal = np.einsum('ii', anal_stress_ideal)/3.0
+    anal_stress_total = anal_stress_kinetic + anal_stress_bonded + anal_stress_nonbonded
+    anal_pressure_kinetic = np.einsum('ii', anal_stress_kinetic)/3.0
     anal_pressure_bonded = np.einsum('ii', anal_stress_bonded)/3.0
     anal_pressure_nonbonded = np.einsum('ii', anal_stress_nonbonded)/3.0
     anal_pressure_nonbonded_inter = np.einsum('ii', anal_stress_nonbonded_inter)/3.0
     anal_pressure_nonbonded_intra = np.einsum('ii', anal_stress_nonbonded_intra)/3.0
-    anal_pressure_total = anal_pressure_ideal + anal_pressure_bonded + anal_pressure_nonbonded
+    anal_pressure_total = anal_pressure_kinetic + anal_pressure_bonded + anal_pressure_nonbonded
 
     print('le_offset = {}'.format(system.lees_edwards_offset))
 
@@ -339,10 +339,10 @@ class stress_lees_edwards_test(ut.TestCase):
     print('particle velocities')
     print(vel)
 
-    print('\nsimulated ideal pressure=')
-    print(sim_pressure_ideal)
-    print('analytical ideal pressure=')
-    print(anal_pressure_ideal)
+    print('\nsimulated kinetic pressure=')
+    print(sim_pressure_kinetic)
+    print('analytical kinetic pressure=')
+    print(anal_pressure_kinetic)
 
     print('\nsimulated bonded pressure=')
     print(sim_pressure_bonded)
@@ -384,10 +384,10 @@ class stress_lees_edwards_test(ut.TestCase):
     print('analytic total pressure=')
     print(anal_pressure_total)
 
-    print('\nsimulated ideal stress=')
-    print(sim_stress_ideal)
-    print('analytic ideal stress=')
-    print(anal_stress_ideal)
+    print('\nsimulated kinetic stress=')
+    print(sim_stress_kinetic)
+    print('analytic kinetic stress=')
+    print(anal_stress_kinetic)
 
     print('\nsimulated bonded stress=')
     print(sim_stress_bonded)
@@ -431,7 +431,7 @@ class stress_lees_edwards_test(ut.TestCase):
 
     system.part.clear()
 
-    self.assertTrue(np.max(np.abs(sim_stress_ideal-anal_stress_ideal)) < tol, 'ideal stress does not match analytical result')
+    self.assertTrue(np.max(np.abs(sim_stress_kinetic-anal_stress_kinetic)) < tol, 'kinetic stress does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_bonded-anal_stress_bonded)) < tol, 'bonded stress does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_bonded_harmonic-anal_stress_bonded)) < tol, 'bonded stress harmonic bond does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_nonbonded-anal_stress_nonbonded)) < tol, 'non-bonded stress does not match analytical result')
@@ -440,7 +440,7 @@ class stress_lees_edwards_test(ut.TestCase):
     self.assertTrue(np.max(np.abs(sim_stress_nonbonded_intra-anal_stress_nonbonded_intra)) < tol, 'non-bonded intramolecular stress does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_nonbonded_intra00-anal_stress_nonbonded_intra)) < tol, 'non-bonded intramolecular stress molecule 0 does not match analytical result')
     self.assertTrue(np.max(np.abs(sim_stress_total-anal_stress_total)) < tol, 'total stress does not match analytical result')
-    self.assertTrue(np.abs(sim_pressure_ideal-anal_pressure_ideal) < tol, 'ideal pressure does not match analytical result')
+    self.assertTrue(np.abs(sim_pressure_kinetic-anal_pressure_kinetic) < tol, 'kinetic pressure does not match analytical result')
     self.assertTrue(np.abs(sim_pressure_bonded-anal_pressure_bonded) < tol, 'bonded pressure does not match analytical result')
     self.assertTrue(np.abs(sim_pressure_bonded_harmonic-anal_pressure_bonded) < tol, 'bonded pressure harmonic bond does not match analytical result')
     self.assertTrue(np.abs(sim_pressure_nonbonded-anal_pressure_nonbonded) < tol, 'non-bonded pressure does not match analytical result')


### PR DESCRIPTION
Fixes indexing of stress tensor contributions thanks to @fweik.
Introduce function that returns the minimum image distance between two positions. The function which was already there took particle types as argument and is not equivalent therefore. The previous function returns the minimal distance between sets of particles with given types.
