### PR TITLE
Only call on_boxl_change if the box size changed.

### DIFF
--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -365,8 +365,6 @@ void cells_on_geometry_change(int flags) {
   case CELL_STRUCTURE_NSQUARE:
     break;
   }
-
-  on_boxl_change();
 }
 
 /*************************************************/

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -363,11 +363,10 @@ void cells_on_geometry_change(int flags) {
     cells_re_init(CELL_STRUCTURE_LAYERED);
     break;
   case CELL_STRUCTURE_NSQUARE:
-    /* this cell system doesn't need to react, just tell
-       the others */
-    on_boxl_change();
     break;
   }
+
+  on_boxl_change();
 }
 
 /*************************************************/

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -28,8 +28,6 @@
 #include "domain_decomposition.hpp"
 #include "errorhandling.hpp"
 
-#include "initialize.hpp"
-
 /** Returns pointer to the cell which corresponds to the position if
     the position is in the nodes spatial domain otherwise a nullptr
     pointer. */
@@ -682,8 +680,6 @@ void dd_on_geometry_change(int flags) {
     }
   }
   dd_update_communicators_w_boxl();
-  /* tell other algorithms that the box length might have changed. */
-  on_boxl_change();
 }
 
 /************************************************************/

--- a/src/core/initialize.cpp
+++ b/src/core/initialize.cpp
@@ -27,6 +27,7 @@
 #include "cuda_init.hpp"
 #include "cuda_interface.hpp"
 #include "debye_hueckel.hpp"
+#include "dpd.hpp"
 #include "elc.hpp"
 #include "energy.hpp"
 #include "errorhandling.hpp"
@@ -55,20 +56,18 @@
 #include "pressure.hpp"
 #include "random.hpp"
 #include "rattle.hpp"
-#include "swimmer_reaction.hpp"
 #include "reaction_ensemble.hpp"
 #include "reaction_field.hpp"
 #include "rotation.hpp"
 #include "scafacos.hpp"
 #include "statistics.hpp"
-#include "thermostat.hpp"
+#include "swimmer_reaction.hpp"
 #include "thermalized_bond.hpp"
+#include "thermostat.hpp"
 #include "utils.hpp"
-#include "global.hpp"
 #include "virtual_sites.hpp"
-#include "dpd.hpp"
 
-#include "utils/mpi/all_compare.hpp" 
+#include "utils/mpi/all_compare.hpp"
 /** whether the thermostat has to be reinitialized before integration */
 static int reinit_thermo = 1;
 static int reinit_electrostatics = 0;
@@ -159,9 +158,9 @@ void on_integration_start() {
   }
 #endif
 
