### PR TITLE
Quick Spellcheck of Sphinx Documentation

### DIFF
--- a/doc/sphinx/advanced_methods.rst
+++ b/doc/sphinx/advanced_methods.rst
@@ -79,7 +79,7 @@ Several modes are available for different types of binding.
   If all three particles are within the cutoff distance, an angle bond is added
   on each of the three particles in addition
   to the distance based bonds between the particle centers. 
-  If two particles are within the cutoff of a centrla particle (e.g., chain of three particles)
+  If two particles are within the cutoff of a central particle (e.g., chain of three particles)
   an angle bond is placed on the central particle.
   The angular bonds being added are determined from the angle between the particles.
   This method does not depend on the particles’ rotational
@@ -87,7 +87,7 @@ Several modes are available for different types of binding.
   required.
   The method, along with the corresponding bonds are setup as follows::
         
-        n_anlge_bonds=181 # 0 to 180 degrees in one degree steps
+        n_angle_bonds=181 # 0 to 180 degrees in one degree steps
         for i in range(0,res,1):
            self.s.bonded_inter[i]=Angle_Harmonic(bend=1,phi0=float(i)/(res-1)*np.pi)
         
@@ -135,7 +135,7 @@ That is, catalytic surfaces induce a reactions that produce charged species by c
 
 where on the upper half of the catalyst :math:`C^{+}` a species :math:`A` is converted into :math:`B`, and on the lower half :math:`C^{-}` the opposite reaction takes place. Note that when :math:`A` and :math:`B` are charged, this reaction conserves charge, provided the rates are equal.
 
-In |es| the orientation of a catalyzer particle is used to define hemispheres; half spaces going through the particle's center. The reaction region is bounded by the *reaction range*: :math:`r`. Inside the reaction range, we react only rectant-product pairs. The particles in a pair are swapped from hemisphere to another with a rate prescribed by
+In |es| the orientation of a catalyzer particle is used to define hemispheres; half spaces going through the particle's center. The reaction region is bounded by the *reaction range*: :math:`r`. Inside the reaction range, we react only reactant-product pairs. The particles in a pair are swapped from hemisphere to another with a rate prescribed by
 
 .. math::
 
@@ -224,7 +224,7 @@ current implementation with the ``COLLISION_DETECTION`` feature.
     shear with help of an unphysical momentum change in two slabs in the
     system.
 
-    Variants and will initialise NEMD. Two distinct methods exist. Both
+    Variants and will initialize NEMD. Two distinct methods exist. Both
     methods divide the simulation box into slabs that lie parallel to the
     x-y-plane and apply a shear in x direction. The shear is applied in the
     top and the middle slabs. Note, that the methods should be used with a
@@ -293,7 +293,7 @@ The following example introduces the usage::
     absolute_offset = 0.2
     system.lees_edwards_offset = absolute_offset
 
-Lees-Edwards boundary conditions can be used to obtain the shear modulus :math:`G = \frac{\tau}{\gamma}` or the shear viscosity :math:`\eta = \frac{\tau}{\dot\gamma}` outside the linear regime, where Green-Kubo relations are not valid anymore. For this purpose a lees_edwards_offset is set followed by one integration step for multiple times. Strain, strain rate and the shear stress need to be recorded for the calculation. Alternatively a sinusoidal lees_edwards_offset series can be used to carry out oscillatory experiments to calculate viscoelastic moduli (:math:`G', G''`). Furthermore a lees_edwards_offset can be set followed by many integration steps obtain the relaxation behaviour of a system. 
+Lees-Edwards boundary conditions can be used to obtain the shear modulus :math:`G = \frac{\tau}{\gamma}` or the shear viscosity :math:`\eta = \frac{\tau}{\dot\gamma}` outside the linear regime, where Green-Kubo relations are not valid anymore. For this purpose a lees_edwards_offset is set followed by one integration step for multiple times. Strain, strain rate and the shear stress need to be recorded for the calculation. Alternatively a sinusoidal lees_edwards_offset series can be used to carry out oscillatory experiments to calculate viscoelastic moduli (:math:`G', G''`). Furthermore a lees_edwards_offset can be set followed by many integration steps obtain the relaxation behavior of a system. 
 
 When applying a constant shear rate :math:`\dot\gamma` the velocity of the particles changes from :math:`-\frac{\dot\gamma}{2}` at the bottom of the box to :math:`\frac{\dot\gamma}{2}` at the top of the box. 
 
@@ -367,7 +367,7 @@ ibm\_triel, ibm\_tribend and ibm\_volCons:
 
    where , , and are four marker points corresponding to two neighboring
    triangles. The indices and contain the shared edge. Note that the
-   marker points within a triangle must be labelled such that the normal
+   marker points within a triangle must be labeled such that the normal
    vector
    :math:`\vec{n} = (\vec{r}_\text{ind2} - \vec{r}_\text{ind1}) \times (\vec{r}_\text{ind3} - \vec{r}_\text{ind1})`
    points outward of the elastic object.
@@ -416,7 +416,7 @@ are declared in as particles. The edges of the mesh define elastic
 forces keeping the shape of the object. The movement of object is
 achieved by adding forces to the mesh points.
 
-Modelled elastic or rigid objects are immersed in the LB fluid flow. The
+Modeled elastic or rigid objects are immersed in the LB fluid flow. The
 fluid interacts with an elastic object resulting in its deformation;
 this immediately generates forces acting back on the fluid. The aim is
 to describe the immersed object using the notion of particles, and to
@@ -431,7 +431,7 @@ triangulation defines interacting particles distributed on the surface
 of the immersed object :cite:`dupin07`:
 
 -  between two particles, corresponding to the edges in the
