### PR TITLE
testsuite: Increased error threshould for fene test. There were no si…

### DIFF
--- a/testsuite/interactions_bonded.py
+++ b/testsuite/interactions_bonded.py
@@ -125,7 +125,7 @@ class InteractionsBondedTest(ut.TestCase):
             self.assertTrue((f0_sim == -f1_sim).all())
             # and has correct value.
             f1_sim_copy = np.copy(f1_sim)
-            np.testing.assert_almost_equal(f1_sim_copy, f1_ref, decimal = 6)
+            np.testing.assert_almost_equal(f1_sim_copy, f1_ref, decimal = 5)
 
         # Check that bond breaks when distance > r_cut
         self.system.part[1].pos = self.system.part[1].pos + self.step


### PR DESCRIPTION
Fixes #2154.

…gnificant digits left (because fene forces are verly large clsoe to the cutoff).
The `decimals` parameter means digits after the dot.
