### PR TITLE
codecov: ignore libs folder.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -32,3 +32,6 @@ comment:
   layout: "reach, diff, flags, files, footer"
   behavior: default
   require_changes: no
+
+ignore:
+  - "libs"


### PR DESCRIPTION
Fixes #1908 

Description of changes:
 - ignore libs folder in codecov