### PR TITLE
maintainer: Don't run checks in static analysis job.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ clang-static-analysis:
   stage: build
   image: espressomd/espresso-ubuntu-clang-cuda:latest
   script:
-    - export myconfig=maxset with_coverage=false with_static_analysis=true
+    - export myconfig=maxset with_coverage=false with_static_analysis=true make_check=false
     - bash maintainer/cuda_build.sh
 
 clang:


### PR DESCRIPTION
Don't run the testsuite in the static analysis job. This gives no new insights as the build es identical to the clang job.