-/********************************************/
-/* end sanity checks                        */
-/********************************************/
+  /********************************************/
+  /* end sanity checks                        */
+  /********************************************/
 
 #ifdef LB_GPU
   if (lattice_switch & LATTICE_LB_GPU && this_node == 0) {
@@ -203,24 +202,24 @@ void on_integration_start() {
 
 #ifdef ADDITIONAL_CHECKS
 
-  if(!Utils::Mpi::all_compare(comm_cart, cell_structure.type)) {
+  if (!Utils::Mpi::all_compare(comm_cart, cell_structure.type)) {
     runtimeErrorMsg() << "Nodes disagree about cell system type.";
   }
 
-  if(!Utils::Mpi::all_compare(comm_cart, get_resort_particles())) {
+  if (!Utils::Mpi::all_compare(comm_cart, get_resort_particles())) {
     runtimeErrorMsg() << "Nodes disagree about resort type.";
   }
 
-  if(!Utils::Mpi::all_compare(comm_cart, cell_structure.use_verlet_list)) {
+  if (!Utils::Mpi::all_compare(comm_cart, cell_structure.use_verlet_list)) {
     runtimeErrorMsg() << "Nodes disagree about use of verlet lists.";
   }
 
 #ifdef ELECTROSTATICS
-  if (!Utils::Mpi::all_compare(comm_cart,coulomb.method))
+  if (!Utils::Mpi::all_compare(comm_cart, coulomb.method))
     runtimeErrorMsg() << "Nodes disagree about Coulomb long range method";
 #endif
 #ifdef DIPOLES
-  if (!Utils::Mpi::all_compare(comm_cart,coulomb.Dmethod))
+  if (!Utils::Mpi::all_compare(comm_cart, coulomb.Dmethod))
     runtimeErrorMsg() << "Nodes disagree about dipolar long range method";
 #endif
   check_global_consistency();
@@ -432,6 +431,12 @@ void on_resort_particles() {
 void on_boxl_change() {
   EVENT_TRACE(fprintf(stderr, "%d: on_boxl_change\n", this_node));
 
+  grid_changed_box_l();
+  /* Electrostatics cutoffs mostly depend on the system size,
+     therefore recalculate them. */
+  recalc_maximal_cutoff();
+  cells_on_geometry_change(0);
+
 /* Now give methods a chance to react to the change in box length */
 #ifdef ELECTROSTATICS
   switch (coulomb.method) {
@@ -453,6 +458,11 @@ void on_boxl_change() {
   case COULOMB_MAGGS:
     maggs_init();
     break;
+#ifdef SCAFACOS
+  case COULOMB_SCAFACOS:
+    Scafacos::update_system_params();
+    break;
+#endif
   default:
     break;
   }
@@ -465,6 +475,11 @@ void on_boxl_change() {
   // fall through
   case DIPOLAR_P3M:
     dp3m_scaleby_box_l();
+    break;
+#endif
+#ifdef SCAFACOS
+  case DIPOLAR_SCAFACOS:
+    Scafacos::update_system_params();
     break;
 #endif
   default:
@@ -556,7 +571,6 @@ void on_temperature_change() {
     }
   }
 #endif
-
 }
 
 void on_parameter_change(int field) {
@@ -565,24 +579,7 @@ void on_parameter_change(int field) {
 
   switch (field) {
   case FIELD_BOXL:
-    grid_changed_box_l();
-#ifdef SCAFACOS
-    #ifdef ELECTROSTATICS
-    if (coulomb.method == COULOMB_SCAFACOS) {
-      Scafacos::update_system_params(); 
-    }
-    #endif
-    #ifdef DIPOLES
-    if (coulomb.Dmethod == DIPOLAR_SCAFACOS) {
-      Scafacos::update_system_params(); 
-    }
-    #endif
-
-#endif
-    /* Electrostatics cutoffs mostly depend on the system size,
-       therefore recalculate them. */
-    recalc_maximal_cutoff();
-    cells_on_geometry_change(0);
+    on_boxl_change();
     break;
   case FIELD_MIN_GLOBAL_CUT:
     recalc_maximal_cutoff();
@@ -592,16 +589,16 @@ void on_parameter_change(int field) {
     cells_on_geometry_change(0);
   case FIELD_PERIODIC:
 #ifdef SCAFACOS
-    #ifdef ELECTROSTATICS
+#ifdef ELECTROSTATICS
     if (coulomb.method == COULOMB_SCAFACOS) {
-      Scafacos::update_system_params(); 
+      Scafacos::update_system_params();
     }
-    #endif
-    #ifdef DIPOLES
+#endif
+#ifdef DIPOLES
     if (coulomb.Dmethod == DIPOLAR_SCAFACOS) {
-      Scafacos::update_system_params(); 
+      Scafacos::update_system_params();
     }
-    #endif
+#endif
 
 #endif
     cells_on_geometry_change(CELL_FLAG_GRIDCHANGED);
@@ -741,8 +738,7 @@ void on_ghost_flags_change() {
     ghosts_have_v = 1;
   };
 #endif
-  //THERMALIZED_DIST_BOND needs v to calculate v_com and v_dist for thermostats
+  // THERMALIZED_DIST_BOND needs v to calculate v_com and v_dist for thermostats
   if (n_thermalized_bonds)
     ghosts_have_v = 1;
-
 }


### PR DESCRIPTION
Until now on_boxl_changed was always call when the `cells_on_geometry_change` was called, e.g. when short-range interactions were changed. This made it impossible to subscribe only to the box size change. Also the layered cell system failed to notify other methods of a boxl change.