### PR TITLE
Get rid of SQR macro and SQR definition outside Utils namespace.

### DIFF
--- a/src/core/actor/EwaldGPU.cpp
+++ b/src/core/actor/EwaldGPU.cpp
@@ -2,16 +2,16 @@
 
 #ifdef EWALD_GPU
 
-#include <iostream>
 #include <algorithm>
+#include <iostream>
 #include <vector>
 
 #include "cells.hpp"
 #include "grid.hpp"
 #include "integrate.hpp"
 #include "interaction_data.hpp"
-#include "tuning.hpp"
 #include "partCfg_global.hpp"
+#include "tuning.hpp"
 
 #define DEBUG(A) std::cout << #A << ": " << (A) << std::endl;
 
@@ -28,12 +28,13 @@ void EwaldgpuForce::compute_num_k() {
         if (ix * (2 * m_num_ky + 1) * (2 * m_num_kz + 1) +
                     iy * (2 * m_num_kz + 1) + iz >=
                 0 // Half m_k-space
-            and
-            SQR(ix) * SQR(m_num_ky) * SQR(m_num_kz) +
-                    SQR(iy) * SQR(m_num_kx) * SQR(m_num_kz) +
-                    SQR(iz) * SQR(m_num_kx) * SQR(m_num_ky) <=
-                SQR(m_num_kx) * SQR(m_num_ky) *
-                    SQR(m_num_kz)) // m_k-space ellipsoid
+            and Utils::sqr(ix) * Utils::sqr(m_num_ky) * Utils::sqr(m_num_kz) +
+                        Utils::sqr(iy) * Utils::sqr(m_num_kx) *
+                            Utils::sqr(m_num_kz) +
+                        Utils::sqr(iz) * Utils::sqr(m_num_kx) *
+                            Utils::sqr(m_num_ky) <=
+                    Utils::sqr(m_num_kx) * Utils::sqr(m_num_ky) *
+                        Utils::sqr(m_num_kz)) // m_k-space ellipsoid
         {
           Index += 1;
         }
@@ -53,22 +54,23 @@ void EwaldgpuForce::compute_k_AND_influence_factor() {
         if (ix * (2 * m_num_ky + 1) * (2 * m_num_kz + 1) +
                     iy * (2 * m_num_kz + 1) + iz >=
                 0 // Half m_k-space
-            and
-            SQR(ix) * SQR(m_num_ky) * SQR(m_num_kz) +
-                    SQR(iy) * SQR(m_num_kx) * SQR(m_num_kz) +
-                    SQR(iz) * SQR(m_num_kx) * SQR(m_num_ky) <=
-                SQR(m_num_kx) * SQR(m_num_ky) *
-                    SQR(m_num_kz)) // m_k-space ellipsoid
+            and Utils::sqr(ix) * Utils::sqr(m_num_ky) * Utils::sqr(m_num_kz) +
+                        Utils::sqr(iy) * Utils::sqr(m_num_kx) *
+                            Utils::sqr(m_num_kz) +
+                        Utils::sqr(iz) * Utils::sqr(m_num_kx) *
+                            Utils::sqr(m_num_ky) <=
+                    Utils::sqr(m_num_kx) * Utils::sqr(m_num_ky) *
+                        Utils::sqr(m_num_kz)) // m_k-space ellipsoid
         {
           // m_k vectors
           m_k[Index] = 2 * M_PI / m_box_l[0] * ix;
           m_k[Index + m_num_k] = 2 * M_PI / m_box_l[1] * iy;
           m_k[Index + 2 * m_num_k] = 2 * M_PI / m_box_l[2] * iz;
           // Influence factor
-          k_sqr = SQR(m_k[Index]) + SQR(m_k[Index + m_num_k]) +
-                  SQR(m_k[Index + 2 * m_num_k]);
+          k_sqr = Utils::sqr(m_k[Index]) + Utils::sqr(m_k[Index + m_num_k]) +
+                  Utils::sqr(m_k[Index + 2 * m_num_k]);
           m_infl_factor[Index] =
-              8 * M_PI / m_V * expf(-k_sqr / (4 * SQR(m_alpha))) / k_sqr;
+              8 * M_PI / m_V * expf(-k_sqr / (4 * Utils::sqr(m_alpha))) / k_sqr;
           // Index
           Index += 1;
         }
@@ -108,9 +110,11 @@ int EwaldgpuForce::set_params_tune(double accuracy, double precision, int K_max,
 int EwaldgpuForce::adaptive_tune(char **log, SystemInterface &s) {
   ewaldgpu_params.isTuned = false;
   int Kmax = ewaldgpu_params.K_max;
-  std::vector<double> alpha_array(Kmax); //  All computed alpha in dependence of K
-  std::vector<double> rcut_array(Kmax);  //  All computed r_cut in dependence of all computed
-                            //  alpha
+  std::vector<double> alpha_array(
+      Kmax); //  All computed alpha in dependence of K
+  std::vector<double> rcut_array(
+      Kmax); //  All computed r_cut in dependence of all computed
+             //  alpha
 
   // Squared charge
   auto const q_sqr = std::accumulate(
@@ -289,8 +293,8 @@ double EwaldgpuForce::compute_E_error_estimate_r(double alpha, double rcut,
   double std_deviation;
   std_deviation = q_sqr *
                   pow(rcut / (2.0 * box_l[0] * box_l[1] * box_l[2]), 0.5) *
-                  exp(-SQR(alpha) * SQR(rcut)) /
-                  (SQR(alpha * rcut)); // Kolafa-Perram, eq. 18
+                  exp(-Utils::sqr(alpha) * Utils::sqr(rcut)) /
+                  (Utils::sqr(alpha * rcut)); // Kolafa-Perram, eq. 18
 
   return std_deviation;
 }
@@ -300,10 +304,10 @@ double EwaldgpuForce::compute_E_error_estimate_k(double alpha, int num_kx,
                                                  double box_l[3]) {
   // Compute the r space part of the force error estimate
   double std_deviation;
-  std_deviation =
-      q_sqr * alpha * pow(M_PI, -2.0) * pow(num_kx, -1.5) *
-      exp(-(SQR(M_PI * num_kx / (alpha * (box_l[0] + box_l[1] + box_l[2]) /
-                                 3.0)))); // Kolafa Perram, eq. 32
+  std_deviation = q_sqr * alpha * pow(M_PI, -2.0) * pow(num_kx, -1.5) *
+                  exp(-(Utils::sqr(M_PI * num_kx /
+                                   (alpha * (box_l[0] + box_l[1] + box_l[2]) /
+                                    3.0)))); // Kolafa Perram, eq. 32
   return std_deviation;
 }
 double EwaldgpuForce::E_estimate_error(double rcut, int num_kx, int num_ky,
@@ -362,7 +366,7 @@ double EwaldgpuForce::compute_q_sqare(Particle *particle) {
   double q_sqr = 0;
 
   for (int i = 0; i < n_part; i++) {
-    q_sqr += SQR(particle[i].p.q);
+    q_sqr += Utils::sqr(particle[i].p.q);
   }
   return q_sqr;
 }

--- a/src/core/actor/EwaldGPU.cpp
+++ b/src/core/actor/EwaldGPU.cpp
@@ -20,6 +20,8 @@ extern Ewaldgpu_params ewaldgpu_params;
 
 // Compute reciprocal space vectors k
 void EwaldgpuForce::compute_num_k() {
+  using Utils::sqr;
+
   int Index = 0; // Arrayindex
 
   for (long long ix = 0; ix <= m_num_kx; ix++) {
@@ -28,13 +30,11 @@ void EwaldgpuForce::compute_num_k() {
         if (ix * (2 * m_num_ky + 1) * (2 * m_num_kz + 1) +
                     iy * (2 * m_num_kz + 1) + iz >=
                 0 // Half m_k-space
-            and Utils::sqr(ix) * Utils::sqr(m_num_ky) * Utils::sqr(m_num_kz) +
-                        Utils::sqr(iy) * Utils::sqr(m_num_kx) *
-                            Utils::sqr(m_num_kz) +
-                        Utils::sqr(iz) * Utils::sqr(m_num_kx) *
-                            Utils::sqr(m_num_ky) <=
-                    Utils::sqr(m_num_kx) * Utils::sqr(m_num_ky) *
-                        Utils::sqr(m_num_kz)) // m_k-space ellipsoid
+            and sqr(ix) * sqr(m_num_ky) * sqr(m_num_kz) +
+                        sqr(iy) * sqr(m_num_kx) * sqr(m_num_kz) +
+                        sqr(iz) * sqr(m_num_kx) * sqr(m_num_ky) <=
+                    sqr(m_num_kx) * sqr(m_num_ky) *
+                        sqr(m_num_kz)) // m_k-space ellipsoid
         {
           Index += 1;
         }
@@ -44,6 +44,8 @@ void EwaldgpuForce::compute_num_k() {
   m_num_k = Index;
 }
 void EwaldgpuForce::compute_k_AND_influence_factor() {
+  using Utils::sqr;
+
   real k_sqr;    // Absolute square of m_k-vector
   int Index = 0; // Arrayindex
 
@@ -54,23 +56,21 @@ void EwaldgpuForce::compute_k_AND_influence_factor() {
         if (ix * (2 * m_num_ky + 1) * (2 * m_num_kz + 1) +
                     iy * (2 * m_num_kz + 1) + iz >=
                 0 // Half m_k-space
-            and Utils::sqr(ix) * Utils::sqr(m_num_ky) * Utils::sqr(m_num_kz) +
-                        Utils::sqr(iy) * Utils::sqr(m_num_kx) *
-                            Utils::sqr(m_num_kz) +
-                        Utils::sqr(iz) * Utils::sqr(m_num_kx) *
-                            Utils::sqr(m_num_ky) <=
-                    Utils::sqr(m_num_kx) * Utils::sqr(m_num_ky) *
-                        Utils::sqr(m_num_kz)) // m_k-space ellipsoid
+            and sqr(ix) * sqr(m_num_ky) * sqr(m_num_kz) +
+                        sqr(iy) * sqr(m_num_kx) * sqr(m_num_kz) +
+                        sqr(iz) * sqr(m_num_kx) * sqr(m_num_ky) <=
+                    sqr(m_num_kx) * sqr(m_num_ky) *
+                        sqr(m_num_kz)) // m_k-space ellipsoid
         {
           // m_k vectors
           m_k[Index] = 2 * M_PI / m_box_l[0] * ix;
           m_k[Index + m_num_k] = 2 * M_PI / m_box_l[1] * iy;
           m_k[Index + 2 * m_num_k] = 2 * M_PI / m_box_l[2] * iz;
           // Influence factor
-          k_sqr = Utils::sqr(m_k[Index]) + Utils::sqr(m_k[Index + m_num_k]) +
-                  Utils::sqr(m_k[Index + 2 * m_num_k]);
+          k_sqr = sqr(m_k[Index]) + sqr(m_k[Index + m_num_k]) +
+                  sqr(m_k[Index + 2 * m_num_k]);
           m_infl_factor[Index] =
-              8 * M_PI / m_V * expf(-k_sqr / (4 * Utils::sqr(m_alpha))) / k_sqr;
+              8 * M_PI / m_V * expf(-k_sqr / (4 * sqr(m_alpha))) / k_sqr;
           // Index
           Index += 1;
         }

--- a/src/core/actor/EwaldGPU_ShortRange.hpp
+++ b/src/core/actor/EwaldGPU_ShortRange.hpp
@@ -3,35 +3,48 @@
 
 #ifdef EWALD_GPU
 #include "actor/EwaldGPU.hpp"
+#include "utils.hpp"
 
-#define SQR(A) ((A)*(A))
-
-//Add energy
-inline double ewaldgpu_coulomb_pair_energy(double chgfac, double *d,double dist2,double dist)
-{
-  if (dist < ewaldgpu_params.rcut)
-  {
-     return coulomb.prefactor*chgfac*erfc(ewaldgpu_params.alpha*dist)/dist;
+// Add energy
+inline double ewaldgpu_coulomb_pair_energy(double chgfac, double *d,
+                                           double dist2, double dist) {
+  if (dist < ewaldgpu_params.rcut) {
+    return coulomb.prefactor * chgfac * erfc(ewaldgpu_params.alpha * dist) /
+           dist;
   }
   return 0.0;
 }
 
-//Add forces
-inline void add_ewald_gpu_coulomb_pair_force(Particle *p1, Particle *p2, double d[3], double dist, double force[3])
-{
-  const double rcut=ewaldgpu_params.rcut;
-  if(dist < rcut)
-  {
+// Add forces
+inline void add_ewald_gpu_coulomb_pair_force(Particle *p1, Particle *p2,
+                                             double d[3], double dist,
+                                             double force[3]) {
+  const double rcut = ewaldgpu_params.rcut;
+  if (dist < rcut) {
     int j;
     double fac;
 
-    fac=coulomb.prefactor * p1->p.q * p2->p.q * (  2*ewaldgpu_params.alpha*wupii*exp(-SQR(ewaldgpu_params.alpha *dist)) + erfc(ewaldgpu_params.alpha*dist)/dist )/SQR(dist);
+    fac = coulomb.prefactor * p1->p.q * p2->p.q *
+          (2 * ewaldgpu_params.alpha * wupii *
+               exp(-Utils::sqr(ewaldgpu_params.alpha * dist)) +
+           erfc(ewaldgpu_params.alpha * dist) / dist) /
+          Utils::sqr(dist);
 
-    for(j=0;j<3;j++)
+    for (j = 0; j < 3; j++)
       force[j] += fac * d[j];
 
-    ONEPART_TRACE(if(p1->p.identity==check_id) fprintf(stderr,"%d: OPT: EWALD_GPU   f = (%.3e,%.3e,%.3e) with part id=%d at dist %f fac %.3e\n",this_node,p1->f.f[0],p1->f.f[1],p1->f.f[2],p2->p.identity,dist,fac));
-    ONEPART_TRACE(if(p2->p.identity==check_id) fprintf(stderr,"%d: OPT: EWALD_GPU   f = (%.3e,%.3e,%.3e) with part id=%d at dist %f fac %.3e\n",this_node,p2->f.f[0],p2->f.f[1],p2->f.f[2],p1->p.identity,dist,fac));
+    ONEPART_TRACE(if (p1->p.identity == check_id)
+                      fprintf(stderr,
+                              "%d: OPT: EWALD_GPU   f = (%.3e,%.3e,%.3e) with "
+                              "part id=%d at dist %f fac %.3e\n",
+                              this_node, p1->f.f[0], p1->f.f[1], p1->f.f[2],
+                              p2->p.identity, dist, fac));
+    ONEPART_TRACE(if (p2->p.identity == check_id)
+                      fprintf(stderr,
+                              "%d: OPT: EWALD_GPU   f = (%.3e,%.3e,%.3e) with "
+                              "part id=%d at dist %f fac %.3e\n",
+                              this_node, p2->f.f[0], p2->f.f[1], p2->f.f[2],
+                              p1->p.identity, dist, fac));
   }
 }
 

--- a/src/core/angle_cosine.hpp
+++ b/src/core/angle_cosine.hpp
@@ -75,7 +75,7 @@ inline int calc_angle_cosine_force(Particle *p_mid, Particle *p_left, Particle *
 
   if ( cosine >  TINY_COS_VALUE ) cosine = TINY_COS_VALUE;
   if ( cosine < -TINY_COS_VALUE)  cosine = -TINY_COS_VALUE;
-  fac *= iaparams->p.angle_cosine.sin_phi0 * (cosine/sqrt(1-SQR(cosine))) + iaparams->p.angle_cosine.cos_phi0;
+  fac *= iaparams->p.angle_cosine.sin_phi0 * (cosine/sqrt(1-Utils::sqr(cosine))) + iaparams->p.angle_cosine.cos_phi0;
   
   for(j=0;j<3;j++) {
     f1               = fac * (cosine * vec1[j] - vec2[j]) * d1i;
@@ -118,7 +118,7 @@ inline void calc_angle_cosine_3body_forces(Particle *p_mid, Particle *p_left,
   vec31_sqr = sqrlen(vec31);
   vec31_magn = sqrt(vec31_sqr);
   cos_phi = scalar(vec21, vec31) / (vec21_magn * vec31_magn);
-  sin_phi = sqrt(1.0 - SQR(cos_phi));
+  sin_phi = sqrt(1.0 - Utils::sqr(cos_phi));
 
   /* uncomment this block if interested in the angle 
   if(cos_phi < -1.0) cos_phi = -TINY_COS_VALUE;
@@ -184,7 +184,7 @@ inline int angle_cosine_energy(Particle *p_mid, Particle *p_left, Particle *p_ri
   if ( cosine < -TINY_COS_VALUE)  cosine = -TINY_COS_VALUE;
   /* bond angle energy */
 
-  *_energy = iaparams->p.angle_cosine.bend*(cosine*iaparams->p.angle_cosine.cos_phi0 - sqrt(1-SQR(cosine))*iaparams->p.angle_cosine.sin_phi0+1);
+  *_energy = iaparams->p.angle_cosine.bend*(cosine*iaparams->p.angle_cosine.cos_phi0 - sqrt(1-Utils::sqr(cosine))*iaparams->p.angle_cosine.sin_phi0+1);
 
   return 0;
 }

--- a/src/core/angle_cossquare.hpp
+++ b/src/core/angle_cossquare.hpp
@@ -116,7 +116,7 @@ inline void calc_angle_cossquare_3body_forces(Particle *p_mid, Particle *p_left,
   vec31_sqr = sqrlen(vec31);
   vec31_magn = sqrt(vec31_sqr);
   cos_phi = scalar(vec21, vec31) / (vec21_magn * vec31_magn);
-  sin_phi = sqrt(1.0 - SQR(cos_phi));
+  sin_phi = sqrt(1.0 - Utils::sqr(cos_phi));
 
   /* uncomment this block if interested in the angle 
   if(cos_phi < -1.0) cos_phi = -TINY_COS_VALUE;
@@ -178,7 +178,7 @@ inline int angle_cossquare_energy(Particle *p_mid, Particle *p_left, Particle *p
   if ( cosine >  TINY_COS_VALUE)  cosine = TINY_COS_VALUE;
   if ( cosine < -TINY_COS_VALUE)  cosine = -TINY_COS_VALUE;
   /* bond angle energy */
-  *_energy = 0.5*iaparams->p.angle_cossquare.bend*SQR(cosine + iaparams->p.angle_cossquare.cos_phi0);
+  *_energy = 0.5*iaparams->p.angle_cossquare.bend*Utils::sqr(cosine + iaparams->p.angle_cossquare.cos_phi0);
   return 0;
 }
 

--- a/src/core/angle_harmonic.hpp
+++ b/src/core/angle_harmonic.hpp
@@ -126,7 +126,7 @@ inline void calc_angle_harmonic_3body_forces(Particle *p_mid, Particle *p_left,
   vec31_sqr = sqrlen(vec31);
   vec31_magn = sqrt(vec31_sqr);
   cos_phi = scalar(vec21, vec31) / (vec21_magn * vec31_magn);
-  sin_phi = sqrt(1.0 - SQR(cos_phi));
+  sin_phi = sqrt(1.0 - Utils::sqr(cos_phi));
 
   /* uncomment this block if interested in the angle 
   if(cos_phi < -1.0) cos_phi = -TINY_COS_VALUE;
@@ -195,7 +195,7 @@ inline int angle_harmonic_energy(Particle *p_mid, Particle *p_left, Particle *p_
   {
     double phi;
     phi =  acos(-cosine);
-    *_energy = 0.5*iaparams->p.angle_harmonic.bend*SQR(phi - iaparams->p.angle_harmonic.phi0);
+    *_energy = 0.5*iaparams->p.angle_harmonic.bend*Utils::sqr(phi - iaparams->p.angle_harmonic.phi0);
   }
   return 0;
 }

--- a/src/core/angledist.cpp
+++ b/src/core/angledist.cpp
@@ -202,7 +202,7 @@ int angledist_energy(Particle *p_mid, Particle *p_left, Particle *p_right,
     double phi;
     double phi0 = calc_angledist_param(p_mid, p_left, p_right, iaparams);
     phi = acos(-cosine);
-    *_energy = 0.5 * iaparams->p.angledist.bend * SQR(phi - phi0);
+    *_energy = 0.5 * iaparams->p.angledist.bend * Utils::sqr(phi - phi0);
   }
 #endif
 

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -374,7 +374,7 @@ void cells_on_geometry_change(int flags) {
 /*************************************************/
 
 void check_resort_particles() {
-  const double skin2 = SQR(skin / 2.0);
+  const double skin2 = Utils::sqr(skin / 2.0);
 
   resort_particles |= (std::any_of(local_cells.particles().begin(),
                                    local_cells.particles().end(),

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -153,7 +153,7 @@ void add_dpd_pair_force(Particle *p1, Particle *p2, IA_parameters *ia_params,
       omega = dist_inv - 1.0 / ia_params->dpd_r_cut;
     }
 
-    omega2 = SQR(omega);
+    omega2 = Utils::sqr(omega);
     // DPD part
     // friction force prefactor
     for (j = 0; j < 3; j++)
@@ -174,7 +174,7 @@ void add_dpd_pair_force(Particle *p1, Particle *p2, IA_parameters *ia_params,
       omega = dist_inv - 1.0 / ia_params->dpd_tr_cut;
     }
 
-    omega2 = SQR(omega);
+    omega2 = Utils::sqr(omega);
 
     for (i = 0; i < 3; i++) {
       // noise vector

--- a/src/core/elc.cpp
+++ b/src/core/elc.cpp
@@ -358,7 +358,7 @@ static double dipole_energy() {
   for (auto &p : local_cells.particles()) {
     gblcblk[0] += p.p.q;
     gblcblk[2] += p.p.q * (p.r.p[2] - shift);
-    gblcblk[4] += p.p.q * (SQR(p.r.p[2] - shift));
+    gblcblk[4] += p.p.q * (Utils::sqr(p.r.p[2] - shift));
     gblcblk[6] += p.p.q * p.r.p[2];
 
     if (elc_params.dielectric_contrast_on) {
@@ -366,14 +366,14 @@ static double dipole_energy() {
         gblcblk[1] += elc_params.delta_mid_bot * p.p.q;
         gblcblk[3] += elc_params.delta_mid_bot * p.p.q * (-p.r.p[2] - shift);
         gblcblk[5] +=
-            elc_params.delta_mid_bot * p.p.q * (SQR(-p.r.p[2] - shift));
+            elc_params.delta_mid_bot * p.p.q * (Utils::sqr(-p.r.p[2] - shift));
       }
       if (p.r.p[2] > (elc_params.h - elc_params.space_layer)) {
         gblcblk[1] += elc_params.delta_mid_top * p.p.q;
         gblcblk[3] += elc_params.delta_mid_top * p.p.q *
                       (2 * elc_params.h - p.r.p[2] - shift);
         gblcblk[5] += elc_params.delta_mid_top * p.p.q *
-                      (SQR(2 * elc_params.h - p.r.p[2] - shift));
+                      (Utils::sqr(2 * elc_params.h - p.r.p[2] - shift));
       }
     }
   }
@@ -381,18 +381,18 @@ static double dipole_energy() {
   distribute(size);
 
   // Yeh + Berkowitz term
-  double eng = 2 * pref * (SQR(gblcblk[2]) + gblcblk[2] * gblcblk[3]);
+  double eng = 2 * pref * (Utils::sqr(gblcblk[2]) + gblcblk[2] * gblcblk[3]);
 
   if (!elc_params.neutralize) {
     // SUBTRACT the energy of the P3M homogeneous neutralizing background
     eng += 2 * pref * (-gblcblk[0] * gblcblk[4] -
-                       (.25 - .5 / 3.) * SQR(gblcblk[0] * box_l[2]));
+                       (.25 - .5 / 3.) * Utils::sqr(gblcblk[0] * box_l[2]));
   }
 
   if (elc_params.dielectric_contrast_on) {
     if (elc_params.const_pot) {
       // zero potential difference contribution
-      eng += pref * height_inverse / uz * SQR(gblcblk[6]);
+      eng += pref * height_inverse / uz * Utils::sqr(gblcblk[6]);
       // external potential shift contribution
       eng -= elc_params.pot_diff * height_inverse * gblcblk[6];
     }
@@ -401,7 +401,7 @@ static double dipole_energy() {
        boundaries.  We never need that, since a homogeneous background
        spanning the artifical boundary layers is aphysical. */
     eng += pref * (-(gblcblk[1] * gblcblk[4] + gblcblk[0] * gblcblk[5]) -
-                   (1. - 2. / 3.) * gblcblk[0] * gblcblk[1] * SQR(box_l[2]));
+                   (1. - 2. / 3.) * gblcblk[0] * gblcblk[1] * Utils::sqr(box_l[2]));
   }
 
   return this_node == 0 ? eng : 0;
@@ -1072,10 +1072,10 @@ void ELC_add_force() {
   }
 
   for (p = 1; ux * (p - 1) < elc_params.far_cut && p <= n_scxcache; p++) {
-    for (q = 1; SQR(ux * (p - 1)) + SQR(uy * (q - 1)) < elc_params.far_cut2 &&
+    for (q = 1; Utils::sqr(ux * (p - 1)) + Utils::sqr(uy * (q - 1)) < elc_params.far_cut2 &&
                 q <= n_scycache;
          q++) {
-      omega = C_2PI * sqrt(SQR(ux * p) + SQR(uy * q));
+      omega = C_2PI * sqrt(Utils::sqr(ux * p) + Utils::sqr(uy * q));
       setup_PQ(p, q, omega);
       distribute(8);
       add_PQ_force(p, q, omega);
@@ -1112,10 +1112,10 @@ double ELC_energy() {
     checkpoint("E************distri q", 0, q, 2);
   }
   for (p = 1; ux * (p - 1) < elc_params.far_cut && p <= n_scxcache; p++) {
-    for (q = 1; SQR(ux * (p - 1)) + SQR(uy * (q - 1)) < elc_params.far_cut2 &&
+    for (q = 1; Utils::sqr(ux * (p - 1)) + Utils::sqr(uy * (q - 1)) < elc_params.far_cut2 &&
                 q <= n_scycache;
          q++) {
-      omega = C_2PI * sqrt(SQR(ux * p) + SQR(uy * q));
+      omega = C_2PI * sqrt(Utils::sqr(ux * p) + Utils::sqr(uy * q));
       setup_PQ(p, q, omega);
       distribute(8);
       eng += PQ_energy(omega);
@@ -1154,7 +1154,7 @@ int ELC_tune(double error) {
   if (elc_params.far_cut >= MAXIMAL_FAR_CUT)
     return ES_ERROR;
   elc_params.far_cut -= min_inv_boxl;
-  elc_params.far_cut2 = SQR(elc_params.far_cut);
+  elc_params.far_cut2 = Utils::sqr(elc_params.far_cut);
 
   return ES_OK;
 }
@@ -1316,7 +1316,7 @@ int ELC_set_params(double maxPWerror, double gap_size, double far_cut,
 
   elc_params.far_cut = far_cut;
   if (far_cut != -1) {
-    elc_params.far_cut2 = SQR(far_cut);
+    elc_params.far_cut2 = Utils::sqr(far_cut);
     elc_params.far_calculated = 0;
   } else {
     elc_params.far_calculated = 1;
@@ -1592,19 +1592,19 @@ void ELC_P3M_modify_p3m_sums_both() {
     if (p.p.q != 0.0) {
 
       node_sums[0] += 1.0;
-      node_sums[1] += SQR(p.p.q);
+      node_sums[1] += Utils::sqr(p.p.q);
       node_sums[2] += p.p.q;
 
       if (p.r.p[2] < elc_params.space_layer) {
 
         node_sums[0] += 1.0;
-        node_sums[1] += SQR(elc_params.delta_mid_bot * p.p.q);
+        node_sums[1] += Utils::sqr(elc_params.delta_mid_bot * p.p.q);
         node_sums[2] += elc_params.delta_mid_bot * p.p.q;
       }
       if (p.r.p[2] > (elc_params.h - elc_params.space_layer)) {
 
         node_sums[0] += 1.0;
-        node_sums[1] += SQR(elc_params.delta_mid_top * p.p.q);
+        node_sums[1] += Utils::sqr(elc_params.delta_mid_top * p.p.q);
         node_sums[2] += elc_params.delta_mid_top * p.p.q;
       }
     }
@@ -1613,7 +1613,7 @@ void ELC_P3M_modify_p3m_sums_both() {
   MPI_Allreduce(node_sums, tot_sums, 3, MPI_DOUBLE, MPI_SUM, comm_cart);
   p3m.sum_qpart = (int)(tot_sums[0] + 0.1);
   p3m.sum_q2 = tot_sums[1];
-  p3m.square_sum_q = SQR(tot_sums[2]);
+  p3m.square_sum_q = Utils::sqr(tot_sums[2]);
 }
 
 void ELC_P3M_modify_p3m_sums_image() {
@@ -1630,13 +1630,13 @@ void ELC_P3M_modify_p3m_sums_image() {
       if (p.r.p[2] < elc_params.space_layer) {
 
         node_sums[0] += 1.0;
-        node_sums[1] += SQR(elc_params.delta_mid_bot * p.p.q);
+        node_sums[1] += Utils::sqr(elc_params.delta_mid_bot * p.p.q);
         node_sums[2] += elc_params.delta_mid_bot * p.p.q;
       }
       if (p.r.p[2] > (elc_params.h - elc_params.space_layer)) {
 
         node_sums[0] += 1.0;
-        node_sums[1] += SQR(elc_params.delta_mid_top * p.p.q);
+        node_sums[1] += Utils::sqr(elc_params.delta_mid_top * p.p.q);
         node_sums[2] += elc_params.delta_mid_top * p.p.q;
       }
     }
@@ -1646,7 +1646,7 @@ void ELC_P3M_modify_p3m_sums_image() {
 
   p3m.sum_qpart = (int)(tot_sums[0] + 0.1);
   p3m.sum_q2 = tot_sums[1];
-  p3m.square_sum_q = SQR(tot_sums[2]);
+  p3m.square_sum_q = Utils::sqr(tot_sums[2]);
 }
 
 // this function is required in force.cpp for energy evaluation
@@ -1662,7 +1662,7 @@ void ELC_P3M_restore_p3m_sums() {
     if (p.p.q != 0.0) {
 
       node_sums[0] += 1.0;
-      node_sums[1] += SQR(p.p.q);
+      node_sums[1] += Utils::sqr(p.p.q);
       node_sums[2] += p.p.q;
     }
   }
@@ -1671,7 +1671,7 @@ void ELC_P3M_restore_p3m_sums() {
 
   p3m.sum_qpart = (int)(tot_sums[0] + 0.1);
   p3m.sum_q2 = tot_sums[1];
-  p3m.square_sum_q = SQR(tot_sums[2]);
+  p3m.square_sum_q = Utils::sqr(tot_sums[2]);
 }
 
 #endif

--- a/src/core/endangledist.cpp
+++ b/src/core/endangledist.cpp
@@ -194,7 +194,7 @@ int calc_endangledist_pair_force(Particle *p1, Particle *p2,
 //#ifdef BOND_ENDANGLEDIST_HARMONIC
 //    /* Force = -dU/dr_i= k*smooth*(phi-phi0)/sin(phi)(cosphi*vec + n)/|vec| */
 //    fac_a = bend * (phi - phieq) / sinphi;
-//    fac_b = 0.5 * bend * SQR(phi - phieq);
+//    fac_b = 0.5 * bend * Utils::sqr(phi - phieq);
 //    for (i = 0; i < 3; i++) {
 //      gradharm1 = -1.0 * fac_a *
 //                  (cosphi * vec[i] - constraints[clconstr].c.wal.n[i]) * di;
@@ -265,7 +265,7 @@ int endangledist_pair_energy(Particle *p1, Particle *p2,
 //    /*fprintf(stdout,"clconstr=%d smooth=%f\n",clconstr,smooth);*/
 //    bend = iaparams->p.endangledist.bend;
 //    phieq = iaparams->p.endangledist.phi0;
-//    *_energy = 0.5 * bend * smooth * SQR(phi - phieq);
+//    *_energy = 0.5 * bend * smooth * Utils::sqr(phi - phieq);
 //  } else if (distwallmin >= distmx) {
 //    *_energy = 0.0;
 //  }

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -506,13 +506,13 @@ inline void add_kinetic_energy(Particle *p1) {
   //   if (p1->p.smaller_timestep==1) {
   //     ostringstream msg;
   //     msg << "SMALL TIME STEP";
-  //     energy.data.e[0] += SQR(smaller_time_step/time_step) *
-  //       (SQR(p1->m.v[0]) + SQR(p1->m.v[1]) + SQR(p1->m.v[2]))*(*p1).p.mass;
+  //     energy.data.e[0] += Utils::sqr(smaller_time_step/time_step) *
+  //       (Utils::sqr(p1->m.v[0]) + Utils::sqr(p1->m.v[1]) + Utils::sqr(p1->m.v[2]))*(*p1).p.mass;
   //   }
   //   else
   // #endif
   energy.data.e[0] +=
-      (SQR(p1->m.v[0]) + SQR(p1->m.v[1]) + SQR(p1->m.v[2])) * (*p1).p.mass;
+      (Utils::sqr(p1->m.v[0]) + Utils::sqr(p1->m.v[1]) + Utils::sqr(p1->m.v[2])) * (*p1).p.mass;
 
 #ifdef ROTATION
   if (p1->p.rotation)
@@ -520,9 +520,9 @@ inline void add_kinetic_energy(Particle *p1) {
     /* the rotational part is added to the total kinetic energy;
        Here we use the rotational inertia  */
 
-    energy.data.e[0] += (SQR(p1->m.omega[0]) * p1->p.rinertia[0] +
-                         SQR(p1->m.omega[1]) * p1->p.rinertia[1] +
-                         SQR(p1->m.omega[2]) * p1->p.rinertia[2]) *
+    energy.data.e[0] += (Utils::sqr(p1->m.omega[0]) * p1->p.rinertia[0] +
+                         Utils::sqr(p1->m.omega[1]) * p1->p.rinertia[1] +
+                         Utils::sqr(p1->m.omega[2]) * p1->p.rinertia[2]) *
                         time_step * time_step;
   }
 #endif

--- a/src/core/fene.cpp
+++ b/src/core/fene.cpp
@@ -38,7 +38,7 @@ int fene_set_params(int bond_type, double k, double drmax, double r0)
   bonded_ia_params[bond_type].p.fene.drmax = drmax;
   bonded_ia_params[bond_type].p.fene.r0 = r0;
 
-  bonded_ia_params[bond_type].p.fene.drmax2 = SQR(bonded_ia_params[bond_type].p.fene.drmax);
+  bonded_ia_params[bond_type].p.fene.drmax2 = Utils::sqr(bonded_ia_params[bond_type].p.fene.drmax);
   bonded_ia_params[bond_type].p.fene.drmax2i = 1.0/bonded_ia_params[bond_type].p.fene.drmax2;
 
   bonded_ia_params[bond_type].type = BONDED_IA_FENE;

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -109,8 +109,8 @@ inline void init_ghost_force(Particle *part) {
     part->f.torque[2] = 0;
 
     /* and rescale quaternion, so it is exactly of unit length */
-    scale = sqrt(SQR(part->r.quat[0]) + SQR(part->r.quat[1]) +
-                 SQR(part->r.quat[2]) + SQR(part->r.quat[3]));
+    scale = sqrt(Utils::sqr(part->r.quat[0]) + Utils::sqr(part->r.quat[1]) +
+                 Utils::sqr(part->r.quat[2]) + Utils::sqr(part->r.quat[3]));
     part->r.quat[0] /= scale;
     part->r.quat[1] /= scale;
     part->r.quat[2] /= scale;
@@ -164,8 +164,8 @@ inline void init_local_particle_force(Particle *part) {
 #endif
 
     /* and rescale quaternion, so it is exactly of unit length */
-    scale = sqrt(SQR(part->r.quat[0]) + SQR(part->r.quat[1]) +
-                 SQR(part->r.quat[2]) + SQR(part->r.quat[3]));
+    scale = sqrt(Utils::sqr(part->r.quat[0]) + Utils::sqr(part->r.quat[1]) +
+                 Utils::sqr(part->r.quat[2]) + Utils::sqr(part->r.quat[3]));
     part->r.quat[0] /= scale;
     part->r.quat[1] /= scale;
     part->r.quat[2] /= scale;

--- a/src/core/gaussian.hpp
+++ b/src/core/gaussian.hpp
@@ -46,7 +46,7 @@ inline void add_gaussian_pair_force(const Particle *const p1,
   int j;
   if ((dist < ia_params->Gaussian_cut)) {
     fac = ia_params->Gaussian_eps / pow(ia_params->Gaussian_sig, 2) *
-          exp(-0.5 * SQR(dist / ia_params->Gaussian_sig));
+          exp(-0.5 * Utils::sqr(dist / ia_params->Gaussian_sig));
 
     for (j = 0; j < 3; j++)
       force[j] += fac * d[j];
@@ -60,7 +60,7 @@ inline double gaussian_pair_energy(const Particle *p1, const Particle *p2,
                                    double dist2) {
   if ((dist < ia_params->Gaussian_cut)) {
     return ia_params->Gaussian_eps *
-           exp(-0.5 * SQR(dist / ia_params->Gaussian_sig));
+           exp(-0.5 * Utils::sqr(dist / ia_params->Gaussian_sig));
   }
   return 0.0;
 }

--- a/src/core/ghmc.cpp
+++ b/src/core/ghmc.cpp
@@ -144,9 +144,9 @@ double calc_local_temp() {
 
   for (auto &p : local_cells.particles()) {
     for (int j = 0; j < 3; j++) {
-      temp += p.p.mass * SQR(p.m.v[j] / time_step);
+      temp += p.p.mass * Utils::sqr(p.m.v[j] / time_step);
 #ifdef ROTATION
-      temp += SQR(p.m.omega[j]);
+      temp += Utils::sqr(p.m.omega[j]);
 #endif
     }
   }
@@ -168,13 +168,13 @@ void calc_kinetic(double *ek_trans, double *ek_rot) {
 #endif
 
     /* kinetic energy */
-    et += (SQR(p.m.v[0]) + SQR(p.m.v[1]) + SQR(p.m.v[2])) * (p).p.mass;
+    et += (Utils::sqr(p.m.v[0]) + Utils::sqr(p.m.v[1]) + Utils::sqr(p.m.v[2])) * (p).p.mass;
 
 /* rotational energy */
 #ifdef ROTATION
-    er += SQR(p.m.omega[0]) * p.p.rinertia[0] +
-          SQR(p.m.omega[1]) * p.p.rinertia[1] +
-          SQR(p.m.omega[2]) * p.p.rinertia[2];
+    er += Utils::sqr(p.m.omega[0]) * p.p.rinertia[0] +
+          Utils::sqr(p.m.omega[1]) * p.p.rinertia[1] +
+          Utils::sqr(p.m.omega[2]) * p.p.rinertia[2];
 #endif
   }
 

--- a/src/core/harmonic.hpp
+++ b/src/core/harmonic.hpp
@@ -88,7 +88,7 @@ inline int harmonic_pair_energy(Particle *p1, Particle *p2, Bonded_ia_parameters
       (dist > iaparams->p.harmonic.r_cut)) 
     return 1;
 
-  *_energy = 0.5*iaparams->p.harmonic.k*SQR(dist - iaparams->p.harmonic.r);
+  *_energy = 0.5*iaparams->p.harmonic.k*Utils::sqr(dist - iaparams->p.harmonic.r);
   return 0;
 }
 

--- a/src/core/harmonic_dumbbell.hpp
+++ b/src/core/harmonic_dumbbell.hpp
@@ -126,7 +126,7 @@ inline int harmonic_dumbbell_pair_energy(Particle *p1, Particle *p2, Bonded_ia_p
   diff[1] = dhat[1] - p1->r.quatu[1];
   diff[2] = dhat[2] - p1->r.quatu[2];
 
-  *_energy = 0.5*iaparams->p.harmonic_dumbbell.k1*SQR(dist - iaparams->p.harmonic.r)
+  *_energy = 0.5*iaparams->p.harmonic_dumbbell.k1*Utils::sqr(dist - iaparams->p.harmonic.r)
            + 0.5*iaparams->p.harmonic_dumbbell.k2*(torque[0]*diff[0] + torque[1]*diff[1] + torque[2]*diff[2]);
   return 0;
 }

--- a/src/core/hydrogen_bond.cpp
+++ b/src/core/hydrogen_bond.cpp
@@ -47,7 +47,7 @@ inline void cross(double *x1, double *x2, double *x3)
 }
 
 inline double norm2(double *x) {
-  return SQR(x[0]) + SQR(x[1]) + SQR(x[2]);
+  return Utils::sqr(x[0]) + Utils::sqr(x[1]) + Utils::sqr(x[2]);
 }
 
 inline double norm(double *x) {
@@ -183,24 +183,24 @@ int calc_hydrogen_bond_force(Particle *s1, Particle *b1, Particle *b2, Particle 
   dpsi1 = psi1 - params.p.hydrogen_bond.psi10;
   dpsi2 = psi2 - params.p.hydrogen_bond.psi20;
 
-  const double sigma1sqr = (SQR(params.p.hydrogen_bond.sigma1));
-  const double sigma2sqr = (SQR(params.p.hydrogen_bond.sigma2));
+  const double sigma1sqr = (Utils::sqr(params.p.hydrogen_bond.sigma1));
+  const double sigma2sqr = (Utils::sqr(params.p.hydrogen_bond.sigma2));
 
-  f_f1 = -dpsi1 / sqrt(1. - SQR(gamma1)) * params.p.hydrogen_bond.E0/sigma1sqr;
-  f_f2 = -dpsi2 / sqrt(1. - SQR(gamma2)) * params.p.hydrogen_bond.E0/sigma2sqr;
+  f_f1 = -dpsi1 / sqrt(1. - Utils::sqr(gamma1)) * params.p.hydrogen_bond.E0/sigma1sqr;
+  f_f2 = -dpsi2 / sqrt(1. - Utils::sqr(gamma2)) * params.p.hydrogen_bond.E0/sigma2sqr;
   
   tau_rd = tau_r * tau_d;
 
   if(dpsi1 > 0 && dpsi2 > 0) {
-    tau_flip = exp(-(SQR(dpsi1)/(2.*sigma1sqr)+
-		     SQR(dpsi2)/(2.*sigma2sqr)));
+    tau_flip = exp(-(Utils::sqr(dpsi1)/(2.*sigma1sqr)+
+		     Utils::sqr(dpsi2)/(2.*sigma2sqr)));
     f_f1 *= tau_flip * tau_rd;
     f_f2 *= tau_flip * tau_rd;
   } else if (dpsi1 > 0.) {
-    tau_flip = exp(-(SQR(dpsi1)/(2.*sigma1sqr)));
+    tau_flip = exp(-(Utils::sqr(dpsi1)/(2.*sigma1sqr)));
     f_f1 *= tau_flip * tau_rd;
   } else if (dpsi2 > 0.) {
-    tau_flip = exp(-(SQR(dpsi2)/(2.*sigma2sqr)));
+    tau_flip = exp(-(Utils::sqr(dpsi2)/(2.*sigma2sqr)));
     f_f2 *= tau_flip * tau_rd;
   } else {
     tau_flip = 1.;
@@ -212,10 +212,10 @@ int calc_hydrogen_bond_force(Particle *s1, Particle *b1, Particle *b2, Particle 
   const double k_constraint = 50.;
 
   if(psi1 > psi_cutoff) {
-    f_f1 += k_constraint*(psi1-psi_cutoff)/sqrt(1. - SQR(gamma1));
+    f_f1 += k_constraint*(psi1-psi_cutoff)/sqrt(1. - Utils::sqr(gamma1));
   }
   if(psi2 > psi_cutoff) {
-    f_f2 += k_constraint*(psi2-psi_cutoff)/sqrt(1. - SQR(gamma2));
+    f_f2 += k_constraint*(psi2-psi_cutoff)/sqrt(1. - Utils::sqr(gamma2));
   }
 
   f_r *= tau_d*tau_flip;  
@@ -232,12 +232,12 @@ int calc_hydrogen_bond_force(Particle *s1, Particle *b1, Particle *b2, Particle 
   const double dot5 = dot1 + dot3;
 
   const double factor1 = f_f1/(rcc_l * rcb1_l);
-  const double factor2 = f_f1*gamma1/SQR(rcb1_l);
-  const double factor3 = f_f1*gamma1/SQR(rcc_l);
+  const double factor2 = f_f1*gamma1/Utils::sqr(rcb1_l);
+  const double factor3 = f_f1*gamma1/Utils::sqr(rcc_l);
 
   const double factor4 = f_f2/(rcc_l * rcb2_l);
-  const double factor5 = f_f2*gamma2/SQR(rcb2_l);
-  const double factor6 = f_f2*gamma2/SQR(rcc_l);
+  const double factor5 = f_f2*gamma2/Utils::sqr(rcb2_l);
+  const double factor6 = f_f2*gamma2/Utils::sqr(rcc_l);
 
   double fBase1, fSugar2, fBase2, fSugar1;
   double fr, n1n, n2n;
@@ -434,20 +434,20 @@ int calc_hydrogen_bond_energy(Particle *s1, Particle *b1, Particle *b2, Particle
   dpsi1 = psi1 - params.p.hydrogen_bond.psi10;
   dpsi2 = psi2 - params.p.hydrogen_bond.psi20;
 
-  const double sigma1sqr = (SQR(params.p.hydrogen_bond.sigma1));
-  const double sigma2sqr = (SQR(params.p.hydrogen_bond.sigma2));
+  const double sigma1sqr = (Utils::sqr(params.p.hydrogen_bond.sigma1));
+  const double sigma2sqr = (Utils::sqr(params.p.hydrogen_bond.sigma2));
   
   if(dpsi1 > 0 && dpsi2 > 0) {
-    tau_flip = exp(-(SQR(dpsi1)/(2.*sigma1sqr)+SQR(dpsi2)/(2.*sigma2sqr)));
+    tau_flip = exp(-(Utils::sqr(dpsi1)/(2.*sigma1sqr)+Utils::sqr(dpsi2)/(2.*sigma2sqr)));
   } else if (dpsi1 > 0.) {
-    tau_flip = exp(-(SQR(dpsi1)/(2.*sigma1sqr)));
-    potential += SQR(dpsi2)*(-0.5*E0/sigma2sqr);
+    tau_flip = exp(-(Utils::sqr(dpsi1)/(2.*sigma1sqr)));
+    potential += Utils::sqr(dpsi2)*(-0.5*E0/sigma2sqr);
   } else if (dpsi2 > 0.) {
-    tau_flip = exp(-(SQR(dpsi2)/(2.*sigma2sqr)));
-    potential += SQR(dpsi1)*(-0.5*E0/sigma1sqr);
+    tau_flip = exp(-(Utils::sqr(dpsi2)/(2.*sigma2sqr)));
+    potential += Utils::sqr(dpsi1)*(-0.5*E0/sigma1sqr);
   } else {
     tau_flip = 1.;
-    potential += SQR(dpsi2)*(-0.5*E0/sigma2sqr) + SQR(dpsi1)*(-0.5*E0/sigma1sqr);
+    potential += Utils::sqr(dpsi2)*(-0.5*E0/sigma2sqr) + Utils::sqr(dpsi1)*(-0.5*E0/sigma1sqr);
   }
 
   /* Angle at which the constraint sets in */
@@ -456,10 +456,10 @@ int calc_hydrogen_bond_energy(Particle *s1, Particle *b1, Particle *b2, Particle
   const double k_constraint = 50.;
 
   if(psi1 > psi_cutoff) {
-    potential += 0.5*k_constraint*SQR(psi1-psi_cutoff);
+    potential += 0.5*k_constraint*Utils::sqr(psi1-psi_cutoff);
   }
   if(psi2 > psi_cutoff) {
-    potential += 0.5*k_constraint*SQR(psi2-psi_cutoff);
+    potential += 0.5*k_constraint*Utils::sqr(psi2-psi_cutoff);
   }
  
   potential += tau_r * tau_flip * tau_d * E0;

--- a/src/core/immersed_boundary/ibm_main.cpp
+++ b/src/core/immersed_boundary/ibm_main.cpp
@@ -135,7 +135,7 @@ void IBM_UpdateParticlePositions(ParticleRange particles)
   
   
   // Do update: Euler
-  const double skin2 = SQR(0.5 * skin);
+  const double skin2 = Utils::sqr(0.5 * skin);
   // Loop over particles in local cells
   for (int c = 0; c < local_cells.n; c++)
   {

--- a/src/core/immersed_boundary/ibm_triel.cpp
+++ b/src/core/immersed_boundary/ibm_triel.cpp
@@ -65,10 +65,10 @@ int IBM_Triel_CalcForce(Particle *p1,Particle *p2, Particle *p3, Bonded_ia_param
   const double Dyy = l/l0*sinPhi / sinPhi0;
   
   // Tensor G: (C.12)
-  const double Gxx = SQR(Dxx)+SQR(Dyx);
+  const double Gxx = Utils::sqr(Dxx) + Utils::sqr(Dyx);
   const double Gxy = Dxx*Dxy + Dyx*Dyy;
   const double Gyx = Dxx*Dxy + Dyy*Dyx;   // = Gxy because of symmetry
-  const double Gyy = SQR(Dxy) + SQR(Dyy);
+  const double Gyy = Utils::sqr(Dxy) + Utils::sqr(Dyy);
   
   // Strain invariants, C.11 and C.12
   const double i1 = (Gxx + Gyy) - 2;

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -261,7 +261,7 @@ void integrate_vv(int n_steps, int reuse_forces) {
 #endif
 
   /* Verlet list criterion */
-  skin2 = SQR(0.5 * skin);
+  skin2 = Utils::sqr(0.5 * skin);
 
   INTEG_TRACE(fprintf(
       stderr, "%d: integrate_vv: integrating %d steps (recalc_forces=%d)\n",
@@ -669,7 +669,7 @@ void rescale_forces_propagate_vel() {
 #ifdef NPT
         if (integ_switch == INTEG_METHOD_NPT_ISO &&
             (nptiso.geometry & nptiso.nptgeom_dir[j])) {
-          nptiso.p_vel[j] += SQR(p.m.v[j]) * p.p.mass;
+          nptiso.p_vel[j] += Utils::sqr(p.m.v[j]) * p.p.mass;
 #ifdef MULTI_TIMESTEP
           if (smaller_time_step > 0. && current_time_step_is_small == 1)
             p.m.v[j] += p.f.f[j];
@@ -709,10 +709,10 @@ void finalize_p_inst_npt() {
       if (nptiso.geometry & nptiso.nptgeom_dir[i]) {
 #ifdef MULTI_TIMESTEP
         if (smaller_time_step > 0.)
-          nptiso.p_vel[i] /= SQR(smaller_time_step);
+          nptiso.p_vel[i] /= Utils::sqr(smaller_time_step);
         else
 #endif
-          nptiso.p_vel[i] /= SQR(time_step);
+          nptiso.p_vel[i] /= Utils::sqr(time_step);
         nptiso.p_inst += nptiso.p_vir[i] + nptiso.p_vel[i];
       }
     }
@@ -747,7 +747,7 @@ void propagate_press_box_pos_and_rescale_npt() {
       if (smaller_time_step < 0. || current_time_step_is_small == 0)
 #endif
         nptiso.volume += nptiso.inv_piston * nptiso.p_diff * 0.5 * time_step;
-      scal[2] = SQR(box_l[nptiso.non_const_dim]) /
+      scal[2] = Utils::sqr(box_l[nptiso.non_const_dim]) /
                 pow(nptiso.volume, 2.0 / nptiso.dimension);
 #ifdef MULTI_TIMESTEP
       if (smaller_time_step < 0. || current_time_step_is_small == 0)
@@ -890,7 +890,7 @@ void propagate_vel() {
           else
 #endif
             p.m.v[j] += p.f.f[j] + friction_therm0_nptiso(p.m.v[j]) / p.p.mass;
-          nptiso.p_vel[j] += SQR(p.m.v[j]) * p.p.mass;
+          nptiso.p_vel[j] += Utils::sqr(p.m.v[j]) * p.p.mass;
         } else
 #endif
           /* Propagate velocities: v(t+0.5*dt) = v(t) + 0.5*dt * f(t) */
@@ -1047,8 +1047,8 @@ void propagate_vel_pos() {
 #endif
 
     /* Verlet criterion check*/
-    if (SQR(p.r.p[0] - p.l.p_old[0]) + SQR(p.r.p[1] - p.l.p_old[1]) +
-            SQR(p.r.p[2] - p.l.p_old[2]) >
+    if (Utils::sqr(p.r.p[0] - p.l.p_old[0]) + Utils::sqr(p.r.p[1] - p.l.p_old[1]) +
+            Utils::sqr(p.r.p[2] - p.l.p_old[2]) >
         skin2)
       set_resort_particles(Cells::RESORT_LOCAL);
   }

--- a/src/core/lb.cpp
+++ b/src/core/lb.cpp
@@ -27,20 +27,20 @@
  *
  */
 
-#include <mpi.h>
+#include "lb.hpp"
+#include "communication.hpp"
+#include "grid.hpp"
+#include "halo.hpp"
+#include "immersed_boundary/ibm_main.hpp"
+#include "interaction_data.hpp"
+#include "lb-d3q19.hpp"
+#include "lbboundaries.hpp"
+#include "thermostat.hpp"
+#include "utils.hpp"
 #include <cassert>
 #include <cstdio>
 #include <iostream>
-#include "utils.hpp"
-#include "communication.hpp"
-#include "grid.hpp"
-#include "interaction_data.hpp"
-#include "thermostat.hpp"
-#include "halo.hpp"
-#include "lb-d3q19.hpp"
-#include "lbboundaries.hpp"
-#include "lb.hpp"
-#include "immersed_boundary/ibm_main.hpp"
+#include <mpi.h>
 
 #include "cuda_interface.hpp"
 
@@ -57,7 +57,9 @@ static void lb_check_halo_regions();
 int transfer_momentum = 0;
 
 /** Struct holding the Lattice Boltzmann parameters */
-// LB_Parameters lbpar = { .rho={0.0}, .viscosity={0.0}, .bulk_viscosity={-1.0}, .agrid=-1.0, .tau=-1.0, .friction={0.0}, .ext_force={ 0.0, 0.0, 0.0},.rho_lb_units={0.},.gamma_odd={0.}, .gamma_even={0.} };
+// LB_Parameters lbpar = { .rho={0.0}, .viscosity={0.0}, .bulk_viscosity={-1.0},
+// .agrid=-1.0, .tau=-1.0, .friction={0.0}, .ext_force={ 0.0, 0.0,
+// 0.0},.rho_lb_units={0.},.gamma_odd={0.}, .gamma_even={0.} };
 LB_Parameters lbpar = {
     // rho
     0.0,
@@ -72,7 +74,7 @@ LB_Parameters lbpar = {
     // friction
     0.0,
     // ext_force
-    { 0.0, 0.0, 0.0},
+    {0.0, 0.0, 0.0},
     // rho_lb_units
     0.,
     // gamma_odd
@@ -86,11 +88,11 @@ LB_Parameters lbpar = {
     // is_TRT
     false,
     // resend_halo
-    0
-};
+    0};
 
 /** The DnQm model to be used. */
-LB_Model lbmodel = { 19, d3q19_lattice, d3q19_coefficients, d3q19_w, nullptr, 1./3. };
+LB_Model lbmodel = {19,      d3q19_lattice, d3q19_coefficients,
+                    d3q19_w, nullptr,       1. / 3.};
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! MAKE SURE THAT D3Q19 is #undefined WHEN USING OTHER MODELS !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
@@ -101,51 +103,53 @@ LB_Model lbmodel = { 19, d3q19_lattice, d3q19_coefficients, d3q19_w, nullptr, 1.
 
 #if (!defined(FLATNOISE) && !defined(GAUSSRANDOMCUT) && !defined(GAUSSRANDOM))
 #define FLATNOISE
-#endif // (!defined(FLATNOISE) && !defined(GAUSSRANDOMCUT) && !defined(GAUSSRANDOM))
+#endif // (!defined(FLATNOISE) && !defined(GAUSSRANDOMCUT) &&
+       // !defined(GAUSSRANDOM))
 
 /** The underlying lattice structure */
 Lattice lblattice;
 
 /** Pointer to the velocity populations of the fluid nodes */
-double **lbfluid[2] = { nullptr, nullptr };
+double **lbfluid[2] = {nullptr, nullptr};
 
 /** Pointer to the hydrodynamic fields of the fluid nodes */
 LB_FluidNode *lbfields = nullptr;
 
 /** Communicator for halo exchange between processors */
-HaloCommunicator update_halo_comm = { 0, nullptr };
-
+HaloCommunicator update_halo_comm = {0, nullptr};
 
 /*@{*/
 
 /** amplitude of the fluctuations in the viscous coupling */
 static double lb_coupl_pref = 0.0;
-/** amplitude of the fluctuations in the viscous coupling with gaussian random numbers */
+/** amplitude of the fluctuations in the viscous coupling with gaussian random
+ * numbers */
 static double lb_coupl_pref2 = 0.0;
 /*@}*/
 
 /** measures the MD time since the last fluid update */
-static double fluidstep=0.0;
+static double fluidstep = 0.0;
 
 #ifdef ADDITIONAL_CHECKS
 /** counts the random numbers drawn for fluctuating LB and the coupling */
-static int rancounter=0;
+static int rancounter = 0;
 #endif // ADDITIONAL_CHECKS
 
 /***********************************************************************/
 #endif // LB
 
-#if defined (LB) || defined (LB_GPU)
+#if defined(LB) || defined(LB_GPU)
 
-/* *********************** C Interface part *************************************/
+/* *********************** C Interface part
+ * *************************************/
 /* ******************************************************************************/
 
 /*
  * set lattice switch on C-level
-*/
+ */
 int lb_set_lattice_switch(int py_switch) {
 
-  switch(py_switch) {
+  switch (py_switch) {
   case 1:
     lattice_switch = LATTICE_LB;
     mpi_bcast_parameter(FIELD_LATTICE_SWITCH);
@@ -161,34 +165,33 @@ int lb_set_lattice_switch(int py_switch) {
 
 /*
  * get lattice switch on py-level
-*/
-int lb_get_lattice_switch(int* py_switch){
-  if(lattice_switch){
+ */
+int lb_get_lattice_switch(int *py_switch) {
+  if (lattice_switch) {
     *py_switch = lattice_switch;
     return 0;
-  }else
+  } else
     return 1;
 }
 
 #ifdef SHANCHEN
 int lb_lbfluid_set_shanchen_coupling(double *p_coupling) {
 #ifdef LB_GPU
-  int ii,jj,n=0;
-  switch(LB_COMPONENTS){
-    case 1: 
-      lbpar_gpu.coupling[0] = (float)p_coupling[0];
-      lbpar_gpu.coupling[1] = (float)p_coupling[1];
-      break;
-    default:
-      for(ii=0;ii<LB_COMPONENTS;ii++){
-        for(jj=ii;jj<LB_COMPONENTS;jj++){
-          lbpar_gpu.coupling[LB_COMPONENTS*ii+jj] = (float)p_coupling[n]; 
-          lbpar_gpu.coupling[LB_COMPONENTS*jj+ii] = (float)p_coupling[n]; 
-          n++;
-        }
+  int ii, jj, n = 0;
+  switch (LB_COMPONENTS) {
+  case 1:
+    lbpar_gpu.coupling[0] = (float)p_coupling[0];
+    lbpar_gpu.coupling[1] = (float)p_coupling[1];
+    break;
+  default:
+    for (ii = 0; ii < LB_COMPONENTS; ii++) {
+      for (jj = ii; jj < LB_COMPONENTS; jj++) {
+        lbpar_gpu.coupling[LB_COMPONENTS * ii + jj] = (float)p_coupling[n];
+        lbpar_gpu.coupling[LB_COMPONENTS * jj + ii] = (float)p_coupling[n];
+        n++;
       }
-      break;
-
+    }
+    break;
   }
   on_lb_params_change_gpu(LBPAR_COUPLING);
 #endif // LB_GPU
@@ -198,50 +201,51 @@ int lb_lbfluid_set_shanchen_coupling(double *p_coupling) {
   return 0;
 }
 
-
 int lb_lbfluid_set_mobility(double *p_mobility) {
-    int ii;
-    for(ii=0;ii<LB_COMPONENTS-1;ii++){
-        if ( p_mobility[ii] <= 0 ) {
-            return -1;
-        }
-        if (lattice_switch & LATTICE_LB_GPU) {
+  int ii;
+  for (ii = 0; ii < LB_COMPONENTS - 1; ii++) {
+    if (p_mobility[ii] <= 0) {
+      return -1;
+    }
+    if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-            lbpar_gpu.mobility[ii] = (float)p_mobility[ii];
-            on_lb_params_change_gpu(LBPAR_MOBILITY);
+      lbpar_gpu.mobility[ii] = (float)p_mobility[ii];
+      on_lb_params_change_gpu(LBPAR_MOBILITY);
 #endif // LB_GPU
-        } else {
+    } else {
 #ifdef LB
 #error not implemented
 #endif // LB
-        }
     }
-    return 0;
+  }
+  return 0;
 }
 
-
-int affinity_set_params(int part_type_a, int part_type_b, double * affinity)
-{
-    IA_parameters *data = get_ia_param_safe(part_type_a, part_type_b);
-    data->affinity_on=0;
-    if (!data) return ES_ERROR;
-    for(int ii=0;ii<LB_COMPONENTS;ii++) {
-        if(affinity[ii]<0 || affinity[ii]>1) { return ES_ERROR; }
-        data->affinity[ii]= affinity[ii];
-        if (data->affinity[ii]>0) data->affinity_on=1;
+int affinity_set_params(int part_type_a, int part_type_b, double *affinity) {
+  IA_parameters *data = get_ia_param_safe(part_type_a, part_type_b);
+  data->affinity_on = 0;
+  if (!data)
+    return ES_ERROR;
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+    if (affinity[ii] < 0 || affinity[ii] > 1) {
+      return ES_ERROR;
     }
+    data->affinity[ii] = affinity[ii];
+    if (data->affinity[ii] > 0)
+      data->affinity_on = 1;
+  }
 
-    /* broadcast interaction parameters */
-    mpi_bcast_ia_params(part_type_a, part_type_b);
+  /* broadcast interaction parameters */
+  mpi_bcast_ia_params(part_type_a, part_type_b);
 
-    return ES_OK;
+  return ES_OK;
 }
 
 #endif // SHANCHEN
 
 int lb_lbfluid_set_density(double *p_dens) {
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
-    if ( p_dens[ii] <= 0 )
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+    if (p_dens[ii] <= 0)
       return -1;
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
@@ -258,9 +262,9 @@ int lb_lbfluid_set_density(double *p_dens) {
   return 0;
 }
 
-int lb_lbfluid_set_visc(double * p_visc) {
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
-    if ( p_visc[ii] <= 0 )
+int lb_lbfluid_set_visc(double *p_visc) {
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+    if (p_visc[ii] <= 0)
       return -1;
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
@@ -278,8 +282,8 @@ int lb_lbfluid_set_visc(double * p_visc) {
 }
 
 int lb_lbfluid_set_bulk_visc(double *p_bulk_visc) {
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
-    if ( p_bulk_visc[ii] <= 0 )
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+    if (p_bulk_visc[ii] <= 0)
       return -1;
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
@@ -299,8 +303,8 @@ int lb_lbfluid_set_bulk_visc(double *p_bulk_visc) {
 }
 
 int lb_lbfluid_set_gamma_odd(double *p_gamma_odd) {
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
-    if ( fabs(p_gamma_odd[ii]) > 1 )
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+    if (fabs(p_gamma_odd[ii]) > 1)
       return -1;
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
@@ -319,10 +323,9 @@ int lb_lbfluid_set_gamma_odd(double *p_gamma_odd) {
   return 0;
 }
 
-int lb_lbfluid_set_gamma_even(double *p_gamma_even)
-{
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
-    if ( fabs(p_gamma_even[ii]) > 1 )
+int lb_lbfluid_set_gamma_even(double *p_gamma_even) {
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+    if (fabs(p_gamma_even[ii]) > 1)
       return -1;
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
@@ -341,12 +344,10 @@ int lb_lbfluid_set_gamma_even(double *p_gamma_even)
   return 0;
 }
 
-
-int lb_lbfluid_set_friction(double * p_friction)
-{
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
-    if ( p_friction[ii] <= 0 )
-            return -1;
+int lb_lbfluid_set_friction(double *p_friction) {
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+    if (p_friction[ii] <= 0)
+      return -1;
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
       lbpar_gpu.friction[ii] = (float)p_friction[ii];
@@ -362,53 +363,47 @@ int lb_lbfluid_set_friction(double * p_friction)
   return 0;
 }
 
-
-int lb_lbfluid_get_friction(double * p_friction)
-{
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
+int lb_lbfluid_get_friction(double *p_friction) {
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
       p_friction[ii] = (double)lbpar_gpu.friction[ii];
 #endif // LB_GPU
     } else {
 #ifdef LB
-       p_friction[ii] = lbpar.friction;
+      p_friction[ii] = lbpar.friction;
 #endif // LB
     }
   }
   return 0;
 }
 
-
 int lb_lbfluid_set_couple_flag(int couple_flag) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-    if ( couple_flag != LB_COUPLE_TWO_POINT && couple_flag != LB_COUPLE_THREE_POINT )
+    if (couple_flag != LB_COUPLE_TWO_POINT &&
+        couple_flag != LB_COUPLE_THREE_POINT)
       return -1;
     lbpar_gpu.lb_couple_switch = couple_flag;
 #endif // LB_GPU
   } else {
 #ifdef LB
-    /* Only the two point nearest neighbor coupling is present in the case of the cpu,
-       so just throw an error if something else is tried */
-    if ( couple_flag != LB_COUPLE_TWO_POINT )
+    /* Only the two point nearest neighbor coupling is present in the case of
+       the cpu, so just throw an error if something else is tried */
+    if (couple_flag != LB_COUPLE_TWO_POINT)
       return -1;
 #endif // LB
   }
   return 0;
 }
 
-
-int lb_lbfluid_get_couple_flag(int * couple_flag) {
+int lb_lbfluid_get_couple_flag(int *couple_flag) {
   *couple_flag = LB_COUPLE_NULL;
-  if (lattice_switch & LATTICE_LB_GPU)
-  {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     *couple_flag = lbpar_gpu.lb_couple_switch;
 #endif
-  }
-  else
-  {
+  } else {
 #ifdef LB
     *couple_flag = LB_COUPLE_TWO_POINT;
 #endif
@@ -416,33 +411,35 @@ int lb_lbfluid_get_couple_flag(int * couple_flag) {
   return 0;
 }
 
-
-int lb_lbfluid_set_agrid(double p_agrid){
-  if ( p_agrid <= 0)
+int lb_lbfluid_set_agrid(double p_agrid) {
+  if (p_agrid <= 0)
     return -1;
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     lbpar_gpu.agrid = (float)p_agrid;
-    
-    lbpar_gpu.dim_x = (unsigned int)rint(box_l[0]/p_agrid);
-    lbpar_gpu.dim_y = (unsigned int)rint(box_l[1]/p_agrid);
-    lbpar_gpu.dim_z = (unsigned int)rint(box_l[2]/p_agrid);
+
+    lbpar_gpu.dim_x = (unsigned int)rint(box_l[0] / p_agrid);
+    lbpar_gpu.dim_y = (unsigned int)rint(box_l[1] / p_agrid);
+    lbpar_gpu.dim_z = (unsigned int)rint(box_l[2] / p_agrid);
     unsigned int tmp[3];
     tmp[0] = lbpar_gpu.dim_x;
     tmp[1] = lbpar_gpu.dim_y;
     tmp[2] = lbpar_gpu.dim_z;
     /* sanity checks */
-    for (int dir=0;dir<3;dir++) {
+    for (int dir = 0; dir < 3; dir++) {
       /* check if box_l is compatible with lattice spacing */
-      if (fabs(box_l[dir]-tmp[dir]*p_agrid) > ROUND_ERROR_PREC) {
-          runtimeErrorMsg() <<"Lattice spacing p_agrid= " << p_agrid << " is incompatible with box_l[" << dir << "]="
-                << box_l[dir] << ", factor=" << tmp[dir] << " err= " << fabs(box_l[dir]-tmp[dir]*p_agrid);
+      if (fabs(box_l[dir] - tmp[dir] * p_agrid) > ROUND_ERROR_PREC) {
+        runtimeErrorMsg() << "Lattice spacing p_agrid= " << p_agrid
+                          << " is incompatible with box_l[" << dir
+                          << "]=" << box_l[dir] << ", factor=" << tmp[dir]
+                          << " err= " << fabs(box_l[dir] - tmp[dir] * p_agrid);
       }
     }
-    lbpar_gpu.number_of_nodes = lbpar_gpu.dim_x * lbpar_gpu.dim_y * lbpar_gpu.dim_z;
+    lbpar_gpu.number_of_nodes =
+        lbpar_gpu.dim_x * lbpar_gpu.dim_y * lbpar_gpu.dim_z;
     on_lb_params_change_gpu(LBPAR_AGRID);
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
     lbpar.agrid = p_agrid;
     mpi_bcast_lb_params(LBPAR_AGRID);
@@ -451,9 +448,8 @@ int lb_lbfluid_set_agrid(double p_agrid){
   return 0;
 }
 
-
-int lb_lbfluid_set_tau(double p_tau){
-  if ( p_tau <= 0 )
+int lb_lbfluid_set_tau(double p_tau) {
+  if (p_tau <= 0)
     return -1;
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
@@ -469,9 +465,8 @@ int lb_lbfluid_set_tau(double p_tau){
   return 0;
 }
 
-
 #ifdef SHANCHEN
-int lb_lbfluid_set_remove_momentum(void){
+int lb_lbfluid_set_remove_momentum(void) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     lbpar_gpu.remove_momentum = 1;
@@ -486,8 +481,8 @@ int lb_lbfluid_set_remove_momentum(void){
 }
 #endif // SHANCHEN
 
-
-int lb_lbfluid_set_ext_force(int component, double p_fx, double p_fy, double p_fz) {
+int lb_lbfluid_set_ext_force(int component, double p_fx, double p_fy,
+                             double p_fz) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     if (lbpar_gpu.tau < 0.0)
@@ -497,9 +492,9 @@ int lb_lbfluid_set_ext_force(int component, double p_fx, double p_fy, double p_f
       return 3;
 
     /* external force density is stored in MD units */
-    lbpar_gpu.ext_force[3*component+0] = (float)p_fx;
-    lbpar_gpu.ext_force[3*component+1] = (float)p_fy;
-    lbpar_gpu.ext_force[3*component+2] = (float)p_fz;
+    lbpar_gpu.ext_force[3 * component + 0] = (float)p_fx;
+    lbpar_gpu.ext_force[3 * component + 1] = (float)p_fy;
+    lbpar_gpu.ext_force[3 * component + 2] = (float)p_fz;
     lbpar_gpu.external_force = 1;
     lb_reinit_extern_nodeforce_GPU(&lbpar_gpu);
 #endif // LB_GPU
@@ -520,9 +515,8 @@ int lb_lbfluid_set_ext_force(int component, double p_fx, double p_fy, double p_f
   return 0;
 }
 
-
 int lb_lbfluid_get_density(double *p_dens) {
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
       p_dens[ii] = (double)lbpar_gpu.rho[ii];
@@ -536,8 +530,8 @@ int lb_lbfluid_get_density(double *p_dens) {
   return 0;
 }
 
-int lb_lbfluid_get_visc(double* p_visc){
-  for (int ii=0;ii<LB_COMPONENTS;ii++){
+int lb_lbfluid_get_visc(double *p_visc) {
+  for (int ii = 0; ii < LB_COMPONENTS; ii++) {
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
       p_visc[ii] = (double)lbpar_gpu.viscosity[ii];
@@ -546,13 +540,12 @@ int lb_lbfluid_get_visc(double* p_visc){
 #ifdef LB
       p_visc[ii] = lbpar.viscosity;
 #endif // LB
-     }
+    }
   }
   return 0;
 }
 
-
-int lb_lbfluid_get_bulk_visc(double* p_bulk_visc){
+int lb_lbfluid_get_bulk_visc(double *p_bulk_visc) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     *p_bulk_visc = lbpar_gpu.bulk_viscosity[0];
@@ -565,8 +558,7 @@ int lb_lbfluid_get_bulk_visc(double* p_bulk_visc){
   return 0;
 }
 
-
-int lb_lbfluid_get_gamma_odd(double* p_gamma_odd){
+int lb_lbfluid_get_gamma_odd(double *p_gamma_odd) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     *p_gamma_odd = lbpar_gpu.gamma_odd[0];
@@ -579,8 +571,7 @@ int lb_lbfluid_get_gamma_odd(double* p_gamma_odd){
   return 0;
 }
 
-
-int lb_lbfluid_get_gamma_even(double* p_gamma_even){
+int lb_lbfluid_get_gamma_even(double *p_gamma_even) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     *p_gamma_even = lbpar_gpu.gamma_even[0];
@@ -593,8 +584,7 @@ int lb_lbfluid_get_gamma_even(double* p_gamma_even){
   return 0;
 }
 
-
-int lb_lbfluid_get_agrid(double* p_agrid){
+int lb_lbfluid_get_agrid(double *p_agrid) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     *p_agrid = lbpar_gpu.agrid;
@@ -607,7 +597,7 @@ int lb_lbfluid_get_agrid(double* p_agrid){
   return 0;
 }
 
-int lb_lbfluid_get_tau(double* p_tau){
+int lb_lbfluid_get_tau(double *p_tau) {
   if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
     *p_tau = lbpar_gpu.tau;
@@ -620,9 +610,9 @@ int lb_lbfluid_get_tau(double* p_tau){
   return 0;
 }
 
-int lb_lbfluid_get_ext_force(double* p_f){
+int lb_lbfluid_get_ext_force(double *p_f) {
 #ifdef SHANCHEN
-  fprintf(stderr, "Not implemented yet (%s:%d) ",__FILE__,__LINE__);
+  fprintf(stderr, "Not implemented yet (%s:%d) ", __FILE__, __LINE__);
   errexit();
 #endif // SHANCHEN
   if (lattice_switch & LATTICE_LB_GPU) {
@@ -641,633 +631,681 @@ int lb_lbfluid_get_ext_force(double* p_f){
   return 0;
 }
 
+int lb_lbfluid_print_vtk_boundary(char *filename) {
+  FILE *fp = fopen(filename, "w");
 
-int lb_lbfluid_print_vtk_boundary(char* filename) {
-    FILE* fp = fopen(filename, "w");
+  if (fp == nullptr) {
+    return 1;
+  }
 
-    if(fp == nullptr)
-    {
-        return 1;
-    }
-
-    if (lattice_switch & LATTICE_LB_GPU) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        unsigned int* bound_array;
-        bound_array = (unsigned int*) Utils::malloc(lbpar_gpu.number_of_nodes*sizeof(unsigned int));
-        lb_get_boundary_flags_GPU(bound_array);
+    unsigned int *bound_array;
+    bound_array = (unsigned int *)Utils::malloc(lbpar_gpu.number_of_nodes *
+                                                sizeof(unsigned int));
+    lb_get_boundary_flags_GPU(bound_array);
 
-        int j;
-        /** print of the calculated phys values */
-        fprintf(fp, "# vtk DataFile Version 2.0\nlbboundaries\n"
-                "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %u %u %u\n"
-                "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %u\n"
-                "SCALARS boundary float 1\nLOOKUP_TABLE default\n",
-                lbpar_gpu.dim_x, lbpar_gpu.dim_y, lbpar_gpu.dim_z,
-                lbpar_gpu.agrid*0.5, lbpar_gpu.agrid*0.5, lbpar_gpu.agrid*0.5,
-                lbpar_gpu.agrid, lbpar_gpu.agrid, lbpar_gpu.agrid,
-                lbpar_gpu.number_of_nodes);
-        for(j=0; j<int(lbpar_gpu.number_of_nodes); ++j){
-            /** print of the calculated phys values */
-            fprintf(fp, "%d \n", bound_array[j]);
-        }
-        free(bound_array);
+    int j;
+    /** print of the calculated phys values */
+    fprintf(fp,
+            "# vtk DataFile Version 2.0\nlbboundaries\n"
+            "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %u %u %u\n"
+            "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %u\n"
+            "SCALARS boundary float 1\nLOOKUP_TABLE default\n",
+            lbpar_gpu.dim_x, lbpar_gpu.dim_y, lbpar_gpu.dim_z,
+            lbpar_gpu.agrid * 0.5, lbpar_gpu.agrid * 0.5, lbpar_gpu.agrid * 0.5,
+            lbpar_gpu.agrid, lbpar_gpu.agrid, lbpar_gpu.agrid,
+            lbpar_gpu.number_of_nodes);
+    for (j = 0; j < int(lbpar_gpu.number_of_nodes); ++j) {
+      /** print of the calculated phys values */
+      fprintf(fp, "%d \n", bound_array[j]);
+    }
+    free(bound_array);
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        int pos[3];
-        int boundary;
-        int gridsize[3];
-
-        gridsize[0] = box_l[0] / lbpar.agrid;
-        gridsize[1] = box_l[1] / lbpar.agrid;
-        gridsize[2] = box_l[2] / lbpar.agrid;
-
-        fprintf(fp, "# vtk DataFile Version 2.0\nlbboundaries\n"
-                "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %d %d %d\n"
-                "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %d\n"
-                "SCALARS boundary float 1\nLOOKUP_TABLE default\n",
-                gridsize[0], gridsize[1], gridsize[2],
-                lblattice.agrid[0]*0.5, lblattice.agrid[1]*0.5, lblattice.agrid[2]*0.5,
-                lblattice.agrid[0], lblattice.agrid[1], lblattice.agrid[2],
-                gridsize[0]*gridsize[1]*gridsize[2]);
-
-        for (pos[2] = 0; pos[2] < gridsize[2]; pos[2]++)
-        {
-            for (pos[1] = 0; pos[1] < gridsize[1]; pos[1]++)
-            {
-                for (pos[0] = 0; pos[0] < gridsize[0]; pos[0]++) {
-                    lb_lbnode_get_boundary(pos, &boundary);
-                    fprintf(fp, "%d \n", boundary);
-                }
-            }
-        }
-#endif // LB
-    }
-    fclose(fp);
-	return 0;
-}
-
-
-int lb_lbfluid_print_vtk_density(char** filename) {
-    int ii;
-
-    for(ii=0;ii<LB_COMPONENTS;++ii) {
-        FILE* fp = fopen(filename[ii], "w");
-
-        if(fp == nullptr) {
-            perror("lb_lbfluid_print_vtk_density");
-            return 1;
-        }
-
-        if (lattice_switch & LATTICE_LB_GPU) {
-#ifdef LB_GPU
-
-            int j;
-            size_t size_of_values = lbpar_gpu.number_of_nodes * sizeof(LB_rho_v_pi_gpu);
-            host_values = (LB_rho_v_pi_gpu*)Utils::malloc(size_of_values);
-            lb_get_values_GPU(host_values);
-
-            fprintf(fp, "# vtk DataFile Version 2.0\nlbfluid_gpu\nASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %u %u %u\nORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %u\nSCALARS density float 1\nLOOKUP_TABLE default\n",
-                    lbpar_gpu.dim_x, lbpar_gpu.dim_y, lbpar_gpu.dim_z,
-                    lbpar_gpu.agrid*0.5, lbpar_gpu.agrid*0.5, lbpar_gpu.agrid*0.5,
-                    lbpar_gpu.agrid, lbpar_gpu.agrid, lbpar_gpu.agrid, lbpar_gpu.number_of_nodes);
-
-            for(j=0; j<int(lbpar_gpu.number_of_nodes); ++j){
-                /** print the calculated phys values */
-                fprintf(fp, "%f\n", host_values[j].rho[ii]);
-            }
-            free(host_values);
-
-#endif // LB_GPU
-        }
-        else {
-#ifdef LB
-          fprintf(stderr, "Not implemented yet (%s:%d) ",__FILE__,__LINE__);
-          errexit();
-#endif // LB
-        }
-        fclose(fp);
-    }
-    return 0;
-}
-
-
-int lb_lbfluid_print_vtk_velocity(char* filename, std::vector<int> bb1, std::vector<int> bb2) {
-    FILE* fp = fopen(filename, "w");
-
-    if(fp == nullptr)
-    {
-        return 1;
-    }
-
-    std::vector<int> bb_low;
-    std::vector<int> bb_high;
-
-    for(std::vector<int>::iterator val1 = bb1.begin(), val2 = bb2.begin(); val1 != bb1.end() && val2 != bb2.end(); ++val1, ++val2)
-    {
-        if(*val1 == -1 || *val2 == -1)
-        {
-            bb_low = {0, 0, 0};
-            if (lattice_switch & LATTICE_LB_GPU) {
-#ifdef LB_GPU
-            bb_high = {static_cast<int>(lbpar_gpu.dim_x)-1, static_cast<int>(lbpar_gpu.dim_y)-1, static_cast<int>(lbpar_gpu.dim_z)-1};
-#endif // LB_GPU
-            } else {
-#ifdef LB
-            bb_high = {lblattice.global_grid[0]-1, lblattice.global_grid[1]-1, lblattice.global_grid[2]-1};
-#endif // LB
-            }
-            break;
-        }
-
-        bb_low.push_back(std::min(*val1, *val2));
-        bb_high.push_back(std::max(*val1, *val2));
-    }
-
     int pos[3];
-    if (lattice_switch & LATTICE_LB_GPU) {
-#ifdef LB_GPU
-        size_t size_of_values = lbpar_gpu.number_of_nodes * sizeof(LB_rho_v_pi_gpu);
-        host_values = (LB_rho_v_pi_gpu*)Utils::malloc(size_of_values);
-        lb_get_values_GPU(host_values);
-        fprintf(fp, "# vtk DataFile Version 2.0\nlbfluid_gpu\n"
-                "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %d %d %d\n"
-                "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %d\n"
-                "SCALARS velocity float 3\nLOOKUP_TABLE default\n",
-                bb_high[0]-bb_low[0]+1, bb_high[1]-bb_low[1]+1, bb_high[2]-bb_low[2]+1,
-                (bb_low[0]+0.5)*lbpar_gpu.agrid, (bb_low[1]+0.5)*lbpar_gpu.agrid, (bb_low[2]+0.5)*lbpar_gpu.agrid,
-                lbpar_gpu.agrid, lbpar_gpu.agrid, lbpar_gpu.agrid,
-                (bb_high[0]-bb_low[0]+1) * (bb_high[1]-bb_low[1]+1) * (bb_high[2]-bb_low[2]+1) );
-        for(pos[2] = bb_low[2]; pos[2] <= bb_high[2]; pos[2]++)
-            for(pos[1] = bb_low[1]; pos[1] <= bb_high[1]; pos[1]++)
-                for(pos[0] = bb_low[0]; pos[0] <= bb_high[0]; pos[0]++)
-                {
-                    int j = lbpar_gpu.dim_y*lbpar_gpu.dim_x * pos[2] + lbpar_gpu.dim_x * pos[1] + pos[0];
-                    fprintf(fp, "%f %f %f\n", host_values[j].v[0], host_values[j].v[1], host_values[j].v[2]);
-                }
-        free(host_values);
-#endif // LB_GPU
-    } else {
-#ifdef LB
-        double u[3];
+    int boundary;
+    int gridsize[3];
 
-        fprintf(fp, "# vtk DataFile Version 2.0\nlbfluid_cpu\n"
-                "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %d %d %d\n"
-                "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %d\n"
-                "SCALARS velocity float 3\nLOOKUP_TABLE default\n",
-                bb_high[0]-bb_low[0]+1, bb_high[1]-bb_low[1]+1, bb_high[2]-bb_low[2]+1,
-                (bb_low[0]+0.5)*lblattice.agrid[0], (bb_low[1]+0.5)*lblattice.agrid[1], (bb_low[2]+0.5)*lblattice.agrid[2],
-                lblattice.agrid[0], lblattice.agrid[1], lblattice.agrid[2],
-                (bb_high[0]-bb_low[0]+1) * (bb_high[1]-bb_low[1]+1) * (bb_high[2]-bb_low[2]+1) );
+    gridsize[0] = box_l[0] / lbpar.agrid;
+    gridsize[1] = box_l[1] / lbpar.agrid;
+    gridsize[2] = box_l[2] / lbpar.agrid;
 
-        for(pos[2] = bb_low[2]; pos[2] <= bb_high[2]; pos[2]++)
-            for(pos[1] = bb_low[1]; pos[1] <= bb_high[1]; pos[1]++)
-                for(pos[0] = bb_low[0]; pos[0] <= bb_high[0]; pos[0]++)
-                {
-                    lb_lbnode_get_u(pos, u);
-                    fprintf(fp, "%f %f %f\n", u[0], u[1], u[2]);
-                }
-#endif // LB
+    fprintf(fp,
+            "# vtk DataFile Version 2.0\nlbboundaries\n"
+            "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %d %d %d\n"
+            "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %d\n"
+            "SCALARS boundary float 1\nLOOKUP_TABLE default\n",
+            gridsize[0], gridsize[1], gridsize[2], lblattice.agrid[0] * 0.5,
+            lblattice.agrid[1] * 0.5, lblattice.agrid[2] * 0.5,
+            lblattice.agrid[0], lblattice.agrid[1], lblattice.agrid[2],
+            gridsize[0] * gridsize[1] * gridsize[2]);
+
+    for (pos[2] = 0; pos[2] < gridsize[2]; pos[2]++) {
+      for (pos[1] = 0; pos[1] < gridsize[1]; pos[1]++) {
+        for (pos[0] = 0; pos[0] < gridsize[0]; pos[0]++) {
+          lb_lbnode_get_boundary(pos, &boundary);
+          fprintf(fp, "%d \n", boundary);
+        }
+      }
     }
-    fclose(fp);
-
-	return 0;
+#endif // LB
+  }
+  fclose(fp);
+  return 0;
 }
 
-int lb_lbfluid_print_boundary(char* filename) {
-    FILE* fp = fopen(filename, "w");
+int lb_lbfluid_print_vtk_density(char **filename) {
+  int ii;
 
-    if(fp == nullptr)
-    {
-	  	return 1;
+  for (ii = 0; ii < LB_COMPONENTS; ++ii) {
+    FILE *fp = fopen(filename[ii], "w");
+
+    if (fp == nullptr) {
+      perror("lb_lbfluid_print_vtk_density");
+      return 1;
     }
 
     if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        unsigned int* bound_array;
-        bound_array = (unsigned int*) Utils::malloc(lbpar_gpu.number_of_nodes*sizeof(unsigned int));
-        lb_get_boundary_flags_GPU(bound_array);
 
-        int xyz[3];
-        int j;
-        for(j=0; j<int(lbpar_gpu.number_of_nodes); ++j){
-            xyz[0] = j%lbpar_gpu.dim_x;
-            int k = j/lbpar_gpu.dim_x;
-            xyz[1] = k%lbpar_gpu.dim_y;
-            k /= lbpar_gpu.dim_y;
-            xyz[2] = k;
-            /** print of the calculated phys values */
-            fprintf(fp, "%f %f %f %d\n", (xyz[0]+0.5)*lbpar_gpu.agrid, (xyz[1]+0.5)*lbpar_gpu.agrid, (xyz[2]+0.5)*lbpar_gpu.agrid, bound_array[j]);
-        }
-        free(bound_array);
+      int j;
+      size_t size_of_values =
+          lbpar_gpu.number_of_nodes * sizeof(LB_rho_v_pi_gpu);
+      host_values = (LB_rho_v_pi_gpu *)Utils::malloc(size_of_values);
+      lb_get_values_GPU(host_values);
+
+      fprintf(fp,
+              "# vtk DataFile Version 2.0\nlbfluid_gpu\nASCII\nDATASET "
+              "STRUCTURED_POINTS\nDIMENSIONS %u %u %u\nORIGIN %f %f "
+              "%f\nSPACING %f %f %f\nPOINT_DATA %u\nSCALARS density float "
+              "1\nLOOKUP_TABLE default\n",
+              lbpar_gpu.dim_x, lbpar_gpu.dim_y, lbpar_gpu.dim_z,
+              lbpar_gpu.agrid * 0.5, lbpar_gpu.agrid * 0.5,
+              lbpar_gpu.agrid * 0.5, lbpar_gpu.agrid, lbpar_gpu.agrid,
+              lbpar_gpu.agrid, lbpar_gpu.number_of_nodes);
+
+      for (j = 0; j < int(lbpar_gpu.number_of_nodes); ++j) {
+        /** print the calculated phys values */
+        fprintf(fp, "%f\n", host_values[j].rho[ii]);
+      }
+      free(host_values);
+
 #endif // LB_GPU
     } else {
 #ifdef LB
-        int pos[3];
-        int boundary;
-        int gridsize[3];
-
-        gridsize[0] = box_l[0] / lblattice.agrid[0];
-        gridsize[1] = box_l[1] / lblattice.agrid[1];
-        gridsize[2] = box_l[2] / lblattice.agrid[2];
-
-        for(pos[2] = 0; pos[2] < gridsize[2]; pos[2]++)
-        {
-            for(pos[1] = 0; pos[1] < gridsize[1]; pos[1]++)
-            {
-                for(pos[0] = 0; pos[0] < gridsize[0]; pos[0]++) {
-                    lb_lbnode_get_boundary(pos, &boundary);
-                    boundary = ( boundary != 0 ? 1 : 0 );
-                    fprintf(fp, "%f %f %f %d\n",
-                            (pos[0]+0.5)*lblattice.agrid[0],
-                            (pos[1]+0.5)*lblattice.agrid[1],
-                            (pos[2]+0.5)*lblattice.agrid[2],
-                            boundary);
-                }
-            }
-        }
+      fprintf(stderr, "Not implemented yet (%s:%d) ", __FILE__, __LINE__);
+      errexit();
 #endif // LB
     }
-
     fclose(fp);
-    return 0;
+  }
+  return 0;
 }
 
+int lb_lbfluid_print_vtk_velocity(char *filename, std::vector<int> bb1,
+                                  std::vector<int> bb2) {
+  FILE *fp = fopen(filename, "w");
 
-int lb_lbfluid_print_velocity(char* filename) {
-    FILE* fp = fopen(filename, "w");
+  if (fp == nullptr) {
+    return 1;
+  }
 
-    if(fp == nullptr)
-    {
-        return 1;
+  std::vector<int> bb_low;
+  std::vector<int> bb_high;
+
+  for (std::vector<int>::iterator val1 = bb1.begin(), val2 = bb2.begin();
+       val1 != bb1.end() && val2 != bb2.end(); ++val1, ++val2) {
+    if (*val1 == -1 || *val2 == -1) {
+      bb_low = {0, 0, 0};
+      if (lattice_switch & LATTICE_LB_GPU) {
+#ifdef LB_GPU
+        bb_high = {static_cast<int>(lbpar_gpu.dim_x) - 1,
+                   static_cast<int>(lbpar_gpu.dim_y) - 1,
+                   static_cast<int>(lbpar_gpu.dim_z) - 1};
+#endif // LB_GPU
+      } else {
+#ifdef LB
+        bb_high = {lblattice.global_grid[0] - 1, lblattice.global_grid[1] - 1,
+                   lblattice.global_grid[2] - 1};
+#endif // LB
+      }
+      break;
     }
 
-    if (lattice_switch & LATTICE_LB_GPU) {
+    bb_low.push_back(std::min(*val1, *val2));
+    bb_high.push_back(std::max(*val1, *val2));
+  }
+
+  int pos[3];
+  if (lattice_switch & LATTICE_LB_GPU) {
+#ifdef LB_GPU
+    size_t size_of_values = lbpar_gpu.number_of_nodes * sizeof(LB_rho_v_pi_gpu);
+    host_values = (LB_rho_v_pi_gpu *)Utils::malloc(size_of_values);
+    lb_get_values_GPU(host_values);
+    fprintf(fp,
+            "# vtk DataFile Version 2.0\nlbfluid_gpu\n"
+            "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %d %d %d\n"
+            "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %d\n"
+            "SCALARS velocity float 3\nLOOKUP_TABLE default\n",
+            bb_high[0] - bb_low[0] + 1, bb_high[1] - bb_low[1] + 1,
+            bb_high[2] - bb_low[2] + 1, (bb_low[0] + 0.5) * lbpar_gpu.agrid,
+            (bb_low[1] + 0.5) * lbpar_gpu.agrid,
+            (bb_low[2] + 0.5) * lbpar_gpu.agrid, lbpar_gpu.agrid,
+            lbpar_gpu.agrid, lbpar_gpu.agrid,
+            (bb_high[0] - bb_low[0] + 1) * (bb_high[1] - bb_low[1] + 1) *
+                (bb_high[2] - bb_low[2] + 1));
+    for (pos[2] = bb_low[2]; pos[2] <= bb_high[2]; pos[2]++)
+      for (pos[1] = bb_low[1]; pos[1] <= bb_high[1]; pos[1]++)
+        for (pos[0] = bb_low[0]; pos[0] <= bb_high[0]; pos[0]++) {
+          int j = lbpar_gpu.dim_y * lbpar_gpu.dim_x * pos[2] +
+                  lbpar_gpu.dim_x * pos[1] + pos[0];
+          fprintf(fp, "%f %f %f\n", host_values[j].v[0], host_values[j].v[1],
+                  host_values[j].v[2]);
+        }
+    free(host_values);
+#endif // LB_GPU
+  } else {
+#ifdef LB
+    double u[3];
+
+    fprintf(fp,
+            "# vtk DataFile Version 2.0\nlbfluid_cpu\n"
+            "ASCII\nDATASET STRUCTURED_POINTS\nDIMENSIONS %d %d %d\n"
+            "ORIGIN %f %f %f\nSPACING %f %f %f\nPOINT_DATA %d\n"
+            "SCALARS velocity float 3\nLOOKUP_TABLE default\n",
+            bb_high[0] - bb_low[0] + 1, bb_high[1] - bb_low[1] + 1,
+            bb_high[2] - bb_low[2] + 1, (bb_low[0] + 0.5) * lblattice.agrid[0],
+            (bb_low[1] + 0.5) * lblattice.agrid[1],
+            (bb_low[2] + 0.5) * lblattice.agrid[2], lblattice.agrid[0],
+            lblattice.agrid[1], lblattice.agrid[2],
+            (bb_high[0] - bb_low[0] + 1) * (bb_high[1] - bb_low[1] + 1) *
+                (bb_high[2] - bb_low[2] + 1));
+
+    for (pos[2] = bb_low[2]; pos[2] <= bb_high[2]; pos[2]++)
+      for (pos[1] = bb_low[1]; pos[1] <= bb_high[1]; pos[1]++)
+        for (pos[0] = bb_low[0]; pos[0] <= bb_high[0]; pos[0]++) {
+          lb_lbnode_get_u(pos, u);
+          fprintf(fp, "%f %f %f\n", u[0], u[1], u[2]);
+        }
+#endif // LB
+  }
+  fclose(fp);
+
+  return 0;
+}
+
+int lb_lbfluid_print_boundary(char *filename) {
+  FILE *fp = fopen(filename, "w");
+
+  if (fp == nullptr) {
+    return 1;
+  }
+
+  if (lattice_switch & LATTICE_LB_GPU) {
+#ifdef LB_GPU
+    unsigned int *bound_array;
+    bound_array = (unsigned int *)Utils::malloc(lbpar_gpu.number_of_nodes *
+                                                sizeof(unsigned int));
+    lb_get_boundary_flags_GPU(bound_array);
+
+    int xyz[3];
+    int j;
+    for (j = 0; j < int(lbpar_gpu.number_of_nodes); ++j) {
+      xyz[0] = j % lbpar_gpu.dim_x;
+      int k = j / lbpar_gpu.dim_x;
+      xyz[1] = k % lbpar_gpu.dim_y;
+      k /= lbpar_gpu.dim_y;
+      xyz[2] = k;
+      /** print of the calculated phys values */
+      fprintf(fp, "%f %f %f %d\n", (xyz[0] + 0.5) * lbpar_gpu.agrid,
+              (xyz[1] + 0.5) * lbpar_gpu.agrid,
+              (xyz[2] + 0.5) * lbpar_gpu.agrid, bound_array[j]);
+    }
+    free(bound_array);
+#endif // LB_GPU
+  } else {
+#ifdef LB
+    int pos[3];
+    int boundary;
+    int gridsize[3];
+
+    gridsize[0] = box_l[0] / lblattice.agrid[0];
+    gridsize[1] = box_l[1] / lblattice.agrid[1];
+    gridsize[2] = box_l[2] / lblattice.agrid[2];
+
+    for (pos[2] = 0; pos[2] < gridsize[2]; pos[2]++) {
+      for (pos[1] = 0; pos[1] < gridsize[1]; pos[1]++) {
+        for (pos[0] = 0; pos[0] < gridsize[0]; pos[0]++) {
+          lb_lbnode_get_boundary(pos, &boundary);
+          boundary = (boundary != 0 ? 1 : 0);
+          fprintf(fp, "%f %f %f %d\n", (pos[0] + 0.5) * lblattice.agrid[0],
+                  (pos[1] + 0.5) * lblattice.agrid[1],
+                  (pos[2] + 0.5) * lblattice.agrid[2], boundary);
+        }
+      }
+    }
+#endif // LB
+  }
+
+  fclose(fp);
+  return 0;
+}
+
+int lb_lbfluid_print_velocity(char *filename) {
+  FILE *fp = fopen(filename, "w");
+
+  if (fp == nullptr) {
+    return 1;
+  }
+
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
 #ifdef SHANCHEN
-        fprintf(stderr, "TODO:adapt for SHANCHEN (%s:%d)\n",__FILE__,__LINE__);
-        errexit();
+    fprintf(stderr, "TODO:adapt for SHANCHEN (%s:%d)\n", __FILE__, __LINE__);
+    errexit();
 #endif // SHANCHEN
-        size_t size_of_values = lbpar_gpu.number_of_nodes * sizeof(LB_rho_v_pi_gpu);
-        host_values = (LB_rho_v_pi_gpu*)Utils::malloc(size_of_values);
-        lb_get_values_GPU(host_values);
-        int xyz[3];
-        int j;
-        for(j=0; j<int(lbpar_gpu.number_of_nodes); ++j) {
-            xyz[0] = j%lbpar_gpu.dim_x;
-            int k = j/lbpar_gpu.dim_x;
-            xyz[1] = k%lbpar_gpu.dim_y;
-            k /= lbpar_gpu.dim_y;
-            xyz[2] = k;
-            /** print of the calculated phys values */
-            fprintf(fp, "%f %f %f %f %f %f\n", (xyz[0]+0.5)*lbpar_gpu.agrid, (xyz[1]+0.5)*lbpar_gpu.agrid, (xyz[2]+0.5)*lbpar_gpu.agrid, host_values[j].v[0], host_values[j].v[1], host_values[j].v[2]);
-        }
-        free(host_values);
+    size_t size_of_values = lbpar_gpu.number_of_nodes * sizeof(LB_rho_v_pi_gpu);
+    host_values = (LB_rho_v_pi_gpu *)Utils::malloc(size_of_values);
+    lb_get_values_GPU(host_values);
+    int xyz[3];
+    int j;
+    for (j = 0; j < int(lbpar_gpu.number_of_nodes); ++j) {
+      xyz[0] = j % lbpar_gpu.dim_x;
+      int k = j / lbpar_gpu.dim_x;
+      xyz[1] = k % lbpar_gpu.dim_y;
+      k /= lbpar_gpu.dim_y;
+      xyz[2] = k;
+      /** print of the calculated phys values */
+      fprintf(fp, "%f %f %f %f %f %f\n", (xyz[0] + 0.5) * lbpar_gpu.agrid,
+              (xyz[1] + 0.5) * lbpar_gpu.agrid,
+              (xyz[2] + 0.5) * lbpar_gpu.agrid, host_values[j].v[0],
+              host_values[j].v[1], host_values[j].v[2]);
+    }
+    free(host_values);
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        int pos[3];
-        double u[3];
-        int gridsize[3];
+    int pos[3];
+    double u[3];
+    int gridsize[3];
 
-        gridsize[0] = box_l[0] / lblattice.agrid[0];
-        gridsize[1] = box_l[1] / lblattice.agrid[1];
-        gridsize[2] = box_l[2] / lblattice.agrid[2];
+    gridsize[0] = box_l[0] / lblattice.agrid[0];
+    gridsize[1] = box_l[1] / lblattice.agrid[1];
+    gridsize[2] = box_l[2] / lblattice.agrid[2];
 
-        for(pos[2] = 0; pos[2] < gridsize[2]; pos[2]++)
-        {
-            for(pos[1] = 0; pos[1] < gridsize[1]; pos[1]++)
-            {
-                for(pos[0] = 0; pos[0] < gridsize[0]; pos[0]++) {
+    for (pos[2] = 0; pos[2] < gridsize[2]; pos[2]++) {
+      for (pos[1] = 0; pos[1] < gridsize[1]; pos[1]++) {
+        for (pos[0] = 0; pos[0] < gridsize[0]; pos[0]++) {
 #ifdef SHANCHEN
-                    fprintf(stderr, "SHANCHEN not implemented for the CPU LB\n",__FILE__,__LINE__);
-                    errexit();
+          fprintf(stderr, "SHANCHEN not implemented for the CPU LB\n", __FILE__,
+                  __LINE__);
+          errexit();
 #endif // SHANCHEN
-                    lb_lbnode_get_u(pos, u);
-                    fprintf(fp, "%f %f %f %f %f %f\n",
-                            (pos[0]+0.5)*lblattice.agrid[0],
-                            (pos[1]+0.5)*lblattice.agrid[1],
-                            (pos[2]+0.5)*lblattice.agrid[2],
-                            u[0], u[1], u[2]);
-                }
-            }
+          lb_lbnode_get_u(pos, u);
+          fprintf(fp, "%f %f %f %f %f %f\n",
+                  (pos[0] + 0.5) * lblattice.agrid[0],
+                  (pos[1] + 0.5) * lblattice.agrid[1],
+                  (pos[2] + 0.5) * lblattice.agrid[2], u[0], u[1], u[2]);
         }
-#endif // LB
+      }
     }
+#endif // LB
+  }
 
-    fclose(fp);
-    return 0;
+  fclose(fp);
+  return 0;
 }
 
-
-int lb_lbfluid_save_checkpoint(char* filename, int binary) {
-    if(lattice_switch & LATTICE_LB_GPU) {
+int lb_lbfluid_save_checkpoint(char *filename, int binary) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        FILE* cpfile;
-        cpfile=fopen(filename, "w");
-        if (!cpfile) {
-            return ES_ERROR;
-        }
-        float* host_checkpoint_vd = (float *) Utils::malloc(lbpar_gpu.number_of_nodes * 19 * sizeof(float));
-        unsigned int* host_checkpoint_seed = (unsigned int *) Utils::malloc(lbpar_gpu.number_of_nodes * sizeof(unsigned int));
-        unsigned int* host_checkpoint_boundary = (unsigned int *) Utils::malloc(lbpar_gpu.number_of_nodes * sizeof(unsigned int));
-        lbForceFloat* host_checkpoint_force = (lbForceFloat *) Utils::malloc(lbpar_gpu.number_of_nodes * 3 * sizeof(lbForceFloat));
-        lb_save_checkpoint_GPU(host_checkpoint_vd, host_checkpoint_seed, host_checkpoint_boundary, host_checkpoint_force);
-        if(!binary)
-        {
-          for (int n=0; n<(19*int(lbpar_gpu.number_of_nodes)); n++) {
-              fprintf(cpfile, "%.8E \n", host_checkpoint_vd[n]);
-          }
-          for (int n=0; n<int(lbpar_gpu.number_of_nodes); n++) {
-              fprintf(cpfile, "%u \n", host_checkpoint_seed[n]);
-          }
-          for (int n=0; n<int(lbpar_gpu.number_of_nodes); n++) {
-              fprintf(cpfile, "%u \n", host_checkpoint_boundary[n]);
-          }
-          for (int n=0; n<(3*int(lbpar_gpu.number_of_nodes)); n++) {
-              fprintf(cpfile, "%.8E \n", host_checkpoint_force[n]);
-          }
-        }
-        else
-        {
-          fwrite(host_checkpoint_vd, sizeof(float), 19*int(lbpar_gpu.number_of_nodes), cpfile);
-          fwrite(host_checkpoint_seed, sizeof(int), int(lbpar_gpu.number_of_nodes), cpfile);
-          fwrite(host_checkpoint_boundary, sizeof(int), int(lbpar_gpu.number_of_nodes), cpfile);
-          fwrite(host_checkpoint_force, sizeof(lbForceFloat), 3*int(lbpar_gpu.number_of_nodes), cpfile);
-        }
-        fclose(cpfile);
-        free(host_checkpoint_vd);
-        free(host_checkpoint_seed);
-        free(host_checkpoint_boundary);
-        free(host_checkpoint_force);
-#endif // LB_GPU
+    FILE *cpfile;
+    cpfile = fopen(filename, "w");
+    if (!cpfile) {
+      return ES_ERROR;
     }
-    else if(lattice_switch & LATTICE_LB) {
+    float *host_checkpoint_vd =
+        (float *)Utils::malloc(lbpar_gpu.number_of_nodes * 19 * sizeof(float));
+    unsigned int *host_checkpoint_seed = (unsigned int *)Utils::malloc(
+        lbpar_gpu.number_of_nodes * sizeof(unsigned int));
+    unsigned int *host_checkpoint_boundary = (unsigned int *)Utils::malloc(
+        lbpar_gpu.number_of_nodes * sizeof(unsigned int));
+    lbForceFloat *host_checkpoint_force = (lbForceFloat *)Utils::malloc(
+        lbpar_gpu.number_of_nodes * 3 * sizeof(lbForceFloat));
+    lb_save_checkpoint_GPU(host_checkpoint_vd, host_checkpoint_seed,
+                           host_checkpoint_boundary, host_checkpoint_force);
+    if (!binary) {
+      for (int n = 0; n < (19 * int(lbpar_gpu.number_of_nodes)); n++) {
+        fprintf(cpfile, "%.8E \n", host_checkpoint_vd[n]);
+      }
+      for (int n = 0; n < int(lbpar_gpu.number_of_nodes); n++) {
+        fprintf(cpfile, "%u \n", host_checkpoint_seed[n]);
+      }
+      for (int n = 0; n < int(lbpar_gpu.number_of_nodes); n++) {
+        fprintf(cpfile, "%u \n", host_checkpoint_boundary[n]);
+      }
+      for (int n = 0; n < (3 * int(lbpar_gpu.number_of_nodes)); n++) {
+        fprintf(cpfile, "%.8E \n", host_checkpoint_force[n]);
+      }
+    } else {
+      fwrite(host_checkpoint_vd, sizeof(float),
+             19 * int(lbpar_gpu.number_of_nodes), cpfile);
+      fwrite(host_checkpoint_seed, sizeof(int), int(lbpar_gpu.number_of_nodes),
+             cpfile);
+      fwrite(host_checkpoint_boundary, sizeof(int),
+             int(lbpar_gpu.number_of_nodes), cpfile);
+      fwrite(host_checkpoint_force, sizeof(lbForceFloat),
+             3 * int(lbpar_gpu.number_of_nodes), cpfile);
+    }
+    fclose(cpfile);
+    free(host_checkpoint_vd);
+    free(host_checkpoint_seed);
+    free(host_checkpoint_boundary);
+    free(host_checkpoint_force);
+#endif // LB_GPU
+  } else if (lattice_switch & LATTICE_LB) {
 #ifdef LB
-		FILE* cpfile;
-		cpfile=fopen(filename, "w");
-		if (!cpfile) {
-			return ES_ERROR;
-		}
-		double pop[19];
-		int ind[3];
+    FILE *cpfile;
+    cpfile = fopen(filename, "w");
+    if (!cpfile) {
+      return ES_ERROR;
+    }
+    double pop[19];
+    int ind[3];
 
-		int gridsize[3];
+    int gridsize[3];
 
-		gridsize[0] = box_l[0] / lbpar.agrid;
-		gridsize[1] = box_l[1] / lbpar.agrid;
-		gridsize[2] = box_l[2] / lbpar.agrid;
+    gridsize[0] = box_l[0] / lbpar.agrid;
+    gridsize[1] = box_l[1] / lbpar.agrid;
+    gridsize[2] = box_l[2] / lbpar.agrid;
 
-		for (int i=0; i < gridsize[0]; i++) {
-			for (int j=0; j < gridsize[1]; j++) {
-				for (int k=0; k < gridsize[2]; k++) {
-					ind[0]=i;
-					ind[1]=j;
-					ind[2]=k;
-					lb_lbnode_get_pop(ind, pop);
-					if (!binary) {
-						for (int n=0; n<19; n++) {
-							fprintf(cpfile, "%.16e ", pop[n]);
-						}
-						fprintf(cpfile, "\n");
-					}
-					else {
-						fwrite(pop, sizeof(double), 19, cpfile);
-					}
-				}
-			}
-		}
-		fclose(cpfile);
+    for (int i = 0; i < gridsize[0]; i++) {
+      for (int j = 0; j < gridsize[1]; j++) {
+        for (int k = 0; k < gridsize[2]; k++) {
+          ind[0] = i;
+          ind[1] = j;
+          ind[2] = k;
+          lb_lbnode_get_pop(ind, pop);
+          if (!binary) {
+            for (int n = 0; n < 19; n++) {
+              fprintf(cpfile, "%.16e ", pop[n]);
+            }
+            fprintf(cpfile, "\n");
+          } else {
+            fwrite(pop, sizeof(double), 19, cpfile);
+          }
+        }
+      }
+    }
+    fclose(cpfile);
 #endif // LB
-	}
-    return ES_OK;
+  }
+  return ES_OK;
 }
 
-
-int lb_lbfluid_load_checkpoint(char* filename, int binary) {
-    if(lattice_switch & LATTICE_LB_GPU) {
+int lb_lbfluid_load_checkpoint(char *filename, int binary) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        FILE* cpfile;
-        cpfile=fopen(filename, "r");
-        if (!cpfile) {
-            return ES_ERROR;
-        }
-        std::vector<float> host_checkpoint_vd(lbpar_gpu.number_of_nodes * 19);
-        std::vector<unsigned int> host_checkpoint_seed(lbpar_gpu.number_of_nodes);
-        std::vector<unsigned int> host_checkpoint_boundary(lbpar_gpu.number_of_nodes);
-        std::vector<lbForceFloat> host_checkpoint_force(lbpar_gpu.number_of_nodes * 3);
-
-        if (!binary) {
-            for (int n=0; n<(19*int(lbpar_gpu.number_of_nodes)); n++) {
-                assert(fscanf(cpfile, "%f", &host_checkpoint_vd[n]) != EOF);
-            }
-            for (int n=0; n<int(lbpar_gpu.number_of_nodes); n++) {
-                assert(fscanf(cpfile, "%u", &host_checkpoint_seed[n]) != EOF);
-            }
-            for (int n=0; n<int(lbpar_gpu.number_of_nodes); n++) {
-                assert(fscanf(cpfile, "%u", &host_checkpoint_boundary[n]) != EOF);
-            }
-            for (int n=0; n<(3*int(lbpar_gpu.number_of_nodes)); n++) {
-              if (sizeof(lbForceFloat) == sizeof(float))
-                assert(fscanf(cpfile, "%f", &host_checkpoint_force[n]) != EOF);
-              else
-                assert(fscanf(cpfile, "%f", &host_checkpoint_force[n]) != EOF);
-            }
-        }
-        else
-        {
-          if(fread(host_checkpoint_vd.data(), sizeof(float), 19*int(lbpar_gpu.number_of_nodes), cpfile) != (unsigned int) (19*lbpar_gpu.number_of_nodes))
-            return ES_ERROR;
-          if(fread(host_checkpoint_seed.data(), sizeof(int), int(lbpar_gpu.number_of_nodes), cpfile) != (unsigned int) lbpar_gpu.number_of_nodes)
-            return ES_ERROR;
-          if(fread(host_checkpoint_boundary.data(), sizeof(int), int(lbpar_gpu.number_of_nodes), cpfile) != (unsigned int) lbpar_gpu.number_of_nodes)
-            return ES_ERROR;
-          if(fread(host_checkpoint_force.data(), sizeof(lbForceFloat), 3*int(lbpar_gpu.number_of_nodes), cpfile) != (unsigned int) (3*lbpar_gpu.number_of_nodes))
-            return ES_ERROR;
-        }
-        lb_load_checkpoint_GPU(host_checkpoint_vd.data(), host_checkpoint_seed.data(), host_checkpoint_boundary.data(), host_checkpoint_force.data());
-        fclose(cpfile);
-#endif // LB_GPU
+    FILE *cpfile;
+    cpfile = fopen(filename, "r");
+    if (!cpfile) {
+      return ES_ERROR;
     }
-    else if(lattice_switch & LATTICE_LB) {
+    std::vector<float> host_checkpoint_vd(lbpar_gpu.number_of_nodes * 19);
+    std::vector<unsigned int> host_checkpoint_seed(lbpar_gpu.number_of_nodes);
+    std::vector<unsigned int> host_checkpoint_boundary(
+        lbpar_gpu.number_of_nodes);
+    std::vector<lbForceFloat> host_checkpoint_force(lbpar_gpu.number_of_nodes *
+                                                    3);
+
+    if (!binary) {
+      for (int n = 0; n < (19 * int(lbpar_gpu.number_of_nodes)); n++) {
+        assert(fscanf(cpfile, "%f", &host_checkpoint_vd[n]) != EOF);
+      }
+      for (int n = 0; n < int(lbpar_gpu.number_of_nodes); n++) {
+        assert(fscanf(cpfile, "%u", &host_checkpoint_seed[n]) != EOF);
+      }
+      for (int n = 0; n < int(lbpar_gpu.number_of_nodes); n++) {
+        assert(fscanf(cpfile, "%u", &host_checkpoint_boundary[n]) != EOF);
+      }
+      for (int n = 0; n < (3 * int(lbpar_gpu.number_of_nodes)); n++) {
+        if (sizeof(lbForceFloat) == sizeof(float))
+          assert(fscanf(cpfile, "%f", &host_checkpoint_force[n]) != EOF);
+        else
+          assert(fscanf(cpfile, "%f", &host_checkpoint_force[n]) != EOF);
+      }
+    } else {
+      if (fread(host_checkpoint_vd.data(), sizeof(float),
+                19 * int(lbpar_gpu.number_of_nodes),
+                cpfile) != (unsigned int)(19 * lbpar_gpu.number_of_nodes))
+        return ES_ERROR;
+      if (fread(host_checkpoint_seed.data(), sizeof(int),
+                int(lbpar_gpu.number_of_nodes),
+                cpfile) != (unsigned int)lbpar_gpu.number_of_nodes)
+        return ES_ERROR;
+      if (fread(host_checkpoint_boundary.data(), sizeof(int),
+                int(lbpar_gpu.number_of_nodes),
+                cpfile) != (unsigned int)lbpar_gpu.number_of_nodes)
+        return ES_ERROR;
+      if (fread(host_checkpoint_force.data(), sizeof(lbForceFloat),
+                3 * int(lbpar_gpu.number_of_nodes),
+                cpfile) != (unsigned int)(3 * lbpar_gpu.number_of_nodes))
+        return ES_ERROR;
+    }
+    lb_load_checkpoint_GPU(
+        host_checkpoint_vd.data(), host_checkpoint_seed.data(),
+        host_checkpoint_boundary.data(), host_checkpoint_force.data());
+    fclose(cpfile);
+#endif // LB_GPU
+  } else if (lattice_switch & LATTICE_LB) {
 #ifdef LB
-        FILE* cpfile;
-        cpfile=fopen(filename, "r");
-        if (!cpfile) {
-            return ES_ERROR;
-        }
-        double pop[19];
-        int ind[3];
+    FILE *cpfile;
+    cpfile = fopen(filename, "r");
+    if (!cpfile) {
+      return ES_ERROR;
+    }
+    double pop[19];
+    int ind[3];
 
-        int gridsize[3];
-        lbpar.resend_halo=1;
-        mpi_bcast_lb_params(0);
-        gridsize[0] = box_l[0] / lbpar.agrid;
-        gridsize[1] = box_l[1] / lbpar.agrid;
-        gridsize[2] = box_l[2] / lbpar.agrid;
+    int gridsize[3];
+    lbpar.resend_halo = 1;
+    mpi_bcast_lb_params(0);
+    gridsize[0] = box_l[0] / lbpar.agrid;
+    gridsize[1] = box_l[1] / lbpar.agrid;
+    gridsize[2] = box_l[2] / lbpar.agrid;
 
-        for (int i=0; i < gridsize[0]; i++) {
-            for (int j=0; j < gridsize[1]; j++) {
-                for (int k=0; k < gridsize[2]; k++) {
-                    ind[0]=i;
-                    ind[1]=j;
-                    ind[2]=k;
-                    if (!binary) {
-                        if (fscanf(cpfile, "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf \n", &pop[0],&pop[1],&pop[2],&pop[3],&pop[4],&pop[5],&pop[6],&pop[7],&pop[8],&pop[9],&pop[10],&pop[11],&pop[12],&pop[13],&pop[14],&pop[15],&pop[16],&pop[17],&pop[18]) != 19) {
-                            return ES_ERROR;
-                        }
-                    }
-                    else {
-                        if (fread(pop, sizeof(double), 19, cpfile) != 19)
-                            return ES_ERROR;
-                    }
-                    lb_lbnode_set_pop(ind, pop);
-                }
+    for (int i = 0; i < gridsize[0]; i++) {
+      for (int j = 0; j < gridsize[1]; j++) {
+        for (int k = 0; k < gridsize[2]; k++) {
+          ind[0] = i;
+          ind[1] = j;
+          ind[2] = k;
+          if (!binary) {
+            if (fscanf(cpfile,
+                       "%lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf "
+                       "%lf %lf %lf %lf %lf %lf \n",
+                       &pop[0], &pop[1], &pop[2], &pop[3], &pop[4], &pop[5],
+                       &pop[6], &pop[7], &pop[8], &pop[9], &pop[10], &pop[11],
+                       &pop[12], &pop[13], &pop[14], &pop[15], &pop[16],
+                       &pop[17], &pop[18]) != 19) {
+              return ES_ERROR;
             }
+          } else {
+            if (fread(pop, sizeof(double), 19, cpfile) != 19)
+              return ES_ERROR;
+          }
+          lb_lbnode_set_pop(ind, pop);
         }
-        fclose(cpfile);
+      }
+    }
+    fclose(cpfile);
 //  lbpar.resend_halo=1;
 //  mpi_bcast_lb_params(0);
 #endif // LB
-    }
-    else {
-        runtimeErrorMsg() <<"To load an LB checkpoint one needs to have already initialized the LB fluid with the same grid size.";
-        return ES_ERROR;
-    }
-    return ES_OK;
+  } else {
+    runtimeErrorMsg() << "To load an LB checkpoint one needs to have already "
+                         "initialized the LB fluid with the same grid size.";
+    return ES_ERROR;
+  }
+  return ES_OK;
 }
 
-
-int lb_lbnode_get_rho(int* ind, double* p_rho){
-    if (lattice_switch & LATTICE_LB_GPU) {
+int lb_lbnode_get_rho(int *ind, double *p_rho) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        int single_nodeindex = ind[0] + ind[1]*lbpar_gpu.dim_x + ind[2]*lbpar_gpu.dim_x*lbpar_gpu.dim_y;
-        static LB_rho_v_pi_gpu *host_print_values=nullptr;
+    int single_nodeindex = ind[0] + ind[1] * lbpar_gpu.dim_x +
+                           ind[2] * lbpar_gpu.dim_x * lbpar_gpu.dim_y;
+    static LB_rho_v_pi_gpu *host_print_values = nullptr;
 
-        if(host_print_values==nullptr) host_print_values = (LB_rho_v_pi_gpu *) Utils::malloc(sizeof(LB_rho_v_pi_gpu));
-        lb_print_node_GPU(single_nodeindex, host_print_values);
-        for(int ii=0;ii<LB_COMPONENTS;ii++) {
-            p_rho[ii] = (double)(host_print_values->rho[ii]);
-        }
-#endif // LB_GPU
-    } else {
-#ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
-        double rho; double j[3]; double pi[6];
-
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
-
-        mpi_recv_fluid(node,index,&rho,j,pi);
-        // unit conversion
-        rho *= 1/lbpar.agrid/lbpar.agrid/lbpar.agrid;
-        *p_rho = rho;
-#endif // LB
+    if (host_print_values == nullptr)
+      host_print_values =
+          (LB_rho_v_pi_gpu *)Utils::malloc(sizeof(LB_rho_v_pi_gpu));
+    lb_print_node_GPU(single_nodeindex, host_print_values);
+    for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+      p_rho[ii] = (double)(host_print_values->rho[ii]);
     }
-    return 0;
+#endif // LB_GPU
+  } else {
+#ifdef LB
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
+    double rho;
+    double j[3];
+    double pi[6];
+
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
+
+    mpi_recv_fluid(node, index, &rho, j, pi);
+    // unit conversion
+    rho *= 1 / lbpar.agrid / lbpar.agrid / lbpar.agrid;
+    *p_rho = rho;
+#endif // LB
+  }
+  return 0;
 }
 
-
-int lb_lbnode_get_u(int* ind, double* p_u) {
-    if (lattice_switch & LATTICE_LB_GPU) {
+int lb_lbnode_get_u(int *ind, double *p_u) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        static LB_rho_v_pi_gpu *host_print_values=nullptr;
-        if(host_print_values==nullptr) host_print_values= (LB_rho_v_pi_gpu *) Utils::malloc(sizeof(LB_rho_v_pi_gpu));
+    static LB_rho_v_pi_gpu *host_print_values = nullptr;
+    if (host_print_values == nullptr)
+      host_print_values =
+          (LB_rho_v_pi_gpu *)Utils::malloc(sizeof(LB_rho_v_pi_gpu));
 
-        int single_nodeindex = ind[0] + ind[1]*lbpar_gpu.dim_x + ind[2]*lbpar_gpu.dim_x*lbpar_gpu.dim_y;
-        lb_print_node_GPU(single_nodeindex, host_print_values);
+    int single_nodeindex = ind[0] + ind[1] * lbpar_gpu.dim_x +
+                           ind[2] * lbpar_gpu.dim_x * lbpar_gpu.dim_y;
+    lb_print_node_GPU(single_nodeindex, host_print_values);
 
-        p_u[0] = (double)(host_print_values[0].v[0]);
-        p_u[1] = (double)(host_print_values[0].v[1]);
-        p_u[2] = (double)(host_print_values[0].v[2]);
+    p_u[0] = (double)(host_print_values[0].v[0]);
+    p_u[1] = (double)(host_print_values[0].v[1]);
+    p_u[2] = (double)(host_print_values[0].v[2]);
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
-        double rho; double j[3]; double pi[6];
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
+    double rho;
+    double j[3];
+    double pi[6];
 
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
 
-        mpi_recv_fluid(node,index,&rho,j,pi);
-        // unit conversion
-        p_u[0] = j[0]/rho*lbpar.agrid/lbpar.tau;
-        p_u[1] = j[1]/rho*lbpar.agrid/lbpar.tau;
-        p_u[2] = j[2]/rho*lbpar.agrid/lbpar.tau;
+    mpi_recv_fluid(node, index, &rho, j, pi);
+    // unit conversion
+    p_u[0] = j[0] / rho * lbpar.agrid / lbpar.tau;
+    p_u[1] = j[1] / rho * lbpar.agrid / lbpar.tau;
+    p_u[2] = j[2] / rho * lbpar.agrid / lbpar.tau;
 #endif // LB
-    }
-    return 0;
+  }
+  return 0;
 }
-
 
 /** calculates the fluid velocity at a given position of the
  * lattice. Note that it can lead to undefined behavior if the
  * position is not within the local lattice. This version of the function
  * can be called without the position needing to be on the local processor.
  * Note that this gives a slightly different version than the values used to
- * couple to MD beads when near a wall, see lb_lbfluid_get_interpolated_velocity.
+ * couple to MD beads when near a wall, see
+ * lb_lbfluid_get_interpolated_velocity.
  */
-int lb_lbfluid_get_interpolated_velocity_global (double* p, double* v) {
-    double local_v[3] = {0, 0, 0}, delta[6]; //velocity field, relative positions to surrounding nodes
-    int 	 ind[3] = {0,0,0}, tmpind[3]; //node indices
-    int		 x, y, z; //counters
+int lb_lbfluid_get_interpolated_velocity_global(double *p, double *v) {
+  double local_v[3] = {0, 0, 0},
+         delta[6]; // velocity field, relative positions to surrounding nodes
+  int ind[3] = {0, 0, 0}, tmpind[3]; // node indices
+  int x, y, z;                       // counters
 
-    // convert the position into lower left grid point
-    if (lattice_switch & LATTICE_LB_GPU)
-    {
+  // convert the position into lower left grid point
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-      Lattice::map_position_to_lattice_global(p, ind, delta, lbpar_gpu.agrid);
+    Lattice::map_position_to_lattice_global(p, ind, delta, lbpar_gpu.agrid);
 #endif // LB_GPU
-    }
-    else
-    {
+  } else {
 #ifdef LB
-      Lattice::map_position_to_lattice_global(p, ind, delta, lbpar.agrid);
+    Lattice::map_position_to_lattice_global(p, ind, delta, lbpar.agrid);
 #endif // LB
-    }
+  }
 
-  //set the initial velocity to zero in all directions
+  // set the initial velocity to zero in all directions
   v[0] = 0;
   v[1] = 0;
   v[2] = 0;
 
-  for (z=0;z<2;z++) {
-    for (y=0;y<2;y++) {
-      for (x=0;x<2;x++) {
-        //give the index of the neighbouring nodes
-        tmpind[0] = ind[0]+x;
-        tmpind[1] = ind[1]+y;
-        tmpind[2] = ind[2]+z;
+  for (z = 0; z < 2; z++) {
+    for (y = 0; y < 2; y++) {
+      for (x = 0; x < 2; x++) {
+        // give the index of the neighbouring nodes
+        tmpind[0] = ind[0] + x;
+        tmpind[1] = ind[1] + y;
+        tmpind[2] = ind[2] + z;
 
         if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-          if (tmpind[0] == int(lbpar_gpu.dim_x)) tmpind[0] = 0;
-          if (tmpind[1] == int(lbpar_gpu.dim_y)) tmpind[1] = 0;
-          if (tmpind[2] == int(lbpar_gpu.dim_z)) tmpind[2] = 0;
+          if (tmpind[0] == int(lbpar_gpu.dim_x))
+            tmpind[0] = 0;
+          if (tmpind[1] == int(lbpar_gpu.dim_y))
+            tmpind[1] = 0;
+          if (tmpind[2] == int(lbpar_gpu.dim_z))
+            tmpind[2] = 0;
 #endif // LB_GPU
-        } else {  
+        } else {
 #ifdef LB
-          if (tmpind[0] == box_l[0]/lbpar.agrid) tmpind[0] = 0;
-          if (tmpind[1] == box_l[1]/lbpar.agrid) tmpind[1] = 0;
-          if (tmpind[2] == box_l[2]/lbpar.agrid) tmpind[2] = 0;
+          if (tmpind[0] == box_l[0] / lbpar.agrid)
+            tmpind[0] = 0;
+          if (tmpind[1] == box_l[1] / lbpar.agrid)
+            tmpind[1] = 0;
+          if (tmpind[2] == box_l[2] / lbpar.agrid)
+            tmpind[2] = 0;
 #endif // LB
         }
 
 #ifdef SHANCHEN
-        //printf (" %d %d %d %f %f %f\n", tmpind[0], tmpind[1],tmpind[2],v[0], v[1], v[2]);
-        fprintf(stderr, "TODO:adapt for SHANCHEN (%s:%d)\n",__FILE__,__LINE__);
+        // printf (" %d %d %d %f %f %f\n", tmpind[0], tmpind[1],tmpind[2],v[0],
+        // v[1], v[2]);
+        fprintf(stderr, "TODO:adapt for SHANCHEN (%s:%d)\n", __FILE__,
+                __LINE__);
         errexit();
 #endif // SHANCHEN
 
         lb_lbnode_get_u(tmpind, local_v);
 
-        v[0] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*local_v[0];
-        v[1] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*local_v[1];	  
-        v[2] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*local_v[2];
+        v[0] +=
+            delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] * local_v[0];
+        v[1] +=
+            delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] * local_v[1];
+        v[2] +=
+            delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] * local_v[2];
       }
     }
   }
@@ -1275,1602 +1313,1682 @@ int lb_lbfluid_get_interpolated_velocity_global (double* p, double* v) {
   return 0;
 }
 
+int lb_lbnode_get_pi(int *ind, double *p_pi) {
+  double p0 = 0;
 
-int lb_lbnode_get_pi(int* ind, double* p_pi) {
-    double p0 = 0;
+  lb_lbnode_get_pi_neq(ind, p_pi);
 
-    lb_lbnode_get_pi_neq(ind, p_pi);
-
-    if (lattice_switch & LATTICE_LB_GPU) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        for(int ii=0;ii<LB_COMPONENTS;ii++){
-            p0 += lbpar_gpu.rho[ii]*lbpar_gpu.agrid*lbpar_gpu.agrid/lbpar_gpu.tau/lbpar_gpu.tau/3.;
-        }
-#endif // LB_GPU
-    } else {
-#ifdef LB
-        p0 = lbpar.rho*lbpar.agrid*lbpar.agrid/lbpar.tau/lbpar.tau/3.;
-#endif // LB
+    for (int ii = 0; ii < LB_COMPONENTS; ii++) {
+      p0 += lbpar_gpu.rho[ii] * lbpar_gpu.agrid * lbpar_gpu.agrid /
+            lbpar_gpu.tau / lbpar_gpu.tau / 3.;
     }
+#endif // LB_GPU
+  } else {
+#ifdef LB
+    p0 = lbpar.rho * lbpar.agrid * lbpar.agrid / lbpar.tau / lbpar.tau / 3.;
+#endif // LB
+  }
 
-    p_pi[0] += p0;
-    p_pi[2] += p0;
-    p_pi[5] += p0;
+  p_pi[0] += p0;
+  p_pi[2] += p0;
+  p_pi[5] += p0;
 
-    return 0;
+  return 0;
 }
 
-
-int lb_lbnode_get_pi_neq(int* ind, double* p_pi) {
-    if (lattice_switch & LATTICE_LB_GPU) {
+int lb_lbnode_get_pi_neq(int *ind, double *p_pi) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        static LB_rho_v_pi_gpu *host_print_values=nullptr;
-        if(host_print_values==nullptr) host_print_values= (LB_rho_v_pi_gpu *) Utils::malloc(sizeof(LB_rho_v_pi_gpu));
+    static LB_rho_v_pi_gpu *host_print_values = nullptr;
+    if (host_print_values == nullptr)
+      host_print_values =
+          (LB_rho_v_pi_gpu *)Utils::malloc(sizeof(LB_rho_v_pi_gpu));
 
-        int single_nodeindex = ind[0] + ind[1]*lbpar_gpu.dim_x + ind[2]*lbpar_gpu.dim_x*lbpar_gpu.dim_y;
-        lb_print_node_GPU(single_nodeindex, host_print_values);
-        for (int i = 0; i<6; i++) {
-            p_pi[i]=host_print_values->pi[i];
-        }
-        return 0;
-#endif // LB_GPU
-    } else {
-#ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
-        double rho; double j[3]; double pi[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
-
-        mpi_recv_fluid(node,index,&rho,j,pi);
-        // unit conversion
-        p_pi[0] = pi[0]/lbpar.tau/lbpar.tau/lbpar.agrid;
-        p_pi[1] = pi[1]/lbpar.tau/lbpar.tau/lbpar.agrid;
-        p_pi[2] = pi[2]/lbpar.tau/lbpar.tau/lbpar.agrid;
-        p_pi[3] = pi[3]/lbpar.tau/lbpar.tau/lbpar.agrid;
-        p_pi[4] = pi[4]/lbpar.tau/lbpar.tau/lbpar.agrid;
-        p_pi[5] = pi[5]/lbpar.tau/lbpar.tau/lbpar.agrid;
-#endif // LB
+    int single_nodeindex = ind[0] + ind[1] * lbpar_gpu.dim_x +
+                           ind[2] * lbpar_gpu.dim_x * lbpar_gpu.dim_y;
+    lb_print_node_GPU(single_nodeindex, host_print_values);
+    for (int i = 0; i < 6; i++) {
+      p_pi[i] = host_print_values->pi[i];
     }
     return 0;
-}
-
-
-int lb_lbnode_get_boundary(int* ind, int* p_boundary) {
-    if (lattice_switch & LATTICE_LB_GPU) {
-#ifdef LB_GPU
-        unsigned int host_flag;
-        int single_nodeindex = ind[0] + ind[1]*lbpar_gpu.dim_x + ind[2]*lbpar_gpu.dim_x*lbpar_gpu.dim_y;
-        lb_get_boundary_flag_GPU(single_nodeindex, &host_flag);
-        p_boundary[0] = host_flag;
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
+    double rho;
+    double j[3];
+    double pi[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
 
-        mpi_recv_fluid_boundary_flag(node,index,p_boundary);
+    mpi_recv_fluid(node, index, &rho, j, pi);
+    // unit conversion
+    p_pi[0] = pi[0] / lbpar.tau / lbpar.tau / lbpar.agrid;
+    p_pi[1] = pi[1] / lbpar.tau / lbpar.tau / lbpar.agrid;
+    p_pi[2] = pi[2] / lbpar.tau / lbpar.tau / lbpar.agrid;
+    p_pi[3] = pi[3] / lbpar.tau / lbpar.tau / lbpar.agrid;
+    p_pi[4] = pi[4] / lbpar.tau / lbpar.tau / lbpar.agrid;
+    p_pi[5] = pi[5] / lbpar.tau / lbpar.tau / lbpar.agrid;
 #endif // LB
-    }
-    return 0;
+  }
+  return 0;
 }
-#endif  //defined (LB) || defined (LB_GPU)
 
-
-int lb_lbnode_get_pop(int* ind, double* p_pop) {
-    if (lattice_switch & LATTICE_LB_GPU) {
+int lb_lbnode_get_boundary(int *ind, int *p_boundary) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-      float population[19];
-
-      // c is the LB_COMPONENT for SHANCHEN (not yet interfaced)
-      int c = 0;
-      lb_lbfluid_get_population( ind, population, c );
-
-      for (int i = 0; i < LBQ; ++i)
-        p_pop[i] = population[i];
+    unsigned int host_flag;
+    int single_nodeindex = ind[0] + ind[1] * lbpar_gpu.dim_x +
+                           ind[2] * lbpar_gpu.dim_x * lbpar_gpu.dim_y;
+    lb_get_boundary_flag_GPU(single_nodeindex, &host_flag);
+    p_boundary[0] = host_flag;
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
 
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
-        mpi_recv_fluid_populations(node, index, p_pop);
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
+
+    mpi_recv_fluid_boundary_flag(node, index, p_boundary);
 #endif // LB
-    }
-    return 0;
+  }
+  return 0;
+}
+#endif // defined (LB) || defined (LB_GPU)
+
+int lb_lbnode_get_pop(int *ind, double *p_pop) {
+  if (lattice_switch & LATTICE_LB_GPU) {
+#ifdef LB_GPU
+    float population[19];
+
+    // c is the LB_COMPONENT for SHANCHEN (not yet interfaced)
+    int c = 0;
+    lb_lbfluid_get_population(ind, population, c);
+
+    for (int i = 0; i < LBQ; ++i)
+      p_pop[i] = population[i];
+#endif // LB_GPU
+  } else {
+#ifdef LB
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
+
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
+    mpi_recv_fluid_populations(node, index, p_pop);
+#endif // LB
+  }
+  return 0;
 }
 
-
-int lb_lbnode_set_rho(int* ind, double *p_rho){
-    if (lattice_switch & LATTICE_LB_GPU) {
+int lb_lbnode_set_rho(int *ind, double *p_rho) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        float host_rho[LB_COMPONENTS];
-        int single_nodeindex = ind[0] + ind[1]*lbpar_gpu.dim_x + ind[2]*lbpar_gpu.dim_x*lbpar_gpu.dim_y;
-        int i;
-        for(i=0;i<LB_COMPONENTS;i++){
-            host_rho[i]=(float)p_rho[i];
-        }
-        lb_set_node_rho_GPU(single_nodeindex, host_rho);
+    float host_rho[LB_COMPONENTS];
+    int single_nodeindex = ind[0] + ind[1] * lbpar_gpu.dim_x +
+                           ind[2] * lbpar_gpu.dim_x * lbpar_gpu.dim_y;
+    int i;
+    for (i = 0; i < LB_COMPONENTS; i++) {
+      host_rho[i] = (float)p_rho[i];
+    }
+    lb_set_node_rho_GPU(single_nodeindex, host_rho);
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
-        double rho; double j[3]; double pi[6];
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
+    double rho;
+    double j[3];
+    double pi[6];
 
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
 
-        mpi_recv_fluid(node,index,&rho,j,pi);
-        rho  = (*p_rho)*lbpar.agrid*lbpar.agrid*lbpar.agrid;
-        mpi_send_fluid(node,index,rho,j,pi) ;
+    mpi_recv_fluid(node, index, &rho, j, pi);
+    rho = (*p_rho) * lbpar.agrid * lbpar.agrid * lbpar.agrid;
+    mpi_send_fluid(node, index, rho, j, pi);
 
 //  lb_calc_average_rho();
 //  lb_reinit_parameters();
 #endif // LB
-    }
-    return 0;
+  }
+  return 0;
 }
 
-
-int lb_lbnode_set_u(int* ind, double* u){
-    if (lattice_switch & LATTICE_LB_GPU) {
+int lb_lbnode_set_u(int *ind, double *u) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-        float host_velocity[3];
-        host_velocity[0] = (float)u[0]*lbpar_gpu.tau/lbpar_gpu.agrid;
-        host_velocity[1] = (float)u[1]*lbpar_gpu.tau/lbpar_gpu.agrid;
-        host_velocity[2] = (float)u[2]*lbpar_gpu.tau/lbpar_gpu.agrid;
-        int single_nodeindex = ind[0] + ind[1]*lbpar_gpu.dim_x + ind[2]*lbpar_gpu.dim_x*lbpar_gpu.dim_y;
-        lb_set_node_velocity_GPU(single_nodeindex, host_velocity);
+    float host_velocity[3];
+    host_velocity[0] = (float)u[0] * lbpar_gpu.tau / lbpar_gpu.agrid;
+    host_velocity[1] = (float)u[1] * lbpar_gpu.tau / lbpar_gpu.agrid;
+    host_velocity[2] = (float)u[2] * lbpar_gpu.tau / lbpar_gpu.agrid;
+    int single_nodeindex = ind[0] + ind[1] * lbpar_gpu.dim_x +
+                           ind[2] * lbpar_gpu.dim_x * lbpar_gpu.dim_y;
+    lb_set_node_velocity_GPU(single_nodeindex, host_velocity);
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
-        double rho; double j[3]; double pi[6];
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
+    double rho;
+    double j[3];
+    double pi[6];
 
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
 
-        /* transform to lattice units */
+    /* transform to lattice units */
 
-        mpi_recv_fluid(node,index,&rho,j,pi);
-        j[0] = rho*u[0]*lbpar.tau*lbpar.agrid;
-        j[1] = rho*u[1]*lbpar.tau*lbpar.agrid;
-        j[2] = rho*u[2]*lbpar.tau*lbpar.agrid;
-        mpi_send_fluid(node,index,rho,j,pi) ;
+    mpi_recv_fluid(node, index, &rho, j, pi);
+    j[0] = rho * u[0] * lbpar.tau * lbpar.agrid;
+    j[1] = rho * u[1] * lbpar.tau * lbpar.agrid;
+    j[2] = rho * u[2] * lbpar.tau * lbpar.agrid;
+    mpi_send_fluid(node, index, rho, j, pi);
 #endif // LB
-    }
-    return 0;
+  }
+  return 0;
 }
 
+int lb_lbnode_set_pi(int *ind, double *pi) { return -100; }
 
-int lb_lbnode_set_pi(int* ind, double* pi) {
-    return -100;
-}
+int lb_lbnode_set_pi_neq(int *ind, double *pi_neq) { return -100; }
 
-
-int lb_lbnode_set_pi_neq(int* ind, double* pi_neq) {
-    return -100;
-}
-
-
-int lb_lbnode_set_pop(int* ind, double* p_pop) {
-    if (lattice_switch & LATTICE_LB_GPU) {
+int lb_lbnode_set_pop(int *ind, double *p_pop) {
+  if (lattice_switch & LATTICE_LB_GPU) {
 #ifdef LB_GPU
-      float population[19];
+    float population[19];
 
-      for (int i = 0; i < LBQ; ++i)
-        population[i] = p_pop[i];
+    for (int i = 0; i < LBQ; ++i)
+      population[i] = p_pop[i];
 
-      // c is the LB_COMPONENT for SHANCHEN (not yet interfaced)
-      int c = 0;
-      lb_lbfluid_set_population( ind, population, c );
+    // c is the LB_COMPONENT for SHANCHEN (not yet interfaced)
+    int c = 0;
+    lb_lbfluid_set_population(ind, population, c);
 #endif // LB_GPU
-    } else {
+  } else {
 #ifdef LB
-        Lattice::index_t index;
-        int node, grid[3], ind_shifted[3];
+    Lattice::index_t index;
+    int node, grid[3], ind_shifted[3];
 
-        ind_shifted[0] = ind[0]; ind_shifted[1] = ind[1]; ind_shifted[2] = ind[2];
-        node = lblattice.map_lattice_to_node(ind_shifted,grid);
-        index = get_linear_index(ind_shifted[0],ind_shifted[1],ind_shifted[2],lblattice.halo_grid);
-        mpi_send_fluid_populations(node, index, p_pop);
+    ind_shifted[0] = ind[0];
+    ind_shifted[1] = ind[1];
+    ind_shifted[2] = ind[2];
+    node = lblattice.map_lattice_to_node(ind_shifted, grid);
+    index = get_linear_index(ind_shifted[0], ind_shifted[1], ind_shifted[2],
+                             lblattice.halo_grid);
+    mpi_send_fluid_populations(node, index, p_pop);
 #endif // LB
-    }
-    return 0;
+  }
+  return 0;
 }
 
-
-int lb_lbnode_set_extforce(int* ind, double* f) {
-    return -100;
-}
-
+int lb_lbnode_set_extforce(int *ind, double *f) { return -100; }
 
 #ifdef LB
 /********************** The Main LB Part *************************************/
 /* Halo communication for push scheme */
 static void halo_push_communication() {
-    Lattice::index_t index;
-    int x, y, z, count;
-    int rnode, snode;
-    double *buffer=nullptr, *sbuf=nullptr, *rbuf=nullptr;
-    MPI_Status status;
+  Lattice::index_t index;
+  int x, y, z, count;
+  int rnode, snode;
+  double *buffer = nullptr, *sbuf = nullptr, *rbuf = nullptr;
+  MPI_Status status;
 
-    int yperiod = lblattice.halo_grid[0];
-    int zperiod = lblattice.halo_grid[0]*lblattice.halo_grid[1];
+  int yperiod = lblattice.halo_grid[0];
+  int zperiod = lblattice.halo_grid[0] * lblattice.halo_grid[1];
 
-    /***************
-     * X direction *
-     ***************/
-    count = 5*lblattice.halo_grid[1]*lblattice.halo_grid[2];
-    sbuf = (double*) Utils::malloc(count*sizeof(double));
-    rbuf = (double*) Utils::malloc(count*sizeof(double));
+  /***************
+   * X direction *
+   ***************/
+  count = 5 * lblattice.halo_grid[1] * lblattice.halo_grid[2];
+  sbuf = (double *)Utils::malloc(count * sizeof(double));
+  rbuf = (double *)Utils::malloc(count * sizeof(double));
 
-    /* send to right, recv from left i = 1, 7, 9, 11, 13 */
-    snode = node_neighbors[1];
-    rnode = node_neighbors[0];
+  /* send to right, recv from left i = 1, 7, 9, 11, 13 */
+  snode = node_neighbors[1];
+  rnode = node_neighbors[0];
 
-    buffer = sbuf;
-    index = get_linear_index(lblattice.grid[0]+1,0,0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (y=0; y<lblattice.halo_grid[1]; y++) {
+  buffer = sbuf;
+  index = get_linear_index(lblattice.grid[0] + 1, 0, 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (y = 0; y < lblattice.halo_grid[1]; y++) {
 
-            buffer[0] = lbfluid[1][1][index];
-            buffer[1] = lbfluid[1][7][index];
-            buffer[2] = lbfluid[1][9][index];
-            buffer[3] = lbfluid[1][11][index];
-            buffer[4] = lbfluid[1][13][index];
-            buffer += 5;
+      buffer[0] = lbfluid[1][1][index];
+      buffer[1] = lbfluid[1][7][index];
+      buffer[2] = lbfluid[1][9][index];
+      buffer[3] = lbfluid[1][11][index];
+      buffer[4] = lbfluid[1][13][index];
+      buffer += 5;
 
-            index += yperiod;
-        }
+      index += yperiod;
     }
+  }
 
-    if (node_grid[0] > 1) {
-        MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD,
-                     rbuf, count, MPI_DOUBLE, rnode, REQ_HALO_SPREAD,
-                     comm_cart, &status);
-    } else {
-        memmove(rbuf,sbuf,count*sizeof(double));
+  if (node_grid[0] > 1) {
+    MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD, rbuf, count,
+                 MPI_DOUBLE, rnode, REQ_HALO_SPREAD, comm_cart, &status);
+  } else {
+    memmove(rbuf, sbuf, count * sizeof(double));
+  }
+
+  buffer = rbuf;
+  index = get_linear_index(1, 0, 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (y = 0; y < lblattice.halo_grid[1]; y++) {
+
+      lbfluid[1][1][index] = buffer[0];
+      lbfluid[1][7][index] = buffer[1];
+      lbfluid[1][9][index] = buffer[2];
+      lbfluid[1][11][index] = buffer[3];
+      lbfluid[1][13][index] = buffer[4];
+      buffer += 5;
+
+      index += yperiod;
     }
+  }
 
-    buffer = rbuf;
-    index = get_linear_index(1,0,0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (y=0; y<lblattice.halo_grid[1]; y++) {
+  /* send to left, recv from right i = 2, 8, 10, 12, 14 */
+  snode = node_neighbors[0];
+  rnode = node_neighbors[1];
 
-            lbfluid[1][1][index] = buffer[0];
-            lbfluid[1][7][index] = buffer[1];
-            lbfluid[1][9][index] = buffer[2];
-            lbfluid[1][11][index] = buffer[3];
-            lbfluid[1][13][index] = buffer[4];
-            buffer += 5;
+  buffer = sbuf;
+  index = get_linear_index(0, 0, 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (y = 0; y < lblattice.halo_grid[1]; y++) {
 
-            index += yperiod;
-        }
+      buffer[0] = lbfluid[1][2][index];
+      buffer[1] = lbfluid[1][8][index];
+      buffer[2] = lbfluid[1][10][index];
+      buffer[3] = lbfluid[1][12][index];
+      buffer[4] = lbfluid[1][14][index];
+      buffer += 5;
+
+      index += yperiod;
     }
+  }
 
-    /* send to left, recv from right i = 2, 8, 10, 12, 14 */
-    snode = node_neighbors[0];
-    rnode = node_neighbors[1];
+  if (node_grid[0] > 1) {
+    MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD, rbuf, count,
+                 MPI_DOUBLE, rnode, REQ_HALO_SPREAD, comm_cart, &status);
+  } else {
+    memmove(rbuf, sbuf, count * sizeof(double));
+  }
 
-    buffer = sbuf;
-    index = get_linear_index(0,0,0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (y=0; y<lblattice.halo_grid[1]; y++) {
+  buffer = rbuf;
+  index = get_linear_index(lblattice.grid[0], 0, 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (y = 0; y < lblattice.halo_grid[1]; y++) {
 
-            buffer[0] = lbfluid[1][2][index];
-            buffer[1] = lbfluid[1][8][index];
-            buffer[2] = lbfluid[1][10][index];
-            buffer[3] = lbfluid[1][12][index];
-            buffer[4] = lbfluid[1][14][index];
-            buffer += 5;
+      lbfluid[1][2][index] = buffer[0];
+      lbfluid[1][8][index] = buffer[1];
+      lbfluid[1][10][index] = buffer[2];
+      lbfluid[1][12][index] = buffer[3];
+      lbfluid[1][14][index] = buffer[4];
+      buffer += 5;
 
-            index += yperiod;
-        }
+      index += yperiod;
     }
+  }
 
-    if (node_grid[0] > 1) {
-        MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD,
-                     rbuf, count, MPI_DOUBLE, rnode, REQ_HALO_SPREAD,
-                     comm_cart, &status);
-    } else {
-        memmove(rbuf,sbuf,count*sizeof(double));
+  /***************
+   * Y direction *
+   ***************/
+  count = 5 * lblattice.halo_grid[0] * lblattice.halo_grid[2];
+  sbuf = Utils::realloc(sbuf, count * sizeof(double));
+  rbuf = Utils::realloc(rbuf, count * sizeof(double));
+
+  /* send to right, recv from left i = 3, 7, 10, 15, 17 */
+  snode = node_neighbors[3];
+  rnode = node_neighbors[2];
+
+  buffer = sbuf;
+  index = get_linear_index(0, lblattice.grid[1] + 1, 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
+
+      buffer[0] = lbfluid[1][3][index];
+      buffer[1] = lbfluid[1][7][index];
+      buffer[2] = lbfluid[1][10][index];
+      buffer[3] = lbfluid[1][15][index];
+      buffer[4] = lbfluid[1][17][index];
+      buffer += 5;
+
+      ++index;
     }
+    index += zperiod - lblattice.halo_grid[0];
+  }
 
-    buffer = rbuf;
-    index = get_linear_index(lblattice.grid[0],0,0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (y=0; y<lblattice.halo_grid[1]; y++) {
+  if (node_grid[1] > 1) {
+    MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD, rbuf, count,
+                 MPI_DOUBLE, rnode, REQ_HALO_SPREAD, comm_cart, &status);
+  } else {
+    memmove(rbuf, sbuf, count * sizeof(double));
+  }
 
-            lbfluid[1][2][index] = buffer[0];
-            lbfluid[1][8][index] = buffer[1];
-            lbfluid[1][10][index] = buffer[2];
-            lbfluid[1][12][index] = buffer[3];
-            lbfluid[1][14][index] = buffer[4];
-            buffer += 5;
+  buffer = rbuf;
+  index = get_linear_index(0, 1, 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
 
-            index += yperiod;
-        }
+      lbfluid[1][3][index] = buffer[0];
+      lbfluid[1][7][index] = buffer[1];
+      lbfluid[1][10][index] = buffer[2];
+      lbfluid[1][15][index] = buffer[3];
+      lbfluid[1][17][index] = buffer[4];
+      buffer += 5;
+
+      ++index;
     }
+    index += zperiod - lblattice.halo_grid[0];
+  }
 
-    /***************
-     * Y direction *
-     ***************/
-    count = 5*lblattice.halo_grid[0]*lblattice.halo_grid[2];
-    sbuf = Utils::realloc(sbuf, count*sizeof(double));
-    rbuf = Utils::realloc(rbuf, count*sizeof(double));
+  /* send to left, recv from right i = 4, 8, 9, 16, 18 */
+  snode = node_neighbors[2];
+  rnode = node_neighbors[3];
 
-    /* send to right, recv from left i = 3, 7, 10, 15, 17 */
-    snode = node_neighbors[3];
-    rnode = node_neighbors[2];
+  buffer = sbuf;
+  index = get_linear_index(0, 0, 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
 
-    buffer = sbuf;
-    index = get_linear_index(0,lblattice.grid[1]+1,0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
+      buffer[0] = lbfluid[1][4][index];
+      buffer[1] = lbfluid[1][8][index];
+      buffer[2] = lbfluid[1][9][index];
+      buffer[3] = lbfluid[1][16][index];
+      buffer[4] = lbfluid[1][18][index];
+      buffer += 5;
 
-            buffer[0] = lbfluid[1][3][index];
-            buffer[1] = lbfluid[1][7][index];
-            buffer[2] = lbfluid[1][10][index];
-            buffer[3] = lbfluid[1][15][index];
-            buffer[4] = lbfluid[1][17][index];
-            buffer += 5;
-
-            ++index;
-        }
-        index += zperiod - lblattice.halo_grid[0];
+      ++index;
     }
+    index += zperiod - lblattice.halo_grid[0];
+  }
 
-    if (node_grid[1] > 1) {
-        MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD,
-                     rbuf, count, MPI_DOUBLE, rnode, REQ_HALO_SPREAD,
-                     comm_cart, &status);
-    } else {
-        memmove(rbuf,sbuf,count*sizeof(double));
+  if (node_grid[1] > 1) {
+    MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD, rbuf, count,
+                 MPI_DOUBLE, rnode, REQ_HALO_SPREAD, comm_cart, &status);
+  } else {
+    memmove(rbuf, sbuf, count * sizeof(double));
+  }
+
+  buffer = rbuf;
+  index = get_linear_index(0, lblattice.grid[1], 0, lblattice.halo_grid);
+  for (z = 0; z < lblattice.halo_grid[2]; z++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
+
+      lbfluid[1][4][index] = buffer[0];
+      lbfluid[1][8][index] = buffer[1];
+      lbfluid[1][9][index] = buffer[2];
+      lbfluid[1][16][index] = buffer[3];
+      lbfluid[1][18][index] = buffer[4];
+      buffer += 5;
+
+      ++index;
     }
+    index += zperiod - lblattice.halo_grid[0];
+  }
 
-    buffer = rbuf;
-    index = get_linear_index(0,1,0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
+  /***************
+   * Z direction *
+   ***************/
+  count = 5 * lblattice.halo_grid[0] * lblattice.halo_grid[1];
+  sbuf = Utils::realloc(sbuf, count * sizeof(double));
+  rbuf = Utils::realloc(rbuf, count * sizeof(double));
 
-            lbfluid[1][3][index] = buffer[0];
-            lbfluid[1][7][index] = buffer[1];
-            lbfluid[1][10][index] = buffer[2];
-            lbfluid[1][15][index] = buffer[3];
-            lbfluid[1][17][index] = buffer[4];
-            buffer += 5;
+  /* send to right, recv from left i = 5, 11, 14, 15, 18 */
+  snode = node_neighbors[5];
+  rnode = node_neighbors[4];
 
-            ++index;
-        }
-        index += zperiod - lblattice.halo_grid[0];
+  buffer = sbuf;
+  index = get_linear_index(0, 0, lblattice.grid[2] + 1, lblattice.halo_grid);
+  for (y = 0; y < lblattice.halo_grid[1]; y++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
+
+      buffer[0] = lbfluid[1][5][index];
+      buffer[1] = lbfluid[1][11][index];
+      buffer[2] = lbfluid[1][14][index];
+      buffer[3] = lbfluid[1][15][index];
+      buffer[4] = lbfluid[1][18][index];
+      buffer += 5;
+
+      ++index;
     }
+  }
 
-    /* send to left, recv from right i = 4, 8, 9, 16, 18 */
-    snode = node_neighbors[2];
-    rnode = node_neighbors[3];
+  if (node_grid[2] > 1) {
+    MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD, rbuf, count,
+                 MPI_DOUBLE, rnode, REQ_HALO_SPREAD, comm_cart, &status);
+  } else {
+    memmove(rbuf, sbuf, count * sizeof(double));
+  }
 
-    buffer = sbuf;
-    index = get_linear_index(0,0,0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
+  buffer = rbuf;
+  index = get_linear_index(0, 0, 1, lblattice.halo_grid);
+  for (y = 0; y < lblattice.halo_grid[1]; y++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
 
-            buffer[0] = lbfluid[1][4][index];
-            buffer[1] = lbfluid[1][8][index];
-            buffer[2] = lbfluid[1][9][index];
-            buffer[3] = lbfluid[1][16][index];
-            buffer[4] = lbfluid[1][18][index];
-            buffer += 5;
+      lbfluid[1][5][index] = buffer[0];
+      lbfluid[1][11][index] = buffer[1];
+      lbfluid[1][14][index] = buffer[2];
+      lbfluid[1][15][index] = buffer[3];
+      lbfluid[1][18][index] = buffer[4];
+      buffer += 5;
 
-            ++index;
-        }
-        index += zperiod - lblattice.halo_grid[0];
+      ++index;
     }
+  }
 
-    if (node_grid[1] > 1) {
-        MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD,
-                     rbuf, count, MPI_DOUBLE, rnode, REQ_HALO_SPREAD,
-                     comm_cart, &status);
-    } else {
-        memmove(rbuf,sbuf,count*sizeof(double));
+  /* send to left, recv from right i = 6, 12, 13, 16, 17 */
+  snode = node_neighbors[4];
+  rnode = node_neighbors[5];
+
+  buffer = sbuf;
+  index = get_linear_index(0, 0, 0, lblattice.halo_grid);
+  for (y = 0; y < lblattice.halo_grid[1]; y++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
+
+      buffer[0] = lbfluid[1][6][index];
+      buffer[1] = lbfluid[1][12][index];
+      buffer[2] = lbfluid[1][13][index];
+      buffer[3] = lbfluid[1][16][index];
+      buffer[4] = lbfluid[1][17][index];
+      buffer += 5;
+
+      ++index;
     }
+  }
 
-    buffer = rbuf;
-    index = get_linear_index(0,lblattice.grid[1],0,lblattice.halo_grid);
-    for (z=0; z<lblattice.halo_grid[2]; z++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
+  if (node_grid[2] > 1) {
+    MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD, rbuf, count,
+                 MPI_DOUBLE, rnode, REQ_HALO_SPREAD, comm_cart, &status);
+  } else {
+    memmove(rbuf, sbuf, count * sizeof(double));
+  }
 
-            lbfluid[1][4][index] = buffer[0];
-            lbfluid[1][8][index] = buffer[1];
-            lbfluid[1][9][index] = buffer[2];
-            lbfluid[1][16][index] = buffer[3];
-            lbfluid[1][18][index] = buffer[4];
-            buffer += 5;
+  buffer = rbuf;
+  index = get_linear_index(0, 0, lblattice.grid[2], lblattice.halo_grid);
+  for (y = 0; y < lblattice.halo_grid[1]; y++) {
+    for (x = 0; x < lblattice.halo_grid[0]; x++) {
 
-            ++index;
-        }
-        index += zperiod - lblattice.halo_grid[0];
+      lbfluid[1][6][index] = buffer[0];
+      lbfluid[1][12][index] = buffer[1];
+      lbfluid[1][13][index] = buffer[2];
+      lbfluid[1][16][index] = buffer[3];
+      lbfluid[1][17][index] = buffer[4];
+      buffer += 5;
+
+      ++index;
     }
+  }
 
-    /***************
-     * Z direction *
-     ***************/
-    count = 5*lblattice.halo_grid[0]*lblattice.halo_grid[1];
-    sbuf = Utils::realloc(sbuf, count*sizeof(double));
-    rbuf = Utils::realloc(rbuf, count*sizeof(double));
-
-    /* send to right, recv from left i = 5, 11, 14, 15, 18 */
-    snode = node_neighbors[5];
-    rnode = node_neighbors[4];
-
-    buffer = sbuf;
-    index = get_linear_index(0,0,lblattice.grid[2]+1,lblattice.halo_grid);
-    for (y=0; y<lblattice.halo_grid[1]; y++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
-
-            buffer[0] = lbfluid[1][5][index];
-            buffer[1] = lbfluid[1][11][index];
-            buffer[2] = lbfluid[1][14][index];
-            buffer[3] = lbfluid[1][15][index];
-            buffer[4] = lbfluid[1][18][index];
-            buffer += 5;
-
-            ++index;
-        }
-    }
-
-    if (node_grid[2] > 1) {
-        MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD,
-                     rbuf, count, MPI_DOUBLE, rnode, REQ_HALO_SPREAD,
-                     comm_cart, &status);
-    } else {
-        memmove(rbuf,sbuf,count*sizeof(double));
-    }
-
-    buffer = rbuf;
-    index = get_linear_index(0,0,1,lblattice.halo_grid);
-    for (y=0; y<lblattice.halo_grid[1]; y++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
-
-            lbfluid[1][5][index] = buffer[0];
-            lbfluid[1][11][index] = buffer[1];
-            lbfluid[1][14][index] = buffer[2];
-            lbfluid[1][15][index] = buffer[3];
-            lbfluid[1][18][index] = buffer[4];
-            buffer += 5;
-
-            ++index;
-        }
-    }
-
-    /* send to left, recv from right i = 6, 12, 13, 16, 17 */
-    snode = node_neighbors[4];
-    rnode = node_neighbors[5];
-
-    buffer = sbuf;
-    index = get_linear_index(0,0,0,lblattice.halo_grid);
-    for (y=0; y<lblattice.halo_grid[1]; y++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
-
-            buffer[0] = lbfluid[1][6][index];
-            buffer[1] = lbfluid[1][12][index];
-            buffer[2] = lbfluid[1][13][index];
-            buffer[3] = lbfluid[1][16][index];
-            buffer[4] = lbfluid[1][17][index];
-            buffer += 5;
-
-            ++index;
-        }
-    }
-
-    if (node_grid[2] > 1) {
-        MPI_Sendrecv(sbuf, count, MPI_DOUBLE, snode, REQ_HALO_SPREAD,
-                     rbuf, count, MPI_DOUBLE, rnode, REQ_HALO_SPREAD,
-                     comm_cart, &status);
-    } else {
-        memmove(rbuf,sbuf,count*sizeof(double));
-    }
-
-    buffer = rbuf;
-    index = get_linear_index(0,0,lblattice.grid[2],lblattice.halo_grid);
-    for (y=0; y<lblattice.halo_grid[1]; y++) {
-        for (x=0; x<lblattice.halo_grid[0]; x++) {
-
-            lbfluid[1][6][index] = buffer[0];
-            lbfluid[1][12][index] = buffer[1];
-            lbfluid[1][13][index] = buffer[2];
-            lbfluid[1][16][index] = buffer[3];
-            lbfluid[1][17][index] = buffer[4];
-            buffer += 5;
-
-            ++index;
-        }
-    }
-
-    free(rbuf);
-    free(sbuf);
+  free(rbuf);
+  free(sbuf);
 }
 
 /***********************************************************************/
 
 /** Performs basic sanity checks. */
 int lb_sanity_checks() {
-    //char *errtext;
-    int ret = 0;
+  // char *errtext;
+  int ret = 0;
 
-    if (lbpar.agrid <= 0.0) {
-        runtimeErrorMsg() <<"Lattice Boltzmann agrid not set";
-        ret = 1;
-    }
-    if (lbpar.tau <= 0.0) {
-        runtimeErrorMsg() <<"Lattice Boltzmann time step not set";
-        ret = 1;
-    }
-    if (lbpar.rho <= 0.0) {
-        runtimeErrorMsg() <<"Lattice Boltzmann fluid density not set";
-        ret = 1;
-    }
-    if (lbpar.viscosity <= 0.0) {
-        runtimeErrorMsg() <<"Lattice Boltzmann fluid viscosity not set";
-        ret = 1;
-    }
-    if (cell_structure.type != CELL_STRUCTURE_DOMDEC) {
-        runtimeErrorMsg() <<"LB requires domain-decomposition cellsystem";
-        ret = -1;
-    }
-    if (skin == 0.0) {
-        runtimeErrorMsg() <<"LB requires a positive skin";
-        ret = 1;
-    }
-    if (cell_structure.use_verlet_list && skin>=lbpar.agrid/2.0) {
-        runtimeErrorMsg() <<"LB requires either no Verlet lists or that the skin of the verlet list to be less than half of lattice-Boltzmann grid spacing";
-        ret = -1;
-    }
-    if (thermo_switch & ~THERMO_LB) {
-        runtimeErrorMsg() <<"LB must not be used with other thermostats";
-        ret = 1;
-    }
-    return ret;
+  if (lbpar.agrid <= 0.0) {
+    runtimeErrorMsg() << "Lattice Boltzmann agrid not set";
+    ret = 1;
+  }
+  if (lbpar.tau <= 0.0) {
+    runtimeErrorMsg() << "Lattice Boltzmann time step not set";
+    ret = 1;
+  }
+  if (lbpar.rho <= 0.0) {
+    runtimeErrorMsg() << "Lattice Boltzmann fluid density not set";
+    ret = 1;
+  }
+  if (lbpar.viscosity <= 0.0) {
+    runtimeErrorMsg() << "Lattice Boltzmann fluid viscosity not set";
+    ret = 1;
+  }
+  if (cell_structure.type != CELL_STRUCTURE_DOMDEC) {
+    runtimeErrorMsg() << "LB requires domain-decomposition cellsystem";
+    ret = -1;
+  }
+  if (skin == 0.0) {
+    runtimeErrorMsg() << "LB requires a positive skin";
+    ret = 1;
+  }
+  if (cell_structure.use_verlet_list && skin >= lbpar.agrid / 2.0) {
+    runtimeErrorMsg() << "LB requires either no Verlet lists or that the skin "
+                         "of the verlet list to be less than half of "
+                         "lattice-Boltzmann grid spacing";
+    ret = -1;
+  }
+  if (thermo_switch & ~THERMO_LB) {
+    runtimeErrorMsg() << "LB must not be used with other thermostats";
+    ret = 1;
+  }
+  return ret;
 }
 
 /***********************************************************************/
 
 /** (Pre-)allocate memory for data structures */
 void lb_pre_init() {
-    lbfluid[0]    = (double**) Utils::malloc(lbmodel.n_veloc*sizeof(double *));
-    lbfluid[0][0] = (double*) Utils::malloc(lblattice.halo_grid_volume*lbmodel.n_veloc*sizeof(double));
-    lbfluid[1]    = (double**) Utils::malloc(lbmodel.n_veloc*sizeof(double *));
-    lbfluid[1][0] = (double*) Utils::malloc(lblattice.halo_grid_volume*lbmodel.n_veloc*sizeof(double));
+  lbfluid[0] = (double **)Utils::malloc(lbmodel.n_veloc * sizeof(double *));
+  lbfluid[0][0] = (double *)Utils::malloc(lblattice.halo_grid_volume *
+                                          lbmodel.n_veloc * sizeof(double));
+  lbfluid[1] = (double **)Utils::malloc(lbmodel.n_veloc * sizeof(double *));
+  lbfluid[1][0] = (double *)Utils::malloc(lblattice.halo_grid_volume *
+                                          lbmodel.n_veloc * sizeof(double));
 }
-
 
 /** (Re-)allocate memory for the fluid and initialize pointers. */
 static void lb_realloc_fluid() {
-    int i;
+  int i;
 
-    LB_TRACE(printf("reallocating fluid\n"));
+  LB_TRACE(printf("reallocating fluid\n"));
 
-    lbfluid[0]    = Utils::realloc(lbfluid[0],lbmodel.n_veloc*sizeof(double *));
-    lbfluid[1]    = Utils::realloc(lbfluid[1],lbmodel.n_veloc*sizeof(double *));
-    lbfluid[0][0] = Utils::realloc(lbfluid[0][0],lblattice.halo_grid_volume*lbmodel.n_veloc*sizeof(double));
-    lbfluid[1][0] = Utils::realloc(lbfluid[1][0],lblattice.halo_grid_volume*lbmodel.n_veloc*sizeof(double));
+  lbfluid[0] = Utils::realloc(lbfluid[0], lbmodel.n_veloc * sizeof(double *));
+  lbfluid[1] = Utils::realloc(lbfluid[1], lbmodel.n_veloc * sizeof(double *));
+  lbfluid[0][0] =
+      Utils::realloc(lbfluid[0][0], lblattice.halo_grid_volume *
+                                        lbmodel.n_veloc * sizeof(double));
+  lbfluid[1][0] =
+      Utils::realloc(lbfluid[1][0], lblattice.halo_grid_volume *
+                                        lbmodel.n_veloc * sizeof(double));
 
-    for (i=0; i<lbmodel.n_veloc; ++i) {
-        lbfluid[0][i] = lbfluid[0][0] + i*lblattice.halo_grid_volume;
-        lbfluid[1][i] = lbfluid[1][0] + i*lblattice.halo_grid_volume;
-    }
+  for (i = 0; i < lbmodel.n_veloc; ++i) {
+    lbfluid[0][i] = lbfluid[0][0] + i * lblattice.halo_grid_volume;
+    lbfluid[1][i] = lbfluid[1][0] + i * lblattice.halo_grid_volume;
+  }
 
-    lbfields = (LB_FluidNode*) Utils::realloc(lbfields,lblattice.halo_grid_volume*sizeof(*lbfields));
+  lbfields = (LB_FluidNode *)Utils::realloc(
+      lbfields, lblattice.halo_grid_volume * sizeof(*lbfields));
 }
-
 
 /** Sets up the structures for exchange of the halo regions.
  *  See also \ref halo.cpp */
 static void lb_prepare_communication() {
-    int i;
-    HaloCommunicator comm = { 0, nullptr };
+  int i;
+  HaloCommunicator comm = {0, nullptr};
 
-    /* since the data layout is a structure of arrays, we have to
-     * generate a communication for this structure: first we generate
-     * the communication for one of the arrays (the 0-th velocity
-     * population), then we replicate this communication for the other
-     * velocity indices by constructing appropriate vector
-     * datatypes */
+  /* since the data layout is a structure of arrays, we have to
+   * generate a communication for this structure: first we generate
+   * the communication for one of the arrays (the 0-th velocity
+   * population), then we replicate this communication for the other
+   * velocity indices by constructing appropriate vector
+   * datatypes */
 
-    /* prepare the communication for a single velocity */
-    prepare_halo_communication(&comm, &lblattice, FIELDTYPE_DOUBLE, MPI_DOUBLE);
+  /* prepare the communication for a single velocity */
+  prepare_halo_communication(&comm, &lblattice, FIELDTYPE_DOUBLE, MPI_DOUBLE);
 
-    update_halo_comm.num = comm.num;
-    update_halo_comm.halo_info = Utils::realloc(update_halo_comm.halo_info,comm.num*sizeof(HaloInfo));
+  update_halo_comm.num = comm.num;
+  update_halo_comm.halo_info =
+      Utils::realloc(update_halo_comm.halo_info, comm.num * sizeof(HaloInfo));
 
-    /* replicate the halo structure */
-    for (i=0; i<comm.num; i++) {
-        HaloInfo *hinfo = &(update_halo_comm.halo_info[i]);
+  /* replicate the halo structure */
+  for (i = 0; i < comm.num; i++) {
+    HaloInfo *hinfo = &(update_halo_comm.halo_info[i]);
 
-        hinfo->source_node = comm.halo_info[i].source_node;
-        hinfo->dest_node   = comm.halo_info[i].dest_node;
-        hinfo->s_offset    = comm.halo_info[i].s_offset;
-        hinfo->r_offset    = comm.halo_info[i].r_offset;
-        hinfo->type        = comm.halo_info[i].type;
+    hinfo->source_node = comm.halo_info[i].source_node;
+    hinfo->dest_node = comm.halo_info[i].dest_node;
+    hinfo->s_offset = comm.halo_info[i].s_offset;
+    hinfo->r_offset = comm.halo_info[i].r_offset;
+    hinfo->type = comm.halo_info[i].type;
 
-        /* generate the vector datatype for the structure of lattices we
-         * have to use hvector here because the extent of the subtypes
-         * does not span the full lattice and hence we cannot get the
-         * correct vskip out of them */
+    /* generate the vector datatype for the structure of lattices we
+     * have to use hvector here because the extent of the subtypes
+     * does not span the full lattice and hence we cannot get the
+     * correct vskip out of them */
 
-        MPI_Aint lower;
-        MPI_Aint extent;
-        MPI_Type_get_extent(MPI_DOUBLE, &lower, &extent);
-        MPI_Type_create_hvector(lbmodel.n_veloc, 1,
-                                lblattice.halo_grid_volume*extent,
-                                comm.halo_info[i].datatype, &hinfo->datatype);
-        MPI_Type_commit(&hinfo->datatype);
+    MPI_Aint lower;
+    MPI_Aint extent;
+    MPI_Type_get_extent(MPI_DOUBLE, &lower, &extent);
+    MPI_Type_create_hvector(lbmodel.n_veloc, 1,
+                            lblattice.halo_grid_volume * extent,
+                            comm.halo_info[i].datatype, &hinfo->datatype);
+    MPI_Type_commit(&hinfo->datatype);
 
-        halo_create_field_hvector(lbmodel.n_veloc,1,
-                                  lblattice.halo_grid_volume*sizeof(double),
-                                  comm.halo_info[i].fieldtype,&hinfo->fieldtype);
-    }
+    halo_create_field_hvector(lbmodel.n_veloc, 1,
+                              lblattice.halo_grid_volume * sizeof(double),
+                              comm.halo_info[i].fieldtype, &hinfo->fieldtype);
+  }
 
-    release_halo_communication(&comm);
+  release_halo_communication(&comm);
 }
-
 
 /** (Re-)initializes the fluid. */
 void lb_reinit_parameters() {
-    int i;
+  int i;
 
-    if (lbpar.viscosity > 0.0) {
-        /* Eq. (80) Duenweg, Schiller, Ladd, PRE 76(3):036704 (2007). */
-        // unit conversion: viscosity
-        lbpar.gamma_shear = 1. - 2./(6.*lbpar.viscosity*lbpar.tau/(lbpar.agrid*lbpar.agrid)+1.);
-    }
+  if (lbpar.viscosity > 0.0) {
+    /* Eq. (80) Duenweg, Schiller, Ladd, PRE 76(3):036704 (2007). */
+    // unit conversion: viscosity
+    lbpar.gamma_shear = 1. - 2. / (6. * lbpar.viscosity * lbpar.tau /
+                                       (lbpar.agrid * lbpar.agrid) +
+                                   1.);
+  }
 
-    if (lbpar.bulk_viscosity > 0.0) {
-        /* Eq. (81) Duenweg, Schiller, Ladd, PRE 76(3):036704 (2007). */
-        // unit conversion: viscosity
-        lbpar.gamma_bulk = 1. - 2./(9.*lbpar.bulk_viscosity*lbpar.tau/(lbpar.agrid*lbpar.agrid)+1.);
-    }
+  if (lbpar.bulk_viscosity > 0.0) {
+    /* Eq. (81) Duenweg, Schiller, Ladd, PRE 76(3):036704 (2007). */
+    // unit conversion: viscosity
+    lbpar.gamma_bulk = 1. - 2. / (9. * lbpar.bulk_viscosity * lbpar.tau /
+                                      (lbpar.agrid * lbpar.agrid) +
+                                  1.);
+  }
 
-    if (lbpar.is_TRT) {
-        lbpar.gamma_bulk = lbpar.gamma_shear;
-        lbpar.gamma_even = lbpar.gamma_shear;
-        lbpar.gamma_odd = -(7.0*lbpar.gamma_even+1.0)/(lbpar.gamma_even+7.0);
-        //gamma_odd = lbpar.gamma_shear; //uncomment for BGK
-    }
+  if (lbpar.is_TRT) {
+    lbpar.gamma_bulk = lbpar.gamma_shear;
+    lbpar.gamma_even = lbpar.gamma_shear;
+    lbpar.gamma_odd =
+        -(7.0 * lbpar.gamma_even + 1.0) / (lbpar.gamma_even + 7.0);
+    // gamma_odd = lbpar.gamma_shear; //uncomment for BGK
+  }
 
-    //lbpar.gamma_shear = 0.0; //uncomment for special case of BGK
-    //lbpar.gamma_bulk = 0.0;
-    //gamma_odd = 0.0;
-    //gamma_even = 0.0;
+  // lbpar.gamma_shear = 0.0; //uncomment for special case of BGK
+  // lbpar.gamma_bulk = 0.0;
+  // gamma_odd = 0.0;
+  // gamma_even = 0.0;
 
-    //printf("lbpar.gamma_shear=%e\n", lbpar.gamma_shear);
-    //printf("lbpar.gamma_bulk=%e\n", lbpar.gamma_bulk);
-    //printf("gamma_odd=%e\n", gamma_odd);
-    //printf("gamma_even=%e\n", gamma_even);
-    //printf("\n");
+  // printf("lbpar.gamma_shear=%e\n", lbpar.gamma_shear);
+  // printf("lbpar.gamma_bulk=%e\n", lbpar.gamma_bulk);
+  // printf("gamma_odd=%e\n", gamma_odd);
+  // printf("gamma_even=%e\n", gamma_even);
+  // printf("\n");
 
-    double mu = 0.0;
+  double mu = 0.0;
 
-    if (temperature > 0.0)
-      {
-        /* fluctuating hydrodynamics ? */
-        lbpar.fluct = 1;
-        
-        /* Eq. (51) Duenweg, Schiller, Ladd, PRE 76(3):036704 (2007).
-         * Note that the modes are not normalized as in the paper here! */
-        mu = temperature/lbmodel.c_sound_sq*lbpar.tau*lbpar.tau/(lbpar.agrid*lbpar.agrid);
-        //mu *= agrid*agrid*agrid;  // Marcello's conjecture
+  if (temperature > 0.0) {
+    /* fluctuating hydrodynamics ? */
+    lbpar.fluct = 1;
+
+    /* Eq. (51) Duenweg, Schiller, Ladd, PRE 76(3):036704 (2007).
+     * Note that the modes are not normalized as in the paper here! */
+    mu = temperature / lbmodel.c_sound_sq * lbpar.tau * lbpar.tau /
+         (lbpar.agrid * lbpar.agrid);
+    // mu *= agrid*agrid*agrid;  // Marcello's conjecture
 #ifdef D3Q19
-        double (*e)[19] = d3q19_modebase;
-#else // D3Q19
-        double **e = lbmodel.e;
+    double(*e)[19] = d3q19_modebase;
+#else  // D3Q19
+    double **e = lbmodel.e;
 #endif // D3Q19
-        for (i = 0; i < 4; i++) lbpar.phi[i] = 0.0;
-        lbpar.phi[4] = sqrt(mu*e[19][4]*(1.-SQR(lbpar.gamma_bulk))); // SQR(x) == x*x
-        for (i = 5; i < 10; i++) lbpar.phi[i] = sqrt(mu*e[19][i]*(1.-SQR(lbpar.gamma_shear)));
-        for (i = 10; i < 16; i++) lbpar.phi[i] = sqrt(mu*e[19][i]*(1-SQR(lbpar.gamma_odd)));
-        for (i = 16; i < 19; i++) lbpar.phi[i] = sqrt(mu*e[19][i]*(1-SQR(lbpar.gamma_even)));
-        
-        /* lb_coupl_pref is stored in MD units (force)
-         * Eq. (16) Ahlrichs and Duenweg, JCP 111(17):8225 (1999).
-         * The factor 12 comes from the fact that we use random numbers
-         * from -0.5 to 0.5 (equally distributed) which have variance 1/12.
-         * time_step comes from the discretization.
-         */
-        lb_coupl_pref = sqrt(12.*2.*lbpar.friction*temperature/time_step);
-        lb_coupl_pref2 = sqrt(2.*lbpar.friction*temperature/time_step);
-      } else {
-      /* no fluctuations at zero temperature */
-      lbpar.fluct = 0;
-      for (i = 0; i < lbmodel.n_veloc; i++) lbpar.phi[i] = 0.0;
-      lb_coupl_pref = 0.0;
-      lb_coupl_pref2 = 0.0;
-    }
-    LB_TRACE(fprintf(stderr,"%d: lbpar.gamma_shear=%lf lbpar.gamma_bulk=%lf shear_fluct=%lf " \
-                     "bulk_fluct=%lf mu=%lf, bulkvisc=%lf, visc=%lf\n",     \
-                     this_node, lbpar.gamma_shear, lbpar.gamma_bulk, lbpar.phi[9], lbpar.phi[4], mu, \
-                     lbpar.bulk_viscosity, lbpar.viscosity));
-}
+    for (i = 0; i < 4; i++)
+      lbpar.phi[i] = 0.0;
+    lbpar.phi[4] =
+        sqrt(mu * e[19][4] *
+             (1. - Utils::sqr(lbpar.gamma_bulk))); // Utils::sqr(x) == x*x
+    for (i = 5; i < 10; i++)
+      lbpar.phi[i] = sqrt(mu * e[19][i] * (1. - Utils::sqr(lbpar.gamma_shear)));
+    for (i = 10; i < 16; i++)
+      lbpar.phi[i] = sqrt(mu * e[19][i] * (1 - Utils::sqr(lbpar.gamma_odd)));
+    for (i = 16; i < 19; i++)
+      lbpar.phi[i] = sqrt(mu * e[19][i] * (1 - Utils::sqr(lbpar.gamma_even)));
 
+    /* lb_coupl_pref is stored in MD units (force)
+     * Eq. (16) Ahlrichs and Duenweg, JCP 111(17):8225 (1999).
+     * The factor 12 comes from the fact that we use random numbers
+     * from -0.5 to 0.5 (equally distributed) which have variance 1/12.
+     * time_step comes from the discretization.
+     */
+    lb_coupl_pref = sqrt(12. * 2. * lbpar.friction * temperature / time_step);
+    lb_coupl_pref2 = sqrt(2. * lbpar.friction * temperature / time_step);
+  } else {
+    /* no fluctuations at zero temperature */
+    lbpar.fluct = 0;
+    for (i = 0; i < lbmodel.n_veloc; i++)
+      lbpar.phi[i] = 0.0;
+    lb_coupl_pref = 0.0;
+    lb_coupl_pref2 = 0.0;
+  }
+  LB_TRACE(
+      fprintf(stderr,
+              "%d: lbpar.gamma_shear=%lf lbpar.gamma_bulk=%lf shear_fluct=%lf "
+              "bulk_fluct=%lf mu=%lf, bulkvisc=%lf, visc=%lf\n",
+              this_node, lbpar.gamma_shear, lbpar.gamma_bulk, lbpar.phi[9],
+              lbpar.phi[4], mu, lbpar.bulk_viscosity, lbpar.viscosity));
+}
 
 /** Resets the forces on the fluid nodes */
 void lb_reinit_forces() {
-    for (Lattice::index_t index=0; index < lblattice.halo_grid_volume; index++) {
+  for (Lattice::index_t index = 0; index < lblattice.halo_grid_volume;
+       index++) {
 #ifdef EXTERNAL_FORCES
-        // unit conversion: force density
-        lbfields[index].force[0] = lbpar.ext_force[0]*pow(lbpar.agrid,2)*lbpar.tau*lbpar.tau;
-        lbfields[index].force[1] = lbpar.ext_force[1]*pow(lbpar.agrid,2)*lbpar.tau*lbpar.tau;
-        lbfields[index].force[2] = lbpar.ext_force[2]*pow(lbpar.agrid,2)*lbpar.tau*lbpar.tau;
-#else // EXTERNAL_FORCES
-        lbfields[index].force[0] = 0.0;
-        lbfields[index].force[1] = 0.0;
-        lbfields[index].force[2] = 0.0;
-        lbfields[index].has_force = 0;
+    // unit conversion: force density
+    lbfields[index].force[0] =
+        lbpar.ext_force[0] * pow(lbpar.agrid, 2) * lbpar.tau * lbpar.tau;
+    lbfields[index].force[1] =
+        lbpar.ext_force[1] * pow(lbpar.agrid, 2) * lbpar.tau * lbpar.tau;
+    lbfields[index].force[2] =
+        lbpar.ext_force[2] * pow(lbpar.agrid, 2) * lbpar.tau * lbpar.tau;
+#else  // EXTERNAL_FORCES
+    lbfields[index].force[0] = 0.0;
+    lbfields[index].force[1] = 0.0;
+    lbfields[index].force[2] = 0.0;
+    lbfields[index].has_force = 0;
 #endif // EXTERNAL_FORCES
-    }
+  }
 #ifdef LB_BOUNDARIES
-    for (auto it = LBBoundaries::lbboundaries.begin(); it != LBBoundaries::lbboundaries.end(); ++it) {
-      (**it).reset_force();
-    }
+  for (auto it = LBBoundaries::lbboundaries.begin();
+       it != LBBoundaries::lbboundaries.end(); ++it) {
+    (**it).reset_force();
+  }
 #endif // LB_BOUNDARIES
 }
-
 
 /** (Re-)initializes the fluid according to the given value of rho. */
 void lb_reinit_fluid() {
-    /* default values for fields in lattice units */
-    /* here the conversion to lb units is performed */
-    double rho = lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid;
-    double j[3] = { 0., 0., 0. };
-// double pi[6] = { rho*lbmodel.c_sound_sq, 0., rho*lbmodel.c_sound_sq, 0., 0., rho*lbmodel.c_sound_sq };
-    double pi[6] = { 0., 0., 0., 0., 0., 0. };
+  /* default values for fields in lattice units */
+  /* here the conversion to lb units is performed */
+  double rho = lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid;
+  double j[3] = {0., 0., 0.};
+  // double pi[6] = { rho*lbmodel.c_sound_sq, 0., rho*lbmodel.c_sound_sq, 0.,
+  // 0., rho*lbmodel.c_sound_sq };
+  double pi[6] = {0., 0., 0., 0., 0., 0.};
 
-    LB_TRACE(fprintf(stderr, "Initialising the fluid with equilibrium populations\n"););
+  LB_TRACE(fprintf(stderr,
+                   "Initialising the fluid with equilibrium populations\n"););
 
-    for (Lattice::index_t index = 0; index < lblattice.halo_grid_volume; index++) {
-      // calculate equilibrium distribution
-      lb_calc_n_from_rho_j_pi(index,rho,j,pi);
-      
-      lbfields[index].recalc_fields = 1;
+  for (Lattice::index_t index = 0; index < lblattice.halo_grid_volume;
+       index++) {
+    // calculate equilibrium distribution
+    lb_calc_n_from_rho_j_pi(index, rho, j, pi);
+
+    lbfields[index].recalc_fields = 1;
 #ifdef LB_BOUNDARIES
-      lbfields[index].boundary = 0;
+    lbfields[index].boundary = 0;
 #endif // LB_BOUNDARIES
-    }
+  }
 
-    lbpar.resend_halo = 0;
+  lbpar.resend_halo = 0;
 #ifdef LB_BOUNDARIES
-    LBBoundaries::lb_init_boundaries();
+  LBBoundaries::lb_init_boundaries();
 #endif // LB_BOUNDARIES
 }
-
 
 /** Performs a full initialization of
  *  the Lattice Boltzmann system. All derived parameters
  *  and the fluid are reset to their default values. */
 void lb_init() {
   LB_TRACE(printf("Begin initialzing fluid on CPU\n"));
-  
+
   if (lbpar.agrid <= 0.0) {
-      runtimeErrorMsg() <<"Lattice Boltzmann agrid not set when initializing fluid";
+    runtimeErrorMsg()
+        << "Lattice Boltzmann agrid not set when initializing fluid";
   }
-  
-  if (check_runtime_errors()) return;
-  
+
+  if (check_runtime_errors())
+    return;
+
   double temp_agrid[3];
   double temp_offset[3];
-  for (int i =0; i<3; i++) {
-    temp_agrid[i]=lbpar.agrid;
-    temp_offset[i]=0.5;
+  for (int i = 0; i < 3; i++) {
+    temp_agrid[i] = lbpar.agrid;
+    temp_offset[i] = 0.5;
   }
-  
+
   /* initialize the local lattice domain */
   lblattice.init(temp_agrid, temp_offset, 1, 0);
-  
-  if (check_runtime_errors()) return;
+
+  if (check_runtime_errors())
+    return;
 
   /* allocate memory for data structures */
   lb_realloc_fluid();
-  
+
   /* prepare the halo communication */
   lb_prepare_communication();
-  
+
   /* initialize derived parameters */
   lb_reinit_parameters();
 
   /* setup the initial particle velocity distribution */
   lb_reinit_fluid();
-  
+
   /* setup the external forces */
   lb_reinit_forces();
-  
+
   LB_TRACE(printf("Initialzing fluid on CPU successful\n"));
 }
 
-
 /** Release the fluid. */
 void lb_release_fluid() {
-    free(lbfluid[0][0]);
-    free(lbfluid[0]);
-    free(lbfluid[1][0]);
-    free(lbfluid[1]);
-    free(lbfields);
+  free(lbfluid[0][0]);
+  free(lbfluid[0]);
+  free(lbfluid[1][0]);
+  free(lbfluid[1]);
+  free(lbfields);
 }
-
 
 /** Release fluid and communication. */
 void lb_release() {
-    lb_release_fluid();
-    release_halo_communication(&update_halo_comm);
+  lb_release_fluid();
+  release_halo_communication(&update_halo_comm);
 }
 
 /***********************************************************************/
 /** \name Mapping between hydrodynamic fields and particle populations */
 /***********************************************************************/
 /*@{*/
-void lb_calc_n_from_rho_j_pi(const Lattice::index_t index,
-                             const double rho,
-                             const double *j,
-                             double *pi) 
-{
-    int i;
-    double local_rho, local_j[3], local_pi[6], trace;
-    const double avg_rho = lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid;
+void lb_calc_n_from_rho_j_pi(const Lattice::index_t index, const double rho,
+                             const double *j, double *pi) {
+  int i;
+  double local_rho, local_j[3], local_pi[6], trace;
+  const double avg_rho = lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid;
 
-    local_rho  = rho;
+  local_rho = rho;
 
-    local_j[0] = j[0];
-    local_j[1] = j[1];
-    local_j[2] = j[2];
+  local_j[0] = j[0];
+  local_j[1] = j[1];
+  local_j[2] = j[2];
 
-    for (i = 0; i < 6; i++) local_pi[i] = pi[i];
+  for (i = 0; i < 6; i++)
+    local_pi[i] = pi[i];
 
-    trace = local_pi[0] + local_pi[2] + local_pi[5];
+  trace = local_pi[0] + local_pi[2] + local_pi[5];
 
 #ifdef D3Q19
-    double rho_times_coeff;
-    double tmp1,tmp2;
+  double rho_times_coeff;
+  double tmp1, tmp2;
 
-    /* update the q=0 sublattice */
-    lbfluid[0][0][index] = 1./3. * (local_rho-avg_rho) - 1./2. * trace;
+  /* update the q=0 sublattice */
+  lbfluid[0][0][index] = 1. / 3. * (local_rho - avg_rho) - 1. / 2. * trace;
 
-    /* update the q=1 sublattice */
-    rho_times_coeff = 1./18. * (local_rho-avg_rho);
+  /* update the q=1 sublattice */
+  rho_times_coeff = 1. / 18. * (local_rho - avg_rho);
 
-    lbfluid[0][1][index] = rho_times_coeff + 1./6.*local_j[0] + 1./4. * local_pi[0] - 1./12.*trace;
-    lbfluid[0][2][index] = rho_times_coeff - 1./6.*local_j[0] + 1./4. * local_pi[0] - 1./12.*trace;
-    lbfluid[0][3][index] = rho_times_coeff + 1./6.*local_j[1] + 1./4. * local_pi[2] - 1./12.*trace;
-    lbfluid[0][4][index] = rho_times_coeff - 1./6.*local_j[1] + 1./4. * local_pi[2] - 1./12.*trace;
-    lbfluid[0][5][index] = rho_times_coeff + 1./6.*local_j[2] + 1./4. * local_pi[5] - 1./12.*trace;
-    lbfluid[0][6][index] = rho_times_coeff - 1./6.*local_j[2] + 1./4. * local_pi[5] - 1./12.*trace;
+  lbfluid[0][1][index] = rho_times_coeff + 1. / 6. * local_j[0] +
+                         1. / 4. * local_pi[0] - 1. / 12. * trace;
+  lbfluid[0][2][index] = rho_times_coeff - 1. / 6. * local_j[0] +
+                         1. / 4. * local_pi[0] - 1. / 12. * trace;
+  lbfluid[0][3][index] = rho_times_coeff + 1. / 6. * local_j[1] +
+                         1. / 4. * local_pi[2] - 1. / 12. * trace;
+  lbfluid[0][4][index] = rho_times_coeff - 1. / 6. * local_j[1] +
+                         1. / 4. * local_pi[2] - 1. / 12. * trace;
+  lbfluid[0][5][index] = rho_times_coeff + 1. / 6. * local_j[2] +
+                         1. / 4. * local_pi[5] - 1. / 12. * trace;
+  lbfluid[0][6][index] = rho_times_coeff - 1. / 6. * local_j[2] +
+                         1. / 4. * local_pi[5] - 1. / 12. * trace;
 
-    /* update the q=2 sublattice */
-    rho_times_coeff = 1./36. * (local_rho-avg_rho);
+  /* update the q=2 sublattice */
+  rho_times_coeff = 1. / 36. * (local_rho - avg_rho);
 
-    tmp1 = local_pi[0] + local_pi[2];
-    tmp2 = 2.0*local_pi[1];
+  tmp1 = local_pi[0] + local_pi[2];
+  tmp2 = 2.0 * local_pi[1];
 
-    lbfluid[0][7][index]  = rho_times_coeff + 1./12.*(local_j[0]+local_j[1]) + 1./8.*(tmp1+tmp2) - 1./24.*trace;
-    lbfluid[0][8][index]  = rho_times_coeff - 1./12.*(local_j[0]+local_j[1]) + 1./8.*(tmp1+tmp2) - 1./24.*trace;
-    lbfluid[0][9][index]  = rho_times_coeff + 1./12.*(local_j[0]-local_j[1]) + 1./8.*(tmp1-tmp2) - 1./24.*trace;
-    lbfluid[0][10][index] = rho_times_coeff - 1./12.*(local_j[0]-local_j[1]) + 1./8.*(tmp1-tmp2) - 1./24.*trace;
+  lbfluid[0][7][index] = rho_times_coeff +
+                         1. / 12. * (local_j[0] + local_j[1]) +
+                         1. / 8. * (tmp1 + tmp2) - 1. / 24. * trace;
+  lbfluid[0][8][index] = rho_times_coeff -
+                         1. / 12. * (local_j[0] + local_j[1]) +
+                         1. / 8. * (tmp1 + tmp2) - 1. / 24. * trace;
+  lbfluid[0][9][index] = rho_times_coeff +
+                         1. / 12. * (local_j[0] - local_j[1]) +
+                         1. / 8. * (tmp1 - tmp2) - 1. / 24. * trace;
+  lbfluid[0][10][index] = rho_times_coeff -
+                          1. / 12. * (local_j[0] - local_j[1]) +
+                          1. / 8. * (tmp1 - tmp2) - 1. / 24. * trace;
 
-    tmp1 = local_pi[0] + local_pi[5];
-    tmp2 = 2.0*local_pi[3];
+  tmp1 = local_pi[0] + local_pi[5];
+  tmp2 = 2.0 * local_pi[3];
 
-    lbfluid[0][11][index] = rho_times_coeff + 1./12.*(local_j[0]+local_j[2]) + 1./8.*(tmp1+tmp2) - 1./24.*trace;
-    lbfluid[0][12][index] = rho_times_coeff - 1./12.*(local_j[0]+local_j[2]) + 1./8.*(tmp1+tmp2) - 1./24.*trace;
-    lbfluid[0][13][index] = rho_times_coeff + 1./12.*(local_j[0]-local_j[2]) + 1./8.*(tmp1-tmp2) - 1./24.*trace;
-    lbfluid[0][14][index] = rho_times_coeff - 1./12.*(local_j[0]-local_j[2]) + 1./8.*(tmp1-tmp2) - 1./24.*trace;
+  lbfluid[0][11][index] = rho_times_coeff +
+                          1. / 12. * (local_j[0] + local_j[2]) +
+                          1. / 8. * (tmp1 + tmp2) - 1. / 24. * trace;
+  lbfluid[0][12][index] = rho_times_coeff -
+                          1. / 12. * (local_j[0] + local_j[2]) +
+                          1. / 8. * (tmp1 + tmp2) - 1. / 24. * trace;
+  lbfluid[0][13][index] = rho_times_coeff +
+                          1. / 12. * (local_j[0] - local_j[2]) +
+                          1. / 8. * (tmp1 - tmp2) - 1. / 24. * trace;
+  lbfluid[0][14][index] = rho_times_coeff -
+                          1. / 12. * (local_j[0] - local_j[2]) +
+                          1. / 8. * (tmp1 - tmp2) - 1. / 24. * trace;
 
-    tmp1 = local_pi[2] + local_pi[5];
-    tmp2 = 2.0*local_pi[4];
+  tmp1 = local_pi[2] + local_pi[5];
+  tmp2 = 2.0 * local_pi[4];
 
-    lbfluid[0][15][index] = rho_times_coeff + 1./12.*(local_j[1]+local_j[2]) + 1./8.*(tmp1+tmp2) - 1./24.*trace;
-    lbfluid[0][16][index] = rho_times_coeff - 1./12.*(local_j[1]+local_j[2]) + 1./8.*(tmp1+tmp2) - 1./24.*trace;
-    lbfluid[0][17][index] = rho_times_coeff + 1./12.*(local_j[1]-local_j[2]) + 1./8.*(tmp1-tmp2) - 1./24.*trace;
-    lbfluid[0][18][index] = rho_times_coeff - 1./12.*(local_j[1]-local_j[2]) + 1./8.*(tmp1-tmp2) - 1./24.*trace;
+  lbfluid[0][15][index] = rho_times_coeff +
+                          1. / 12. * (local_j[1] + local_j[2]) +
+                          1. / 8. * (tmp1 + tmp2) - 1. / 24. * trace;
+  lbfluid[0][16][index] = rho_times_coeff -
+                          1. / 12. * (local_j[1] + local_j[2]) +
+                          1. / 8. * (tmp1 + tmp2) - 1. / 24. * trace;
+  lbfluid[0][17][index] = rho_times_coeff +
+                          1. / 12. * (local_j[1] - local_j[2]) +
+                          1. / 8. * (tmp1 - tmp2) - 1. / 24. * trace;
+  lbfluid[0][18][index] = rho_times_coeff -
+                          1. / 12. * (local_j[1] - local_j[2]) +
+                          1. / 8. * (tmp1 - tmp2) - 1. / 24. * trace;
 
-#else // D3Q19
+#else  // D3Q19
 
-    int i;
-    double tmp=0.0;
-    double (*c)[3] = lbmodel.c;
-    double (*coeff)[4] = lbmodel.coeff;
+  int i;
+  double tmp = 0.0;
+  double(*c)[3] = lbmodel.c;
+  double(*coeff)[4] = lbmodel.coeff;
 
-    for (i = 0; i < lbmodel.n_veloc; i++) {
-      tmp = local_pi[0] * SQR(c[i][0])
-          + (2.0 * local_pi[1] * c[i][0] + local_pi[2] * c[i][1])*c[i][1]
-          + (2.0 * (local_pi[3]*c[i][0] + local_pi[4] * c[i][1]) + local_pi[5] * c[i][2]) * c[i][2];
+  for (i = 0; i < lbmodel.n_veloc; i++) {
+    tmp = local_pi[0] * Utils::sqr(c[i][0]) +
+          (2.0 * local_pi[1] * c[i][0] + local_pi[2] * c[i][1]) * c[i][1] +
+          (2.0 * (local_pi[3] * c[i][0] + local_pi[4] * c[i][1]) +
+           local_pi[5] * c[i][2]) *
+              c[i][2];
 
-        lbfluid[0][i][index] =  coeff[i][0] * (local_rho-avg_rho);
-        lbfluid[0][i][index] += coeff[i][1] * scalar(local_j,c[i]);
-        lbfluid[0][i][index] += coeff[i][2] * tmp;
-        lbfluid[0][i][index] += coeff[i][3] * trace;
-    }
+    lbfluid[0][i][index] = coeff[i][0] * (local_rho - avg_rho);
+    lbfluid[0][i][index] += coeff[i][1] * scalar(local_j, c[i]);
+    lbfluid[0][i][index] += coeff[i][2] * tmp;
+    lbfluid[0][i][index] += coeff[i][3] * trace;
+  }
 #endif // D3Q19
 }
 
 /*@}*/
 
-
 /** Calculation of hydrodynamic modes */
-void lb_calc_modes(Lattice::index_t index, double *mode) 
-{
+void lb_calc_modes(Lattice::index_t index, double *mode) {
 #ifdef D3Q19
-    double n0, n1p, n1m, n2p, n2m, n3p, n3m, n4p, n4m, n5p, n5m, n6p, n6m, n7p, n7m, n8p, n8m, n9p, n9m;
+  double n0, n1p, n1m, n2p, n2m, n3p, n3m, n4p, n4m, n5p, n5m, n6p, n6m, n7p,
+      n7m, n8p, n8m, n9p, n9m;
 
-    n0  = lbfluid[0][0][index];
-    n1p = lbfluid[0][1][index] + lbfluid[0][2][index];
-    n1m = lbfluid[0][1][index] - lbfluid[0][2][index];
-    n2p = lbfluid[0][3][index] + lbfluid[0][4][index];
-    n2m = lbfluid[0][3][index] - lbfluid[0][4][index];
-    n3p = lbfluid[0][5][index] + lbfluid[0][6][index];
-    n3m = lbfluid[0][5][index] - lbfluid[0][6][index];
-    n4p = lbfluid[0][7][index] + lbfluid[0][8][index];
-    n4m = lbfluid[0][7][index] - lbfluid[0][8][index];
-    n5p = lbfluid[0][9][index] + lbfluid[0][10][index];
-    n5m = lbfluid[0][9][index] - lbfluid[0][10][index];
-    n6p = lbfluid[0][11][index] + lbfluid[0][12][index];
-    n6m = lbfluid[0][11][index] - lbfluid[0][12][index];
-    n7p = lbfluid[0][13][index] + lbfluid[0][14][index];
-    n7m = lbfluid[0][13][index] - lbfluid[0][14][index];
-    n8p = lbfluid[0][15][index] + lbfluid[0][16][index];
-    n8m = lbfluid[0][15][index] - lbfluid[0][16][index];
-    n9p = lbfluid[0][17][index] + lbfluid[0][18][index];
-    n9m = lbfluid[0][17][index] - lbfluid[0][18][index];
-//  printf("n: ");
-//  for (i=0; i<19; i++)
-//    printf("%f ", lbfluid[1][i][index]);
-//  printf("\n");
+  n0 = lbfluid[0][0][index];
+  n1p = lbfluid[0][1][index] + lbfluid[0][2][index];
+  n1m = lbfluid[0][1][index] - lbfluid[0][2][index];
+  n2p = lbfluid[0][3][index] + lbfluid[0][4][index];
+  n2m = lbfluid[0][3][index] - lbfluid[0][4][index];
+  n3p = lbfluid[0][5][index] + lbfluid[0][6][index];
+  n3m = lbfluid[0][5][index] - lbfluid[0][6][index];
+  n4p = lbfluid[0][7][index] + lbfluid[0][8][index];
+  n4m = lbfluid[0][7][index] - lbfluid[0][8][index];
+  n5p = lbfluid[0][9][index] + lbfluid[0][10][index];
+  n5m = lbfluid[0][9][index] - lbfluid[0][10][index];
+  n6p = lbfluid[0][11][index] + lbfluid[0][12][index];
+  n6m = lbfluid[0][11][index] - lbfluid[0][12][index];
+  n7p = lbfluid[0][13][index] + lbfluid[0][14][index];
+  n7m = lbfluid[0][13][index] - lbfluid[0][14][index];
+  n8p = lbfluid[0][15][index] + lbfluid[0][16][index];
+  n8m = lbfluid[0][15][index] - lbfluid[0][16][index];
+  n9p = lbfluid[0][17][index] + lbfluid[0][18][index];
+  n9m = lbfluid[0][17][index] - lbfluid[0][18][index];
+  //  printf("n: ");
+  //  for (i=0; i<19; i++)
+  //    printf("%f ", lbfluid[1][i][index]);
+  //  printf("\n");
 
-    /* mass mode */
-    mode[0] = n0 + n1p + n2p + n3p + n4p + n5p + n6p + n7p + n8p + n9p;
+  /* mass mode */
+  mode[0] = n0 + n1p + n2p + n3p + n4p + n5p + n6p + n7p + n8p + n9p;
 
-    /* momentum modes */
-    mode[1] = n1m + n4m + n5m + n6m + n7m;
-    mode[2] = n2m + n4m - n5m + n8m + n9m;
-    mode[3] = n3m + n6m - n7m + n8m - n9m;
+  /* momentum modes */
+  mode[1] = n1m + n4m + n5m + n6m + n7m;
+  mode[2] = n2m + n4m - n5m + n8m + n9m;
+  mode[3] = n3m + n6m - n7m + n8m - n9m;
 
-    /* stress modes */
-    mode[4] = -n0 + n4p + n5p + n6p + n7p + n8p + n9p;
-    mode[5] = n1p - n2p + n6p + n7p - n8p - n9p;
-    mode[6] = n1p + n2p - n6p - n7p - n8p - n9p - 2.*(n3p - n4p - n5p);
-    mode[7] = n4p - n5p;
-    mode[8] = n6p - n7p;
-    mode[9] = n8p - n9p;
+  /* stress modes */
+  mode[4] = -n0 + n4p + n5p + n6p + n7p + n8p + n9p;
+  mode[5] = n1p - n2p + n6p + n7p - n8p - n9p;
+  mode[6] = n1p + n2p - n6p - n7p - n8p - n9p - 2. * (n3p - n4p - n5p);
+  mode[7] = n4p - n5p;
+  mode[8] = n6p - n7p;
+  mode[9] = n8p - n9p;
 
 #ifndef OLD_FLUCT
-    /* kinetic modes */
-    mode[10] = -2.*n1m + n4m + n5m + n6m + n7m;
-    mode[11] = -2.*n2m + n4m - n5m + n8m + n9m;
-    mode[12] = -2.*n3m + n6m - n7m + n8m - n9m;
-    mode[13] = n4m + n5m - n6m - n7m;
-    mode[14] = n4m - n5m - n8m - n9m;
-    mode[15] = n6m - n7m - n8m + n9m;
-    mode[16] = n0 + n4p + n5p + n6p + n7p + n8p + n9p
-        - 2.*(n1p + n2p + n3p);
-    mode[17] = - n1p + n2p + n6p + n7p - n8p - n9p;
-    mode[18] = - n1p - n2p -n6p - n7p - n8p - n9p
-        + 2.*(n3p + n4p + n5p);
+  /* kinetic modes */
+  mode[10] = -2. * n1m + n4m + n5m + n6m + n7m;
+  mode[11] = -2. * n2m + n4m - n5m + n8m + n9m;
+  mode[12] = -2. * n3m + n6m - n7m + n8m - n9m;
+  mode[13] = n4m + n5m - n6m - n7m;
+  mode[14] = n4m - n5m - n8m - n9m;
+  mode[15] = n6m - n7m - n8m + n9m;
+  mode[16] = n0 + n4p + n5p + n6p + n7p + n8p + n9p - 2. * (n1p + n2p + n3p);
+  mode[17] = -n1p + n2p + n6p + n7p - n8p - n9p;
+  mode[18] = -n1p - n2p - n6p - n7p - n8p - n9p + 2. * (n3p + n4p + n5p);
 #endif // !OLD_FLUCT
 
-#else // D3Q19
-    int i, j;
-    for (i = 0; i < lbmodel.n_veloc; i++) {
-        mode[i] = 0.0;
-        for (j = 0; j < lbmodel.n_veloc; j++) {
-            mode[i] += lbmodel.e[i][j] * lbfluid[0][i][index];
-        }
+#else  // D3Q19
+  int i, j;
+  for (i = 0; i < lbmodel.n_veloc; i++) {
+    mode[i] = 0.0;
+    for (j = 0; j < lbmodel.n_veloc; j++) {
+      mode[i] += lbmodel.e[i][j] * lbfluid[0][i][index];
     }
+  }
 #endif // D3Q19
 }
-
 
 /** Streaming and calculation of modes (pull scheme) */
 inline void lb_pull_calc_modes(Lattice::index_t index, double *mode) {
 
-    int yperiod = lblattice.halo_grid[0];
-    int zperiod = lblattice.halo_grid[0]*lblattice.halo_grid[1];
+  int yperiod = lblattice.halo_grid[0];
+  int zperiod = lblattice.halo_grid[0] * lblattice.halo_grid[1];
 
-    double n[19];
-    n[0]  = lbfluid[0][0][index];
-    n[1]  = lbfluid[0][1][index-1];
-    n[2]  = lbfluid[0][2][index+1];
-    n[3]  = lbfluid[0][3][index-yperiod];
-    n[4]  = lbfluid[0][4][index+yperiod];
-    n[5]  = lbfluid[0][5][index-zperiod];
-    n[6]  = lbfluid[0][6][index+zperiod];
-    n[7]  = lbfluid[0][7][index-(1+yperiod)];
-    n[8]  = lbfluid[0][8][index+(1+yperiod)];
-    n[9]  = lbfluid[0][9][index-(1-yperiod)];
-    n[10] = lbfluid[0][10][index+(1-yperiod)];
-    n[11] = lbfluid[0][11][index-(1+zperiod)];
-    n[12] = lbfluid[0][12][index+(1+zperiod)];
-    n[13] = lbfluid[0][13][index-(1-zperiod)];
-    n[14] = lbfluid[0][14][index+(1-zperiod)];
-    n[15] = lbfluid[0][15][index-(yperiod+zperiod)];
-    n[16] = lbfluid[0][16][index+(yperiod+zperiod)];
-    n[17] = lbfluid[0][17][index-(yperiod-zperiod)];
-    n[18] = lbfluid[0][18][index+(yperiod-zperiod)];
+  double n[19];
+  n[0] = lbfluid[0][0][index];
+  n[1] = lbfluid[0][1][index - 1];
+  n[2] = lbfluid[0][2][index + 1];
+  n[3] = lbfluid[0][3][index - yperiod];
+  n[4] = lbfluid[0][4][index + yperiod];
+  n[5] = lbfluid[0][5][index - zperiod];
+  n[6] = lbfluid[0][6][index + zperiod];
+  n[7] = lbfluid[0][7][index - (1 + yperiod)];
+  n[8] = lbfluid[0][8][index + (1 + yperiod)];
+  n[9] = lbfluid[0][9][index - (1 - yperiod)];
+  n[10] = lbfluid[0][10][index + (1 - yperiod)];
+  n[11] = lbfluid[0][11][index - (1 + zperiod)];
+  n[12] = lbfluid[0][12][index + (1 + zperiod)];
+  n[13] = lbfluid[0][13][index - (1 - zperiod)];
+  n[14] = lbfluid[0][14][index + (1 - zperiod)];
+  n[15] = lbfluid[0][15][index - (yperiod + zperiod)];
+  n[16] = lbfluid[0][16][index + (yperiod + zperiod)];
+  n[17] = lbfluid[0][17][index - (yperiod - zperiod)];
+  n[18] = lbfluid[0][18][index + (yperiod - zperiod)];
 
 #ifdef D3Q19
-    /* mass mode */
-    mode[ 0] =   n[ 0] + n[ 1] + n[ 2] + n[ 3] + n[4] + n[5] + n[6]
-        + n[ 7] + n[ 8] + n[ 9] + n[10]
-        + n[11] + n[12] + n[13] + n[14]
-        + n[15] + n[16] + n[17] + n[18];
+  /* mass mode */
+  mode[0] = n[0] + n[1] + n[2] + n[3] + n[4] + n[5] + n[6] + n[7] + n[8] +
+            n[9] + n[10] + n[11] + n[12] + n[13] + n[14] + n[15] + n[16] +
+            n[17] + n[18];
 
-    /* momentum modes */
-    mode[ 1] =   n[ 1] - n[ 2]
-        + n[ 7] - n[ 8] + n[ 9] - n[10] + n[11] - n[12] + n[13] - n[14];
-    mode[ 2] =   n[ 3] - n[ 4]
-        + n[ 7] - n[ 8] - n[ 9] + n[10] + n[15] - n[16] + n[17] - n[18];
-    mode[ 3] =   n[ 5] - n[ 6]
-        + n[11] - n[12] - n[13] + n[14] + n[15] - n[16] - n[17] + n[18];
+  /* momentum modes */
+  mode[1] =
+      n[1] - n[2] + n[7] - n[8] + n[9] - n[10] + n[11] - n[12] + n[13] - n[14];
+  mode[2] =
+      n[3] - n[4] + n[7] - n[8] - n[9] + n[10] + n[15] - n[16] + n[17] - n[18];
+  mode[3] = n[5] - n[6] + n[11] - n[12] - n[13] + n[14] + n[15] - n[16] -
+            n[17] + n[18];
 
-    /* stress modes */
-    mode[ 4] = - n[ 0]
-        + n[ 7] + n[ 8] + n[ 9] + n[10]
-        + n[11] + n[12] + n[13] + n[14]
-        + n[15] + n[16] + n[17] + n[18];
-    mode[ 5] =   n[ 1] + n[ 2] - n[ 3] - n[4]
-        + n[11] + n[12] + n[13] + n[14] - n[15] - n[16] - n[17] - n[18];
-    mode[ 6] =   n[ 1] + n[ 2] + n[ 3] + n[ 4]
-        - n[11] - n[12] - n[13] - n[14] - n[15] - n[16] - n[17] - n[18]
-        - 2.*(n[5] + n[6] - n[7] - n[8] - n[9] - n[10]);
-    mode[ 7] =   n[ 7] + n[ 8] - n[ 9] - n[10];
-    mode[ 8] =   n[11] + n[12] - n[13] - n[14];
-    mode[ 9] =   n[15] + n[16] - n[17] - n[18];
+  /* stress modes */
+  mode[4] = -n[0] + n[7] + n[8] + n[9] + n[10] + n[11] + n[12] + n[13] + n[14] +
+            n[15] + n[16] + n[17] + n[18];
+  mode[5] = n[1] + n[2] - n[3] - n[4] + n[11] + n[12] + n[13] + n[14] - n[15] -
+            n[16] - n[17] - n[18];
+  mode[6] = n[1] + n[2] + n[3] + n[4] - n[11] - n[12] - n[13] - n[14] - n[15] -
+            n[16] - n[17] - n[18] -
+            2. * (n[5] + n[6] - n[7] - n[8] - n[9] - n[10]);
+  mode[7] = n[7] + n[8] - n[9] - n[10];
+  mode[8] = n[11] + n[12] - n[13] - n[14];
+  mode[9] = n[15] + n[16] - n[17] - n[18];
 
-    /* kinetic modes */
-    mode[10] = 2.*(n[2] - n[1])
-        + n[7] - n[8] + n[9] - n[10] + n[11] - n[12] + n[13] - n[14];
-    mode[11] = 2.*(n[4] - n[3])
-        + n[7] - n[8] - n[9] + n[10] + n[15] - n[16] + n[17] - n[18];
-    mode[12] = 2.*(n[6] - n[5])
-        + n[11] - n[12] - n[13] + n[14] + n[15] - n[16] - n[17] + n[18];
-    mode[13] =   n[ 7] - n[ 8] + n[ 9] - n[10] - n[11] + n[12] - n[13] + n[14];
-    mode[14] =   n[ 7] - n[ 8] - n[ 9] + n[10] - n[15] + n[16] - n[17] + n[18];
-    mode[15] =   n[11] - n[12] - n[13] + n[14] - n[15] + n[16] + n[17] - n[18];
-    mode[16] =   n[ 0]
-        + n[ 7] + n[ 8] + n[ 9] + n[10]
-        + n[11] + n[12] + n[13] + n[14]
-        + n[15] + n[16] + n[17] + n[18]
-        - 2.*(n[1] + n[2] + n[3] + n[4] + n[5] + n[6]);
-    mode[17] =   n[ 3] + n[ 4] - n[ 1] - n[ 2]
-        + n[11] + n[12] + n[13] + n[14]
-        - n[15] - n[16] - n[17] - n[18];
-    mode[18] = - n[ 1] - n[ 2] - n[ 3] - n[ 4]
-        - n[11] - n[12] - n[13] - n[14] - n[15] - n[16] - n[17] - n[18]
-        + 2.*(n[5] + n[6] + n[7] + n[8] + n[9] + n[10]);
-#else // D3Q19
-    int i, j;
-    double **e = lbmodel.e;
-    for (i = 0; i < lbmodel.n_veloc; i++)
-    {
-        mode[i] = 0.0;
-        for (j = 0; j < lbmodel.n_veloc; j++) 
-        {
-            mode[i] += e[i][j]*n[j];
-        }
+  /* kinetic modes */
+  mode[10] = 2. * (n[2] - n[1]) + n[7] - n[8] + n[9] - n[10] + n[11] - n[12] +
+             n[13] - n[14];
+  mode[11] = 2. * (n[4] - n[3]) + n[7] - n[8] - n[9] + n[10] + n[15] - n[16] +
+             n[17] - n[18];
+  mode[12] = 2. * (n[6] - n[5]) + n[11] - n[12] - n[13] + n[14] + n[15] -
+             n[16] - n[17] + n[18];
+  mode[13] = n[7] - n[8] + n[9] - n[10] - n[11] + n[12] - n[13] + n[14];
+  mode[14] = n[7] - n[8] - n[9] + n[10] - n[15] + n[16] - n[17] + n[18];
+  mode[15] = n[11] - n[12] - n[13] + n[14] - n[15] + n[16] + n[17] - n[18];
+  mode[16] = n[0] + n[7] + n[8] + n[9] + n[10] + n[11] + n[12] + n[13] + n[14] +
+             n[15] + n[16] + n[17] + n[18] -
+             2. * (n[1] + n[2] + n[3] + n[4] + n[5] + n[6]);
+  mode[17] = n[3] + n[4] - n[1] - n[2] + n[11] + n[12] + n[13] + n[14] - n[15] -
+             n[16] - n[17] - n[18];
+  mode[18] = -n[1] - n[2] - n[3] - n[4] - n[11] - n[12] - n[13] - n[14] -
+             n[15] - n[16] - n[17] - n[18] +
+             2. * (n[5] + n[6] + n[7] + n[8] + n[9] + n[10]);
+#else  // D3Q19
+  int i, j;
+  double **e = lbmodel.e;
+  for (i = 0; i < lbmodel.n_veloc; i++) {
+    mode[i] = 0.0;
+    for (j = 0; j < lbmodel.n_veloc; j++) {
+      mode[i] += e[i][j] * n[j];
     }
+  }
 #endif // D3Q19
 }
 
+inline void lb_relax_modes(Lattice::index_t index, double *mode) {
+  double rho, j[3], pi_eq[6];
 
-inline void lb_relax_modes(Lattice::index_t index, double *mode) 
-{
-    double rho, j[3], pi_eq[6];
+  /* re-construct the real density
+   * remember that the populations are stored as differences to their
+   * equilibrium value */
+  rho = mode[0] + lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid;
 
-    /* re-construct the real density
-     * remember that the populations are stored as differences to their
-     * equilibrium value */
-    rho = mode[0] + lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid;
+  j[0] = mode[1];
+  j[1] = mode[2];
+  j[2] = mode[3];
 
-    j[0] = mode[1];
-    j[1] = mode[2];
-    j[2] = mode[3];
-
-    /* if forces are present, the momentum density is redefined to
-     * include one half-step of the force action.  See the
-     * Chapman-Enskog expansion in [Ladd & Verberg]. */
+  /* if forces are present, the momentum density is redefined to
+   * include one half-step of the force action.  See the
+   * Chapman-Enskog expansion in [Ladd & Verberg]. */
 #ifndef EXTERNAL_FORCES
-    if (lbfields[index].has_force || local_cells.particles().size())
+  if (lbfields[index].has_force || local_cells.particles().size())
 #endif // !EXTERNAL_FORCES
-    {
-        j[0] += 0.5 * lbfields[index].force[0];
-        j[1] += 0.5 * lbfields[index].force[1];
-        j[2] += 0.5 * lbfields[index].force[2];
-    }
+  {
+    j[0] += 0.5 * lbfields[index].force[0];
+    j[1] += 0.5 * lbfields[index].force[1];
+    j[2] += 0.5 * lbfields[index].force[2];
+  }
 
-    /* equilibrium part of the stress modes */
-    pi_eq[0] = scalar(j,j) / rho;
-    pi_eq[1] = (SQR(j[0])-SQR(j[1])) / rho;
-    pi_eq[2] = (scalar(j,j) - 3.0 * SQR(j[2])) / rho;
-    pi_eq[3] = j[0] * j[1] / rho;
-    pi_eq[4] = j[0] * j[2] / rho;
-    pi_eq[5] = j[1] * j[2] / rho;
+  /* equilibrium part of the stress modes */
+  pi_eq[0] = scalar(j, j) / rho;
+  pi_eq[1] = (Utils::sqr(j[0]) - Utils::sqr(j[1])) / rho;
+  pi_eq[2] = (scalar(j, j) - 3.0 * Utils::sqr(j[2])) / rho;
+  pi_eq[3] = j[0] * j[1] / rho;
+  pi_eq[4] = j[0] * j[2] / rho;
+  pi_eq[5] = j[1] * j[2] / rho;
 
-    /* relax the stress modes */
-    mode[4] = pi_eq[0] + lbpar.gamma_bulk * (mode[4] - pi_eq[0]);
-    mode[5] = pi_eq[1] + lbpar.gamma_shear * (mode[5] - pi_eq[1]);
-    mode[6] = pi_eq[2] + lbpar.gamma_shear * (mode[6] - pi_eq[2]);
-    mode[7] = pi_eq[3] + lbpar.gamma_shear * (mode[7] - pi_eq[3]);
-    mode[8] = pi_eq[4] + lbpar.gamma_shear * (mode[8] - pi_eq[4]);
-    mode[9] = pi_eq[5] + lbpar.gamma_shear * (mode[9] - pi_eq[5]);
+  /* relax the stress modes */
+  mode[4] = pi_eq[0] + lbpar.gamma_bulk * (mode[4] - pi_eq[0]);
+  mode[5] = pi_eq[1] + lbpar.gamma_shear * (mode[5] - pi_eq[1]);
+  mode[6] = pi_eq[2] + lbpar.gamma_shear * (mode[6] - pi_eq[2]);
+  mode[7] = pi_eq[3] + lbpar.gamma_shear * (mode[7] - pi_eq[3]);
+  mode[8] = pi_eq[4] + lbpar.gamma_shear * (mode[8] - pi_eq[4]);
+  mode[9] = pi_eq[5] + lbpar.gamma_shear * (mode[9] - pi_eq[5]);
 
 #ifndef OLD_FLUCT
-    /* relax the ghost modes (project them out) */
-    /* ghost modes have no equilibrium part due to orthogonality */
-    mode[10] = lbpar.gamma_odd*mode[10];
-    mode[11] = lbpar.gamma_odd*mode[11];
-    mode[12] = lbpar.gamma_odd*mode[12];
-    mode[13] = lbpar.gamma_odd*mode[13];
-    mode[14] = lbpar.gamma_odd*mode[14];
-    mode[15] = lbpar.gamma_odd*mode[15];
-    mode[16] = lbpar.gamma_even*mode[16];
-    mode[17] = lbpar.gamma_even*mode[17];
-    mode[18] = lbpar.gamma_even*mode[18];
+  /* relax the ghost modes (project them out) */
+  /* ghost modes have no equilibrium part due to orthogonality */
+  mode[10] = lbpar.gamma_odd * mode[10];
+  mode[11] = lbpar.gamma_odd * mode[11];
+  mode[12] = lbpar.gamma_odd * mode[12];
+  mode[13] = lbpar.gamma_odd * mode[13];
+  mode[14] = lbpar.gamma_odd * mode[14];
+  mode[15] = lbpar.gamma_odd * mode[15];
+  mode[16] = lbpar.gamma_even * mode[16];
+  mode[17] = lbpar.gamma_even * mode[17];
+  mode[18] = lbpar.gamma_even * mode[18];
 #endif // !OLD_FLUCT
 }
 
-
 inline void lb_thermalize_modes(Lattice::index_t index, double *mode) {
-    double fluct[6];
+  double fluct[6];
 #ifdef GAUSSRANDOM
-    double rootrho_gauss = sqrt(fabs(mode[0]+lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid));
+  double rootrho_gauss =
+      sqrt(fabs(mode[0] + lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid));
 
-    /* stress modes */
-    mode[4] += (fluct[0] = rootrho_gauss*lbpar.phi[4]*gaussian_random());
-    mode[5] += (fluct[1] = rootrho_gauss*lbpar.phi[5]*gaussian_random());
-    mode[6] += (fluct[2] = rootrho_gauss*lbpar.phi[6]*gaussian_random());
-    mode[7] += (fluct[3] = rootrho_gauss*lbpar.phi[7]*gaussian_random());
-    mode[8] += (fluct[4] = rootrho_gauss*lbpar.phi[8]*gaussian_random());
-    mode[9] += (fluct[5] = rootrho_gauss*lbpar.phi[9]*gaussian_random());
+  /* stress modes */
+  mode[4] += (fluct[0] = rootrho_gauss * lbpar.phi[4] * gaussian_random());
+  mode[5] += (fluct[1] = rootrho_gauss * lbpar.phi[5] * gaussian_random());
+  mode[6] += (fluct[2] = rootrho_gauss * lbpar.phi[6] * gaussian_random());
+  mode[7] += (fluct[3] = rootrho_gauss * lbpar.phi[7] * gaussian_random());
+  mode[8] += (fluct[4] = rootrho_gauss * lbpar.phi[8] * gaussian_random());
+  mode[9] += (fluct[5] = rootrho_gauss * lbpar.phi[9] * gaussian_random());
 
 #ifndef OLD_FLUCT
-    /* ghost modes */
-    mode[10] += rootrho_gauss*lbpar.phi[10]*gaussian_random();
-    mode[11] += rootrho_gauss*lbpar.phi[11]*gaussian_random();
-    mode[12] += rootrho_gauss*lbpar.phi[12]*gaussian_random();
-    mode[13] += rootrho_gauss*lbpar.phi[13]*gaussian_random();
-    mode[14] += rootrho_gauss*lbpar.phi[14]*gaussian_random();
-    mode[15] += rootrho_gauss*lbpar.phi[15]*gaussian_random();
-    mode[16] += rootrho_gauss*lbpar.phi[16]*gaussian_random();
-    mode[17] += rootrho_gauss*lbpar.phi[17]*gaussian_random();
-    mode[18] += rootrho_gauss*lbpar.phi[18]*gaussian_random();
+  /* ghost modes */
+  mode[10] += rootrho_gauss * lbpar.phi[10] * gaussian_random();
+  mode[11] += rootrho_gauss * lbpar.phi[11] * gaussian_random();
+  mode[12] += rootrho_gauss * lbpar.phi[12] * gaussian_random();
+  mode[13] += rootrho_gauss * lbpar.phi[13] * gaussian_random();
+  mode[14] += rootrho_gauss * lbpar.phi[14] * gaussian_random();
+  mode[15] += rootrho_gauss * lbpar.phi[15] * gaussian_random();
+  mode[16] += rootrho_gauss * lbpar.phi[16] * gaussian_random();
+  mode[17] += rootrho_gauss * lbpar.phi[17] * gaussian_random();
+  mode[18] += rootrho_gauss * lbpar.phi[18] * gaussian_random();
 #endif // !OLD_FLUCT
 
-#elif defined (GAUSSRANDOMCUT)
-    double rootrho_gauss = sqrt(fabs(mode[0]+lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid));
+#elif defined(GAUSSRANDOMCUT)
+  double rootrho_gauss =
+      sqrt(fabs(mode[0] + lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid));
 
-    /* stress modes */
-    mode[4] += (fluct[0] = rootrho_gauss*lbpar.phi[4]*gaussian_random_cut());
-    mode[5] += (fluct[1] = rootrho_gauss*lbpar.phi[5]*gaussian_random_cut());
-    mode[6] += (fluct[2] = rootrho_gauss*lbpar.phi[6]*gaussian_random_cut());
-    mode[7] += (fluct[3] = rootrho_gauss*lbpar.phi[7]*gaussian_random_cut());
-    mode[8] += (fluct[4] = rootrho_gauss*lbpar.phi[8]*gaussian_random_cut());
-    mode[9] += (fluct[5] = rootrho_gauss*lbpar.phi[9]*gaussian_random_cut());
+  /* stress modes */
+  mode[4] += (fluct[0] = rootrho_gauss * lbpar.phi[4] * gaussian_random_cut());
+  mode[5] += (fluct[1] = rootrho_gauss * lbpar.phi[5] * gaussian_random_cut());
+  mode[6] += (fluct[2] = rootrho_gauss * lbpar.phi[6] * gaussian_random_cut());
+  mode[7] += (fluct[3] = rootrho_gauss * lbpar.phi[7] * gaussian_random_cut());
+  mode[8] += (fluct[4] = rootrho_gauss * lbpar.phi[8] * gaussian_random_cut());
+  mode[9] += (fluct[5] = rootrho_gauss * lbpar.phi[9] * gaussian_random_cut());
 
 #ifndef OLD_FLUCT
-    /* ghost modes */
-    mode[10] += rootrho_gauss*lbpar.phi[10]*gaussian_random_cut();
-    mode[11] += rootrho_gauss*lbpar.phi[11]*gaussian_random_cut();
-    mode[12] += rootrho_gauss*lbpar.phi[12]*gaussian_random_cut();
-    mode[13] += rootrho_gauss*lbpar.phi[13]*gaussian_random_cut();
-    mode[14] += rootrho_gauss*lbpar.phi[14]*gaussian_random_cut();
-    mode[15] += rootrho_gauss*lbpar.phi[15]*gaussian_random_cut();
-    mode[16] += rootrho_gauss*lbpar.phi[16]*gaussian_random_cut();
-    mode[17] += rootrho_gauss*lbpar.phi[17]*gaussian_random_cut();
-    mode[18] += rootrho_gauss*lbpar.phi[18]*gaussian_random_cut();
+  /* ghost modes */
+  mode[10] += rootrho_gauss * lbpar.phi[10] * gaussian_random_cut();
+  mode[11] += rootrho_gauss * lbpar.phi[11] * gaussian_random_cut();
+  mode[12] += rootrho_gauss * lbpar.phi[12] * gaussian_random_cut();
+  mode[13] += rootrho_gauss * lbpar.phi[13] * gaussian_random_cut();
+  mode[14] += rootrho_gauss * lbpar.phi[14] * gaussian_random_cut();
+  mode[15] += rootrho_gauss * lbpar.phi[15] * gaussian_random_cut();
+  mode[16] += rootrho_gauss * lbpar.phi[16] * gaussian_random_cut();
+  mode[17] += rootrho_gauss * lbpar.phi[17] * gaussian_random_cut();
+  mode[18] += rootrho_gauss * lbpar.phi[18] * gaussian_random_cut();
 #endif // OLD_FLUCT
 
-#elif defined (FLATNOISE)
-    double rootrho = sqrt(fabs(12.0*(mode[0]+lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid)));
+#elif defined(FLATNOISE)
+  double rootrho = sqrt(fabs(
+      12.0 * (mode[0] + lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid)));
 
-    /* stress modes */
-    mode[4] += (fluct[0] = rootrho*lbpar.phi[4]*(d_random()-0.5));
-    mode[5] += (fluct[1] = rootrho*lbpar.phi[5]*(d_random()-0.5));
-    mode[6] += (fluct[2] = rootrho*lbpar.phi[6]*(d_random()-0.5));
-    mode[7] += (fluct[3] = rootrho*lbpar.phi[7]*(d_random()-0.5));
-    mode[8] += (fluct[4] = rootrho*lbpar.phi[8]*(d_random()-0.5));
-    mode[9] += (fluct[5] = rootrho*lbpar.phi[9]*(d_random()-0.5));
+  /* stress modes */
+  mode[4] += (fluct[0] = rootrho * lbpar.phi[4] * (d_random() - 0.5));
+  mode[5] += (fluct[1] = rootrho * lbpar.phi[5] * (d_random() - 0.5));
+  mode[6] += (fluct[2] = rootrho * lbpar.phi[6] * (d_random() - 0.5));
+  mode[7] += (fluct[3] = rootrho * lbpar.phi[7] * (d_random() - 0.5));
+  mode[8] += (fluct[4] = rootrho * lbpar.phi[8] * (d_random() - 0.5));
+  mode[9] += (fluct[5] = rootrho * lbpar.phi[9] * (d_random() - 0.5));
 
 #ifndef OLD_FLUCT
-    /* ghost modes */
-    mode[10] += rootrho*lbpar.phi[10]*(d_random()-0.5);
-    mode[11] += rootrho*lbpar.phi[11]*(d_random()-0.5);
-    mode[12] += rootrho*lbpar.phi[12]*(d_random()-0.5);
-    mode[13] += rootrho*lbpar.phi[13]*(d_random()-0.5);
-    mode[14] += rootrho*lbpar.phi[14]*(d_random()-0.5);
-    mode[15] += rootrho*lbpar.phi[15]*(d_random()-0.5);
-    mode[16] += rootrho*lbpar.phi[16]*(d_random()-0.5);
-    mode[17] += rootrho*lbpar.phi[17]*(d_random()-0.5);
-    mode[18] += rootrho*lbpar.phi[18]*(d_random()-0.5);
+  /* ghost modes */
+  mode[10] += rootrho * lbpar.phi[10] * (d_random() - 0.5);
+  mode[11] += rootrho * lbpar.phi[11] * (d_random() - 0.5);
+  mode[12] += rootrho * lbpar.phi[12] * (d_random() - 0.5);
+  mode[13] += rootrho * lbpar.phi[13] * (d_random() - 0.5);
+  mode[14] += rootrho * lbpar.phi[14] * (d_random() - 0.5);
+  mode[15] += rootrho * lbpar.phi[15] * (d_random() - 0.5);
+  mode[16] += rootrho * lbpar.phi[16] * (d_random() - 0.5);
+  mode[17] += rootrho * lbpar.phi[17] * (d_random() - 0.5);
+  mode[18] += rootrho * lbpar.phi[18] * (d_random() - 0.5);
 #endif // !OLD_FLUCT
-#else // GAUSSRANDOM
+#else  // GAUSSRANDOM
 #error No noise type defined for the CPU LB
-#endif //GAUSSRANDOM
+#endif // GAUSSRANDOM
 
 #ifdef ADDITIONAL_CHECKS
-    rancounter += 15;
+  rancounter += 15;
 #endif // ADDITIONAL_CHECKS
 }
 
+inline void lb_apply_forces(Lattice::index_t index, double *mode) {
 
-inline void lb_apply_forces(Lattice::index_t index, double* mode) {
+  double rho, *f, u[3], C[6];
 
-    double rho, *f, u[3], C[6];
+  f = lbfields[index].force;
 
-    f = lbfields[index].force;
+  rho = mode[0] + lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid;
 
-    rho = mode[0] + lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid;
+  /* hydrodynamic momentum density is redefined when external forces present */
+  u[0] = (mode[1] + 0.5 * f[0]) / rho;
+  u[1] = (mode[2] + 0.5 * f[1]) / rho;
+  u[2] = (mode[3] + 0.5 * f[2]) / rho;
 
-    /* hydrodynamic momentum density is redefined when external forces present */
-    u[0] = (mode[1] + 0.5 * f[0])/rho;
-    u[1] = (mode[2] + 0.5 * f[1])/rho;
-    u[2] = (mode[3] + 0.5 * f[2])/rho;
+  C[0] = (1. + lbpar.gamma_bulk) * u[0] * f[0] +
+         1. / 3. * (lbpar.gamma_bulk - lbpar.gamma_shear) * scalar(u, f);
+  C[2] = (1. + lbpar.gamma_bulk) * u[1] * f[1] +
+         1. / 3. * (lbpar.gamma_bulk - lbpar.gamma_shear) * scalar(u, f);
+  C[5] = (1. + lbpar.gamma_bulk) * u[2] * f[2] +
+         1. / 3. * (lbpar.gamma_bulk - lbpar.gamma_shear) * scalar(u, f);
+  C[1] = 1. / 2. * (1. + lbpar.gamma_shear) * (u[0] * f[1] + u[1] * f[0]);
+  C[3] = 1. / 2. * (1. + lbpar.gamma_shear) * (u[0] * f[2] + u[2] * f[0]);
+  C[4] = 1. / 2. * (1. + lbpar.gamma_shear) * (u[1] * f[2] + u[2] * f[1]);
 
-    C[0] = (1.+lbpar.gamma_bulk)*u[0]*f[0] + 1./3.*(lbpar.gamma_bulk-lbpar.gamma_shear)*scalar(u,f);
-    C[2] = (1.+lbpar.gamma_bulk)*u[1]*f[1] + 1./3.*(lbpar.gamma_bulk-lbpar.gamma_shear)*scalar(u,f);
-    C[5] = (1.+lbpar.gamma_bulk)*u[2]*f[2] + 1./3.*(lbpar.gamma_bulk-lbpar.gamma_shear)*scalar(u,f);
-    C[1] = 1./2. * (1.+lbpar.gamma_shear)*(u[0]*f[1]+u[1]*f[0]);
-    C[3] = 1./2. * (1.+lbpar.gamma_shear)*(u[0]*f[2]+u[2]*f[0]);
-    C[4] = 1./2. * (1.+lbpar.gamma_shear)*(u[1]*f[2]+u[2]*f[1]);
+  /* update momentum modes */
+  mode[1] += f[0];
+  mode[2] += f[1];
+  mode[3] += f[2];
 
-    /* update momentum modes */
-    mode[1] += f[0];
-    mode[2] += f[1];
-    mode[3] += f[2];
+  /* update stress modes */
+  mode[4] += C[0] + C[2] + C[5];
+  mode[5] += C[0] - C[2];
+  mode[6] += C[0] + C[2] - 2. * C[5];
+  mode[7] += C[1];
+  mode[8] += C[3];
+  mode[9] += C[4];
 
-    /* update stress modes */
-    mode[4] += C[0] + C[2] + C[5];
-    mode[5] += C[0] - C[2];
-    mode[6] += C[0] + C[2] - 2. * C[5];
-    mode[7] += C[1];
-    mode[8] += C[3];
-    mode[9] += C[4];
-
-    /* reset force */
+  /* reset force */
 #ifdef EXTERNAL_FORCES
-    // unit conversion: force density
-    lbfields[index].force[0] = lbpar.ext_force[0]*pow(lbpar.agrid,2)*lbpar.tau*lbpar.tau;
-    lbfields[index].force[1] = lbpar.ext_force[1]*pow(lbpar.agrid,2)*lbpar.tau*lbpar.tau;
-    lbfields[index].force[2] = lbpar.ext_force[2]*pow(lbpar.agrid,2)*lbpar.tau*lbpar.tau;
-#else // EXTERNAL_FORCES
-    lbfields[index].force[0] = 0.0;
-    lbfields[index].force[1] = 0.0;
-    lbfields[index].force[2] = 0.0;
-    lbfields[index].has_force = 0;
+  // unit conversion: force density
+  lbfields[index].force[0] =
+      lbpar.ext_force[0] * pow(lbpar.agrid, 2) * lbpar.tau * lbpar.tau;
+  lbfields[index].force[1] =
+      lbpar.ext_force[1] * pow(lbpar.agrid, 2) * lbpar.tau * lbpar.tau;
+  lbfields[index].force[2] =
+      lbpar.ext_force[2] * pow(lbpar.agrid, 2) * lbpar.tau * lbpar.tau;
+#else  // EXTERNAL_FORCES
+  lbfields[index].force[0] = 0.0;
+  lbfields[index].force[1] = 0.0;
+  lbfields[index].force[2] = 0.0;
+  lbfields[index].has_force = 0;
 #endif // EXTERNAL_FORCES
- 
 }
 
+inline void lb_calc_n_from_modes(Lattice::index_t index, double *mode) {
 
-inline void lb_calc_n_from_modes(Lattice::index_t index, double *mode) 
-{
-  
   double *w = lbmodel.w;
-  
-#ifdef D3Q19
-  double (*e)[19] = d3q19_modebase;
-  double m[19];
-  
-  /* normalization factors enter in the back transformation */
-  for (int i = 0; i < 19; i++) 
-    m[i] = (1./e[19][i])*mode[i];
 
-  lbfluid[0][ 0][index] = m[0] - m[4] + m[16];
-  lbfluid[0][ 1][index] = m[0] + m[1] + m[5] + m[6] - m[17] - m[18] - 2.*(m[10] + m[16]);
-  lbfluid[0][ 2][index] = m[0] - m[1] + m[5] + m[6] - m[17] - m[18] + 2.*(m[10] - m[16]);
-  lbfluid[0][ 3][index] = m[0] + m[2] - m[5] + m[6] + m[17] - m[18] - 2.*(m[11] + m[16]);
-  lbfluid[0][ 4][index] = m[0] - m[2] - m[5] + m[6] + m[17] - m[18] + 2.*(m[11] - m[16]);
-  lbfluid[0][ 5][index] = m[0] + m[3] - 2.*(m[6] + m[12] + m[16] - m[18]);
-  lbfluid[0][ 6][index] = m[0] - m[3] - 2.*(m[6] - m[12] + m[16] - m[18]);
-  lbfluid[0][ 7][index] = m[0] + m[ 1] + m[ 2] + m[ 4] + 2.*m[6]
-    + m[7] + m[10] + m[11] + m[13] + m[14] + m[16] + 2.*m[18];
-  lbfluid[0][ 8][index] = m[0] - m[ 1] - m[ 2] + m[ 4] + 2.*m[6]
-    + m[7] - m[10] - m[11] - m[13] - m[14] + m[16] + 2.*m[18];
-  lbfluid[0][ 9][index] = m[0] + m[ 1] - m[ 2] + m[ 4] + 2.*m[6]
-    - m[7] + m[10] - m[11] + m[13] - m[14] + m[16] + 2.*m[18];
-  lbfluid[0][10][index] = m[0] - m[ 1] + m[ 2] + m[ 4] + 2.*m[6]
-    - m[7] - m[10] + m[11] - m[13] + m[14] + m[16] + 2.*m[18];
-  lbfluid[0][11][index] = m[0] + m[ 1] + m[ 3] + m[ 4] + m[ 5] - m[ 6]
-    + m[8] + m[10] + m[12] - m[13] + m[15] + m[16] + m[17] - m[18];
-  lbfluid[0][12][index] = m[0] - m[ 1] - m[ 3] + m[ 4] + m[ 5] - m[ 6]
-    + m[8] - m[10] - m[12] + m[13] - m[15] + m[16] + m[17] - m[18];
-  lbfluid[0][13][index] = m[0] + m[ 1] - m[ 3] + m[ 4] + m[ 5] - m[ 6]
-    - m[8] + m[10] - m[12] - m[13] - m[15] + m[16] + m[17] - m[18];
-  lbfluid[0][14][index] = m[0] - m[ 1] + m[ 3] + m[ 4] + m[ 5] - m[ 6]
-    - m[8] - m[10] + m[12] + m[13] + m[15] + m[16] + m[17] - m[18];
-  lbfluid[0][15][index] = m[0] + m[ 2] + m[ 3] + m[ 4] - m[ 5] - m[ 6]
-    + m[9] + m[11] + m[12] - m[14] - m[15] + m[16] - m[17] - m[18];
-  lbfluid[0][16][index] = m[0] - m[ 2] - m[ 3] + m[ 4] - m[ 5] - m[ 6]
-    + m[9] - m[11] - m[12] + m[14] + m[15] + m[16] - m[17] - m[18];
-  lbfluid[0][17][index] = m[0] + m[ 2] - m[ 3] + m[ 4] - m[ 5] - m[ 6]
-    - m[9] + m[11] - m[12] - m[14] + m[15] + m[16] - m[17] - m[18];
-  lbfluid[0][18][index] = m[0] - m[ 2] + m[ 3] + m[ 4] - m[ 5] - m[ 6]
-    - m[9] - m[11] + m[12] + m[14] - m[15] + m[16] - m[17] - m[18];
-  
+#ifdef D3Q19
+  double(*e)[19] = d3q19_modebase;
+  double m[19];
+
+  /* normalization factors enter in the back transformation */
+  for (int i = 0; i < 19; i++)
+    m[i] = (1. / e[19][i]) * mode[i];
+
+  lbfluid[0][0][index] = m[0] - m[4] + m[16];
+  lbfluid[0][1][index] =
+      m[0] + m[1] + m[5] + m[6] - m[17] - m[18] - 2. * (m[10] + m[16]);
+  lbfluid[0][2][index] =
+      m[0] - m[1] + m[5] + m[6] - m[17] - m[18] + 2. * (m[10] - m[16]);
+  lbfluid[0][3][index] =
+      m[0] + m[2] - m[5] + m[6] + m[17] - m[18] - 2. * (m[11] + m[16]);
+  lbfluid[0][4][index] =
+      m[0] - m[2] - m[5] + m[6] + m[17] - m[18] + 2. * (m[11] - m[16]);
+  lbfluid[0][5][index] = m[0] + m[3] - 2. * (m[6] + m[12] + m[16] - m[18]);
+  lbfluid[0][6][index] = m[0] - m[3] - 2. * (m[6] - m[12] + m[16] - m[18]);
+  lbfluid[0][7][index] = m[0] + m[1] + m[2] + m[4] + 2. * m[6] + m[7] + m[10] +
+                         m[11] + m[13] + m[14] + m[16] + 2. * m[18];
+  lbfluid[0][8][index] = m[0] - m[1] - m[2] + m[4] + 2. * m[6] + m[7] - m[10] -
+                         m[11] - m[13] - m[14] + m[16] + 2. * m[18];
+  lbfluid[0][9][index] = m[0] + m[1] - m[2] + m[4] + 2. * m[6] - m[7] + m[10] -
+                         m[11] + m[13] - m[14] + m[16] + 2. * m[18];
+  lbfluid[0][10][index] = m[0] - m[1] + m[2] + m[4] + 2. * m[6] - m[7] - m[10] +
+                          m[11] - m[13] + m[14] + m[16] + 2. * m[18];
+  lbfluid[0][11][index] = m[0] + m[1] + m[3] + m[4] + m[5] - m[6] + m[8] +
+                          m[10] + m[12] - m[13] + m[15] + m[16] + m[17] - m[18];
+  lbfluid[0][12][index] = m[0] - m[1] - m[3] + m[4] + m[5] - m[6] + m[8] -
+                          m[10] - m[12] + m[13] - m[15] + m[16] + m[17] - m[18];
+  lbfluid[0][13][index] = m[0] + m[1] - m[3] + m[4] + m[5] - m[6] - m[8] +
+                          m[10] - m[12] - m[13] - m[15] + m[16] + m[17] - m[18];
+  lbfluid[0][14][index] = m[0] - m[1] + m[3] + m[4] + m[5] - m[6] - m[8] -
+                          m[10] + m[12] + m[13] + m[15] + m[16] + m[17] - m[18];
+  lbfluid[0][15][index] = m[0] + m[2] + m[3] + m[4] - m[5] - m[6] + m[9] +
+                          m[11] + m[12] - m[14] - m[15] + m[16] - m[17] - m[18];
+  lbfluid[0][16][index] = m[0] - m[2] - m[3] + m[4] - m[5] - m[6] + m[9] -
+                          m[11] - m[12] + m[14] + m[15] + m[16] - m[17] - m[18];
+  lbfluid[0][17][index] = m[0] + m[2] - m[3] + m[4] - m[5] - m[6] - m[9] +
+                          m[11] - m[12] - m[14] + m[15] + m[16] - m[17] - m[18];
+  lbfluid[0][18][index] = m[0] - m[2] + m[3] + m[4] - m[5] - m[6] - m[9] -
+                          m[11] + m[12] + m[14] - m[15] + m[16] - m[17] - m[18];
+
   /* weights enter in the back transformation */
-  for (int i = 0; i < lbmodel.n_veloc; i++) 
+  for (int i = 0; i < lbmodel.n_veloc; i++)
     lbfluid[0][i][index] *= w[i];
 
-#else // D3Q19
+#else  // D3Q19
   double **e = lbmodel.e;
   for (int i = 0; i < lbmodel.n_veloc; i++) {
     lbfluid[0][i][index] = 0.0;
-    for (int j = 0; j < lbmodel.n_veloc; j++) 
+    for (int j = 0; j < lbmodel.n_veloc; j++)
       lbfluid[0][i][index] += mode[j] * e[j][i] / e[19][j];
-    
+
     lbfluid[0][i][index] *= w[i];
   }
 #endif // D3Q19
 }
 
-
 inline void lb_calc_n_from_modes_push(Lattice::index_t index, double *m) {
 #ifdef D3Q19
-    int yperiod = lblattice.halo_grid[0];
-    int zperiod = lblattice.halo_grid[0]*lblattice.halo_grid[1];
-    Lattice::index_t next[19];
-    next[0]  = index;
-    next[1]  = index + 1;
-    next[2]  = index - 1;
-    next[3]  = index + yperiod;
-    next[4]  = index - yperiod;
-    next[5]  = index + zperiod;
-    next[6]  = index - zperiod;
-    next[7]  = index + (1 + yperiod);
-    next[8]  = index - (1 + yperiod);
-    next[9]  = index + (1 - yperiod);
-    next[10] = index - (1 - yperiod);
-    next[11] = index + (1 + zperiod);
-    next[12] = index - (1 + zperiod);
-    next[13] = index + (1 - zperiod);
-    next[14] = index - (1 - zperiod);
-    next[15] = index + (yperiod + zperiod);
-    next[16] = index - (yperiod + zperiod);
-    next[17] = index + (yperiod - zperiod);
-    next[18] = index - (yperiod - zperiod);
+  int yperiod = lblattice.halo_grid[0];
+  int zperiod = lblattice.halo_grid[0] * lblattice.halo_grid[1];
+  Lattice::index_t next[19];
+  next[0] = index;
+  next[1] = index + 1;
+  next[2] = index - 1;
+  next[3] = index + yperiod;
+  next[4] = index - yperiod;
+  next[5] = index + zperiod;
+  next[6] = index - zperiod;
+  next[7] = index + (1 + yperiod);
+  next[8] = index - (1 + yperiod);
+  next[9] = index + (1 - yperiod);
+  next[10] = index - (1 - yperiod);
+  next[11] = index + (1 + zperiod);
+  next[12] = index - (1 + zperiod);
+  next[13] = index + (1 - zperiod);
+  next[14] = index - (1 - zperiod);
+  next[15] = index + (yperiod + zperiod);
+  next[16] = index - (yperiod + zperiod);
+  next[17] = index + (yperiod - zperiod);
+  next[18] = index - (yperiod - zperiod);
 
-    /* normalization factors enter in the back transformation */
-    for (int i = 0; i < lbmodel.n_veloc; i++) 
-        m[i] = (1./d3q19_modebase[19][i])*m[i];
+  /* normalization factors enter in the back transformation */
+  for (int i = 0; i < lbmodel.n_veloc; i++)
+    m[i] = (1. / d3q19_modebase[19][i]) * m[i];
 
 #ifndef OLD_FLUCT
-    lbfluid[1][ 0][next[0]] = m[0] - m[4] + m[16];
-    lbfluid[1][ 1][next[1]] = m[0] + m[1] + m[5] + m[6] - m[17] - m[18] - 2.*(m[10] + m[16]);
-    lbfluid[1][ 2][next[2]] = m[0] - m[1] + m[5] + m[6] - m[17] - m[18] + 2.*(m[10] - m[16]);
-    lbfluid[1][ 3][next[3]] = m[0] + m[2] - m[5] + m[6] + m[17] - m[18] - 2.*(m[11] + m[16]);
-    lbfluid[1][ 4][next[4]] = m[0] - m[2] - m[5] + m[6] + m[17] - m[18] + 2.*(m[11] - m[16]);
-    lbfluid[1][ 5][next[5]] = m[0] + m[3] - 2.*(m[6] + m[12] + m[16] - m[18]);
-    lbfluid[1][ 6][next[6]] = m[0] - m[3] - 2.*(m[6] - m[12] + m[16] - m[18]);
-    lbfluid[1][ 7][next[7]] = m[0] + m[1] + m[2] + m[4] + 2.*m[6] + m[7] + m[10] + m[11] + m[13] + m[14] + m[16] + 2.*m[18];
-    lbfluid[1][ 8][next[8]] = m[0] - m[1] - m[2] + m[4] + 2.*m[6] + m[7] - m[10] - m[11] - m[13] - m[14] + m[16] + 2.*m[18];
-    lbfluid[1][ 9][next[9]] = m[0] + m[1] - m[2] + m[4] + 2.*m[6] - m[7] + m[10] - m[11] + m[13] - m[14] + m[16] + 2.*m[18];
-    lbfluid[1][10][next[10]] = m[0] - m[1] + m[2] + m[4] + 2.*m[6] - m[7] - m[10] + m[11] - m[13] + m[14] + m[16] + 2.*m[18];
-    lbfluid[1][11][next[11]] = m[0] + m[1] + m[3] + m[4] + m[5] - m[6] + m[8] + m[10] + m[12] - m[13] + m[15] + m[16] + m[17] - m[18];
-    lbfluid[1][12][next[12]] = m[0] - m[1] - m[3] + m[4] + m[5] - m[6] + m[8] - m[10] - m[12] + m[13] - m[15] + m[16] + m[17] - m[18];
-    lbfluid[1][13][next[13]] = m[0] + m[1] - m[3] + m[4] + m[5] - m[6] - m[8] + m[10] - m[12] - m[13] - m[15] + m[16] + m[17] - m[18];
-    lbfluid[1][14][next[14]] = m[0] - m[1] + m[3] + m[4] + m[5] - m[6] - m[8] - m[10] + m[12] + m[13] + m[15] + m[16] + m[17] - m[18];
-    lbfluid[1][15][next[15]] = m[0] + m[2] + m[3] + m[4] - m[5] - m[6] + m[9] + m[11] + m[12] - m[14] - m[15] + m[16] - m[17] - m[18];
-    lbfluid[1][16][next[16]] = m[0] - m[2] - m[3] + m[4] - m[5] - m[6] + m[9] - m[11] - m[12] + m[14] + m[15] + m[16] - m[17] - m[18];
-    lbfluid[1][17][next[17]] = m[0] + m[2] - m[3] + m[4] - m[5] - m[6] - m[9] + m[11] - m[12] - m[14] + m[15] + m[16] - m[17] - m[18];
-    lbfluid[1][18][next[18]] = m[0] - m[2] + m[3] + m[4] - m[5] - m[6] - m[9] - m[11] + m[12] + m[14] - m[15] + m[16] - m[17] - m[18];
-#else // !OLD_FLUCT
-    lbfluid[1][ 0][next[0]] = m[0] - m[4];
-    lbfluid[1][ 1][next[1]] = m[0] + m[1] + m[5] + m[6];
-    lbfluid[1][ 2][next[2]] = m[0] - m[1] + m[5] + m[6];
-    lbfluid[1][ 3][next[3]] = m[0] + m[2] - m[5] + m[6];
-    lbfluid[1][ 4][next[4]] = m[0] - m[2] - m[5] + m[6];
-    lbfluid[1][ 5][next[5]] = m[0] + m[3] - 2.*m[6];
-    lbfluid[1][ 6][next[6]] = m[0] - m[3] - 2.*m[6];
-    lbfluid[1][ 7][next[7]] = m[0] + m[1] + m[2] + m[4] + 2.*m[6] + m[7];
-    lbfluid[1][ 8][next[8]] = m[0] - m[1] - m[2] + m[4] + 2.*m[6] + m[7];
-    lbfluid[1][ 9][next[9]] = m[0] + m[1] - m[2] + m[4] + 2.*m[6] - m[7];
-    lbfluid[1][10][next[10]] = m[0] - m[1] + m[2] + m[4] + 2.*m[6] - m[7];
-    lbfluid[1][11][next[11]] = m[0] + m[1] + m[3] + m[4] + m[5] - m[6] + m[8];
-    lbfluid[1][12][next[12]] = m[0] - m[1] - m[3] + m[4] + m[5] - m[6] + m[8];
-    lbfluid[1][13][next[13]] = m[0] + m[1] - m[3] + m[4] + m[5] - m[6] - m[8];
-    lbfluid[1][14][next[14]] = m[0] - m[1] + m[3] + m[4] + m[5] - m[6] - m[8];
-    lbfluid[1][15][next[15]] = m[0] + m[2] + m[3] + m[4] - m[5] - m[6] + m[9];
-    lbfluid[1][16][next[16]] = m[0] - m[2] - m[3] + m[4] - m[5] - m[6] + m[9];
-    lbfluid[1][17][next[17]] = m[0] + m[2] - m[3] + m[4] - m[5] - m[6] - m[9];
-    lbfluid[1][18][next[18]] = m[0] - m[2] + m[3] + m[4] - m[5] - m[6] - m[9];
+  lbfluid[1][0][next[0]] = m[0] - m[4] + m[16];
+  lbfluid[1][1][next[1]] =
+      m[0] + m[1] + m[5] + m[6] - m[17] - m[18] - 2. * (m[10] + m[16]);
+  lbfluid[1][2][next[2]] =
+      m[0] - m[1] + m[5] + m[6] - m[17] - m[18] + 2. * (m[10] - m[16]);
+  lbfluid[1][3][next[3]] =
+      m[0] + m[2] - m[5] + m[6] + m[17] - m[18] - 2. * (m[11] + m[16]);
+  lbfluid[1][4][next[4]] =
+      m[0] - m[2] - m[5] + m[6] + m[17] - m[18] + 2. * (m[11] - m[16]);
+  lbfluid[1][5][next[5]] = m[0] + m[3] - 2. * (m[6] + m[12] + m[16] - m[18]);
+  lbfluid[1][6][next[6]] = m[0] - m[3] - 2. * (m[6] - m[12] + m[16] - m[18]);
+  lbfluid[1][7][next[7]] = m[0] + m[1] + m[2] + m[4] + 2. * m[6] + m[7] +
+                           m[10] + m[11] + m[13] + m[14] + m[16] + 2. * m[18];
+  lbfluid[1][8][next[8]] = m[0] - m[1] - m[2] + m[4] + 2. * m[6] + m[7] -
+                           m[10] - m[11] - m[13] - m[14] + m[16] + 2. * m[18];
+  lbfluid[1][9][next[9]] = m[0] + m[1] - m[2] + m[4] + 2. * m[6] - m[7] +
+                           m[10] - m[11] + m[13] - m[14] + m[16] + 2. * m[18];
+  lbfluid[1][10][next[10]] = m[0] - m[1] + m[2] + m[4] + 2. * m[6] - m[7] -
+                             m[10] + m[11] - m[13] + m[14] + m[16] + 2. * m[18];
+  lbfluid[1][11][next[11]] = m[0] + m[1] + m[3] + m[4] + m[5] - m[6] + m[8] +
+                             m[10] + m[12] - m[13] + m[15] + m[16] + m[17] -
+                             m[18];
+  lbfluid[1][12][next[12]] = m[0] - m[1] - m[3] + m[4] + m[5] - m[6] + m[8] -
+                             m[10] - m[12] + m[13] - m[15] + m[16] + m[17] -
+                             m[18];
+  lbfluid[1][13][next[13]] = m[0] + m[1] - m[3] + m[4] + m[5] - m[6] - m[8] +
+                             m[10] - m[12] - m[13] - m[15] + m[16] + m[17] -
+                             m[18];
+  lbfluid[1][14][next[14]] = m[0] - m[1] + m[3] + m[4] + m[5] - m[6] - m[8] -
+                             m[10] + m[12] + m[13] + m[15] + m[16] + m[17] -
+                             m[18];
+  lbfluid[1][15][next[15]] = m[0] + m[2] + m[3] + m[4] - m[5] - m[6] + m[9] +
+                             m[11] + m[12] - m[14] - m[15] + m[16] - m[17] -
+                             m[18];
+  lbfluid[1][16][next[16]] = m[0] - m[2] - m[3] + m[4] - m[5] - m[6] + m[9] -
+                             m[11] - m[12] + m[14] + m[15] + m[16] - m[17] -
+                             m[18];
+  lbfluid[1][17][next[17]] = m[0] + m[2] - m[3] + m[4] - m[5] - m[6] - m[9] +
+                             m[11] - m[12] - m[14] + m[15] + m[16] - m[17] -
+                             m[18];
+  lbfluid[1][18][next[18]] = m[0] - m[2] + m[3] + m[4] - m[5] - m[6] - m[9] -
+                             m[11] + m[12] + m[14] - m[15] + m[16] - m[17] -
+                             m[18];
+#else  // !OLD_FLUCT
+  lbfluid[1][0][next[0]] = m[0] - m[4];
+  lbfluid[1][1][next[1]] = m[0] + m[1] + m[5] + m[6];
+  lbfluid[1][2][next[2]] = m[0] - m[1] + m[5] + m[6];
+  lbfluid[1][3][next[3]] = m[0] + m[2] - m[5] + m[6];
+  lbfluid[1][4][next[4]] = m[0] - m[2] - m[5] + m[6];
+  lbfluid[1][5][next[5]] = m[0] + m[3] - 2. * m[6];
+  lbfluid[1][6][next[6]] = m[0] - m[3] - 2. * m[6];
+  lbfluid[1][7][next[7]] = m[0] + m[1] + m[2] + m[4] + 2. * m[6] + m[7];
+  lbfluid[1][8][next[8]] = m[0] - m[1] - m[2] + m[4] + 2. * m[6] + m[7];
+  lbfluid[1][9][next[9]] = m[0] + m[1] - m[2] + m[4] + 2. * m[6] - m[7];
+  lbfluid[1][10][next[10]] = m[0] - m[1] + m[2] + m[4] + 2. * m[6] - m[7];
+  lbfluid[1][11][next[11]] = m[0] + m[1] + m[3] + m[4] + m[5] - m[6] + m[8];
+  lbfluid[1][12][next[12]] = m[0] - m[1] - m[3] + m[4] + m[5] - m[6] + m[8];
+  lbfluid[1][13][next[13]] = m[0] + m[1] - m[3] + m[4] + m[5] - m[6] - m[8];
+  lbfluid[1][14][next[14]] = m[0] - m[1] + m[3] + m[4] + m[5] - m[6] - m[8];
+  lbfluid[1][15][next[15]] = m[0] + m[2] + m[3] + m[4] - m[5] - m[6] + m[9];
+  lbfluid[1][16][next[16]] = m[0] - m[2] - m[3] + m[4] - m[5] - m[6] + m[9];
+  lbfluid[1][17][next[17]] = m[0] + m[2] - m[3] + m[4] - m[5] - m[6] - m[9];
+  lbfluid[1][18][next[18]] = m[0] - m[2] + m[3] + m[4] - m[5] - m[6] - m[9];
 #endif // !OLD_FLUCT
 
-    /* weights enter in the back transformation */
-    for (int i = 0; i < lbmodel.n_veloc; i++)
-        lbfluid[1][i][next[i]] *= lbmodel.w[i];
-#else // D3Q19
-    double **e = lbmodel.e;
-    Lattice::index_t next[lbmodel.n_veloc];
-    for (int i = 0; i < lbmodel.n_veloc; i++) {
-        next[i] = get_linear_index(c[i][0],c[i][1],c[i][2],lblattic.halo_grid);
-        lbfluid[1][i][next[i]] = 0.0;
-        for (int j = 0; j < lbmodel.n_veloc; j++)
-          lbfluid[1][i][next[i]] += mode[j]*e[j][i]/e[19][j];
-        lbfluid[1][i][index] *= w[i];
-    }
+  /* weights enter in the back transformation */
+  for (int i = 0; i < lbmodel.n_veloc; i++)
+    lbfluid[1][i][next[i]] *= lbmodel.w[i];
+#else  // D3Q19
+  double **e = lbmodel.e;
+  Lattice::index_t next[lbmodel.n_veloc];
+  for (int i = 0; i < lbmodel.n_veloc; i++) {
+    next[i] = get_linear_index(c[i][0], c[i][1], c[i][2], lblattic.halo_grid);
+    lbfluid[1][i][next[i]] = 0.0;
+    for (int j = 0; j < lbmodel.n_veloc; j++)
+      lbfluid[1][i][next[i]] += mode[j] * e[j][i] / e[19][j];
+    lbfluid[1][i][index] *= w[i];
+  }
 #endif // D3Q19
 }
 
-
 /* Collisions and streaming (push scheme) */
 inline void lb_collide_stream() {
-    Lattice::index_t index;
-    int x, y, z;
-    double modes[19];
+  Lattice::index_t index;
+  int x, y, z;
+  double modes[19];
 
-    /* loop over all lattice cells (halo excluded) */
+  /* loop over all lattice cells (halo excluded) */
 #ifdef LB_BOUNDARIES
-    for (auto it = LBBoundaries::lbboundaries.begin(); it != LBBoundaries::lbboundaries.end(); ++it) {
-      (**it).reset_force();
-    }
+  for (auto it = LBBoundaries::lbboundaries.begin();
+       it != LBBoundaries::lbboundaries.end(); ++it) {
+    (**it).reset_force();
+  }
 #endif // LB_BOUNDARIES
-  
-  
+
 #ifdef IMMERSED_BOUNDARY
-// Safeguard the node forces so that we can later use them for the IBM particle update
-// In the following loop the lbfields[XX].force are reset to zero
-  for (int i = 0; i<lblattice.halo_grid_volume; ++i)
-  {
+  // Safeguard the node forces so that we can later use them for the IBM
+  // particle update In the following loop the lbfields[XX].force are reset to
+  // zero
+  for (int i = 0; i < lblattice.halo_grid_volume; ++i) {
     lbfields[i].force_buf[0] = lbfields[i].force[0];
     lbfields[i].force_buf[1] = lbfields[i].force[1];
     lbfields[i].force_buf[2] = lbfields[i].force[2];
   }
 #endif
-  
-  
-  
 
-    index = lblattice.halo_offset;
-    for (z = 1; z <= lblattice.grid[2]; z++) {
-      for (y = 1; y<=lblattice.grid[1]; y++) {
-        for (x = 1; x<=lblattice.grid[0]; x++) {
-          // as we only want to apply this to non-boundary nodes we can throw out the if-clause
-          // if we have a non-bounded domain
+  index = lblattice.halo_offset;
+  for (z = 1; z <= lblattice.grid[2]; z++) {
+    for (y = 1; y <= lblattice.grid[1]; y++) {
+      for (x = 1; x <= lblattice.grid[0]; x++) {
+      // as we only want to apply this to non-boundary nodes we can throw out
+      // the if-clause if we have a non-bounded domain
 #ifdef LB_BOUNDARIES
-          if (!lbfields[index].boundary)
+        if (!lbfields[index].boundary)
 #endif // LB_BOUNDARIES
-            {
+        {
 
-              /* calculate modes locally */
-              lb_calc_modes(index, modes);
+          /* calculate modes locally */
+          lb_calc_modes(index, modes);
 
-              /* deterministic collisions */
-              lb_relax_modes(index, modes);
+          /* deterministic collisions */
+          lb_relax_modes(index, modes);
 
-              /* fluctuating hydrodynamics */
-              if (lbpar.fluct) lb_thermalize_modes(index, modes);
+          /* fluctuating hydrodynamics */
+          if (lbpar.fluct)
+            lb_thermalize_modes(index, modes);
 
-              /* apply forces */
+            /* apply forces */
 #ifdef EXTERNAL_FORCES
-              lb_apply_forces(index, modes);
-#else // EXTERNAL_FORCES
-              if (lbfields[index].has_force || local_cells.particles().size()) lb_apply_forces(index, modes);
+          lb_apply_forces(index, modes);
+#else  // EXTERNAL_FORCES
+          if (lbfields[index].has_force || local_cells.particles().size())
+            lb_apply_forces(index, modes);
 #endif // EXTERNAL_FORCES
 
-              /* transform back to populations and streaming */
-              lb_calc_n_from_modes_push(index, modes);
-
-            }
-//  #ifdef LB_BOUNDARIES
-//           else {
-//      // Here collision in the boundary nodes
-//      // can be included, if this is necessary
-//             //                     lb_boundary_collisions(index, modes);
-//           }
-// #endif // LB_BOUNDARIES
-                ++index; /* next node */
-            }
-            index += 2; /* skip halo region */
+          /* transform back to populations and streaming */
+          lb_calc_n_from_modes_push(index, modes);
         }
-        index += 2*lblattice.halo_grid[0]; /* skip halo region */
+        //  #ifdef LB_BOUNDARIES
+        //           else {
+        //      // Here collision in the boundary nodes
+        //      // can be included, if this is necessary
+        //             //                     lb_boundary_collisions(index,
+        //             modes);
+        //           }
+        // #endif // LB_BOUNDARIES
+        ++index; /* next node */
+      }
+      index += 2; /* skip halo region */
     }
+    index += 2 * lblattice.halo_grid[0]; /* skip halo region */
+  }
 
-    /* exchange halo regions */
-    halo_push_communication();
+  /* exchange halo regions */
+  halo_push_communication();
 
 #ifdef LB_BOUNDARIES
-    /* boundary conditions for links */
-    LBBoundaries::lb_bounce_back();
+  /* boundary conditions for links */
+  LBBoundaries::lb_bounce_back();
 #endif // LB_BOUNDARIES
 
-    /* swap the pointers for old and new population fields */
-    double **tmp;
-    tmp = lbfluid[0];
-    lbfluid[0] = lbfluid[1];
-    lbfluid[1] = tmp;
+  /* swap the pointers for old and new population fields */
+  double **tmp;
+  tmp = lbfluid[0];
+  lbfluid[0] = lbfluid[1];
+  lbfluid[1] = tmp;
 
-    /* halo region is invalid after update */
-    lbpar.resend_halo = 1;
+  /* halo region is invalid after update */
+  lbpar.resend_halo = 1;
 }
-
 
 /** Streaming and collisions (pull scheme) */
 inline void lb_stream_collide() {
-    Lattice::index_t index;
-    int x, y, z;
-    double modes[19];
+  Lattice::index_t index;
+  int x, y, z;
+  double modes[19];
 
-    /* exchange halo regions */
-    halo_communication(&update_halo_comm,(char*)**lbfluid);
+  /* exchange halo regions */
+  halo_communication(&update_halo_comm, (char *)**lbfluid);
 
 #ifdef ADDITIONAL_CHECKS
-    lb_check_halo_regions();
+  lb_check_halo_regions();
 #endif // ADDITIONAL_CHECKS
 
-    /* loop over all lattice cells (halo excluded) */
-    index = lblattice.halo_offset;
-    for (z = 1; z <= lblattice.grid[2]; z++) {
-        for (y = 1; y <= lblattice.grid[1]; y++) {
-            for (x = 1; x <= lblattice.grid[0]; x++) {
-                // as we only want to apply this to non-boundary nodes we can throw out the if-clause
-                // if we have a non-bounded domain
+  /* loop over all lattice cells (halo excluded) */
+  index = lblattice.halo_offset;
+  for (z = 1; z <= lblattice.grid[2]; z++) {
+    for (y = 1; y <= lblattice.grid[1]; y++) {
+      for (x = 1; x <= lblattice.grid[0]; x++) {
+      // as we only want to apply this to non-boundary nodes we can throw out
+      // the if-clause if we have a non-bounded domain
 #ifdef LB_BOUNDARIES
-                if (!lbfields[index].boundary)
+        if (!lbfields[index].boundary)
 #endif // LB_BOUNDARIES
-                {
+        {
 
-                    /* stream (pull) and calculate modes */
-                    lb_pull_calc_modes(index, modes);
-                    
-                    /* deterministic collisions */
-                    lb_relax_modes(index, modes);
-                    
-                    /* fluctuating hydrodynamics */
-                    if (lbpar.fluct) lb_thermalize_modes(index, modes);
-                    
-                    /* apply forces */
-                    if (lbfields[index].has_force || local_cells.particles().size()) lb_apply_forces(index, modes);
-                    
-                    /* calculate new particle populations */
-                    lb_calc_n_from_modes(index, modes);
-                }
-                // Here collision in the boundary nodes
-                // can be included, if this is necessary
-// #ifdef LB_BOUNDARIES
-//                 else {
-//                     lb_boundary_collisions(index, modes);
-//                 }
-// #endif // LB_BOUNDARIES
-                ++index; /* next node */
-            }
-            index += 2; /* skip halo region */
+          /* stream (pull) and calculate modes */
+          lb_pull_calc_modes(index, modes);
+
+          /* deterministic collisions */
+          lb_relax_modes(index, modes);
+
+          /* fluctuating hydrodynamics */
+          if (lbpar.fluct)
+            lb_thermalize_modes(index, modes);
+
+          /* apply forces */
+          if (lbfields[index].has_force || local_cells.particles().size())
+            lb_apply_forces(index, modes);
+
+          /* calculate new particle populations */
+          lb_calc_n_from_modes(index, modes);
         }
-        index += 2*lblattice.halo_grid[0]; /* skip halo region */
+        // Here collision in the boundary nodes
+        // can be included, if this is necessary
+        // #ifdef LB_BOUNDARIES
+        //                 else {
+        //                     lb_boundary_collisions(index, modes);
+        //                 }
+        // #endif // LB_BOUNDARIES
+        ++index; /* next node */
+      }
+      index += 2; /* skip halo region */
     }
+    index += 2 * lblattice.halo_grid[0]; /* skip halo region */
+  }
 
-    /* swap the pointers for old and new population fields */
-    //fprintf(stderr,"swapping pointers\n");
-    double **tmp = lbfluid[0];
-    lbfluid[0] = lbfluid[1];
-    lbfluid[1] = tmp;
+  /* swap the pointers for old and new population fields */
+  // fprintf(stderr,"swapping pointers\n");
+  double **tmp = lbfluid[0];
+  lbfluid[0] = lbfluid[1];
+  lbfluid[1] = tmp;
 
-    /* halo region is invalid after update */
-    lbpar.resend_halo = 1;
-  
+  /* halo region is invalid after update */
+  lbpar.resend_halo = 1;
+
   // Re-reset the node forces to include also the halo nodes
 #ifdef IMMERSED_BOUNDARY
   IBM_ResetLBForces_CPU();
 #endif
 }
-
 
 /***********************************************************************/
 /** \name Update step for the lattice Boltzmann fluid                  */
@@ -2885,17 +3003,17 @@ inline void lb_stream_collide() {
  * monitor the time since the last lattice update.
  */
 void lattice_boltzmann_update() {
-    int factor = (int)round(lbpar.tau/time_step);
+  int factor = (int)round(lbpar.tau / time_step);
 
-    fluidstep += 1;
-    if (fluidstep>=factor) {
-        fluidstep=0;
+  fluidstep += 1;
+  if (fluidstep >= factor) {
+    fluidstep = 0;
 #ifdef PULL
-        lb_stream_collide();
-#else // PULL
-        lb_collide_stream();
+    lb_stream_collide();
+#else  // PULL
+    lb_collide_stream();
 #endif // PULL
-    }
+  }
 }
 
 /***********************************************************************/
@@ -2911,54 +3029,43 @@ void lattice_boltzmann_update() {
  * @param force      Coupling force between particle and fluid (Output).
  */
 inline void lb_viscous_coupling(Particle *p, double force[3]) {
-  int x,y,z;
+  int x, y, z;
   Lattice::index_t node_index[8];
   double delta[6];
-  double *local_f, interpolated_u[3],delta_j[3];
-  
+  double *local_f, interpolated_u[3], delta_j[3];
+
 #ifdef EXTERNAL_FORCES
-  if (!(p->p.ext_flag & COORD_FIXED(0)) 
-      && !(p->p.ext_flag & COORD_FIXED(1)) && !(p->p.ext_flag & COORD_FIXED(2)))
-    {
-      ONEPART_TRACE(
-                    if(p->p.identity == check_id) 
-                      {
-                        fprintf(stderr,
-                                "%d: OPT: f = (%.3e,%.3e,%.3e)\n",
-                                this_node, p->f.f[0], p->f.f[1], p->f.f[2]);
-                      }
-                    );
-    }
+  if (!(p->p.ext_flag & COORD_FIXED(0)) && !(p->p.ext_flag & COORD_FIXED(1)) &&
+      !(p->p.ext_flag & COORD_FIXED(2))) {
+    ONEPART_TRACE(if (p->p.identity == check_id) {
+      fprintf(stderr, "%d: OPT: f = (%.3e,%.3e,%.3e)\n", this_node, p->f.f[0],
+              p->f.f[1], p->f.f[2]);
+    });
+  }
 #endif
 
   /* determine elementary lattice cell surrounding the particle
      and the relative position of the particle in this cell */
-  lblattice.map_position_to_lattice(p->r.p,node_index,delta);
-  
-  ONEPART_TRACE(
-                if(p->p.identity == check_id) 
-                  {
-                    fprintf(stderr,
-                            "%d: OPT: LB delta=(%.3f,%.3f,%.3f,%.3f,%.3f,%.3f) pos=(%.3f,%.3f,%.3f)\n",
-                            this_node, delta[0], delta[1], delta[2], delta[3],
-                            delta[4], delta[5], p->r.p[0], p->r.p[1], p->r.p[2]);
-                  }
-                );
-  
+  lblattice.map_position_to_lattice(p->r.p, node_index, delta);
+
+  ONEPART_TRACE(if (p->p.identity == check_id) {
+    fprintf(stderr,
+            "%d: OPT: LB delta=(%.3f,%.3f,%.3f,%.3f,%.3f,%.3f) "
+            "pos=(%.3f,%.3f,%.3f)\n",
+            this_node, delta[0], delta[1], delta[2], delta[3], delta[4],
+            delta[5], p->r.p[0], p->r.p[1], p->r.p[2]);
+  });
+
   /* calculate fluid velocity at particle's position
      this is done by linear interpolation
      (Eq. (11) Ahlrichs and Duenweg, JCP 111(17):8225 (1999)) */
   lb_lbfluid_get_interpolated_velocity(p->r.p, interpolated_u);
-  
-  ONEPART_TRACE(
-                if (p->p.identity==check_id) 
-                  {
-                    fprintf(stderr,
-                            "%d: OPT: LB u = (%.16e,%.3e,%.3e) v = (%.16e,%.3e,%.3e)\n",
-                            this_node, interpolated_u[0], interpolated_u[1], interpolated_u[2],
-                            p->m.v[0], p->m.v[1], p->m.v[2]);
-                  }
-                );
+
+  ONEPART_TRACE(if (p->p.identity == check_id) {
+    fprintf(stderr, "%d: OPT: LB u = (%.16e,%.3e,%.3e) v = (%.16e,%.3e,%.3e)\n",
+            this_node, interpolated_u[0], interpolated_u[1], interpolated_u[2],
+            p->m.v[0], p->m.v[1], p->m.v[2]);
+  });
 
   /* calculate viscous force
    * take care to rescale velocities with time_step and transform to MD units
@@ -2969,11 +3076,10 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
   velocity[2] = p->m.v[2];
 
 #ifdef ENGINE
-  if ( p->swim.swimming )
-  {
-    velocity[0] -= (p->swim.v_swim*time_step)*p->r.quatu[0];
-    velocity[1] -= (p->swim.v_swim*time_step)*p->r.quatu[1];
-    velocity[2] -= (p->swim.v_swim*time_step)*p->r.quatu[2];
+  if (p->swim.swimming) {
+    velocity[0] -= (p->swim.v_swim * time_step) * p->r.quatu[0];
+    velocity[1] -= (p->swim.v_swim * time_step) * p->r.quatu[1];
+    velocity[2] -= (p->swim.v_swim * time_step) * p->r.quatu[2];
     p->swim.v_center[0] = interpolated_u[0];
     p->swim.v_center[1] = interpolated_u[1];
     p->swim.v_center[2] = interpolated_u[2];
@@ -2981,75 +3087,68 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
 #endif
 
 #ifdef LB_ELECTROHYDRODYNAMICS
-  force[0] = - lbpar.friction * (velocity[0]/time_step - interpolated_u[0] - p->p.mu_E[0]);
-  force[1] = - lbpar.friction * (velocity[1]/time_step - interpolated_u[1] - p->p.mu_E[1]);
-  force[2] = - lbpar.friction * (velocity[2]/time_step - interpolated_u[2] - p->p.mu_E[2]);
+  force[0] = -lbpar.friction *
+             (velocity[0] / time_step - interpolated_u[0] - p->p.mu_E[0]);
+  force[1] = -lbpar.friction *
+             (velocity[1] / time_step - interpolated_u[1] - p->p.mu_E[1]);
+  force[2] = -lbpar.friction *
+             (velocity[2] / time_step - interpolated_u[2] - p->p.mu_E[2]);
 #else
-  force[0] = - lbpar.friction * (velocity[0]/time_step - interpolated_u[0]);
-  force[1] = - lbpar.friction * (velocity[1]/time_step - interpolated_u[1]);
-  force[2] = - lbpar.friction * (velocity[2]/time_step - interpolated_u[2]);
+  force[0] = -lbpar.friction * (velocity[0] / time_step - interpolated_u[0]);
+  force[1] = -lbpar.friction * (velocity[1] / time_step - interpolated_u[1]);
+  force[2] = -lbpar.friction * (velocity[2] / time_step - interpolated_u[2]);
 #endif
 
-  ONEPART_TRACE(
-                if (p->p.identity == check_id)
-                  {
-                    fprintf(stderr,
-                            "%d: OPT: LB f_drag = (%.6e,%.3e,%.3e)\n",
-                            this_node, force[0], force[1], force[2]);
-                  }
-                );
+  ONEPART_TRACE(if (p->p.identity == check_id) {
+    fprintf(stderr, "%d: OPT: LB f_drag = (%.6e,%.3e,%.3e)\n", this_node,
+            force[0], force[1], force[2]);
+  });
 
-  ONEPART_TRACE(
-                if (p->p.identity == check_id)
-                  {
-                    fprintf(stderr,
-                            "%d: OPT: LB f_random = (%.6e,%.3e,%.3e)\n",
-                            this_node, p->lc.f_random[0], p->lc.f_random[1], p->lc.f_random[2]);
-                  }
-                );
+  ONEPART_TRACE(if (p->p.identity == check_id) {
+    fprintf(stderr, "%d: OPT: LB f_random = (%.6e,%.3e,%.3e)\n", this_node,
+            p->lc.f_random[0], p->lc.f_random[1], p->lc.f_random[2]);
+  });
 
   force[0] = force[0] + p->lc.f_random[0];
   force[1] = force[1] + p->lc.f_random[1];
   force[2] = force[2] + p->lc.f_random[2];
 
-  ONEPART_TRACE(
-                if (p->p.identity == check_id) 
-                  {
-                    fprintf(stderr,
-                            "%d: OPT: LB f_tot = (%.6e,%.3e,%.3e)\n",
-                            this_node, force[0], force[1], force[2]);
-                  }
-                );
+  ONEPART_TRACE(if (p->p.identity == check_id) {
+    fprintf(stderr, "%d: OPT: LB f_tot = (%.6e,%.3e,%.3e)\n", this_node,
+            force[0], force[1], force[2]);
+  });
 
   /* transform momentum transfer to lattice units
      (Eq. (12) Ahlrichs and Duenweg, JCP 111(17):8225 (1999)) */
-  delta_j[0] = - force[0]*time_step*lbpar.tau/lbpar.agrid;
-  delta_j[1] = - force[1]*time_step*lbpar.tau/lbpar.agrid;
-  delta_j[2] = - force[2]*time_step*lbpar.tau/lbpar.agrid;
+  delta_j[0] = -force[0] * time_step * lbpar.tau / lbpar.agrid;
+  delta_j[1] = -force[1] * time_step * lbpar.tau / lbpar.agrid;
+  delta_j[2] = -force[2] * time_step * lbpar.tau / lbpar.agrid;
 
   for (z = 0; z < 2; z++) {
     for (y = 0; y < 2; y++) {
       for (x = 0; x < 2; x++) {
-        local_f = lbfields[node_index[(z*2+y)*2+x]].force;
+        local_f = lbfields[node_index[(z * 2 + y) * 2 + x]].force;
 
-        local_f[0] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*delta_j[0];
-        local_f[1] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*delta_j[1];
-        local_f[2] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*delta_j[2];
+        local_f[0] +=
+            delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] * delta_j[0];
+        local_f[1] +=
+            delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] * delta_j[1];
+        local_f[2] +=
+            delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] * delta_j[2];
       }
     }
   }
 
-  // map_position_to_lattice: position ... not inside a local plaquette in ...
+    // map_position_to_lattice: position ... not inside a local plaquette in ...
 
 #ifdef ENGINE
-  if ( p->swim.swimming )
-  {
+  if (p->swim.swimming) {
     // TODO: Fix LB mapping
-    if ( n_nodes > 1 )
-    {
-      if ( this_node == 0 ) {
-        fprintf(stderr,"ERROR: Swimming is not compatible with Open MPI and CPU LB on more than 1 node.\n");
-        fprintf(stderr,"       Please use LB_GPU instead.\n");
+    if (n_nodes > 1) {
+      if (this_node == 0) {
+        fprintf(stderr, "ERROR: Swimming is not compatible with Open MPI and "
+                        "CPU LB on more than 1 node.\n");
+        fprintf(stderr, "       Please use LB_GPU instead.\n");
       }
       errexit();
     }
@@ -3061,136 +3160,165 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
     source_position[1] = p->r.p[1] + direction * p->r.quatu[1];
     source_position[2] = p->r.p[2] + direction * p->r.quatu[2];
 
-    int corner[3] = {0,0,0};
-    fold_position( source_position , corner );
+    int corner[3] = {0, 0, 0};
+    fold_position(source_position, corner);
 
-    // get lattice cell corresponding to source position and interpolate velocity
-    lblattice.map_position_to_lattice(source_position,node_index,delta);
+    // get lattice cell corresponding to source position and interpolate
+    // velocity
+    lblattice.map_position_to_lattice(source_position, node_index, delta);
     lb_lbfluid_get_interpolated_velocity(source_position, p->swim.v_source);
 
     // calculate and set force at source position
-    delta_j[0] = - p->swim.f_swim*p->r.quatu[0]*time_step*lbpar.tau/lbpar.agrid;
-    delta_j[1] = - p->swim.f_swim*p->r.quatu[1]*time_step*lbpar.tau/lbpar.agrid;
-    delta_j[2] = - p->swim.f_swim*p->r.quatu[2]*time_step*lbpar.tau/lbpar.agrid;
+    delta_j[0] =
+        -p->swim.f_swim * p->r.quatu[0] * time_step * lbpar.tau / lbpar.agrid;
+    delta_j[1] =
+        -p->swim.f_swim * p->r.quatu[1] * time_step * lbpar.tau / lbpar.agrid;
+    delta_j[2] =
+        -p->swim.f_swim * p->r.quatu[2] * time_step * lbpar.tau / lbpar.agrid;
 
-    for (z=0;z<2;z++) {
-      for (y=0;y<2;y++) {
-        for (x=0;x<2;x++) {
-          local_f = lbfields[node_index[(z*2+y)*2+x]].force;
+    for (z = 0; z < 2; z++) {
+      for (y = 0; y < 2; y++) {
+        for (x = 0; x < 2; x++) {
+          local_f = lbfields[node_index[(z * 2 + y) * 2 + x]].force;
 
-          local_f[0] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*delta_j[0];
-          local_f[1] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*delta_j[1];
-          local_f[2] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*delta_j[2];
+          local_f[0] += delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] *
+                        delta_j[0];
+          local_f[1] += delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] *
+                        delta_j[1];
+          local_f[2] += delta[3 * x + 0] * delta[3 * y + 1] * delta[3 * z + 2] *
+                        delta_j[2];
         }
       }
     }
   }
 #endif
-
 }
 
-
-int lb_lbfluid_get_interpolated_velocity(double* p, double* v) {
+int lb_lbfluid_get_interpolated_velocity(double *p, double *v) {
   Lattice::index_t node_index[8], index;
   double delta[6];
   double local_rho, local_j[3], interpolated_u[3];
   double modes[19];
-  int x,y,z;
+  int x, y, z;
   double pos[3];
 
 #ifdef LB_BOUNDARIES
   double lbboundary_mindist, distvec[3];
   int boundary_no;
-  int boundary_flag=-1; // 0 if more than agrid/2 away from the boundary, 1 if 0<dist<agrid/2, 2 if dist <0
+  int boundary_flag = -1; // 0 if more than agrid/2 away from the boundary, 1 if
+                          // 0<dist<agrid/2, 2 if dist <0
 
-  LBBoundaries::lbboundary_mindist_position(p, &lbboundary_mindist, distvec, &boundary_no);
+  LBBoundaries::lbboundary_mindist_position(p, &lbboundary_mindist, distvec,
+                                            &boundary_no);
   if (lbboundary_mindist > 0.5 * lbpar.agrid) {
-    boundary_flag=0;
-    pos[0]=p[0];
-    pos[1]=p[1];
-    pos[2]=p[2];
-  } else if (lbboundary_mindist > 0 ) {
-    boundary_flag=1;
-    pos[0] = p[0] - distvec[0] + distvec[0]/lbboundary_mindist * lbpar.agrid/2.;
-    pos[1] = p[1] - distvec[1] + distvec[1]/lbboundary_mindist * lbpar.agrid/2.;
-    pos[2] = p[2] - distvec[2] + distvec[2]/lbboundary_mindist * lbpar.agrid/2.;
+    boundary_flag = 0;
+    pos[0] = p[0];
+    pos[1] = p[1];
+    pos[2] = p[2];
+  } else if (lbboundary_mindist > 0) {
+    boundary_flag = 1;
+    pos[0] =
+        p[0] - distvec[0] + distvec[0] / lbboundary_mindist * lbpar.agrid / 2.;
+    pos[1] =
+        p[1] - distvec[1] + distvec[1] / lbboundary_mindist * lbpar.agrid / 2.;
+    pos[2] =
+        p[2] - distvec[2] + distvec[2] / lbboundary_mindist * lbpar.agrid / 2.;
   } else {
-    boundary_flag=2;
-    v[0]= (*LBBoundaries::lbboundaries[boundary_no]).velocity()[0]*lbpar.agrid/lbpar.tau;
-    v[1]= (*LBBoundaries::lbboundaries[boundary_no]).velocity()[1]*lbpar.agrid/lbpar.tau;
-    v[2]= (*LBBoundaries::lbboundaries[boundary_no]).velocity()[2]*lbpar.agrid/lbpar.tau;
+    boundary_flag = 2;
+    v[0] = (*LBBoundaries::lbboundaries[boundary_no]).velocity()[0] *
+           lbpar.agrid / lbpar.tau;
+    v[1] = (*LBBoundaries::lbboundaries[boundary_no]).velocity()[1] *
+           lbpar.agrid / lbpar.tau;
+    v[2] = (*LBBoundaries::lbboundaries[boundary_no]).velocity()[2] *
+           lbpar.agrid / lbpar.tau;
     return 0; // we can return without interpolating
   }
-#else // LB_BOUNDARIES
-  pos[0]=p[0];
-  pos[1]=p[1];
-  pos[2]=p[2];
+#else  // LB_BOUNDARIES
+  pos[0] = p[0];
+  pos[1] = p[1];
+  pos[2] = p[2];
 #endif // LB_BOUNDARIES
 
   /* determine elementary lattice cell surrounding the particle
      and the relative position of the particle in this cell */
-  lblattice.map_position_to_lattice(pos,node_index,delta);
+  lblattice.map_position_to_lattice(pos, node_index, delta);
 
   /* calculate fluid velocity at particle's position
      this is done by linear interpolation
      (Eq. (11) Ahlrichs and Duenweg, JCP 111(17):8225 (1999)) */
-  interpolated_u[0] = interpolated_u[1] = interpolated_u[2] = 0.0 ;
+  interpolated_u[0] = interpolated_u[1] = interpolated_u[2] = 0.0;
 
-  for (z=0;z<2;z++) {
-    for (y=0;y<2;y++) {
-      for (x=0;x<2;x++) {
-        index = node_index[(z*2+y)*2+x];
+  for (z = 0; z < 2; z++) {
+    for (y = 0; y < 2; y++) {
+      for (x = 0; x < 2; x++) {
+        index = node_index[(z * 2 + y) * 2 + x];
 
 #ifdef LB_BOUNDARIES
         if (lbfields[index].boundary) {
-          local_rho=lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid;
-          local_j[0] = lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid*(*LBBoundaries::lbboundaries[lbfields[index].boundary-1]).velocity()[0]; // TODO
-          local_j[1] = lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid*(*LBBoundaries::lbboundaries[lbfields[index].boundary-1]).velocity()[1]; // TODO This might not work properly
-          local_j[2] = lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid*(*LBBoundaries::lbboundaries[lbfields[index].boundary-1]).velocity()[2]; // TODO
+          local_rho = lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid;
+          local_j[0] =
+              lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid *
+              (*LBBoundaries::lbboundaries[lbfields[index].boundary - 1])
+                  .velocity()[0]; // TODO
+          local_j[1] =
+              lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid *
+              (*LBBoundaries::lbboundaries[lbfields[index].boundary - 1])
+                  .velocity()[1]; // TODO This might not work properly
+          local_j[2] =
+              lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid *
+              (*LBBoundaries::lbboundaries[lbfields[index].boundary - 1])
+                  .velocity()[2]; // TODO
         } else {
           lb_calc_modes(index, modes);
-          local_rho = lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid + modes[0];
+          local_rho =
+              lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid + modes[0];
           local_j[0] = modes[1];
           local_j[1] = modes[2];
           local_j[2] = modes[3];
         }
-#else // LB_BOUNDARIES
+#else  // LB_BOUNDARIES
         lb_calc_modes(index, modes);
-        local_rho = lbpar.rho*lbpar.agrid*lbpar.agrid*lbpar.agrid + modes[0];
+        local_rho =
+            lbpar.rho * lbpar.agrid * lbpar.agrid * lbpar.agrid + modes[0];
         local_j[0] = modes[1];
         local_j[1] = modes[2];
         local_j[2] = modes[3];
 #endif // LB_BOUNDARIES
-        interpolated_u[0] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*local_j[0]/(local_rho);
-        interpolated_u[1] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*local_j[1]/(local_rho);
-        interpolated_u[2] += delta[3*x+0]*delta[3*y+1]*delta[3*z+2]*local_j[2]/(local_rho) ;
+        interpolated_u[0] += delta[3 * x + 0] * delta[3 * y + 1] *
+                             delta[3 * z + 2] * local_j[0] / (local_rho);
+        interpolated_u[1] += delta[3 * x + 0] * delta[3 * y + 1] *
+                             delta[3 * z + 2] * local_j[1] / (local_rho);
+        interpolated_u[2] += delta[3 * x + 0] * delta[3 * y + 1] *
+                             delta[3 * z + 2] * local_j[2] / (local_rho);
       }
     }
   }
 #ifdef LB_BOUNDARIES
-  if (boundary_flag==1) {
-    v[0] = lbboundary_mindist / (0.5 * lbpar.agrid) * interpolated_u[0] 
-      + (1 - lbboundary_mindist/(0.5 * lbpar.agrid)) * (*LBBoundaries::lbboundaries[boundary_no]).velocity()[0];
-    v[1] = lbboundary_mindist / (0.5 * lbpar.agrid) * interpolated_u[1]
-      + (1 - lbboundary_mindist/(0.5 * lbpar.agrid)) * (*LBBoundaries::lbboundaries[boundary_no]).velocity()[1];
-    v[2] = lbboundary_mindist / (0.5 * lbpar.agrid) * interpolated_u[2]
-      + (1 - lbboundary_mindist/(0.5 * lbpar.agrid)) * (*LBBoundaries::lbboundaries[boundary_no]).velocity()[2];
+  if (boundary_flag == 1) {
+    v[0] = lbboundary_mindist / (0.5 * lbpar.agrid) * interpolated_u[0] +
+           (1 - lbboundary_mindist / (0.5 * lbpar.agrid)) *
+               (*LBBoundaries::lbboundaries[boundary_no]).velocity()[0];
+    v[1] = lbboundary_mindist / (0.5 * lbpar.agrid) * interpolated_u[1] +
+           (1 - lbboundary_mindist / (0.5 * lbpar.agrid)) *
+               (*LBBoundaries::lbboundaries[boundary_no]).velocity()[1];
+    v[2] = lbboundary_mindist / (0.5 * lbpar.agrid) * interpolated_u[2] +
+           (1 - lbboundary_mindist / (0.5 * lbpar.agrid)) *
+               (*LBBoundaries::lbboundaries[boundary_no]).velocity()[2];
   } else {
     v[0] = interpolated_u[0];
     v[1] = interpolated_u[1];
     v[2] = interpolated_u[2];
   }
-#else // LB_BOUNDARIES
+#else  // LB_BOUNDARIES
   v[0] = interpolated_u[0];
   v[1] = interpolated_u[1];
   v[2] = interpolated_u[2];
 #endif // LB_BOUNDARIES
-  v[0] *= lbpar.agrid/lbpar.tau;
-  v[1] *= lbpar.agrid/lbpar.tau;
-  v[2] *= lbpar.agrid/lbpar.tau;
+  v[0] *= lbpar.agrid / lbpar.tau;
+  v[1] *= lbpar.agrid / lbpar.tau;
+  v[2] *= lbpar.agrid / lbpar.tau;
   return 0;
 }
-
 
 /** Calculate particle lattice interactions.
  * So far, only viscous coupling with Stokesian friction is
@@ -3229,21 +3357,21 @@ void calc_particle_lattice_ia() {
   double force[3];
 
   if (transfer_momentum) {
-      
+
     if (lbpar.resend_halo) { /* first MD step after last LB update */
-        
+
       /* exchange halo regions (for fluid-particle coupling) */
-      halo_communication(&update_halo_comm, (char*)**lbfluid);
+      halo_communication(&update_halo_comm, (char *)**lbfluid);
 #ifdef ADDITIONAL_CHECKS
       lb_check_halo_regions();
 #endif // ADDITIONAL_CHECKS
-        
+
       /* halo is valid now */
       lbpar.resend_halo = 0;
-        
+
       /* all fields have to be recalculated */
-      for (int i = 0; i < lblattice.halo_grid_volume; ++i) 
-          lbfields[i].recalc_fields = 1;
+      for (int i = 0; i < lblattice.halo_grid_volume; ++i)
+        lbfields[i].recalc_fields = 1;
     }
 
     /* draw random numbers for local particles */
@@ -3336,48 +3464,47 @@ void calc_particle_lattice_ia() {
  * This function has to be called after changing the density of
  * a local lattice site in order to set lbpar.rho consistently. */
 void lb_calc_average_rho() {
-    Lattice::index_t index;
-    int x, y, z;
-    double rho, local_rho, sum_rho;
+  Lattice::index_t index;
+  int x, y, z;
+  double rho, local_rho, sum_rho;
 
-    rho = 0.0;
-    local_rho = 0.0;
-    index = 0;
-    for (z = 1; z <= lblattice.grid[2]; z++) {
-      for (y = 1; y <= lblattice.grid[1]; y++) {
-        for (x = 1; x<=lblattice.grid[0]; x++) {
-          lb_calc_local_rho(index, &rho);
-          local_rho += rho;
-          
-          index++;
-        }
-        // skip halo region
-        index += 2;
+  rho = 0.0;
+  local_rho = 0.0;
+  index = 0;
+  for (z = 1; z <= lblattice.grid[2]; z++) {
+    for (y = 1; y <= lblattice.grid[1]; y++) {
+      for (x = 1; x <= lblattice.grid[0]; x++) {
+        lb_calc_local_rho(index, &rho);
+        local_rho += rho;
+
+        index++;
       }
       // skip halo region
-      index += 2*lblattice.halo_grid[0];
+      index += 2;
     }
-    MPI_Allreduce(&rho, &sum_rho, 1, MPI_DOUBLE, MPI_SUM, comm_cart);
-    
-    /* calculate average density in MD units */
-    // TODO!!!
-    lbpar.rho = sum_rho / (box_l[0]*box_l[1]*box_l[2]);
+    // skip halo region
+    index += 2 * lblattice.halo_grid[0];
+  }
+  MPI_Allreduce(&rho, &sum_rho, 1, MPI_DOUBLE, MPI_SUM, comm_cart);
+
+  /* calculate average density in MD units */
+  // TODO!!!
+  lbpar.rho = sum_rho / (box_l[0] * box_l[1] * box_l[2]);
 }
 
-/*@}*/
+  /*@}*/
 
 #ifdef ADDITIONAL_CHECKS
 static int compare_buffers(double *buf1, double *buf2, int size) {
-    int ret;
-    if (memcmp(buf1,buf2,size) != 0) {
-        runtimeErrorMsg() <<"Halo buffers are not identical";
-        ret = 1;
-    } else {
-        ret = 0;
-    }
-    return ret;
+  int ret;
+  if (memcmp(buf1, buf2, size) != 0) {
+    runtimeErrorMsg() << "Halo buffers are not identical";
+    ret = 1;
+  } else {
+    ret = 0;
+  }
+  return ret;
 }
-
 
 /** Checks consistency of the halo regions (ADDITIONAL_CHECKS)
     This function can be used as an additional check. It test whether the
@@ -3385,18 +3512,19 @@ static int compare_buffers(double *buf1, double *buf2, int size) {
 */
 static void lb_check_halo_regions() {
   Lattice::index_t index;
-  int i,x,y,z, s_node, r_node, count=lbmodel.n_veloc;
+  int i, x, y, z, s_node, r_node, count = lbmodel.n_veloc;
   double *s_buffer, *r_buffer;
   MPI_Status status[2];
 
-  r_buffer = (double*) Utils::malloc(count*sizeof(double));
-  s_buffer = (double*) Utils::malloc(count*sizeof(double));
+  r_buffer = (double *)Utils::malloc(count * sizeof(double));
+  s_buffer = (double *)Utils::malloc(count * sizeof(double));
 
   if (PERIODIC(0)) {
     for (z = 0; z < lblattice.halo_grid[2]; ++z) {
       for (y = 0; y < lblattice.halo_grid[1]; ++y) {
-        index  = get_linear_index(0,y,z,lblattice.halo_grid);
-        for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
+        index = get_linear_index(0, y, z, lblattice.halo_grid);
+        for (i = 0; i < lbmodel.n_veloc; i++)
+          s_buffer[i] = lbfluid[1][i][index];
 
         s_node = node_neighbors[1];
         r_node = node_neighbors[0];
@@ -3404,19 +3532,26 @@ static void lb_check_halo_regions() {
           MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
                        r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
                        comm_cart, status);
-          index = get_linear_index(lblattice.grid[0],y,z,lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-          compare_buffers(s_buffer,r_buffer,count*sizeof(double));
+          index =
+              get_linear_index(lblattice.grid[0], y, z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            s_buffer[i] = lbfluid[1][i][index];
+          compare_buffers(s_buffer, r_buffer, count * sizeof(double));
         } else {
-          index = get_linear_index(lblattice.grid[0],y,z,lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) r_buffer[i] = lbfluid[1][i][index];
-          if (compare_buffers(s_buffer,r_buffer,count*sizeof(double))) {
-            std::cerr << "buffers differ in dir=" << 0 << " at index=" << index << " y=" << y << " z=" << z << "\n";
+          index =
+              get_linear_index(lblattice.grid[0], y, z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            r_buffer[i] = lbfluid[1][i][index];
+          if (compare_buffers(s_buffer, r_buffer, count * sizeof(double))) {
+            std::cerr << "buffers differ in dir=" << 0 << " at index=" << index
+                      << " y=" << y << " z=" << z << "\n";
           }
         }
 
-        index = get_linear_index(lblattice.grid[0]+1,y,z,lblattice.halo_grid);
-        for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
+        index =
+            get_linear_index(lblattice.grid[0] + 1, y, z, lblattice.halo_grid);
+        for (i = 0; i < lbmodel.n_veloc; i++)
+          s_buffer[i] = lbfluid[1][i][index];
 
         s_node = node_neighbors[0];
         r_node = node_neighbors[1];
@@ -3424,117 +3559,138 @@ static void lb_check_halo_regions() {
           MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
                        r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
                        comm_cart, status);
-          index = get_linear_index(1,y,z,lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-          compare_buffers(s_buffer,r_buffer,count*sizeof(double));
+          index = get_linear_index(1, y, z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            s_buffer[i] = lbfluid[1][i][index];
+          compare_buffers(s_buffer, r_buffer, count * sizeof(double));
         } else {
-          index = get_linear_index(1,y,z,lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) r_buffer[i] = lbfluid[1][i][index];
-          if (compare_buffers(s_buffer,r_buffer,count*sizeof(double))) {
-            std::cerr << "buffers differ in dir=0 at index=" << index << " y=" << y << " z=" << z << "\n";
+          index = get_linear_index(1, y, z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            r_buffer[i] = lbfluid[1][i][index];
+          if (compare_buffers(s_buffer, r_buffer, count * sizeof(double))) {
+            std::cerr << "buffers differ in dir=0 at index=" << index
+                      << " y=" << y << " z=" << z << "\n";
           }
         }
-
       }
     }
   }
 
   if (PERIODIC(1)) {
     for (z = 0; z < lblattice.halo_grid[2]; ++z) {
-        for (x = 0; x < lblattice.halo_grid[0]; ++x) {
-            index = get_linear_index(x,0,z,lblattice.halo_grid);
-            for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-            
-            s_node = node_neighbors[3];
-            r_node = node_neighbors[2];
-            if (n_nodes > 1) {
-              MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
-                           r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
-                           comm_cart, status);
-              index = get_linear_index(x,lblattice.grid[1],z,lblattice.halo_grid);
-              for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-              compare_buffers(s_buffer,r_buffer,count*sizeof(double));
-            } else {
-              index = get_linear_index(x,lblattice.grid[1],z,lblattice.halo_grid);
-              for (i = 0; i < lbmodel.n_veloc; i++) r_buffer[i] = lbfluid[1][i][index];
-              if (compare_buffers(s_buffer,r_buffer,count*sizeof(double))) {
-                std::cerr << "buffers differ in dir=1 at index=" << index << " x=" << x << " z=" << z << "\n";
-              }
-            }
+      for (x = 0; x < lblattice.halo_grid[0]; ++x) {
+        index = get_linear_index(x, 0, z, lblattice.halo_grid);
+        for (i = 0; i < lbmodel.n_veloc; i++)
+          s_buffer[i] = lbfluid[1][i][index];
 
+        s_node = node_neighbors[3];
+        r_node = node_neighbors[2];
+        if (n_nodes > 1) {
+          MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
+                       r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
+                       comm_cart, status);
+          index =
+              get_linear_index(x, lblattice.grid[1], z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            s_buffer[i] = lbfluid[1][i][index];
+          compare_buffers(s_buffer, r_buffer, count * sizeof(double));
+        } else {
+          index =
+              get_linear_index(x, lblattice.grid[1], z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            r_buffer[i] = lbfluid[1][i][index];
+          if (compare_buffers(s_buffer, r_buffer, count * sizeof(double))) {
+            std::cerr << "buffers differ in dir=1 at index=" << index
+                      << " x=" << x << " z=" << z << "\n";
           }
-        for (x = 0; x < lblattice.halo_grid[0]; ++x) {
-          index = get_linear_index(x,lblattice.grid[1]+1,z,lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-
-          s_node = node_neighbors[2];
-          r_node = node_neighbors[3];
-          if (n_nodes > 1) {
-            MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
-                         r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
-                         comm_cart, status);
-            index = get_linear_index(x,1,z,lblattice.halo_grid);
-            for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-            compare_buffers(s_buffer,r_buffer,count*sizeof(double));
-          } else {
-            index = get_linear_index(x,1,z,lblattice.halo_grid);
-            for (i = 0;i < lbmodel.n_veloc; i++) r_buffer[i] = lbfluid[1][i][index];
-            if (compare_buffers(s_buffer,r_buffer,count*sizeof(double))) {
-              std::cerr << "buffers differ in dir=1 at index=" << index << " x=" << x << " z=" << z << "\n";
-            }
-          }
-          
         }
+      }
+      for (x = 0; x < lblattice.halo_grid[0]; ++x) {
+        index =
+            get_linear_index(x, lblattice.grid[1] + 1, z, lblattice.halo_grid);
+        for (i = 0; i < lbmodel.n_veloc; i++)
+          s_buffer[i] = lbfluid[1][i][index];
+
+        s_node = node_neighbors[2];
+        r_node = node_neighbors[3];
+        if (n_nodes > 1) {
+          MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
+                       r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
+                       comm_cart, status);
+          index = get_linear_index(x, 1, z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            s_buffer[i] = lbfluid[1][i][index];
+          compare_buffers(s_buffer, r_buffer, count * sizeof(double));
+        } else {
+          index = get_linear_index(x, 1, z, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            r_buffer[i] = lbfluid[1][i][index];
+          if (compare_buffers(s_buffer, r_buffer, count * sizeof(double))) {
+            std::cerr << "buffers differ in dir=1 at index=" << index
+                      << " x=" << x << " z=" << z << "\n";
+          }
+        }
+      }
     }
   }
-  
+
   if (PERIODIC(2)) {
     for (y = 0; y < lblattice.halo_grid[1]; ++y) {
       for (x = 0; x < lblattice.halo_grid[0]; ++x) {
-        index = get_linear_index(x,y,0,lblattice.halo_grid);
-        for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-        
+        index = get_linear_index(x, y, 0, lblattice.halo_grid);
+        for (i = 0; i < lbmodel.n_veloc; i++)
+          s_buffer[i] = lbfluid[1][i][index];
+
         s_node = node_neighbors[5];
         r_node = node_neighbors[4];
         if (n_nodes > 1) {
           MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
                        r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
                        comm_cart, status);
-          index = get_linear_index(x,y,lblattice.grid[2],lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-          compare_buffers(s_buffer,r_buffer,count*sizeof(double));
+          index =
+              get_linear_index(x, y, lblattice.grid[2], lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            s_buffer[i] = lbfluid[1][i][index];
+          compare_buffers(s_buffer, r_buffer, count * sizeof(double));
         } else {
-          index = get_linear_index(x,y,lblattice.grid[2],lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) r_buffer[i] = lbfluid[1][i][index];
-          if (compare_buffers(s_buffer,r_buffer,count*sizeof(double))) {
-            std::cerr << "buffers differ in dir=2 at index=" << index << " x=" << x << " y=" << y << " z=" << lblattice.grid[2] << "\n";
+          index =
+              get_linear_index(x, y, lblattice.grid[2], lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            r_buffer[i] = lbfluid[1][i][index];
+          if (compare_buffers(s_buffer, r_buffer, count * sizeof(double))) {
+            std::cerr << "buffers differ in dir=2 at index=" << index
+                      << " x=" << x << " y=" << y << " z=" << lblattice.grid[2]
+                      << "\n";
           }
         }
-
       }
     }
     for (y = 0; y < lblattice.halo_grid[1]; ++y) {
       for (x = 0; x < lblattice.halo_grid[0]; ++x) {
-        index = get_linear_index(x,y,lblattice.grid[2]+1,lblattice.halo_grid);
-        for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-        
+        index =
+            get_linear_index(x, y, lblattice.grid[2] + 1, lblattice.halo_grid);
+        for (i = 0; i < lbmodel.n_veloc; i++)
+          s_buffer[i] = lbfluid[1][i][index];
+
         s_node = node_neighbors[4];
         r_node = node_neighbors[5];
         if (n_nodes > 1) {
           MPI_Sendrecv(s_buffer, count, MPI_DOUBLE, r_node, REQ_HALO_CHECK,
                        r_buffer, count, MPI_DOUBLE, s_node, REQ_HALO_CHECK,
                        comm_cart, status);
-          index = get_linear_index(x,y,1,lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) s_buffer[i] = lbfluid[1][i][index];
-          compare_buffers(s_buffer,r_buffer,count*sizeof(double));
+          index = get_linear_index(x, y, 1, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            s_buffer[i] = lbfluid[1][i][index];
+          compare_buffers(s_buffer, r_buffer, count * sizeof(double));
         } else {
-          index = get_linear_index(x,y,1,lblattice.halo_grid);
-          for (i = 0; i < lbmodel.n_veloc; i++) r_buffer[i] = lbfluid[1][i][index];
-          if(compare_buffers(s_buffer,r_buffer,count*sizeof(double))) {
-            std::cerr << "buffers differ in dir=2 at index=" << index << " x=" << x << " y=" << y << "\n";
+          index = get_linear_index(x, y, 1, lblattice.halo_grid);
+          for (i = 0; i < lbmodel.n_veloc; i++)
+            r_buffer[i] = lbfluid[1][i][index];
+          if (compare_buffers(s_buffer, r_buffer, count * sizeof(double))) {
+            std::cerr << "buffers differ in dir=2 at index=" << index
+                      << " x=" << x << " y=" << y << "\n";
           }
         }
-
       }
     }
   }
@@ -3542,19 +3698,16 @@ static void lb_check_halo_regions() {
   free(r_buffer);
   free(s_buffer);
 
-  //if (check_runtime_errors());
-  //else fprintf(stderr,"halo check successful\n");
+  // if (check_runtime_errors());
+  // else fprintf(stderr,"halo check successful\n");
 }
 #endif /* ADDITIONAL_CHECKS */
 
-
-#if 0 /* These debug functions are used nowhere. If you need it, here they are.
-         Remove this comment line and the matching #endif.
-         The functions in question are:
-         lb_lattice_sum
-         lb_check_mode_transformation
-         lb_init_mode_transformation
-         lb_check_negative_n
+#if 0 /* These debug functions are used nowhere. If you need it, here they     \
+         are. Remove this comment line and the matching #endif. The functions                                                                 \
+         in question are: lb_lattice_sum lb_check_mode_transformation                                                  \
+         lb_init_mode_transformation                                           \
+         lb_check_negative_n                                                   \
       */
 #ifdef ADDITIONAL_CHECKS
 /** counts the occurences of negative populations due to fluctuations */
@@ -3683,8 +3836,8 @@ static void lb_check_mode_transformation(Lattice::index_t index, double *mode) {
     /* equilibrium part of the stress modes */
     /* remember that the modes have (\todo not?) been normalized! */
     m_eq[4] = /*1./6.*/scalar(j,j)/rho;
-    m_eq[5] = /*1./4.*/(SQR(j[0])-SQR(j[1]))/rho;
-    m_eq[6] = /*1./12.*/(scalar(j,j) - 3.0*SQR(j[2]))/rho;
+    m_eq[5] = /*1./4.*/(Utils::sqr(j[0])-Utils::sqr(j[1]))/rho;
+    m_eq[6] = /*1./12.*/(scalar(j,j) - 3.0*Utils::sqr(j[2]))/rho;
     m_eq[7] = j[0]*j[1]/rho;
     m_eq[8] = j[0]*j[2]/rho;
     m_eq[9] = j[1]*j[2]/rho;
@@ -3694,12 +3847,12 @@ static void lb_check_mode_transformation(Lattice::index_t index, double *mode) {
     }
 
     for (i=0;i<lbmodel.n_veloc;i++) {
-        n_eq[i] = w[i]*((rho-avg_rho) + 3.*scalar(j,c[i]) + 9./2.*SQR(scalar(j,c[i]))/rho - 3./2.*scalar(j,j)/rho);
+        n_eq[i] = w[i]*((rho-avg_rho) + 3.*scalar(j,c[i]) + 9./2.*Utils::sqr(scalar(j,c[i]))/rho - 3./2.*scalar(j,j)/rho);
     }
 
     for (i=0;i<lbmodel.n_veloc;i++) {
-        sum_n += SQR(lbfluid[1][i][index]-n_eq[i])/w[i];
-        sum_m += SQR(mode[i]-m_eq[i])/e[19][i];
+        sum_n += Utils::sqr(lbfluid[1][i][index]-n_eq[i])/w[i];
+        sum_m += Utils::sqr(mode[i]-m_eq[i])/e[19][i];
     }
 
     if (fabs(sum_n-sum_m)>ROUND_ERROR_PREC) {
@@ -3765,7 +3918,7 @@ static void lb_init_mode_transformation() {
         b[2][i]  = c[i][1];
         b[3][i]  = c[i][2];
         b[4][i]  = scalar(c[i],c[i]);
-        b[5][i]  = SQR(c[i][0])-SQR(c[i][1]);
+        b[5][i]  = Utils::sqr(c[i][0])-Utils::sqr(c[i][1]);
         b[6][i]  = c[i][0]*c[i][1];
         b[7][i]  = c[i][0]*c[i][2];
         b[8][i]  = c[i][1]*c[i][2];
@@ -3788,7 +3941,7 @@ static void lb_init_mode_transformation() {
             for (i=0;i<n_veloc;i++) e[j][i] -= proj/norm[k]*e[k][i];
         }
         norm[j] = 0.0;
-        for (i=0;i<n_veloc;i++) norm[j] += w[i]*SQR(e[j][i]);
+        for (i=0;i<n_veloc;i++) norm[j] += w[i]*Utils::sqr(e[j][i]);
     }
 
     fprintf(stderr,"e[%d][%d] = {\n",n_veloc,n_veloc);
@@ -3876,11 +4029,11 @@ static void lb_init_mode_transformation() {
         b[0][i] = 1;
         b[1][i] = c[i][0];
         b[2][i] = c[i][1];
-        b[3][i] = 3*(SQR(c[i][0]) + SQR(c[i][1]));
+        b[3][i] = 3*(Utils::sqr(c[i][0]) + Utils::sqr(c[i][1]));
         b[4][i] = c[i][0]*c[i][0]-c[i][1]*c[i][1];
         b[5][i] = c[i][0]*c[i][1];
-        b[6][i] = 3*(SQR(c[i][0])+SQR(c[i][1]))*c[i][0];
-        b[7][i] = 3*(SQR(c[i][0])+SQR(c[i][1]))*c[i][1];
+        b[6][i] = 3*(Utils::sqr(c[i][0])+Utils::sqr(c[i][1]))*c[i][0];
+        b[7][i] = 3*(Utils::sqr(c[i][0])+Utils::sqr(c[i][1]))*c[i][1];
         b[8][i] = (b[3][i]-5)*b[3][i]/2;
     }
 
@@ -3895,7 +4048,7 @@ static void lb_init_mode_transformation() {
             for (i=0;i<n_veloc;i++) e[j][i] -= proj/norm[k]*e[k][i];
         }
         norm[j] = 0.0;
-        for (i=0;i<n_veloc;i++) norm[j] += w[i]*SQR(e[j][i]);
+        for (i=0;i<n_veloc;i++) norm[j] += w[i]*Utils::sqr(e[j][i]);
     }
 
     fprintf(stderr,"e[%d][%d] = {\n",n_veloc,n_veloc);
@@ -3911,7 +4064,6 @@ static void lb_init_mode_transformation() {
 #endif // D3Q19
 }
 #endif /* ADDITIONAL_CHECKS */
-
 
 #ifdef ADDITIONAL_CHECKS
 /** Check for negative populations.
@@ -3937,6 +4089,6 @@ static int lb_check_negative_n(Lattice::index_t index)
 }
 #endif /* ADDITIONAL_CHECKS */
 #endif /* #if 0 */
-/* Here, the unused "ADDITIONAL_CHECKS functions end. */
+  /* Here, the unused "ADDITIONAL_CHECKS functions end. */
 
-#endif // LB 
+#endif // LB

--- a/src/core/lb.hpp
+++ b/src/core/lb.hpp
@@ -462,8 +462,8 @@ inline void lb_calc_local_fields(Lattice::index_t index, double *rho, double *j,
 
   /* equilibrium part of the stress modes */
   modes_from_pi_eq[0] = scalar(j, j) / *rho;
-  modes_from_pi_eq[1] = (SQR(j[0]) - SQR(j[1])) / *rho;
-  modes_from_pi_eq[2] = (scalar(j, j) - 3.0 * SQR(j[2])) / *rho;
+  modes_from_pi_eq[1] = (Utils::sqr(j[0]) - Utils::sqr(j[1])) / *rho;
+  modes_from_pi_eq[2] = (scalar(j, j) - 3.0 * Utils::sqr(j[2])) / *rho;
   modes_from_pi_eq[3] = j[0] * j[1] / *rho;
   modes_from_pi_eq[4] = j[0] * j[2] / *rho;
   modes_from_pi_eq[5] = j[1] * j[2] / *rho;

--- a/src/core/lj.hpp
+++ b/src/core/lj.hpp
@@ -54,7 +54,7 @@ inline void add_lj_pair_force(const Particle *const p1,
   if ((dist < ia_params->LJ_cut + ia_params->LJ_offset) &&
       (dist > ia_params->LJ_min + ia_params->LJ_offset)) {
     r_off = dist - ia_params->LJ_offset;
-    frac2 = SQR(ia_params->LJ_sig / r_off);
+    frac2 = Utils::sqr(ia_params->LJ_sig / r_off);
     frac6 = frac2 * frac2 * frac2;
     fac = 48.0 * ia_params->LJ_eps * frac6 * (frac6 - 0.5) / (r_off * dist);
 #ifdef SHANCHEN
@@ -109,9 +109,9 @@ inline double lj_pair_energy(const Particle *p1, const Particle *p2,
   if ((dist < ia_params->LJ_cut + ia_params->LJ_offset) &&
       (dist > ia_params->LJ_min + ia_params->LJ_offset)) {
     r_off = dist - ia_params->LJ_offset;
-    frac2 = SQR(ia_params->LJ_sig / r_off);
+    frac2 = Utils::sqr(ia_params->LJ_sig / r_off);
     frac6 = frac2 * frac2 * frac2;
-    return 4.0 * ia_params->LJ_eps * (SQR(frac6) - frac6 + ia_params->LJ_shift);
+    return 4.0 * ia_params->LJ_eps * (Utils::sqr(frac6) - frac6 + ia_params->LJ_shift);
   }
   return 0.0;
 }

--- a/src/core/ljangle.hpp
+++ b/src/core/ljangle.hpp
@@ -171,7 +171,7 @@ inline void add_ljangle_force(Particle *p1, Particle *p2,
         }
       }
 
-      frac2 = SQR(ia_params->LJANGLE_sig / dist);
+      frac2 = Utils::sqr(ia_params->LJANGLE_sig / dist);
       frac10 = frac2 * frac2 * frac2 * frac2 * frac2;
       rad = effective_eps * frac10 * (5.0 * frac2 - 6.0);
       radprime = 60.0 * effective_eps * frac10 * (1.0 - frac2) / dist;
@@ -327,7 +327,7 @@ inline double ljangle_pair_energy(const Particle *p1, const Particle *p2,
         }
       }
 
-      frac2 = SQR(ia_params->LJANGLE_sig / dist);
+      frac2 = Utils::sqr(ia_params->LJANGLE_sig / dist);
       frac10 = frac2 * frac2 * frac2 * frac2 * frac2;
       return effective_eps * frac10 * (5.0 * frac2 - 6.0) * angular_jik *
              angular_ikn;

--- a/src/core/ljcos.cpp
+++ b/src/core/ljcos.cpp
@@ -40,10 +40,10 @@ int ljcos_set_params(int part_type_a, int part_type_b,
   data->LJCOS_offset = offset;
 
   /* Calculate dependent parameters */
-  facsq = driwu2*SQR(sig);
+  facsq = driwu2*Utils::sqr(sig);
   data->LJCOS_rmin = sqrt(driwu2)*sig;
-  data->LJCOS_alfa = PI/(SQR(data->LJCOS_cut)-facsq);
-  data->LJCOS_beta = PI*(1.-(1./(SQR(data->LJCOS_cut)/facsq-1.)));
+  data->LJCOS_alfa = PI/(Utils::sqr(data->LJCOS_cut)-facsq);
+  data->LJCOS_beta = PI*(1.-(1./(Utils::sqr(data->LJCOS_cut)/facsq-1.)));
 
   /* broadcast interaction parameters */
   mpi_bcast_ia_params(part_type_a, part_type_b);

--- a/src/core/ljcos.hpp
+++ b/src/core/ljcos.hpp
@@ -50,13 +50,13 @@ inline void add_ljcos_pair_force(const Particle *const p1,
     /* cos part of ljcos potential. */
     if (dist > ia_params->LJCOS_rmin + ia_params->LJCOS_offset) {
       fac = (r_off / dist) * ia_params->LJCOS_alfa * ia_params->LJCOS_eps *
-            (sin(ia_params->LJCOS_alfa * SQR(r_off) + ia_params->LJCOS_beta));
+            (sin(ia_params->LJCOS_alfa * Utils::sqr(r_off) + ia_params->LJCOS_beta));
       for (j = 0; j < 3; j++)
         force[j] += fac * d[j];
     }
     /* lennard-jones part of the potential. */
     else if (dist > 0) {
-      frac2 = SQR(ia_params->LJCOS_sig / r_off);
+      frac2 = Utils::sqr(ia_params->LJCOS_sig / r_off);
       frac6 = frac2 * frac2 * frac2;
       fac =
           48.0 * ia_params->LJCOS_eps * frac6 * (frac6 - 0.5) / (r_off * dist);
@@ -99,14 +99,14 @@ inline double ljcos_pair_energy(const Particle *p1, const Particle *p2,
     /* lennard-jones part of the potential. */
     if (dist < (ia_params->LJCOS_rmin + ia_params->LJCOS_offset)) {
       // printf("this is nomal ,  %.3e \n",r_off);
-      frac2 = SQR(ia_params->LJCOS_sig / r_off);
+      frac2 = Utils::sqr(ia_params->LJCOS_sig / r_off);
       frac6 = frac2 * frac2 * frac2;
-      return 4.0 * ia_params->LJCOS_eps * (SQR(frac6) - frac6);
+      return 4.0 * ia_params->LJCOS_eps * (Utils::sqr(frac6) - frac6);
     }
     /* cosine part of the potential. */
     else if (dist < (ia_params->LJCOS_cut + ia_params->LJCOS_offset)) {
       return .5 * ia_params->LJCOS_eps *
-             (cos(ia_params->LJCOS_alfa * SQR(r_off) + ia_params->LJCOS_beta) -
+             (cos(ia_params->LJCOS_alfa * Utils::sqr(r_off) + ia_params->LJCOS_beta) -
               1.);
     }
     /* this should not happen! */

--- a/src/core/ljcos2.hpp
+++ b/src/core/ljcos2.hpp
@@ -52,7 +52,7 @@ inline void add_ljcos2_pair_force(const Particle *const p1,
   if ((dist < ia_params->LJCOS2_cut + ia_params->LJCOS2_offset)) {
     r_off = dist - ia_params->LJCOS2_offset;
     if (r_off < ia_params->LJCOS2_rchange) {
-      frac2 = SQR(ia_params->LJCOS2_sig / r_off);
+      frac2 = Utils::sqr(ia_params->LJCOS2_sig / r_off);
       frac6 = frac2 * frac2 * frac2;
       fac =
           48.0 * ia_params->LJCOS2_eps * frac6 * (frac6 - 0.5) / (r_off * dist);
@@ -98,9 +98,9 @@ inline double ljcos2_pair_energy(const Particle *p1, const Particle *p2,
   if ((dist < ia_params->LJCOS2_cut + ia_params->LJCOS2_offset)) {
     r_off = dist - ia_params->LJCOS2_offset;
     if (r_off < ia_params->LJCOS2_rchange) {
-      frac2 = SQR(ia_params->LJCOS2_sig / r_off);
+      frac2 = Utils::sqr(ia_params->LJCOS2_sig / r_off);
       frac6 = frac2 * frac2 * frac2;
-      return 4.0 * ia_params->LJCOS2_eps * (SQR(frac6) - frac6);
+      return 4.0 * ia_params->LJCOS2_eps * (Utils::sqr(frac6) - frac6);
     } else if (r_off < ia_params->LJCOS2_rchange + ia_params->LJCOS2_w) {
       return -ia_params->LJCOS2_eps / 2 *
              (cos(M_PI * (r_off - ia_params->LJCOS2_rchange) /

--- a/src/core/maggs.cpp
+++ b/src/core/maggs.cpp
@@ -1187,7 +1187,7 @@ void maggs_calc_self_energy_coeffs()
 
   factor = M_PI / maggs.mesh;
   prefac = 1. / maggs.mesh;
-  prefac = 0.5 * prefac * prefac * prefac * SQR(maggs.pref1);
+  prefac = 0.5 * prefac * prefac * prefac * Utils::sqr(maggs.pref1);
   
   for(i=0;i<8;i++) 
     {
@@ -1580,7 +1580,7 @@ void maggs_calc_init_e_field()
   sqrE = 0.;
   FORALL_INNER_SITES(ix, iy, iz) {
     i = maggs_get_linear_index(ix, iy, iz, lparams.dim);
-    FOR3D(k) sqrE += SQR(Dfield[3*i+k]);
+    FOR3D(k) sqrE += Utils::sqr(Dfield[3*i+k]);
   }
 
   MPI_Allreduce(&sqrE,&gsqrE,1,MPI_DOUBLE,MPI_SUM,comm_cart); 
@@ -1599,7 +1599,7 @@ void maggs_calc_init_e_field()
 		
     FORALL_INNER_SITES(ix, iy, iz) {
       i = maggs_get_linear_index(ix, iy, iz, lparams.dim);
-      FOR3D(k) sqrE += SQR(Dfield[3*i+k]);
+      FOR3D(k) sqrE += Utils::sqr(Dfield[3*i+k]);
     }
     MPI_Allreduce(&sqrE,&gsqrE,1,MPI_DOUBLE,MPI_SUM,comm_cart); 
     gsqrE = gsqrE/(SPACE_DIM*maggs.mesh*maggs.mesh*maggs.mesh);  
@@ -1962,7 +1962,7 @@ void maggs_add_transverse_field(double dt)
   int offset, xoffset, yoffset;
   double help;
 	
-  invasq = SQR(maggs.inva);
+  invasq = Utils::sqr(maggs.inva);
   help = dt * invasq * maggs.invsqrt_f_mass;
 	
   /***calculate e-field***/ 
@@ -2285,7 +2285,7 @@ double maggs_electric_energy()
   FORALL_INNER_SITES(x, y, z) {
     i = maggs_get_linear_index(x, y, z, lparams.dim);	  
     FOR3D(k){
-      localresult += SQR(Dfield[i*3+k]) / lattice[i].permittivity[k];
+      localresult += Utils::sqr(Dfield[i*3+k]) / lattice[i].permittivity[k];
     }
   }
   localresult *= 0.5*maggs.a;
@@ -2307,7 +2307,7 @@ double maggs_magnetic_energy()
 	
   FORALL_INNER_SITES(x, y, z) {
     i = maggs_get_linear_index(x, y, z, lparams.dim);	  
-    result += SQR(Bfield[i*3]) + SQR(Bfield[i*3+1]) + SQR(Bfield[i*3+2]);
+    result += Utils::sqr(Bfield[i*3]) + Utils::sqr(Bfield[i*3+1]) + Utils::sqr(Bfield[i*3+2]);
   }
   /* B is rescaled !!! ATTENTION!!! */
   result *= 0.5*maggs.a;

--- a/src/core/minimize_energy.cpp
+++ b/src/core/minimize_energy.cpp
@@ -75,14 +75,14 @@ bool steepest_descent_step(void) {
 #endif
         {
           // Square of force on particle
-          f += SQR(p.f.f[j]);
+          f += Utils::sqr(p.f.f[j]);
 
           // Positional increment
           dp = params->gamma * p.f.f[j];
           if (fabs(dp) > params->max_displacement)
             // Crop to maximum allowed by user
             dp = sgn<double>(dp) * params->max_displacement;
-          dp2 += SQR(dp);
+          dp2 += Utils::sqr(dp);
 
           // Move particle
           p.r.p[j] += dp;
@@ -97,7 +97,7 @@ bool steepest_descent_step(void) {
     for (int j = 0; j < 3; j++) {
       dq[j] = 0;
       // Square of torque
-      t += SQR(p.f.torque[j]);
+      t += Utils::sqr(p.f.torque[j]);
 
       // Rotational increment
       dq[j] = params->gamma * p.f.torque[j];

--- a/src/core/mmm1d.cpp
+++ b/src/core/mmm1d.cpp
@@ -1,39 +1,39 @@
 /*
   Copyright (C) 2010,2012,2013,2014,2015,2016 The ESPResSo project
-  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010 
+  Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
     Max-Planck-Institute for Polymer Research, Theory Group
-  
+
   This file is part of ESPResSo.
-  
+
   ESPResSo is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   ESPResSo is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file mmm1d.cpp  MMM1D algorithm for long range coulomb interaction.
  *
  *  For more information about MMM1D, see \ref mmm1d.hpp "mmm1d.h".
  */
 
-#include "utils.hpp"
 #include "mmm1d.hpp"
-#include "polynom.hpp"
-#include "specfunc.hpp"
-#include "communication.hpp"
 #include "cells.hpp"
+#include "communication.hpp"
+#include "errorhandling.hpp"
 #include "grid.hpp"
-#include "tuning.hpp"
 #include "interaction_data.hpp"
 #include "mmm-common.hpp"
-#include "errorhandling.hpp"
+#include "polynom.hpp"
+#include "specfunc.hpp"
+#include "tuning.hpp"
+#include "utils.hpp"
 
 #ifdef ELECTROSTATICS
 
@@ -62,25 +62,22 @@
 static double uz, L2, uz2, prefuz2, prefL3_i;
 /*@}*/
 
-MMM1D_struct mmm1d_params = { 0.05, 1e-5 };
+MMM1D_struct mmm1d_params = {0.05, 1e-5};
 /** From which distance a certain bessel cutoff is valid. Can't be part of the
     params since these get broadcasted. */
 static double *bessel_radii;
-  
 
-static double far_error(int P, double minrad)
-{
+static double far_error(int P, double minrad) {
   // this uses an upper bound to all force components and the potential
-  double rhores = 2*M_PI*uz*minrad;
-  double pref = 4*uz*std::max(1.0, 2*M_PI*uz);
+  double rhores = 2 * M_PI * uz * minrad;
+  double pref = 4 * uz * std::max(1.0, 2 * M_PI * uz);
 
-  return pref*K1(rhores*P)*exp(rhores)/rhores*(P - 1 + 1/rhores);
+  return pref * K1(rhores * P) * exp(rhores) / rhores * (P - 1 + 1 / rhores);
 }
 
-static double determine_minrad(double maxPWerror, int P)
-{
+static double determine_minrad(double maxPWerror, int P) {
   // bisection to search for where the error is maxPWerror
-  double rgranularity = MIN_RAD*box_l[2];
+  double rgranularity = MIN_RAD * box_l[2];
   double rmin = rgranularity;
   double rmax = std::min(box_l[0], box_l[1]);
   double errmin = far_error(P, rmin);
@@ -91,11 +88,11 @@ static double determine_minrad(double maxPWerror, int P)
   }
   if (errmax > maxPWerror) {
     // make sure that this switching radius cannot be reached
-    return 2*std::max(box_l[0], box_l[1]);
+    return 2 * std::max(box_l[0], box_l[1]);
   }
 
   while (rmax - rmin > rgranularity) {
-    double c = 0.5*(rmin + rmax);
+    double c = 0.5 * (rmin + rmax);
     double errc = far_error(P, c);
     if (errc > maxPWerror) {
       rmin = c;
@@ -103,43 +100,40 @@ static double determine_minrad(double maxPWerror, int P)
       rmax = c;
     }
   }
-  return 0.5*(rmin + rmax);
+  return 0.5 * (rmin + rmax);
 }
 
-static void determine_bessel_radii(double maxPWerror, int maxP)
-{
-  bessel_radii = Utils::realloc(bessel_radii, sizeof(double)*maxP);
+static void determine_bessel_radii(double maxPWerror, int maxP) {
+  bessel_radii = Utils::realloc(bessel_radii, sizeof(double) * maxP);
   for (int P = 1; P <= maxP; ++P) {
-    bessel_radii[P-1] = determine_minrad(maxPWerror, P);
-    //printf("cutoff %d %f\n", P, bessel_radii[P-1]);
+    bessel_radii[P - 1] = determine_minrad(maxPWerror, P);
+    // printf("cutoff %d %f\n", P, bessel_radii[P-1]);
   }
 }
 
-static void prepare_polygamma_series(double maxPWerror, double maxrad2)
-{
+static void prepare_polygamma_series(double maxPWerror, double maxrad2) {
   /* polygamma, determine order */
   int n;
   double err;
-  double rhomax2nm2, rhomax2 = uz2*maxrad2;
+  double rhomax2nm2, rhomax2 = uz2 * maxrad2;
   /* rhomax2 < 1, so rhomax2m2 falls monotonously */
 
   n = 1;
   rhomax2nm2 = 1.0;
   do {
-    create_mod_psi_up_to(n+1);
+    create_mod_psi_up_to(n + 1);
 
     /* |uz*z| <= 0.5 */
-    err = 2*n*fabs(mod_psi_even(n, 0.5))*rhomax2nm2;
+    err = 2 * n * fabs(mod_psi_even(n, 0.5)) * rhomax2nm2;
     rhomax2nm2 *= rhomax2;
     n++;
     // fprintf(stderr, "%f\n", err);
-  }
-  while (err > 0.1*maxPWerror);
+  } while (err > 0.1 * maxPWerror);
 }
 
-int MMM1D_set_params(double switch_rad, double maxPWerror)
-{
-  mmm1d_params.far_switch_radius_2 = (switch_rad > 0) ? SQR(switch_rad) : -1;
+int MMM1D_set_params(double switch_rad, double maxPWerror) {
+  mmm1d_params.far_switch_radius_2 =
+      (switch_rad > 0) ? Utils::sqr(switch_rad) : -1;
   mmm1d_params.maxPWerror = maxPWerror;
   coulomb.method = COULOMB_MMM1D;
 
@@ -148,50 +142,49 @@ int MMM1D_set_params(double switch_rad, double maxPWerror)
   return 0;
 }
 
-int MMM1D_sanity_checks()
-{
-  //char *errtxt;
+int MMM1D_sanity_checks() {
+  // char *errtxt;
   if (PERIODIC(0) || PERIODIC(1) || !PERIODIC(2)) {
-      runtimeErrorMsg() <<"MMM1D requires periodicity 0 0 1";
+    runtimeErrorMsg() << "MMM1D requires periodicity 0 0 1";
     return 1;
   }
 
   if (cell_structure.type != CELL_STRUCTURE_NSQUARE) {
-      runtimeErrorMsg() <<"MMM1D requires n-square cellsystem";
+    runtimeErrorMsg() << "MMM1D requires n-square cellsystem";
     return 1;
   }
   return 0;
 }
 
-void MMM1D_init()
-{
-  if (MMM1D_sanity_checks()) return;
+void MMM1D_init() {
+  if (MMM1D_sanity_checks())
+    return;
 
-  if (mmm1d_params.far_switch_radius_2 >= SQR(box_l[2]))
-    mmm1d_params.far_switch_radius_2 = 0.8*SQR(box_l[2]);
+  if (mmm1d_params.far_switch_radius_2 >= Utils::sqr(box_l[2]))
+    mmm1d_params.far_switch_radius_2 = 0.8 * Utils::sqr(box_l[2]);
 
-  uz  = 1/box_l[2];
-  L2  = box_l[2]*box_l[2];
-  uz2 = uz*uz;
-  prefuz2 = coulomb.prefactor*uz2;
-  prefL3_i = prefuz2*uz;
+  uz = 1 / box_l[2];
+  L2 = box_l[2] * box_l[2];
+  uz2 = uz * uz;
+  prefuz2 = coulomb.prefactor * uz2;
+  prefL3_i = prefuz2 * uz;
 
   determine_bessel_radii(mmm1d_params.maxPWerror, MAXIMAL_B_CUT);
-  prepare_polygamma_series(mmm1d_params.maxPWerror, mmm1d_params.far_switch_radius_2);
+  prepare_polygamma_series(mmm1d_params.maxPWerror,
+                           mmm1d_params.far_switch_radius_2);
 }
 
-void add_mmm1d_coulomb_pair_force(double chpref, double d[3], double r2, double r, double force[3])
-{
+void add_mmm1d_coulomb_pair_force(double chpref, double d[3], double r2,
+                                  double r, double force[3]) {
   int dim;
   double F[3];
   double rxy2, rxy2_d, z_d;
   double pref;
   double Fx, Fy, Fz;
-  
 
-  rxy2   = d[0]*d[0] + d[1]*d[1];
-  rxy2_d = rxy2*uz2;
-  z_d    = d[2]*uz;
+  rxy2 = d[0] * d[0] + d[1] * d[1];
+  rxy2_d = rxy2 * uz2;
+  z_d = d[2] * uz;
 
   if (rxy2 <= mmm1d_params.far_switch_radius_2) {
     /* near range formula */
@@ -204,175 +197,173 @@ void add_mmm1d_coulomb_pair_force(double chpref, double d[3], double r2, double 
 
     r2nm1 = 1.0;
     for (n = 1; n < n_modPsi; n++) {
-      double deriv = 2*n;
-      double mpe   = mod_psi_even(n, z_d);
-      double mpo   = mod_psi_odd(n, z_d);
-      double r2n   = r2nm1*rxy2_d;
+      double deriv = 2 * n;
+      double mpe = mod_psi_even(n, z_d);
+      double mpo = mod_psi_odd(n, z_d);
+      double r2n = r2nm1 * rxy2_d;
 
-      sz +=         r2n*mpo;
-      sr += deriv*r2nm1*mpe;
+      sz += r2n * mpo;
+      sr += deriv * r2nm1 * mpe;
 
-      if (fabs(deriv*r2nm1*mpe) < mmm1d_params.maxPWerror)
-	break;
+      if (fabs(deriv * r2nm1 * mpe) < mmm1d_params.maxPWerror)
+        break;
 
       r2nm1 = r2n;
     }
     // fprintf(stderr, "max_n %d\n", n);
 
-    Fx = prefL3_i*sr*d[0];
-    Fy = prefL3_i*sr*d[1];
-    Fz = prefuz2*sz;
+    Fx = prefL3_i * sr * d[0];
+    Fy = prefL3_i * sr * d[1];
+    Fz = prefuz2 * sz;
 
     /* real space parts */
 
-    pref = coulomb.prefactor/(r2*r); 
-    Fx += pref*d[0];
-    Fy += pref*d[1];
-    Fz += pref*d[2];
+    pref = coulomb.prefactor / (r2 * r);
+    Fx += pref * d[0];
+    Fy += pref * d[1];
+    Fz += pref * d[2];
 
     shift_z = d[2] + box_l[2];
-    rt2 = rxy2 + shift_z*shift_z;
-    rt  = sqrt(rt2);
-    pref = coulomb.prefactor/(rt2*rt); 
-    Fx += pref*d[0];
-    Fy += pref*d[1];
-    Fz += pref*shift_z;
+    rt2 = rxy2 + shift_z * shift_z;
+    rt = sqrt(rt2);
+    pref = coulomb.prefactor / (rt2 * rt);
+    Fx += pref * d[0];
+    Fy += pref * d[1];
+    Fz += pref * shift_z;
 
     shift_z = d[2] - box_l[2];
-    rt2 = rxy2 + shift_z*shift_z;
-    rt  = sqrt(rt2);
-    pref = coulomb.prefactor/(rt2*rt); 
-    Fx += pref*d[0];
-    Fy += pref*d[1];
-    Fz += pref*shift_z;
+    rt2 = rxy2 + shift_z * shift_z;
+    rt = sqrt(rt2);
+    pref = coulomb.prefactor / (rt2 * rt);
+    Fx += pref * d[0];
+    Fy += pref * d[1];
+    Fz += pref * shift_z;
 
     F[0] = Fx;
     F[1] = Fy;
     F[2] = Fz;
-  }
-  else {
+  } else {
     /* far range formula */
-    double rxy   = sqrt(rxy2);
-    double rxy_d = rxy*uz;
+    double rxy = sqrt(rxy2);
+    double rxy_d = rxy * uz;
     double sr = 0, sz = 0;
     int bp;
 
     for (bp = 1; bp < MAXIMAL_B_CUT; bp++) {
-      if (bessel_radii[bp-1] < rxy)
+      if (bessel_radii[bp - 1] < rxy)
         break;
 
-      double fq = C_2PI*bp, k0, k1;
+      double fq = C_2PI * bp, k0, k1;
 #ifdef BESSEL_MACHINE_PREC
-      k0 = K0(fq*rxy_d);
-      k1 = K1(fq*rxy_d);
+      k0 = K0(fq * rxy_d);
+      k1 = K1(fq * rxy_d);
 #else
-      LPK01(fq*rxy_d, &k0, &k1);
+      LPK01(fq * rxy_d, &k0, &k1);
 #endif
-      sr += bp*k1*cos(fq*z_d);
-      sz += bp*k0*sin(fq*z_d);
+      sr += bp * k1 * cos(fq * z_d);
+      sz += bp * k0 * sin(fq * z_d);
     }
-    sr *= uz2*4*C_2PI;
-    sz *= uz2*4*C_2PI;
-    
-    pref = coulomb.prefactor*(sr/rxy + 2*uz/rxy2);
+    sr *= uz2 * 4 * C_2PI;
+    sz *= uz2 * 4 * C_2PI;
 
-    F[0] = pref*d[0];
-    F[1] = pref*d[1];
-    F[2] = coulomb.prefactor*sz;
+    pref = coulomb.prefactor * (sr / rxy + 2 * uz / rxy2);
+
+    F[0] = pref * d[0];
+    F[1] = pref * d[1];
+    F[2] = coulomb.prefactor * sz;
   }
 
   for (dim = 0; dim < 3; dim++)
     force[dim] += chpref * F[dim];
 }
 
-double mmm1d_coulomb_pair_energy(Particle *p1, Particle *p2, double d[3], double r2, double r)
-{
-  double chpref = p1->p.q*p2->p.q;
+double mmm1d_coulomb_pair_energy(Particle *p1, Particle *p2, double d[3],
+                                 double r2, double r) {
+  double chpref = p1->p.q * p2->p.q;
   double rxy2, rxy2_d, z_d;
   double E;
 
   if (chpref == 0)
     return 0;
 
-  rxy2   = d[0]*d[0] + d[1]*d[1];
-  rxy2_d = rxy2*uz2;
-  z_d    = d[2]*uz;
+  rxy2 = d[0] * d[0] + d[1] * d[1];
+  rxy2_d = rxy2 * uz2;
+  z_d = d[2] * uz;
 
   if (rxy2 <= mmm1d_params.far_switch_radius_2) {
     /* near range formula */
     double r2n, rt, shift_z;
     int n;
 
-    E = -2*C_GAMMA;
+    E = -2 * C_GAMMA;
 
     /* polygamma summation */
     r2n = 1.0;
     for (n = 0; n < n_modPsi; n++) {
-      double add = mod_psi_even(n, z_d)*r2n;
+      double add = mod_psi_even(n, z_d) * r2n;
       E -= add;
-      
+
       if (fabs(add) < mmm1d_params.maxPWerror)
-	break;
- 
+        break;
+
       r2n *= rxy2_d;
     }
-    E *= coulomb.prefactor*uz;
+    E *= coulomb.prefactor * uz;
 
     /* real space parts */
 
-    E += coulomb.prefactor/r; 
+    E += coulomb.prefactor / r;
 
     shift_z = d[2] + box_l[2];
-    rt = sqrt(rxy2 + shift_z*shift_z);
-    E += coulomb.prefactor/rt; 
+    rt = sqrt(rxy2 + shift_z * shift_z);
+    E += coulomb.prefactor / rt;
 
     shift_z = d[2] - box_l[2];
-    rt = sqrt(rxy2 + shift_z*shift_z);
-    E += coulomb.prefactor/rt; 
-  }
-  else {
+    rt = sqrt(rxy2 + shift_z * shift_z);
+    E += coulomb.prefactor / rt;
+  } else {
     /* far range formula */
-    double rxy   = sqrt(rxy2);
-    double rxy_d = rxy*uz;
+    double rxy = sqrt(rxy2);
+    double rxy_d = rxy * uz;
     int bp;
     /* The first Bessel term will compensate a little bit the
        log term, so add them close together */
-    E = -0.25*log(rxy2_d) + 0.5*(M_LN2 - C_GAMMA);
+    E = -0.25 * log(rxy2_d) + 0.5 * (M_LN2 - C_GAMMA);
     for (bp = 1; bp < MAXIMAL_B_CUT; bp++) {
-      if (bessel_radii[bp-1] < rxy)
+      if (bessel_radii[bp - 1] < rxy)
         break;
 
-      double fq = C_2PI*bp;
-      E += K0(fq*rxy_d)*cos(fq*z_d);
+      double fq = C_2PI * bp;
+      E += K0(fq * rxy_d) * cos(fq * z_d);
     }
-    E *= 4*coulomb.prefactor*uz;
+    E *= 4 * coulomb.prefactor * uz;
   }
 
-  return chpref*E;
+  return chpref * E;
 }
 
-int mmm1d_tune(char **log)
-{
-  if (MMM1D_sanity_checks()) return ES_ERROR;
-  char buffer[32 + 2*ES_DOUBLE_SPACE + ES_INTEGER_SPACE];
-  double int_time, min_time=1e200, min_rad = -1;
+int mmm1d_tune(char **log) {
+  if (MMM1D_sanity_checks())
+    return ES_ERROR;
+  char buffer[32 + 2 * ES_DOUBLE_SPACE + ES_INTEGER_SPACE];
+  double int_time, min_time = 1e200, min_rad = -1;
   double maxrad = box_l[2]; /* N_psi = 2, theta=2/3 maximum for rho */
   double switch_radius;
 
   if (mmm1d_params.far_switch_radius_2 < 0) {
-    /* determine besselcutoff and optimal switching radius. Should be around 0.33 */
-    for (switch_radius = 0.2*maxrad;
-	 switch_radius < 0.4*maxrad;
-	 switch_radius += 0.025*maxrad) {
+    /* determine besselcutoff and optimal switching radius. Should be around
+     * 0.33 */
+    for (switch_radius = 0.2 * maxrad; switch_radius < 0.4 * maxrad;
+         switch_radius += 0.025 * maxrad) {
       if (switch_radius <= bessel_radii[MAXIMAL_B_CUT - 1]) {
         // this switching radius is too small for our Bessel series
         continue;
       }
 
-      mmm1d_params.far_switch_radius_2 = SQR(switch_radius);
+      mmm1d_params.far_switch_radius_2 = Utils::sqr(switch_radius);
 
       coulomb.method = COULOMB_MMM1D;
-      
+
       /* initialize mmm1d temporary structures */
       mpi_bcast_coulomb_params();
 
@@ -381,24 +372,24 @@ int mmm1d_tune(char **log)
 
       /* exit on errors */
       if (int_time < 0)
-	return ES_ERROR;
+        return ES_ERROR;
 
       sprintf(buffer, "r= %f t= %f ms\n", switch_radius, int_time);
       *log = strcat_alloc(*log, buffer);
 
       if (int_time < min_time) {
-	min_time = int_time;
-	min_rad = switch_radius;
+        min_time = int_time;
+        min_rad = switch_radius;
       }
       /* stop if all hope is vain... */
-      else if (int_time > 2*min_time)
-	break;
+      else if (int_time > 2 * min_time)
+        break;
     }
     switch_radius = min_rad;
-    mmm1d_params.far_switch_radius_2 = SQR(switch_radius);
-  }
-  else {
-    if (mmm1d_params.far_switch_radius_2 <= SQR(bessel_radii[MAXIMAL_B_CUT - 1])) {
+    mmm1d_params.far_switch_radius_2 = Utils::sqr(switch_radius);
+  } else {
+    if (mmm1d_params.far_switch_radius_2 <=
+        Utils::sqr(bessel_radii[MAXIMAL_B_CUT - 1])) {
       // this switching radius is too small for our Bessel series
       *log = strcat_alloc(*log, "could not find reasonable bessel cutoff");
       return ES_ERROR;

--- a/src/core/mmm2d.cpp
+++ b/src/core/mmm2d.cpp
@@ -1221,7 +1221,7 @@ static void add_force_contribution(int p, int q)
     checkpoint("************distri q", 0, q, 2);
   }
   else {
-    omega = C_2PI*sqrt(SQR(ux*p) + SQR(uy*q));
+    omega = C_2PI*sqrt(Utils::sqr(ux*p) + Utils::sqr(uy*q));
     fac = exp(-omega*layer_h);
     setup_PQ(p, q, omega, fac);
     if (mmm2d_params.dielectric_contrast_on)
@@ -1273,7 +1273,7 @@ static double energy_contribution(int p, int q)
     checkpoint("************distri q", 0, q, 2);
   }
   else {
-    omega = C_2PI*sqrt(SQR(ux*p) + SQR(uy*q));
+    omega = C_2PI*sqrt(Utils::sqr(ux*p) + Utils::sqr(uy*q));
     fac = exp(-omega*layer_h);
     setup_PQ(p, q, omega, fac);
     if (mmm2d_params.dielectric_contrast_on)
@@ -1313,7 +1313,7 @@ double MMM2D_add_far(int f, int e)
     if (p == 0)
       q =  n_scycache;
     else {
-      q2 = mmm2d_params.far_cut2 - SQR(ux*(p - 1));
+      q2 = mmm2d_params.far_cut2 - Utils::sqr(ux*(p - 1));
       if (q2 > 0)
 	q = 1 + (int)ceil(box_l[1]*sqrt(q2));
       else
@@ -1329,7 +1329,7 @@ double MMM2D_add_far(int f, int e)
   for(R = mmm2d_params.far_cut; R > 0; R -= dR) {
     for (p = n_scxcache; p >= 0; p--) {
       for (q = undone[p]; q >= 0; q--) {
-	if (ux2*SQR(p)  + uy2*SQR(q) < SQR(R))
+	if (ux2*Utils::sqr(p)  + uy2*Utils::sqr(q) < Utils::sqr(R))
 	  break;
 	if (f)
 	  add_force_contribution(p, q);
@@ -1374,7 +1374,7 @@ static int MMM2D_tune_far(double error)
     return ERROR_FARC;
   // fprintf(stderr, "far cutoff %g %g %g\n", mmm2d_params.far_cut, err, min_far);
   mmm2d_params.far_cut -= min_inv_boxl;
-  mmm2d_params.far_cut2 = SQR(mmm2d_params.far_cut);
+  mmm2d_params.far_cut2 = Utils::sqr(mmm2d_params.far_cut);
   return 0;
 }
 
@@ -1437,7 +1437,7 @@ static int MMM2D_tune_near(double error)
 
   /* polygamma, determine order */
   n = 1;
-  uxrhomax2 = SQR(ux*box_l[1])/2;
+  uxrhomax2 = Utils::sqr(ux*box_l[1])/2;
   uxrho2m2max = 1.0;
   do {
     create_mod_psi_up_to(n+1);
@@ -1801,7 +1801,7 @@ void MMM2D_self_energy() {
   auto parts = local_cells.particles();
   self_energy = std::accumulate(
       parts.begin(), parts.end(), 0.0,
-      [seng](double sum, Particle const &p) { return sum + seng * SQR(p.p.q); });
+      [seng](double sum, Particle const &p) { return sum + seng * Utils::sqr(p.p.q); });
 }
 
 /****************************************
@@ -1857,7 +1857,7 @@ int MMM2D_set_params(double maxPWerror, double far_cut, double delta_top, double
   }
   else {
     mmm2d_params.far_cut = far_cut;
-    mmm2d_params.far_cut2 = SQR(far_cut);
+    mmm2d_params.far_cut2 = Utils::sqr(far_cut);
     if (mmm2d_params.far_cut > 0)
       mmm2d_params.far_calculated = 0;
     else {

--- a/src/core/p3m-common.cpp
+++ b/src/core/p3m-common.cpp
@@ -117,7 +117,7 @@ void p3m_add_block(double *in, double *out, int start[3], int size[3], int dim[3
 double p3m_analytic_cotangent_sum(int n, double mesh_i, int cao)
 {
   double c, res=0.0;
-  c = SQR(cos(PI*mesh_i*(double)n));
+  c = Utils::sqr(cos(PI*mesh_i*(double)n));
 
   switch (cao) {
   case 1 : { 
@@ -166,9 +166,9 @@ double p3m_caf(int i, double x, int cao_value) {
   } 
   case 3 : { 
     switch (i) {
-    case 0: return 0.5*SQR(0.5 - x);
-    case 1: return 0.75 - SQR(x);
-    case 2: return 0.5*SQR(0.5 + x);
+    case 0: return 0.5*Utils::sqr(0.5 - x);
+    case 1: return 0.75 - Utils::sqr(x);
+    case 2: return 0.5*Utils::sqr(0.5 + x);
     default:
       fprintf(stderr,"%d: Tried to access charge assignment function of degree %d in scheme of order %d.\n",this_node,i,cao_value);
       return 0.0;

--- a/src/core/p3m-dipolar.cpp
+++ b/src/core/p3m-dipolar.cpp
@@ -325,13 +325,13 @@ void dp3m_init() {
   int n;
 
   if (coulomb.Dprefactor <= 0.0) {
-      dp3m.params.r_cut = 0.0;
-      dp3m.params.r_cut_iL = 0.0;
-      if (this_node == 0) {
-        P3M_TRACE(
-            fprintf(stderr, "0: dp3m_init: dipolar prefactor is zero.\n");
-            fprintf(stderr, "   Magnetostatics of dipoles switched off!\n"));
-      }
+    dp3m.params.r_cut = 0.0;
+    dp3m.params.r_cut_iL = 0.0;
+    if (this_node == 0) {
+      P3M_TRACE(
+          fprintf(stderr, "0: dp3m_init: dipolar prefactor is zero.\n");
+          fprintf(stderr, "   Magnetostatics of dipoles switched off!\n"));
+    }
   } else {
     P3M_TRACE(fprintf(stderr, "%d: dp3m_init: \n", this_node));
 
@@ -388,25 +388,24 @@ void dp3m_init() {
                       dp3m.pos_shift));
 
     /* FFT */
-    P3M_TRACE(
-        fprintf(stderr, "%d: dp3m.rs_mesh ADR=%p\n", this_node, (void*) dp3m.rs_mesh));
+    P3M_TRACE(fprintf(stderr, "%d: dp3m.rs_mesh ADR=%p\n", this_node,
+                      (void *)dp3m.rs_mesh));
 
     int ca_mesh_size =
         dfft_init(&dp3m.rs_mesh, dp3m.local_mesh.dim, dp3m.local_mesh.margin,
                   dp3m.params.mesh, dp3m.params.mesh_off, &dp3m.ks_pnum);
-    dp3m.ks_mesh =
-        Utils::realloc(dp3m.ks_mesh, ca_mesh_size * sizeof(double));
+    dp3m.ks_mesh = Utils::realloc(dp3m.ks_mesh, ca_mesh_size * sizeof(double));
 
     for (n = 0; n < 3; n++)
-      dp3m.rs_mesh_dip[n] = Utils::realloc(
-          dp3m.rs_mesh_dip[n], ca_mesh_size * sizeof(double));
+      dp3m.rs_mesh_dip[n] =
+          Utils::realloc(dp3m.rs_mesh_dip[n], ca_mesh_size * sizeof(double));
 
     P3M_TRACE(fprintf(stderr, "%d: dp3m.rs_mesh_dip[0] ADR=%p\n", this_node,
-                      (void*) dp3m.rs_mesh_dip[0]));
+                      (void *)dp3m.rs_mesh_dip[0]));
     P3M_TRACE(fprintf(stderr, "%d: dp3m.rs_mesh_dip[1] ADR=%p\n", this_node,
-                      (void*) dp3m.rs_mesh_dip[1]));
+                      (void *)dp3m.rs_mesh_dip[1]));
     P3M_TRACE(fprintf(stderr, "%d: dp3m.rs_mesh_dip[2] ADR=%p\n", this_node,
-                      (void*) dp3m.rs_mesh_dip[2]));
+                      (void *)dp3m.rs_mesh_dip[2]));
 
     /* k-space part: */
 
@@ -461,9 +460,10 @@ double dp3m_average_dipolar_self_energy(double box_l, int mesh) {
           node_phi += 0.0;
         else {
           U2 = dp3m_perform_aliasing_sums_dipolar_self_energy(n);
-          node_phi += dp3m.g_energy[ind] * U2 *
-                      (SQR(dp3m.d_op[n[0]]) + SQR(dp3m.d_op[n[1]]) +
-                       SQR(dp3m.d_op[n[2]]));
+          node_phi +=
+              dp3m.g_energy[ind] * U2 *
+              (Utils::sqr(dp3m.d_op[n[0]]) + Utils::sqr(dp3m.d_op[n[1]]) +
+               Utils::sqr(dp3m.d_op[n[2]]));
         }
       }
     }
@@ -526,7 +526,6 @@ void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
 
   if (n_interpol != -1)
     dp3m.params.inter = n_interpol;
-
 }
 
 /*****************************************************************************/
@@ -613,8 +612,9 @@ void dp3m_interpolate_dipole_assignment_function() {
   if (dp3m.params.inter == 0)
     return;
 
-  P3M_TRACE(fprintf(stderr, "dipolar %d - interpolating (%d) the order-%d "
-                            "charge assignment function\n",
+  P3M_TRACE(fprintf(stderr,
+                    "dipolar %d - interpolating (%d) the order-%d "
+                    "charge assignment function\n",
                     this_node, dp3m.params.inter, dp3m.params.cao));
 
   dp3m.params.inter2 = 2 * dp3m.params.inter + 1;
@@ -843,8 +843,8 @@ static void P3M_assign_torques(double prefac, int d_rs) {
       cp_cnt++;
 
       ONEPART_TRACE(if (p.p.identity == check_id) fprintf(
-          stderr, "%d: OPT: P3M  f = (%.3e,%.3e,%.3e) in dir %d\n",
-          this_node, p.f.f[0], p.f.f[1], p.f.f[2], d_rs));
+          stderr, "%d: OPT: P3M  f = (%.3e,%.3e,%.3e) in dir %d\n", this_node,
+          p.f.f[0], p.f.f[1], p.f.f[2], d_rs));
     }
   }
 }
@@ -883,8 +883,8 @@ static void dp3m_assign_forces_dip(double prefac, int d_rs) {
       cp_cnt++;
 
       ONEPART_TRACE(if (p.p.identity == check_id) fprintf(
-          stderr, "%d: OPT: P3M  f = (%.3e,%.3e,%.3e) in dir %d\n",
-          this_node, p.f.f[0], p.f.f[1], p.f.f[2], d_rs));
+          stderr, "%d: OPT: P3M  f = (%.3e,%.3e,%.3e) in dir %d\n", this_node,
+          p.f.f[0], p.f.f[1], p.f.f[2], d_rs));
     }
   }
 }
@@ -943,18 +943,18 @@ double dp3m_calc_kspace_forces(int force_flag, int energy_flag) {
           for (j[2] = 0; j[2] < dfft.plan[3].new_mesh[2]; j[2]++) {
             node_k_space_energy_dip +=
                 dp3m.g_energy[i] *
-                (SQR(dp3m.rs_mesh_dip[0][ind] *
-                         dp3m.d_op[j[2] + dfft.plan[3].start[2]] +
-                     dp3m.rs_mesh_dip[1][ind] *
-                         dp3m.d_op[j[0] + dfft.plan[3].start[0]] +
-                     dp3m.rs_mesh_dip[2][ind] *
-                         dp3m.d_op[j[1] + dfft.plan[3].start[1]]) +
-                 SQR(dp3m.rs_mesh_dip[0][ind + 1] *
-                         dp3m.d_op[j[2] + dfft.plan[3].start[2]] +
-                     dp3m.rs_mesh_dip[1][ind + 1] *
-                         dp3m.d_op[j[0] + dfft.plan[3].start[0]] +
-                     dp3m.rs_mesh_dip[2][ind + 1] *
-                         dp3m.d_op[j[1] + dfft.plan[3].start[1]]));
+                (Utils::sqr(dp3m.rs_mesh_dip[0][ind] *
+                                dp3m.d_op[j[2] + dfft.plan[3].start[2]] +
+                            dp3m.rs_mesh_dip[1][ind] *
+                                dp3m.d_op[j[0] + dfft.plan[3].start[0]] +
+                            dp3m.rs_mesh_dip[2][ind] *
+                                dp3m.d_op[j[1] + dfft.plan[3].start[1]]) +
+                 Utils::sqr(dp3m.rs_mesh_dip[0][ind + 1] *
+                                dp3m.d_op[j[2] + dfft.plan[3].start[2]] +
+                            dp3m.rs_mesh_dip[1][ind + 1] *
+                                dp3m.d_op[j[0] + dfft.plan[3].start[0]] +
+                            dp3m.rs_mesh_dip[2][ind + 1] *
+                                dp3m.d_op[j[1] + dfft.plan[3].start[1]]));
             ind += 2;
             i++;
           }
@@ -1349,8 +1349,8 @@ void dp3m_realloc_ca_fields(int newsize) {
       "%d: p3m_realloc_ca_fields: dipolar,  old_size=%d -> new_size=%d\n",
       this_node, dp3m.ca_num, newsize));
   dp3m.ca_num = newsize;
-  dp3m.ca_frac = Utils::realloc(
-      dp3m.ca_frac, dp3m.params.cao3 * dp3m.ca_num * sizeof(double));
+  dp3m.ca_frac = Utils::realloc(dp3m.ca_frac, dp3m.params.cao3 * dp3m.ca_num *
+                                                  sizeof(double));
   dp3m.ca_fmp = Utils::realloc(dp3m.ca_fmp, dp3m.ca_num * sizeof(int));
 }
 
@@ -1360,8 +1360,8 @@ void dp3m_calc_meshift(void) {
   int i;
   double dmesh;
   dmesh = (double)dp3m.params.mesh[0];
-  dp3m.meshift = Utils::realloc(dp3m.meshift,
-                                          dp3m.params.mesh[0] * sizeof(double));
+  dp3m.meshift =
+      Utils::realloc(dp3m.meshift, dp3m.params.mesh[0] * sizeof(double));
   for (i = 0; i < dp3m.params.mesh[0]; i++)
     dp3m.meshift[i] = i - dround(i / dmesh) * dmesh;
 }
@@ -1373,8 +1373,7 @@ void dp3m_calc_differential_operator() {
   double dmesh;
 
   dmesh = (double)dp3m.params.mesh[0];
-  dp3m.d_op =
-      Utils::realloc(dp3m.d_op, dp3m.params.mesh[0] * sizeof(double));
+  dp3m.d_op = Utils::realloc(dp3m.d_op, dp3m.params.mesh[0] * sizeof(double));
 
   for (i = 0; i < dp3m.params.mesh[0]; i++)
     dp3m.d_op[i] = (double)i - dround((double)i / dmesh) * dmesh;
@@ -1418,10 +1417,11 @@ void dp3m_calc_influence_function_force() {
         else {
           denominator = dp3m_perform_aliasing_sums_force(n, nominator);
           fak2 = nominator[0];
-          fak2 /= pow(SQR(dp3m.d_op[n[0]]) + SQR(dp3m.d_op[n[1]]) +
-                          SQR(dp3m.d_op[n[2]]),
-                      3) *
-                  SQR(denominator);
+          fak2 /=
+              pow(Utils::sqr(dp3m.d_op[n[0]]) + Utils::sqr(dp3m.d_op[n[1]]) +
+                      Utils::sqr(dp3m.d_op[n[2]]),
+                  3) *
+              Utils::sqr(denominator);
           dp3m.g_force[ind] = fak1 * fak2;
         }
       }
@@ -1440,7 +1440,7 @@ double dp3m_perform_aliasing_sums_force(int n[3], double nominator[1]) {
   nominator[0] = 0.0;
 
   f1 = 1.0 / (double)dp3m.params.mesh[0];
-  f2 = SQR(PI / (dp3m.params.alpha_L));
+  f2 = Utils::sqr(PI / (dp3m.params.alpha_L));
 
   for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
     nmx = dp3m.meshift[n[0]] + dp3m.params.mesh[0] * mx;
@@ -1452,7 +1452,7 @@ double dp3m_perform_aliasing_sums_force(int n[3], double nominator[1]) {
         nmz = dp3m.meshift[n[2]] + dp3m.params.mesh[0] * mz;
         sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
 
-        nm2 = SQR(nmx) + SQR(nmy) + SQR(nmz);
+        nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
         expo = f2 * nm2;
         f3 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
 
@@ -1483,8 +1483,7 @@ void dp3m_calc_influence_function_energy() {
     size *= dfft.plan[3].new_mesh[i];
     end[i] = dfft.plan[3].start[i] + dfft.plan[3].new_mesh[i];
   }
-  dp3m.g_energy =
-      Utils::realloc(dp3m.g_energy, size * sizeof(double));
+  dp3m.g_energy = Utils::realloc(dp3m.g_energy, size * sizeof(double));
   fak1 = dp3m.params.mesh[0] * dp3m.params.mesh[0] * dp3m.params.mesh[0] * 2.0 /
          (box_l[0] * box_l[0]);
 
@@ -1505,10 +1504,11 @@ void dp3m_calc_influence_function_energy() {
         else {
           denominator = dp3m_perform_aliasing_sums_energy(n, nominator);
           fak2 = nominator[0];
-          fak2 /= pow(SQR(dp3m.d_op[n[0]]) + SQR(dp3m.d_op[n[1]]) +
-                          SQR(dp3m.d_op[n[2]]),
-                      2) *
-                  SQR(denominator);
+          fak2 /=
+              pow(Utils::sqr(dp3m.d_op[n[0]]) + Utils::sqr(dp3m.d_op[n[1]]) +
+                      Utils::sqr(dp3m.d_op[n[2]]),
+                  2) *
+              Utils::sqr(denominator);
           dp3m.g_energy[ind] = fak1 * fak2;
         }
       }
@@ -1527,7 +1527,7 @@ double dp3m_perform_aliasing_sums_energy(int n[3], double nominator[1]) {
   nominator[0] = 0.0;
 
   f1 = 1.0 / (double)dp3m.params.mesh[0];
-  f2 = SQR(PI / (dp3m.params.alpha_L));
+  f2 = Utils::sqr(PI / (dp3m.params.alpha_L));
 
   for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
     nmx = dp3m.meshift[n[0]] + dp3m.params.mesh[0] * mx;
@@ -1539,7 +1539,7 @@ double dp3m_perform_aliasing_sums_energy(int n[3], double nominator[1]) {
         nmz = dp3m.meshift[n[2]] + dp3m.params.mesh[0] * mz;
         sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
 
-        nm2 = SQR(nmx) + SQR(nmy) + SQR(nmz);
+        nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
         expo = f2 * nm2;
         f3 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
 
@@ -1554,13 +1554,13 @@ double dp3m_perform_aliasing_sums_energy(int n[3], double nominator[1]) {
   return denominator;
 }
 
-/*****************************************************************************/
+  /*****************************************************************************/
 
-/************************************************
- * Functions for dipoloar P3M Parameter tuning
- * This tuning is based on the P3M tuning of the charges
- which in turn is based on the P3M_tune by M. Deserno
- ************************************************/
+  /************************************************
+   * Functions for dipoloar P3M Parameter tuning
+   * This tuning is based on the P3M tuning of the charges
+   which in turn is based on the P3M_tune by M. Deserno
+   ************************************************/
 
 #define P3M_TUNE_MAX_CUTS 50
 /** Tune dipolar P3M parameters to desired accuracy.
@@ -1647,7 +1647,7 @@ double dp3m_get_accuracy(int mesh, int cao, double r_cut_iL, double *_alpha_L,
   *_ks_err = ks_err;
   P3M_TRACE(fprintf(stderr, "dipolar tuning resulting: %f -> %f %f\n", alpha_L,
                     rs_err, ks_err));
-  return sqrt(SQR(rs_err) + SQR(ks_err));
+  return sqrt(Utils::sqr(rs_err) + Utils::sqr(ks_err));
 }
 
 /*****************************************************************************/
@@ -1924,8 +1924,9 @@ static double dp3m_m_time(char **log, int mesh, int cao_min, int cao_max,
     else if (tmp_time > best_time + P3M_TIME_GRAN)
       break;
   }
-  P3M_TRACE(fprintf(stderr, "dp3m_m_time: "
-                            "Dmesh=%d final Dcao=%d Dr_cut=%f time=%f\n",
+  P3M_TRACE(fprintf(stderr,
+                    "dp3m_m_time: "
+                    "Dmesh=%d final Dcao=%d Dr_cut=%f time=%f\n",
                     mesh, *_cao, *_r_cut_iL, best_time));
   return best_time;
 }
@@ -1968,8 +1969,9 @@ int dp3m_adaptive_tune(char **logger) {
   mpi_bcast_event(P3M_COUNT_DIPOLES);
 
   /* Print Status */
-  sprintf(b, "Dipolar P3M tune parameters: Accuracy goal = %.5e prefactor "
-             "= %.5e\n",
+  sprintf(b,
+          "Dipolar P3M tune parameters: Accuracy goal = %.5e prefactor "
+          "= %.5e\n",
           dp3m.params.accuracy, coulomb.Dprefactor);
   *logger = strcat_alloc(*logger, b);
   sprintf(b, "System: box_l = %.5e # charged part = %d Sum[q_i^2] = %.5e\n",
@@ -2110,7 +2112,8 @@ void dp3m_count_magnetic_particles() {
 
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm != 0.0) {
-      node_sums[0] += SQR(p.r.dip[0]) + SQR(p.r.dip[1]) + SQR(p.r.dip[2]);
+      node_sums[0] += Utils::sqr(p.r.dip[0]) + Utils::sqr(p.r.dip[1]) +
+                      Utils::sqr(p.r.dip[2]);
       node_sums[1] += 1.0;
     }
   }
@@ -2143,13 +2146,13 @@ static double dp3m_k_space_error(double box_size, double prefac, int mesh,
     for (ny = -mesh / 2; ny < mesh / 2; ny++)
       for (nz = -mesh / 2; nz < mesh / 2; nz++)
         if ((nx != 0) || (ny != 0) || (nz != 0)) {
-          n2 = SQR(nx) + SQR(ny) + SQR(nz);
+          n2 = Utils::sqr(nx) + Utils::sqr(ny) + Utils::sqr(nz);
           cs = p3m_analytic_cotangent_sum(nx, mesh_i, cao) *
                p3m_analytic_cotangent_sum(ny, mesh_i, cao) *
                p3m_analytic_cotangent_sum(nz, mesh_i, cao);
           dp3m_tune_aliasing_sums(nx, ny, nz, mesh, mesh_i, cao, alpha_L_i,
                                   &alias1, &alias2);
-          double d = alias1 - SQR(alias2 / cs) / (n2 * n2 * n2);
+          double d = alias1 - Utils::sqr(alias2 / cs) / (n2 * n2 * n2);
           /* at high precisions, d can become negative due to extinction;
              also, don't take values that have no significant digits left*/
           if (d > 0 && (fabs(d / alias1) > ROUND_ERROR_PREC))
@@ -2169,7 +2172,7 @@ void dp3m_tune_aliasing_sums(int nx, int ny, int nz, int mesh, double mesh_i,
 
   double ex, ex2, nm2, U2, factor1;
 
-  factor1 = SQR(PI * alpha_L_i);
+  factor1 = Utils::sqr(PI * alpha_L_i);
 
   *alias1 = *alias2 = 0.0;
   for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
@@ -2179,8 +2182,8 @@ void dp3m_tune_aliasing_sums(int nx, int ny, int nz, int mesh, double mesh_i,
       for (mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
         fnmz = mesh_i * (nmz = nz + mz * mesh);
 
-        nm2 = SQR(nmx) + SQR(nmy) + SQR(nmz);
-        ex2 = SQR(ex = exp(-factor1 * nm2));
+        nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
+        ex2 = Utils::sqr(ex = exp(-factor1 * nm2));
 
         U2 = pow(sinc(fnmx) * sinc(fnmy) * sinc(fnmz), 2.0 * cao);
 
@@ -2223,9 +2226,9 @@ double P3M_DIPOLAR_real_space_error(double box_size, double prefac,
   d_con = 1.0 / sqrt(box_size * box_size * box_size * d_a2 * d_a2 * d_rcut2 *
                      d_rcut2 * d_rcut2 * d_rcut2 * d_RCUT * (double)n_c_part);
 
-  d_error_f =
-      d_c * d_con * sqrt((13. / 6.) * d_cc * d_cc + (2. / 15.) * d_dc * d_dc -
-                         (13. / 15.) * d_cc * d_dc);
+  d_error_f = d_c * d_con *
+              sqrt((13. / 6.) * d_cc * d_cc + (2. / 15.) * d_dc * d_dc -
+                   (13. / 15.) * d_cc * d_dc);
 
   return d_error_f;
 }
@@ -2538,7 +2541,7 @@ void dp3m_calc_send_mesh() {
 
 void dp3m_scaleby_box_l() {
   if (coulomb.Dprefactor < 0.0) {
-    runtimeErrorMsg() << "Dipolar prefactor has to be >=0" ;
+    runtimeErrorMsg() << "Dipolar prefactor has to be >=0";
     return;
   }
 
@@ -2576,8 +2579,8 @@ void dp3m_compute_constants_energy_dipolar() {
   dp3m.energy_correction = -dp3m.sum_mu2 * (Ukp3m + Eself + 2. * PI / 3.);
 }
 
-/*****************************************************************************/
+  /*****************************************************************************/
 
-/*****************************************************************************/
+  /*****************************************************************************/
 
 #endif /* DP3M */

--- a/src/core/p3m.cpp
+++ b/src/core/p3m.cpp
@@ -837,8 +837,8 @@ double p3m_calc_kspace_forces(int force_flag, int energy_flag) {
 
     for (i = 0; i < fft.plan[3].new_size; i++) {
       // Use the energy optimized influence function for energy!
-      node_k_space_energy += p3m.g_energy[i] * (SQR(p3m.rs_mesh[2 * i]) +
-                                                SQR(p3m.rs_mesh[2 * i + 1]));
+      node_k_space_energy += p3m.g_energy[i] * (Utils::sqr(p3m.rs_mesh[2 * i]) +
+                                                Utils::sqr(p3m.rs_mesh[2 * i + 1]));
     }
     node_k_space_energy *= force_prefac;
 
@@ -851,7 +851,7 @@ double p3m_calc_kspace_forces(int force_flag, int energy_flag) {
       /* net charge correction */
       k_space_energy -=
           coulomb.prefactor * p3m.square_sum_q * PI /
-          (2.0 * box_l[0] * box_l[1] * box_l[2] * SQR(p3m.params.alpha));
+          (2.0 * box_l[0] * box_l[1] * box_l[2] * Utils::sqr(p3m.params.alpha));
     }
 
   } /* if (energy_flag) */
@@ -960,7 +960,7 @@ double p3m_calc_dipole_term(int force_flag, int energy_flag) {
   MPI_Allreduce(lcl_dm, gbl_dm, 3, MPI_DOUBLE, MPI_SUM, comm_cart);
 
   if (energy_flag)
-    en = 0.5 * pref * (SQR(gbl_dm[0]) + SQR(gbl_dm[1]) + SQR(gbl_dm[2]));
+    en = 0.5 * pref * (Utils::sqr(gbl_dm[0]) + Utils::sqr(gbl_dm[1]) + Utils::sqr(gbl_dm[2]));
   else
     en = 0;
   if (force_flag) {
@@ -1139,7 +1139,7 @@ inline double perform_aliasing_sums_force(int n[3], double numerator[3]) {
   for (i = 0; i < 3; i++)
     numerator[i] = 0.0;
 
-  f1 = SQR(PI / (p3m.params.alpha));
+  f1 = Utils::sqr(PI / (p3m.params.alpha));
 
   for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
     nmx = p3m.meshift_x[n[KX]] + p3m.params.mesh[RX] * mx;
@@ -1152,7 +1152,7 @@ inline double perform_aliasing_sums_force(int n[3], double numerator[3]) {
         sz = sy * int_pow<2 * cao>(sinc(nmz / (double)p3m.params.mesh[RZ]));
 
         nm2 =
-            SQR(nmx / box_l[RX]) + SQR(nmy / box_l[RY]) + SQR(nmz / box_l[RZ]);
+            Utils::sqr(nmx / box_l[RX]) + Utils::sqr(nmy / box_l[RY]) + Utils::sqr(nmz / box_l[RZ]);
         expo = f1 * nm2;
         f2 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
 
@@ -1211,11 +1211,11 @@ template <int cao> void calc_influence_function_force() {
           fak1 = p3m.d_op[RX][n[KX]] * nominator[RX] / box_l[RX] +
                  p3m.d_op[RY][n[KY]] * nominator[RY] / box_l[RY] +
                  p3m.d_op[RZ][n[KZ]] * nominator[RZ] / box_l[RZ];
-          fak2 = SQR(p3m.d_op[RX][n[KX]] / box_l[RX]) +
-                 SQR(p3m.d_op[RY][n[KY]] / box_l[RY]) +
-                 SQR(p3m.d_op[RZ][n[KZ]] / box_l[RZ]);
+          fak2 = Utils::sqr(p3m.d_op[RX][n[KX]] / box_l[RX]) +
+                 Utils::sqr(p3m.d_op[RY][n[KY]] / box_l[RY]) +
+                 Utils::sqr(p3m.d_op[RZ][n[KZ]] / box_l[RZ]);
 
-          fak3 = fak1 / (fak2 * SQR(denominator));
+          fak3 = fak1 / (fak2 * Utils::sqr(denominator));
           p3m.g_force[ind] = 2 * fak3 / (PI);
         }
       }
@@ -1260,7 +1260,7 @@ template <int cao> inline double perform_aliasing_sums_energy(int n[3]) {
   double sx, sy, sz, f1, f2, mx, my, mz, nmx, nmy, nmz, nm2, expo;
   double limit = 30;
 
-  f1 = SQR(PI / (p3m.params.alpha));
+  f1 = Utils::sqr(PI / (p3m.params.alpha));
 
   for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
     nmx = p3m.meshift_x[n[KX]] + p3m.params.mesh[RX] * mx;
@@ -1273,7 +1273,7 @@ template <int cao> inline double perform_aliasing_sums_energy(int n[3]) {
         sz = sy * int_pow<2 * cao>(sinc(nmz / (double)p3m.params.mesh[RZ]));
         /* k = 2*pi * (nx/lx, ny/ly, nz/lz); expo = -k^2 / 4*alpha^2 */
         nm2 =
-            SQR(nmx / box_l[RX]) + SQR(nmy / box_l[RY]) + SQR(nmz / box_l[RZ]);
+            Utils::sqr(nmx / box_l[RX]) + Utils::sqr(nmy / box_l[RY]) + Utils::sqr(nmz / box_l[RZ]);
         expo = f1 * nm2;
         f2 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
 
@@ -1283,7 +1283,7 @@ template <int cao> inline double perform_aliasing_sums_energy(int n[3]) {
     }
   }
 
-  return numerator / SQR(denominator);
+  return numerator / Utils::sqr(denominator);
 }
 
 template <int cao> void calc_influence_function_energy() {
@@ -1408,8 +1408,8 @@ static double p3m_get_accuracy(int mesh[3], int cao, double r_cut_iL,
   *_ks_err = ks_err;
   P3M_TRACE(fprintf(
       stderr, "resulting: alpha_L %g -> rs_err: %g, ks_err %g, total_err %g\n",
-      alpha_L, rs_err, ks_err, sqrt(SQR(rs_err) + SQR(ks_err))));
-  return sqrt(SQR(rs_err) + SQR(ks_err));
+      alpha_L, rs_err, ks_err, sqrt(Utils::sqr(rs_err) + Utils::sqr(ks_err))));
+  return sqrt(Utils::sqr(rs_err) + Utils::sqr(ks_err));
 }
 
 /** get the optimal alpha and the corresponding computation time for fixed
@@ -1945,7 +1945,7 @@ void p3m_count_charged_particles() {
   for (auto const &p : local_cells.particles()) {
     if (p.p.q != 0.0) {
       node_sums[0] += 1.0;
-      node_sums[1] += SQR(p.p.q);
+      node_sums[1] += Utils::sqr(p.p.q);
       node_sums[2] += p.p.q;
     }
   }
@@ -1953,7 +1953,7 @@ void p3m_count_charged_particles() {
   MPI_Allreduce(node_sums, tot_sums, 3, MPI_DOUBLE, MPI_SUM, comm_cart);
   p3m.sum_qpart = (int)(tot_sums[0] + 0.1);
   p3m.sum_q2 = tot_sums[1];
-  p3m.square_sum_q = SQR(tot_sums[2]);
+  p3m.square_sum_q = Utils::sqr(tot_sums[2]);
 
   P3M_TRACE(fprintf(
       stderr, "%d: p3m.sum_qpart: %d, p3m.sum_q2: %lf, total_charge %lf\n",
@@ -1962,7 +1962,7 @@ void p3m_count_charged_particles() {
 
 double p3m_real_space_error(double prefac, double r_cut_iL, int n_c_part,
                             double sum_q2, double alpha_L) {
-  return (2.0 * prefac * sum_q2 * exp(-SQR(r_cut_iL * alpha_L))) /
+  return (2.0 * prefac * sum_q2 * exp(-Utils::sqr(r_cut_iL * alpha_L))) /
          sqrt((double)n_c_part * r_cut_iL * box_l[0] * box_l[0] * box_l[1] *
               box_l[2]);
 }
@@ -1981,12 +1981,12 @@ double p3m_k_space_error(double prefac, int mesh[3], int cao, int n_c_part,
       ctan_y = ctan_x * p3m_analytic_cotangent_sum(ny, mesh_i[1], cao);
       for (nz = -mesh[2] / 2; nz < mesh[2] / 2; nz++) {
         if ((nx != 0) || (ny != 0) || (nz != 0)) {
-          n2 = SQR(nx) + SQR(ny) + SQR(nz);
+          n2 = Utils::sqr(nx) + Utils::sqr(ny) + Utils::sqr(nz);
           cs = p3m_analytic_cotangent_sum(nz, mesh_i[2], cao) * ctan_y;
           p3m_tune_aliasing_sums(nx, ny, nz, mesh, mesh_i, cao, alpha_L_i,
                                  &alias1, &alias2);
 
-          double d = alias1 - SQR(alias2 / cs) / n2;
+          double d = alias1 - Utils::sqr(alias2 / cs) / n2;
           /* at high precisions, d can become negative due to extinction;
              also, don't take values that have no significant digits left*/
           if (d > 0 && (fabs(d / alias1) > ROUND_ERROR_PREC))
@@ -2009,7 +2009,7 @@ void p3m_tune_aliasing_sums(int nx, int ny, int nz, int mesh[3],
 
   double ex, ex2, nm2, U2, factor1;
 
-  factor1 = SQR(PI * alpha_L_i);
+  factor1 = Utils::sqr(PI * alpha_L_i);
 
   *alias1 = *alias2 = 0.0;
   for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
@@ -2019,8 +2019,8 @@ void p3m_tune_aliasing_sums(int nx, int ny, int nz, int mesh[3],
       for (mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
         fnmz = mesh_i[2] * (nmz = nz + mz * mesh[2]);
 
-        nm2 = SQR(nmx) + SQR(nmy) + SQR(nmz);
-        ex2 = SQR(ex = exp(-factor1 * nm2));
+        nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
+        ex2 = Utils::sqr(ex = exp(-factor1 * nm2));
 
         U2 = pow(sinc(fnmx) * sinc(fnmy) * sinc(fnmz), 2.0 * cao);
 
@@ -2340,19 +2340,19 @@ void p3m_calc_kspace_stress(double *stress) {
                box_l[RY];
           kz = 2.0 * PI * p3m.d_op[RZ][j[KZ] + fft.plan[3].start[KZ]] /
                box_l[RZ];
-          sqk = SQR(kx) + SQR(ky) + SQR(kz);
+          sqk = Utils::sqr(kx) + Utils::sqr(ky) + Utils::sqr(kz);
           if (sqk == 0) {
             node_k_space_energy = 0.0;
             vterm = 0.0;
           } else {
-            vterm = -2.0 * (1 / sqk + SQR(1.0 / 2.0 / p3m.params.alpha));
+            vterm = -2.0 * (1 / sqk + Utils::sqr(1.0 / 2.0 / p3m.params.alpha));
             node_k_space_energy =
                 p3m.g_energy[ind] *
-                (SQR(p3m.rs_mesh[2 * ind]) + SQR(p3m.rs_mesh[2 * ind + 1]));
+                (Utils::sqr(p3m.rs_mesh[2 * ind]) + Utils::sqr(p3m.rs_mesh[2 * ind + 1]));
           }
           ind++;
           node_k_space_stress[0] +=
-              node_k_space_energy * (1.0 + vterm * SQR(kx)); /* sigma_xx */
+              node_k_space_energy * (1.0 + vterm * Utils::sqr(kx)); /* sigma_xx */
           node_k_space_stress[1] +=
               node_k_space_energy * (vterm * kx * ky); /* sigma_xy */
           node_k_space_stress[2] +=
@@ -2361,7 +2361,7 @@ void p3m_calc_kspace_stress(double *stress) {
           node_k_space_stress[3] +=
               node_k_space_energy * (vterm * kx * ky); /* sigma_yx */
           node_k_space_stress[4] +=
-              node_k_space_energy * (1.0 + vterm * SQR(ky)); /* sigma_yy */
+              node_k_space_energy * (1.0 + vterm * Utils::sqr(ky)); /* sigma_yy */
           node_k_space_stress[5] +=
               node_k_space_energy * (vterm * ky * kz); /* sigma_yz */
 
@@ -2370,7 +2370,7 @@ void p3m_calc_kspace_stress(double *stress) {
           node_k_space_stress[7] +=
               node_k_space_energy * (vterm * ky * kz); /* sigma_zy */
           node_k_space_stress[8] +=
-              node_k_space_energy * (1.0 + vterm * SQR(kz)); /* sigma_zz */
+              node_k_space_energy * (1.0 + vterm * Utils::sqr(kz)); /* sigma_zz */
         }
       }
     }

--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -96,7 +96,7 @@ double buf_mindist4(double pos[3], int n_add, double *add) {
     dy -= dround(dy / box_l[1]) * box_l[1];
     dz = pos[2] - add[3 * i + 2];
     dz -= dround(dz / box_l[2]) * box_l[2];
-    mindist = std::min(mindist, SQR(dx) + SQR(dy) + SQR(dz));
+    mindist = std::min(mindist, Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
   }
   if (mindist < 30000.0)
     return (sqrt(mindist));
@@ -204,8 +204,8 @@ int polymerC(PartCfg & partCfg, int N_P, int MPC, double bond_length, int part_i
         pos[1] = posed2[1];
         pos[2] = posed2[2];
         /* calculate preceding monomer so that bond_length is correct */
-        absc = sqrt(SQR(pos[0] - poz[0]) + SQR(pos[1] - poz[1]) +
-                    SQR(pos[2] - poz[2]));
+        absc = sqrt(Utils::sqr(pos[0] - poz[0]) + Utils::sqr(pos[1] - poz[1]) +
+                    Utils::sqr(pos[2] - poz[2]));
         poz[0] = pos[0] + (poz[0] - pos[0]) * bond_length / absc;
         poz[1] = pos[1] + (poz[1] - pos[1]) * bond_length / absc;
         poz[2] = pos[2] + (poz[2] - pos[2]) * bond_length / absc;
@@ -215,7 +215,7 @@ int polymerC(PartCfg & partCfg, int N_P, int MPC, double bond_length, int part_i
         /* randomly place 2nd monomer */
         for (cnt1 = 0; cnt1 < max_try; cnt1++) {
           zz = (2.0 * d_random() - 1.0) * bond_length;
-          rr = sqrt(SQR(bond_length) - SQR(zz));
+          rr = sqrt(Utils::sqr(bond_length) - Utils::sqr(zz));
           phi = 2.0 * PI * d_random();
           pos[0] = poz[0] + rr * cos(phi);
           pos[1] = poz[1] + rr * sin(phi);
@@ -322,7 +322,7 @@ int polymerC(PartCfg & partCfg, int N_P, int MPC, double bond_length, int part_i
 
           } else {
             zz = (2.0 * d_random() - 1.0) * bond_length;
-            rr = sqrt(SQR(bond_length) - SQR(zz));
+            rr = sqrt(Utils::sqr(bond_length) - Utils::sqr(zz));
             phi = 2.0 * PI * d_random();
             pos[0] = poz[0] + rr * cos(phi);
             pos[1] = poz[1] + rr * sin(phi);
@@ -330,7 +330,7 @@ int polymerC(PartCfg & partCfg, int N_P, int MPC, double bond_length, int part_i
           }
 
 // POLY_TRACE(/* printf("a=(%f,%f,%f) absa=%f M=(%f,%f,%f) c=(%f,%f,%f) absMc=%f
-// a*c=%f)\n",a[0],a[1],a[2],sqrt(SQR(a[0])+SQR(a[1])+SQR(a[2])),M[0],M[1],M[2],c[0],c[1],c[2],sqrt(SQR(M[0]+c[0])+SQR(M[1]+c[1])+SQR(M[2]+c[2])),a[0]*c[0]+a[1]*c[1]+a[2]*c[2])
+// a*c=%f)\n",a[0],a[1],a[2],sqrt(Utils::sqr(a[0])+Utils::sqr(a[1])+Utils::sqr(a[2])),M[0],M[1],M[2],c[0],c[1],c[2],sqrt(Utils::sqr(M[0]+c[0])+Utils::sqr(M[1]+c[1])+Utils::sqr(M[2]+c[2])),a[0]*c[0]+a[1]*c[1]+a[2]*c[2])
 // */);
 // POLY_TRACE(/* printf("placed Monomer %d at
 // (%f,%f,%f)\n",n,pos[0],pos[1],pos[2]) */);
@@ -583,7 +583,7 @@ int icosaederC(PartCfg & partCfg, double ico_a, int MPC, int N_CI, double val_cM
         for (l = 0; l < 3; l++)
           vec[l] =
               (ico_coord[ico_NN[i][0]][l] - ico_coord[ico_NN[i][4]][l]) / 3.;
-      vec_l = sqrt(SQR(vec[0]) + SQR(vec[1]) + SQR(vec[2]));
+      vec_l = sqrt(Utils::sqr(vec[0]) + Utils::sqr(vec[1]) + Utils::sqr(vec[2]));
       for (l = 0; l < 3; l++)
         e_vec[l] = vec[l] / vec_l;
 
@@ -617,7 +617,7 @@ int icosaederC(PartCfg & partCfg, double ico_a, int MPC, int N_CI, double val_cM
       if (i < ico_NN[i][j]) {
         for (l = 0; l < 3; l++)
           vec[l] = (ico_coord[ico_NN[i][j]][l] - ico_coord[i][l]) / 3.;
-        vec_l = sqrt(SQR(vec[0]) + SQR(vec[1]) + SQR(vec[2]));
+        vec_l = sqrt(Utils::sqr(vec[0]) + Utils::sqr(vec[1]) + Utils::sqr(vec[2]));
         for (l = 0; l < 3; l++)
           e_vec[l] = vec[l] / vec_l;
 

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -826,7 +826,7 @@ int get_nonbonded_interaction(Particle *p1, Particle *p2, double *force, Distanc
   if ((p1->p.identity != p2->p.identity)&&(checkIfParticlesInteract(p1->p.type, p2->p.type))) {
     /* distance calculation */
     get_mi_vector(d, p1->r.p, p2->r.p);
-    dist2 = SQR(d[0]) + SQR(d[1]) + SQR(d[2]);
+    dist2 = Utils::sqr(d[0]) + Utils::sqr(d[1]) + Utils::sqr(d[2]);
     dist  = sqrt(dist2);
     calc_non_bonded_pair_force(p1,p2,d,dist,dist2,force);
 #ifdef ELECTROSTATICS

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -25,14 +25,13 @@
 #ifndef CORE_PRESSURE_INLINE_HPP
 #define CORE_PRESSURE_INLINE_HPP
 
-#include "pressure.hpp"
-#include "forces_inline.hpp"
-#include "utils.hpp"
 #include "debug.hpp"
-#include "integrate.hpp"
-#include "thermostat.hpp"
 #include "forces_inline.hpp"
+#include "integrate.hpp"
 #include "npt.hpp"
+#include "pressure.hpp"
+#include "thermostat.hpp"
+#include "utils.hpp"
 
 /** Calculate non bonded energies between a pair of particles.
     @param p1        pointer to particle 1.
@@ -41,8 +40,7 @@
     @param dist      distance between p1 and p2.
     @param dist2     distance squared between p1 and p2. */
 inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2, double d[3],
-					  double dist, double dist2)
-{
+                                        double dist, double dist2) {
   int p1molid, p2molid, k, l;
   double force[3] = {0, 0, 0};
 
@@ -89,12 +87,14 @@ inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2, double d[3],
 #ifdef P3M
     case COULOMB_P3M_GPU:
     case COULOMB_P3M:
-	  force[0] = 0.0; force[1] = 0.0; force[2] = 0.0;
-	  p3m_add_pair_force(p1->p.q*p2->p.q, d, dist2, dist, force);
-      virials.coulomb[0] += p3m_pair_energy(p1->p.q*p2->p.q,d,dist2,dist);
-	  for (k = 0; k<3; k++)
-		  for (l = 0; l<3; l++)
-			  p_tensor.coulomb[k*3 + l] += force[k]*d[l];
+      force[0] = 0.0;
+      force[1] = 0.0;
+      force[2] = 0.0;
+      p3m_add_pair_force(p1->p.q * p2->p.q, d, dist2, dist, force);
+      virials.coulomb[0] += p3m_pair_energy(p1->p.q * p2->p.q, d, dist2, dist);
+      for (k = 0; k < 3; k++)
+        for (l = 0; l < 3; l++)
+          p_tensor.coulomb[k * 3 + l] += force[k] * d[l];
 
       break;
 #endif
@@ -103,29 +103,30 @@ inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2, double d[3],
     /***************************************************/
     case COULOMB_DH: {
       double force[3] = {0, 0, 0};
-    
-      add_dh_coulomb_pair_force(p1,p2,d,dist, force);
-      for(k=0;k<3;k++)
-	for(l=0;l<3;l++)
-	  p_tensor.coulomb[k*3 + l] += force[k]*d[l];
-      virials.coulomb[0] += force[0]*d[0] + force[1]*d[1] + force[2]*d[2];
+
+      add_dh_coulomb_pair_force(p1, p2, d, dist, force);
+      for (k = 0; k < 3; k++)
+        for (l = 0; l < 3; l++)
+          p_tensor.coulomb[k * 3 + l] += force[k] * d[l];
+      virials.coulomb[0] += force[0] * d[0] + force[1] * d[1] + force[2] * d[2];
       break;
     }
     case COULOMB_RF: {
       double force[3] = {0, 0, 0};
-    
-      add_rf_coulomb_pair_force(p1,p2,d,dist, force);
-      for(k=0;k<3;k++)
-	for(l=0;l<3;l++)
-	  p_tensor.coulomb[k*3 + l] += force[k]*d[l];
-      virials.coulomb[0] += force[0]*d[0] + force[1]*d[1] + force[2]*d[2];
+
+      add_rf_coulomb_pair_force(p1, p2, d, dist, force);
+      for (k = 0; k < 3; k++)
+        for (l = 0; l < 3; l++)
+          p_tensor.coulomb[k * 3 + l] += force[k] * d[l];
+      virials.coulomb[0] += force[0] * d[0] + force[1] * d[1] + force[2] * d[2];
       break;
     }
     case COULOMB_INTER_RF:
       // this is done together with the other short range interactions
       break;
     default:
-      fprintf(stderr,"calculating pressure for electrostatics method that doesn't have it implemented\n");
+      fprintf(stderr, "calculating pressure for electrostatics method that "
+                      "doesn't have it implemented\n");
       break;
     }
   }
@@ -134,104 +135,140 @@ inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2, double d[3],
 #ifdef DIPOLES
   /* real space magnetic dipole-dipole */
   if (coulomb.Dmethod != DIPOLAR_NONE) {
-    fprintf(stderr,"calculating pressure for magnetostatics which doesn't have it implemented\n");
+    fprintf(stderr, "calculating pressure for magnetostatics which doesn't "
+                    "have it implemented\n");
   }
 #endif /*ifdef DIPOLES */
 }
 
-inline void calc_bonded_force(Particle *p1, Particle *p2, Bonded_ia_parameters *iaparams, int *i, double dx[3], double force[3]) {
+inline void calc_bonded_force(Particle *p1, Particle *p2,
+                              Bonded_ia_parameters *iaparams, int *i,
+                              double dx[3], double force[3]) {
 #ifdef TABULATED
-  //char* errtxt;
+// char* errtxt;
 #endif
 
   /* Calculates the bonded force between two particles */
-    switch(iaparams->type) {
-    case BONDED_IA_FENE:
-      calc_fene_pair_force(p1,p2,iaparams,dx,force);
-      break;
+  switch (iaparams->type) {
+  case BONDED_IA_FENE:
+    calc_fene_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #ifdef ROTATION
-    case BONDED_IA_HARMONIC_DUMBBELL:
-      calc_harmonic_dumbbell_pair_force(p1,p2,iaparams,dx,force);
-      break;
+  case BONDED_IA_HARMONIC_DUMBBELL:
+    calc_harmonic_dumbbell_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
-    case BONDED_IA_HARMONIC:
-      calc_harmonic_pair_force(p1,p2,iaparams,dx,force);
-      break;
+  case BONDED_IA_HARMONIC:
+    calc_harmonic_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #ifdef LENNARD_JONES
-    case BONDED_IA_SUBT_LJ:
-      calc_subt_lj_pair_force(p1,p2,iaparams,dx,force);
-      break;
+  case BONDED_IA_SUBT_LJ:
+    calc_subt_lj_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
-      /* since it is not clear at the moment how to handle a many body interaction here, I skip it */
-    case BONDED_IA_ANGLE_HARMONIC:
-      (*i)++; force[0] = force[1] = force[2] = 0; break;
-    case BONDED_IA_ANGLE_COSINE:
-      (*i)++; force[0] = force[1] = force[2] = 0; break;
-    case BONDED_IA_ANGLE_COSSQUARE:
-      (*i)++; force[0] = force[1] = force[2] = 0; break;
-    case BONDED_IA_ANGLEDIST:
-      (*i)++; force[0] = force[1] = force[2] = 0; break;
-    case BONDED_IA_DIHEDRAL:
-      (*i)+=2; force[0] = force[1] = force[2] = 0; break;
+    /* since it is not clear at the moment how to handle a many body interaction
+     * here, I skip it */
+  case BONDED_IA_ANGLE_HARMONIC:
+    (*i)++;
+    force[0] = force[1] = force[2] = 0;
+    break;
+  case BONDED_IA_ANGLE_COSINE:
+    (*i)++;
+    force[0] = force[1] = force[2] = 0;
+    break;
+  case BONDED_IA_ANGLE_COSSQUARE:
+    (*i)++;
+    force[0] = force[1] = force[2] = 0;
+    break;
+  case BONDED_IA_ANGLEDIST:
+    (*i)++;
+    force[0] = force[1] = force[2] = 0;
+    break;
+  case BONDED_IA_DIHEDRAL:
+    (*i) += 2;
+    force[0] = force[1] = force[2] = 0;
+    break;
 
 #ifdef TABULATED
-    case BONDED_IA_TABULATED:
-      // printf("BONDED TAB, Particle: %d, P2: %d TYPE_TAB: %d\n",p1->p.identity,p2->p.identity,iparams->p.tab.type);
-      switch(iaparams->p.tab.type) {
-        case TAB_BOND_LENGTH:
-	  calc_tab_bond_force(p1, p2, iaparams, dx, force); break;
-        case TAB_BOND_ANGLE:
-          (*i)++; force[0] = force[1] = force[2] = 0; break;
-        case TAB_BOND_DIHEDRAL:
-          (*i)+=2; force[0] = force[1] = force[2] = 0; break;
-        default:
-          runtimeErrorMsg() <<"calc_bonded_force: tabulated bond type of atom " << p1->p.identity << " unknown\n";
-	  return;
-      }
+  case BONDED_IA_TABULATED:
+    // printf("BONDED TAB, Particle: %d, P2: %d TYPE_TAB:
+    // %d\n",p1->p.identity,p2->p.identity,iparams->p.tab.type);
+    switch (iaparams->p.tab.type) {
+    case TAB_BOND_LENGTH:
+      calc_tab_bond_force(p1, p2, iaparams, dx, force);
       break;
-#endif
-#ifdef OVERLAPPED
-    case BONDED_IA_OVERLAPPED:
-      // printf("BONDED OVERLAP, Particle: %d, P2: %d TYPE_OVERLAP: %d\n",p1->p.identity,p2->p.identity,iparams->p.tab.type);
-      //char *errtxt;
-      switch(iaparams->p.overlap.type) {
-        case OVERLAP_BOND_LENGTH:
-          calc_overlap_bond_force(p1, p2, iaparams, dx, force); break;
-        case OVERLAP_BOND_ANGLE:
-          (*i)++; force[0] = force[1] = force[2] = 0; break;
-        case OVERLAP_BOND_DIHEDRAL:
-          (*i)+=2; force[0] = force[1] = force[2] = 0; break;
-        default:
-          runtimeErrorMsg() <<"calc_bonded_force: overlapped bond type of atom " << p1->p.identity << " unknown\n";
-          return;
-      }
-      break;
-#endif
-#ifdef BOND_CONSTRAINT
-    case BONDED_IA_RIGID_BOND:
-      force[0] = force[1] = force[2] = 0; break;
-#endif
-    case BONDED_IA_VIRTUAL_BOND:
-      force[0] = force[1] = force[2] = 0; break;
-    default :
-      //      fprintf(stderr,"add_bonded_virials: WARNING: Bond type %d of atom %d unhandled\n",bonded_ia_params[type_num].type,p1->p.identity);
-      fprintf(stderr,"add_bonded_virials: WARNING: Bond type %d , atom %d unhandled, Atom 2: %d\n",iaparams->type,p1->p.identity,p2->p.identity);
+    case TAB_BOND_ANGLE:
+      (*i)++;
       force[0] = force[1] = force[2] = 0;
       break;
+    case TAB_BOND_DIHEDRAL:
+      (*i) += 2;
+      force[0] = force[1] = force[2] = 0;
+      break;
+    default:
+      runtimeErrorMsg() << "calc_bonded_force: tabulated bond type of atom "
+                        << p1->p.identity << " unknown\n";
+      return;
     }
+    break;
+#endif
+#ifdef OVERLAPPED
+  case BONDED_IA_OVERLAPPED:
+    // printf("BONDED OVERLAP, Particle: %d, P2: %d TYPE_OVERLAP:
+    // %d\n",p1->p.identity,p2->p.identity,iparams->p.tab.type);
+    // char *errtxt;
+    switch (iaparams->p.overlap.type) {
+    case OVERLAP_BOND_LENGTH:
+      calc_overlap_bond_force(p1, p2, iaparams, dx, force);
+      break;
+    case OVERLAP_BOND_ANGLE:
+      (*i)++;
+      force[0] = force[1] = force[2] = 0;
+      break;
+    case OVERLAP_BOND_DIHEDRAL:
+      (*i) += 2;
+      force[0] = force[1] = force[2] = 0;
+      break;
+    default:
+      runtimeErrorMsg() << "calc_bonded_force: overlapped bond type of atom "
+                        << p1->p.identity << " unknown\n";
+      return;
+    }
+    break;
+#endif
+#ifdef BOND_CONSTRAINT
+  case BONDED_IA_RIGID_BOND:
+    force[0] = force[1] = force[2] = 0;
+    break;
+#endif
+  case BONDED_IA_VIRTUAL_BOND:
+    force[0] = force[1] = force[2] = 0;
+    break;
+  default:
+    //      fprintf(stderr,"add_bonded_virials: WARNING: Bond type %d of atom %d
+    //      unhandled\n",bonded_ia_params[type_num].type,p1->p.identity);
+    fprintf(stderr,
+            "add_bonded_virials: WARNING: Bond type %d , atom %d unhandled, "
+            "Atom 2: %d\n",
+            iaparams->type, p1->p.identity, p2->p.identity);
+    force[0] = force[1] = force[2] = 0;
+    break;
+  }
 }
-
 
 /* calc_three_body_bonded_forces is called by add_three_body_bonded_stress. This
    routine is only entered for angular potentials. */
-inline void calc_three_body_bonded_forces(Particle *p1, Particle *p2, Particle *p3,
-              Bonded_ia_parameters *iaparams, double force1[3], double force2[3], double force3[3]) {
+inline void calc_three_body_bonded_forces(Particle *p1, Particle *p2,
+                                          Particle *p3,
+                                          Bonded_ia_parameters *iaparams,
+                                          double force1[3], double force2[3],
+                                          double force3[3]) {
 
 #ifdef TABULATED
-  //char* errtxt;
+// char* errtxt;
 #endif
 
-  switch(iaparams->type) {
+  switch (iaparams->type) {
 #ifdef BOND_ANGLE_OLD
   case BONDED_IA_ANGLE_OLD:
     // p1 is *p_mid, p2 is *p_left, p3 is *p_right
@@ -241,48 +278,52 @@ inline void calc_three_body_bonded_forces(Particle *p1, Particle *p2, Particle *
 #ifdef BOND_ANGLE
   case BONDED_IA_ANGLE_HARMONIC:
     // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-    calc_angle_harmonic_3body_forces(p1, p2, p3, iaparams, force1, force2, force3);
+    calc_angle_harmonic_3body_forces(p1, p2, p3, iaparams, force1, force2,
+                                     force3);
     break;
- case BONDED_IA_ANGLE_COSINE:
+  case BONDED_IA_ANGLE_COSINE:
     // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-    calc_angle_cosine_3body_forces(p1, p2, p3, iaparams, force1, force2, force3);
+    calc_angle_cosine_3body_forces(p1, p2, p3, iaparams, force1, force2,
+                                   force3);
     break;
   case BONDED_IA_ANGLE_COSSQUARE:
     // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-    calc_angle_cossquare_3body_forces(p1, p2, p3, iaparams, force1, force2, force3);
+    calc_angle_cossquare_3body_forces(p1, p2, p3, iaparams, force1, force2,
+                                      force3);
     break;
 #endif
 #ifdef TABULATED
   case BONDED_IA_TABULATED:
-    switch(iaparams->p.tab.type) {
-      case TAB_BOND_ANGLE:
-        // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-        calc_angle_3body_tabulated_forces(p1, p2, p3, iaparams, force1, force2, force3);
-        break;
-      default:
-        runtimeErrorMsg() <<"calc_bonded_force: tabulated bond type of atom " << p1->p.identity << " unknown\n";
-        return;
-      }
+    switch (iaparams->p.tab.type) {
+    case TAB_BOND_ANGLE:
+      // p1 is *p_mid, p2 is *p_left, p3 is *p_right
+      calc_angle_3body_tabulated_forces(p1, p2, p3, iaparams, force1, force2,
+                                        force3);
       break;
+    default:
+      runtimeErrorMsg() << "calc_bonded_force: tabulated bond type of atom "
+                        << p1->p.identity << " unknown\n";
+      return;
+    }
+    break;
 #endif
-  default :
-    fprintf(stderr,"calc_three_body_bonded_forces: \
-            WARNING: Bond type %d , atom %d unhandled, Atom 2: %d\n", \
-            iaparams->type, p1->p.identity, p2->p.identity);
+  default:
+    fprintf(stderr, "calc_three_body_bonded_forces: \
+            WARNING: Bond type %d , atom %d unhandled, Atom 2: %d\n", iaparams->type,
+            p1->p.identity, p2->p.identity);
     break;
   }
 }
 
-
 /** Calculate bonded virials for one particle.
-    For performance reasons the force routines add their values directly to the particles.
-    So here we do some tricks to get the value out without changing the forces.
+    For performance reasons the force routines add their values directly to the
+   particles. So here we do some tricks to get the value out without changing
+   the forces.
     @param p1 particle for which to calculate virials
 */
-inline void add_bonded_virials(Particle *p1)
-{
-  double force[3] = {0,0,0};
-  //char *errtxt;
+inline void add_bonded_virials(Particle *p1) {
+  double force[3] = {0, 0, 0};
+  // char *errtxt;
   Particle *p2;
   Bonded_ia_parameters *iaparams;
 
@@ -290,17 +331,21 @@ inline void add_bonded_virials(Particle *p1)
   int type_num;
 
   i = 0;
-  while(i<p1->bl.n) {
+  while (i < p1->bl.n) {
     type_num = p1->bl.e[i++];
     iaparams = &bonded_ia_params[type_num];
 
     /* fetch particle 2 */
     p2 = local_particles[p1->bl.e[i++]];
-    if ( ! p2 ) {
+    if (!p2) {
       // for harmonic spring:
-      // if cutoff was defined and p2 is not there it is anyway outside the cutoff, see calc_maximal_cutoff()
-      if ((type_num==BONDED_IA_HARMONIC)&&(iaparams->p.harmonic.r_cut>0)) return;
-      runtimeErrorMsg() <<"bond broken between particles " << p1->p.identity << " and " << p1->bl.e[i-1] << " (particles not stored on the same node)";
+      // if cutoff was defined and p2 is not there it is anyway outside the
+      // cutoff, see calc_maximal_cutoff()
+      if ((type_num == BONDED_IA_HARMONIC) && (iaparams->p.harmonic.r_cut > 0))
+        return;
+      runtimeErrorMsg() << "bond broken between particles " << p1->p.identity
+                        << " and " << p1->bl.e[i - 1]
+                        << " (particles not stored on the same node)";
       return;
     }
 
@@ -308,20 +353,20 @@ inline void add_bonded_virials(Particle *p1)
     double b[3] = {p2->r.p[0], p2->r.p[1], p2->r.p[2]};
     auto dx = get_mi_vector(a, b);
 #ifdef LEES_EDWARDS
-    double n_le_shifts = dround((a[1]-b[1]) * box_l_i[1]);
+    double n_le_shifts = dround((a[1] - b[1]) * box_l_i[1]);
 
     if (PERIODIC(1) == 1) {
       dx[0] -= lees_edwards_offset * n_le_shifts;
     }
 #endif
-    calc_bonded_force(p1,p2,iaparams,&i,dx.data(),force);
-    *obsstat_bonded(&virials, type_num) += dx[0]*force[0] + dx[1]*force[1] + dx[2]*force[2];
+    calc_bonded_force(p1, p2, iaparams, &i, dx.data(), force);
+    *obsstat_bonded(&virials, type_num) +=
+        dx[0] * force[0] + dx[1] * force[1] + dx[2] * force[2];
 
- /* stress tensor part */
-    for(k=0;k<3;k++)
-      for(l=0;l<3;l++)
-        obsstat_bonded(&p_tensor, type_num)[k*3 + l] += force[k]*dx[l];
-
+    /* stress tensor part */
+    for (k = 0; k < 3; k++)
+      for (l = 0; l < 3; l++)
+        obsstat_bonded(&p_tensor, type_num)[k * 3 + l] += force[k] * dx[l];
   }
 }
 
@@ -338,7 +383,7 @@ inline void add_three_body_bonded_stress(Particle *p1) {
   double force2[3];
   double force3[3];
 
-  //char *errtxt;
+  // char *errtxt;
   Particle *p2;
   Particle *p3;
   Bonded_ia_parameters *iaparams;
@@ -348,160 +393,176 @@ inline void add_three_body_bonded_stress(Particle *p1) {
   BondedInteraction type;
 
   i = 0;
-  while(i < p1->bl.n) {
+  while (i < p1->bl.n) {
     /* scan bond list for angular interactions */
     type_num = p1->bl.e[i];
     iaparams = &bonded_ia_params[type_num];
     type = iaparams->type;
 
-    if(type == BONDED_IA_ANGLE_HARMONIC || type == BONDED_IA_ANGLE_COSINE || type == BONDED_IA_ANGLE_COSSQUARE){
+    if (type == BONDED_IA_ANGLE_HARMONIC || type == BONDED_IA_ANGLE_COSINE ||
+        type == BONDED_IA_ANGLE_COSSQUARE) {
       p2 = local_particles[p1->bl.e[++i]];
       p3 = local_particles[p1->bl.e[++i]];
 
       get_mi_vector(dx12, p1->r.p, p2->r.p);
-      for(j = 0; j < 3; j++)
+      for (j = 0; j < 3; j++)
         dx21[j] = -dx12[j];
 
       get_mi_vector(dx31, p3->r.p, p1->r.p);
 
-      for(j = 0; j < 3; j++) {
+      for (j = 0; j < 3; j++) {
         force1[j] = 0.0;
         force2[j] = 0.0;
         force3[j] = 0.0;
       }
 
-      calc_three_body_bonded_forces(p1, p2, p3, iaparams, force1, force2, force3);
+      calc_three_body_bonded_forces(p1, p2, p3, iaparams, force1, force2,
+                                    force3);
 
       /* uncomment the next line to see that the virial is indeed zero */
-      //printf("W = %g\n", scalar(force2, dx21) + scalar(force3, dx31));
+      // printf("W = %g\n", scalar(force2, dx21) + scalar(force3, dx31));
 
-      /* three-body bonded interactions contribute to the stress but not the scalar pressure */
-      for(k = 0; k < 3; k++) {
-        for(l = 0; l < 3; l++) {
-          obsstat_bonded(&p_tensor, type_num)[3 * k + l] += force2[k] * dx21[l] + force3[k] * dx31[l];
+      /* three-body bonded interactions contribute to the stress but not the
+       * scalar pressure */
+      for (k = 0; k < 3; k++) {
+        for (l = 0; l < 3; l++) {
+          obsstat_bonded(&p_tensor, type_num)[3 * k + l] +=
+              force2[k] * dx21[l] + force3[k] * dx31[l];
         }
       }
       i = i + 1;
     }
     // skip over non-angular interactions
-    else if(type == BONDED_IA_FENE) {
+    else if (type == BONDED_IA_FENE) {
       i = i + 2;
-    }
-    else if(type == BONDED_IA_OIF_GLOBAL_FORCES) {
+    } else if (type == BONDED_IA_OIF_GLOBAL_FORCES) {
       i = i + 3;
-    }
-    else if(type == BONDED_IA_OIF_LOCAL_FORCES) {
+    } else if (type == BONDED_IA_OIF_LOCAL_FORCES) {
       i = i + 4;
-    }
-    else if(type == BONDED_IA_OIF_OUT_DIRECTION) {
+    } else if (type == BONDED_IA_OIF_OUT_DIRECTION) {
       i = i + 3;
-    }
-    else if(type == BONDED_IA_HARMONIC) {
+    } else if (type == BONDED_IA_HARMONIC) {
       i = i + 2;
     }
 #ifdef LENNARD_JONES
-    else if(type == BONDED_IA_SUBT_LJ) {
+    else if (type == BONDED_IA_SUBT_LJ) {
       i = i + 2;
     }
 #endif
-    else if(type == BONDED_IA_ANGLEDIST) {
+    else if (type == BONDED_IA_ANGLEDIST) {
       i = i + 3;
-    }
-    else if(type == BONDED_IA_DIHEDRAL) {
+    } else if (type == BONDED_IA_DIHEDRAL) {
       i = i + 4;
     }
 #ifdef TABULATED
-    else if(type == BONDED_IA_TABULATED) {
-      if(iaparams->p.tab.type == TAB_BOND_LENGTH) {
+    else if (type == BONDED_IA_TABULATED) {
+      if (iaparams->p.tab.type == TAB_BOND_LENGTH) {
         i = i + 2;
-      }
-      else if(iaparams->p.tab.type == TAB_BOND_ANGLE) {
+      } else if (iaparams->p.tab.type == TAB_BOND_ANGLE) {
         p2 = local_particles[p1->bl.e[++i]];
         p3 = local_particles[p1->bl.e[++i]];
 
         get_mi_vector(dx12, p1->r.p, p2->r.p);
-        for(j = 0; j < 3; j++)
+        for (j = 0; j < 3; j++)
           dx21[j] = -dx12[j];
 
         get_mi_vector(dx31, p3->r.p, p1->r.p);
 
-        for(j = 0; j < 3; j++) {
+        for (j = 0; j < 3; j++) {
           force1[j] = 0.0;
           force2[j] = 0.0;
           force3[j] = 0.0;
         }
 
-        calc_three_body_bonded_forces(p1, p2, p3, iaparams, force1, force2, force3);
+        calc_three_body_bonded_forces(p1, p2, p3, iaparams, force1, force2,
+                                      force3);
 
         /* uncomment the next line to see that the virial is indeed zero */
-        //printf("W = %g\n", scalar(force2, dx21) + scalar(force3, dx31));
+        // printf("W = %g\n", scalar(force2, dx21) + scalar(force3, dx31));
 
-        /* three-body bonded interactions contribute to the stress but not the scalar pressure */
-        for(k = 0; k < 3; k++) {
-          for(l = 0; l < 3; l++) {
-            obsstat_bonded(&p_tensor, type_num)[3 * k + l] += force2[k] * dx21[l] + force3[k] * dx31[l];
+        /* three-body bonded interactions contribute to the stress but not the
+         * scalar pressure */
+        for (k = 0; k < 3; k++) {
+          for (l = 0; l < 3; l++) {
+            obsstat_bonded(&p_tensor, type_num)[3 * k + l] +=
+                force2[k] * dx21[l] + force3[k] * dx31[l];
           }
         }
         i = i + 1;
-      }
-      else if (iaparams->p.tab.type == TAB_BOND_DIHEDRAL) {
+      } else if (iaparams->p.tab.type == TAB_BOND_DIHEDRAL) {
         i = i + 4;
-      }
-      else {
-        runtimeErrorMsg() <<"add_three_body_bonded_stress: match not found for particle " << p1->p.identity << ".\n";
+      } else {
+        runtimeErrorMsg()
+            << "add_three_body_bonded_stress: match not found for particle "
+            << p1->p.identity << ".\n";
       }
     }
 #endif
 #ifdef BOND_CONSTRAINT
-    else if(type == BONDED_IA_RIGID_BOND) {
+    else if (type == BONDED_IA_RIGID_BOND) {
       i = i + 2;
     }
 #endif
-    else if(type == BONDED_IA_VIRTUAL_BOND) {
+    else if (type == BONDED_IA_VIRTUAL_BOND) {
       i = i + 2;
+    } else {
+      runtimeErrorMsg()
+          << "add_three_body_bonded_stress: match not found for particle "
+          << p1->p.identity << ".\n";
     }
-    else {
-      runtimeErrorMsg() <<"add_three_body_bonded_stress: match not found for particle " << p1->p.identity << ".\n";
-    }
-  } 
+  }
 }
- 
+
 /** Calculate kinetic pressure (aka energy) for one particle.
     @param p1 particle for which to calculate pressure
     @param v_comp flag which enables (1) compensation of the velocities required
-		  for deriving a pressure reflecting \ref nptiso_struct::p_inst
-		  (hence it only works with domain decomposition); naturally it
-		  therefore doesn't make sense to use it without NpT.
+                  for deriving a pressure reflecting \ref nptiso_struct::p_inst
+                  (hence it only works with domain decomposition); naturally it
+                  therefore doesn't make sense to use it without NpT.
 */
-inline void add_kinetic_virials(Particle *p1,int v_comp)
-{
+inline void add_kinetic_virials(Particle *p1, int v_comp) {
   int k, l;
   /* kinetic energy */
 #ifdef MULTI_TIMESTEP
   if (smaller_time_step > 0.) {
-    if(v_comp)
-      virials.data.e[0] += SQR(time_step/smaller_time_step)*(SQR(p1->m.v[0] - p1->f.f[0]) + SQR(p1->m.v[1] - p1->f.f[1]) + SQR(p1->m.v[2] - p1->f.f[2]))*(*p1).p.mass;
+    if (v_comp)
+      virials.data.e[0] += Utils::sqr(time_step / smaller_time_step) *
+                           (Utils::sqr(p1->m.v[0] - p1->f.f[0]) +
+                            Utils::sqr(p1->m.v[1] - p1->f.f[1]) +
+                            Utils::sqr(p1->m.v[2] - p1->f.f[2])) *
+                           (*p1).p.mass;
     else
-      virials.data.e[0] += SQR(time_step/smaller_time_step)*(SQR(p1->m.v[0]) + SQR(p1->m.v[1]) + SQR(p1->m.v[2]))*(*p1).p.mass;
+      virials.data.e[0] += Utils::sqr(time_step / smaller_time_step) *
+                           (Utils::sqr(p1->m.v[0]) + Utils::sqr(p1->m.v[1]) +
+                            Utils::sqr(p1->m.v[2])) *
+                           (*p1).p.mass;
   } else
 #endif
   {
-    if(v_comp) 
-      virials.data.e[0] += (SQR(p1->m.v[0] - p1->f.f[0]) + SQR(p1->m.v[1] - p1->f.f[1]) + SQR(p1->m.v[2] - p1->f.f[2]))*(*p1).p.mass;
+    if (v_comp)
+      virials.data.e[0] += (Utils::sqr(p1->m.v[0] - p1->f.f[0]) +
+                            Utils::sqr(p1->m.v[1] - p1->f.f[1]) +
+                            Utils::sqr(p1->m.v[2] - p1->f.f[2])) *
+                           (*p1).p.mass;
     else
-      virials.data.e[0] += (SQR(p1->m.v[0]) + SQR(p1->m.v[1]) + SQR(p1->m.v[2]))*(*p1).p.mass;
+      virials.data.e[0] += (Utils::sqr(p1->m.v[0]) + Utils::sqr(p1->m.v[1]) +
+                            Utils::sqr(p1->m.v[2])) *
+                           (*p1).p.mass;
   }
 
-  /* ideal gas contribution (the rescaling of the velocities by '/=time_step' each will be done later) */
-  for(k=0;k<3;k++)
-    for(l=0;l<3;l++)
+  /* ideal gas contribution (the rescaling of the velocities by '/=time_step'
+   * each will be done later) */
+  for (k = 0; k < 3; k++)
+    for (l = 0; l < 3; l++)
 #ifdef MULTI_TIMESTEP
-      if (smaller_time_step > 0.) 
-        p_tensor.data.e[k*3 + l] += SQR(time_step/smaller_time_step)*(p1->m.v[k])*(p1->m.v[l])*(*p1).p.mass;
+      if (smaller_time_step > 0.)
+        p_tensor.data.e[k * 3 + l] +=
+            Utils::sqr(time_step / smaller_time_step) * (p1->m.v[k]) *
+            (p1->m.v[l]) * (*p1).p.mass;
       else
 #endif
-        p_tensor.data.e[k*3 + l] += (p1->m.v[k])*(p1->m.v[l])*(*p1).p.mass;
-
+        p_tensor.data.e[k * 3 + l] +=
+            (p1->m.v[k]) * (p1->m.v[l]) * (*p1).p.mass;
 }
 
 #endif

--- a/src/core/quartic.hpp
+++ b/src/core/quartic.hpp
@@ -84,9 +84,9 @@ inline int quartic_pair_energy(Particle *p1, Particle *p2, Bonded_ia_parameters 
       (dist > iaparams->p.quartic.r_cut)) 
     return 1;
  
-  double dr2 = SQR(dist - iaparams->p.quartic.r);
+  double dr2 = Utils::sqr(dist - iaparams->p.quartic.r);
 
-  *_energy = 0.5*iaparams->p.quartic.k0*dr2 + 0.25 * iaparams->p.quartic.k1 * SQR(dr2);
+  *_energy = 0.5*iaparams->p.quartic.k0*dr2 + 0.25 * iaparams->p.quartic.k1 * Utils::sqr(dr2);
   return 0;
 }
 

--- a/src/core/shapes/Cylinder.cpp
+++ b/src/core/shapes/Cylinder.cpp
@@ -20,11 +20,11 @@
 */
 
 #include "Cylinder.hpp"
+#include "utils.hpp"
 #include <cmath>
 
 using namespace std;
 
-#define SQR(A) ((A) * (A))
 
 namespace Shapes {
 int Cylinder::calculate_dist(const double *ppos, double *dist,
@@ -35,7 +35,7 @@ int Cylinder::calculate_dist(const double *ppos, double *dist,
   d_real = 0.0;
   for (int i = 0; i < 3; i++) {
     d_real_vec[i] = ppos[i] - m_pos[i];
-    d_real += SQR(d_real_vec[i]);
+    d_real += Utils::sqr(d_real_vec[i]);
   }
   d_real = sqrt(d_real);
 
@@ -49,7 +49,7 @@ int Cylinder::calculate_dist(const double *ppos, double *dist,
     d_per_vec[i] = ppos[i] - (m_pos[i] + d_par_vec[i]);
   }
 
-  d_per = sqrt(SQR(d_real) - SQR(d_par));
+  d_per = sqrt(Utils::sqr(d_real) - Utils::sqr(d_par));
   d_par = fabs(d_par);
 
   if (m_direction == -1) {
@@ -82,7 +82,7 @@ int Cylinder::calculate_dist(const double *ppos, double *dist,
         vec[i] = d_par_vec[i] * d_par / (d_par + half_length);
       }
     } else {
-      *dist = sqrt(SQR(d_par) + SQR(d_per));
+      *dist = sqrt(Utils::sqr(d_par) + Utils::sqr(d_per));
       for (int i = 0; i < 3; i++) {
         vec[i] = d_per_vec[i] * d_per / (d_per + m_rad) +
                  d_par_vec[i] * d_par / (d_par + half_length);

--- a/src/core/shapes/Maze.cpp
+++ b/src/core/shapes/Maze.cpp
@@ -38,7 +38,7 @@ int Maze::calculate_dist(const double *ppos, double *dist, double *vec) const {
   for (i = 0; i < 3; i++) {
     cursph[i] = (int)(ppos[i] / diasph);
     sph_vec[i] = (cursph[i] + 0.5) * diasph - (ppos[i]);
-    c_dist += SQR(sph_vec[i]);
+    c_dist += Utils::sqr(sph_vec[i]);
   }
   c_dist = sqrt(c_dist);
   sph_dist = m_sphrad - c_dist;

--- a/src/core/shapes/Pore.cpp
+++ b/src/core/shapes/Pore.cpp
@@ -26,7 +26,6 @@
 
 using namespace std;
 
-#define SQR(A) ((A) * (A))
 
 namespace Shapes {
 int Pore::calculate_dist(const double *ppos, double *dist, double *vec) const {
@@ -98,9 +97,9 @@ int Pore::calculate_dist(const double *ppos, double *dist, double *vec) const {
                 sqrt(slope * slope / (1 + slope * slope)) * m_smoothing_radius;
 
   c1_r = m_rad_left + slope * (z_left + half_length) +
-         sqrt(m_smoothing_radius * m_smoothing_radius - SQR(z_left - c1_z));
+         sqrt(m_smoothing_radius * m_smoothing_radius - Utils::sqr(z_left - c1_z));
   c2_r = m_rad_left + slope * (z_right + half_length) +
-         sqrt(m_smoothing_radius * m_smoothing_radius - SQR(z_right - c2_z));
+         sqrt(m_smoothing_radius * m_smoothing_radius - Utils::sqr(z_right - c2_z));
   c1_r = m_rad_left + m_smoothing_radius;
   c2_r = m_rad_right + m_smoothing_radius;
 

--- a/src/core/shapes/Slitpore.cpp
+++ b/src/core/shapes/Slitpore.cpp
@@ -20,12 +20,11 @@
 */
 
 #include "Slitpore.hpp"
+#include "utils.hpp"
 /* For box_l */
 #include "grid.hpp"
 
 #include <cmath>
-
-#define SQR(A) ((A) * (A))
 
 using namespace std;
 
@@ -64,8 +63,9 @@ int Slitpore::calculate_dist(const double *ppos, double *dist,
   if (ppos[2] > c11[1]) {
     // Feel the upper smoothing
     if (ppos[0] < box_l_x / 2) {
-      *dist = sqrt(SQR(c11[0] - ppos[0]) + SQR(c11[1] - ppos[2])) -
-              m_upper_smoothing_radius;
+      *dist =
+          sqrt(Utils::sqr(c11[0] - ppos[0]) + Utils::sqr(c11[1] - ppos[2])) -
+          m_upper_smoothing_radius;
       vec[0] =
           -(c11[0] - ppos[0]) * (*dist) / (*dist + m_upper_smoothing_radius);
       vec[1] = 0;
@@ -73,8 +73,9 @@ int Slitpore::calculate_dist(const double *ppos, double *dist,
           -(c11[1] - ppos[2]) * (*dist) / (*dist + m_upper_smoothing_radius);
       return 0;
     } else {
-      *dist = sqrt(SQR(c21[0] - ppos[0]) + SQR(c21[1] - ppos[2])) -
-              m_upper_smoothing_radius;
+      *dist =
+          sqrt(Utils::sqr(c21[0] - ppos[0]) + Utils::sqr(c21[1] - ppos[2])) -
+          m_upper_smoothing_radius;
       vec[0] =
           -(c21[0] - ppos[0]) * (*dist) / (*dist + m_upper_smoothing_radius);
       vec[1] = 0;
@@ -110,14 +111,14 @@ int Slitpore::calculate_dist(const double *ppos, double *dist,
   // Else
   // Feel the lower smoothing
   if (ppos[0] < box_l_x / 2) {
-    *dist = -sqrt(SQR(c12[0] - ppos[0]) + SQR(c12[1] - ppos[2])) +
+    *dist = -sqrt(Utils::sqr(c12[0] - ppos[0]) + Utils::sqr(c12[1] - ppos[2])) +
             m_lower_smoothing_radius;
     vec[0] = (c12[0] - ppos[0]) * (*dist) / (-*dist + m_lower_smoothing_radius);
     vec[1] = 0;
     vec[2] = (c12[1] - ppos[2]) * (*dist) / (-*dist + m_lower_smoothing_radius);
     return 0;
   } else {
-    *dist = -sqrt(SQR(c22[0] - ppos[0]) + SQR(c22[1] - ppos[2])) +
+    *dist = -sqrt(Utils::sqr(c22[0] - ppos[0]) + Utils::sqr(c22[1] - ppos[2])) +
             m_lower_smoothing_radius;
     vec[0] = (c22[0] - ppos[0]) * (*dist) / (-*dist + m_lower_smoothing_radius);
     vec[1] = 0;
@@ -127,4 +128,4 @@ int Slitpore::calculate_dist(const double *ppos, double *dist,
 
   return 0;
 }
-}
+} // namespace Shapes

--- a/src/core/shapes/Sphere.cpp
+++ b/src/core/shapes/Sphere.cpp
@@ -20,11 +20,11 @@
 */
 
 #include "Sphere.hpp"
+#include "utils.hpp"
 #include <cmath>
 
 using namespace std;
 
-#define SQR(A) ((A) * (A))
 
 namespace Shapes {
 int Sphere::calculate_dist(const double *ppos, double *dist,
@@ -35,7 +35,7 @@ int Sphere::calculate_dist(const double *ppos, double *dist,
   c_dist = 0.0;
   for (i = 0; i < 3; i++) {
     vec[i] = m_pos[i] - ppos[i];
-    c_dist += SQR(vec[i]);
+    c_dist += Utils::sqr(vec[i]);
   }
   c_dist = sqrt(c_dist);
 

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -451,7 +451,7 @@ void calc_part_distribution(PartCfg &partCfg, int *p1_types, int n_p1,
   double inv_bin_width = 0.0;
   double min_dist, min_dist2 = 0.0, start_dist2, act_dist2;
 
-  start_dist2 = SQR(box_l[0] + box_l[1] + box_l[2]);
+  start_dist2 = Utils::sqr(box_l[0] + box_l[1] + box_l[2]);
   /* bin preparation */
   *low = 0.0;
   for (int i = 0; i < r_bins; i++)

--- a/src/core/statistics_chain.cpp
+++ b/src/core/statistics_chain.cpp
@@ -63,7 +63,7 @@ void calc_re(PartCfg & partCfg, double **_re) {
          partCfg[chain_start + i * chain_length].r.p[1];
     dz = partCfg[chain_start + i * chain_length + chain_length - 1].r.p[2] -
          partCfg[chain_start + i * chain_length].r.p[2];
-    tmp = (SQR(dx) + SQR(dy) + SQR(dz));
+    tmp = (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
     dist += sqrt(tmp);
     dist2 += tmp;
     dist4 += tmp * tmp;
@@ -92,7 +92,7 @@ void calc_re_av(double **_re) {
       dz = configs[j][3 * (chain_start + i * chain_length + chain_length - 1) +
                       2] -
            configs[j][3 * (chain_start + i * chain_length) + 2];
-      tmp = (SQR(dx) + SQR(dy) + SQR(dz));
+      tmp = (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
       dist += sqrt(tmp);
       dist2 += tmp;
       dist4 += tmp * tmp;
@@ -133,7 +133,7 @@ void calc_rg(PartCfg & partCfg, double **_rg) {
       dx = partCfg[p].r.p[0] - r_CM_x;
       dy = partCfg[p].r.p[1] - r_CM_y;
       dz = partCfg[p].r.p[2] - r_CM_z;
-      tmp += (SQR(dx) + SQR(dy) + SQR(dz));
+      tmp += (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
     }
     tmp *= IdoubMPC;
     r_G += sqrt(tmp);
@@ -176,7 +176,7 @@ void calc_rg_av(PartCfg & partCfg, double **_rg) {
         dx = configs[k][3 * p] - r_CM_x;
         dy = configs[k][3 * p + 1] - r_CM_y;
         dz = configs[k][3 * p + 2] - r_CM_z;
-        tmp += (SQR(dx) + SQR(dy) + SQR(dz));
+        tmp += (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
       }
       tmp *= IdoubMPC;
       r_G += sqrt(tmp);
@@ -266,7 +266,7 @@ void calc_internal_dist(PartCfg & partCfg, double **_idf) {
              partCfg[chain_start + i * chain_length + j].r.p[1];
         dz = partCfg[chain_start + i * chain_length + j + k].r.p[2] -
              partCfg[chain_start + i * chain_length + j].r.p[2];
-        idf[k] += (SQR(dx) + SQR(dy) + SQR(dz));
+        idf[k] += (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
       }
     }
     idf[k] = sqrt(idf[k] / (1.0 * (chain_length - k) * chain_n_chains));
@@ -290,7 +290,7 @@ void calc_internal_dist_av(double **_idf) {
           dx = configs[n][3 * i1] - configs[n][3 * i2];
           dy = configs[n][3 * i1 + 1] - configs[n][3 * i2 + 1];
           dz = configs[n][3 * i1 + 2] - configs[n][3 * i2 + 2];
-          idf[k] += (SQR(dx) + SQR(dy) + SQR(dz));
+          idf[k] += (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
         }
       }
     }
@@ -315,7 +315,7 @@ void calc_bond_l(PartCfg & partCfg, double **_bond_l) {
            partCfg[chain_start + i * chain_length + j].r.p[1];
       dz = partCfg[chain_start + i * chain_length + j + 1].r.p[2] -
            partCfg[chain_start + i * chain_length + j].r.p[2];
-      tmp = SQR(dx) + SQR(dy) + SQR(dz);
+      tmp = Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz);
       bond_l[0] += sqrt(tmp);
       bond_l[1] += tmp;
       if (tmp > bond_l[2]) {
@@ -328,7 +328,7 @@ void calc_bond_l(PartCfg & partCfg, double **_bond_l) {
   }
   tmp = (double)(chain_length - 1) * chain_n_chains;
   bond_l[0] = bond_l[0] / tmp;
-  bond_l[1] = sqrt(bond_l[1] / tmp - SQR(bond_l[0]));
+  bond_l[1] = sqrt(bond_l[1] / tmp - Utils::sqr(bond_l[0]));
   bond_l[2] = sqrt(bond_l[2]);
   bond_l[3] = sqrt(bond_l[3]);
 }
@@ -349,7 +349,7 @@ void calc_bond_l_av(double **_bond_l) {
         dx = configs[n][3 * i1] - configs[n][3 * i2];
         dy = configs[n][3 * i1 + 1] - configs[n][3 * i2 + 1];
         dz = configs[n][3 * i1 + 2] - configs[n][3 * i2 + 2];
-        tmp = SQR(dx) + SQR(dy) + SQR(dz);
+        tmp = Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz);
         bond_l[0] += sqrt(tmp);
         bond_l[1] += tmp;
         if (tmp > bond_l[2]) {
@@ -363,7 +363,7 @@ void calc_bond_l_av(double **_bond_l) {
   }
   tmp = (double)(chain_length - 1) * chain_n_chains * n_configs;
   bond_l[0] = bond_l[0] / tmp;
-  bond_l[1] = sqrt(bond_l[1] / tmp - SQR(bond_l[0]));
+  bond_l[1] = sqrt(bond_l[1] / tmp - Utils::sqr(bond_l[0]));
   bond_l[2] = sqrt(bond_l[2]);
   bond_l[3] = sqrt(bond_l[3]);
 }
@@ -385,7 +385,7 @@ void calc_bond_dist(PartCfg & partCfg, double **_bdf, int ind_n) {
              partCfg[chain_start + i * chain_length + j].r.p[1];
         dz = partCfg[chain_start + i * chain_length + j + k].r.p[2] -
              partCfg[chain_start + i * chain_length + j].r.p[2];
-        bdf[k] += (SQR(dx) + SQR(dy) + SQR(dz));
+        bdf[k] += (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
       }
     }
     bdf[k] = sqrt(bdf[k] / (1.0 * chain_n_chains));
@@ -409,7 +409,7 @@ void calc_bond_dist_av(double **_bdf, int ind_n) {
           dx = configs[n][3 * i1] - configs[n][3 * i2];
           dy = configs[n][3 * i1 + 1] - configs[n][3 * i2 + 1];
           dz = configs[n][3 * i1 + 2] - configs[n][3 * i2 + 2];
-          bdf[k] += (SQR(dx) + SQR(dy) + SQR(dz));
+          bdf[k] += (Utils::sqr(dx) + Utils::sqr(dy) + Utils::sqr(dz));
         }
       }
     }
@@ -471,19 +471,19 @@ void calc_g123(PartCfg & partCfg, double *_g1, double *_g2, double *_g3) {
     cm_tmp[2] /= M;
     for (i = 0; i < chain_length; i++) {
       p = chain_start + j * chain_length + i;
-      g1 += SQR(partCfg[p].r.p[0] - partCoord_g[3 * p]) +
-            SQR(partCfg[p].r.p[1] - partCoord_g[3 * p + 1]) +
-            SQR(partCfg[p].r.p[2] - partCoord_g[3 * p + 2]);
-      g2 += SQR((partCfg[p].r.p[0] - partCoord_g[3 * p]) -
+      g1 += Utils::sqr(partCfg[p].r.p[0] - partCoord_g[3 * p]) +
+            Utils::sqr(partCfg[p].r.p[1] - partCoord_g[3 * p + 1]) +
+            Utils::sqr(partCfg[p].r.p[2] - partCoord_g[3 * p + 2]);
+      g2 += Utils::sqr((partCfg[p].r.p[0] - partCoord_g[3 * p]) -
                 (cm_tmp[0] - partCM_g[3 * j])) +
-            SQR((partCfg[p].r.p[1] - partCoord_g[3 * p + 1]) -
+            Utils::sqr((partCfg[p].r.p[1] - partCoord_g[3 * p + 1]) -
                 (cm_tmp[1] - partCM_g[3 * j + 1])) +
-            SQR((partCfg[p].r.p[2] - partCoord_g[3 * p + 2]) -
+            Utils::sqr((partCfg[p].r.p[2] - partCoord_g[3 * p + 2]) -
                 (cm_tmp[2] - partCM_g[3 * j + 2]));
     }
-    g3 += SQR(cm_tmp[0] - partCM_g[3 * j]) +
-          SQR(cm_tmp[1] - partCM_g[3 * j + 1]) +
-          SQR(cm_tmp[2] - partCM_g[3 * j + 2]);
+    g3 += Utils::sqr(cm_tmp[0] - partCM_g[3 * j]) +
+          Utils::sqr(cm_tmp[1] - partCM_g[3 * j + 1]) +
+          Utils::sqr(cm_tmp[2] - partCM_g[3 * j + 2]);
   }
   *_g1 = g1 / (1. * chain_n_chains * chain_length);
   *_g2 = g2 / (1. * chain_n_chains * chain_length);
@@ -502,11 +502,11 @@ void calc_g1_av(double **_g1, int window, double weights[3]) {
       for (j = 0; j < chain_n_chains; j++) {
         for (i = 0; i < chain_length; i++) {
           p = chain_start + j * chain_length + i;
-          g1[k] += weights[0] * SQR(configs[t + k][3 * p] - configs[t][3 * p]) +
+          g1[k] += weights[0] * Utils::sqr(configs[t + k][3 * p] - configs[t][3 * p]) +
                    weights[1] *
-                       SQR(configs[t + k][3 * p + 1] - configs[t][3 * p + 1]) +
+                       Utils::sqr(configs[t + k][3 * p + 1] - configs[t][3 * p + 1]) +
                    weights[2] *
-                       SQR(configs[t + k][3 * p + 2] - configs[t][3 * p + 2]);
+                       Utils::sqr(configs[t + k][3 * p + 2] - configs[t][3 * p + 2]);
         }
       }
     }
@@ -544,12 +544,12 @@ void calc_g2_av(PartCfg & partCfg, double **_g2, int window, double weights[3]) 
           p = chain_start + j * chain_length + i;
           g2[k] +=
               weights[0] *
-                  SQR((configs[t + k][3 * p] - configs[t][3 * p]) - cm_tmp[0]) +
+                  Utils::sqr((configs[t + k][3 * p] - configs[t][3 * p]) - cm_tmp[0]) +
               weights[1] *
-                  SQR((configs[t + k][3 * p + 1] - configs[t][3 * p + 1]) -
+                  Utils::sqr((configs[t + k][3 * p + 1] - configs[t][3 * p + 1]) -
                       cm_tmp[1]) +
               weights[2] *
-                  SQR((configs[t + k][3 * p + 2] - configs[t][3 * p + 2]) -
+                  Utils::sqr((configs[t + k][3 * p + 2] - configs[t][3 * p + 2]) -
                       cm_tmp[2]);
         }
       }
@@ -581,9 +581,9 @@ void calc_g3_av(PartCfg & partCfg, double **_g3, int window, double weights[3]) 
                        (partCfg[p]).p.mass;
           M += (partCfg[p]).p.mass;
         }
-        g3[k] += (weights[0] * SQR(cm_tmp[0]) + weights[1] * SQR(cm_tmp[1]) +
-                  weights[2] * SQR(cm_tmp[2])) /
-                 SQR(M);
+        g3[k] += (weights[0] * Utils::sqr(cm_tmp[0]) + weights[1] * Utils::sqr(cm_tmp[1]) +
+                  weights[2] * Utils::sqr(cm_tmp[2])) /
+                 Utils::sqr(M);
       }
     }
     g3[k] /= ((double)chain_n_chains * cnt);

--- a/src/core/statistics_fluid.cpp
+++ b/src/core/statistics_fluid.cpp
@@ -270,7 +270,7 @@ void lb_calc_velprof(double *result, int *params) {
       if (rho < ROUND_ERROR_PREC) {
 	velprof[dir[pdir]-1] = 0.0;
       } else {
-	//velprof[dir[pdir]-1] = local_j / (SQR(lbpar.agrid)*lbpar.tau);
+	//velprof[dir[pdir]-1] = local_j / (Utils::sqr(lbpar.agrid)*lbpar.tau);
 	velprof[dir[pdir]-1] = j[vcomp]/rho * lbpar.agrid/lbpar.tau;
 	//fprintf(stderr,"%f %f %f\n",velprof[dir[pdir]-1],local_j,local_rho);
       }

--- a/src/core/steppot.hpp
+++ b/src/core/steppot.hpp
@@ -52,7 +52,7 @@ inline void add_SmSt_pair_force(const Particle *const p1,
   er = exp(2. * ia_params->SmSt_k0 * (dist - ia_params->SmSt_sig));
   fac = (ia_params->SmSt_n * fracP +
          2. * ia_params->SmSt_eps * ia_params->SmSt_k0 * dist * er /
-             SQR(1.0 + er)) /
+             Utils::sqr(1.0 + er)) /
         dist2;
 
   for (j = 0; j < 3; j++)

--- a/src/core/tab.hpp
+++ b/src/core/tab.hpp
@@ -249,7 +249,7 @@ inline void calc_angle_3body_tabulated_forces(Particle *p_mid, Particle *p_left,
   vec31_sqr = sqrlen(vec31);
   vec31_magn = sqrt(vec31_sqr);
   cos_phi = scalar(vec21, vec31) / (vec21_magn * vec31_magn);
-  sin_phi = sqrt(1.0 - SQR(cos_phi));
+  sin_phi = sqrt(1.0 - Utils::sqr(cos_phi));
 
   if (cos_phi < -1.0)
     cos_phi = -TINY_COS_VALUE;

--- a/src/core/twist_stack.cpp
+++ b/src/core/twist_stack.cpp
@@ -21,14 +21,13 @@
 
 #include "twist_stack.hpp"
 #include "communication.hpp"
+#include "utils.hpp"
 
 #ifdef TWIST_STACK
 
 // extrema for cos(theta), used for the force calculations that involve angles
 #define COS_MAX (0.99999999)
 #define COS_MIN (-0.99999999)
-
-#define SQR(x) ((x)*(x))
 
 /* @TODO: Remove code duplication, use vector class */
 
@@ -47,7 +46,7 @@ inline void cross(double *x1, double *x2, double *x3)
 }
 
 inline double norm2(double *x) {
-  return SQR(x[0]) + SQR(x[1]) + SQR(x[2]);
+  return Utils::sqr(x[0]) + Utils::sqr(x[1]) + Utils::sqr(x[2]);
 }
 
 inline double norm(double *x) {
@@ -160,7 +159,7 @@ int calc_twist_stack_energy(Particle *si1, Particle *bi1, Particle *bi2, Particl
   double pot_stack;
 
   const double ir = 1. / r;
-  const double ir2 =SQR(ir);        
+  const double ir2 =Utils::sqr(ir);        
   const double ir5 = ir2*ir2*ir;
   const double ir6 = ir5*ir;
 
@@ -190,7 +189,7 @@ int calc_twist_stack_energy(Particle *si1, Particle *bi1, Particle *bi2, Particl
   const double rcci_l = norm(rcci);
   const double rccj_l = norm(rccj);
 
-  const double rccj_p_l2 = SQR(rccj_l) - SQR(rccj_parallel);
+  const double rccj_p_l2 = Utils::sqr(rccj_l) - Utils::sqr(rccj_parallel);
   const double rccj_p_l = sqrt(rccj_p_l2);
 
   double cos1 = dot(rccj_p, rcci)/(rccj_p_l * rcci_l);
@@ -200,7 +199,7 @@ int calc_twist_stack_energy(Particle *si1, Particle *bi1, Particle *bi2, Particl
 
   cross(rcci, rccj_p, vec1);
 
-  const double sin1 = (dot(vec1, n1) < 0.) ? -sqrt(1.-SQR(cos1)) : sqrt(1.-SQR(cos1));
+  const double sin1 = (dot(vec1, n1) < 0.) ? -sqrt(1.-Utils::sqr(cos1)) : sqrt(1.-Utils::sqr(cos1));
 
   // Evaluation of cos(n*theta) by Chebyshev polynomials
   const double cos2 = 2.*cos1*cos1 - 1.;
@@ -321,7 +320,7 @@ int calc_twist_stack_force(Particle *si1, Particle *bi1, Particle *bi2, Particle
   double pot_stack;
 
   const double ir = 1. / r;
-  const double ir2 =SQR(ir);        
+  const double ir2 =Utils::sqr(ir);        
   const double ir5 = ir2*ir2*ir;
   const double ir6 = ir5*ir;
 
@@ -391,7 +390,7 @@ int calc_twist_stack_force(Particle *si1, Particle *bi1, Particle *bi2, Particle
   const double rcci_l = norm(rcci);
   const double rccj_l = norm(rccj);
 
-  const double rccj_p_l2 = SQR(rccj_l) - SQR(rccj_parallel);
+  const double rccj_p_l2 = Utils::sqr(rccj_l) - Utils::sqr(rccj_parallel);
   const double rccj_p_l = sqrt(rccj_p_l2);
 
   double cos1 = dot(rccj_p, rcci)/(rccj_p_l * rcci_l);
@@ -414,7 +413,7 @@ int calc_twist_stack_force(Particle *si1, Particle *bi1, Particle *bi2, Particle
 
   cross(rcci, rccj_p, vec1);
 
-  const double sin1 = (dot(vec1, n1) < 0.) ? -sqrt(1.-SQR(cos1)) : sqrt(1.-SQR(cos1));
+  const double sin1 = (dot(vec1, n1) < 0.) ? -sqrt(1.-Utils::sqr(cos1)) : sqrt(1.-Utils::sqr(cos1));
 
   // Evaluation of cos(n*theta) by Chebyshev polynomials
   const double cos2 = 2.*cos1*cos1 - 1.;
@@ -445,7 +444,7 @@ int calc_twist_stack_force(Particle *si1, Particle *bi1, Particle *bi2, Particle
   dot01 = dot(u1, rcci)/n1_l;
   dot11 = dot(u1, rcb1)/n1_l;
   double factor1 = fmag/(rcci_l*rccj_p_l);
-  double factor2 = fmag*cos1/SQR(rcci_l);
+  double factor2 = fmag*cos1/Utils::sqr(rcci_l);
   double factor3 = fmag*cos1/rccj_p_l2;
   const double factor4 = factor3*rccj_parallel;
 

--- a/src/core/umbrella.hpp
+++ b/src/core/umbrella.hpp
@@ -68,7 +68,7 @@ inline int umbrella_pair_energy(Particle *p1, Particle *p2, Bonded_ia_parameters
 { 
   double distn;
   distn = d[ia_params->p.umbrella.dir];  
-  *_energy = 0.5 * ia_params->p.umbrella.k * SQR(distn - ia_params->p.umbrella.r);
+  *_energy = 0.5 * ia_params->p.umbrella.k * Utils::sqr(distn - ia_params->p.umbrella.r);
   return 0;
 }
 

--- a/src/core/utils.hpp
+++ b/src/core/utils.hpp
@@ -167,7 +167,7 @@ inline double normr(double v[3]) {
   double d2 = 0.0;
   int i;
   for (i = 0; i < 3; i++)
-    d2 += SQR(v[i]);
+    d2 += Utils::sqr(v[i]);
   d2 = sqrtf(d2);
   return d2;
 }
@@ -177,7 +177,7 @@ template <typename T> double sqrlen(T const &v) {
   double d2 = 0.0;
   int i;
   for (i = 0; i < 3; i++)
-    d2 += SQR(v[i]);
+    d2 += Utils::sqr(v[i]);
   return d2;
 }
 
@@ -223,15 +223,15 @@ inline void vec_rotate(double *axis, double alpha, double *vector,
   a[1] = axis[1] / absa;
   a[2] = axis[2] / absa;
 
-  result[0] = (cosa + SQR(a[0]) * (1 - cosa)) * vector[0] +
+  result[0] = (cosa + Utils::sqr(a[0]) * (1 - cosa)) * vector[0] +
               (a[0] * a[1] * (1 - cosa) - a[2] * sina) * vector[1] +
               (a[0] * a[2] * (1 - cosa) + a[1] * sina) * vector[2];
   result[1] = (a[0] * a[1] * (1 - cosa) + a[2] * sina) * vector[0] +
-              (cosa + SQR(a[1]) * (1 - cosa)) * vector[1] +
+              (cosa + Utils::sqr(a[1]) * (1 - cosa)) * vector[1] +
               (a[1] * a[2] * (1 - cosa) - a[0] * sina) * vector[2];
   result[2] = (a[0] * a[2] * (1 - cosa) - a[1] * sina) * vector[0] +
               (a[1] * a[2] * (1 - cosa) + a[0] * sina) * vector[1] +
-              (cosa + SQR(a[2]) * (1 - cosa)) * vector[2];
+              (cosa + Utils::sqr(a[2]) * (1 - cosa)) * vector[2];
 
   return;
 }
@@ -444,8 +444,8 @@ inline void get_grid_pos(int i, int *a, int *b, int *c, int adim[3]) {
  *  \param pos2 Position two.
  */
 inline double distance(double pos1[3], double pos2[3]) {
-  return sqrt(SQR(pos1[0] - pos2[0]) + SQR(pos1[1] - pos2[1]) +
-              SQR(pos1[2] - pos2[2]));
+  return sqrt(Utils::sqr(pos1[0] - pos2[0]) + Utils::sqr(pos1[1] - pos2[1]) +
+              Utils::sqr(pos1[2] - pos2[2]));
 }
 
 /** returns the distance between two positions squared.
@@ -453,8 +453,8 @@ inline double distance(double pos1[3], double pos2[3]) {
  *  \param pos2 Position two.
  */
 inline double distance2(double const pos1[3], double const pos2[3]) {
-  return SQR(pos1[0] - pos2[0]) + SQR(pos1[1] - pos2[1]) +
-         SQR(pos1[2] - pos2[2]);
+  return Utils::sqr(pos1[0] - pos2[0]) + Utils::sqr(pos1[1] - pos2[1]) +
+         Utils::sqr(pos1[2] - pos2[2]);
 }
 
 /** Returns the distance between two positions squared and stores the
@@ -469,7 +469,7 @@ inline double distance2vec(double const pos1[3], double const pos2[3],
   vec[0] = pos1[0] - pos2[0];
   vec[1] = pos1[1] - pos2[1];
   vec[2] = pos1[2] - pos2[2];
-  return SQR(vec[0]) + SQR(vec[1]) + SQR(vec[2]);
+  return Utils::sqr(vec[0]) + Utils::sqr(vec[1]) + Utils::sqr(vec[2]);
 }
 
 /*@}*/

--- a/src/core/utils/math/sqr.hpp
+++ b/src/core/utils/math/sqr.hpp
@@ -1,9 +1,6 @@
 #ifndef UTILS_MATH_SQR_HPP
 #define UTILS_MATH_SQR_HPP
 
-/** Calculates the SQuaRe of 'double' x, returning 'double'. */
-template <typename T> inline T SQR(T x) { return x * x; }
-
 namespace Utils {
   /** Calculates the SQuaRe of 'double' x, returning 'double'. */
   template <typename T> inline T sqr(T x) { return x * x; }


### PR DESCRIPTION
There were two identical Template definitions for square calculation (`sqr` and `SQR`) in `src/core/utils/math/sqr.hpp`---one within, the other outside the `Utils` namespace.
This PR gets rid of the the latter (`SQR`) using `Utils::sqr()` instead.
`SQR` was also defined as macro several times. These were also replaced.