-   triangulation (modelling the stretching of the membrane),
+   triangulation (modeling the stretching of the membrane),
 
 -  between three particles, corresponding to the triangles of the
    triangulation (local area, or local surface preservation of the
@@ -472,10 +472,10 @@ be calibrated according to the intended application.
    the dynamics.
 
 -  Friction coefficient. The main parameter describing the
-   fluid-particle interaction is the ``riction \ parameter ``\ rom the
+   fluid-particle interaction is the ``friction \ parameter ``\ rom the
    command ``bf``\ uid .
 
--  Parameters of elastic moduli. Elastic behaviour can be described by
+-  Parameters of elastic moduli. Elastic behavior can be described by
    five different elastic moduli: hyperelastic stretching, linear
    stretching, bending, local and global area preservation and volume
    preservation. Each of them has its own scaling parameter:
@@ -522,7 +522,7 @@ The IDs are assigned in the same order as in the ``mesh-nodes.dat``
 file.
 
 The ``mesh-triangles.dat`` contains ``mesh_ntriangle`` lines with three
-nonnegative integers separated by blank space. Each line represents one
+non-negative integers separated by blank space. Each line represents one
 triangle in the triangulation. For algorithmic purposes it is crucial to
 have defined a correct orientation of the triangle. The orientation is
 defined using the normal vector associated with the triangle. The
@@ -756,7 +756,7 @@ Output information about specific object
 object-id
 
 This command is used to output information about the object that can be
-used for visualisation or as input for other simulations.
+used for visualization or as input for other simulations.
 
 - the id of the object
 

--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -55,9 +55,9 @@ For example, ::
     1.0
     
 
-.. _Particles in the neighbourhood:
+.. _Particles in the neighborhood:
 
-Particles in the neighbourhood
+Particles in the neighborhood
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :meth:`espressomd.analyze.Analysis.nbhood`
@@ -126,13 +126,13 @@ Two arrays are returned corresponding to the normalized distribution and the bin
 
     #. is the number of bins in the radial direction.
 
-    #. The centre point () of the cylinder is located in the lower cap,
-       i.e., is the height of the cylinder with respect to this centre
+    #. The center point () of the cylinder is located in the lower cap,
+       i.e., is the height of the cylinder with respect to this center
        point.
 
     #. The bins are distributed along starting from 0 ().
 
-    #. The seem to average with respect to the centre of mass of the
+    #. The seem to average with respect to the center of mass of the
        particles in the individual bins rather than with respect to the
        central axis, which one would think is natural.
 
@@ -511,7 +511,7 @@ molecule, defined as
 
 where :math:`\vec r_i` are position vectors of individual particles
 constituting a molecule and :math:`\vec r_{\mathrm{cm}}` is the position
-vector of its centre of mass. The sum runs over all :math:`N` particles
+vector of its center of mass. The sum runs over all :math:`N` particles
 comprising the molecule. For more information see any polymer science
 book, e.g. :cite:`rubinstein03a`.
 
@@ -552,7 +552,7 @@ configurations (see section ).
 { … }
 
 The index corresponds to the number of beads between the two monomers
-considered (0 = next neighbours, 1 = one monomer in between, …).
+considered (0 = next neighbors, 1 = one monomer in between, …).
 
 
 .. _Internal distances II (specific monomer):

--- a/doc/sphinx/appendix.rst
+++ b/doc/sphinx/appendix.rst
@@ -65,7 +65,7 @@ Ewald sum, and MMM1D and MMM2D do not require a dipole correction.
 
 Starting from this convergence factor approach, Strebel constructed a
 method of computational order :math:`O(N\log N)`, which is called MMM
-:cite:`strebel99a`. The favourable scaling is obtained,
+:cite:`strebel99a`. The favorable scaling is obtained,
 very much like in the Ewald case, by technical tricks in the calculation
 of the far formula. The far formula has a product decomposition and can
 be evaluated hierarchically similarly to the fast multipole methods.
@@ -96,7 +96,7 @@ exponentials on the left side and on the right side and multiply them
 together, which can be done in :math:`O(N)` computation time. As can be
 seen easily, the convergence of the series is excellent as long as z is
 sufficiently large. By symmetry one can choose the coordinate with the
-largest distance as z to optimise the convergence. Similar to the Lekner
+largest distance as z to optimize the convergence. Similar to the Lekner
 sum, we need a different formula if all coordinates are small, i. e. for
 particles close to each other. For sufficiently small :math:`u_y\rho`
 and :math:`u_xx` we obtain the near formula as
@@ -455,7 +455,7 @@ where
        - 1)}\cos(\omega_q y). \end{array}
 
 The implementation is very similar to MMM2d, except that the separation
-between slices closeby, and above and below is not necessary.
+between slices close by, and above and below is not necessary.
 
 .. _Errors:
 
@@ -474,9 +474,9 @@ estimates is of little importance here, for details see
 :cite:`arnold02c`.
 
 One important aspect is that the error estimates are also exponential in
-the non-periodic coordinate. Since the number of closeby and far away
+the non-periodic coordinate. Since the number of close by and far away
 particles is different for particles near the border and in the center
-of the system, the error distribution is highly non–homogenous. This is
+of the system, the error distribution is highly non–homogeneous. This is
 unproblematic as long as the maximal error is really much smaller than
 the thermal energy. However, one cannot interpret the error simply as an
 additional error source.
@@ -488,7 +488,7 @@ additional error source.
 
 Figure [fig:ELC-error] shows the error distribution of the ELC method
 for a gap size of :math:`10\%` of the total system height. For MMM2D and
-MMM1D the error distribution is less homogenous, however, also here it
+MMM1D the error distribution is less homogeneous, however, also here it
 is always better to have some extra precision, especially since it is
 computationally cheap.
 
@@ -512,7 +512,7 @@ computationally cheap.
 
     Denoting the particle masses with :math:`m_i`, their charges with
     :math:`q_i`, their coordinates and momentum with :math:`\vec r_i` and
