### PR TITLE
Update multi gpu message + documentation

### DIFF
--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -435,10 +435,10 @@ available, but load-independent.::
     
     system=espressomd.System()
 
-    dev=system.cu()
-    system.cu(dev)
+    dev = system.cuda_init_handle.device
+    system.cuda_init_handle.device = dev
 
-The first invocation in the sample above return the id of the set graphics card, the second one sets the 
+The first invocation in the sample above returns the id of the set graphics card, the second one sets the 
 device id.
 
 .. _GPU Acceleration with CUDA:
@@ -457,8 +457,7 @@ to check whether your desired method can be used on the GPU.
 In order to use GPU acceleration you need a NVIDIA GPU
 and it needs to have at least compute capability 2.0.
 
-For more information please check :attr:`espressomd._system.cu`
-or :class:`espressomd.cuda_init.CudaInitHandle`.
+For more information please check :class:`espressomd.cuda_init.CudaInitHandle`.
 
 .. _List available CUDA devices:
 
@@ -466,9 +465,11 @@ List available CUDA devices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to list available CUDA devices
-you should access :attr:`espressomd._system.cu.device_list`::
+you should access :attr:`espressomd.cuda_init.CudaInitHandle.device_list`, e.g.,::
 
-    espressomd._system.cu.device_list
+    system=espressomd.System()
+
+    print(system.cuda_init_handle.device_list)
 
 This attribute is read only and will return a dictionary containing
 the device id as key and the device name as its' value.
@@ -481,9 +482,11 @@ Selection of CUDA device
 When you start ``pypresso`` your first GPU should
 be selected. 
 If you wanted to use the second GPU, this can be done 
-by setting :attr:`espressomd._system.cu.device` as follows::
+by setting :attr:`espressomd.cuda_init.CudaInitHandle.device` as follows::
 
-    espressomd._system.cu.device = 1
+    system=espressomd.System()
+
+    system.cuda_init_handle.device = 1
 
 Setting a device id outside the valid range or a device
 which does not meet the minimum requirements will raise

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -20,12 +20,12 @@
 #include "config.hpp"
 #include "debug.hpp"
 
-#include "cuda_utils.hpp"
-#include "cuda_interface.hpp"
-#include "random.hpp"
-#include "interaction_data.hpp"
 #include "cuda_init.hpp"
+#include "cuda_interface.hpp"
+#include "cuda_utils.hpp"
 #include "errorhandling.hpp"
+#include "interaction_data.hpp"
+#include "random.hpp"
 
 #if defined(OMPI_MPI_H) || defined(_MPI_H)
 #error CU-file includes mpi.h! This should not happen!
@@ -347,25 +347,23 @@ void gpu_change_number_of_part_to_comm() {
 void gpu_init_particle_comm() {
   if (this_node == 0 && global_part_vars_host.communication_enabled == 0) {
     if (cuda_get_n_gpus() == -1) {
-      fprintf(stderr,
-              "Unable to initialize CUDA as no sufficient GPU is available.\n");
+      runtimeErrorMsg()
+          << "Unable to initialize CUDA as no sufficient GPU is available.";
       errexit();
     }
     if (cuda_get_n_gpus() > 1) {
-      fprintf(stderr, "More than one GPU detected, please note Espresso uses "
-                      "device 0 by default regardless of usage or "
-                      "capability\n");
-      fprintf(stderr, "Note that the GPU to be used can be modified using cuda "
-                      "setdevice <int>\n");
+      runtimeWarningMsg() << "More than one GPU detected, please note ESPResSo "
+                             "uses device 0 by default regardless of usage or "
+                             "capability. The GPU to be used can be modified "
+                             "by setting System.cuda_init_handle.device.";
       if (cuda_check_gpu(0) != ES_OK) {
-        fprintf(stderr, "WARNING!  CUDA device 0 is not capable of running "
-                        "Espresso but is used by default.  Espresso has "
-                        "detected a CUDA capable card but it is not the one "
-                        "used by Espresso by default\n");
-        fprintf(stderr, "Please set the GPU to use with the cuda setdevice "
-                        "<int> command.\n");
-        fprintf(stderr,
-                "A list of available GPUs can be accessed using cuda list.\n");
+        runtimeWarningMsg()
+            << "CUDA device 0 is not capable of running ESPResSo but is used "
+               "by default. Espresso has detected a CUDA capable card but it "
+               "is not the one used by ESPResSo by default. Please set the "
+               "GPU to use by setting System.cuda_init_handle.device. A list "
+               "of avalable GPUs is available through "
+               "System.cuda_init_handle.device_list.";
       }
     }
   }


### PR DESCRIPTION
Fixes #1735

For now, the resulting warnings are unhandled until ESPResSo is closed, due to missing `handle_errors()`. This will be fixed by PR #1790.

The documentation describes the desired behavior. However setting the device is currently an issue (#1824).
