### PR TITLE
force box_l to be set first for dependencies

### DIFF
--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -111,6 +111,8 @@ cdef class System(object):
             self.globals = Globals()
             if 'box_l' not in kwargs:
                 raise ValueError("Required argument box_l not provided.")
+            System.__setattr__(self, "box_l", kwargs.get("box_l"))
+            del kwargs["box_l"]
             for arg in kwargs:
                 if arg in setable_properties:
                     System.__setattr__(self, arg, kwargs.get(arg))


### PR DESCRIPTION
Fixes # problem encountered by Jan

```
system = espressomd.System(box_l = [box_l, box_l, box_l], min_global_cut=5+1)
```
throws 

```
There were unhandled errors.
ERROR: box_l in direction 0 is too small
ERROR: box_l in direction 1 is too small
ERROR: box_l in direction 2 is too small
ERROR: interaction range 6 in direction 0 is larger than the local box size 1
ERROR: interaction range 6 in direction 1 is larger than the local box size 1
ERROR: interaction range 6 in direction 2 is larger than the local box size 1
ERROR: number of cells 1 is smaller than minimum 8 (interaction range too large or min_num_cells too large)
```
whereas the following works Ok

```
import espressomd
from espressomd.virtual_sites import VirtualSitesOff, VirtualSitesRelative

box_l=40

system = espressomd.System(box_l = [box_l, box_l, box_l])
system.min_global_cut=5+1
```

With this PR also variant 1 works and probably some other stuff too.