### PR TITLE
Fix Python 3 printing and integer division in samples

### DIFF
--- a/samples/dpd.py
+++ b/samples/dpd.py
@@ -1,4 +1,5 @@
 # A minimal DPD fluid
+from __future__ import print_function
 import espressomd
 import numpy as np
 
@@ -50,4 +51,4 @@ for V in range(100, 1000, 100):
     # And std
     p_std = np.std(p_samples)
 
-    print 'rho {:.2f} p {:.2f} ({:.2f})'.format(float(n_part) / V, p_avg, p_std)
+    print('rho {:.2f} p {:.2f} ({:.2f})'.format(float(n_part) / V, p_avg, p_std))

--- a/samples/minimal-charged-particles.py
+++ b/samples/minimal-charged-particles.py
@@ -78,7 +78,7 @@ for i in range(n_part):
     system.part.add(id=i, pos=np.random.random(3) * system.box_l)
 
 # Assingn charge to particles
-for i in range(n_part / 2 - 1):
+for i in range(n_part // 2 - 1):
     system.part[2 * i].q = -1.0
     system.part[2 * i + 1].q = 1.0
 

--- a/samples/minimal-polymer.py
+++ b/samples/minimal-polymer.py
@@ -28,7 +28,7 @@ from espressomd import polymer
 
 system = espressomd.System(box_l=[1.0, 1.0, 1.0])
 system.set_random_state_PRNG()
-#system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
+system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
 
 system.time_step = 0.01
 system.cell_system.skin = 0.4

--- a/samples/observables_correlators.py
+++ b/samples/observables_correlators.py
@@ -1,6 +1,6 @@
 # This scripts demonstrates the measurement of the mean square displacement
 # using the Observables/Correlators mechanism
-
+from __future__ import print_function
 import espressomd
 from espressomd.observables import *
 from espressomd.correlators import *
@@ -22,11 +22,11 @@ system.integrator.run(1000)
 # Initialize obzervable for a particle with id 0
 p = ParticlePositions(ids=(0,))
 # ASk the observable for its parameters
-print p.get_params()
+print(p.get_params())
 # Calculate and return current value
-print p.calculate()
+print(p.calculate())
 # Return stored current value
-print p.value()
+print(p.value())
 
 
 # Instance a correlator correlating the p observable with itself, calculating the mean squared displacement (msd).
@@ -36,7 +36,7 @@ c = Correlator(tau_lin=16, tau_max=1000, dt=0.01, obs1=p,
 fcs = Correlator(tau_lin=16, tau_max=10000, dt=0.1, obs1=p,
                  corr_operation="fcs_acf", args=[10, 10, 10], compress1="discard2")
 # Ask the correlator for its parameters
-print c.get_params()
+print(c.get_params())
 
 # Register the correlator for auto updating at the interval given by its dt (currently every timestep)
 system.auto_update_correlators.add(c)


### PR DESCRIPTION
Fixes a few Python 3 incompatibilites in `samples`.

Description of changes:
 - Mostly "print" related fixes
 - Make integer division explicit in minimal-charged-particles.py

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
