### PR TITLE
Python3 checkpoint

### DIFF
--- a/samples/coulomb_debye_hueckel.py
+++ b/samples/coulomb_debye_hueckel.py
@@ -105,7 +105,7 @@ print(system.non_bonded_inter[0, 0].lennard_jones.get_params())
 for i in range(n_part):
     system.part.add(id=i, pos=np.random.random(3) * system.box_l)
 
-for i in range(n_part / 2):
+for i in range(n_part // 2):
     system.part[2 * i].q = -1.0
     system.part[2 * i].type = 1
     system.part[2 * i + 1].q = 1.0

--- a/samples/debye_hueckel.py
+++ b/samples/debye_hueckel.py
@@ -104,7 +104,7 @@ print(system.non_bonded_inter[0, 0].lennard_jones.get_params())
 for i in range(n_part):
     system.part.add(id=i, pos=np.random.random(3) * system.box_l)
 
-for i in range(n_part / 2):
+for i in range(n_part // 2):
     system.part[2 * i].q = -1.0
     system.part[2 * i].type = 1
     system.part[2 * i + 1].q = 1.0

--- a/samples/load_checkpoint.py
+++ b/samples/load_checkpoint.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import espressomd
 from espressomd import checkpointing
 
@@ -10,42 +11,42 @@ system.set_random_state_PRNG()
 #system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
 
 # test user variable
-print "\n### user variable test ###"
-print "myvar = {}".format(myvar)
-print "skin = {}".format(skin)
+print("\n### user variable test ###")
+print("myvar = {}".format(myvar))
+print("skin = {}".format(skin))
 
 # test "system"
-print "\n### system test ###"
-print "system.time = {}".format(system.time)
-print "system.box_l = {}".format(system.box_l)
+print("\n### system test ###")
+print("system.time = {}".format(system.time))
+print("system.box_l = {}".format(system.box_l))
 # system.cell_system not implemented yet, see sample script store_properties.py
 system.cell_system.skin = skin
 
 # test "system.non_bonded_inter"
-print "\n### system.non_bonded_inter test ###"
-print "system.non_bonded_inter[0, 0].lennard_jones.get_params() = {}".format(system.non_bonded_inter[0, 0].lennard_jones.get_params())
+print("\n### system.non_bonded_inter test ###")
+print("system.non_bonded_inter[0, 0].lennard_jones.get_params() = {}".format(system.non_bonded_inter[0, 0].lennard_jones.get_params()))
 
 # test "system.part"
-print "\n### system.part test ###"
-print "system.part[:].pos = {}".format(system.part[:].pos)
+print("\n### system.part test ###")
+print("system.part[:].pos = {}".format(system.part[:].pos))
 
 # test "system.thermostat"
-print "\n### system.thermostat test ###"
-print "system.thermostat.get_state() = {}".format(system.thermostat.get_state())
+print("\n### system.thermostat test ###")
+print("system.thermostat.get_state() = {}".format(system.thermostat.get_state()))
 
 # test "p3m"
-print "\n### p3m test ###"
-print "p3m.get_params() = {}".format(p3m.get_params())
+print("\n### p3m test ###")
+print("p3m.get_params() = {}".format(p3m.get_params()))
 system.actors.add(p3m)
 
 # test registered objects
 # all objects that are registered when writing a checkpoint are automatically registered after loading this checkpoint
-print "\n### checkpoint register test ###"
-print "checkpoint.get_registered_objects() = {}".format(checkpoint.get_registered_objects())
+print("\n### checkpoint register test ###")
+print("checkpoint.get_registered_objects() = {}".format(checkpoint.get_registered_objects()))
 
 
 # integrate system and finally save checkpoint
-print "\n### Integrate until user presses ctrl+c ###"
-print "Integrating..."
+print("\n### Integrate until user presses ctrl+c ###")
+print("Integrating...")
 while True:
     system.integrator.run(1000)

--- a/samples/p3m.py
+++ b/samples/p3m.py
@@ -107,7 +107,7 @@ system.cell_system.max_num_cells = 2744
 
 
 # Assingn charge to particles
-for i in range(n_part / 2 - 1):
+for i in range(n_part // 2 - 1):
     system.part[2 * i].q = -1.0
     system.part[2 * i + 1].q = 1.0
 # P3M setup after charge assigned
@@ -173,6 +173,7 @@ import pprint
 pprint.pprint(system.cell_system.get_state(), width=1)
 # pprint.pprint(system.part.__getstate__(), width=1)
 pprint.pprint(system.__getstate__(), width=1)
+
 
 # write parameter file
 set_file = open("pylj_liquid.set", "w")

--- a/samples/samples_common.py
+++ b/samples/samples_common.py
@@ -24,4 +24,4 @@ def open(*args, **kwargs):
     -------
     file-like object
     """
-    return tempfile.TemporaryFile()
+    return tempfile.TemporaryFile(mode='w')

--- a/samples/save_checkpoint.py
+++ b/samples/save_checkpoint.py
@@ -58,7 +58,7 @@ checkpoint.register("system.part")
 
 
 # test for "p3m"
-for i in range(n_part / 2 - 1):
+for i in range(n_part // 2 - 1):
     system.part[2 * i].q = -1.0
     system.part[2 * i + 1].q = 1.0
 p3m = electrostatics.P3M(prefactor=1.0, accuracy=1e-2)

--- a/samples/store_properties.py
+++ b/samples/store_properties.py
@@ -108,7 +108,7 @@ system.cell_system.max_num_cells = 2744
 
 
 # Assingn charge to particles
-for i in range(n_part / 2 - 1):
+for i in range(n_part // 2 - 1):
     system.part[2 * i].q = -1.0
     system.part[2 * i + 1].q = 1.0
 

--- a/src/python/espressomd/checkpointing.py
+++ b/src/python/espressomd/checkpointing.py
@@ -68,7 +68,7 @@ class Checkpointing(object):
         """
         names = name.split('.')
 
-        for i in xrange(len(names)-1):
+        for i in range(len(names)-1):
             obj = getattr(obj, names[i], default)
 
         return getattr(obj, names[-1], default)
@@ -83,7 +83,7 @@ class Checkpointing(object):
         """
         names = name.split('.')
         tmp_obj = obj
-        for i in xrange(len(names)-1):
+        for i in range(len(names)-1):
             obj = getattr(obj, names[i], None)
 
         if obj == None:
@@ -97,7 +97,7 @@ class Checkpointing(object):
         
         """
         names = name.split('.')
-        for i in xrange(len(names)-1):
+        for i in range(len(names)-1):
             obj = getattr(obj, names[i], None)
 
         return hasattr(obj, names[-1])
@@ -180,7 +180,7 @@ class Checkpointing(object):
         filename = os.path.join(self.checkpoint_dir, "{}.checkpoint".format(checkpoint_index))
 
         tmpname = filename + ".__tmp__"
-        with open(tmpname,"w") as checkpoint_file:
+        with open(tmpname,"wb") as checkpoint_file:
             pickle.dump(checkpoint_data, checkpoint_file, -1)
         os.rename(tmpname, filename)
 
@@ -195,7 +195,7 @@ class Checkpointing(object):
             checkpoint_index = self.get_last_checkpoint_index()
 
         filename = os.path.join(self.checkpoint_dir, "{}.checkpoint".format(checkpoint_index))
-        with open(filename,"r") as checkpoint_file:
+        with open(filename,"rb") as checkpoint_file:
             checkpoint_data = pickle.load(checkpoint_file)
 
         for key in checkpoint_data:
@@ -233,6 +233,7 @@ class Checkpointing(object):
         Writes the given signal integer signum to the signal file.
         
         """
+        signum = int(signum)
         if not is_valid_type(signum, int):
             raise ValueError("Signal must be an integer number.")
 


### PR DESCRIPTION
Python 3 related fixed in checkpointing

Description of changes:
 - Fix Python 3 printing syntax in `samples/load_checkpoint.py`
 - Replace xrange by range. The corresponding ranges are not performance
   sensitive.
 - Use binary mode for pickled files.
 - Cast the signals to int. The signals are subclassed from int and so pass
   the "isinstance" validation. But they print their "<signals...." repr
   and so store non-integers to the signal file.

I tested the fixes with Python 2 and 3 with the "save" and "load" checkpoint samples.

The cast to "int" in "checkpointing.py" is now duplicating the "is_valid_type" but actually performs the same check. A failed cast will raise an exception.

BTW, I left the commit from "python3_samples_fixes" by inadvertence. I can close this PR and reopen another one if needed but if #1878 is accepted it should work alright.

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
