### PR TITLE
warmup and force type

### DIFF
--- a/samples/minimal-polymer.py
+++ b/samples/minimal-polymer.py
@@ -22,6 +22,7 @@ import espressomd
 from espressomd import thermostat
 from espressomd import interactions
 from espressomd import polymer
+from espressomd.io.writer import vtf  # pylint: disable=import-error
 
 # System parameters
 #############################################################
@@ -35,7 +36,8 @@ system.cell_system.skin = 0.4
 system.box_l = [100, 100, 100]
 system.thermostat.set_langevin(kT=1.0, gamma=1.0)
 system.cell_system.set_n_square(use_verlet_lists=False)
-i
+outfile = open('polymer.vtf', 'w')
+
 system.non_bonded_inter[0, 0].lennard_jones.set_params(
     epsilon=1, sigma=1,
     cutoff=2**(1. / 6), shift="auto")
@@ -45,8 +47,6 @@ system.bonded_inter.add(fene)
 
 
 polymer.create_polymer(N_P=1, bond_length=1.0, type_poly_neutral=0, type_poly_charged=0, MPC=50, bond=fene)
-
-outfile = open('polymer.vtf', 'w')
 vtf.writevsf(system, outfile)
 
 

--- a/samples/minimal-polymer.py
+++ b/samples/minimal-polymer.py
@@ -35,7 +35,7 @@ system.cell_system.skin = 0.4
 system.box_l = [100, 100, 100]
 system.thermostat.set_langevin(kT=1.0, gamma=1.0)
 system.cell_system.set_n_square(use_verlet_lists=False)
-
+i
 system.non_bonded_inter[0, 0].lennard_jones.set_params(
     epsilon=1, sigma=1,
     cutoff=2**(1. / 6), shift="auto")
@@ -43,14 +43,59 @@ system.non_bonded_inter[0, 0].lennard_jones.set_params(
 fene = interactions.FeneBond(k=10, d_r_max=2)
 system.bonded_inter.add(fene)
 
-polymer.create_polymer(N_P=1, bond_length=1.0, MPC=50, bond=fene)
+
+polymer.create_polymer(N_P=1, bond_length=1.0, type_poly_neutral=0, type_poly_charged=0, MPC=50, bond=fene)
+
+outfile = open('polymer.vtf', 'w')
+vtf.writevsf(system, outfile)
+
+
+#############################################################
+#      Warmup                                               #
+#############################################################
+
+warm_steps=10
+lj_cap = 1
+system.force_cap = lj_cap
+i = 0
+act_min_dist = system.analysis.min_dist()
+
+# warmp with zero temperature to remove overlaps
+system.thermostat.set_langevin(kT=0.0, gamma=1.0)
+
+# slowly ramp un up the cap
+while ( act_min_dist < 0.95):
+    vtf.writevcf(system, outfile)
+    print("min_dist: {} \t force cap: {}".format(act_min_dist, lj_cap))
+    system.integrator.run(warm_steps)
+    system.part[:].v=[0,0,0]
+    # Warmup criterion
+    act_min_dist = system.analysis.min_dist()
+    lj_cap = lj_cap*1.01
+    system.force_cap = lj_cap
+
+#remove force cap
+lj_cap = 0
+system.force_cap = lj_cap
+system.integrator.run(warm_steps*10)
+
+# restore simulation temperature
+system.thermostat.set_langevin(kT=1.0, gamma=1.0)
+system.integrator.run(warm_steps*10)
+print("Finished warmup")
+
+
 
 #############################################################
 #      Integration                                          #
 #############################################################
 
-for i in range(20):
-    system.integrator.run(1000)
+print("simulating...")
+t_steps=1000
+for t in range(t_steps):
+    print("step {} of {}".format(t, t_steps))
+    system.integrator.run(warm_steps)
+    vtf.writevcf(system, outfile)
 
-    energies = system.analysis.energy()
-    print(energies)
+outfile.close()
+

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -133,6 +133,23 @@ def create_polymer(**kwargs):
             bond_length = 1, 
             bond = fene, 
             val_poly = -1.0)
+
+    Note that a the first monomer of a polymer is always assigned the type `type_poly_charge`.
+    The next `charge_distance` monomers have type `type_poly_neutral`.
+    This process repeats untill all monomers are placed.
+    Afterwards, all monomers of type `type_poly_charge` are assigned the charge `val_poly`.
+    Thus the following example creates a single uncharged polymer where all monomers are of `type=0`:
+
+    >>> fene = interactions.FeneBond(k=10, d_r_max=2)
+    >>> polymer.create_polymer(
+            N_P = 1, 
+            MPC = 10, 
+            bond_length = 1, 
+            bond = fene, 
+            val_poly = 0.0,
+            charge_distance = 1,
+            type_poly_charge = 0)
+
     """
 
     params=dict()


### PR DESCRIPTION
Fixes #

create_polymer() creates type 1 monomers with type_poly_uncharged=0. This is a bit confusing when one wants uncharged monomers and ends up with what seems to be the wrong type.
The example script now forces all monomer types to be type=0. and the Docs have a better explaination of particle type assignment from create_polmyer()

create_polymer()  did not have a warmup steps, now it does.

Description of changes:
 - warmup in minimal-polymer,
 - writes trajectory file
 - forces particle type
 


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [x] Docs?
