### PR TITLE
Fix rintertia build

### DIFF
--- a/src/core/constraints/HomogeneousMagneticField.cpp
+++ b/src/core/constraints/HomogeneousMagneticField.cpp
@@ -4,10 +4,8 @@
 namespace Constraints {
 
 ParticleForce HomogeneousMagneticField::force(const Particle &p, const Vector3d &folded_pos) {
-#ifdef ROTATION
-#ifdef DIPOLES
+#if defined(ROTATION) && defined(DIPOLES)
     return {Vector3d{}, Vector3d::cross(p.r.dip, m_field)};
-#endif
 #else
     return {Vector3d{}};
 #endif

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -341,7 +341,6 @@ const Particle &get_particle_data(int part) {
   return *cache_ptr;
 }
 
-
 void mpi_get_particles_slave(int, int) {
   std::vector<int> ids;
   boost::mpi::scatter(comm_cart, ids, 0);
@@ -509,6 +508,8 @@ int set_particle_rotational_inertia(int part, double rinertia[3]) {
   mpi_send_rotational_inertia(pnode, part, rinertia);
   return ES_OK;
 }
+#else
+const constexpr double ParticleProperties::rinertia[3];
 #endif
 #ifdef ROTATION
 int set_particle_rotation(int part, int rot) {
@@ -623,7 +624,7 @@ int set_particle_type(int p_id, int type) {
     // it from the list which contains it
     auto const &cur_par = get_particle_data(p_id);
     int prev_type = cur_par.p.type;
-    if (prev_type != type ) {
+    if (prev_type != type) {
       // particle existed before so delete it from the list
       remove_id_from_map(p_id, prev_type);
     }
@@ -1200,7 +1201,7 @@ void init_type_map(int type) {
 }
 
 void remove_id_from_map(int part_id, int type) {
-  if(particle_type_map.find(type)!=particle_type_map.end())
+  if (particle_type_map.find(type) != particle_type_map.end())
     particle_type_map.at(type).erase(part_id);
 }
 
@@ -1212,7 +1213,7 @@ int get_random_p_id(int type) {
 }
 
 void add_id_to_type_map(int part_id, int type) {
-  if(particle_type_map.find(type)!=particle_type_map.end())
+  if (particle_type_map.find(type) != particle_type_map.end())
     particle_type_map.at(type).insert(part_id);
 }
 
@@ -1234,7 +1235,9 @@ void pointer_to_torque_lab(Particle const *p, double const *&res) {
   res = p->f.torque.data();
 }
 
-void pointer_to_quat(Particle const *p, double const *&res) { res = p->r.quat.data(); }
+void pointer_to_quat(Particle const *p, double const *&res) {
+  res = p->r.quat.data();
+}
 
 void pointer_to_quatu(Particle const *p, double const *&res) {
   res = p->r.quatu.data();
@@ -1265,7 +1268,9 @@ void pointer_to_vs_relative(Particle const *p, int const *&res1,
 #endif
 
 #ifdef DIPOLES
-void pointer_to_dip(Particle const *p, double const *&res) { res = p->r.dip.data(); }
+void pointer_to_dip(Particle const *p, double const *&res) {
+  res = p->r.dip.data();
+}
 
 void pointer_to_dipm(Particle const *p, double const *&res) {
   res = &(p->p.dipm);
@@ -1332,18 +1337,16 @@ void pointer_to_rotational_inertia(Particle const *p, double const *&res) {
 #endif
 
 #ifdef AFFINITY
-void pointer_to_bond_site(Particle const* p, double const*& res) {
-  res =p->p.bond_site.data();
+void pointer_to_bond_site(Particle const *p, double const *&res) {
+  res = p->p.bond_site.data();
 }
 #endif
 
 #ifdef MEMBRANE_COLLISION
-void pointer_to_out_direction(const Particle* p, const double*& res) {
- res = p->p.out_direction.data();
+void pointer_to_out_direction(const Particle *p, const double *&res) {
+  res = p->p.out_direction.data();
 }
 #endif
-
-
 
 bool particle_exists(int part_id) {
   if (particle_node.empty())


### PR DESCRIPTION
Fixes missing symbol if ROTATIONAL_INTERTIA is not defined,
and added missing return value if !DIPOLES.
