### PR TITLE
Python-shifts

### DIFF
--- a/src/core/gaussian.cpp
+++ b/src/core/gaussian.cpp
@@ -28,7 +28,8 @@
 #ifdef GAUSSIAN
 
 int gaussian_set_params(int part_type_a, int part_type_b,
-			double eps, double sig, double cut)
+			double eps, double sig, double cut,
+		        double shift)
 {
   IA_parameters *data = get_ia_param_safe(part_type_a, part_type_b);
   
@@ -37,6 +38,7 @@ int gaussian_set_params(int part_type_a, int part_type_b,
   data->Gaussian_eps = eps;
   data->Gaussian_sig = sig;
   data->Gaussian_cut = cut;
+  data->Gaussian_shift = shift;
 
   /* broadcast interaction parameters */
   mpi_bcast_ia_params(part_type_a, part_type_b);

--- a/src/core/gaussian.hpp
+++ b/src/core/gaussian.hpp
@@ -60,7 +60,7 @@ inline double gaussian_pair_energy(const Particle *p1, const Particle *p2,
                                    double dist2) {
   if ((dist < ia_params->Gaussian_cut)) {
     return ia_params->Gaussian_eps *
-           exp(-0.5 * Utils::sqr(dist / ia_params->Gaussian_sig)) - ia_params->Gaussian_shift;
+           exp(-0.5 * Utils::sqr(dist / ia_params->Gaussian_sig)) + ia_params->Gaussian_shift;
   }
   return 0.0;
 }

--- a/src/core/gaussian.hpp
+++ b/src/core/gaussian.hpp
@@ -34,7 +34,7 @@
 
 ///
 int gaussian_set_params(int part_type_a, int part_type_b, double eps,
-                        double sig, double cut);
+                        double sig, double cut, double shift);
 
 /** Calculate Gaussian force between particle p1 and p2 */
 inline void add_gaussian_pair_force(const Particle *const p1,
@@ -60,7 +60,7 @@ inline double gaussian_pair_energy(const Particle *p1, const Particle *p2,
                                    double dist2) {
   if ((dist < ia_params->Gaussian_cut)) {
     return ia_params->Gaussian_eps *
-           exp(-0.5 * Utils::sqr(dist / ia_params->Gaussian_sig));
+           exp(-0.5 * Utils::sqr(dist / ia_params->Gaussian_sig)) - ia_params->Gaussian_shift;
   }
   return 0.0;
 }

--- a/src/core/interaction_data.hpp
+++ b/src/core/interaction_data.hpp
@@ -262,6 +262,7 @@ struct IA_parameters {
   double SmSt_d = 0.0;
   int SmSt_n = 0.0;
   double SmSt_k0 = 0.0;
+  double SmSt_shift = 0.0;
 /*@}*/
 #endif
 
@@ -279,6 +280,7 @@ struct IA_parameters {
   double Gaussian_eps = 0.0;
   double Gaussian_sig = 1.0;
   double Gaussian_cut = INACTIVE_CUTOFF;
+  double Gaussian_shift = 1.0;
 /*@}*/
 #endif
 
@@ -328,6 +330,7 @@ struct IA_parameters {
   double soft_n = 0.0;
   double soft_cut = INACTIVE_CUTOFF;
   double soft_offset = 0.0;
+  double soft_shift = 0.0;
 /*@}*/
 #endif
 

--- a/src/core/interaction_data.hpp
+++ b/src/core/interaction_data.hpp
@@ -280,7 +280,7 @@ struct IA_parameters {
   double Gaussian_eps = 0.0;
   double Gaussian_sig = 1.0;
   double Gaussian_cut = INACTIVE_CUTOFF;
-  double Gaussian_shift = 1.0;
+  double Gaussian_shift = 0.0;
 /*@}*/
 #endif
 

--- a/src/core/soft_sphere.cpp
+++ b/src/core/soft_sphere.cpp
@@ -30,7 +30,7 @@
 #include "communication.hpp"
 
 int soft_sphere_set_params(int part_type_a, int part_type_b,
-			   double a, double n, double cut, double offset)
+			   double a, double n, double cut, double offset, double shift)
 {
   IA_parameters *data = get_ia_param_safe(part_type_a, part_type_b);
 
@@ -40,6 +40,7 @@ int soft_sphere_set_params(int part_type_a, int part_type_b,
   data->soft_n      = n;
   data->soft_cut    = cut;
   data->soft_offset = offset;
+  data->soft_shift  = shift;
  
   /* broadcast interaction parameters */
   mpi_bcast_ia_params(part_type_a, part_type_b);

--- a/src/core/soft_sphere.hpp
+++ b/src/core/soft_sphere.hpp
@@ -98,7 +98,7 @@ inline double soft_pair_energy(const Particle *p1, const Particle *p2,
     r_off = dist - ia_params->soft_offset;
     /* normal case: resulting force/energy smaller than zero. */
 
-    return soft_energy_r(ia_params->soft_a, ia_params->soft_n, r_off) - ia_params->soft_shift;
+    return soft_energy_r(ia_params->soft_a, ia_params->soft_n, r_off) + ia_params->soft_shift;
   }
   return 0.0;
 }

--- a/src/core/soft_sphere.hpp
+++ b/src/core/soft_sphere.hpp
@@ -38,7 +38,7 @@
 
 ///
 int soft_sphere_set_params(int part_type_a, int part_type_b, double a, double n,
-                           double cut, double offset);
+                           double cut, double offset, double shift);
 
 /** Resultant Force due to a soft-sphere potential between two
     particles at interatomic separation r */
@@ -98,7 +98,7 @@ inline double soft_pair_energy(const Particle *p1, const Particle *p2,
     r_off = dist - ia_params->soft_offset;
     /* normal case: resulting force/energy smaller than zero. */
 
-    return soft_energy_r(ia_params->soft_a, ia_params->soft_n, r_off);
+    return soft_energy_r(ia_params->soft_a, ia_params->soft_n, r_off) - ia_params->soft_shift;
   }
   return 0.0;
 }

--- a/src/core/steppot.cpp
+++ b/src/core/steppot.cpp
@@ -30,7 +30,7 @@
 int smooth_step_set_params(int part_type_a, int part_type_b,
 			   double d, int n, double eps,
 			   double k0, double sig,
-			   double cut)
+			   double cut, double shift)
 {
   IA_parameters *data = get_ia_param_safe(part_type_a, part_type_b);
   
@@ -42,6 +42,7 @@ int smooth_step_set_params(int part_type_a, int part_type_b,
   data->SmSt_d      = d;
   data->SmSt_n      = n;
   data->SmSt_k0     = k0;
+  data->SmSt_shift  = shift;
  
   /* broadcast interaction parameters */
   mpi_bcast_ia_params(part_type_a, part_type_b);

--- a/src/core/steppot.hpp
+++ b/src/core/steppot.hpp
@@ -72,7 +72,7 @@ inline double SmSt_pair_energy(const Particle *p1, const Particle *p2,
   fracP = pow(frac, ia_params->SmSt_n);
   er = exp(2. * ia_params->SmSt_k0 * (dist - ia_params->SmSt_sig));
 
-  return fracP + ia_params->SmSt_eps / (1.0 + er) - ia_params->SmSt_shift;
+  return fracP + ia_params->SmSt_eps / (1.0 + er) + ia_params->SmSt_shift;
 }
 
 #endif /* ifdef SMOOTH_STEP */

--- a/src/core/steppot.hpp
+++ b/src/core/steppot.hpp
@@ -35,7 +35,7 @@
 
 ///
 int smooth_step_set_params(int part_type_a, int part_type_b, double d, int n,
-                           double eps, double k0, double sig, double cut);
+                           double eps, double k0, double sig, double cut, double shift);
 
 /** Calculate smooth step force between particle p1 and p2 */
 inline void add_SmSt_pair_force(const Particle *const p1,
@@ -72,7 +72,7 @@ inline double SmSt_pair_energy(const Particle *p1, const Particle *p2,
   fracP = pow(frac, ia_params->SmSt_n);
   er = exp(2. * ia_params->SmSt_k0 * (dist - ia_params->SmSt_sig));
 
-  return fracP + ia_params->SmSt_eps / (1.0 + er);
+  return fracP + ia_params->SmSt_eps / (1.0 + er) - ia_params->SmSt_shift;
 }
 
 #endif /* ifdef SMOOTH_STEP */

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -78,6 +78,7 @@ cdef extern from "interaction_data.hpp":
         double SmSt_d
         int SmSt_n
         double SmSt_k0
+        double SmSt_shift
 
         double BMHTF_A;
         double BMHTF_B;
@@ -104,6 +105,7 @@ cdef extern from "interaction_data.hpp":
         double soft_n
         double soft_cut
         double soft_offset
+        double soft_shift
 
         double Hertzian_eps
         double Hertzian_sig
@@ -111,6 +113,7 @@ cdef extern from "interaction_data.hpp":
         double Gaussian_eps
         double Gaussian_sig
         double Gaussian_cut
+        double Gaussian_shift
 
         int dpd_wf
         int dpd_twf
@@ -172,7 +175,7 @@ IF SMOOTH_STEP:
         int smooth_step_set_params(int part_type_a, int part_type_b,
                                    double d, int n, double eps,
                                    double k0, double sig,
-                                   double cut);
+                                   double cut, double shift);
 IF BMHTF_NACL:
     cdef extern from "bmhtf-nacl.hpp":
         int BMHTF_set_params(int part_type_a, int part_type_b,
@@ -194,7 +197,7 @@ IF BUCKINGHAM:
 IF SOFT_SPHERE:
     cdef extern from "soft_sphere.hpp":
         int soft_sphere_set_params(int part_type_a, int part_type_b,
-                                   double a, double n, double cut, double offset);
+                                   double a, double n, double cut, double offset, double shift);
 
 IF HERTZIAN:
     cdef extern from "hertzian.hpp":
@@ -204,7 +207,7 @@ IF HERTZIAN:
 IF GAUSSIAN:
     cdef extern from "gaussian.hpp":
         int gaussian_set_params(int part_type_a, int part_type_b,
-                                double eps, double sig, double cut);
+                                double eps, double sig, double cut, double shift);
 
 IF DPD:
     cdef extern from "dpd.hpp":

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -893,9 +893,9 @@ IF SMOOTH_STEP == 1:
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
                 # Calc shift
-                self._params["shift"] = (self._params["sigma"] / self._params["cutoff"])**self._params["n"] 
+                self._params["shift"] = - ((self._params["sigma"] / self._params["cutoff"])**self._params["n"] 
                                          - (self._params["eps"] / (1. + 2.718281828459045**(2*self._params["k0"] * 
-                                                                  (self._params["cutoff"]-self._params["sig"]))))
+                                                                  (self._params["cutoff"]-self._params["sig"])))))
                                             # used value of e to 15 dp.
             
             if smooth_step_set_params(self._part_types[0], self._part_types[1],
@@ -1303,7 +1303,7 @@ IF SOFT_SPHERE == 1:
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
                 # Calc shift
-                self._params["shift"] = self._params["a"]*(self._params["cutoff"]-self._params["offset"])**(-self._params["n"])                              
+                self._params["shift"] = - self._params["a"]*(self._params["cutoff"]-self._params["offset"])**(-self._params["n"])                              
                                             
             if soft_sphere_set_params(self._part_types[0], self._part_types[1],
                                       self._params["a"],
@@ -1480,7 +1480,7 @@ IF GAUSSIAN == 1:
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
                 # Calc shift
-                self._params["shift"] = self._params["eps"]*2.718281828459045**(- (self._params["cutoff"]
+                self._params["shift"] = - self._params["eps"]*2.718281828459045**(- (self._params["cutoff"]
                                                                                  /self._params["sig"])**2 * 0.5 )
                                                                                 
             if gaussian_set_params(self._part_types[0], self._part_types[1],

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -879,7 +879,8 @@ IF SMOOTH_STEP == 1:
                 "eps": ia_params.SmSt_eps,
                 "k0": ia_params.SmSt_k0,
                 "sig": ia_params.SmSt_sig,
-                "cutoff": ia_params.SmSt_cut
+                "cutoff": ia_params.SmSt_cut,
+                "shift": ia_params.SmSt_shift
             }
 
         def is_active(self):
@@ -895,7 +896,8 @@ IF SMOOTH_STEP == 1:
                                       self._params["eps"],
                                       self._params["k0"],
                                       self._params["sig"],
-                                      self._params["cutoff"]):
+                                      self._params["cutoff"],
+                                      self._params["shift"]):
                 raise Exception("Could not set smooth-step parameters")
 
         def default_params(self):
@@ -908,7 +910,8 @@ IF SMOOTH_STEP == 1:
                 "eps": 0.,
                 "k0": 0.,
                 "sig": 0.,
-                "cutoff": 0.}
+                "cutoff": 0.,
+                "shift": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -934,6 +937,8 @@ IF SMOOTH_STEP == 1:
                   Length scale of second (soft) repulsion.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
+            shift : :obj:`float`, string
+                Constant shift of the potential.
 
             """
             super(SmoothStepInteraction, self).set_params(**kwargs)
@@ -942,7 +947,7 @@ IF SMOOTH_STEP == 1:
             """All parameters that can be set.
 
             """
-            return "d", "n", "eps", "k0", "sig", "cutoff"
+            return "d", "n", "eps", "k0", "sig", "cutoff", "shift"
 
         def required_keys(self):
             """Parameters that have to be set.
@@ -1277,6 +1282,7 @@ IF SOFT_SPHERE == 1:
                 "n": ia_params.soft_n,
                 "cutoff": ia_params.soft_cut,
                 "offset": ia_params.soft_offset
+                "shift": ia_params.soft_shift
             }
 
         def is_active(self):
