### PR TITLE
Add h5md group

### DIFF
--- a/src/core/io/writer/h5md/h5md_core.cpp
+++ b/src/core/io/writer/h5md/h5md_core.cpp
@@ -282,6 +282,15 @@ void File::create_new_file(const std::string &filename) {
   m_h5md_file =
       h5xx::file(filename, m_hdf5_comm, MPI_INFO_NULL, h5xx::file::out);
 
+  auto h5md_group = h5xx::group(m_h5md_file, "h5md");
+  std::vector<int> h5md_version = {1, 1};
+  h5xx::write_attribute(h5md_group, "version", h5md_version);
+  auto h5md_creator_group = h5xx::group(h5md_group, "creator");
+  h5xx::write_attribute(h5md_creator_group, "name", "ESPResSo");
+  h5xx::write_attribute(h5md_creator_group, "version", ESPRESSO_VERSION);
+  auto h5md_author_group = h5xx::group(h5md_group, "author");
+  h5xx::write_attribute(h5md_author_group, "name", "N/A");
+
   bool only_load = false;
   create_datasets(only_load);
 

--- a/testsuite/h5md.py
+++ b/testsuite/h5md.py
@@ -71,12 +71,12 @@ class CommonTests(ut.TestCase):
 
     def test_metadata(self):
         """Test if the H5MD metadata has been written properly."""
-        self.assertTrue(self.py_file['h5md'].attrs['version'][0] == 1)
-        self.assertTrue(self.py_file['h5md'].attrs['version'][1] == 1)
+        self.assertEqual(self.py_file['h5md'].attrs['version'][0], 1)
+        self.assertEqual(self.py_file['h5md'].attrs['version'][1], 1)
         self.assertTrue('creator' in self.py_file['h5md'])
         self.assertTrue('name' in self.py_file['h5md/creator'].attrs)
         self.assertTrue('version' in self.py_file['h5md/creator'].attrs)
-        self.assertTrue(self.py_file['h5md/creator'].attrs['name'][:] == b'ESPResSo')
+        self.assertEqual(self.py_file['h5md/creator'].attrs['name'][:], b'ESPResSo')
         self.assertTrue('author' in self.py_file['h5md'])
         self.assertTrue('name' in self.py_file['h5md/author'].attrs)
 

--- a/testsuite/h5md.py
+++ b/testsuite/h5md.py
@@ -69,6 +69,11 @@ class CommonTests(ut.TestCase):
             os.remove('test.h5')
         cls.py_file = cls.py_pos = cls.py_vel = cls.py_f = cls.py_id = cls.py_img = None
 
+    def test_metadata(self):
+        """Test if the H5MD metadata has been written properly."""
+        self.assertTrue(self.py_file['h5md'].attrs['version'][0] == 1)
+        self.assertTrue(self.py_file['h5md'].attrs['version'][1] == 1)
+
     def test_pos(self):
         """Test if positions have been written properly."""
         self.assertTrue(

--- a/testsuite/h5md.py
+++ b/testsuite/h5md.py
@@ -73,6 +73,12 @@ class CommonTests(ut.TestCase):
         """Test if the H5MD metadata has been written properly."""
         self.assertTrue(self.py_file['h5md'].attrs['version'][0] == 1)
         self.assertTrue(self.py_file['h5md'].attrs['version'][1] == 1)
+        self.assertTrue('creator' in self.py_file['h5md'])
+        self.assertTrue('name' in self.py_file['h5md/creator'].attrs)
+        self.assertTrue('version' in self.py_file['h5md/creator'].attrs)
+        self.assertTrue(self.py_file['h5md/creator'].attrs['name'][:] == b'ESPResSo')
+        self.assertTrue('author' in self.py_file['h5md'])
+        self.assertTrue('name' in self.py_file['h5md/author'].attrs)
 
     def test_pos(self):
         """Test if positions have been written properly."""

--- a/testsuite/h5md.py
+++ b/testsuite/h5md.py
@@ -73,12 +73,12 @@ class CommonTests(ut.TestCase):
         """Test if the H5MD metadata has been written properly."""
         self.assertEqual(self.py_file['h5md'].attrs['version'][0], 1)
         self.assertEqual(self.py_file['h5md'].attrs['version'][1], 1)
-        self.assertTrue('creator' in self.py_file['h5md'])
-        self.assertTrue('name' in self.py_file['h5md/creator'].attrs)
-        self.assertTrue('version' in self.py_file['h5md/creator'].attrs)
+        self.assertIn('creator', self.py_file['h5md'])
+        self.assertIn('name', self.py_file['h5md/creator'].attrs)
+        self.assertIn('version', self.py_file['h5md/creator'].attrs)
         self.assertEqual(self.py_file['h5md/creator'].attrs['name'][:], b'ESPResSo')
-        self.assertTrue('author' in self.py_file['h5md'])
-        self.assertTrue('name' in self.py_file['h5md/author'].attrs)
+        self.assertIn('author', self.py_file['h5md'])
+        self.assertIn('name', self.py_file['h5md/author'].attrs)
 
     def test_pos(self):
         """Test if positions have been written properly."""


### PR DESCRIPTION
Fixes #

Description of changes:
 - Add H5MD metadata in H5MD files, according to the specification http://nongnu.org/h5md/h5md.html#h5md-metadata
 - The appropriate version if H5MD 1.1 because at least the addition of connectivity

I tested locally with Python 2 and 3, filing the PR to see CI testing.

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
