### PR TITLE
Rotation and VirtualSitesRelative updates

### DIFF
--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -171,7 +171,7 @@ static int terminated = 0;
   CB(mpi_iccp3m_iteration_slave)                                               \
   CB(mpi_iccp3m_init_slave)                                                    \
   CB(mpi_send_rotational_inertia_slave)                                        \
-  CB(mpi_send_rotational_inertia_slave)                                        \
+  CB(mpi_send_affinity_slave)                                                  \
   CB(mpi_rotate_particle_slave)                                                  \
   CB(mpi_send_out_direction_slave)                                             \
   CB(mpi_send_mu_E_slave)                                                      \

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -50,6 +50,7 @@
 #include "initialize.hpp"
 #include "integrate.hpp"
 #include "interaction_data.hpp"
+#include "io/mpiio/mpiio.hpp"
 #include "lb.hpp"
 #include "lbboundaries.hpp"
 #include "lbboundaries/LBBoundary.hpp"
@@ -65,7 +66,6 @@
 #include "mmm2d.hpp"
 #include "molforces.hpp"
 #include "morse.hpp"
-#include "io/mpiio/mpiio.hpp"
 #include "npt.hpp"
 #include "overlap.hpp"
 #include "p3m-dipolar.hpp"
@@ -73,13 +73,13 @@
 #include "partCfg_global.hpp"
 #include "particle_data.hpp"
 #include "pressure.hpp"
-#include "swimmer_reaction.hpp"
 #include "reaction_field.hpp"
 #include "rotation.hpp"
 #include "scafacos.hpp"
 #include "statistics.hpp"
 #include "statistics_chain.hpp"
 #include "statistics_fluid.hpp"
+#include "swimmer_reaction.hpp"
 #include "tab.hpp"
 #include "topology.hpp"
 #include "virtual_sites.hpp"
