### PR TITLE
added charge rescaling (with minimum absolute nonzero charge) in electroneutrality test in Reaction Algorithms

### DIFF
--- a/samples/grand_canonical.py
+++ b/samples/grand_canonical.py
@@ -76,7 +76,7 @@ for type_1 in types:
             cutoff=lj_cut, shift="auto")
 
 RE = reaction_ensemble.ReactionEnsemble(temperature=temperature, exclusion_radius=1.0, standard_pressure=1.0)
-RE.add(equilibrium_constant=cs_bulk**2*np.exp(excess_chemical_potential_pair/temperature), reactant_types=[], reactant_coefficients=[], product_types=[1, 2], product_coefficients=[1, 1], default_charges={"1": -1, "2": +1})
+RE.add(equilibrium_constant=cs_bulk**2*np.exp(excess_chemical_potential_pair/temperature), reactant_types=[], reactant_coefficients=[], product_types=[1, 2], product_coefficients=[1, 1], default_charges={1: -1, 2: +1})
 print(RE.get_status())
 system.setup_type_map([0, 1, 2])
 

--- a/samples/wang_landau_reaction_ensemble.py
+++ b/samples/wang_landau_reaction_ensemble.py
@@ -69,7 +69,7 @@ system.part[0].add_bond((h, 1))
 RE = reaction_ensemble.ReactionEnsemble(
     standard_pressure=0.00108, temperature=1, exclusion_radius=0)
 RE.add(equilibrium_constant=K_diss, reactant_types=[0], reactant_coefficients=[
-       1], product_types=[1, 2], product_coefficients=[1, 1], default_charges={"0": 0, "1": -1, "2": +1})
+       1], product_types=[1, 2], product_coefficients=[1, 1], default_charges={0: 0, 1: -1, 2: +1})
 print(RE.get_status())
 grand_canonical.setup([0, 1, 2, 3])
 

--- a/samples/widom_insertion.py
+++ b/samples/widom_insertion.py
@@ -106,7 +106,7 @@ system.force_cap=0
 
 unimportant_K_diss = 0.0088
 RE = reaction_ensemble.WidomInsertion(temperature=temperature, exclusion_radius=1.0)
-RE.add(equilibrium_constant=unimportant_K_diss, reactant_types=[], reactant_coefficients=[], product_types=[1,2], product_coefficients=[1,1], default_charges={"1": -1,"2": +1})
+RE.add(equilibrium_constant=unimportant_K_diss, reactant_types=[], reactant_coefficients=[], product_types=[1,2], product_coefficients=[1,1], default_charges={1: -1,2: +1})
 print(RE.get_status())
 system.setup_type_map([0, 1, 2])
 

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -234,12 +234,13 @@ cdef class ReactionAlgorithm(object):
         if(self._params["check_for_electroneutrality"]== True):
             total_charge_change=0.0
             for i in range(len(self._params["reactant_coefficients"])):
-                type=self._params["reactant_types"][i]
-                total_charge_change-=self._params["reactant_coefficients"][i]*self._params["default_charges"][type]
+                type_here=self._params["reactant_types"][i]
+                total_charge_change-=self._params["reactant_coefficients"][i]*self._params["default_charges"][type_here]
             for j in range(len(self._params["product_coefficients"])):
-                total_charge_change+=self._params["product_coefficients"][j]*self._params["default_charges"][self._params["product_types"][j]]
-            charges=np.array(self._params["default_charges"].values())
-            min_abs_nonzero_charge = np.min(np.abs(charges[np.nonzero(charges)]))
+                type_here=self._params["product_types"][j]
+                total_charge_change+=self._params["product_coefficients"][j]*self._params["default_charges"][type_here]
+            charges=np.array(list(self._params["default_charges"].values()))
+            min_abs_nonzero_charge = np.min(np.abs(charges[np.nonzero(charges)[0]]))
             if abs(total_charge_change)/min_abs_nonzero_charge>1e-10:
                 raise ValueError("Reaction system is not charge neutral")
 

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -3,7 +3,7 @@ from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libc.string cimport strdup
 from utils import to_char_pointer
-
+import numpy as np
 
 class WangLandauHasConverged(Exception):
     pass
@@ -237,8 +237,10 @@ cdef class ReactionAlgorithm(object):
                 type=self._params["reactant_types"][i]
                 total_charge_change+=self._params["reactant_coefficients"][i]*self._params["default_charges"][type]
             for j in range(len(self._params["product_coefficients"])):
-                total_charge_change+=self._params["product_coefficients"][j]*self._params["default_charges"][self._params["product_types"][j]]            
-            if abs(total_charge_change)>1e-10:
+                total_charge_change+=self._params["product_coefficients"][j]*self._params["default_charges"][self._params["product_types"][j]]
+            charges=np.array(self._params["default_charges"].values())
+            min_abs_nonzero_charge = np.min(np.abs(charges[np.nonzero(charges)]))
+            if abs(total_charge_change)/min_abs_nonzero_charge>1e-10:
                 raise ValueError("Reaction system is not charge neutral")
 
     def reaction(self, reaction_steps=1):

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -235,7 +235,7 @@ cdef class ReactionAlgorithm(object):
             total_charge_change=0.0
             for i in range(len(self._params["reactant_coefficients"])):
                 type=self._params["reactant_types"][i]
-                total_charge_change+=self._params["reactant_coefficients"][i]*self._params["default_charges"][type]
+                total_charge_change-=self._params["reactant_coefficients"][i]*self._params["default_charges"][type]
             for j in range(len(self._params["product_coefficients"])):
                 total_charge_change+=self._params["product_coefficients"][j]*self._params["default_charges"][self._params["product_types"][j]]
             charges=np.array(self._params["default_charges"].values())

--- a/testsuite/reaction_ensemble.py
+++ b/testsuite/reaction_ensemble.py
@@ -70,7 +70,7 @@ class ReactionEnsembleTest(ut.TestCase):
             reactant_types=cls.reactant_types,
             reactant_coefficients=cls.reactant_coefficients,
             product_types=cls.product_types,
-            product_coefficients=cls.product_coefficients, default_charges={0: 0, 1: -1, 2: +1}, check_for_electroneutrality=True)
+            product_coefficients=cls.product_coefficients, default_charges={cls.type_HA: 0, cls.type_A: -1, cls.type_H: +1}, check_for_electroneutrality=True)
 
     @classmethod
     def ideal_degree_of_association(cls, pK_a, pH):


### PR DESCRIPTION
Description of changes:
Fixes #1786 in adding reaction systems in all reaction algorithms (constant pH, reaction ensemble, wang_landau reaction ensemble, widom_insertion) via raising an exception if the system can become charge neutral. This PR introduces the rescaling of the charge difference which is introduced via a "reaction" with a typical charge (minimum absolute nonzero charge in the reaction).