### PR TITLE
python: Make core error msg part of python exception.

### DIFF
--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -265,7 +265,7 @@ cpdef handle_errors(msg):
     for err in errors:
     # Cast because cython does not support typed enums completely
         if < int > err.level() == <int > ERROR:
-            raise Exception(msg)
+            raise Exception("{}: {}".format(msg, err.format()))
 
 def get_unravelled_index(len_dims, n_dims, flattened_index):
     """


### PR DESCRIPTION
Fixes #2172.

Description of changes:
 - Make the core error message part of the python exception that is thrown,
   so that it get's displayed in ipython notebooks.
