### PR TITLE
Decouple Domain Decomposition and Collision Detection

### DIFF
--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -509,17 +509,44 @@ void three_particle_binding_full_search(
   }
 }
 
+static void three_particle_binding_dd_do_search(
+    Cell *basecell, Particle &p1, Particle &p2) {
+  int basecellno = std::distance(&cells[0], basecell);
+  for (int n = 0; n < 27; ++n) {
+    Cell &cell = cells[dd_full_shell_neigh(basecellno, n)];
+    for (int pno = 0; pno < cell.n; ++pno) {
+      Particle &P = cell.part[pno];
+      // Skip collided particles themselves
+      if ((P.p.identity == p1.p.identity) ||
+          (P.p.identity == p2.p.identity)) {
+        continue;
+      }
+
+      // We need all cyclical permutations, here (bond is placed on 1st
+      // particle, order of bond partners does not matter, so we don't need
+      // non-cyclic permutations).
+      // coldet_do_three_particle_bond checks the bonding criterion and if
+      // the involved particles are not already bonded before it binds them.
+      if (!P.l.ghost) {
+        coldet_do_three_particle_bond(P, p1, p2);
+      }
+
+      if (!p1.l.ghost) {
+        coldet_do_three_particle_bond(p1, P, p2);
+      }
+
+      if (!p2.l.ghost) {
+        coldet_do_three_particle_bond(p2, P, p1);
+      }
+    }
+  }
+}
+
 // Goes through the collision queue and for each pair in it
 // looks for a third particle by using the domain decomposition
 // cell system. If found, it performs three particle binding
 void three_particle_binding_domain_decomposition(
     const std::vector<collision_struct> &gathered_queue) {
-  // We have domain decomposition
-
-  // Indices of the cells in which the colliding particles reside
-  int cellIdx[2][3];
-
-  // Iterate over collision queue
 
   for (auto &c : gathered_queue) {
 
@@ -527,68 +554,14 @@ void three_particle_binding_domain_decomposition(
     // indices
     if ((local_particles[c.pp1] != NULL) && (local_particles[c.pp2] != NULL)) {
 
-      Particle *p1 = local_particles[c.pp1];
-      Particle *p2 = local_particles[c.pp2];
-      dd_position_to_cell_indices(p1->r.p, cellIdx[0]);
-      dd_position_to_cell_indices(p2->r.p, cellIdx[1]);
+      Particle &p1 = *local_particles[c.pp1];
+      Particle &p2 = *local_particles[c.pp2];
+      auto cell1 = cell_structure.position_to_cell(p1.r.p);
+      auto cell2 = cell_structure.position_to_cell(p2.r.p);
 
-      // Iterate over the cells + their neighbors
-      // if p1 and p2 are in the same cell, we don't need to consider it 2x
-      int lim = 1;
-
-      if ((cellIdx[0][0] == cellIdx[1][0]) &&
-          (cellIdx[0][1] == cellIdx[1][1]) && (cellIdx[0][2] == cellIdx[1][2]))
-        lim = 0; // Only consider the 1st cell
-
-      for (int j = 0; j <= lim; j++) {
-
-        // Iterate the cell with indices cellIdx[j][] and all its neighbors.
-        // code taken from dd_init_cell_interactions()
-        for (int p = cellIdx[j][0] - 1; p <= cellIdx[j][0] + 1; p++)
-          for (int q = cellIdx[j][1] - 1; q <= cellIdx[j][1] + 1; q++)
-            for (int r = cellIdx[j][2] - 1; r <= cellIdx[j][2] + 1; r++) {
-              int ind2 = get_linear_index(p, q, r, dd.ghost_cell_grid);
-              Cell *cell = &cells[ind2];
-
-              // Iterate over particles in this cell
-              for (int a = 0; a < cell->n; a++) {
-                Particle *P = &cell->part[a];
-                // for all p:
-                // Check, whether p is equal to one of the particles in the
-                // collision. If so, skip
-                if ((P->p.identity == p1->p.identity) ||
-                    (P->p.identity == p2->p.identity)) {
-                  continue;
-                }
-
-                // The following checks,
-                // if the particle p is closer that the cutoff from p1 and/or
-                // p2.
-                // If yes, three particle bonds are created on all particles
-                // which have two other particles within the cutoff distance,
-                // unless such a bond already exists
-
-                // We need all cyclical permutations, here
-                // (bond is placed on 1st particle, order of bond partners
-                // does not matter, so we don't need non-cyclic permutations):
-
-                if (!P->l.ghost) {
-                  coldet_do_three_particle_bond(*P, *p1, *p2);
-                }
-
-                if (!p1->l.ghost) {
-                  coldet_do_three_particle_bond(*p1, *P, *p2);
-                }
-
-                if (!p2->l.ghost) {
-                  coldet_do_three_particle_bond(*p2, *P, *p1);
-                }
-
-              } // loop over particles in this cell
-
-            } // Loop over cell
-
-      } // Loop over particles if they are in different cells
+      three_particle_binding_dd_do_search(cell1, p1, p2);
+      if (cell1 != cell2)
+        three_particle_binding_dd_do_search(cell2, p1, p2);
 
     } // If local particles exist
 

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -62,6 +62,9 @@ int max_num_cells = CELLS_MAX_NUM_CELLS;
 int min_num_cells = 1;
 double max_skin = 0.0;
 
+// Full shell neighbor index offsets for dd_full_shell_neigh()
+std::vector<int> dd_fs_neigh;
+
 /*@}*/
 
 /************************************************************/
@@ -544,6 +547,12 @@ void dd_update_communicators_w_boxl() {
 void dd_init_cell_interactions() {
   int m, n, o, p, q, r, ind1, ind2;
 
+  dd_fs_neigh.clear();
+  for (p = -1; p <= 1; p++)
+    for (q = -1; q <= 1; q++)
+      for (r = -1; r <= 1; r++)
+        dd_fs_neigh.push_back(get_linear_index(r, q, p, dd.ghost_cell_grid));
+
   /* loop all local cells */
   DD_LOCAL_CELLS_LOOP(m, n, o) {
 
@@ -599,23 +608,6 @@ Cell *dd_save_position_to_cell(double pos[3]) {
   }
   i = get_linear_index(cpos[0], cpos[1], cpos[2], dd.ghost_cell_grid);
   return &(cells[i]);
-}
-
-void dd_position_to_cell_indices(double pos[3], int *idx) {
-  int i;
-  double lpos;
-
-  for (i = 0; i < 3; i++) {
-    lpos = pos[i] - my_left[i];
-
-    idx[i] = (int)(lpos * dd.inv_cell_size[i]) + 1;
-
-    if (idx[i] < 1) {
-      idx[i] = 1;
-    } else if (idx[i] > dd.cell_grid[i]) {
-      idx[i] = dd.cell_grid[i];
-    }
-  }
 }
 
 /*************************************************/
@@ -1168,3 +1160,8 @@ int calc_processor_min_num_cells() {
 }
 
 /************************************************************/
+
+int dd_full_shell_neigh(int cellidx, int neigh)
+{
+    return cellidx + dd_fs_neigh[neigh];
+}

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -155,9 +155,6 @@ void dd_topology_release();
 */
 void dd_exchange_and_sort_particles(int global_flag);
 
-/** Get three cell indices (coordinates in cell gird) from particle position */
-void dd_position_to_cell_indices(double pos[3], int *idx);
-
 /** calculate physical (processor) minimal number of cells */
 int calc_processor_min_num_cells();
 
@@ -175,6 +172,14 @@ int dd_fill_comm_cell_lists(Cell **part_lists, int lc[3], int hc[3]);
 /** Of every two communication rounds, set the first receivers to prefetch and
  * poststore */
 void dd_assign_prefetches(GhostCommunicator *comm);
+
+/** Return a full shell neighbor index.
+ * Required for collision.cpp.
+ * @param cellidx Index of a local cell
+ * @param neigh Number of full shell neighbor to get (0 <= neigh < 27)
+ * @return Index to cells (local or ghost cell) of the requested neighbor.
+ */
+int dd_full_shell_neigh(int cellidx, int neigh);
 /*@}*/
 
 #endif


### PR DESCRIPTION
In collision.cpp there is a collection of three raw for-loops iterating over the full shell neighborhood of a domain decomposition. This PR slightly increases the decoupling between the two modules by offering a function dd_full_shell_neigh which can be used. This also makes the function dd_position_to_cell_indices obsolete which exists only for this piece of code in the collision detection.

Description of changes:
 - Remove dd_position_to_cell_indices
 - Offer dd_full_shell_neigh
 - Get rid of irritating j-loop in three_particle_binding_domain_decomposition by moving the actual search code to a separate function
 - Use a 1d loop and calls to dd_full_shell_neigh instead of a 3d iteration directly over cell indices
 - Remove some useless comments
 - Convert pointers to references in the updated code

The three particle binding collision detection test still exits successfully and the pairs (basecell, neighborcell) traversed during this test are exactly the same and in the same ordering as before.

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
