### PR TITLE
LB boundaries: reinit boundaries after change in velocity.

### DIFF
--- a/src/core/lbboundaries/LBBoundary.hpp
+++ b/src/core/lbboundaries/LBBoundary.hpp
@@ -12,6 +12,7 @@
 namespace LBBoundaries {
 #if defined(LB_BOUNDARIES) || defined(LB_BOUNDARIES_GPU)
 int lbboundary_get_force(void* lbb, double *f);
+void lb_init_boundaries();
 #endif
 class LBBoundary {
 public:
@@ -35,7 +36,10 @@ public:
     m_shape = shape;
   }
 
-  void set_velocity(Vector3d velocity) { m_velocity = velocity; }
+  void set_velocity(Vector3d velocity) {
+    m_velocity = velocity;
+    lb_init_boundaries();
+  }
   void reset_force() { m_force = Vector3d{0,0,0}; }
 
   Shapes::Shape const &shape() const { return *m_shape; }

--- a/src/core/lbboundaries/LBBoundary.hpp
+++ b/src/core/lbboundaries/LBBoundary.hpp
@@ -38,7 +38,9 @@ public:
 
   void set_velocity(Vector3d velocity) {
     m_velocity = velocity;
+#if defined(LB_BOUNDARIES) || defined(LB_BOUNDARIES_GPU)
     lb_init_boundaries();
+#endif
   }
   void reset_force() { m_force = Vector3d{0,0,0}; }
 

--- a/src/script_interface/lbboundaries/LBBoundary.hpp
+++ b/src/script_interface/lbboundaries/LBBoundary.hpp
@@ -11,7 +11,14 @@ namespace LBBoundaries {
 class LBBoundary : public AutoParameters<LBBoundary> {
 public:
   LBBoundary() : m_lbboundary(new ::LBBoundaries::LBBoundary()) {
-    add_parameters({{"velocity", m_lbboundary->velocity()},
+    add_parameters({{"velocity",
+                     [this](Variant const &value) {
+                       m_lbboundary->set_velocity(get_value<Vector3d>(value));
+                     },
+                     [this]() {
+                       return m_lbboundary->velocity();
+                     }
+                    },
                     {"shape",
                      [this](Variant const &value) {
                        m_shape =


### PR DESCRIPTION
Fixes #2033