### PR TITLE
original loop length for thermalized bond test

### DIFF
--- a/testsuite/thermalized_bond.py
+++ b/testsuite/thermalized_bond.py
@@ -94,7 +94,7 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
         self.system.integrator.run(50)
         
         # Sampling
-        loops = 160
+        loops = 16000
         v_stored = np.zeros((N2 * loops, 3))
         for i in range(loops):
             self.system.integrator.run(2)
@@ -138,7 +138,7 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
         self.system.integrator.run(50)
         
         # Sampling
-        loops = 160
+        loops = 16000
         v_stored = np.zeros((N2 * loops, 3))
         for i in range(loops):
             self.system.integrator.run(2)

--- a/testsuite/thermalized_bond.py
+++ b/testsuite/thermalized_bond.py
@@ -94,10 +94,10 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
         self.system.integrator.run(50)
         
         # Sampling
-        loops = 1600
+        loops = 200
         v_stored = np.zeros((N2 * loops, 3))
         for i in range(loops):
-            self.system.integrator.run(2)
+            self.system.integrator.run(12)
             v_com = 1.0/(m1+m2)*(m1*self.system.part[::2].v+m2*self.system.part[1::2].v)
             v_stored[i * N2:(i + 1) * N2, :] = v_com 
 
@@ -138,10 +138,10 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
         self.system.integrator.run(50)
         
         # Sampling
-        loops = 1600
+        loops = 200
         v_stored = np.zeros((N2 * loops, 3))
         for i in range(loops):
-            self.system.integrator.run(2)
+            self.system.integrator.run(12)
             v_dist = self.system.part[1::2].v - self.system.part[::2].v 
             v_stored[i * N2:(i + 1) * N2, :] = v_dist 
 

--- a/testsuite/thermalized_bond.py
+++ b/testsuite/thermalized_bond.py
@@ -94,7 +94,7 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
         self.system.integrator.run(50)
         
         # Sampling
-        loops = 16000
+        loops = 1600
         v_stored = np.zeros((N2 * loops, 3))
         for i in range(loops):
             self.system.integrator.run(2)
@@ -138,7 +138,7 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
         self.system.integrator.run(50)
         
         # Sampling
-        loops = 16000
+        loops = 1600
         v_stored = np.zeros((N2 * loops, 3))
         for i in range(loops):
             self.system.integrator.run(2)


### PR DESCRIPTION
Back to 16000 configurations for the thermalized bond test. 
Runs in approx. 16 seconds.