### PR TITLE
Auto-activate SCAFACOS_DIPOLES when FCS_ENABLE_DIPOLES in fcs_config.h

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ status_pending:
 
 no_cuda_default:
   stage: build
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu:latest
   script:
     - export with_cuda=false
     - export myconfig=default with_coverage=true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,9 @@ cmake_minimum_required(VERSION 2.8)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+if(SCAFACOS)
+  include_directories(${SCAFACOS_INCLUDE_DIRS})
+endif(SCAFACOS)
 
 configure_file(${CMAKE_SOURCE_DIR}/cmake/cmake_config.cmakein
                cmake_config.hpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -36,7 +36,6 @@ set_target_properties(EspressoCore PROPERTIES SOVERSION ${SOVERSION})
 target_link_libraries(EspressoCore EspressoConfig ${LIBRARIES} Actor ObjectInFluid ImmersedBoundary Shapes Constraints Observables Accumulators cluster_analysis VirtualSites)
 
 if(SCAFACOS)
-  include_directories(${SCAFACOS_INCLUDE_DIRS})
   target_link_libraries(EspressoCore Scafacos)
 endif(SCAFACOS)
 if(GSL)

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -42,6 +42,13 @@ extern const char *ESPRESSO_VERSION;
 /*********************************************************/
 /*@{*/
 
+#ifdef SCAFACOS
+#include "fcs_config.h"
+#if defined(FCS_ENABLE_DIPOLES) && defined(DIPOLES)
+#define SCAFACOS_DIPOLES
+#endif
+#endif
+
 #ifndef ONEPART_DEBUG_ID
 #define ONEPART_DEBUG_ID 13
 #endif

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -40,6 +40,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/myconfig.pxi
                    DEPENDS gen_pxiconfig
                    )
 
+
 include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
 include_directories(SYSTEM ${NUMPY_INCLUDE_DIR})
 


### PR DESCRIPTION
Fixes #2103.
+CI. 
Charge-only should be built via default_no_cuda.
Dipoles should be built via maxset_no_cuda.