-    :math:`\vec p_i` respectively, the interparticle potential (of
+    :math:`\vec p_i` respectively, the inter-particle potential (of
     *non*-electromagnetic type) with :math:`U`, for the coupled system of
     charges and fields we write the following equations of motion
 
@@ -576,7 +576,7 @@ computationally cheap.
     Initialization of the algorithm
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    The algorithm as it is implemented only calculates stepwise time updates
+    The algorithm as it is implemented only calculates step-wise time updates
     of the exact field solution. Therefore in order to start the simulation
     for the given random distribution of charges we have to calculate the
     initial electrostatic field, i. e. the exact solution of the
@@ -732,11 +732,11 @@ computationally cheap.
     -  Only 3D periodic systems are possible for now.
 
     -  With the given interpolation scheme, the short-range part of the
-       potential is highy underestimated when two particles are in the same
+       potential is highly underestimated when two particles are in the same
        lattice cube!
 
     -  The initialization routine scales with :math:`\mathcal{O}(N^3)` and
-       takes a long time for larger (and also inhomogenous) systems.
+       takes a long time for larger (and also inhomogeneous) systems.
 
     -  The algorithm is a local update scheme and spatially varying
        properties can be applied (in the future).
@@ -781,7 +781,7 @@ chemical reactions which can be represented by the general equation:
        \label{general-eq}
 
 where :math:`\nu_i` is the stoichiometric coefficient of species
-:math:`S_i`. By convention, stoichiometric coefficents of the
+:math:`S_i`. By convention, stoichiometric coefficients of the
 species on the left-hand side of the reaction (*reactants*) attain
 negative values, and those on the right-hand side (*products*) attain
 positive values, so that the reaction can be equivalently written as
@@ -807,7 +807,7 @@ Here :math:`k_B` is the Boltzmann constant, :math:`T` is temperature,
 of the reaction, and :math:`\mu_i^{\ominus}` the standard chemical
 potential (per particle) of species :math:`i`. Note that thermodynamic equilibrium is
 independent of the direction in which we write the reaction. If it is
-written with left and righ-hand side swapped, 
+written with left and right-hand side swapped, 
 both :math:`\Delta_{\mathrm{r}}G^{\ominus}` and the stoichiometric
 coefficients attain opposite signs, and the equilibrium constant attains the inverse value. 
 Further, note that the equilibrium constant :math:`K` is the
@@ -818,7 +818,7 @@ defined as
 
    K(c^{\ominus}) = (c^{\ominus})^{-\bar\nu} \prod_i (c_i)^{\nu_i}
 
-wher :math:`\bar\nu=\sum_i \nu_i`, and :math:`c^{\ominus}` is the reference concentration,
+where :math:`\bar\nu=\sum_i \nu_i`, and :math:`c^{\ominus}` is the reference concentration,
 at which the standard chemical potential :math:`\Delta_{\mathrm{r}}G^{\ominus}` was determined.
 In practice, this constant is often used with the dimension of :math:`(c^{\ominus})^{\bar\nu}`
 
@@ -831,7 +831,7 @@ the reaction ensemble consists of two types of moves: the *reaction move*
 and the *configuration move*. The configuration move changes the configuration
 of the system. It is not performed by the Reaction Ensemble module, and can be
 performed by a suitable molecular dynamics or a Monte Carlo scheme. The
-``reacton_ensemble`` command takes care only of the reaction moves.
+``reactant_ensemble`` command takes care only of the reaction moves.
 In the *forward* reaction, the appropriate number of reactants (given by
 :math:`\nu_i`) is removed from the system, and the concomitant number of
 products is inserted into the system. In the *backward* reaction,
@@ -891,7 +891,7 @@ value of :math:`K_c` has to be converted as
    \Bigl( N_{\mathrm{A}}\bigl(\frac{\sigma}{\mathrm{dm}}\bigr)^3\Bigr)^{\bar\nu}
    
 where :math:`N_{\mathrm{A}}` is the Avogardo number.  For gas-phase reactions,
-the pressure-based eaction constant, :math:`K_p` is often used, which can
+the pressure-based reaction constant, :math:`K_p` is often used, which can
 be converted to :math:`K_c` as
 
 .. math::

--- a/doc/sphinx/constraints.rst
+++ b/doc/sphinx/constraints.rst
@@ -6,7 +6,7 @@ Single particle forces (constraints)
 :class:`espressomd.constraints.Constraint`
 
 A Constraint is an immobile surface which can interact with particles via a
-nonbonded potential, where the distance between the two particles is
+non-bonded potential, where the distance between the two particles is
 replaced by the distance of the center of the particle to the surface.
 
 The constraints are identified like a particle via its type ``particle_type`` for the
@@ -31,7 +31,7 @@ Shapes define geometries which can be used in |es| either as
 constraints in particle interactions or as a boundary for a
 Lattice-Boltzmann fluid. 
 
-To avoid unexpected behaviour make sure all parts of your shape are 
+To avoid unexpected behavior make sure all parts of your shape are 
 within the central box since the distance to the shape is calculated only 
 within the central box. If parts of the shape are placed 
 outside of the central box these parts are truncated by the box boundaries. This may 
@@ -71,13 +71,13 @@ invoke the :meth:`espressomd.constraints.add` method::
 
     system.constraints.add(shape_constraint)
 
-All previosly listed shapes can be added to the system's constraints 
+All previously listed shapes can be added to the system's constraints 
 by passing a initialized shape object to :meth:`system.constraints.add`, returning a constraint object ::
   
-    myShape = Wall( dist=20, normal=[0.1, 0.0, 1] )
+    misshaped = Wall( dist=20, normal=[0.1, 0.0, 1] )
     myConstraint = system.constraints.add(shape = myShape, particle_type=p_type)
 
-The extra argument ``particle_type`` specifies the nonbonded interaction to be used with
+The extra argument ``particle_type`` specifies the non-bonded interaction to be used with
 that constraint.
 
 There are two further optional parameters and that can
@@ -114,7 +114,7 @@ This command will delete the specified constraint.
 Getting the currently defined constraints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-One can interate through constraints, for example ::
+One can iterate through constraints, for example ::
   
     >>> for c in system.constraints:
     >>>    print(c.shape)
@@ -191,7 +191,7 @@ Therefore negative distances are quite common!
    :align: center
    :height: 6.00000cm
    
-Pictured is an example cosntraint with a ``Wall`` shape created with ::
+Pictured is an example constraint with a ``Wall`` shape created with ::
 
     wall = Wall( dist=20, normal=[0.1,0.0,1] )
     system.constraints.add(shape=wall, particle_type=0)
@@ -202,7 +202,7 @@ pointing.
 This has only an effect for penetrable walls. If the flag is
 set to 1, then slip boundary interactions apply that are essential for
 microchannel flows like the Plane Poiseuille or Plane Couette Flow.
-Youalso need to use the tunable\_slip interaction (see [sec:tunableSlip])
+You also need to use the tunable\_slip interaction (see [sec:tunableSlip])
 for this too work.
 
 
@@ -219,7 +219,7 @@ The direction ``direction`` determines the force direction, ``-1`` or for inward
    :align: center
    :height: 6.00000cm
    
-Pictured is an example cosntraint with a ``Sphere`` shape created with ::
+Pictured is an example constraint with a ``Sphere`` shape created with ::
   
     sphere = Sphere(center=[25,25,25], radius = 15, direction = 1 )
     system.constraints.add(shape=sphere, particle_type=0)
@@ -323,7 +323,7 @@ and the orientation of the (cylindrically symmetric) stomatocyte is given by a v
 which points in the direction of the symmetry axis, 
 it does not need to be normalized. 
 The parameters: ``outer_radius``, ``inner_radius``, and ``layer_width``, specify the shape of the stomatocyte.
-Here inappropriate choices of these parameters can yield undersired results. 
+Here inappropriate choices of these parameters can yield undesired results. 
 The width ``layer_width`` is used as a scaling parameter.
 That is, a stomatocyte given by ``outer_radius``:``inner_radius``:``layer_width`` = 7:3:1 
 is half the size of the stomatocyte given by 7:3:2. 
@@ -366,10 +366,10 @@ The region is described as a pore (lower vertical part of the "T"-shape) and a c
 The parameter ``channel_width`` specifies the distance between the top and the the plateau edge.
 The parameter ``pore_length`` specifies the distance between the bottom and the plateau edge.
 The parameter ``pore_width`` specifies the distance between the two plateau edges, it is the space between the left and right walls of the pore region.
-The parameter ``pore_mouth`` specifies the location (z-coordinate) of the pore opening (centre). It is always centered in the x-direction.
+The parameter ``pore_mouth`` specifies the location (z-coordinate) of the pore opening (center). It is always centered in the x-direction.
 
 All the edges  are smoothed via the parameters ``upper_smoothing_radius`` (for the concave corner at the edge of the plateau region) and ``lower_smoothing_radius`` (for the convex corner at the bottom of the pore region).
-The meaning of the geometrical parameters can be inferred from the shcematic in fig. [fig:slitpore].
+The meaning of the geometrical parameters can be inferred from the schematic in fig. [fig:slitpore].
 
 
 .. figure:: figures/shape-slitpore.png
@@ -412,7 +412,7 @@ The resulting surface is a section of a hollow cone.
 The parameters ``inner_radius`` and ``outer_radius`` specifies the two radii .
 The parameter ``opening_angle`` specifies the opening angle of the cone (in radians, between 0 and:math:`\pi/2` ), and thus also determines the length.
 
-The orientation of the (cylindrically symmetric) codne is specified with the parameters ``orientation_x``, ``orientation_y`` and ``orientation_z``. It points in the direction of the symmetry axis, and does not need to be normalized.
+The orientation of the (cylindrically symmetric) cone is specified with the parameters ``orientation_x``, ``orientation_y`` and ``orientation_z``. It points in the direction of the symmetry axis, and does not need to be normalized.
 
 The position is specified with ``position_x``, ``position_y`` and ``position_z`` can be any point in the simulation box.
 
@@ -431,13 +431,13 @@ Pictured is an example constraint with a ``Hollowcone`` shape created with ::
     system.constraints.add(shape=hollowcone, particle_type = 0, penetrable = 1)
 
 
-For the shapes ``wall``; ``sphere``; ``cylinder``; ``rhomboid``; ``maze``; ``pore`` and ``stomacyte``, constraints are able to be penetrated if ``penetrable`` is set to ``True``.
+For the shapes ``wall``; ``sphere``; ``cylinder``; ``rhomboid``; ``maze``; ``pore`` and ``stomatocyte``, constraints are able to be penetrated if ``penetrable`` is set to ``True``.
 Otherwise, when the ``penetrable`` option is
 ignored or is set to `False`, the constraint cannot be violated, i.e. no
 particle can go through the constraint surface (|es| will exit if it does).
 
 
-In variants ``wall``; ``sphere``; ``cylinder``; ``rhomboid`` and ``stomacyte`` it is
+In variants ``wall``; ``sphere``; ``cylinder``; ``rhomboid`` and ``stomatocyte`` it is
 also possible to specify a flag indicating if the constraints should be
 reflecting. The flags can equal 1 or 2. The flag 1 corresponds to a
 reflection process where the normal component of the velocity is
@@ -446,7 +446,7 @@ reflected and the tangential component remains unchanged. If the flag is
 motion is performed. The second variant is useful for boundaries of DPD.
 The reflection property is only activated if an interaction is defined
 between a particular particle and the constraint! This will usually be a
-lennard-jones interaction with :math:`\epsilon=0`, but finite
+Lennard-Jones interaction with :math:`\epsilon=0`, but finite
 interaction range.
 
 ..

--- a/doc/sphinx/dg.rst
+++ b/doc/sphinx/dg.rst
@@ -107,7 +107,7 @@ Testsuite
 ---------
 
 -  New or significantly changed features will only be accepted, if they have a test case. 
-   This is to make sure, the feature is not broken by future changes to |es|, and so other users can get an impression of what behaviour is guaranteed to work.
+   This is to make sure, the feature is not broken by future changes to |es|, and so other users can get an impression of what behavior is guaranteed to work.
 -  There are two kinds of tests:
 
   -  C++-unit tests, testing individual C++ functions and classes. They make use of the boost unit test framework and reside in ``src/core/unit_tests``
@@ -128,7 +128,7 @@ Documentation
 The documentation of |es| consists of four parts:
 
   -  The users' guide and developers' guide are located in ``doc/sphinx``, and make use of the Sphinx Python package
-  -  In-code documentation for the Python interface is located in the various files in src/python/espressomd and also makes use of the Sphinx Python package. We make use of the napolean extension and use the NumPy documentation style.
+  -  In-code documentation for the Python interface is located in the various files in src/python/espressomd and also makes use of the Sphinx Python package. We make use of the napoleon extension and use the NumPy documentation style.
   -  In-code documentation of the C++ core is located in the .cpp and .hpp files in ``/src/core`` and its sub-directories and makes use of Doxygen.
 
 Doxygen Code Documentation
@@ -171,7 +171,7 @@ description of the most common commands we need:
 -  | ``\param`` *name* *description*
    | Document the parameter of a function.
 
--  | ``\return`` *decription*
+-  | ``\return`` *description*
    | Document the return value of a function.
 
 .. _Programmers's Guide:
@@ -242,7 +242,7 @@ Using an instance of MpiCallback
 * Write the callback slave function, which will be executed on all nodes except the head node (0)::
 
     void my_callback(int p1, int p2) {
-      // Do something. The two int-parameters can be usued for anything
+      // Do something. The two int-parameters can be used for anything
     }
 
 * On all nodes, the callback has to be registered::
@@ -322,7 +322,7 @@ Use these two files as templates for your interaction.
 
 Notes:
 
-* The names of function arguments mentioned below are taken from the FENE bond in ``src/core/feine.cpp`` and ``src/core/fene.hpp``. It is recommended to use the same names for the corresponding functions for your interaction. 
+* The names of function arguments mentioned below are taken from the FENE bond in ``src/core/fene.cpp`` and ``src/core/fene.hpp``. It is recommended to use the same names for the corresponding functions for your interaction. 
 * The recommended signatures of the force and energy functions are::
 
     inline int calc_fene_pair_force(Particle *p1, Particle *p2, 
@@ -389,7 +389,7 @@ Including the bonded interaction in the force calculation and the energy and pre
   implement a custom solution for virial calculation.
 
 
-Adding the bonded interaciton in the Python interface
+Adding the bonded interaction in the Python interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Please note that the following is Cython code (www.cython.org), rather than pure Python.
@@ -433,7 +433,7 @@ Please note that the following is Cython code (www.cython.org), rather than pure
         
             def __init__(self, *args, **kwargs):
                 """ 
-                FeneBond initialiser. Used to instatiate a FeneBond identifier
+                FeneBond initializer. Used to instantiate a FeneBond identifier
                 with a given set of parameters.
         
                 Parameters
@@ -492,7 +492,7 @@ Please note that the following is Cython code (www.cython.org), rather than pure
 Outdated: Adding New Nonbonded Interactions 
 -------------------------------------------
 
-Writing nonbonded interactions is similar to writing nonbonded
+Writing non-bonded interactions is similar to writing non-bonded
 interactions. Again we start with ``interaction_data.h``, where the
 parameter structure has to be set up. Just add your parameters *with
 reasonable names* to ``IA_parameters``. Note that there must be a
@@ -691,7 +691,7 @@ that your errormessage will automatically be added to the
 your errors an unique 3-digit errorcode (for already used errorcodes
 have a look at the “runtime-errors resolved”-page), have the curled
 braces around your message and the space at the end, otherwise the final
-error message will look awful and will propably not automatically be
+error message will look awful and will probably not automatically be
 added to our error-page. Typically, this looks like this::
 
     if (some_error_code != OK) {

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -16,7 +16,7 @@ where
    :label: coulomb_prefactor
     
 is a prefactor which can be set by the user. 
-The commonly used Bjerrum length :math:`l_B = e_o^2 / (4 \pi \e\epsilon k_B T)` is the length at which the Coulomb energy between two unit charges is equal to the thermal energy :math:`k_B T`.
+The commonly used Bdrm length :math:`l_B = e_o^2 / (4 \pi \e\epsilon k_B T)` is the length at which the Coulomb energy between two unit charges is equal to the thermal energy :math:`k_B T`.
 Based on the this length, the prefactor is given by :math:`C=l_B *k_B T`.
 
 Computing electrostatic interactions is computationally very expensive.
@@ -239,7 +239,7 @@ actor and can be activated via::
 	icc=ICC(<See the following list of ICC parameters>)
 	system.actors.add(icc)
 
-Paremters are:
+Parameters are:
 
 	* first_id: 
 		ID of the first ICC Particle.
@@ -366,11 +366,11 @@ using it.
     leads to the following rule of thumb for the parameter choices:
 
     -  The lattice should be of the size of your particle size (i.e. the
-       lennard jones epsilon). That means: 
+       Lennard Jones epsilon). That means: 
        :math:`\text{mesh} \approx \text{box_l} / \text{lj_sigma}`
 
     -  The integration timestep should be in a range where no particle moves
-       more than one lattice box (i.e. lennard jones sigma) per timestep.
+       more than one lattice box (i.e. Lennard Jones sigma) per timestep.
 
     -  The speed of light should satisfy the stability criterion
        :math:`c\ll a/dt`, where :math:`a` is the lattice spacing and
@@ -533,12 +533,12 @@ MMM2D
 
 MMM2D is an electrostatics solver for explicit 2D periodic systems.
 It can account for different dielectric jumps on both sides of the 
-nonperiodic direction. MMM2D coulomb method needs periodicity 1 1 0 and the
+non-periodic direction. MMM2D coulomb method needs periodicity 1 1 0 and the
 layered cell system. The performance of the method depends on the number of
 slices of the cell system, which has to be tuned manually. It is
 automatically ensured that the maximal pairwise error is smaller than
-the given bound. Note thate the user has to take care that the particles don't
-leave the box in the nonperiodic z-direction e.g. with constraints. By default,
+the given bound. Note that the user has to take care that the particles don't
+leave the box in the non-periodic z-direction e.g. with constraints. By default,
 no dielectric contrast is set and it is used as::
 
 	mmm2d = electrostatics.MMM2D(prefactor=C, maxPWerror = 1e-3)
@@ -632,9 +632,9 @@ Parameters are:
         forces/energies in *ELC* and is therefore only possible with the
         ``const_pot_on`` option.
     * const_pot_on: 
-        As descibed, setting this to ``1`` leads to fully metallic boundaries and
-        behaves just like the mmm2d parameter of the same name: It maintaines a
-        constant potential ``pot_diff`` by countering the total dipol moment of
+        As described, setting this to ``1`` leads to fully metallic boundaries and
+        behaves just like the mmm2d parameter of the same name: It maintains a
+        constant potential ``pot_diff`` by countering the total dipole moment of
         the system and adding a homogeneous electric field according to
         ``pot_diff``.
     * pot_diff:

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -194,7 +194,7 @@ invocation is implementation dependent, but in many cases, such as
 
     mpirun -n <N> ./pypresso <SCRIPT>
 
-where ``<N>`` is the number of prcessors to be used.
+where ``<N>`` is the number of processors to be used.
 
 
 .. _Configuring:
@@ -417,7 +417,7 @@ integrator or thermostat:
 ..
     -  ``NEMD`` Enables the non-equilbrium (shear) MD support.
 
-       .. seealso:: :ref:`\`\`nemd\`\`\: Setting up non-equilibirum MD`
+       .. seealso:: :ref:`\`\`nemd\`\`\: Setting up non-equilibrium MD`
 
 -  ``NPT`` Enables an on–the–fly NPT integration scheme.
    
@@ -706,7 +706,7 @@ platforms as you want.
 
 When the source directory is ``srcdir`` (the files where unpacked to this
 directory), then the user can create a build directory ``build`` below that
-path by calling ``mkdir srcdir/build``. In the build direcotry `cmake` is to be
+path by calling ``mkdir srcdir/build``. In the build directory `cmake` is to be
 executed, followed by a call of make. None of the files in the source directory
 is ever modified when by the build process.
 
@@ -730,7 +730,7 @@ to configure |es| interactively.
 **Example:**
 
 Alternatively to the previous example instead of , the executable is
-called in the build direcotry to configure ESPResSo previous to its
+called in the build directory to configure ESPResSo previous to its
 compilation followed by a call of make:
 
 .. code-block:: bash
@@ -756,7 +756,7 @@ Fig. :ref:`ccmake-figure` shows the interactive ccmake UI.
 Options and Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
-The behaviour of |es| can be controlled by the means of options and variables
+The behavior of |es| can be controlled by the means of options and variables
 in the CMakeLists.txt file. Also options are defined there. The following
 options are available:
 
@@ -772,7 +772,7 @@ options are available:
   markers
 
 When the value in the CMakeLists.txt file is set to ON the corresponding
-option is created if the value of the opition is set to OFF the
+option is created if the value of the option is set to OFF the
 corresponding option is not created. These options can also be modified
 by calling cmake with the command line argument ``-D``::
 
@@ -872,7 +872,7 @@ Debugging |es|
 Exceptional situations occur in every program.  If |es| crashes with a
 segmentation fault that means that there was a memory fault in the
 simulation core which requires running the program in a debugger.  The
-`pypresso` executable file is acutally not a program but a script
+`pypresso` executable file is actually not a program but a script
 which sets the Python path appropriately and starts the Python
 interpreter with your arguments.  Thus it is not possible to directly
 run `pypresso` in a debugger.  However, we provide some useful

--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -305,7 +305,7 @@ The parameter ``bond_angle`` is a bond type identifier of three possible bond-an
     .. math:: V(\phi) = \frac{K}{2} \left(\phi - \phi_0\right)^2.
 
     :math:`K` is the bending constant,
-    and the optional parameter :math:`\phi_0` is the equilibirum bond angle in
+    and the optional parameter :math:`\phi_0` is the equilibrium bond angle in
     radians ranging from 0 to :math:`\pi`.
 
     If this parameter is not given, it defaults to :math:`\phi_0 = \pi`,
@@ -329,7 +329,7 @@ The parameter ``bond_angle`` is a bond type identifier of three possible bond-an
     .. math:: V(\phi) = K \left[1 - \cos(\phi - \phi0)\right]
 
     :math:`K` is the bending constant,
-    and the optional parameter :math:`\phi_0` is the equilibirum bond angle in
+    and the optional parameter :math:`\phi_0` is the equilibrium bond angle in
     radians ranging from 0 to :math:`\pi`.
 
     If this parameter is not given, it defaults to :math:`\phi_0 = \pi`,

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -559,7 +559,7 @@ DPD interaction
     `Feature DPD required.`
 
 This is a special interaction that is to be used in conjunction with the
-`Dissipative Particle Dynamics (DPD)` thermostat, for a genral description
+`Dissipative Particle Dynamics (DPD)` thermostat, for a general description
 of the algorithm see there. The parameters can be set via::
 
     system.non_bonded_inter[type1, type2].dpd.set_params(**kwargs)
@@ -588,7 +588,7 @@ and random weight function are related by the dissipation-fluctuation theorem:
 
 .. math:: (\sigma w^R (r_{ij}))^2=\zeta w^D (r_{ij}) \text{k}_\text{B} T
 
-The possible values for weight_function are 0 and 1, correcpoding to the
+The possible values for weight_function are 0 and 1, corresponding to the
 order of :math:`w^D`:
 
 .. math::

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -112,7 +112,7 @@ can be changed at any moment of runtime. In this way methods like
 thermodynamic integration become readily accessible.
 
 The focus of the user guide is documenting the scripting interface, its
-behaviour and use in the simulation. It only describes certain technical
+behavior and use in the simulation. It only describes certain technical
 details of implementation which are necessary for understanding how the
 script interface works. Technical documentation of the code and program
 structure is contained in the Developers’ guide (see section [sec:dg]).
@@ -355,7 +355,7 @@ Several scripts that can serve as usage examples can be found in the directory `
     Visualization for poisseuille flow with Lattice-Boltzmann.
 
 * ``visualization_constraints.py``
-    Constraint visualization with opengl with all avaiable constraints (commented out).
+    Constraint visualization with opengl with all available constraints (commented out).
 
 * ``visualization_mmm2d.py``
     A visual sample for a constant potential plate capacitor simulated with mmm2d.

--- a/doc/sphinx/io.rst
+++ b/doc/sphinx/io.rst
@@ -120,7 +120,7 @@ To give an example::
     checkpoint.register("p3m")
 
 will register the user variables ``skin`` and ``myvar``, system properties, a
-langevin thermostat, non-bonded interactions, particle properties and a p3m
+Langevin thermostat, non-bonded interactions, particle properties and a p3m
 object for checkpointing. It is important to note that the checkpointing of
 |es| will only save basic system properties. This excludes for example the
 system thermostat or the particle data. For this reason one has to explicitly

--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -75,7 +75,7 @@ For vectorial particle properties, component-wise manipulation like ``system.par
 = 1`` or in-place operators like ``+=`` or ``*=`` are not allowed and result in an error.
 This behavior is inherited, so the same applies to ``a`` after ``a =
 system.part[0].pos``. If you want to use an vectorial property for further
-calculations, you should explicity make a copy e.g. via
+calculations, you should explicitly make a copy e.g. via
 ``a = numpy.copy(system.part[0].pos)``.
 
 .. _Interacting with groups of particles:
@@ -103,7 +103,7 @@ Setting slices can be done by
 
     system.part[0:3].ext_force = [[1, 0, 0], [2, 0, 0], [3, 0, 0]]
 
-For list properties that have no fixed length like ``exculsions`` or ``bonds``, some care has to be taken.
+For list properties that have no fixed length like ``exclusions`` or ``bonds``, some care has to be taken.
 There, *single value* assignment also accepts lists/tuples just like setting the property of an individual particle. For example::
 
     system.part[0].exclusions = [1, 2]
@@ -160,9 +160,9 @@ You can iterate over all pairs of particles using::
 Exclusions
 ----------
 
-Particles can have an exclusion list of all other particles where nonbonded interactions are ignored.
+Particles can have an exclusion list of all other particles where non-bonded interactions are ignored.
 This is typically used in atomistic simulations, 
-where nearest and next nearest neighbour interactions along the chain have to be omitted since they are included in the bonding potentials.
+where nearest and next nearest neighbor interactions along the chain have to be omitted since they are included in the bonding potentials.
 Be aware that currently, exclusions also remove the short range part of electrostatics and dipolar interactions. Hence, exclusions should not be applied to pairs of particles which are charged or carry a dipole.
 
 
@@ -316,7 +316,7 @@ To switch the active scheme, the attribute :attr:`espressomd.system.System.virtu
     s.virtual_sites=VirtualSitesOff()
 
 By default, :class:`espressomd.virtual_sites.VirtualSitesOff` is selected. This means that virtual particles are not touched during integration.
-the `have_velocity` attribute determines, whether or not the velocity of virtual sites is calcualted, which carries a performance cost.
+the `have_velocity` attribute determines, whether or not the velocity of virtual sites is calculated, which carries a performance cost.
 
 .. _Rigid arrangements of particles: 
 
@@ -462,7 +462,7 @@ Please note:
     Additional features
     ~~~~~~~~~~~~~~~~~~~
 
-    The behaviour of virtual sites can be fine-tuned with the following
+    The behavior of virtual sites can be fine-tuned with the following
     switches in ``myconfig.hpp``.
 
     - VIRTUAL_SITES_NO_VELOCITY specifies that the velocity of virtual sites is not computed

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -75,7 +75,7 @@ and can be called from there (second variant)::
     system.minimize_energy.minimize()
 
 This command runs a steepest descent energy minimization on the system.
-Please note that the behaviour is undefined if either a thermostat,
+Please note that the behavior is undefined if either a thermostat,
 Maggs electrostatics or Lattice-Boltzmann is activated. It runs a simple
 steepest descent algorithm:
 
@@ -141,7 +141,7 @@ Notes:
 * The space-frame direction of the particle's z-axis in its body frame is accessible through the `espressomd.particle_data.ParticleHandle.director` property.
 * Any other vector can be converted from body to space fixed frame using the `espressomd.particle_data.ParticleHandle.convert_vector_body_to_space` method.
 * When DIPOLES are compiled in, the particles dipole moment is always co-aligned with the z-axis in the body-fixed frame.
-* Changing the particles dipole moment and director will re-orient the particle such that its z-axis in space frame is aligned parallel to the given vector. No guarantees are made for the other two axes after setting the direcotr or the dipole moment.
+* Changing the particles dipole moment and director will re-orient the particle such that its z-axis in space frame is aligned parallel to the given vector. No guarantees are made for the other two axes after setting the director or the dipole moment.
 
 
 The following particle properties are related to rotation:

--- a/doc/sphinx/system_manipulation.rst
+++ b/doc/sphinx/system_manipulation.rst
@@ -86,7 +86,7 @@ Force capping can be activated via  :class:`espressomd.system.System`::
     system.force_cap = F_max
 
 This command will limit the magnitude of the force to :math:`r F_\mathrm{max}`.
-Enegies are not affected by the capping, so the energy can be used to
+Energies are not affected by the capping, so the energy can be used to
 identify the remaining overlap. The force capping is switched off by setting
 :math:`F_\mathrm{max}=0`.
 
@@ -122,7 +122,7 @@ This command sets all forces on the particles to zero, as well as all
 torques if the option ``torque`` is specified and the feature ROTATION
 has been compiled in.
 
-* The centre of mass of the system
+* The center of mass of the system
 
 ::
 
@@ -131,7 +131,7 @@ has been compiled in.
 Returns the center of mass of the whole system. It currently does not
 factor in the density fluctuations of the Lattice-Boltzmann fluid.
 
-* The centre-of-mass velocity
+* The center-of-mass velocity
 
 ::
     

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -17,7 +17,7 @@ vectorial properties ``box_l`` and ``periodicity``, component-wise manipulation
 like ``system.box_l[0] = 1`` or in-place operators like ``+=`` or ``*=`` are not
 allowed and result in an error. This behavior is inherited, so the same applies
 to ``a`` after ``a = system.box_l``. If you want to use an vectorial property
-for further calculations, you should explicity make a copy e.g. via
+for further calculations, you should explicitly make a copy e.g. via
 ``a = numpy.copy(system.box_l)``.
 
 * :py:attr:`~espressomd.system.System.box_l`
@@ -419,7 +419,7 @@ See this code snippet for the two commands::
 
 Be aware that this feature is neither properly examined for all systems
 nor is it maintained regularly. If you use it and notice strange
-behaviour, please contribute to solving the problem.
+behavior, please contribute to solving the problem.
 
 .. _CUDA:
 

--- a/doc/sphinx/under_the_hood.rst
+++ b/doc/sphinx/under_the_hood.rst
@@ -15,22 +15,22 @@ Internal particle organization
 Since basically all major parts of the main MD integration have to
 access the particle data, efficient access to the particle data is
 crucial for a fast MD code. Therefore the particle data needs some more
-elaborate organisation, which will be presented here. A particle itself
+elaborate organization, which will be presented here. A particle itself
 is represented by a structure (Particle) consisting of several
 substructures (e. g. ParticlePosition, ParticleForce or
 ParticleProperties), which in turn represent basic physical properties
-such as position, force or charge. The particles are organised in one or
+such as position, force or charge. The particles are organized in one or
 more particle lists on each node, called Cell cells. The cells are
 arranged by several possible systems, the cellsystems as described
 above. A cell system defines a way the particles are stored in , i. e.
 how they are distributed onto the processor nodes and how they are
-organised on each of them. Moreover a cell system also defines
+organized on each of them. Moreover a cell system also defines
 procedures to efficiently calculate the force, energy and pressure for
-the short ranged interactions, since these can be heavily optimised
+the short ranged interactions, since these can be heavily optimized
 depending on the cell system. For example, the domain decomposition
 cellsystem allows an order N interactions evaluation.
 
-Technically, a cell is organised as a dynamically growing array, not as
+Technically, a cell is organized as a dynamically growing array, not as
 a list. This ensures that the data of all particles in a cell is stored
 contiguously in the memory. The particle data is accessed transparently
 through a set of methods common to all cell systems, which allocate the
@@ -51,13 +51,13 @@ a :math:`10\times 20\times 20` box. If the maximal interaction range is
 coordinate, allowing for a small skin of 0.05. If one chooses only 6
 boxes in the first coordinate, the skin depth increases to 0.467. In
 this example we assume that the number of cells in the first coordinate
-was chosen to be 6 and that the cells are cubic. would then organise the
+was chosen to be 6 and that the cells are cubic. would then organize the
 cells on each node in a :math:`6\times
-12\times 12` cell grid embedded at the centre of a
+12\times 12` cell grid embedded at the center of a
 :math:`8\times 14 \times
 14` grid. The additional cells around the cells containing the particles
 represent the ghost shell in which the information of the ghost
-particles from the neighbouring nodes is stored. Therefore the particle
+particles from the neighboring nodes is stored. Therefore the particle
 information stored on each node resides in 1568 particle lists of which
 864 cells contain particles assigned to the node, the rest contain
 information of particles from other nodes.a
@@ -81,16 +81,16 @@ double data rate (DDR) RAM transfers up to 3.2GB/s at this clock speed
 (at each edge of the clock signal 8 bytes are transferred). But in
 addition to the data transfer speed, DDR RAM has some latency for
 fetching the data, which can be up to 50ns in the worst case. Memory is
-organised internally in pages or rows of typically 8KB size. The full
+organized internally in pages or rows of typically 8KB size. The full
 :math:`2\times 200` MHz data rate can only be achieved if the access is
 within the same memory page (page hit), otherwise some latency has to be
 added (page miss). The actual latency depends on some other aspects of
-the memory organisation which will not be discussed here, but the
+the memory organization which will not be discussed here, but the
 penalty is at least 10ns, resulting in an effective memory transfer rate
 of only 800MB/s. To remedy this, modern processors have a small amount
 of low latency memory directly attached to the processor, the cache.
 
-The processor cache is organised in different levels. The level 1 (L1)
+The processor cache is organized in different levels. The level 1 (L1)
 cache is built directly into the processor core, has no latency and
 delivers the data immediately on demand, but has only a small size of
 around 128KB. This is important since modern processors can issue
@@ -103,11 +103,11 @@ In a typical implementation of the link cell scheme the order of the
 particles is fairly random, determined e. g. by the order in which the
 particles are set up or have been communicated across the processor
 boundaries. The force loop therefore accesses the particle array in
-arbitrary order, resulting in a lot of unfavourable page misses. In the
-memory organisation of , the particles are accessed in a virtually
+arbitrary order, resulting in a lot of unfavorable page misses. In the
+memory organization of , the particles are accessed in a virtually
 linear order. Because the force calculation goes through the cells in a
 linear fashion, all accesses to a single cell occur close in time, for
-the force calculation of the cell itself as well as for its neighbours.
+the force calculation of the cell itself as well as for its neighbors.
 Using the domain decomposition cell scheme, two cell layers have to be
 kept in the processor cache. For 10000 particles and a typical cell grid
 size of 20, these two cell layers consume roughly 200 KBytes, which

--- a/doc/sphinx/visualization.rst
+++ b/doc/sphinx/visualization.rst
@@ -31,7 +31,7 @@ General usage
 
 The recommended usage of both tools is similar: Create the visualizer of
 your choice and pass it the ``espressomd.System()`` object. Then write
-your integration loop in a seperate function, which is started in a
+your integration loop in a separate function, which is started in a
 non-blocking thread. Whenever needed, call ``update()`` to synchronize
 the renderer with your system. Finally start the blocking visualization
 window with ``start()``. See the following minimal code example::
@@ -69,14 +69,14 @@ Common methods for openGL and mayavi
 | :meth:`espressomd.visualization.mayaviLive.update()` 
 | :meth:`espressomd.visualization.openGLLive.update()`
 
-``update()`` synchonizes system and visualizer, handles keyboard events for
+``update()`` synchronizes system and visualizer, handles keyboard events for
 openGLLive.
 
 | :meth:`espressomd.visualization.mayaviLive.start()` 
 | :meth:`espressomd.visualization.openGLLive.start()`
 
 ``start()`` starts the blocking visualizer window. 
-Should be called after a seperate thread containing ``update()`` has been started.
+Should be called after a separate thread containing ``update()`` has been started.
 
 | :meth:`espressomd.visualization.mayaviLive.register_callback()`
 | :meth:`espressomd.visualization.openGLLive.register_callback()`
@@ -93,7 +93,7 @@ The mayavi visualizer is created with the following syntax:
 
 :class:`espressomd.visualization.mayaviLive()`
 
-Required paramters:
+Required parameters:
     * `system`: The espressomd.System() object.
 Optional keywords:
     * `particle_sizes`:
@@ -109,7 +109,7 @@ OpenGL visualizer
 | :meth:`espressomd.visualization.openGLLive.run()` 
 
 To visually debug your simulation, ``run()`` can be used to conveniently start 
-an integration loop in a seperate thread once the visualizer is initialized::
+an integration loop in a separate thread once the visualizer is initialized::
 
     import espressomd 
     from espressomd import visualization 
@@ -130,7 +130,7 @@ an integration loop in a seperate thread once the visualizer is initialized::
 The optional keywords in ``**kwargs`` are used to adjust the appearance of the visualization.
 The parameters have suitable default values for most simulations. 
 
-Required paramters:
+Required parameters:
     * `system`: The espressomd.System() object.
 Optional keywords:
     * `window_size`: Size of the visualizer window in pixels.
@@ -145,7 +145,7 @@ Optional keywords:
     * `quality_constraints`: The number of subdivisions for primitive constraints.
     * `close_cut_distance`: The distance from the viewer to the near clipping plane.
     * `far_cut_distance`: The distance from the viewer to the far clipping plane.
-    * `camera_position`: Initial camera position. `auto` (default) for shiftet position in z-direction. 
+    * `camera_position`: Initial camera position. `auto` (default) for shifted position in z-direction. 
     * `camera_target`: Initial camera target. `auto` (default) to look towards the system center.
     * `camera_right`: Camera right vector in system coordinates. Default is [1, 0, 0] 
     * `particle_sizes`:     
@@ -163,7 +163,7 @@ Optional keywords:
     * `rasterize_pointsize`: Point size for the rasterization dots.
     * `rasterize_resolution`: Accuracy of the rasterization.
     * `quality_constraints`: The number of subdivisions for primitive constraints.
-    * `constraint_type_colors`: Colors of the constaints by type.
+    * `constraint_type_colors`: Colors of the constraints by type.
     * `constraint_type_materials`: Materials of the constraints by type.
     * `draw_bonds`: Enables bond visualization.
     * `bond_type_radius`: Radii of bonds by type.


### PR DESCRIPTION
Realized that there were some typos in sphinx documentation while reading.
Had a quick spellcheck with aspell (en_US).