### PR TITLE
Summed normal force on constraints for pressure calculation

### DIFF
--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -16,12 +16,12 @@ Vector3d ShapeBasedConstraint::total_force() const {
   return total_force;
 }
 
-double ShapeBasedConstraint::total_summed_outer_normal_force() const {
-  double total_summed_scalar_product_outer_normal_force;
-  boost::mpi::all_reduce(comm_cart, m_summed_scalar_product_outer_normal_force, total_summed_scalar_product_outer_normal_force,
+double ShapeBasedConstraint::total_normal_force() const {
+  double total_normal_force;
+  boost::mpi::all_reduce(comm_cart, m_outer_normal_force, total_normal_force,
                          std::plus<double>());
 
-  return total_summed_scalar_product_outer_normal_force;
+  return total_normal_force;
 }
 
 double ShapeBasedConstraint::min_dist() {
@@ -140,7 +140,7 @@ void ShapeBasedConstraint::add_force(Particle *p, Vector3d& folded_pos) {
   }
   force=-force; //Newtons third law. Force acting on constraint due to particle is minus the force acting on the particle
   m_local_force += force;
-  m_summed_scalar_product_outer_normal_force+=outer_normal_vec.dot(force);  
+  m_outer_normal_force+=outer_normal_vec.dot(force);  
 }
 
 void ShapeBasedConstraint::add_energy(Particle *p, Vector3d& folded_pos,

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -107,7 +107,7 @@ void ShapeBasedConstraint::add_force(Particle *p, Vector3d& folded_pos) {
                                  force.data(), torque1.data(), torque2.data());
 #ifdef DPD
       if (thermo_switch & THERMO_DPD) {
-        add_dpd_pair_force(p, &part_rep, ia_params, dist_vec, dist, dist2);
+        add_dpd_pair_force(p, &part_rep, ia_params, dist_vec.data(), dist, dist2);
       }
 #endif
     } else if (m_penetrable && (dist <= 0)) {

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -9,19 +9,11 @@
 
 namespace Constraints {
 Vector3d ShapeBasedConstraint::total_force() const {
-  Vector3d total_force;
-  boost::mpi::all_reduce(comm_cart, m_local_force, total_force,
-                         std::plus<Vector3d>());
-
-  return total_force;
+  return all_reduce(comm_cart, m_local_force, std::plus<Vector3d>());
 }
 
 double ShapeBasedConstraint::total_normal_force() const {
-  double total_normal_force;
-  boost::mpi::all_reduce(comm_cart, m_outer_normal_force, total_normal_force,
-                         std::plus<double>());
-
-  return total_normal_force;
+  return all_reduce(comm_cart, m_outer_normal_force, std::plus<double>());
 }
 
 double ShapeBasedConstraint::min_dist() {

--- a/src/core/constraints/ShapeBasedConstraint.hpp
+++ b/src/core/constraints/ShapeBasedConstraint.hpp
@@ -45,7 +45,7 @@ public:
 
   ReflectionType const &reflection_type() const;
 
-  void reset_force() override { m_local_force = Vector3d{0, 0, 0}; }
+  void reset_force() override { m_local_force = Vector3d{0, 0, 0}; m_summed_scalar_product_outer_normal_force=0.0;}
   int &only_positive() { return m_only_positive; }
   int &penetrable() { return m_penetrable; }
   int &type() { return part_rep.p.type; }
@@ -63,6 +63,7 @@ public:
   }
 
   Vector3d total_force() const;
+  double total_summed_outer_normal_force() const;
 
 private:
   Particle part_rep;
@@ -78,6 +79,7 @@ private:
   int m_penetrable;
   int m_only_positive;
   Vector3d m_local_force;
+  double m_summed_scalar_product_outer_normal_force;
 };
 
 } /* namespace Constaints */

--- a/src/core/constraints/ShapeBasedConstraint.hpp
+++ b/src/core/constraints/ShapeBasedConstraint.hpp
@@ -45,7 +45,7 @@ public:
 
   ReflectionType const &reflection_type() const;
 
-  void reset_force() override { m_local_force = Vector3d{0, 0, 0}; m_summed_scalar_product_outer_normal_force=0.0;}
+  void reset_force() override { m_local_force = Vector3d{0, 0, 0}; m_outer_normal_force=0.0;}
   int &only_positive() { return m_only_positive; }
   int &penetrable() { return m_penetrable; }
   int &type() { return part_rep.p.type; }
@@ -63,7 +63,7 @@ public:
   }
 
   Vector3d total_force() const;
-  double total_summed_outer_normal_force() const;
+  double total_normal_force() const;
 
 private:
   Particle part_rep;
@@ -79,7 +79,7 @@ private:
   int m_penetrable;
   int m_only_positive;
   Vector3d m_local_force;
-  double m_summed_scalar_product_outer_normal_force;
+  double m_outer_normal_force;
 };
 
 } /* namespace Constaints */

