### PR TITLE
ParticleSlice: dont allow setting of nonexisting properties.

### DIFF
--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1713,7 +1713,10 @@ class ParticleSlice(_ParticleSliceImpl):
 
     """
 
-    pass
+    def __setattr__(self, name, value):
+        if name != "_chunk_size" and not hasattr(ParticleHandle, name):
+            raise AttributeError("ParticleHandle does not have the attribute {}.".format(name))
+        super(ParticleSlice, self).__setattr__(name, value)
 
 
 cdef class ParticleList(object):

--- a/testsuite/particle_slice.py
+++ b/testsuite/particle_slice.py
@@ -355,5 +355,9 @@ class ParticleSliceTest(ut.TestCase):
         self.assertEqual(len(self.system.part[0:1]), 1)
         self.assertEqual(len(self.system.part[0:2]), 2)
 
+    def test_non_exising_property(self):
+        with self.assertRaises(AttributeError):
+            self.system.part[:].thispropertydoesnotexist = 1.0
+
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/particle_slice.py
+++ b/testsuite/particle_slice.py
@@ -355,7 +355,7 @@ class ParticleSliceTest(ut.TestCase):
         self.assertEqual(len(self.system.part[0:1]), 1)
         self.assertEqual(len(self.system.part[0:2]), 2)
 
-    def test_non_exising_property(self):
+    def test_non_existing_property(self):
         with self.assertRaises(AttributeError):
             self.system.part[:].thispropertydoesnotexist = 1.0
 


### PR DESCRIPTION
Fixes #1881 

Description of changes:
 - implemented custom ```__setattr__``` method to raise an error if trying to set a non-ParticleHandle property


PR Checklist
------------
 - [x] Tests?
   - [x] Interface
