### PR TITLE
Force exact resorting without Verlet lists

### DIFF
--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -385,6 +385,10 @@ void check_resort_particles() {
 
 /*************************************************/
 void cells_update_ghosts() {
+  // If no Verlet lists are used we need exact sorting of the particles
+  if (!cell_structure.use_verlet_list)
+    resort_particles |= Cells::RESORT_LOCAL;
+
   if (resort_particles) {
     int global = (resort_particles & Cells::RESORT_GLOBAL)
                      ? CELL_GLOBAL_EXCHANGE


### PR DESCRIPTION
9c9ef3b removed the forced particle resort in `cells_update_ghosts` if Verlet lists are not used. However, this resort is necessary for correctness. This PR reintroduces it.


Description of changes:
 - Force `resort_particles` to at least `Cells::RESORT_LOCAL` if Verlet lists are not used.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
