### PR TITLE
Guard array access in validate_parameters

### DIFF
--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -127,6 +127,14 @@ bool validate_collision_parameters() {
     return false;
   }
 
+
+  if ((collision_params.mode & COLLISION_MODE_BOND) &&
+      collision_params.bond_centers == -1) {
+    runtimeErrorMsg() << "The bond_centers parameter is unknown. Did you add "
+                         "the interaction using system.bonded_inter.add?";
+    return false;
+  }
+
   // If the bond type to bind particle centers is not a pair bond...
   // Check that the bonds have the right number of partners
   if ((collision_params.mode & COLLISION_MODE_BOND) &&


### PR DESCRIPTION
Fixes a segfault in validate_parameters in collision.cpp caused by this script:
```python
from espressomd import system
from espressomd.interactions import HarmonicBond

H = HarmonicBond(k=1, r_0=1)
#s.bonded_inter.add(H)

s = system.System(box_l=[1, 1, 1])
s.collision_detection.set_params(mode="bind_centers", distance=1, bond_centers=H)
```
If the commented out line is missing, the current version of ESPResSo will run into a segfault:
```
0x00007ffff41c0fa1 in validate_collision_parameters () at ./espresso/src/core/collision.cpp:133
133           (bonded_ia_params[collision_params.bond_centers].num != 1)) {
```

Here, collision_params.bond_centers == -1 because the interaction `H` was not added to `bonded_inter`.

Description of changes:
 - Guard array access by checking if collision_params.bond_centers == -1 and issue an error message including a suggestion to fix it.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
