### PR TITLE
clang-format and autopep8 in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,14 +248,19 @@ style:
   stage: additional_checks
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang:6.0
   script:
-    - find . -name '*.h' -o -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs clang-format-6.0 -i -style=file
-    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs autopep8 --in-place --aggressive --aggressive
-    - git --no-pager diff
-    - git diff-index --quiet HEAD -- || echo "Failed style check" && exit 1
+    - find . -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs -P 8 clang-format-6.0 -i -style=file
+    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -P 8 autopep8 --in-place --aggressive --aggressive
+    - git --no-pager diff > style.patch
+    - git diff-index --quiet HEAD -- || echo "Failed style check. Download the build artifact to see which changes are necessary." && exit 1
     - echo "Passed style check"
   tags:
     - docker
     - linux
+  artifacts:
+    paths:
+    - style.patch
+    expire_in: 1 week
+    when: on_failure
 
 check_sphinx:
   stage: additional_checks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,7 +249,7 @@ style:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang:6.0
   script:
     - find . -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs -n 5 -P 8 clang-format-6.0 -i -style=file
-    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -n 5 -P 8 autopep8 --in-place --aggressive --aggressive
+    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -n 5 -P 8 autopep8 --ignore=E266--in-place --aggressive --aggressive
     - git --no-pager diff > style.patch
     - git diff-index --quiet HEAD -- || echo "Failed style check. Download the build artifact to see which changes are necessary." && exit 1
     - echo "Passed style check"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,13 +249,15 @@ style:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang:6.0
   script:
     - find . -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs -n 5 -P 8 clang-format-6.0 -i -style=file
-    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -n 5 -P 8 autopep8 --ignore=E266--in-place --aggressive --aggressive
+    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -n 5 -P 8 autopep8 --ignore=E266 --in-place --aggressive --aggressive
     - git --no-pager diff > style.patch
     - git diff-index --quiet HEAD -- || echo "Failed style check. Download the build artifact to see which changes are necessary." && exit 1
     - echo "Passed style check"
   tags:
     - docker
     - linux
+  variables:
+    GIT_SUBMODULE_STRATEGY: none
   artifacts:
     paths:
     - style.patch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -251,7 +251,7 @@ style:
     - find . -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs -n 5 -P 8 clang-format-6.0 -i -style=file
     - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -n 5 -P 8 autopep8 --ignore=E266 --in-place --aggressive --aggressive
     - git --no-pager diff > style.patch
-    - git diff-index --quiet HEAD -- || echo "Failed style check. Download the build artifact to see which changes are necessary." && exit 1
+    - git diff-index --quiet HEAD -- || echo "Failed style check. Download $CI_JOB_URL/artifacts/raw/style.patch to see which changes are necessary." && exit 1
     - echo "Passed style check"
   tags:
     - docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,6 +244,19 @@ intel:17:
 
 ### Other builds
 
+style:
+  stage: additional_checks
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang:6.0
+  script:
+    - find . -name '*.h' -o -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs clang-format-6.0 -i -style=file
+    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs autopep8 --in-place --aggressive --aggressive
+    - git --no-pager diff
+    - git diff-index --quiet HEAD -- || echo "Failed style check" && exit 1
+    - echo "Passed style check"
+  tags:
+    - docker
+    - linux
+
 check_sphinx:
   stage: additional_checks
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:8.0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,8 +248,8 @@ style:
   stage: additional_checks
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang:6.0
   script:
-    - find . -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs -P 8 clang-format-6.0 -i -style=file
-    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -P 8 autopep8 --in-place --aggressive --aggressive
+    - find . -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' | xargs -n 5 -P 8 clang-format-6.0 -i -style=file
+    - find . -name '*.py' -o -name '*.pyx' -o -name '*.pxd' | xargs -n 5 -P 8 autopep8 --in-place --aggressive --aggressive
     - git --no-pager diff > style.patch
     - git diff-index --quiet HEAD -- || echo "Failed style check. Download the build artifact to see which changes are necessary." && exit 1
     - echo "Passed style check"


### PR DESCRIPTION
Inspired by #2190 and #2191.

If necessary, we can switch to [git-clang-format](https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format) so that only changed lines are checked for style.