### PR TITLE
Fix 'else clause does not guard' warning

### DIFF
--- a/src/core/readpdb.cpp
+++ b/src/core/readpdb.cpp
@@ -24,11 +24,12 @@ static void  add_lj_interaction(std::set<PdbParser::itp_atomtype, PdbParser::itp
       if((epsilon_ij <= 0) || (sigma_ij <= 0)) {
 	continue;
       }
-      else
+      else {
 	READPDB_TRACE(printf("adding lj interaction types %d %d eps %e sig %e cut %e shift %e\n", 
 			   it->other_type, jt->espresso_id, epsilon_ij, sigma_ij, cutoff_ij, shift_ij););
 	lennard_jones_set_params(it->other_type, jt->espresso_id, epsilon_ij, sigma_ij,
 			       cutoff_ij, shift_ij, 0.0, 0.0);
+      }
     }
   }
 }
@@ -48,11 +49,12 @@ static void add_lj_internal(std::set<PdbParser::itp_atomtype, PdbParser::itp_ato
       if((epsilon_ij <= 0) || (sigma_ij <= 0)) {
 	continue;
       }
-      else
+      else {
 	READPDB_TRACE(printf("adding internal lj interaction types %d %d eps %e sig %e cut %e shift %e epsilon_i %e\n", 
 			   it->espresso_id, jt->espresso_id, epsilon_ij, sigma_ij, cutoff_ij, shift_ij, it->epsilon););
 	lennard_jones_set_params(it->espresso_id, jt->espresso_id, epsilon_ij, sigma_ij,
 			       cutoff_ij, shift_ij, 0.0, 0.0);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes compiler warning 'else clause does not guard' (see below). It seems fairly obvious that both statements belong to in the else block. It is not a bug as the loop exits early (with the `continue` in the if clause), however, the warning is annoying. Another possibility would be to simply remove the `else`.



```
./espresso/src/core/readpdb.cpp: In function ‘void add_lj_interaction(std::set<PdbParser::itp_atomtype, PdbParser::itp_atomtype_compare>&, std::vector<PdbLJInteraction>, double)’:
/tmp/espresso/src/core/readpdb.cpp:27:7: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
       else
       ^~~~
./espresso/src/core/readpdb.cpp:30:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
  lennard_jones_set_params(it->other_type, jt->espresso_id, epsilon_ij, sigma_ij,
  ^~~~~~~~~~~~~~~~~~~~~~~~
./espresso/src/core/readpdb.cpp: In function ‘void add_lj_internal(std::set<PdbParser::itp_atomtype, PdbParser::itp_atomtype_compare>&, double, bool)’:
./espresso/src/core/readpdb.cpp:51:7: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
       else
       ^~~~
./espresso/src/core/readpdb.cpp:54:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
  lennard_jones_set_params(it->espresso_id, jt->espresso_id, epsilon_ij, sigma_ij,
  ^~~~~~~~~~~~~~~~~~~~~~~~
```