@@ -103,7 +103,7 @@ std::unique_ptr<boost::mpi::environment> mpi_env;
 boost::mpi::communicator comm_cart;
 
 namespace Communication {
-  std::unique_ptr<MpiCallbacks> m_callbacks;
+std::unique_ptr<MpiCallbacks> m_callbacks;
 
 /* We use a singelton callback class for now. */
 MpiCallbacks &mpiCallbacks() {
@@ -172,7 +172,7 @@ static int terminated = 0;
   CB(mpi_iccp3m_init_slave)                                                    \
   CB(mpi_send_rotational_inertia_slave)                                        \
   CB(mpi_send_affinity_slave)                                                  \
-  CB(mpi_rotate_particle_slave)                                                  \
+  CB(mpi_rotate_particle_slave)                                                \
   CB(mpi_send_out_direction_slave)                                             \
   CB(mpi_send_mu_E_slave)                                                      \
   CB(mpi_bcast_max_mu_slave)                                                   \
@@ -268,7 +268,8 @@ void mpi_init() {
 #else
   int argc{};
   char **argv{};
-  Communication::mpi_env = Utils::make_unique<boost::mpi::environment>(argc, argv);
+  Communication::mpi_env =
+      Utils::make_unique<boost::mpi::environment>(argc, argv);
 #endif
 
   MPI_Comm_size(MPI_COMM_WORLD, &n_nodes);
@@ -626,7 +627,7 @@ void mpi_send_rotational_inertia(int pnode, int part, double rinertia[3]) {
   on_particle_change();
 #endif
 }
- 
+
 void mpi_send_rotational_inertia_slave(int pnode, int part) {
 #ifdef ROTATIONAL_INERTIA
   if (pnode == this_node) {
@@ -639,13 +640,13 @@ void mpi_send_rotational_inertia_slave(int pnode, int part) {
 #endif
 }
 
-void mpi_rotate_particle(int pnode, int part, double axis[3],double angle) { 
+void mpi_rotate_particle(int pnode, int part, double axis[3], double angle) {
 #ifdef ROTATION
   mpi_call(mpi_rotate_particle_slave, pnode, part);
 
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    local_rotate_particle(p,axis,angle);
+    local_rotate_particle(p, axis, angle);
   } else {
     MPI_Send(axis, 3, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
     MPI_Send(&angle, 1, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
@@ -659,18 +660,15 @@ void mpi_rotate_particle_slave(int pnode, int part) {
 #ifdef ROTATION
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    double axis[3],angle;
-    MPI_Recv(axis, 3, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
-             MPI_STATUS_IGNORE);
-    MPI_Recv(&angle, 1, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
-             MPI_STATUS_IGNORE);
-    local_rotate_particle(p,axis,angle);
+    double axis[3], angle;
+    MPI_Recv(axis, 3, MPI_DOUBLE, 0, SOME_TAG, comm_cart, MPI_STATUS_IGNORE);
+    MPI_Recv(&angle, 1, MPI_DOUBLE, 0, SOME_TAG, comm_cart, MPI_STATUS_IGNORE);
+    local_rotate_particle(p, axis, angle);
   }
 
   on_particle_change();
 #endif
 }
-
 
 /********************* REQ_SET_BOND_SITE ********/
 
@@ -997,7 +995,7 @@ void mpi_send_vs_quat(int pnode, int part, double *vs_quat) {
   mpi_call(mpi_send_vs_quat_slave, pnode, part);
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    for (int i=0; i<4; ++i) {
+    for (int i = 0; i < 4; ++i) {
       p->p.vs_quat[i] = vs_quat[i];
     }
   } else {
@@ -1011,8 +1009,8 @@ void mpi_send_vs_quat_slave(int pnode, int part) {
 #ifdef VIRTUAL_SITES_RELATIVE
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    MPI_Recv(p->p.vs_quat, 4, MPI_DOUBLE, 0, SOME_TAG,
-             comm_cart, MPI_STATUS_IGNORE);
+    MPI_Recv(p->p.vs_quat, 4, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
+             MPI_STATUS_IGNORE);
   }
 
   on_particle_change();
@@ -1078,12 +1076,12 @@ void mpi_send_rotation_slave(int pnode, int part) {
   if (pnode == this_node) {
     Particle *p = local_particles[part];
     MPI_Status status;
-    MPI_Recv(&p->p.rotation, 1, MPI_SHORT, 0, SOME_TAG, MPI_COMM_WORLD, &status);
+    MPI_Recv(&p->p.rotation, 1, MPI_SHORT, 0, SOME_TAG, MPI_COMM_WORLD,
+             &status);
   }
 
   on_particle_change();
 }
-
 
 /********************* REQ_SET_BOND ********/
 
@@ -1182,7 +1180,7 @@ int mpi_integrate(int n_steps, int reuse_forces) {
   mpi_call(mpi_integrate_slave, n_steps, reuse_forces);
   integrate_vv(n_steps, reuse_forces);
   COMM_TRACE(
-        fprintf(stderr, "%d: integration task %d done.\n", this_node, n_steps));
+      fprintf(stderr, "%d: integration task %d done.\n", this_node, n_steps));
   return mpi_check_runtime_errors();
 }
 

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -223,6 +223,16 @@ void mpi_send_mu_E(int node, int part, double mu_E[3]);
 */
 void mpi_send_rotational_inertia(int node, int part, double rinertia[3]);
 #endif
+#ifdef ROTATION
+/** Mpi call for rotating a single particle 
+    Also calls \ref on_particle_change.
+    \param part the particle.
+    \param node the node it is attached to.
+    \param axis rotation axis
+    \param angle rotation angle
+*/
+void mpi_rotate_particle(int node, int part, double axis[3],double angle);
+#endif
 
 #ifdef AFFINITY
 /** Issue REQ_SET_AFFINITY: send particle affinity.

--- a/src/core/minimize_energy.cpp
+++ b/src/core/minimize_energy.cpp
@@ -113,7 +113,7 @@ bool steepest_descent_step(void) {
         l = sgn(l) * params->max_displacement;
 
       // Rotate the particle around axis dq by amount l
-      rotate_particle(&(p), dq, l);
+      local_rotate_particle(&(p), dq, l);
     }
 #endif
 

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -521,6 +521,14 @@ int set_particle_rotation(int part, int rot) {
   return ES_OK;
 }
 #endif
+#ifdef ROTATION
+int rotate_particle(int part, double axis[3], double angle) {
+  auto const pnode = get_particle_node(part);
+
+  mpi_rotate_particle(pnode, part, axis, angle);
+  return ES_OK;
+}
+#endif
 
 #ifdef AFFINITY
 int set_particle_affinity(int part, double bond_site[3]) {

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -646,6 +646,14 @@ int set_particle_rotational_inertia(int part, double rinertia[3]);
 */
 int set_particle_rotation(int part, int rot);
 
+/** @brief rotate a particle around an axis
+   
+   @param part particle id
+   @param axis rotation axis
+   @param angle rotation angle
+*/
+int rotate_particle(int part, double axis[3], double angle);
+
 #ifdef AFFINITY
 /** Call only on the master node: set particle affinity.
     @param part the particle.

--- a/src/core/rotate_system.cpp
+++ b/src/core/rotate_system.cpp
@@ -46,7 +46,7 @@ void local_rotate_system(double phi, double theta, double alpha) {
       p.r.p[j] = com[j] + res[j];
     }
 #ifdef ROTATION
-    rotate_particle(&p, axis, alpha);
+    local_rotate_particle(&p, axis, alpha);
 #endif
   }
 

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -482,6 +482,20 @@ Vector3d convert_vector_body_to_space(const Particle& p, const Vector3d& vec) {
   return res;
 }
 
+Vector3d convert_vector_space_to_body(const Particle& p, const Vector3d& v) {
+  Vector3d res={0,0,0};
+  double A[9];
+  define_rotation_matrix(p, A);
+  res[0] = A[0 + 3 * 0] * v[0] + A[0 + 3 * 1] * v[1] +
+                A[0 + 3 * 2] * v[2];
+  res[1] = A[1 + 3 * 0] * v[0] + A[1 + 3 * 1] * v[1] +
+                A[1 + 3 * 2] * v[2];
+  res[2] = A[2 + 3 * 0] * v[0] + A[2 + 3 * 1] * v[1] +
+                 A[2 + 3 * 2] * v[2];
+  return res;
+}
+
+
 
 void convert_torques_body_to_space(const Particle *p, double *torque) {
   double A[9];
@@ -519,7 +533,7 @@ void convert_vec_space_to_body(Particle *p, double *v, double *res) {
 
 /** Rotate the particle p around the NORMALIZED axis aSpaceFrame by amount phi
  */
-void rotate_particle(Particle *p, double *aSpaceFrame, double phi) {
+void local_rotate_particle(Particle *p, double *aSpaceFrame, double phi) {
   // Convert rotation axis to body-fixed frame
   double a[3];
   convert_vec_space_to_body(p, aSpaceFrame, a);

--- a/src/core/rotation.hpp
+++ b/src/core/rotation.hpp
@@ -59,6 +59,7 @@ void convert_torques_body_to_space(const Particle *p, double *torque);
 
 
 Vector3d convert_vector_body_to_space(const Particle& p, const Vector3d& v);
+Vector3d convert_vector_space_to_body(const Particle& p, const Vector3d& v);
 
 /** convert velocity form the lab-fixed coordinates
     to the body-fixed frame */
@@ -114,7 +115,7 @@ inline void convert_quatu_to_dip(double quatu[3], double dipm, double dip[3]) {
 #endif
 
 /** Rotate the particle p around the NORMALIZED axis a by amount phi */
-void rotate_particle(Particle *p, double *a, double phi);
+void local_rotate_particle(Particle *p, double *a, double phi);
 
 inline void normalize_quaternion(double *q) {
   double tmp = sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -52,6 +52,10 @@ void VirtualSitesRelative::update_virtual_particle_quaternion(Particle& p) const
  }
  multiply_quaternions(p_real->r.quat, p.p.vs_quat, p.r.quat);
  convert_quat_to_quatu(p.r.quat, p.r.quatu);
+#ifdef DIPOLES
+  // When dipoles are enabled, update dipole moment
+  convert_quatu_to_dip(p.r.quatu, p.p.dipm, p.r.dip);
+#endif
 }
 
 
@@ -182,7 +186,7 @@ void VirtualSitesRelative::back_transfer_forces_and_torques() const {
 
       // Add forces and torques
       for (int j = 0; j < 3; j++) {
-        p_real->f.torque[j] += tmp[j];
+        p_real->f.torque[j] += tmp[j]+p.f.torque[j];
         p_real->f.f[j] += p.f.f[j];
       }
     }

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -218,6 +218,8 @@ cdef extern from "rotation.hpp":
     void convert_omega_body_to_space(const particle * p, double * omega)
     void convert_torques_body_to_space(const particle * p, double * torque)
     Vector3d convert_vector_body_to_space(const particle& p,const Vector3d& v)
+    Vector3d convert_vector_space_to_body(const particle& p,const Vector3d& v)
+    void rotate_particle(int id, double* axis, double angle)
 
 # The bonded_ia_params stuff has to be included here, because the setter/getter
 # of the particles' bond property needs to now about the correct number of

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1597,7 +1597,35 @@ cdef class ParticleHandle(object):
             self.update_particle_data()
             res= convert_vector_body_to_space(self.particle_data[0],_v)
             return np.array((res[0],res[1],res[2]))
+        
+        def convert_vector_space_to_body(self, vec):
+            """Converts the given vector from the space frame to the particle's body frame"""
+            cdef Vector3d res
+            cdef Vector3d _v
+            _v[0] = vec[0]
+            _v[1] = vec[1]
+            _v[2] = vec[2]
+            self.update_particle_data()
+            res= convert_vector_space_to_body(self.particle_data[0],_v)
+            return np.array((res[0],res[1],res[2]))
+        
 
+        def rotate(self,axis=None,angle=None):
+            """Rotates the particle around the given axis
+
+            Parameters
+            ----------
+            axis : array-like
+
+            angle : float
+
+            """
+            cdef double[3] a
+            a[0]=axis[0]
+            a[1]=axis[1]
+            a[2]=axis[2]
+
+            rotate_particle(self.id,a,angle)
 
 cdef class _ParticleSliceImpl(object):
     """Handles slice inputs.

--- a/testsuite/rotation_per_particle.py
+++ b/testsuite/rotation_per_particle.py
@@ -87,7 +87,56 @@ class Rotation(ut.TestCase):
                     self.assertLess(np.dot(axis,s.part[0].convert_vector_body_to_space(axis)),0.95)
 
                     
-                 
+
+
+    def test_frame_conversion_and_rotation(self):
+        s=self.s
+        s.part.clear()
+        p=s.part.add(pos=np.random.random(3),rotation=(1,1,1))
+        
+        # Space and body frame co-incide?
+        np.testing.assert_allclose(p.director,p.convert_vector_body_to_space((0,0,1)),atol=1E-10)
+
+        # Random vector should still co-incide
+        v=(1.,5.5,17)
+        np.testing.assert_allclose(v,p.convert_vector_space_to_body(v),atol=1E-10)
+        np.testing.assert_allclose(v,p.convert_vector_body_to_space(v),atol=1E-10)
+
+        # Particle rotation
+        
+        p.rotate((1,2,0),np.pi/4)
+        # Check angle for director
+        self.assertAlmostEqual(np.arccos(np.dot(p.director, (0,0,1))),np.pi/4,delta=1E-10)
+        # Check other vector
+        v=(5,-7,3)
+        v_r=p.convert_vector_body_to_space(v)
+        self.assertAlmostEqual(np.dot(v,v),np.dot(v_r,v_r),delta=1e-10)
+        np.testing.assert_allclose(p.convert_vector_space_to_body(v_r),v,atol=1E-10)
+
+        # Rotation axis should co-incide
+        np.testing.assert_allclose((1,2,0),p.convert_vector_body_to_space((1,2,0)))
+        
+        
+        # Check rotation axis with all elements set
+        p.rotate(axis=(-5,2,17),angle=1.)
+        v=(5,-7,3)
+        v_r=p.convert_vector_body_to_space(v)
+        self.assertAlmostEqual(np.dot(v,v),np.dot(v_r,v_r),delta=1e-10)
+        np.testing.assert_allclose(p.convert_vector_space_to_body(v_r),v,atol=1E-10)
+
+
+
+
+
+
+
+
+
+
+        # 
+
+
+
 
         
 


### PR DESCRIPTION
* space to body vector conversion accessible from py
* Rotation of particle around axis by angle accessible form py (mpi callback)
* Tests
* VirtualSitesRelative: torques are transferred back to no-virtual particle
* Update of virtual sites orientaiton updates director AND dipole moment