--- a/src/core/shapes/Wall.hpp
+++ b/src/core/shapes/Wall.hpp
@@ -46,7 +46,7 @@ public:
   double &d() { return m_d; }
 
 private:
-  /** normal vector on the plane, facing inwards */
+  /** normal vector on the plane */
   Vector3d m_n;
   /** distance of the wall from the origin. */
   double m_d;

--- a/src/core/shapes/Wall.hpp
+++ b/src/core/shapes/Wall.hpp
@@ -46,7 +46,7 @@ public:
   double &d() { return m_d; }
 
 private:
-  /** normal vector on the plane. */
+  /** normal vector on the plane, facing inwards */
   Vector3d m_n;
   /** distance of the wall from the origin. */
   double m_d;

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -137,7 +137,7 @@ class ShapeBasedConstraint(Constraint):
 
     def total_force(self):
         """
-        Get total force acting on this constraint.
+        Get total force acting on this constraint. (This cannot be used to obtain the pressure acting on the constraint).
 
         Examples
         ----------
@@ -169,7 +169,8 @@ class ShapeBasedConstraint(Constraint):
         
     def total_summed_outer_normal_force(self):
         """
-        Get the total summed normal force acting on this constraint.
+        Get the total summed normal force acting on this constraint. Via dividing by the area of the constraint one can obtain the Pressure acting on the constraint. A positive value means that the constraint
+        would want to move in the direction of the outer normal vector if it could do so.
         
         """
         return self.call_method("total_summed_outer_normal_force", constraint=self)

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -167,13 +167,13 @@ class ShapeBasedConstraint(Constraint):
         """
         return self.call_method("total_force", constraint=self)
         
-    def total_summed_outer_normal_force(self):
+    def total_normal_force(self):
         """
         Get the total summed normal force acting on this constraint. Via dividing by the area of the constraint one can obtain the Pressure acting on the constraint. A positive value means that the constraint
         would want to move in the direction of the outer normal vector if it could do so.
         
         """
-        return self.call_method("total_summed_outer_normal_force", constraint=self)
+        return self.call_method("total_normal_force", constraint=self)
 
 class HomogeneousMagneticField(Constraint):
     """

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -166,7 +166,13 @@ class ShapeBasedConstraint(Constraint):
 
         """
         return self.call_method("total_force", constraint=self)
-
+        
+    def total_summed_outer_normal_force(self):
+        """
+        Get the total summed normal force acting on this constraint.
+        
+        """
+        return self.call_method("total_summed_outer_normal_force", constraint=self)
 
 class HomogeneousMagneticField(Constraint):
     """

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -137,7 +137,7 @@ class ShapeBasedConstraint(Constraint):
 
     def total_force(self):
         """
-        Get total force acting on this constraint. (This cannot be used to obtain the pressure acting on the constraint).
+        Get total force acting on this constraint.
 
         Examples
         ----------
@@ -169,8 +169,7 @@ class ShapeBasedConstraint(Constraint):
         
     def total_normal_force(self):
         """
-        Get the total summed normal force acting on this constraint. Via dividing by the area of the constraint one can obtain the Pressure acting on the constraint. A positive value means that the constraint
-        would want to move in the direction of the outer normal vector if it could do so.
+        Get the total summed normal force acting on this constraint.
         
         """
         return self.call_method("total_normal_force", constraint=self)

--- a/src/script_interface/constraints/Constraints.hpp
+++ b/src/script_interface/constraints/Constraints.hpp
@@ -39,6 +39,7 @@ class Constraints : public ScriptObjectRegistry<Constraint> {
   }
   virtual void remove_in_core(std::shared_ptr<Constraint> obj_ptr) override {
     ::Constraints::constraints.remove(obj_ptr->constraint());
+    ::on_constraint_change();
   };
 };
 } /* namespace Constraints */

