### PR TITLE
Add ICP gitlab domain to codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,7 @@ codecov:
     require_ci_to_pass: yes
   ci:
     - !travis-ci.org
+    - gitlab.icp.uni-stuttgart.de
 
 coverage:
   precision: 0


### PR DESCRIPTION
Maybe helps to avoid the PR comment update for each coverage upload
