### PR TITLE
Doc observables and test observable/analysis consistency for stress tensor

### DIFF
--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -747,7 +747,7 @@ The following observables are available:
      The particles are ordered according to the list of ids passed to the observable.
    - ParticleForces: Forces on the particles in the form
      :math:`f_{x1},\ f_{y1},\ f_{z1},\ f_{x2},\ f_{y2},\ f_{z2},\ \dots\ f_{xn},\ f_{yn},\ f_{zn}`.
-   - ParticleBodyVelocities: the particles' velocity in their respective body-fixed frames.
+   - ParticleBodyVelocities: the particles' velocities in their respective body-fixed frames (as per their orientation in space stored in their quaternions).
      :math:`v_{x1},\ v_{y1},\ v_{z1},\ v_{x2},\ v_{y2},\ v_{z2},\ \dots\ v_{xn},\ v_{yn},\ v_{zn}`.
      The particles are ordered according to the list of ids passed to the observable.
    - ParticleAngularVelocities: The particles' angular velocities in the space-fixed frame
@@ -779,6 +779,10 @@ The following observables are available:
    -  ForceDensityProfile
 
    -  LBVelocityProfile
+
+- System-wide observables
+  StressTensor: Total stress tensor (see :ref:`stress tensor`)
+
 
 
 .. _Correlations:

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -189,16 +189,47 @@ class MagneticDipoleMoment(Observable):
 @script_interface_register
 class ParticleAngularVelocities(Observable):
     _so_name = "Observables::ParticleAngularVelocities"
+    
+    """Calculates the angular velocity (omega) in the spaced-fixed frame of reference
+   
+    Parameters
+    ----------
+    ids : array_like of :obj:`int`
+          The ids of (existing) particles to take into account.
+
+    """
 
 
 @script_interface_register
 class ParticleBodyAngularVelocities(Observable):
     _so_name = "Observables::ParticleBodyAngularVelocities"
+    """Calculates the angular velocity (omega) in the particles'  body-fixed frame of reference.
+   
+   For each particle, the body-fixed frame of reference is obtained from the particle's
+   orientation stored in the quaternions.
+
+    Parameters
+    ----------
+    ids : array_like of :obj:`int`
+          The ids of (existing) particles to take into account.
+
+    """
 
 
 @script_interface_register
 class ParticleBodyVelocities(Observable):
     _so_name = "Observables::ParticleBodyVelocities"
+    """Calculates the particle velocity in the particles'  body-fixed frame of reference.
+   
+   For each particle, the body-fixed frame of reference is obtained from the particle's
+   orientation stored in the quaternions.
+
+    Parameters
+    ----------
+    ids : array_like of :obj:`int`
+          The ids of (existing) particles to take into account.
+
+    """
 
 
 @script_interface_register
@@ -257,10 +288,10 @@ class ParticleVelocities(Observable):
 class StressTensor(Observable):
     _so_name = "Observables::StressTensor"
 
+    """Calculates the total stress tensor. See :ref:`stress tensor`)
 
-@script_interface_register
-class StressTensorAcf(Observable):
-    _so_name = "Observables::StressTensorAcf"
+    """
+
 
 
 @script_interface_register

--- a/testsuite/stress.py
+++ b/testsuite/stress.py
@@ -8,7 +8,7 @@ import espressomd
 from espressomd.interactions import HarmonicBond
 from espressomd.interactions import FeneBond
 from espressomd import analyze
-from espressomd.observables import StressTensor,StressTensorAcf
+from espressomd.observables import StressTensor
 
 import itertools
 from tests_common import fene_force, fene_potential, fene_force2


### PR DESCRIPTION
Fixes #1617 
StressTensor does what is says. Consistency checked in stress testcase.
StressTensorAcf doesn't seem to exist in the core. IIRC, it was just the symmetrized stress tensor.
The rest had doc in sphinx/analysis.rst which is now also in-code.
