### PR TITLE
core: Use folded coords for constraint energy calc.

### DIFF
--- a/src/core/constraints.hpp
+++ b/src/core/constraints.hpp
@@ -38,14 +38,10 @@ inline void init_constraint_forces() {
 }
 
 inline void add_constraints_energy(Particle *p) {
+  auto pos = folded_position(*p);
 
-  int image[3];
-  double pos[3];
-  memcpy(pos, p->r.p, 3 * sizeof(double));
-  memcpy(image, p->l.i, 3 * sizeof(int));
-  fold_position(pos, image);
   for (auto const &c : Constraints::constraints) {
-    c->add_energy(p, p->r.p, energy);
+    c->add_energy(p, pos.data(), energy);
   }
 }
 

--- a/src/core/constraints/Constraint.hpp
+++ b/src/core/constraints/Constraint.hpp
@@ -16,7 +16,6 @@ public:
   virtual void add_force(Particle *p, double *folded_pos) {};
 
   virtual void reset_force() {};
-
 };
 
 } /* namespace Constaints */


### PR DESCRIPTION
Fixes #1986.
