### PR TITLE
OpenGL Visualizer: Fix casting error when drawing director_arrow.

### DIFF
--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -1077,7 +1077,7 @@ class openGLLive(object):
             col = self._modulo_indexing(type_colors, ptype)
             radius = self._modulo_indexing(type_radii, ptype)
             draw_arrow(self.particles['pos'][pid], np.array(
-                v) * sc, radius, col, self.materials['chrome'], self.specs['quality_arrows'])
+                v, dtype=float) * sc, radius, col, self.materials['chrome'], self.specs['quality_arrows'])
 
     def _draw_bonds(self):
         pIds = range(len(self.particles['pos']))


### PR DESCRIPTION
Drawing `director_arrows` resulted in a stack overflow. Sample script:
```python
import espressomd
from espressomd import visualization
from threading import Thread
import numpy as np

system = espressomd.System(box_l=[4.]*3)
system.time_step = 0.01
system.cell_system.skin = 0.4

system.part.add(pos = [1.,1.,1.], dip = [1.,0.,0.])
system.part.add(pos = [3.,3.,3.], dip = [1.,1.,1.])
    
visualizer = visualization.openGLLive(system, director_arrows = True)

def main_loop():
    while True:
        system.integrator.run(100)
        visualizer.update()

t = Thread(target=main_loop)
t.deamon = True
t.start()
visualizer.start()
```
resulted in 
```
TypeError: ufunc 'multiply' output (typecode 'O') could not be coerced to provided output parameter (typecode 'd') according to the casting rule ''same_kind'
```
Is related to tightened up ufunc casting rule in numpy, and fixed by an explicit cast to `dtype=float`.