### PR TITLE
Get rid of GCC 8.1.1 compiler warnings.

### DIFF
--- a/src/core/immersed_boundary/ImmersedBoundaries.cpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.cpp
@@ -270,7 +270,8 @@ void ImmersedBoundaries::calc_volume_force()
       // Loop over all bonds of this particle
       // Actually j loops over the bond-list, i.e. the bond partners (see particle_data.hpp)
       int softID = -1;
-      double volRef, kappaV;
+      double volRef = 0.;
+      double kappaV = 0.;
       int j = 0;
       while ( j < p1.bl.n )
       {

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -3,9 +3,7 @@
 
 char *strcat_alloc(char *left, const char *right) {
   if (!left) {
-    char *res = (char *)Utils::malloc(strlen(right) + 1);
-    strncpy(res, right, strlen(right) + 1);
-    return res;
+    return strdup(right);
   } else {
     size_t newlen = strlen(left) + strlen(right) + 1;
     char *res = Utils::realloc(left, newlen);


### PR DESCRIPTION
Compiling with GCC 8.1.1.  resulted in the following compiler warnings, which this PR gets rid of:
```
In file included from /home/pkreissl/git/espresso/src/core/lb.cpp:36,
                 from /home/pkreissl/git/espresso/src/core/observables/CylindricalLBVelocityProfileAtParticlePositions.cpp:20:
/home/pkreissl/git/espresso/src/core/lb.hpp:97:9: warning: unnecessary parentheses in declaration of 'w' [-Wparentheses]
   double(*w);
         ^
```
```
/home/pkreissl/git/espresso/src/core/immersed_boundary/ImmersedBoundaries.cpp: In member function 'void ImmersedBoundaries::calc_volume_force()':
/home/pkreissl/git/espresso/src/core/immersed_boundary/ImmersedBoundaries.cpp:352:40: warning: 'kappaV' may be used uninitialized in this function [-Wmaybe-uninitialized]
             const double fact = kappaV * (VolumesCurrent[softID] - volRef) / VolumesCurrent[softID];
                                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/pkreissl/git/espresso/src/core/immersed_boundary/ImmersedBoundaries.cpp:352:66: warning: 'volRef' may be used uninitialized in this function [-Wmaybe-uninitialized]
             const double fact = kappaV * (VolumesCurrent[softID] - volRef) / VolumesCurrent[softID];
                                          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```
```
/home/pkreissl/git/espresso/src/core/utils.cpp: In function 'char* strcat_alloc(char*, const char*)':
/home/pkreissl/git/espresso/src/core/utils.cpp:7:12: warning: 'char* strncpy(char*, const char*, size_t)' specified bound depends on the length of the source argument [-Wstringop-overflow=]
     strncpy(res, right, strlen(right) + 1);
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/pkreissl/git/espresso/src/core/utils.cpp:7:31: note: length computed here
     strncpy(res, right, strlen(right) + 1);
                         ~~~~~~^~~~~~~

```