### PR TITLE
Fix Python 3 builds on macOS on Travis

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -109,7 +109,7 @@ Alternatively, you can use Homebrew.
     sudo xcode-select --install
     sudo xcodebuild -license accept
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    brew install cmake python cython boost boost-mpi fftw
+    brew install cmake python@2 cython boost boost-mpi fftw
     brew install numpy --without-python3
     ln -s /usr/local/bin/python2 /usr/local/bin/python
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -109,8 +109,8 @@ Alternatively, you can use Homebrew.
     sudo xcode-select --install
     sudo xcodebuild -license accept
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    brew install cmake python@2 cython boost boost-mpi fftw
-    brew install numpy --without-python3
+    brew install cmake python@3 cython boost boost-mpi fftw
+    brew install numpy --without-python@2
     ln -s /usr/local/bin/python2 /usr/local/bin/python
 
 Note: If both MacPorts and Homebrew are installed, you will not be able to

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -29,20 +29,21 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	brew install cmake || brew upgrade cmake
 	case "$image" in
 		python3)
-			brew install python3
+			brew install python@3 || brew upgrade python@3
 			pip3 install h5py
 			pip3 install cython
 			pip3 install numpy
 			pip3 install pep8
 			pip3 install pylint
-			PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}' | awk -F . '{print $1"."$2}')
 			export cmake_params="-DPYTHON_EXECUTABLE=$(which python3) $cmake_params"
 		;;
 		*)
+			brew install python@2 || brew upgrade python@2
 			pip install h5py
 			pip install cython
 			pip install numpy
 			pip install pep8
+			export cmake_params="-DPYTHON_EXECUTABLE=$(which python2) $cmake_params"
             pip install pylint
 		;;
 	esac

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -40,7 +40,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 		*)
 			brew uninstall --ignore-dependencies python
 			brew install python@2 || brew upgrade python@2
-			export PATH="/usr/local/opt/python@2/libexec/bin:$PATH"
+			export PATH="/usr/local/opt/python@2/bin:$PATH"
 			pip2 install h5py
 			pip2 install cython
 			pip2 install numpy

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -38,6 +38,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 			export cmake_params="-DPYTHON_EXECUTABLE=$(which python3) $cmake_params"
 		;;
 		*)
+			brew uninstall python
 			brew install python@2 || brew upgrade python@2
 			pip2 install h5py
 			pip2 install cython

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -40,6 +40,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 		*)
 			brew uninstall --ignore-dependencies python
 			brew install python@2 || brew upgrade python@2
+			export PATH="/usr/local/opt/python@2/libexec/bin:$PATH"
 			pip2 install h5py
 			pip2 install cython
 			pip2 install numpy

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -38,7 +38,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 			export cmake_params="-DPYTHON_EXECUTABLE=$(which python3) $cmake_params"
 		;;
 		*)
-			brew uninstall python
+			brew uninstall --ignore-dependencies python
 			brew install python@2 || brew upgrade python@2
 			pip2 install h5py
 			pip2 install cython

--- a/maintainer/travis/build_docker.sh
+++ b/maintainer/travis/build_docker.sh
@@ -39,12 +39,12 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 		;;
 		*)
 			brew install python@2 || brew upgrade python@2
-			pip install h5py
-			pip install cython
-			pip install numpy
-			pip install pep8
+			pip2 install h5py
+			pip2 install cython
+			pip2 install numpy
+			pip2 install pep8
+			pip2 install pylint
 			export cmake_params="-DPYTHON_EXECUTABLE=$(which python2) $cmake_params"
-            pip install pylint
 		;;
 	esac
 	brew install boost-mpi


### PR DESCRIPTION
Reported by @hmenke in https://github.com/espressomd/espresso/pull/1644#issuecomment-370131362. Homebrew switched to Python 3 as the default version last week: https://github.com/Homebrew/homebrew-core/pull/24604.