### PR TITLE
pickle particles before actors

### DIFF
--- a/samples/load_checkpoint.py
+++ b/samples/load_checkpoint.py
@@ -5,22 +5,21 @@ from espressomd import checkpointing
 checkpoint = checkpointing.Checkpointing(checkpoint_id="mycheckpoint")
 checkpoint.load()
 
-# necessary for using e.g. system.actors, since explicit checkpointing of actors is not implemented yet
-system = espressomd.System(box_l=[10.7437, 10.7437, 10.7437])
-system.set_random_state_PRNG()
-#system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
+# print out actors
+
+print("\n### current active actors ###")
+for act in system.actors.active_actors:
+    #print(act.__class__.__name__)
+    print(act)
 
 # test user variable
 print("\n### user variable test ###")
 print("myvar = {}".format(myvar))
-print("skin = {}".format(skin))
 
 # test "system"
 print("\n### system test ###")
 print("system.time = {}".format(system.time))
 print("system.box_l = {}".format(system.box_l))
-# system.cell_system not implemented yet, see sample script store_properties.py
-system.cell_system.skin = skin
 
 # test "system.non_bonded_inter"
 print("\n### system.non_bonded_inter test ###")

--- a/samples/load_checkpoint.py
+++ b/samples/load_checkpoint.py
@@ -37,7 +37,7 @@ print("system.thermostat.get_state() = {}".format(system.thermostat.get_state())
 # test "p3m"
 print("\n### p3m test ###")
 print("p3m.get_params() = {}".format(p3m.get_params()))
-system.actors.add(p3m)
+
 
 # test registered objects
 # all objects that are registered when writing a checkpoint are automatically registered after loading this checkpoint

--- a/samples/load_checkpoint.py
+++ b/samples/load_checkpoint.py
@@ -9,7 +9,6 @@ checkpoint.load()
 
 print("\n### current active actors ###")
 for act in system.actors.active_actors:
-    #print(act.__class__.__name__)
     print(act)
 
 # test user variable

--- a/samples/save_checkpoint.py
+++ b/samples/save_checkpoint.py
@@ -15,10 +15,6 @@ myvar = "some script variable"
 checkpoint.register("myvar")
 myvar = "updated value"  # demo of how the register function works
 
-skin = 0.4
-checkpoint.register("skin")
-
-
 # test for "system"
 box_l = 10.7437
 
@@ -27,16 +23,12 @@ system.set_random_state_PRNG()
 #system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
 np.random.seed(seed=system.seed)
 system.time_step = 0.01
-system.cell_system.skin = skin
+system.cell_system.skin = 0.4
 
 checkpoint.register("system")
 
-
 # test for "system.thermostat"
 system.thermostat.set_langevin(kT=1.0, gamma=1.0)
-
-checkpoint.register("system.thermostat")
-
 
 # test for "system.non_bonded_inter"
 lj_eps = 1.0
@@ -49,16 +41,10 @@ system.non_bonded_inter[0, 0].lennard_jones.set_params(
     cutoff=lj_cut, shift="auto")
 system.force_cap = lj_cap
 
-checkpoint.register("system.non_bonded_inter")
-
-
 # test for "system.part"
 n_part = 10
 for i in range(n_part):
     system.part.add(id=i, pos=np.random.random(3) * system.box_l)
-
-checkpoint.register("system.part")
-
 
 # test for "p3m"
 for i in range(n_part // 2 - 1):
@@ -67,8 +53,7 @@ for i in range(n_part // 2 - 1):
 p3m = electrostatics.P3M(prefactor=1.0, accuracy=1e-2)
 system.actors.add(p3m)
 
+# let's also register the p3m reference for easy access later
 checkpoint.register("p3m")
-
-
 
 checkpoint.save()

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -153,6 +153,7 @@ cdef class System(object):
         for property_ in setable_properties:
             if not hasattr(self.globals, property_):
                 odict[property_] = System.__getattribute__(self, property_)
+        odict['part'] = System.__getattribute__(self, "part")
         odict['actors'] = System.__getattribute__(self, "actors")
         odict['analysis'] = System.__getattribute__(self, "analysis")
         odict['auto_update_accumulators'] = System.__getattribute__(self, "auto_update_accumulators")
@@ -166,7 +167,6 @@ cdef class System(object):
         IF LB_BOUNDARIES or LB_BOUNDARIES_GPU:
             odict['lbboundaries'] = System.__getattribute__(self, "lbboundaries")
         odict['minimize_energy'] = System.__getattribute__(self, "minimize_energy")
-        odict['part'] = System.__getattribute__(self, "part")
         odict['thermostat'] = System.__getattribute__(self, "thermostat")
         odict['non_bonded_inter'] = System.__getattribute__(self, "non_bonded_inter")
         return odict


### PR DESCRIPTION
Fixes
Loading a checkpoint with P3M fails when it tunes since particles are not yet present.

Description of changes:
 - pickling order changed: particles before actors 


PR Checklist
------------
 - [ ] Tests?
   - [x] Interface
   - [ ] Core 
 - [ ] Docs?
