### PR TITLE
core: Reset min_num_cells to default if the node grid has changed.

### DIFF
--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -629,7 +629,6 @@ int dd_append_particles(ParticleList *pl, int fold_dir) {
 /************************************************************/
 
 void dd_on_geometry_change(int flags) {
-
   /* check that the CPU domains are still sufficiently large. */
   for (int i = 0; i < 3; i++)
     if (local_box_l[i] < max_range) {
@@ -642,6 +641,10 @@ void dd_on_geometry_change(int flags) {
   if (flags & CELL_FLAG_GRIDCHANGED) {
     CELL_TRACE(
         fprintf(stderr, "%d: dd_on_geometry_change full redo\n", this_node));
+
+    /* Reset min num cells to default */
+    min_num_cells = calc_processor_min_num_cells();
+
     cells_re_init(CELL_STRUCTURE_CURRENT);
     return;
   }

--- a/src/core/p3m.cpp
+++ b/src/core/p3m.cpp
@@ -1534,6 +1534,7 @@ static double p3m_mc_time(char **log, int mesh[3], int cao, double r_cut_iL_min,
             mesh[0], cao, r_cut_iL, *_alpha_L, *_accuracy, rs_err, ks_err);
     *log = strcat_alloc(*log, b);
   }
+
   int_time = p3m_mcr_time(mesh, cao, r_cut_iL, *_alpha_L);
   if (int_time == -1) {
     *log = strcat_alloc(*log, "tuning failed, test integration not possible\n");


### PR DESCRIPTION
Fixes #2061.

Description of changes:
 - Reset `min_num_cells` to default after node grid change.

This is not the ideal solution, but works for now.