@@ -1290,7 +1296,8 @@ IF SOFT_SPHERE == 1:
                                       self._params["a"],
                                       self._params["n"],
                                       self._params["cutoff"],
-                                      self._params["offset"]):
+                                      self._params["offset"],
+                                      self._params["shift"]):
                 raise Exception("Could not set Soft-sphere parameters")
 
         def default_params(self):
@@ -1301,7 +1308,8 @@ IF SOFT_SPHERE == 1:
                 "a": 0.,
                 "n": 0.,
                 "cutoff": 0.,
-                "offset": 0.}
+                "offset": 0.,
+                "shift": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -1323,6 +1331,8 @@ IF SOFT_SPHERE == 1:
                      Cutoff distance of the interaction.
             offset : :obj:`float`, optional
                      Offset distance of the interaction.
+            shift : :obj:`float`, string, optional
+                Constant shift of the potential.
 
             """
             super(SoftSphereInteraction, self).set_params(**kwargs)
@@ -1331,7 +1341,7 @@ IF SOFT_SPHERE == 1:
             """All parameters that can be set.
 
             """
-            return "a", "n", "cutoff", "offset"
+            return "a", "n", "cutoff", "offset", "shift"
 
         def required_keys(self):
             """Parameters that have to be set.
@@ -1443,7 +1453,8 @@ IF GAUSSIAN == 1:
             return {
                 "eps": ia_params.Gaussian_eps,
                 "sig": ia_params.Gaussian_sig,
-                "cutoff": ia_params.Gaussian_cut
+                "cutoff": ia_params.Gaussian_cut,
+                "shift": ia_params.Gaussian_shift
             }
 
         def is_active(self):
