### PR TITLE
doc: Corrected exclusions doc.

### DIFF
--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -169,7 +169,7 @@ Exclusions
 Particles can have an exclusion list of all other particles where non-bonded interactions are ignored.
 This is typically used in atomistic simulations, 
 where nearest and next nearest neighbor interactions along the chain have to be omitted since they are included in the bonding potentials.
-Exclusions do not apply to the short range part of electrstatics and magnetostatics methods, e.g. to P3M.
+Exclusions do not apply to the short range part of electrostatics and magnetostatics methods, e.g. to P3M.
 
   ::
 

--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -169,8 +169,7 @@ Exclusions
 Particles can have an exclusion list of all other particles where non-bonded interactions are ignored.
 This is typically used in atomistic simulations, 
 where nearest and next nearest neighbor interactions along the chain have to be omitted since they are included in the bonding potentials.
-Be aware that currently, exclusions also remove the short range part of electrostatics and dipolar interactions. Hence, exclusions should not be applied to pairs of particles which are charged or carry a dipole.
-
+Exclusions do not apply to the short range part of electrstatics and magnetostatics methods, e.g. to P3M.
 
   ::
 


### PR DESCRIPTION
Fixes #1839.

Corrected the exclusion docs to reflect that in fact the short range parts of electrostatics and magnetostatics methods are not excluded. This is already tested in the exclusion test.
