### PR TITLE
core: Removed usage of std::reference_wrapper.

### DIFF
--- a/src/core/Cell.hpp
+++ b/src/core/Cell.hpp
@@ -14,21 +14,13 @@
 #include "utils/Range.hpp"
 
 class Cell : public ParticleList {
-  struct GetReference {
-    using result_type = Cell;
-    Cell &operator()(std::reference_wrapper<Cell> & cell_ref) const {
-      return cell_ref.get();
-    }
-  };
-
-  using neighbors_t = std::vector<std::reference_wrapper<Cell>>;
+  using neighbors_t = std::vector<Cell *>;
 
 public:
-  using neighbor_iterator =
-      boost::transform_iterator<GetReference, neighbors_t::iterator>;
+  using neighbor_iterator = neighbors_t::iterator;
 
   /** Topological neighbors of the cell */
-  std::vector<std::reference_wrapper<Cell>> m_neighbors;
+  std::vector<Cell *> m_neighbors;
 
   /** Interaction pairs */
   std::vector<std::pair<Particle *, Particle *>> m_verlet_list;

--- a/src/core/algorithm/link_cell.hpp
+++ b/src/core/algorithm/link_cell.hpp
@@ -27,8 +27,8 @@ for (int j = i + 1; j < first->n; j++) {
 
 /* Pairs with neighbors */
 for (auto &neighbor : first->neighbors()) {
-  for (int j = 0; j < neighbor.n; j++) {
-    auto &p2 = neighbor.part[j];
+  for (int j = 0; j < neighbor->n; j++) {
+    auto &p2 = neighbor->part[j];
     auto dist = distance_function(p1, p2);
     pair_kernel(p1, p2, dist);
   }

--- a/src/core/algorithm/verlet_ia.hpp
+++ b/src/core/algorithm/verlet_ia.hpp
@@ -33,8 +33,8 @@ void update_and_kernel(CellIterator first, CellIterator last,
 
       /* Pairs with neighbors */
       for (auto &neighbor : first->neighbors()) {
-        for (int j = 0; j < neighbor.n; j++) {
-          auto &p2 = neighbor.part[j];
+        for (int j = 0; j < neighbor->n; j++) {
+          auto &p2 = neighbor->part[j];
           auto dist = distance_function(p1, p2);
           if (verlet_criterion(p1, p2, dist)) {
             pair_kernel(p1, p2, dist);

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -567,7 +567,7 @@ void dd_init_cell_interactions() {
         for (r = m - 1; r <= m + 1; r++) {
           ind2 = get_linear_index(r, q, p, dd.ghost_cell_grid);
           if (ind2 > ind1) {
-            cells[ind1].m_neighbors.emplace_back(std::ref(cells[ind2]));
+            cells[ind1].m_neighbors.emplace_back(&cells[ind2]);
           }
         }
 
@@ -1161,7 +1161,6 @@ int calc_processor_min_num_cells() {
 
 /************************************************************/
 
-int dd_full_shell_neigh(int cellidx, int neigh)
-{
-    return cellidx + dd_fs_neigh[neigh];
+int dd_full_shell_neigh(int cellidx, int neigh) {
+  return cellidx + dd_fs_neigh[neigh];
 }

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -367,7 +367,7 @@ void layered_topology_init(CellPList *old) {
   realloc_cellplist(&local_cells, local_cells.n = n_layers);
   for (c = 0; c < n_layers; c++) {
     local_cells.cell[c] = &cells[c + 1];
-    cells[c + 1].m_neighbors.push_back(std::ref(cells[c]));
+    cells[c + 1].m_neighbors.push_back(&cells[c]);
   }
 
   realloc_cellplist(&ghost_cells, ghost_cells.n = 2);

--- a/src/core/lees_edwards_domain_decomposition.cpp
+++ b/src/core/lees_edwards_domain_decomposition.cpp
@@ -78,7 +78,7 @@ void le_dd_init_cell_interactions() {
               ind2 = get_linear_index(r, q, p, dd.ghost_cell_grid);
 
               if (ind2 >= ind1) {
-                cells[ind1].m_neighbors.push_back(std::ref(cells[ind2]));
+                cells[ind1].m_neighbors.push_back(&cells[ind2]);
               }
             }
           }

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -26,9 +26,9 @@
 #include "nsquare.hpp"
 #include "communication.hpp"
 #include "constraints.hpp"
+#include "debug.hpp"
 #include "ghosts.hpp"
 #include "utils.hpp"
-#include "debug.hpp"
 
 #include <cstring>
 #include <mpi.h>
@@ -100,7 +100,7 @@ void nsq_topology_init(CellPList *old) {
     if (((diff > 0 && (diff % 2) == 0) || (diff < 0 && ((-diff) % 2) == 1))) {
       CELL_TRACE(
           fprintf(stderr, "%d: doing interactions with %d\n", this_node, n));
-      cells[this_node].m_neighbors.push_back(std::ref(cells[n]));
+      cells[this_node].m_neighbors.push_back(&cells[n]);
     }
   }
 
@@ -229,8 +229,7 @@ void nsq_balance_particles(int global_flag) {
 #ifdef ADDITIONAL_CHECKS
       check_particle_consistency();
 #endif
-    }
-    else if (l_node == this_node) {
+    } else if (l_node == this_node) {
       ParticleList recv_buf{};
 
       recv_particles(&recv_buf, s_node);

--- a/src/core/unit_tests/link_cell_test.cpp
+++ b/src/core/unit_tests/link_cell_test.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(link_cell) {
   for (auto &c : cells) {
     for (auto &n : cells) {
       if (&c != &n)
-        c.m_neighbors.push_back(std::ref(n));
+        c.m_neighbors.push_back(&n);
     }
 
     c.part = new Particle[n_part_per_cell];

--- a/src/core/unit_tests/verlet_ia_test.cpp
+++ b/src/core/unit_tests/verlet_ia_test.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(verlet_ia) {
   for (auto &c : cells) {
     for (auto &n : cells) {
       if (&c != &n)
-        c.m_neighbors.push_back(std::ref(n));
+        c.m_neighbors.push_back(&n);
     }
 
     c.part = new Particle[n_part_per_cell];


### PR DESCRIPTION
Fixes #1983.

Description of changes:
 - Turned Cell::m_neighbors from vector<reference_wrapper<Cell>> into vector<Cell *>