@@ -1456,7 +1467,8 @@ IF GAUSSIAN == 1:
             if gaussian_set_params(self._part_types[0], self._part_types[1],
                                    self._params["eps"],
                                    self._params["sig"],
-                                   self._params["cutoff"]):
+                                   self._params["cutoff"],
+                                   self._params["shift"]):
                 raise Exception(
                     "Could not set Gaussian interaction parameters")
 
@@ -1467,7 +1479,8 @@ IF GAUSSIAN == 1:
             return {
                 "eps": 0.,
                 "sig": 1.,
-                "cutoff": 0.}
+                "cutoff": 0.
+                "shift": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -1487,6 +1500,8 @@ IF GAUSSIAN == 1:
                   Variance sigma of the Gaussian interactin.
             cutoff : :obj:`float`
                      Cutoff distance of the interaction.
+            shift : :obj:`float`, string, optional
+                Constant shift of the potential.
 
             """
             super(GaussianInteraction, self).set_params(**kwargs)
@@ -1495,7 +1510,7 @@ IF GAUSSIAN == 1:
             """All parameters that can be set.
 
             """
-            return "eps", "sig", "cutoff"
+            return "eps", "sig", "cutoff", "shift"
 
         def required_keys(self):
             """Parameters that have to be set.

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -895,7 +895,7 @@ IF SMOOTH_STEP == 1:
                 # Calc shift
                 self._params["shift"] = (self._params["sigma"] / self._params["cutoff"])**self._params["n"] 
                                          - (self._params["eps"] / (1. + 2.718281828459045**(2*self._params["k0"] * 
-                                                                  (self._params["cutoff"]-self._params["sig"])))
+                                                                  (self._params["cutoff"]-self._params["sig"]))))
                                             # used value of e to 15 dp.
             
             if smooth_step_set_params(self._part_types[0], self._part_types[1],
@@ -1289,7 +1289,7 @@ IF SOFT_SPHERE == 1:
                 "a": ia_params.soft_a,
                 "n": ia_params.soft_n,
                 "cutoff": ia_params.soft_cut,
-                "offset": ia_params.soft_offset
+                "offset": ia_params.soft_offset,
                 "shift": ia_params.soft_shift
             }
 
