### PR TITLE
python: Accept a single value for ParticleHandle.gamma{,_rot} even if…

### DIFF
--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -990,6 +990,10 @@ cdef class ParticleHandle(object):
                     """
                     def __set__(self, _gamma_rot):
                         cdef Vector3d gamma_rot
+                        # We accept a single number by just repeating it
+                        if not isinstance(_gamma_rot, collections.Iterable):
+                            _gamma_rot = 3 * [_gamma_rot]
+
                         check_type_or_throw_except(
                             _gamma_rot, 3, float, "Rotational friction has to be 3 floats.")
                         for i in range(3):

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -918,7 +918,7 @@ cdef class ParticleHandle(object):
         IF PARTICLE_ANISOTROPY:
             property gamma:
                 """
-                The rotational frictional coefficient used in the the Langevin thermostat.
+                The body-fixed frictional coefficient used in the the Langevin thermostat.
 
                 gamma : list of :obj:`float`
 
@@ -932,6 +932,11 @@ cdef class ParticleHandle(object):
                 """
                 def __set__(self, _gamma):
                     cdef Vector3d gamma
+
+                    # We accept a single number by just repeating it
+                    if not isinstance(_gamma, collections.Iterable):
+                        _gamma = 3 * [_gamma]
+
                     check_type_or_throw_except(
                         _gamma, 3, float, "Friction has to be 3 floats.")
                     for i in range(3):

--- a/testsuite/particle.py
+++ b/testsuite/particle.py
@@ -132,6 +132,11 @@ class ParticleProperties(ut.TestCase):
             if espressomd.has_features(["PARTICLE_ANISOTROPY"]):
                 test_gamma_rot = generateTestForVectorProperty(
                     "gamma_rot", np.array([5., 10., 0.33]))
+                def test_gamma_rot_single(self):
+                    self.system.part[self.pid].gamma_rot = 15.4
+                    np.testing.assert_array_equal(np.copy(self.system.part[self.pid].gamma_rot),
+                                                  np.array([15.4, 15.4, 15.4]),
+                                                  "gamma_rot: value set and value gotten back differ.")
             else:
                 test_gamma_rot = generateTestForScalarProperty(
                     "gamma_rot", 14.23)

--- a/testsuite/particle.py
+++ b/testsuite/particle.py
@@ -121,6 +121,11 @@ class ParticleProperties(ut.TestCase):
             if espressomd.has_features(["PARTICLE_ANISOTROPY"]):
                 test_gamma = generateTestForVectorProperty(
                     "gamma", np.array([2., 9., 0.23]))
+                def test_gamma_single(self):
+                    self.system.part[self.pid].gamma = 17.4
+                    np.testing.assert_array_equal(np.copy(self.system.part[self.pid].gamma),
+                                                  np.array([17.4, 17.4, 17.4]),
+                                                  "gamma: value set and value gotten back differ.")
             else:
                 test_gamma = generateTestForScalarProperty("gamma", 17.3)
 


### PR DESCRIPTION
… PARTICLE_ANISOTROPY.

Fixes #2176.
