### PR TITLE
Enable visualizer to handle discontinuous particle ids.

### DIFF
--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -831,8 +831,8 @@ class openGLLive(object):
     def _update_bonds(self):
         if self.specs['draw_bonds']:
             self.bonds = []
-            for i in range(len(self.system.part)):
-                bs = self.system.part[i].bonds
+            for i, p in enumerate(self.system.part):
+                bs = p.bonds
                 for b in bs:
                     t = b[0].type_number()
                     # b[0]: Bond, b[1:] Partners


### PR DESCRIPTION
Fixes #2048 

This fix works also if particles are added while visualizing, and later removed between `visualizer.update()`s, as tested by the following script:
```python
import espressomd
from espressomd import visualization
from threading import Thread
import time

system = espressomd.System(box_l=[3.]*3)
system.time_step = 0.01
system.cell_system.skin = 0.4

visualizer = visualization.openGLLive(system)

def main():
    for i in range(3):
        system.part.add(pos=[i, i, i], id=i)
        visualizer.update()
        system.integrator.run(int(1e6))

    system.part[1].remove()

    while True:
        system.integrator.run(100)
        visualizer.update()

t = Thread(target=main)
t.deamon = True
t.start()
visualizer.start()
```