### PR TITLE
fix Python 3 string/map issues

### DIFF
--- a/src/python/espressomd/MDA_ESP/__init__.py
+++ b/src/python/espressomd/MDA_ESP/__init__.py
@@ -30,7 +30,12 @@ A minimal working example is the following:
 <Universe with 1 atoms>
 
 """
-from six import StringIO
+
+try:
+    import cStringIO as StringIO
+except ImportError:
+    from io import StringIO
+
 import numpy as np
 import MDAnalysis
 

--- a/src/python/espressomd/MDA_ESP/__init__.py
+++ b/src/python/espressomd/MDA_ESP/__init__.py
@@ -30,7 +30,7 @@ A minimal working example is the following:
 <Universe with 1 atoms>
 
 """
-import cStringIO
+from six import StringIO
 import numpy as np
 import MDAnalysis
 
@@ -102,7 +102,7 @@ class Stream(object):
             _xyz+=str(_p.v)+'\n'
         for _p in self.system.part:
             _xyz+=str(_p.f)+'\n'
-        return  NamedStream(cStringIO.StringIO(_xyz), "__.ESP")
+        return  NamedStream(StringIO(_xyz), "__.ESP")
 
 class ESPParser(TopologyReaderBase):
     """
@@ -202,7 +202,7 @@ class ESPReader(SingleFrameReaderBase):
                     self.ts = ts = self._Timestep(self.n_atoms, **self._ts_kwargs)
                     self.ts.time = time
                 elif(pos==-1):
-                    self.ts._unitcell[:3] = np.array(map(float,line[1:-2].split()))
+                    self.ts._unitcell[:3] = np.array(list(map(float,line[1:-2].split())))
                 elif(pos < n_atoms):
                     positions[pos] = np.array(list(map(float, line[1:-2].split())))
                 elif(pos < 2*n_atoms):

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -330,7 +330,7 @@ cdef class System(object):
             for j in range(_state_size_plus_one + 1):
                 states_on_node_i.append(
                     rng.randint(0, numeric_limits[int].max()))
-            states[i] = " ".join(map(str, states_on_node_i))
+            states[i] = (" ".join(map(str, states_on_node_i))).encode('utf-8')
         mpi_random_set_stat(states)
 
     property seed:

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -369,14 +369,15 @@ cdef class System(object):
             if(len(rng_state) == n_nodes * _state_size_plus_one):
                 states = string_vec(n_nodes)
                 for i in range(n_nodes):
-                    states[i] = " ".join(
-                        map(str, rng_state[i * _state_size_plus_one:(i + 1) * _state_size_plus_one]))
+                    states[i] = (" ".join(map(str,
+                                 rng_state[i*_state_size_plus_one:(i+1)*_state_size_plus_one])
+                                 )).encode('utf-8')
                 mpi_random_set_stat(states)
             else:
                 raise ValueError("Wrong # of args: Usage: 'random_number_generator_state \"<state(1)> ... <state(n_nodes*(state_size+1))>, where each <state(i)> is an integer. The state size of the PRNG can be obtained by calling _get_PRNG_state_size().")
 
         def __get__(self):
-            rng_state = map(int, (mpi_random_get_stat().c_str()).split())
+            rng_state = list(map(int, (mpi_random_get_stat().c_str()).split()))
             return rng_state
 
     IF LEES_EDWARDS == 1:


### PR DESCRIPTION
Description of changes:
1. explicitly set encoding in set_random_state_PRNG in
   src/python/espressomd/system.pyx
2. use (c)StringIO from six in src/python/espressomd/MDA_ESP/__init__.py
3. "listify" a map in src/python/espressomd/MDA_ESP/__init__.py

There were a few Python 3 incompatibilities I encountered.

I used https://stackoverflow.com/questions/42678779/how-to-pass-string-from-python3-to-cythonized-c-function for the Python 3 `libcpp.string` vector issue.

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
