### PR TITLE
force serial

### DIFF
--- a/doc/sphinx/CMakeLists.txt
+++ b/doc/sphinx/CMakeLists.txt
@@ -1,6 +1,4 @@
-include(ProcessorCount)
 find_package(Sphinx 1.5.2)
-ProcessorCount(N)
 if(SPHINX_FOUND) 
     # configured documentation tools and
     # intermediate build results
@@ -74,7 +72,6 @@ if(SPHINX_FOUND)
             ${EXCLUDE}
         COMMAND
         ${SPHINX_EXECUTABLE}
-            -j ${N}
             -q
             -W
             -b html


### PR DESCRIPTION
Fixes # 

Fixes

Warning, treated as error:
WARNING: the sphinxcontrib.bibtex extension is not safe for parallel
reading, doing serial read

Description of changes:
 - forces serial build of sphinx

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [x] Docs?
