### PR TITLE
[codecov] Increase threshold for failed coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,8 +10,14 @@ coverage:
   range: "70...100"
 
   status:
-    project: yes
-    patch: yes
+    project:
+      default:
+        enabled: yes
+        threshold: 1%
+    patch:
+      default:
+        enabled: yes
+        threshold: 1%
     changes: no
 
 parsers:


### PR DESCRIPTION
Currently almost all PRs show as failed because of things like

> codecov/project — 61% (-1%) compared to ...

This is caused by statistical testcases which have to be non-deterministic.  In this PR I increase the threshold for failing to a change of 1% in the hope to suppress such noise.  Let's see if it works.