### PR TITLE
Prevent OpenMPI version detection from leaking to stderr

### DIFF
--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -42,7 +42,7 @@ function(UNIT_TEST)
     endif()
 
     # OpenMPI 3.0 and higher checks the number of processes against the number of CPUs
-    execute_process(COMMAND ${MPIEXEC} --version RESULT_VARIABLE mpi_version_result OUTPUT_VARIABLE mpi_version_output)
+    execute_process(COMMAND ${MPIEXEC} --version RESULT_VARIABLE mpi_version_result OUTPUT_VARIABLE mpi_version_output ERROR_VARIABLE mpi_version_output)
     if (mpi_version_result EQUAL 0 AND mpi_version_output MATCHES "\\(Open(RTE| MPI)\\) ([3-9]\\.|1[0-9])")
       add_test(${TEST_NAME} ${MPIEXEC} -oversubscribe ${MPIEXEC_NUMPROC_FLAG} ${TEST_NUM_PROC} ${TEST_NAME})
     else()

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -17,7 +17,7 @@ function(PYTHON_TEST)
 
   if(EXISTS ${MPIEXEC})
     # OpenMPI 3.0 and higher checks the number of processes against the number of CPUs
-    execute_process(COMMAND ${MPIEXEC} --version RESULT_VARIABLE mpi_version_result OUTPUT_VARIABLE mpi_version_output)
+    execute_process(COMMAND ${MPIEXEC} --version RESULT_VARIABLE mpi_version_result OUTPUT_VARIABLE mpi_version_output ERROR_VARIABLE mpi_version_output)
     if (mpi_version_result EQUAL 0 AND mpi_version_output MATCHES "\\(Open(RTE| MPI)\\) ([3-9]\\.|1[0-9])")
       add_test(${TEST_NAME} ${MPIEXEC} -oversubscribe ${MPIEXEC_NUMPROC_FLAG} ${TEST_NUM_PROC} ${CMAKE_BINARY_DIR}/pypresso ${TEST_FILE})
     else()


### PR DESCRIPTION
Builds with OpenMPI 1.6 show lots of the following warnings during CMake since #1765:

```
mpiexec (OpenRTE) 1.6.5

Report bugs to http://www.open-mpi.org/community/help/
```