### PR TITLE
cmake: Actually use CYTHON_FLAGS, extend warnings are errors to cython.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,10 @@ if (WITH_PYTHON)
   else()
     set(CYTHON_FLAGS "-3" CACHE STRING "Flags used by the Cython compiler during all build types.")
   endif()
+
+  if(WARNINGS_ARE_ERRORS)
+    set(CYTHON_FLAGS "--warning-errors;${CYTHON_FLAGS}")
+  endif()
 endif(WITH_PYTHON)
 
 

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -81,7 +81,7 @@ foreach(cython_file ${cython_SRC})
   else()
       list(APPEND cython_generated_SRC "${basename}.cpp")
       add_custom_command(OUTPUT ${outputpath}
-                         COMMAND ${CYTHON_EXECUTABLE}  --cplus
+                         COMMAND ${CYTHON_EXECUTABLE} ${CYTHON_FLAGS} --cplus
                          --directive embedsignature=True
                          --directive binding=True
                          -I ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -41,7 +41,6 @@ cdef extern from "cells.hpp":
 cdef extern from "layered.hpp":
     int determine_n_layers
     int n_layers_ "n_layers"
-    int determine_n_layers
 
 cdef extern from "grid.hpp":
     int node_grid[3]

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -211,26 +211,6 @@ IF ELECTROSTATICS:
     cdef extern from "interaction_data.hpp":
         int coulomb_set_prefactor(double prefactor)
 
-        ctypedef enum CoulombMethod :
-            COULOMB_NONE, 
-            COULOMB_DH, 
-            COULOMB_P3M, 
-            COULOMB_MMM1D, 
-            COULOMB_MMM2D, 
-            COULOMB_MAGGS, 
-            COULOMB_ELC_P3M,
-            COULOMB_RF, 
-            COULOMB_INTER_RF, 
-            COULOMB_P3M_GPU,
-            COULOMB_MMM1D_GPU,
-            COULOMB_EK 
-
-        ctypedef struct Coulomb_parameters:
-            double prefactor
-            CoulombMethod method
-
-        cdef extern Coulomb_parameters coulomb
-
     cdef inline pyMMM1D_tune():
         cdef char *log = NULL 
         cdef int resp

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -25,7 +25,6 @@ cdef extern from "global.hpp":
     int FIELD_NODEGRID
     int FIELD_MAXNUMCELLS
     int FIELD_MINNUMCELLS
-    int FIELD_NODEGRID
     int FIELD_NPTISO_PISTON
     int FIELD_NPTISO_PDIFF
     int FIELD_PERIODIC
@@ -34,7 +33,6 @@ cdef extern from "global.hpp":
     int FIELD_LEES_EDWARDS_OFFSET
     int FIELD_TEMPERATURE
     int FIELD_THERMO_SWITCH
-    int FIELD_TEMPERATURE
     int FIELD_LANGEVIN_GAMMA
     IF ROTATION:
         int FIELD_LANGEVIN_GAMMA_ROTATION

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -585,8 +585,8 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
         :meth:`update_maximum_and_minimum_energies_at_current_state` was used.
 
         """
-        self.WLRptr.write_out_preliminary_energy_run_results(
-            "preliminary_energy_run_results")
+        filename="preliminary_energy_run_results".encode("utf-8")
+        self.WLRptr.write_out_preliminary_energy_run_results(filename)
 
     def write_wang_landau_results_to_file(self, filename):
         """
@@ -594,7 +594,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
         collective variables.
 
         """
-        self.WLRptr.write_wang_landau_results_to_file(filename)
+        self.WLRptr.write_wang_landau_results_to_file(filename.encode("utf-8"))
 
 
     def displacement_mc_move_for_particles_of_type(self, type_mc, particle_number_to_be_changed=1):

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -1,8 +1,6 @@
 include "myconfig.pxi"
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-from libc.string cimport strdup
-from utils import to_char_pointer
 import numpy as np
 
 class WangLandauHasConverged(Exception):
@@ -496,7 +494,8 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
                     raise ValueError(
                         "At least the following keys have to be given as keyword arguments: " + self._required_keys_add_collective_variable_degree_of_association().__str__() + " got " + kwargs.__str__())
                 self._params[k] = kwargs[k]
-        self.WLRptr.add_new_CV_potential_energy(to_char_pointer(self._params["filename"]), self._params["delta"])
+        filname_potential_energy_boundaries_file=self._params["filename"].encode("utf-8")
+        self.WLRptr.add_new_CV_potential_energy(filname_potential_energy_boundaries_file, self._params["delta"])
 
     def _valid_keys_add_collective_variable_potential_energy(self):
         return "filename", "delta"
@@ -540,7 +539,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
         self.WLRptr.final_wang_landau_parameter = self._params[
             "final_wang_landau_parameter"]
-        self.WLRptr.output_filename = to_char_pointer(self._params["full_path_to_output_filename"])
+        self.WLRptr.output_filename = self._params["full_path_to_output_filename"].encode("utf-8")
         self.WLRptr.do_not_sample_reaction_partition_function = self._params[
             "do_not_sample_reaction_partition_function"]
 
@@ -552,7 +551,8 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
         Loads the dumped wang landau potential file.
 
         """
-        self.WLRptr.load_wang_landau_checkpoint("checkpoint")
+        checkpoint_name="checkpoint".encode("utf-8")
+        self.WLRptr.load_wang_landau_checkpoint(checkpoint_name)
 
     def write_wang_landau_checkpoint(self):
         """
@@ -561,7 +561,8 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
         number of executed trial moves.
 
         """
-        self.WLRptr.write_wang_landau_checkpoint("checkpoint")
+        checkpoint_name="checkpoint".encode("utf-8")
+        self.WLRptr.write_wang_landau_checkpoint(checkpoint_name)
 
     def update_maximum_and_minimum_energies_at_current_state(self):
         """

--- a/src/python/espressomd/thermostat.pxd
+++ b/src/python/espressomd/thermostat.pxd
@@ -31,8 +31,6 @@ cdef extern from "thermostat.hpp":
     int THERMO_LB
     int THERMO_NPT_ISO
     int THERMO_DPD
-    int THERMO_INTER_DPD
-    int THERMO_DPD
 
     IF PARTICLE_ANISOTROPY:
         Vector3d langevin_gamma_rotation


### PR DESCRIPTION
Description of changes:
 - Use CYTHON_FLAGS
 - Made cython fail on warnings is  warnings are errors.

