### PR TITLE
Fixed neighbor search

### DIFF
--- a/src/core/Cell.hpp
+++ b/src/core/Cell.hpp
@@ -4,36 +4,81 @@
 #include <functional>
 #include <vector>
 
-/* Needed for transform_iterator to work with
-   lambdas on older compilers. */
-#define BOOST_RESULT_OF_USE_DECLTYPE
-
-#include <boost/iterator/transform_iterator.hpp>
-
 #include "particle_data.hpp"
-#include "utils/Range.hpp"
 
-class Cell : public ParticleList {
-  using neighbors_t = std::vector<Cell *>;
+#include "utils/Range.hpp"
+#include "utils/Span.hpp"
+
+template <class CellRef> class Neighbors {
+  using storage_type = std::vector<CellRef>;
 
 public:
-  using neighbor_iterator = neighbors_t::iterator;
+  using value_type = typename storage_type::value_type;
+  using iterator = typename storage_type::iterator;
+  using cell_range = Utils::Range<iterator>;
 
-  /** Topological neighbors of the cell */
-  std::vector<Cell *> m_neighbors;
+  Neighbors() = default;
+  Neighbors(const Neighbors &) = delete;
+  Neighbors(Neighbors &&) = default;
+  Neighbors &operator=(const Neighbors &) = delete;
+  Neighbors &operator=(Neighbors &&) = default;
+
+  Neighbors(Utils::Span<const CellRef> red_neighbors,
+            Utils::Span<const CellRef> black_neighbors) {
+    m_neighbors.resize(red_neighbors.size() + black_neighbors.size());
+    m_red_black_divider = std::copy(red_neighbors.begin(), red_neighbors.end(),
+                                    m_neighbors.begin());
+    std::copy(black_neighbors.begin(), black_neighbors.end(),
+              m_red_black_divider);
+  }
+
+  /**
+   * @brief All neighbors.
+   */
+  cell_range all() { return {m_neighbors.begin(), m_neighbors.end()}; }
+  /**
+   * @brief Red partition of neighbors.
+   *
+   * An partition of the neighbors so that iterating over all
+   * neighbors_red of all cells visits every pair exactly once.
+   * Complement of neighbors_black.
+   */
+  cell_range red() { return {m_neighbors.begin(), m_red_black_divider}; }
+  /**
+   * @brief Black partition of neighbors.
+   *
+   * An partition of the neighbors so that iterating over all
+   * neighbors_black of all cells visits every pair exactly once.
+   * Complement of neighbors_red.
+   */
+  cell_range black() { return {m_red_black_divider, m_neighbors.end()}; }
+
+private:
+  /** Container with all the neighbors.
+      Red neighbors are first, black second. */
+  storage_type m_neighbors;
+  /** Iterator pointing to the first black neighbor
+      in the container. */
+  iterator m_red_black_divider;
+};
+
+class Cell : public ParticleList {
+  using neighbors_type = Neighbors<Cell *>;
+
+public:
+  neighbors_type m_neighbors;
 
   /** Interaction pairs */
   std::vector<std::pair<Particle *, Particle *>> m_verlet_list;
 
-  Utils::Range<neighbor_iterator> neighbors() {
-    return Utils::make_range(neighbor_iterator(m_neighbors.begin()),
-                             neighbor_iterator(m_neighbors.end()));
-  }
+  /**
+   * @brief All neighbors of the cell.
+   */
+  neighbors_type &neighbors() { return m_neighbors; }
 
   void resize(size_t size) {
     realloc_particlelist(static_cast<ParticleList *>(this), this->n = size);
   }
-
 };
 
 #endif

--- a/src/core/Cell.hpp
+++ b/src/core/Cell.hpp
@@ -19,9 +19,9 @@ public:
 
   Neighbors() = default;
   Neighbors(const Neighbors &) = delete;
-  Neighbors(Neighbors &&) = default;
+  Neighbors(Neighbors &&) noexcept = default;
   Neighbors &operator=(const Neighbors &) = delete;
-  Neighbors &operator=(Neighbors &&) = default;
+  Neighbors &operator=(Neighbors &&) noexcept = default;
 
   Neighbors(Utils::Span<const CellRef> red_neighbors,
             Utils::Span<const CellRef> black_neighbors) {

--- a/src/core/Cell.hpp
+++ b/src/core/Cell.hpp
@@ -15,13 +15,25 @@ template <class CellRef> class Neighbors {
 public:
   using value_type = typename storage_type::value_type;
   using iterator = typename storage_type::iterator;
+  using const_iterator = typename storage_type::const_iterator;
   using cell_range = Utils::Range<iterator>;
 
+private:
+  void copy(const Neighbors &rhs) {
+    m_neighbors = rhs.m_neighbors;
+    m_red_black_divider =
+        m_neighbors.begin() +
+        std::distance(rhs.m_neighbors.begin(),
+                      const_iterator(rhs.m_red_black_divider));
+  }
+
+public:
   Neighbors() = default;
-  Neighbors(const Neighbors &) = delete;
-  Neighbors(Neighbors &&) noexcept = default;
-  Neighbors &operator=(const Neighbors &) = delete;
-  Neighbors &operator=(Neighbors &&) noexcept = default;
+  Neighbors(const Neighbors &rhs) { copy(rhs); }
+  Neighbors &operator=(const Neighbors &rhs) {
+    copy(rhs);
+    return *this;
+  }
 
   Neighbors(Utils::Span<const CellRef> red_neighbors,
             Utils::Span<const CellRef> black_neighbors) {

--- a/src/core/algorithm/link_cell.hpp
+++ b/src/core/algorithm/link_cell.hpp
@@ -9,32 +9,32 @@ namespace Algorithm {
  *        their neighbors.
  */
 template <typename CellIterator, typename ParticleKernel, typename PairKernel,
-        typename DistanceFunction>
+          typename DistanceFunction>
 void link_cell(CellIterator first, CellIterator last,
-             ParticleKernel &&particle_kernel, PairKernel &&pair_kernel,
-             DistanceFunction &&distance_function) {
-for (; first != last; ++first) {
-  for (int i = 0; i != first->n; i++) {
-    auto &p1 = first->part[i];
+               ParticleKernel &&particle_kernel, PairKernel &&pair_kernel,
+               DistanceFunction &&distance_function) {
+  for (; first != last; ++first) {
+    for (int i = 0; i != first->n; i++) {
+      auto &p1 = first->part[i];
 
-    particle_kernel(p1);
+      particle_kernel(p1);
 
-    /* Pairs in this cell */
-for (int j = i + 1; j < first->n; j++) {
-  auto dist = distance_function(p1, first->part[j]);
-  pair_kernel(p1, first->part[j], dist);
-}
+      /* Pairs in this cell */
+      for (int j = i + 1; j < first->n; j++) {
+        auto dist = distance_function(p1, first->part[j]);
+        pair_kernel(p1, first->part[j], dist);
+      }
 
-/* Pairs with neighbors */
-for (auto &neighbor : first->neighbors()) {
-  for (int j = 0; j < neighbor->n; j++) {
-    auto &p2 = neighbor->part[j];
-    auto dist = distance_function(p1, p2);
-    pair_kernel(p1, p2, dist);
+      /* Pairs with neighbors */
+      for (auto &neighbor : first->neighbors().red()) {
+        for (int j = 0; j < neighbor->n; j++) {
+          auto &p2 = neighbor->part[j];
+          auto dist = distance_function(p1, p2);
+          pair_kernel(p1, p2, dist);
+        }
+      }
+    }
   }
-}
-}
-}
 }
 }
 

--- a/src/core/algorithm/verlet_ia.hpp
+++ b/src/core/algorithm/verlet_ia.hpp
@@ -32,7 +32,7 @@ void update_and_kernel(CellIterator first, CellIterator last,
       }
 
       /* Pairs with neighbors */
-      for (auto &neighbor : first->neighbors()) {
+      for (auto &neighbor : first->neighbors().red()) {
         for (int j = 0; j < neighbor->n; j++) {
           auto &p2 = neighbor->part[j];
           auto dist = distance_function(p1, p2);

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -101,12 +101,6 @@ bool validate_collision_parameters() {
   }
 #endif
 
-  if ((collision_params.mode != COLLISION_MODE_OFF) && (n_nodes > 1)) {
-    runtimeErrorMsg() << "The collision detection schemes are currently not "
-                         "available in parallel simulations";
-    return false;
-  }
-
   // Check if bonded ia exist
   if ((collision_params.mode & COLLISION_MODE_BOND) &&
       (collision_params.bond_centers >= bonded_ia_params.size())) {

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -101,6 +101,12 @@ bool validate_collision_parameters() {
   }
 #endif
 
+  if ((collision_params.mode != COLLISION_MODE_OFF) && (n_nodes > 1)) {
+    runtimeErrorMsg() << "The collision detection schemes are currently not "
+                         "available in parallel simulations";
+    return false;
+  }
+
   // Check if bonded ia exist
   if ((collision_params.mode & COLLISION_MODE_BOND) &&
       (collision_params.bond_centers >= bonded_ia_params.size())) {

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -171,13 +171,6 @@ int dd_fill_comm_cell_lists(Cell **part_lists, int lc[3], int hc[3]);
  * poststore */
 void dd_assign_prefetches(GhostCommunicator *comm);
 
-/** Return a full shell neighbor index.
- * Required for collision.cpp.
- * @param cellidx Index of a local cell
- * @param neigh Number of full shell neighbor to get (0 <= neigh < 27)
- * @return Index to cells (local or ghost cell) of the requested neighbor.
- */
-int dd_full_shell_neigh(int cellidx, int neigh);
 /*@}*/
 
 #endif

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -30,7 +30,6 @@
 #include "utils.hpp"
 #include "debug.hpp"
 #include "errorhandling.hpp"
-#include "domain_decomposition.hpp"
 
 #include <algorithm>
 #include <cstdio>

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -92,7 +92,8 @@ void layered_get_mi_vector(double res[3], double a[3], double b[3]) {
 }
 
 Cell *layered_position_to_cell(double pos[3]) {
-  int cpos = static_cast<int>(std::floor((pos[2] - my_left[2]) * layer_h_i)) + 1;
+  int cpos =
+      static_cast<int>(std::floor((pos[2] - my_left[2]) * layer_h_i)) + 1;
   if (cpos < 1) {
     if (!LAYERED_BTM_NEIGHBOR)
       cpos = 1;
@@ -300,9 +301,9 @@ static void layered_prepare_comm(GhostCommunicator *comm, int data_parts) {
 void layered_topology_init(CellPList *old) {
   int c, p;
 
-  CELL_TRACE(fprintf(stderr,
-                     "%d: layered_topology_init, %d old particle lists max_range %g\n",
-                     this_node, old->n, max_range));
+  CELL_TRACE(fprintf(
+      stderr, "%d: layered_topology_init, %d old particle lists max_range %g\n",
+      this_node, old->n, max_range));
 
   cell_structure.type = CELL_STRUCTURE_LAYERED;
   cell_structure.position_to_node = map_position_node_array;
@@ -311,8 +312,7 @@ void layered_topology_init(CellPList *old) {
   /* check node grid. All we can do is 1x1xn. */
   if (node_grid[0] != 1 || node_grid[1] != 1) {
     runtimeErrorMsg() << "selected node grid is not suitable for layered cell "
-                         "structure (needs 1x1x"
-                      << n_nodes << " grid";
+                         "structure (needs 1x1x" << n_nodes << " grid";
     node_grid[0] = node_grid[1] = 1;
     node_grid[2] = n_nodes;
   }
@@ -363,9 +363,12 @@ void layered_topology_init(CellPList *old) {
   /* allocate cells and mark them */
   realloc_cells(n_layers + 2);
   realloc_cellplist(&local_cells, local_cells.n = n_layers);
-  for (c = 0; c < n_layers; c++) {
-    local_cells.cell[c] = &cells[c + 1];
-    cells[c + 1].m_neighbors.push_back(&cells[c]);
+  for (c = 1; c <= n_layers; c++) {
+    Cell *red[] = {&cells[c - 1]};
+    Cell *black[] = {&cells[c + 1]};
+
+    local_cells.cell[c - 1] = &cells.at(c);
+    cells[c].m_neighbors = Neighbors<Cell *>(red, black);
   }
 
   realloc_cellplist(&ghost_cells, ghost_cells.n = 2);
@@ -417,7 +420,8 @@ static void layered_append_particles(ParticleList *pl, ParticleList *up,
                          this_node, pl->part[p].p.identity));
       move_indexed_particle(up, pl, p);
     } else
-      move_indexed_particle(layered_position_to_cell(pl->part[p].r.p.data()), pl, p);
+      move_indexed_particle(layered_position_to_cell(pl->part[p].r.p.data()),
+                            pl, p);
     /* same particle again, as this is now a new one */
     if (p < pl->n)
       p--;
@@ -430,7 +434,8 @@ void layered_exchange_and_sort_particles(int global_flag) {
   Cell *nc, *oc;
   int c, p, flag, redo;
   ParticleList send_buf_dn, send_buf_up;
-  ParticleList recv_buf_up, recv_buf_dn;;
+  ParticleList recv_buf_up, recv_buf_dn;
+  ;
 
   CELL_TRACE(fprintf(stderr, "%d:layered exchange and sort %d\n", this_node,
                      global_flag));
@@ -475,12 +480,14 @@ void layered_exchange_and_sort_particles(int global_flag) {
       if (this_node % 2 == 0) {
         /* send down */
         if (LAYERED_BTM_NEIGHBOR) {
-          CELL_TRACE(fprintf(stderr, "%d: send dn %d\n", this_node, send_buf_dn.n));
+          CELL_TRACE(
+              fprintf(stderr, "%d: send dn %d\n", this_node, send_buf_dn.n));
           send_particles(&send_buf_dn, btm);
         }
         if (LAYERED_TOP_NEIGHBOR) {
           recv_particles(&recv_buf_up, top);
-          CELL_TRACE(fprintf(stderr, "%d: recv up %d\n", this_node, recv_buf_up.n));
+          CELL_TRACE(
+              fprintf(stderr, "%d: recv up %d\n", this_node, recv_buf_up.n));
         }
         /* send up */
         if (LAYERED_TOP_NEIGHBOR) {
@@ -489,7 +496,8 @@ void layered_exchange_and_sort_particles(int global_flag) {
         }
         if (LAYERED_BTM_NEIGHBOR) {
           recv_particles(&recv_buf_dn, btm);
-          CELL_TRACE(fprintf(stderr, "%d: recv dn %d\n", this_node, recv_buf_dn.n));
+          CELL_TRACE(
+              fprintf(stderr, "%d: recv dn %d\n", this_node, recv_buf_dn.n));
         }
       } else {
         if (LAYERED_TOP_NEIGHBOR) {
@@ -497,7 +505,8 @@ void layered_exchange_and_sort_particles(int global_flag) {
           recv_particles(&recv_buf_up, top);
         }
         if (LAYERED_BTM_NEIGHBOR) {
-          CELL_TRACE(fprintf(stderr, "%d: send dn %d\n", this_node, send_buf_dn.n));
+          CELL_TRACE(
+              fprintf(stderr, "%d: send dn %d\n", this_node, send_buf_dn.n));
           send_particles(&send_buf_dn, btm);
         }
         if (LAYERED_BTM_NEIGHBOR) {
@@ -510,9 +519,10 @@ void layered_exchange_and_sort_particles(int global_flag) {
         }
       }
     } else {
-      if (recv_buf_up.n != 0 || recv_buf_dn.n != 0 || send_buf_dn.n != 0 || send_buf_up.n != 0) {
+      if (recv_buf_up.n != 0 || recv_buf_dn.n != 0 || send_buf_dn.n != 0 ||
+          send_buf_up.n != 0) {
         fprintf(stderr, "1 node but transfer buffers are not empty. send up "
-                "%d, down %d, recv up %d recv dn %d\n",
+                        "%d, down %d, recv up %d recv dn %d\n",
                 send_buf_up.n, send_buf_dn.n, recv_buf_up.n, recv_buf_dn.n);
         errexit();
       }

--- a/src/core/maggs.cpp
+++ b/src/core/maggs.cpp
@@ -43,11 +43,10 @@
  *  
  */
 
+#include "maggs.hpp"
 
-#include <mpi.h>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#ifdef ELECTROSTATICS
+
 #include "ghosts.hpp"
 #include "global.hpp"
 #include "grid.hpp"
@@ -59,10 +58,12 @@
 #include "maggs.hpp"
 #include "thermostat.hpp"
 #include "cells.hpp"
-#include "domain_decomposition.hpp"
 #include "errorhandling.hpp"
 
-#ifdef ELECTROSTATICS
+#include <mpi.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 /* MPI tags for the maggs communications: */
 /* Used in maggs_init() -> calc_glue_patch(). */

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -66,9 +66,6 @@ static void nsq_prepare_comm(GhostCommunicator *comm, int data_parts) {
 }
 
 void nsq_topology_init(CellPList *old) {
-  Particle *part;
-  int n, p, np, diff;
-
   CELL_TRACE(fprintf(stderr, "%d: nsq_topology_init, %d\n", this_node, old->n));
 
   cell_structure.type = CELL_STRUCTURE_NSQUARE;
@@ -82,27 +79,35 @@ void nsq_topology_init(CellPList *old) {
   realloc_cellplist(&local_cells, local_cells.n = 1);
   local_cells.cell[0] = local;
 
-  cells[this_node].m_neighbors.clear();
-
   realloc_cellplist(&ghost_cells, ghost_cells.n = n_nodes - 1);
-  auto c = 0;
-  for (n = 0; n < n_nodes; n++)
+  int c = 0;
+  for (int n = 0; n < n_nodes; n++)
     if (n != this_node)
       ghost_cells.cell[c++] = &cells[n];
 
-  /* distribute force calculation work  */
+  std::vector<Cell *> red_neighbors;
+  std::vector<Cell *> black_neighbors;
 
-  for (n = 0; n < n_nodes; n++) {
-    diff = n - this_node;
+  /* distribute force calculation work  */
+  for (int n = 0; n < n_nodes; n++) {
+    auto const diff = n - this_node;
     /* simple load balancing formula. Basically diff % n, where n >= n_nodes, n
        odd.
        The node itself is also left out, as it is treated differently */
+    if (diff == 0) {
+      continue;
+    }
+
     if (((diff > 0 && (diff % 2) == 0) || (diff < 0 && ((-diff) % 2) == 1))) {
       CELL_TRACE(
           fprintf(stderr, "%d: doing interactions with %d\n", this_node, n));
-      cells[this_node].m_neighbors.push_back(&cells[n]);
+      red_neighbors.push_back(&cells.at(n));
+    } else {
+      black_neighbors.push_back(&cells.at(n));
     }
   }
+
+  local->m_neighbors = Neighbors<Cell *>(red_neighbors, black_neighbors);
 
   /* create communicators */
   nsq_prepare_comm(&cell_structure.ghost_cells_comm, GHOSTTRANS_PARTNUM);
@@ -113,7 +118,7 @@ void nsq_topology_init(CellPList *old) {
 
   /* here we just decide what to transfer where */
   if (n_nodes > 1) {
-    for (n = 0; n < n_nodes; n++) {
+    for (int n = 0; n < n_nodes; n++) {
       /* use the prefetched send buffers. Node 0 transmits first and never
        * prefetches. */
       if (this_node == 0 || this_node != n) {
@@ -139,10 +144,10 @@ void nsq_topology_init(CellPList *old) {
   }
 
   /* copy particles */
-  for (c = 0; c < old->n; c++) {
-    part = old->cell[c]->part;
-    np = old->cell[c]->n;
-    for (p = 0; p < np; p++)
+  for (int c = 0; c < old->n; c++) {
+    auto part = old->cell[c]->part;
+    auto np = old->cell[c]->n;
+    for (int p = 0; p < np; p++)
       append_unindexed_particle(local, std::move(part[p]));
   }
   update_local_particles(local);

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -157,7 +157,7 @@ struct ParticleProperties {
   // Store the orientation of the virtual particle in the body fixed frame.
   double vs_quat[4] = {0., 0., 0., 0.};
 #endif
-#else /* VIRTUAL_SITES */
+#else  /* VIRTUAL_SITES */
   static constexpr const int is_virtual = 0;
 #endif /* VIRTUAL_SITES */
 
@@ -236,13 +236,13 @@ struct ParticlePosition {
 struct ParticleForce {
   ParticleForce() = default;
   ParticleForce(ParticleForce const &) = default;
-  ParticleForce(const Vector3d & f) : f(f) {}
+  ParticleForce(const Vector3d &f) : f(f) {}
 #ifdef ROTATION
-  ParticleForce(const Vector3d & f,
-                const Vector3d &torque) : f(f), torque(torque) {}
+  ParticleForce(const Vector3d &f, const Vector3d &torque)
+      : f(f), torque(torque) {}
 #endif
 
-ParticleForce & operator+=(ParticleForce const& rhs) {
+  ParticleForce &operator+=(ParticleForce const &rhs) {
     f += rhs.f;
 #ifdef ROTATION
     torque += rhs.torque;
@@ -250,7 +250,7 @@ ParticleForce & operator+=(ParticleForce const& rhs) {
 
     return *this;
   }
-  
+
   /** force. */
   Vector3d f = {0., 0., 0.};
 
@@ -695,7 +695,7 @@ int set_particle_q(int part, double q);
     @return ES_OK if particle existed
 */
 int set_particle_mu_E(int part, double mu_E[3]);
-void get_particle_mu_E(int part, double (&mu_E)[3]);
+void get_particle_mu_E(int part, double(&mu_E)[3]);
 #endif
 
 /** Call only on the master node: set particle type.

--- a/src/core/unit_tests/Span_test.cpp
+++ b/src/core/unit_tests/Span_test.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define BOOST_TEST_MODULE Utils::Batch test
+#define BOOST_TEST_MODULE Utils::Span test
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
@@ -31,7 +31,34 @@ BOOST_AUTO_TEST_CASE(const_expr_ctor) {
   static_assert(4 == Span<int>(nullptr, 4).size(), "");
 }
 
+BOOST_AUTO_TEST_CASE(array_ctor) {
+  BOOST_CHECK((std::is_constructible<Span<const int>, int[3]>::value));
+  BOOST_CHECK(
+          (std::is_constructible<Span<const int>, const int[3]>::value));
+  BOOST_CHECK(not (std::is_constructible<Span<int>, const int[3]>::value));
+  BOOST_CHECK((std::is_convertible<int[3], Span<const int>>::value));
+  BOOST_CHECK(
+          (std::is_convertible<const int[3], Span<const int>>::value));
+
+  int a[4] = {1, 2, 3, 4};
+  Span<int> s(a);
+
+  BOOST_CHECK_EQUAL(s.data(), a);
+  BOOST_CHECK_EQUAL(s.size(), 4);
+}
+
 BOOST_AUTO_TEST_CASE(ctor) {
+  /* Container conversion rules */
+  {
+    BOOST_CHECK((std::is_constructible<Span<const int>, std::vector<int>>::value));
+    BOOST_CHECK(
+            (std::is_constructible<Span<const int>, const std::vector<int>>::value));
+    BOOST_CHECK(not(std::is_constructible<Span<int>, const std::vector<int>>::value));
+    BOOST_CHECK((std::is_convertible<std::vector<int>, Span<const int>>::value));
+    BOOST_CHECK(
+            (std::is_convertible<const std::vector<int>, Span<const int>>::value));
+  }
+
   /* from ptr + size */
   {
   std::vector<int> v(23);
@@ -42,15 +69,15 @@ BOOST_AUTO_TEST_CASE(ctor) {
   BOOST_CHECK(v.data() == s.data());
   }
 
-  /* from ptr + size */
+  /* From container */
   {
-    const std::vector<int> v(23);
-
-    auto s = Span<const int>(v.data(), v.size());
+    std::vector<int> v{{1, 2, 3}};
+    auto s = Span<int>(v);
 
     BOOST_CHECK(v.size() == s.size());
     BOOST_CHECK(v.data() == s.data());
   }
+
 }
 
 BOOST_AUTO_TEST_CASE(iterators) {

--- a/src/core/unit_tests/Span_test.cpp
+++ b/src/core/unit_tests/Span_test.cpp
@@ -27,6 +27,10 @@ using Utils::Span;
 #include <vector>
 #include <numeric>
 
+BOOST_AUTO_TEST_CASE(const_expr_ctor) {
+  static_assert(4 == Span<int>(nullptr, 4).size(), "");
+}
+
 BOOST_AUTO_TEST_CASE(ctor) {
   /* from ptr + size */
   {

--- a/src/core/unit_tests/link_cell_test.cpp
+++ b/src/core/unit_tests/link_cell_test.cpp
@@ -11,7 +11,7 @@
 #include "core/algorithm/link_cell.hpp"
 
 BOOST_AUTO_TEST_CASE(link_cell) {
-  const unsigned n_cells = 100;
+  const unsigned n_cells = 10;
   const auto n_part_per_cell = 10;
   const auto n_part = n_cells * n_part_per_cell;
 
@@ -19,10 +19,14 @@ BOOST_AUTO_TEST_CASE(link_cell) {
 
   auto id = 0;
   for (auto &c : cells) {
+    std::vector<Cell *> neighbors;
+
     for (auto &n : cells) {
       if (&c != &n)
-        c.m_neighbors.push_back(&n);
+        neighbors.push_back(&n);
     }
+
+    c.m_neighbors = Neighbors<Cell *>(neighbors, {});
 
     c.part = new Particle[n_part_per_cell];
     c.n = c.max = n_part_per_cell;

--- a/src/core/unit_tests/verlet_ia_test.cpp
+++ b/src/core/unit_tests/verlet_ia_test.cpp
@@ -42,10 +42,14 @@ BOOST_AUTO_TEST_CASE(verlet_ia) {
 
   auto id = 0;
   for (auto &c : cells) {
+    std::vector<Cell *> neighbors;
+
     for (auto &n : cells) {
       if (&c != &n)
-        c.m_neighbors.push_back(&n);
+        neighbors.push_back(&n);
     }
+
+    c.m_neighbors = Neighbors<Cell *>(neighbors, {});
 
     c.part = new Particle[n_part_per_cell];
     c.n = c.max = n_part_per_cell;

--- a/src/core/utils.hpp
+++ b/src/core/utils.hpp
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <cassert>
 
 namespace Utils {
 /**
@@ -251,7 +252,10 @@ inline ::Vector<3, double> vec_rotate(::Vector<3, double> axis, double alpha,
  * @param c       z position
  * @param adim    dimensions of the underlying grid
  */
-inline int get_linear_index(int a, int b, int c, int adim[3]) {
+inline int get_linear_index(int a, int b, int c, const int adim[3]) {
+  assert((a >= 0) && (a < adim[0]));
+  assert((b >= 0) && (b < adim[1]));
+  assert((c >= 0) && (c < adim[2]));
   return (a + adim[0] * (b + adim[1] * c));
 }
 

--- a/src/core/utils/Span.hpp
+++ b/src/core/utils/Span.hpp
@@ -11,7 +11,7 @@ namespace Utils {
 /**
  * @brief A sripped-down version of std::span from C++17.
  *
- * Behaves like a std::span where implemented
+ * Behaves like a std::span where implemented.
  */
 
 template <class T> class Span {
@@ -37,28 +37,27 @@ public:
   Span(const Span &) = default;
   Span &operator=(const Span &) = default;
 
-  Span(pointer array, size_type length) : m_ptr(array), m_size(length) {}
+  constexpr Span(pointer array, size_type length) : m_ptr(array), m_size(length) {}
 
-  size_type size() const { return m_size; }
-  bool empty() const { return size() == 0; }
+  constexpr size_type size() const { return m_size; }
+  constexpr bool empty() const { return size() == 0; }
 
-  iterator begin() const { return m_ptr; }
-  const_iterator cbegin() const { return m_ptr; }
-  iterator end() const { return m_ptr + m_size; }
-  const_iterator cend() const { return m_ptr + m_size; }
+  constexpr iterator begin() const { return m_ptr; }
+  constexpr const_iterator cbegin() const { return m_ptr; }
+  constexpr iterator end() const { return m_ptr + m_size; }
+  constexpr const_iterator cend() const { return m_ptr + m_size; }
 
-  reference operator[](size_type i) const {
-    assert(i < size());
-    return m_ptr[i];
+  constexpr reference operator[](size_type i) const {
+    return assert(i < size()), m_ptr[i];
   }
 
-  reference at(size_type i) const {
+  constexpr reference at(size_type i) const {
     return (i < size())
                ? m_ptr[i]
       : throw std::out_of_range("span access out of bounds."), m_ptr[i];
   }
 
-  pointer data() const { return m_ptr; }
+  constexpr pointer data() const { return m_ptr; }
 };
 }
 

--- a/src/core/utils/Span.hpp
+++ b/src/core/utils/Span.hpp
@@ -8,6 +8,15 @@
 #include <type_traits>
 
 namespace Utils {
+    namespace detail {
+        template<typename T>
+        using decay_t = typename std::decay<T>::type;
+
+    template<class T, class C>
+    using has_data = std::is_convertible<
+            decay_t<decltype(std::declval<C>().data())> *, T * const*>;
+    }
+
 /**
  * @brief A sripped-down version of std::span from C++17.
  *
@@ -30,7 +39,14 @@ public:
 
 private:
   T *m_ptr;
-  size_t m_size;
+  size_t m_size{};
+
+  template<typename U>
+  using enable_if_const_t = typename std::enable_if<std::is_const<T>::value, U>::type;
+  template <class U>
+  using enable_if_mutable_t = typename std::enable_if<!std::is_const<T>::value, U>::type;
+  template <class U>
+  using enable_if_has_data_t = typename std::enable_if<detail::has_data<T, U>::value, U>::type;
 
 public:
   Span() = default;
@@ -38,6 +54,13 @@ public:
   Span &operator=(const Span &) = default;
 
   constexpr Span(pointer array, size_type length) : m_ptr(array), m_size(length) {}
+  template <size_t N>
+  constexpr Span(T (&a)[N]) noexcept : Span(a, N) {}
+
+  template<typename C, typename = enable_if_mutable_t<C>, typename = enable_if_has_data_t<C>>
+         explicit Span(C & c) noexcept : Span(c.data(), c.size()) {}
+  template<typename C, typename = enable_if_const_t<C>, typename = enable_if_has_data_t<C>>
+        Span(const C & c) noexcept : Span(c.data(), c.size()) {}
 
   constexpr size_type size() const { return m_size; }
   constexpr bool empty() const { return size() == 0; }
@@ -46,6 +69,8 @@ public:
   constexpr const_iterator cbegin() const { return m_ptr; }
   constexpr iterator end() const { return m_ptr + m_size; }
   constexpr const_iterator cend() const { return m_ptr + m_size; }
+  constexpr reverse_iterator rbegin() const { return reverse_iterator(end()); }
+  constexpr reverse_iterator rend() const { return reverse_iterator(begin()); }
 
   constexpr reference operator[](size_type i) const {
     return assert(i < size()), m_ptr[i];


### PR DESCRIPTION
Fixes #2102.

Description of changes:
 - Store complete neighbor information on cells
 - Use this to do collision detection independent of cell system.
 - Added range assertions on `get_linear_index`. (This would have catched
    the bug right away).

I think this is finally correct now. Maybe we can now even release with properly working collision detection.