@@ -1480,7 +1480,7 @@ IF GAUSSIAN == 1:
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
                 # Calc shift
-                self._params["shift"] = self._params["eps"]*2.718281828459045**(((self._params["cutoff"]-self._params["offset"])
+                self._params["shift"] = self._params["eps"]*2.718281828459045**(- (self._params["cutoff"]
                                                                                  /self._params["sig"])**2 * 0.5 )
                                                                                 
             if gaussian_set_params(self._part_types[0], self._part_types[1],
@@ -1498,7 +1498,7 @@ IF GAUSSIAN == 1:
             return {
                 "eps": 0.,
                 "sig": 1.,
-                "cutoff": 0.
+                "cutoff": 0.,
                 "shift": 0.}
 
         def type_name(self):

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -890,6 +890,14 @@ IF SMOOTH_STEP == 1:
             return ((self._params["eps"] > 0) and (self._params["sig"] > 0))
 
         def _set_params_in_es_core(self):
+            # Handle the case of shift="auto"
+            if self._params["shift"] == "auto":
+                # Calc shift
+                self._params["shift"] = (self._params["sigma"] / self._params["cutoff"])**self._params["n"] 
+                                         - (self._params["eps"] / (1. + 2.718281828459045**(2*self._params["k0"] * 
+                                                                  (self._params["cutoff"]-self._params["sig"])))
+                                            # used value of e to 15 dp.
+            
             if smooth_step_set_params(self._part_types[0], self._part_types[1],
                                       self._params["d"],
                                       self._params["n"],
@@ -1292,6 +1300,11 @@ IF SOFT_SPHERE == 1:
             return (self._params["a"] > 0)
 
         def _set_params_in_es_core(self):
+            # Handle the case of shift="auto"
+            if self._params["shift"] == "auto":
+                # Calc shift
+                self._params["shift"] = self._params["a"]*(self._params["cutoff"]-self._params["offset"])**(-self._params["n"])                              
+                                            
             if soft_sphere_set_params(self._part_types[0], self._part_types[1],
                                       self._params["a"],
                                       self._params["n"],
@@ -1464,6 +1477,12 @@ IF GAUSSIAN == 1:
             return (self._params["eps"] > 0)
 
         def _set_params_in_es_core(self):
+            # Handle the case of shift="auto"
+            if self._params["shift"] == "auto":
+                # Calc shift
+                self._params["shift"] = self._params["eps"]*2.718281828459045**(((self._params["cutoff"]-self._params["offset"])
+                                                                                 /self._params["sig"])**2 * 0.5 )
+                                                                                
             if gaussian_set_params(self._part_types[0], self._part_types[1],
                                    self._params["eps"],
                                    self._params["sig"],


### PR DESCRIPTION
Fixes #

Description of changes:
 - 
added potential shifts to Smooth Step, Soft Sphere and Gaussian non-bonded interactions. 

had to define the value of 'e', this was taken as 2.718281828459045 from https://oeis.org/A001113.

PR Checklist
------------
 - [x] Tests? - no tests need to be updated 
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs? - documentation will need to be amended to state that potential shifts have been added to the Smooth Step, Soft Sphere and Gaussian non bonded interactions. I couldn't find where to do this. 