--- a/src/script_interface/constraints/Constraints.hpp
+++ b/src/script_interface/constraints/Constraints.hpp
@@ -27,6 +27,7 @@
 #include "ScriptObjectRegistry.hpp"
 #include "core/constraints.hpp"
 #include "script_interface/ScriptInterface.hpp"
+#include "core/initialize.hpp"
 
 namespace ScriptInterface {
 namespace Constraints {
@@ -34,6 +35,7 @@ namespace Constraints {
 class Constraints : public ScriptObjectRegistry<Constraint> {
   virtual void add_in_core(std::shared_ptr<Constraint> obj_ptr) override {
     ::Constraints::constraints.add(obj_ptr->constraint());
+    ::on_constraint_change();
   }
   virtual void remove_in_core(std::shared_ptr<Constraint> obj_ptr) override {
     ::Constraints::constraints.remove(obj_ptr->constraint());

--- a/src/script_interface/constraints/ShapeBasedConstraint.hpp
+++ b/src/script_interface/constraints/ShapeBasedConstraint.hpp
@@ -67,8 +67,8 @@ public:
     if (name == "min_dist") {
       return shape_based_constraint()->min_dist();
     }
-    if (name == "total_summed_outer_normal_force") {
-      return shape_based_constraint()->total_summed_outer_normal_force();
+    if (name == "total_normal_force") {
+      return shape_based_constraint()->total_normal_force();
     }
 
     return none;

--- a/src/script_interface/constraints/ShapeBasedConstraint.hpp
+++ b/src/script_interface/constraints/ShapeBasedConstraint.hpp
@@ -67,6 +67,9 @@ public:
     if (name == "min_dist") {
       return shape_based_constraint()->min_dist();
     }
+    if (name == "total_summed_outer_normal_force") {
+      return shape_based_constraint()->total_summed_outer_normal_force();
+    }
 
     return none;
   }

--- a/testsuite/constraint_shape_based.py
+++ b/testsuite/constraint_shape_based.py
@@ -193,7 +193,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         
         dist_part2=self.box_l-y_part2
         self.assertAlmostEqual(outer_cylinder_wall.total_force()[2],0.0)
-        self.assertAlmostEqual(outer_cylinder_wall.total_summed_outer_normal_force(),2*tests_common.lj_force( espressomd, cutoff=2.0, offset=0., eps=1.0, sig=1.0, r=dist_part2))
+        self.assertAlmostEqual(outer_cylinder_wall.total_normal_force(),2*tests_common.lj_force( espressomd, cutoff=2.0, offset=0., eps=1.0, sig=1.0, r=dist_part2))
         
         # Reset
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
@@ -282,9 +282,9 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 r=0.83),
             places=10)
 
-        #check whether total_summed_outer_normal_force is correct
+        #check whether total_normal_force is correct
         self.assertAlmostEqual(
-        wall_xy.total_summed_outer_normal_force(),
+        wall_xy.total_normal_force(),
         tests_common.lj_force(
             espressomd,
             cutoff=2.0,

--- a/testsuite/constraint_shape_based.py
+++ b/testsuite/constraint_shape_based.py
@@ -212,6 +212,13 @@ class ShapeBasedConstraintTest(ut.TestCase):
         system = self.system
         system.part.add(id=0,pos=[5., 1.21, 0.83], type=0)
 
+        # Check forces are initialized to zero
+        f_part = system.part[0].f
+
+        self.assertEqual(f_part[0], 0.)
+        self.assertEqual(f_part[1], 0.)
+        self.assertEqual(f_part[2], 0.)
+
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
             epsilon=1.0, sigma=1.0, cutoff=2.0, shift=0)
         system.non_bonded_inter[0, 2].lennard_jones.set_params(
@@ -227,13 +234,6 @@ class ShapeBasedConstraintTest(ut.TestCase):
 
         # (3)
         wall_xy = system.constraints.add(shape=shape_xy, particle_type=2)
-
-        # Check forces
-        f_part = system.part[0].f
-
-        self.assertEqual(f_part[0], 0.)
-        self.assertEqual(f_part[1], 0.)
-        self.assertEqual(f_part[2], 0.)
 
         system.integrator.run(0)  # update forces
         f_part = system.part[0].f

--- a/testsuite/constraint_shape_based.py
+++ b/testsuite/constraint_shape_based.py
@@ -141,10 +141,9 @@ class ShapeBasedConstraintTest(ut.TestCase):
         system.time_step = 0.01
         system.cell_system.skin = 0.4
 
-        system.part.add(pos=[5., 1.21, 0.83], type=0)
+        system.part.add(id=0, pos=[self.box_l / 2.0, 1.02, self.box_l / 2.0], type=0)
 
         # check force calculation of cylinder constraint
-        system.part[0].pos = [self.box_l / 2.0, 1.02, self.box_l / 2.0]
         interactio_dir = -1  # constraint is directed inwards
         cylinder_shape = espressomd.shapes.Cylinder(
             center=[
@@ -175,7 +174,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
 
         self.assertAlmostEqual(outer_cylinder_constraint.min_dist(), 1.02)
 
-        # test forces on walls
+        # test summed forces on cylinder wall
         self.assertAlmostEqual(
             -1.0 * outer_cylinder_wall.total_force()[1],
             tests_common.lj_force(
@@ -186,13 +185,23 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 sig=1.0,
                 r=1.02),
             places=10)  # minus for newtons thrid law
+            
+        #check whether total_summed_outer_normal_force is correct
+        y_part2=self.box_l-1.02
+        system.part.add(id=1, pos=[self.box_l / 2.0, y_part2, self.box_l / 2.0], type=0)
+        system.integrator.run(0)
+        
+        dist_part2=self.box_l-y_part2
+        self.assertAlmostEqual(outer_cylinder_wall.total_force()[2],0.0)
+        self.assertAlmostEqual(outer_cylinder_wall.total_summed_outer_normal_force(),2*tests_common.lj_force( espressomd, cutoff=2.0, offset=0., eps=1.0, sig=1.0, r=dist_part2))
+        
         # Reset
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
             epsilon=0.0, sigma=0.0, cutoff=0.0, shift=0)
         system.non_bonded_inter[0, 2].lennard_jones.set_params(
             epsilon=0.0, sigma=0.0, cutoff=0.0, shift=0)
 
-    def test_wall(self):
+    def test_wall_forces(self):
         """Tests if shape based constraints can be added to a system both by
         (1) defining a constraint object which is then added
         (2) and via keyword arguments.
@@ -201,7 +210,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
 
         """
         system = self.system
-        system.part.add(pos=[5., 1.21, 0.83], type=0)
+        system.part.add(id=0,pos=[5., 1.21, 0.83], type=0)
 
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
             epsilon=1.0, sigma=1.0, cutoff=2.0, shift=0)
@@ -251,7 +260,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 r=0.83),
             places=10)
 
-        # test forces on walls
+        # test summed forces on walls
         self.assertAlmostEqual(
             -1.0 * wall_xz.total_force()[1],
             tests_common.lj_force(
@@ -272,11 +281,26 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 sig=1.0,
                 r=0.83),
             places=10)
+
+        #check whether total_summed_outer_normal_force is correct
+        self.assertAlmostEqual(
+        wall_xy.total_summed_outer_normal_force(),
+        tests_common.lj_force(
+            espressomd,
+            cutoff=2.0,
+            offset=0.,
+            eps=1.5,
+            sig=1.0,
+            r=0.83),
+        places=10)
+        
         # this one is closer and should get the mindist()
         system.part.add(pos=[5., 1.20, 0.82], type=0)
         self.assertAlmostEqual(constraint_xz.min_dist(), system.part[1].pos[1])
         self.assertAlmostEqual(wall_xz.min_dist(), system.part[1].pos[1])
         self.assertAlmostEqual(wall_xy.min_dist(), system.part[1].pos[2])
+        
+        
         # Reset
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
             epsilon=0.0, sigma=0.0, cutoff=0.0, shift=0)


### PR DESCRIPTION
Fixes # constraint.total_force() was useless to calculate the pressure. introducing constraint.total_normal_force() which can be used to calculate the pressure acting on a constraint.
Contains tests for wall and cylinder.