### PR TITLE
Add cmath include for std::sqrt

### DIFF
--- a/src/core/utils/Accumulator.hpp
+++ b/src/core/utils/Accumulator.hpp
@@ -2,6 +2,7 @@
 #define CORE_UTILS_ACCUMULATOR
 
 #include <boost/serialization/access.hpp>
+#include <cmath>
 
 namespace Utils {
 


### PR DESCRIPTION
Fixes compilation error during make check with some (non-default) features turned on:

```
./espresso/src/core/utils/Accumulator.hpp: In lambda function:
./espresso/src/core/utils/Accumulator.hpp:95:38: error: ‘sqrt’ is not a member of ‘std’
                          return std::sqrt(d/m_n);
                                      ^~~~
./espresso/src/core/utils/Accumulator.hpp:95:38: note: suggested alternative: ‘sort’
                          return std::sqrt(d/m_n);
                                      ^~~~
                                      sort
In file included from /usr/include/c++/7/algorithm:62:0,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:39,
                 from /usr/include/boost/shared_ptr.hpp:17,
                 from /usr/include/boost/test/tools/assertion_result.hpp:21,
                 from /usr/include/boost/test/tools/old/impl.hpp:20,
                 from /usr/include/boost/test/test_tools.hpp:46,
                 from /usr/include/boost/test/unit_test.hpp:18,
                 from /tmp/espresso/src/core/unit_tests/accumulator.cpp:3:
/usr/include/c++/7/bits/stl_algo.h: In instantiation of ‘_OIter std::transform(_IIter, _IIter, _OIter, _UnaryOperation) [with _IIter = __gnu_cxx::__normal_iterator<const double*, std::vector<double> >; _OIter = __gnu_cxx::__normal_iterator<double*, std::vector<double> >; _UnaryOperation = Utils::Accumulator::get_std_error() const::<lambda(double)>]’:
/tmp/espresso/src/core/utils/Accumulator.hpp:96:25:   required from here
/usr/include/c++/7/bits/stl_algo.h:4306:12: error: void value not ignored as it ought to be
  *__result = __unary_op(*__first);
  ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```


Description of changes:
 - Add cmath include in src/core/utils/Accumulator.hpp


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
