### PR TITLE
Gamma rot deadlock

### DIFF
--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -2199,7 +2199,7 @@ void mpi_set_particle_gamma_rot_slave(int pnode, int part) {
 #if defined(LANGEVIN_PER_PARTICLE) && defined(ROTATION)
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    comm_cart.recv(pnode, SOME_TAG, p->p.gamma_rot);
+    comm_cart.recv(0, SOME_TAG, p->p.gamma_rot);
   }
 
   on_particle_change();

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -195,7 +195,7 @@ cdef class ParticleHandle(object):
         """
 
         def __set__(self, pos_folded):
-            raise Exception("setting a folded position is not implemented")
+            raise AttributeError("setting a folded position is not implemented")
 
         def __get__(self):
             self.update_particle_data()
@@ -378,7 +378,7 @@ cdef class ParticleHandle(object):
                 if set_particle_mass(self.id, _mass) == 1:
                     raise Exception("Set particle position first.")
             ELSE:
-                raise Exception("You are trying to set the particle mass \
+                raise AttributeError("You are trying to set the particle mass \
                                      but the mass feature is not compiled in.")
 
         def __get__(self):
@@ -466,7 +466,7 @@ cdef class ParticleHandle(object):
             """
 
             def __set__(self, _q):
-                raise Exception(
+                raise AttributeError(
                     "Setting the director is not implemented in the c++-core of Espresso.")
 
             def __get__(self):

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -2159,7 +2159,7 @@ def _add_particle_slice_properties():
 
         elif attribute == "vs_relative":
             nlvl = nesting_level(values)
-            if nlvl == 2: 
+            if nlvl in [1, 2]: 
                 set_slice_one_for_all(particle_slice, attribute, values)
             elif nlvl == 3 and len(values) == N:  
                 set_slice_one_for_each(particle_slice, attribute, values)

--- a/testsuite/particle.py
+++ b/testsuite/particle.py
@@ -232,10 +232,15 @@ class ParticleProperties(ut.TestCase):
         # Copy individual properties of particle 0
         print("If this test hangs, there is an mpi deadlock in a particle property setter." )
         for p in espressomd.particle_data.particle_attributes:
-            if p in ["director","image_box","node","vs_relative"  ]: continue
             # Uncomment to identify guilty property
             #print( p)
-            setattr(s.part[:],p,getattr(s.part[0],p))
+            
+            if not hasattr(s.part[0],p):
+                raise Exception("Inconsistency between ParticleHandle and particle_data.particle_attributes")
+            try: 
+                setattr(s.part[:],p,getattr(s.part[0],p))
+            except AttributeError:
+                print("Skipping read-only",p)
             # Cause a differtn mpi callback to uncover deadlock immediately
             x=getattr(s.part[:],p)
             


### PR DESCRIPTION
Fix gamma_rot setter mpi deadlock. Add testcase, which should detect any future deadlocks in particle property setters.
