### PR TITLE
CI: Build no_cuda_maxset with "ubuntu" rather than "ubuntu-cuda" dock…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,7 @@ no_cuda_default:
 
 no_cuda_maxset:
   stage: build
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu:latest
   except:
     - doc
   script:


### PR DESCRIPTION
The Ubuntu (without Cuda) was never used in the CI. As a consequence, scafacos tests never ran.
Due to old Autotools, it is non-trivial to get Scafacos into the 14.4 based ubuntu-cuda img.
