### PR TITLE
Fixes for tutorial 04

### DIFF
--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -287,18 +287,20 @@ of the system are printed: ::
 Tutorials
 ---------
 
-There is a number of tutorials that guide you through the different features of |es|:
+There is a number of tutorials that introduce the use of ESPResSo for different
+physical systems. You can also find the tutorials and related scripts in the
+directory ``/doc/tutorials`` or `online on github <https://github.com/espressomd/espresso/blob/python/doc/tutorials/>`_.
+Currently, the following tutorials are available:
 
-* `Building |es|						  <https://github.com/espressomd/espresso/blob/python/doc/tutorials/00-building_espresso/00-building_espresso.pdf>`_
-* `Simulate a simple Lennard-Jones liquid <https://github.com/espressomd/espresso/blob/python/doc/tutorials/01-lennard_jones/01-lennard_jones.pdf>`_
-* `Charged systems                        <https://github.com/espressomd/espresso/blob/python/doc/tutorials/02-charged_system/02-charged_system.pdf>`_
-* `Lattice Boltzmann                      <https://github.com/espressomd/espresso/blob/python/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann.pdf>`_
-* `Raspberry electrophoresis              <https://github.com/espressomd/espresso/blob/python/doc/tutorials/05-raspberry_electrophoresis/05-raspberry_electrophoresis.pdf>`_
-* `Electrokinetics                        <https://github.com/espressomd/espresso/blob/python/doc/tutorials/07-electrokinetics/07-electrokinetics.pdf>`_
-* `Visualization                          <https://github.com/espressomd/espresso/blob/python/doc/tutorials/08-visualization/08-visualization.pdf>`_
-* `Swimmer reactions                    <https://github.com/espressomd/espresso/blob/python/doc/tutorials/09-swimmer_reactions/09-swimmer_reactions.pdf>`_
-
-You can also find the tutorials and related scripts in the directory ``/doc/tutorials``.
+* 01-lennard_jones: Modelling of a single-component and a two-component Lennard-Jones liquid.
+* 02-charged_system: Modelling of charged systems such as ionic crystals.
+* 04-lattice_boltzmann: Simulations including hydrodynamic interactions using the Lattice-Boltzmann method.
+* 05-raspberry_electrophoresis: Extended objects in a Lattice-Boltzmann fluid, raspberry particles.
+* 06-active_matter: Modelling of self-propelling particles.
+* 07-electrokinetics: Modelling electrokinetics together with hydrodynamic interactions.
+* 08-visualization: Using the online visualizers of ESPResSo.
+* 09-swimmer_reactions: Further modelling of self-propelling particles.
+* 10-reaction_ensemble: Modelling chemical reactions by means of the reaction ensemble.
 
 .. _Sample scripts:
 

--- a/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part1.ipynb
+++ b/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part1.ipynb
@@ -1,713 +1,729 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:7bf10e1ad79f3121679f3de156a26f449e60e73ce459be400662ac7f00e5ea24"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial 4 : The Lattice Boltzmann Method in ESPResSo - Part 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Before you start:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With this tutorial you can get started using the Lattice-Boltzmann method\n",
+    "for scientific applications. We give a brief introduction about the theory\n",
+    "and how to use it in **ESPResSo**. We have selected three interesting problems for which LB can be applied and which are well understood. You can start with any of them.  \n",
+    "The tutorial is relatively long and working through it carefully is work for at least a full day. You can however get a glimpse of different aspects by starting to work on the tasks.  \n",
+    "Note: LB can not be used as a black box. It is unavoidable to spend time\n",
+    "learning the theory and gaining practical experience.\n",
+    "  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial, you will learn basics about the Lattice Boltzmann Method (LBM) with\n",
+    "special focus on the application on soft matter simulations or more precisely on how to\n",
+    "apply it in combination with molecular dynamics to take into account hydrodynamic\n",
+    "solvent effects without the need to introduce thousands of solvent particles.  \n",
+    "The LBM – its theory as well as its applications – is still a very active field of research.\n",
+    "After almost 20 years of development there are many cases in which the LBM has proven\n",
+    "to be fruitful, in other cases the LBM is considered promising, and in some cases it has\n",
+    "not been of any help. We encourage you to contribute to the scientific discussion of\n",
+    "the LBM because there is still a lot that is unknown or only vaguely known about this\n",
+    "fascinating method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tutorial Outline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial should enable you to start a scientific project applying the LB method\n",
+    "with **ESPResSo**. In the first part we summarize a few basic ideas behind LB and\n",
+    "describe the interface. In the second part we suggest three different classic examples\n",
+    "where hydrodynamics are important. These are"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* **Hydrodynamic resistance of settling particles.** We measure the drag force\n",
+    "of single particles and arrays of particles when sedimenting in solution.\n",
+    "\n",
+    "* **Polymer diffusion.** We show that the diffusion of polymers is accelerated by\n",
+    "hydrodynamic interactions.\n",
+    "\n",
+    "* **Poiseuille flow.** We reproduce the flow profile between two walls."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Notes on the **ESPResSo** version you will need  \n",
+    "With Version 3.1 **ESPResSo** has learned GPU support for LB. We recommend however\n",
+    "version 3.3, to have all features available. We absolutely recommend using the GPU code,\n",
+    "as it is much (100x) faster than the CPU code.  \n",
+    "For the tutorial you will have to compile in the following features: <tt>PARTIAL_PERIODIC,\n",
+    "EXTERNAL_FORCES, CONSTRAINTS, ELECTROSTATICS, LB_GPU, LB_BOUNDARIES_GPU,\n",
+    "LENNARD_JONES.</tt>  \n",
+    "All necessary files for this tutorial are located in the directory  \n",
+    "<tt>espresso/doc/tutorials/python/04-lattice_boltzmann/scripts.</tt>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 The LBM in brief"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Linearized Boltzmann equation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we want to repeat a few very basic facts about the LBM. You will find much better\n",
+    "introductions in various books and articles, e.g. [1, 2]. It will however help clarifying\n",
+    "our choice of words and we will eventually say something about the implementation in\n",
+    "**ESPResSo**. It is very loosely written, with the goal that the reader understands basic\n",
+    "concepts and how they are implemented in **ESPResSo**.  \n",
+    "The LBM essentially consists of solving a fully discretized version of the linearized\n",
+    "Boltzmann equation. The Boltzmann equation describes the time evolution of the one\n",
+    "particle distribution function $f (x, p, t)$, which is the probability to find a molecule in\n",
+    "a phase space volume $dxdp$ at time $t$.The function $f$ is normalized so that the integral\n",
+    "over the whole phase space is the total mass of the particles:\n",
+    "$$\\int f (x, p) dxdp = N m,$$\n",
+    "where $N$ denotes the particle number and m the particle mass. The quantity $f(x, p) dxdp$\n",
+    "corresponds to the mass of particles in this particular cell of the phase space, the\n",
+    "population."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Discretization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The LBM discretizes the Boltzmann equation not only in real space (the lattice!) and\n",
+    "time, but also the velocity space is discretized. A surprisingly small number of velocities,\n",
+    "in 3D usually 19, is sufficient to describe incompressible, viscous flow correctly. Mostly\n",
+    "we will refer to the three-dimensional model with a discrete set of 19 velocities, which is\n",
+    "conventionally called D3Q19. These velocities, $\\vec{c_i}$ , are chosen so that they correspond to\n",
+    "the movement from one lattice node to another in one time step. A two step scheme is\n",
+    "used to transport information through the system: In the streaming step the particles\n",
+    "(in terms of populations) are transported to the cell where they corresponding velocity\n",
+    "points to. In the collision step, the distribution functions in each cell are relaxed towards\n",
+    "the local thermodynamic equilibrium. This will be described in more detail below.  \n",
+    "The hydrodynamic fields, the density, the fluid momentum density, the pressure tensor can be calculated straightforwardly from the populations. They correspond to the\n",
+    "moments of the distribution function:  \n",
+    "\n",
+    "\\begin{align}\n",
+    "  \\rho &= \\sum f_i \\\\\n",
+    "  \\vec{j} = \\rho \\vec{u} &= \\sum f_i \\vec{c_i} \\\\\n",
+    "  \\Pi^{\\alpha \\beta} &= \\sum f_i \\vec{c_i}^{\\alpha}\\vec{c_i}^{\\beta}\n",
+    "  \\label{eq:fields}\n",
+    "\\end{align}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the Greek indices denotes the cartesian axis and the\n",
+    "Latin indices indicate the number in the disrete velocity set.\n",
+    "Note that the pressure tensor is symmetric.\n",
+    "It is easy to see that these equations are linear transformations\n",
+    "of the $f_i$ and that they carry the most important information. They\n",
+    "are 10 independent variables, but this is not enough to store the\n",
+    "full information of 19 populations. Therefore 9 additional quantities\n",
+    "are introduced. Together they form a different basis set of the\n",
+    "19-dimensional population space, the modes space and the modes are denoted by \n",
+    "$m_i$. The 9 extra modes are referred to as kinetic modes or\n",
+    "ghost modes. It is possible to explicitly write down the \n",
+    "base transformation matrix, and its inverse and in the **ESPResSo**\n",
+    "LBM implementation this basis transformation is made for every\n",
+    "cell in every LBM step. It is possible to write a code that does not\n",
+    "need this basis transformation, but it has been shown, that this\n",
+    "only costs 20% of the computational time and allows for \n",
+    "larger flexibility."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<figure>\n",
+    "<img src='figures/latticeboltzmann-grid.png', style=\"width: 300px;\"/>\n",
+    "<center>\n",
+    "<figcaption>*The 19 velocity vectors $\\vec{c_i}$ for a D3Q19 lattice. From the central grid point, the velocity vectors point towards all 18 nearest neighbours marked by filled circles. The 19th velocity vector is the rest mode (zero velocity).*</figcaption>\n",
+    "</figure>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The second step: collision\n",
+    "The second step is the collision part, where the actual physics happens. For the LBM it is assumed that the collision process linearly relaxes the populations to the local equilibrium, thus that it is a linear (=matrix) operator \n",
+    "acting on the populations in each LB cell. It should conserve \n",
+    "the particle number and the momentum. At this point it is clear\n",
+    "why the mode space is helpful. A 19 dimensional matrix that\n",
+    "conserves the first 4 modes (with the eigenvalue 1) is diagonal in the\n",
+    "first four rows and columns.\n",
+    "Some struggling with lattice symmetries shows that four independent\n",
+    "variables are enough to characterize the linear relaxation\n",
+    "process so that all symmetries of the lattice are obeyed. \n",
+    "Two of them are closely related to \n",
+    "the shear and bulk viscosity of the fluid, and two of them\n",
+    "do not have a direct physical equivalent. They are just called\n",
+    "relaxation rates of the kinetic modes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The equilibrium distribution to which the populations relax \n",
+    "is obtained from maximizing the information entropy \n",
+    "$\\sum f_i \\log f_i$ under the constraint that the density\n",
+    "and velocity take their particular instantaneous \n",
+    "values. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In mode space the equilbrium distribution is calculated much from \n",
+    "the local density and velocity.\n",
+    "The kinetic modes 11-19 have the value 0 in equilibrium.\n",
+    "The collision operator is diagonal in mode space\n",
+    "and has the form\n",
+    "\\begin{align*}\n",
+    "  m^\\star_i &= \\gamma_i \\left( m_i - m_i^\\text{eq} \\right) + m_i ^\\text{eq}.\n",
+    "\\end{align*}\n",
+    "Here $m^\\star_i$ is the $i$th mode after the collision.\n",
+    "In words we would say; each mode is relaxed towards\n",
+    "it's equilibrium value with a relaxation rate $\\gamma_i$.\n",
+    "The conserved modes are not relaxed, or, the corresponding\n",
+    "relaxation parameter is one.\n",
+    "\n",
+    "By symmetry consideration one finds that only four independent\n",
+    "relaxation rates are allowed. We summarize them here.\n",
+    "\\begin{align*}\n",
+    "  m^\\star_i &= \\gamma_i m_i  \\\\\n",
+    "  \\gamma_1=\\dots=\\gamma_4&=1 \\\\\n",
+    "  \\gamma_5&=\\gamma_\\text{b} \\\\\n",
+    "  \\gamma_6=\\dots=\\gamma_{10}&=\\gamma_\\text{s} \\\\\n",
+    "  \\gamma_{11}=\\dots=\\gamma_{16}&=\\gamma_\\text{odd} \\\\\n",
+    "  \\gamma_{17}=\\dots = \\gamma_{19}&=\\gamma_\\text{even} \\\\\n",
+    "\\end{align*}\n",
+    "\n",
+    "To include hydrodynamic fluctuations of the fluid, \n",
+    "random fluctuations are added to the nonconserved modes $4\\dots 19$ on every LB node so that\n",
+    "the LB fluid temperature is well defined and the corresponding\n",
+    "fluctuation formula, according to the fluctuation dissipation theorem holds.\n",
+    "An extensive discussion of this topic is found in [3]."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Particle coupling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Particles are coupled to the LB fluid with the force coupling;\n",
+    "the fluid velocity at the position of a particle is calculated \n",
+    "by a multilinear interpolation and a force is applied on the particle\n",
+    "that is proportional to the velocity difference between particle \n",
+    "and fluid:\n",
+    "\\begin{equation}\n",
+    "  \\vec{F}_D = - \\gamma \\left(v-u\\right) \n",
+    "\\end{equation}\n",
+    "The opposite force is distributed on the surrounding LB nodes. Additionally\n",
+    "a random force is added to maintain a constant temperature, according\n",
+    "to the fluctuation dissipation theorem. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<figure>\n",
+    "<img src='figures/latticeboltzmann-momentumexchange.png', style=\"width: 300px;\"/>\n",
+    "<center>\n",
+    "<figcaption>*The coupling scheme between fluid and particles is based on the interpolation of the fluid velocity $\\vec{u}$ from the grid nodes. This is done by linear interpolation. The difference between the actual particle velocity $\\vec{v}(t)$ and the interpolated velocity $\\vec{u}(\\vec{r},t)$ is used in the momentum exchange of equation above.*</figcaption>\n",
+    "</figure>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 The LB interface in ESPResSo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**ESPResSo** features two virtually independent implementations of LB. One implementation uses CPUs and one uses a GPU to perform the computational work. For this, we provide two actor classes <tt>LBFluid</tt> and <tt>LBFluid_GPU</tt> with the module <tt>espressomd.lb</tt>,\n",
+    "as well as the optional <tt>LBBoundary</tt> class found in <tt>espressomd.lbboundaries</tt>.  \n",
+    "The LB lattice is a cubic lattice, with a lattice constant <tt>agrid</tt> that\n",
+    "is the same in all spacial directions. The chosen box length must be an integer multiple\n",
+    "of <tt>agrid</tt>. The LB lattice is shifted by 0.5 <tt>agrid</tt> in all directions: the node\n",
+    "with integer coordinates $\\left(0,0,0\\right)$ is located at\n",
+    "$\\left(0.5a,0.5a,0.5a\\right)$.\n",
+    "The LB scheme and the MD scheme are not synchronized: In one\n",
+    "LB time step, several MD steps may be performed. This allows to speed\n",
+    "up the simulations and is adjusted with the parameter <tt>tau</tt>.\n",
+    "The LB parameter <tt>tau</tt> must be an integer multiple of the MD timestep.  \n",
+    "Even if MD features are not used, the System parameters <tt>cell_system.skin</tt> and <tt>time_step</tt> must be set. LB steps are performed \n",
+    "in regular intervals, such that the timestep $\\tau$ for LB is recovered.  \n",
+    "Important Notice: All commands of the LB interface use\n",
+    "MD units. This is convenient, as e.g. a particular \n",
+    "viscosity can be set and the LB time step can be changed without\n",
+    "altering the viscosity. On the other hand this is a source\n",
+    "of a plethora of mistakes: The LBM is only reliable in a certain \n",
+    "range of parameters (in LB units) and the unit conversion\n",
+    "may take some of them far out of this range. So note that you always\n",
+    "have to assure that you are not messing with that!  \n",
+    "One brief example: a certain velocity may be 10 in MD units.\n",
+    "If the LB time step is 0.1 in MD units, and the lattice constant\n",
+    "is 1, then it corresponds to a velocity of $1\\ \\frac{a}{\\tau}$ in LB units.\n",
+    "This is the maximum velocity of the discrete velocity set and therefore\n",
+    "causes numerical instabilities like negative populations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The <tt>LBFluid</tt> class"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The <tt>LBFluid</tt> class provides an interface to the LB-Method in the **ESPResSo** core. When initializing an object, one can pass the aforementioned parameters as keyword arguments. Parameters are given in MD units. The available keyword arguments are:  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<tt>dens</tt> : The density of the fluid.  \n",
+    "<tt>agrid</tt> : The lattice constant of the fluid. It is used to determine the number of LB nodes per direction from <tt>box_l</tt>. *They have to be compatible.*  \n",
+    "<tt>visc</tt> : The kinematic viscosity\n",
+    "<tt>tau</tt> : The time step of LB. It has to be an integer multiple of <tt>System.time_step.</tt>  \n",
+    "<tt>fric</tt> : The frction coefficient $\\gamma$ for the coupling scheme.\n",
+    "<tt>ext_force</tt> : An external force applied to every node. This is given as a list, tuple or array with three components."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using these arguments, one can initialize an <tt>LBFluid</tt> object. This object then needs to be added to the system's actor list. The code below provides a minimum example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "from espressomd import lb, assert_features\n",
+    "assert_features(['LB_GPU', 'LB_BOUNDARIES_GPU'])\n",
+    "\n",
+    "# initialize the System and set the necessary MD parameters for LB.\n",
+    "system = System()\n",
+    "system.box_l = [31, 41, 59]\n",
+    "system.time_step = 0.01\n",
+    "system.cell_system.skin = 0.4\n",
+    "\n",
+    "# Initialize and LBFluid with the minimum set of valid parameters.\n",
+    "lbf = lb.LBFluid_GPU(agrid = 1, dens = 10, visc = .1, tau = 0.01)\n",
+    "# Activate the LB by adding it to the System's actor list.\n",
+    "system.actors.add(lbf)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sampling data from a node"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The <tt>LBFluid</tt> class also provides a set of methods which can be used to sample data from\n",
+    "the fluid nodes. For example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "lbf[X ,Y ,Z].quantity\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "returns the quantity of the node with $(X, Y, Z)$ coordinates. Note that the indexing in every direction starts with 0. The possible properties are:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<tt>velocity</tt> : the fluid velocity (list of three floats)\n",
+    "<tt>pi</tt> : the stress tensor (list of six floats: $\\Pi_{xx}$, $\\Pi_{xy}$, $\\Pi_{yy}$, $\\Pi_{xz}$, $\\Pi_{yz}$, and $\\Pi_{zz}$)\n",
+    "<tt>pi_neq</tt> : the nonequilibrium part of the stress tensor, components as above.\n",
+    "<tt>population</tt> : the 19 populations of the D3Q19 lattice.\n",
+    "<tt>boundary</tt> : the boundary index.\n",
+    "<tt>density</tt> : the local density."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The <tt>LBBoundary</tt> class"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The <tt>LBBoundary</tt> class represents a boundary on the <tt>LBFluid</tt>\n",
+    "lattice. It is dependent on the classes of the module <tt>espressomd.shapes</tt> as it derives its geometry from them. For the initialization, the arguments <tt>shape</tt> and <tt>velocity</tt> are supported. The <tt>shape</tt> argument takes an object from the <tt>shapes</tt> module and the <tt>velocity</tt> argument expects a list, tuple or array containing 3 floats. Setting the <tt>velocity</tt> will results in a slip boundary condition.  \n",
+    "Note that the boundaries are not constructed through the periodic boundary. If, for example, one would set a sphere with its center in one of the corner of the boxes, a sphere fragment will be generated. To avoid this, make sure the sphere, or any other boundary, fits inside the original box.  \n",
+    "This part of the LB implementation is still experimental, so please tell us about your experience with it. In general even the simple case of no-slip\n",
+    "boundary is still an important research topic in the lb community and in combination with point particle coupling not much experience exists. This means: Do research on that topic, play around with parameters and figure out what happens.  \n",
+    "Boundaries are initialized by passing a shape object to the <tt>LBBoundary</tt> class. One way to initialize a wall is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "from espressomd import lbboundaries, shapes\n",
+    "wall = lbboundaries.LBBoundary(shape=shapes.Wall(normal = [1, 0, 0], dist = 1), velocity = [0, 0, 0.01])\n",
+    "system.lbboundaries.add(wall)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that all used variables are inherited from previous examples. This will create a wall a surface normal of $(1, 0, 0)$ at a distance of 1 from the origin of the coordinate system in direction of the normal vector. The wall exhibits a slip boundary condition with a velocity of $(0, 0, 0.01)$. For the a no-slip condition, leave out the velocity argument or set it so zero. Please refer to the user guide for a complete list of constraints.  \n",
+    "Currently only the so called *link bounce back* method is implemented, where the effective hydrodynamic boundary is located midway between two nodes. This is the simplest and yet a rather effective approach for boundary implementation. Using the shape objects distance function, the nodes determine once during initialisation whether they are boundary or fluid nodes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4 Drag force on objects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a first test, we measure the drag force on different objects in a simulation\n",
+    "box. Under low Reynolds number conditions, an object with velocity $\\vec{v}$\n",
+    "experiences a drag force $\\vec{F}_\\text{D}$ proportional to the velocity:\n",
+    "\\begin{align*}\n",
+    "\t\\vec{F}_\\text{D}=-\\gamma\\vec{v},\n",
+    "\\end{align*}\n",
+    "where $\\gamma$ is denoted the friction coefficient. In general $\\gamma$ is a\n",
+    "tensor thus the drag force is generally not parallel to the velocity. For\n",
+    "spherical particles the drag force is given by Stokes' law:\n",
+    "\\begin{align*}\n",
+    "\t\\vec{F}_\\text{D}=-6\\pi\\eta a\\vec{v},\n",
+    "\\end{align*}\n",
+    "where $a$ is the radius of the sphere."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this task you will measure the drag force on falling objects with LB and **ESPResSo**. In the sample script <tt>lb_stokes_force.py</tt> a spherical object at rest is centered in a square channel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#This code is from 'lb_stokes_force.py'.\n",
+    "from espressomd import System, lb, lbboundaries, shapes\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "\n",
+    "# System setup\n",
+    "system = System(box_l = [1.0, 1.0, 1.0]) # The box_l is specified below.\n",
+    "                                         # [1.0,1.0,1.0] is dummy values\n",
+    "agrid = 1\n",
+    "radius = 5.5\n",
+    "box_width = 64\n",
+    "real_width = box_width+2*agrid\n",
+    "box_length = 64\n",
+    "system.box_l = [real_width, real_width, box_length]\n",
+    "system.set_random_state_PRNG()\n",
+    "np.random.seed(seed = system.seed)\n",
+    "system.time_step = 0.2\n",
+    "system.cell_system.skin = 0.4\n",
+    "\n",
+    "# The temperature is zero.\n",
+    "system.thermostat.set_lb(kT=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bounce back boundary conditions are assumed on the sphere. At the channel boundary the velocity is fixed by using appropriate boundary conditions. Within a few hundred or thousand  integration steps a steady state develops and the force on the sphere converges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Tutorial 4 : The Lattice Boltzmann Method in\n",
-      "ESPResSo - Part 1"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loop: 09\n",
+      "Integration finished.\n",
+      "Measured force: f=1.094700\n",
+      "Stokes' Law says: f=1.036726\n"
      ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 4,
-     "metadata": {},
-     "source": [
-      "Before you start:"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "With this tutorial you can get started using the Lattice-Boltzmann method\n",
-      "for scientific applications. We give a brief introduction about the theory\n",
-      "and how to use it in **ESPResSo**. We have selected three interesting problems for which LB can be applied and which are well understood. You can start with any of them.  \n",
-      "The tutorial is relatively long and working through it carefully is work for at least a full day. You can however get a glimpse of different aspects by starting to work on the tasks.  \n",
-      "Note: LB can not be used as a black box. It is unavoidable to spend time\n",
-      "learning the theory and gaining practical experience.\n",
-      "  "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "1 Introduction"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In this tutorial, you will learn basics about the Lattice Boltzmann Method (LBM) with\n",
-      "special focus on the application on soft matter simulations or more precisely on how to\n",
-      "apply it in combination with molecular dynamics to take into account hydrodynamic\n",
-      "solvent effects without the need to introduce thousands of solvent particles.  \n",
-      "The LBM \u2013 its theory as well as its applications \u2013 is still a very active field of research.\n",
-      "After almost 20 years of development there are many cases in which the LBM has proven\n",
-      "to be fruitful, in other cases the LBM is considered promising, and in some cases it has\n",
-      "not been of any help. We encourage you to contribute to the scientific discussion of\n",
-      "the LBM because there is still a lot that is unknown or only vaguely known about this\n",
-      "fascinating method."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Tutorial Outline"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This tutorial should enable you to start a scientific project applying the LB method\n",
-      "with **ESPResSo**. In the first part we summarize a few basic ideas behind LB and\n",
-      "describe the interface. In the second part we suggest three different classic examples\n",
-      "where hydrodynamics are important. These are"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "* **Hydrodynamic resistance of settling particles.** We measure the drag force\n",
-      "of single particles and arrays of particles when sedimenting in solution.\n",
-      "\n",
-      "* **Polymer diffusion.** We show that the diffusion of polymers is accelerated by\n",
-      "hydrodynamic interactions.\n",
-      "\n",
-      "* **Poiseuille flow.** We reproduce the flow profile between two walls."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### Notes on the **ESPResSo** version you will need  \n",
-      "With Version 3.1 **ESPResSo** has learned GPU support for LB. We recommend however\n",
-      "version 3.3, to have all features available. We absolutely recommend using the GPU code,\n",
-      "as it is much (100x) faster than the CPU code.  \n",
-      "For the tutorial you will have to compile in the following features: <tt>PARTIAL_PERIODIC,\n",
-      "EXTERNAL_FORCES, CONSTRAINTS, ELECTROSTATICS, LB_GPU, LB_BOUNDARIES_GPU,\n",
-      "LENNARD_JONES.</tt>  \n",
-      "All necessary files for this tutorial are located in the directory  \n",
-      "<tt>espresso/doc/tutorials/python/04-lattice_boltzmann/scripts.</tt>\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##2 The LBM in brief"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Linearized Boltzmann equation"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Here we want to repeat a few very basic facts about the LBM. You will find much better\n",
-      "introductions in various books and articles, e.g. [1, 2]. It will however help clarifying\n",
-      "our choice of words and we will eventually say something about the implementation in\n",
-      "**ESPResSo**. It is very loosely written, with the goal that the reader understands basic\n",
-      "concepts and how they are implemented in **ESPResSo**.  \n",
-      "The LBM essentially consists of solving a fully discretized version of the linearized\n",
-      "Boltzmann equation. The Boltzmann equation describes the time evolution of the one\n",
-      "particle distribution function $f (x, p, t)$, which is the probability to find a molecule in\n",
-      "a phase space volume $dxdp$ at time $t$.The function $f$ is normalized so that the integral\n",
-      "over the whole phase space is the total mass of the particles:\n",
-      "$$\\int f (x, p) dxdp = N m,$$\n",
-      "where $N$ denotes the particle number and m the particle mass. The quantity $f(x, p) dxdp$\n",
-      "corresponds to the mass of particles in this particular cell of the phase space, the\n",
-      "population."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Discretization"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The LBM discretizes the Boltzmann equation not only in real space (the lattice!) and\n",
-      "time, but also the velocity space is discretized. A surprisingly small number of velocities,\n",
-      "in 3D usually 19, is sufficient to describe incompressible, viscous flow correctly. Mostly\n",
-      "we will refer to the three-dimensional model with a discrete set of 19 velocities, which is\n",
-      "conventionally called D3Q19. These velocities, $\\vec{c_i}$ , are chosen so that they correspond to\n",
-      "the movement from one lattice node to another in one time step. A two step scheme is\n",
-      "used to transport information through the system: In the streaming step the particles\n",
-      "(in terms of populations) are transported to the cell where they corresponding velocity\n",
-      "points to. In the collision step, the distribution functions in each cell are relaxed towards\n",
-      "the local thermodynamic equilibrium. This will be described in more detail below.  \n",
-      "The hydrodynamic fields, the density, the fluid momentum density, the pressure tensor can be calculated straightforwardly from the populations. They correspond to the\n",
-      "moments of the distribution function:  \n",
-      "\n",
-      "\\begin{align}\n",
-      "  \\rho &= \\sum f_i \\\\\n",
-      "  \\vec{j} = \\rho \\vec{u} &= \\sum f_i \\vec{c_i} \\\\\n",
-      "  \\Pi^{\\alpha \\beta} &= \\sum f_i \\vec{c_i}^{\\alpha}\\vec{c_i}^{\\beta}\n",
-      "  \\label{eq:fields}\n",
-      "\\end{align}\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Here the Greek indices denotes the cartesian axis and the\n",
-      "Latin indices indicate the number in the disrete velocity set.\n",
-      "Note that the pressure tensor is symmetric.\n",
-      "It is easy to see that these equations are linear transformations\n",
-      "of the $f_i$ and that they carry the most important information. They\n",
-      "are 10 independent variables, but this is not enough to store the\n",
-      "full information of 19 populations. Therefore 9 additional quantities\n",
-      "are introduced. Together they form a different basis set of the\n",
-      "19-dimensional population space, the modes space and the modes are denoted by \n",
-      "$m_i$. The 9 extra modes are referred to as kinetic modes or\n",
-      "ghost modes. It is possible to explicitly write down the \n",
-      "base transformation matrix, and its inverse and in the **ESPResSo**\n",
-      "LBM implementation this basis transformation is made for every\n",
-      "cell in every LBM step. It is possible to write a code that does not\n",
-      "need this basis transformation, but it has been shown, that this\n",
-      "only costs 20% of the computational time and allows for \n",
-      "larger flexibility."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "<figure>\n",
-      "<img src='figures/latticeboltzmann-grid.png', style=\"width: 300px;\"/>\n",
-      "<center>\n",
-      "<figcaption>*The 19 velocity vectors $\\vec{c_i}$ for a D3Q19 lattice. From the central grid point, the velocity vectors point towards all 18 nearest neighbours marked by filled circles. The 19th velocity vector is the rest mode (zero velocity).*</figcaption>\n",
-      "</figure>"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###The second step: collision\n",
-      "The second step is the collision part, where the actual physics happens. For the LBM it is assumed that the collision process linearly relaxes the populations to the local equilibrium, thus that it is a linear (=matrix) operator \n",
-      "acting on the populations in each LB cell. It should conserve \n",
-      "the particle number and the momentum. At this point it is clear\n",
-      "why the mode space is helpful. A 19 dimensional matrix that\n",
-      "conserves the first 4 modes (with the eigenvalue 1) is diagonal in the\n",
-      "first four rows and columns.\n",
-      "Some struggling with lattice symmetries shows that four independent\n",
-      "variables are enough to characterize the linear relaxation\n",
-      "process so that all symmetries of the lattice are obeyed. \n",
-      "Two of them are closely related to \n",
-      "the shear and bulk viscosity of the fluid, and two of them\n",
-      "do not have a direct physical equivalent. They are just called\n",
-      "relaxation rates of the kinetic modes."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The equilibrium distribution to which the populations relax \n",
-      "is obtained from maximizing the information entropy \n",
-      "$\\sum f_i \\log f_i$ under the constraint that the density\n",
-      "and velocity take their particular instantaneous \n",
-      "values. "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In mode space the equilbrium distribution is calculated much from \n",
-      "the local density and velocity.\n",
-      "The kinetic modes 11-19 have the value 0 in equilibrium.\n",
-      "The collision operator is diagonal in mode space\n",
-      "and has the form\n",
-      "\\begin{align*}\n",
-      "  m^\\star_i &= \\gamma_i \\left( m_i - m_i^\\text{eq} \\right) + m_i ^\\text{eq}.\n",
-      "\\end{align*}\n",
-      "Here $m^\\star_i$ is the $i$th mode after the collision.\n",
-      "In words we would say; each mode is relaxed towards\n",
-      "it's equilibrium value with a relaxation rate $\\gamma_i$.\n",
-      "The conserved modes are not relaxed, or, the corresponding\n",
-      "relaxation parameter is one.\n",
-      "\n",
-      "By symmetry consideration one finds that only four independent\n",
-      "relaxation rates are allowed. We summarize them here.\n",
-      "\\begin{align*}\n",
-      "  m^\\star_i &= \\gamma_i m_i  \\\\\n",
-      "  \\gamma_1=\\dots=\\gamma_4&=1 \\\\\n",
-      "  \\gamma_5&=\\gamma_\\text{b} \\\\\n",
-      "  \\gamma_6=\\dots=\\gamma_{10}&=\\gamma_\\text{s} \\\\\n",
-      "  \\gamma_{11}=\\dots=\\gamma_{16}&=\\gamma_\\text{odd} \\\\\n",
-      "  \\gamma_{17}=\\dots = \\gamma_{19}&=\\gamma_\\text{even} \\\\\n",
-      "\\end{align*}\n",
-      "\n",
-      "To include hydrodynamic fluctuations of the fluid, \n",
-      "random fluctuations are added to the nonconserved modes $4\\dots 19$ on every LB node so that\n",
-      "the LB fluid temperature is well defined and the corresponding\n",
-      "fluctuation formula, according to the fluctuation dissipation theorem holds.\n",
-      "An extensive discussion of this topic is found in [3]."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Particle coupling"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Particles are coupled to the LB fluid with the force coupling;\n",
-      "the fluid velocity at the position of a particle is calculated \n",
-      "by a multilinear interpolation and a force is applied on the particle\n",
-      "that is proportional to the velocity difference between particle \n",
-      "and fluid:\n",
-      "\\begin{equation}\n",
-      "  \\vec{F}_D = - \\gamma \\left(v-u\\right) \n",
-      "\\end{equation}\n",
-      "The opposite force is distributed on the surrounding LB nodes. Additionally\n",
-      "a random force is added to maintain a constant temperature, according\n",
-      "to the fluctuation dissipation theorem. "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "<figure>\n",
-      "<img src='figures/latticeboltzmann-momentumexchange.png', style=\"width: 300px;\"/>\n",
-      "<center>\n",
-      "<figcaption>*The coupling scheme between fluid and particles is based on the interpolation of the fluid velocity $\\vec{u}$ from the grid nodes. This is done by linear interpolation. The difference between the actual particle velocity $\\vec{v}(t)$ and the interpolated velocity $\\vec{u}(\\vec{r},t)$ is used in the momentum exchange of equation above.*</figcaption>\n",
-      "</figure>"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## 3 The LB interface in ESPResSo"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "**ESPResSo** features two virtually independent implementations of LB. One implementation uses CPUs and one uses a GPU to perform the computational work. For this, we provide two actor classes <tt>LBFluid</tt> and <tt>LBFluid_GPU</tt> with the module <tt>espressomd.lb</tt>,\n",
-      "as well as the optional <tt>LBBoundary</tt> class found in <tt>espressomd.lbboundaries</tt>.  \n",
-      "The LB lattice is a cubic lattice, with a lattice constant <tt>agrid</tt> that\n",
-      "is the same in all spacial directions. The chosen box length must be an integer multiple\n",
-      "of <tt>agrid</tt>. The LB lattice is shifted by 0.5 <tt>agrid</tt> in all directions: the node\n",
-      "with integer coordinates $\\left(0,0,0\\right)$ is located at\n",
-      "$\\left(0.5a,0.5a,0.5a\\right)$.\n",
-      "The LB scheme and the MD scheme are not synchronized: In one\n",
-      "LB time step, several MD steps may be performed. This allows to speed\n",
-      "up the simulations and is adjusted with the parameter <tt>tau</tt>.\n",
-      "The LB parameter <tt>tau</tt> must be an integer multiple of the MD timestep.  \n",
-      "Even if MD features are not used, the System parameters <tt>cell_system.skin</tt> and <tt>time_step</tt> must be set. LB steps are performed \n",
-      "in regular intervals, such that the timestep $\\tau$ for LB is recovered.  \n",
-      "Important Notice: All commands of the LB interface use\n",
-      "MD units. This is convenient, as e.g. a particular \n",
-      "viscosity can be set and the LB time step can be changed without\n",
-      "altering the viscosity. On the other hand this is a source\n",
-      "of a plethora of mistakes: The LBM is only reliable in a certain \n",
-      "range of parameters (in LB units) and the unit conversion\n",
-      "may take some of them far out of this range. So note that you always\n",
-      "have to assure that you are not messing with that!  \n",
-      "One brief example: a certain velocity may be 10 in MD units.\n",
-      "If the LB time step is 0.1 in MD units, and the lattice constant\n",
-      "is 1, then it corresponds to a velocity of $1\\ \\frac{a}{\\tau}$ in LB units.\n",
-      "This is the maximum velocity of the discrete velocity set and therefore\n",
-      "causes numerical instabilities like negative populations."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### The <tt>LBFluid</tt> class"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The <tt>LBFluid</tt> class provides an interface to the LB-Method in the **ESPResSo** core. When initializing an object, one can pass the aforementioned parameters as keyword arguments. Parameters are given in MD units. The available keyword arguments are:  "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "<tt>dens</tt> : The density of the fluid.  \n",
-      "<tt>agrid</tt> : The lattice constant of the fluid. It is used to determine the number of LB nodes per direction from <tt>box_l</tt>. *They have to be compatible.*  \n",
-      "<tt>visc</tt> : The kinematic viscosity\n",
-      "<tt>tau</tt> : The time step of LB. It has to be an integer multiple of <tt>System.time_step.</tt>  \n",
-      "<tt>fric</tt> : The frction coefficient $\\gamma$ for the coupling scheme.\n",
-      "<tt>ext_force</tt> : An external force applied to every node. This is given as a list, tuple or array with three components."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Using these arguments, one can initialize an <tt>LBFluid</tt> object. This object then needs to be added to the system's actor list. The code below provides a minimum example."
-     ]
-    },
-    {
-     "cell_type": "raw",
-     "metadata": {},
-     "source": [
-      "from espressomd import lb, assert_features\n",
-      "assert_features(['LB_GPU', 'LB_BOUNDARIES_GPU'])\n",
-      "\n",
-      "# initialize the System and set the necessary MD parameters for LB.\n",
-      "system = System()\n",
-      "system.box_l = [31, 41, 59]\n",
-      "system.time_step = 0.01\n",
-      "system.cell_system.skin = 0.4\n",
-      "\n",
-      "# Initialize and LBFluid with the minimum set of valid parameters.\n",
-      "lbf = lb.LBFluid_GPU(agrid = 1, dens = 10, visc = .1, tau = 0.01)\n",
-      "# Activate the LB by adding it to the System's actor list.\n",
-      "system.actors.add(lbf)"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Sampling data from a node"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The <tt>LBFluid</tt> class also provides a set of methods which can be used to sample data from\n",
-      "the fluid nodes. For example"
-     ]
-    },
-    {
-     "cell_type": "raw",
-     "metadata": {},
-     "source": [
-      "lbf[X ,Y ,Z].quantity"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "returns the quantity of the node with $(X, Y, Z)$ coordinates. Note that the indexing in every direction starts with 0. The possible properties are:"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "<tt>velocity</tt> : the fluid velocity (list of three floats)\n",
-      "<tt>pi</tt> : the stress tensor (list of six floats: $\\Pi_{xx}$, $\\Pi_{xy}$, $\\Pi_{yy}$, $\\Pi_{xz}$, $\\Pi_{yz}$, and $\\Pi_{zz}$)\n",
-      "<tt>pi_neq</tt> : the nonequilibrium part of the stress tensor, components as above.\n",
-      "<tt>population</tt> : the 19 populations of the D3Q19 lattice.\n",
-      "<tt>boundary</tt> : the boundary index.\n",
-      "<tt>density</tt> : the local density."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### The <tt>LBBoundary</tt> class"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The <tt>LBBoundary</tt> class represents a boundary on the <tt>LBFluid</tt>\n",
-      "lattice. It is dependent on the classes of the module <tt>espressomd.shapes</tt> as it derives its geometry from them. For the initialization, the arguments <tt>shape</tt> and <tt>velocity</tt> are supported. The <tt>shape</tt> argument takes an object from the <tt>shapes</tt> module and the <tt>velocity</tt> argument expects a list, tuple or array containing 3 floats. Setting the <tt>velocity</tt> will results in a slip boundary condition.  \n",
-      "Note that the boundaries are not constructed through the periodic boundary. If, for example, one would set a sphere with its center in one of the corner of the boxes, a sphere fragment will be generated. To avoid this, make sure the sphere, or any other boundary, fits inside the original box.  \n",
-      "This part of the LB implementation is still experimental, so please tell us about your experience with it. In general even the simple case of no-slip\n",
-      "boundary is still an important research topic in the lb community and in combination with point particle coupling not much experience exists. This means: Do research on that topic, play around with parameters and figure out what happens.  \n",
-      "Boundaries are initialized by passing a shape object to the <tt>LBBoundary</tt> class. One way to initialize a wall is:"
-     ]
-    },
-    {
-     "cell_type": "raw",
-     "metadata": {},
-     "source": [
-      "from espressomd import lbboundaries, shapes\n",
-      "wall = lbboundaries.LBBoundary(shape=shapes.Wall(normal = [1, 0, 0], dist = 1), velocity = [0, 0, 0.01])\n",
-      "system.lbboundaries.add(wall)"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note that all used variables are inherited from previous examples. This will create a wall a surface normal of $(1, 0, 0)$ at a distance of 1 from the origin of the coordinate system in direction of the normal vector. The wall exhibits a slip boundary condition with a velocity of $(0, 0, 0.01)$. For the a no-slip condition, leave out the velocity argument or set it so zero. Please refer to the user guide for a complete list of constraints.  \n",
-      "Currently only the so called *link bounce back* method is implemented, where the effective hydrodynamic boundary is located midway between two nodes. This is the simplest and yet a rather effective approach for boundary implementation. Using the shape objects distance function, the nodes determine once during initialisation whether they are boundary or fluid nodes."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## 4 Drag force on objects"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "As a first test, we measure the drag force on different objects in a simulation\n",
-      "box. Under low Reynolds number conditions, an object with velocity $\\vec{v}$\n",
-      "experiences a drag force $\\vec{F}_\\text{D}$ proportional to the velocity:\n",
-      "\\begin{align*}\n",
-      "\t\\vec{F}_\\text{D}=-\\gamma\\vec{v},\n",
-      "\\end{align*}\n",
-      "where $\\gamma$ is denoted the friction coefficient. In general $\\gamma$ is a\n",
-      "tensor thus the drag force is generally not parallel to the velocity. For\n",
-      "spherical particles the drag force is given by Stokes' law:\n",
-      "\\begin{align*}\n",
-      "\t\\vec{F}_\\text{D}=-6\\pi\\eta a\\vec{v},\n",
-      "\\end{align*}\n",
-      "where $a$ is the radius of the sphere."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In this task you will measure the drag force on falling objects with LB and **ESPResSo**. In the sample script <tt>lb_stokes_force.py</tt> a spherical object at rest is centered in a square channel."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "#This code is from 'lb_stokes_force.py'.\n",
-      "from espressomd import System, lb, lbboundaries, shapes\n",
-      "import numpy as np\n",
-      "import sys\n",
-      "\n",
-      "# System setup\n",
-      "system = System(box_l = [1.0, 1.0, 1.0]) # The box_l is specified below.\n",
-      "                                         # [1.0,1.0,1.0] is dummy values\n",
-      "agrid = 1\n",
-      "radius = 5.5\n",
-      "box_width = 64\n",
-      "real_width = box_width+2*agrid\n",
-      "box_length = 64\n",
-      "system.box_l = [real_width, real_width, box_length]\n",
-      "system.set_random_state_PRNG()\n",
-      "np.random.seed(seed = system.seed)\n",
-      "system.time_step = 0.2\n",
-      "system.cell_system.skin = 0.4\n",
-      "\n",
-      "# The temperature is zero.\n",
-      "system.thermostat.set_lb(kT=0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Bounce back boundary conditions are assumed on the sphere. At the channel boundary the velocity is fixed by using appropriate boundary conditions. Within a few hundred or thousand  integration steps a steady state develops and the force on the sphere converges."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# LB Parameters\n",
-      "v = [0,0,0.01] # The boundary slip \n",
-      "kinematic_visc = 1.0\n",
-      "\n",
-      "# Invoke LB fluid\n",
-      "lbf = lb.LBFluidGPU(visc=kinematic_visc, dens=1\n",
-      "                     , agrid=agrid, tau=system.time_step, fric=1)\n",
-      "system.actors.add(lbf)\n",
-      "\n",
-      "# Setup walls\n",
-      "walls = [None] * 4\n",
-      "walls[0] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[-1,0,0], \n",
-      "                                   dist = -(1+box_width)), velocity=v)\n",
-      "walls[1] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[1,0,0],\n",
-      "                                    dist = 1),velocity=v)\n",
-      "walls[2] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[0,-1,0], \n",
-      "                                   dist = -(1+box_width)), velocity=v)\n",
-      "walls[3] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[0,1,0],\n",
-      "                                    dist = 1),velocity=v)\n",
-      "\n",
-      "for wall in walls:\n",
-      "    system.lbboundaries.add(wall)\n",
-      "\n",
-      "# setup sphere without slip in the middle\n",
-      "sphere = lbboundaries.LBBoundary(shape=shapes.Sphere(radius=radius,\n",
-      "                                 center = [real_width/2] * 2 + [box_length/2],\n",
-      "                                 direction = 1))\n",
-      "\n",
-      "system.lbboundaries.add(sphere)\n",
-      "\n",
-      "\n",
-      "lbf.print_vtk_boundary(\"./boundary.vtk\")\n",
-      "\n",
-      "\n",
-      "def size(vector):\n",
-      "    tmp = 0\n",
-      "    for k in vector:\n",
-      "        tmp+=k*k\n",
-      "    return np.sqrt(tmp)\n",
-      "\n",
-      "for i in range(40):\n",
-      "    system.integrator.run(400)\n",
-      "    lbf.print_vtk_velocity(\"fluid%04i.vtk\" %i)\n",
-      "    sys.stdout.write(\"\\rloop: %02i\"%i)\n",
-      "    sys.stdout.flush()\n",
-      "\n",
-      "\n",
-      "print(\"\\nIntegration finished.\")\n",
-      "\n",
-      "# get force that is exerted on the sphere\n",
-      "force = sphere.get_force()\n",
-      "print(\"Measured force: f=%f\" %size(force))\n",
-      "\n",
-      "stokes_force = 6*np.pi*kinematic_visc*radius*size(v)\n",
-      "print(\"Stokes' Law says: f=%f\" %stokes_force)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Radius dependence of the drag force"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Measure the drag force for three different input radii of the sphere. How good is the agreement with Stokes\u2019 law? Calculate an effective radius from Stokes\u2019 law and the drag force measured in the simulation. Is there a clear relation to the input radius? Remember how the bounce back boundary condition work and how good spheres can be represented by them."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###Visualization of the flow field"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The script produces <tt>vtk</tt> files of the flow field. Visualize the flow field with <tt>paraview</tt>. Open <tt>paraview</tt> by typing it on the command line. Make sure you are in the folder where the files are located. So the agenda is:"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "+ Click in the menu <tt>File</tt>, <tt>Open...</tt>\n",
-      "+ Choose the files with flow field <tt>fluid...vtk</tt>\n",
-      "+ Click <tt>Apply</tt>\n",
-      "+ Add a stream tracer filter <tt>Filters, Alphabetial, Stream tracer</tt>\n",
-      "+ Change the seed type from <tt>point source</tt> to <tt>high resolution line source</tt>\n",
-      "+ Click <tt>Apply</tt>\n",
-      "+ Rotate the visualization box to see the stream lines.\n",
-      "+ Use the play button in the bar below the mean bar to show the time evolution."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###System size dependence"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Measure the drag force for a fixed radius but varying system size. Does the drag force increase of decrease with the system size? Can you find a qualitative explanation?"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##References"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
-      "[2] B. D\u00fcnweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89\u2013166. Springer, 2009.  \n",
-      "[3] B. D\u00fcnweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
-      "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
-      "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
-      "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
-      "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 0
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
     }
    ],
-   "metadata": {}
+   "source": [
+    "# LB Parameters\n",
+    "v = [0,0,0.01] # The boundary slip \n",
+    "kinematic_visc = 1.0\n",
+    "\n",
+    "# Invoke LB fluid\n",
+    "lbf = lb.LBFluidGPU(visc=kinematic_visc, dens=1\n",
+    "                     , agrid=agrid, tau=system.time_step, fric=1)\n",
+    "system.actors.add(lbf)\n",
+    "\n",
+    "# Setup walls\n",
+    "walls = [None] * 4\n",
+    "walls[0] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[-1,0,0], \n",
+    "                                   dist = -(1+box_width)), velocity=v)\n",
+    "walls[1] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[1,0,0],\n",
+    "                                    dist = 1),velocity=v)\n",
+    "walls[2] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[0,-1,0], \n",
+    "                                   dist = -(1+box_width)), velocity=v)\n",
+    "walls[3] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[0,1,0],\n",
+    "                                    dist = 1),velocity=v)\n",
+    "\n",
+    "for wall in walls:\n",
+    "    system.lbboundaries.add(wall)\n",
+    "\n",
+    "# setup sphere without slip in the middle\n",
+    "sphere = lbboundaries.LBBoundary(shape=shapes.Sphere(radius=radius,\n",
+    "                                 center = [real_width/2] * 2 + [box_length/2],\n",
+    "                                 direction = 1))\n",
+    "\n",
+    "system.lbboundaries.add(sphere)\n",
+    "\n",
+    "\n",
+    "lbf.print_vtk_boundary(\"./boundary.vtk\")\n",
+    "\n",
+    "\n",
+    "def size(vector):\n",
+    "    tmp = 0\n",
+    "    for k in vector:\n",
+    "        tmp+=k*k\n",
+    "    return np.sqrt(tmp)\n",
+    "\n",
+    "for i in range(10):\n",
+    "    system.integrator.run(400)\n",
+    "    lbf.print_vtk_velocity(\"fluid%04i.vtk\" %i)\n",
+    "    sys.stdout.write(\"\\rloop: %02i\"%i)\n",
+    "    sys.stdout.flush()\n",
+    "\n",
+    "\n",
+    "print(\"\\nIntegration finished.\")\n",
+    "\n",
+    "# get force that is exerted on the sphere\n",
+    "force = sphere.get_force()\n",
+    "print(\"Measured force: f=%f\" %size(force))\n",
+    "\n",
+    "stokes_force = 6*np.pi*kinematic_visc*radius*size(v)\n",
+    "print(\"Stokes' Law says: f=%f\" %stokes_force)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Radius dependence of the drag force"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Measure the drag force for three different input radii of the sphere. How good is the agreement with Stokes’ law? Calculate an effective radius from Stokes’ law and the drag force measured in the simulation. Is there a clear relation to the input radius? Remember how the bounce back boundary condition work and how good spheres can be represented by them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualization of the flow field"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The script produces <tt>vtk</tt> files of the flow field. Visualize the flow field with <tt>paraview</tt>. Open <tt>paraview</tt> by typing it on the command line. Make sure you are in the folder where the files are located. So the agenda is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "+ Click in the menu <tt>File</tt>, <tt>Open...</tt>\n",
+    "+ Choose the files with flow field <tt>fluid...vtk</tt>\n",
+    "+ Click <tt>Apply</tt>\n",
+    "+ Add a stream tracer filter <tt>Filters, Alphabetial, Stream tracer</tt>\n",
+    "+ Change the seed type from <tt>point source</tt> to <tt>high resolution line source</tt>\n",
+    "+ Click <tt>Apply</tt>\n",
+    "+ Rotate the visualization box to see the stream lines.\n",
+    "+ Use the play button in the bar below the mean bar to show the time evolution."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### System size dependence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Measure the drag force for a fixed radius but varying system size. Does the drag force increase of decrease with the system size? Can you find a qualitative explanation?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
+    "[2] B. Dünweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89–166. Springer, 2009.  \n",
+    "[3] B. Dünweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
+    "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
+    "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
+    "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
+    "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part2.ipynb
+++ b/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part2.ipynb
@@ -1,249 +1,265 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:ceaa5618f82a717df94e7e729ec23aaa8b5878c587921e441db8085572c39e5e"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial 4 : The Lattice Boltzmann Method in ESPResSo - Part 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5 Polymer Diffusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In these exercises we want to use the LBM-MD-Hybrid to reproduce a classic result of polymer physics: The dependence of the diffusion coefficient of a polymer on its chain length. If no hydrodynamic interactions are present, one expects a scaling law $D \\propto N −1$ and if they are present, a scaling law $D \\propto N −\\nu $ is expected. Here ν is the Flory exponent\n",
+    "that plays a very prominent role in polymer physics. It has a value of $∼ 3/5$ in good\n",
+    "solvent conditions in 3D. Discussions of these scaling laws can be found in polymer\n",
+    "physics textbooks like [4–6].  \n",
+    "The reason for the different scaling law is the following: When being transported, every monomer creates a flow field that follows the direction of its motion. This flow field makes it easier for other monomers to follow its motion. This makes a polymer long enough diffuse more like compact object including the fluid inside it, although it does not have clear boundaries. It can be shown that its motion can be described by its\n",
+    "hydrodynamic radius. It is defined as:  \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\\begin{equation}\n",
+    "  \\langle \\frac{1}{R_h} \\rangle = \\langle \\frac{1}{N^2}\\sum_{i\\neq j} \\frac{1}{\\left| r_i - r_j \\right|} \\rangle\n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This hydrodynamic radius exhibits the scaling law  $R_h \\propto N^{\\nu}$\n",
+    "and the diffusion coefficient of long polymer is proportional to its inverse.  \n",
+    "For shorter polymers there is a transition region. It can be described\n",
+    "by the Kirkwood-Zimm model:\n",
+    "\\begin{equation}\n",
+    "  D=\\frac{D_0}{N} + \\frac{k_B T}{6 \\pi \\eta } \\langle \\frac{1}{R_h} \\rangle\n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here $D_0$ is the monomer diffusion coefficient and $\\eta$ the \n",
+    "viscosity of the fluid. For a finite system size the second part of the\n",
+    "diffusion is subject of a $1/L$ finite size effect, because\n",
+    "hydrodynamic interactions are proportional to the inverse\n",
+    "distance and thus long ranged. It can be taken into account\n",
+    "by a correction:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\\begin{equation}\n",
+    "  D=\\frac{D_0}{N} + \\frac{k_B T}{6 \\pi \\eta } \\langle \\frac{1}{R_h} \\rangle \\left( 1- \\langle\\frac{R_h}{L} \\rangle \\right)\n",
+    "\\end{equation}\n",
+    "It is quite difficult to prove this formula with good accuracy. It will \n",
+    "need quite some computer time and a careful analysis. So please don't be\n",
+    "too disappointed if you don't manage to do so.  \n",
+    "We want to determine the diffusion coefficient from the mean square\n",
+    "distance that a particle travels in the time $t$. For large $t$ it is\n",
+    "be proportional to the time and the diffusion coefficient occurs as \n",
+    "prefactor: \n",
+    "\\begin{equation}\n",
+    "  \\frac{\\partial \\langle r^2 \\left(t\\right)\\rangle}{\\partial t} = 2 d D. \n",
+    "\\end{equation}\n",
+    "Here $d$ denotes the dimensionality of the system, in our case 3.This equation can be\n",
+    "found in virtually any simulation textbook, like [7]. We will therefore set up a polymer\n",
+    "in an LB fluid, simulate for an appropriate amount of time, calculate the mean square\n",
+    "displacement as a function of time and obtain the diffusion coefficient from a linear\n",
+    "fit. However we make a couple of steps in between and divide the full problem into\n",
+    "subproblems that allow to (hopefully) fully understand the process."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.1 Step 1: Diffusion of a single particle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our first step is to investigate the diffusion of a single particle that is coupled to an LB fluid by the point coupling method. Take a look at the script <tt>single_particle_diffusion.py</tt>. The script takes the LB-friction coefficient as an argument. Start with an friction coefficient of 1.0:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Tutorial 4 : The Lattice Boltzmann Method in\n",
-      "ESPResSo - Part 2"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equilibrating the system.\n",
+      "Equlibration finished.\n",
+      "Sampling started.\n",
+      "Sampling: 00900Sampling finished.\n"
      ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##5 Polymer Diffusion"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In these exercises we want to use the LBM-MD-Hybrid to reproduce a classic result of polymer physics: The dependence of the diffusion coefficient of a polymer on its chain length. If no hydrodynamic interactions are present, one expects a scaling law $D \\propto N \u22121$ and if they are present, a scaling law $D \\propto N \u2212\\nu $ is expected. Here \u03bd is the Flory exponent\n",
-      "that plays a very prominent role in polymer physics. It has a value of $\u223c 3/5$ in good\n",
-      "solvent conditions in 3D. Discussions of these scaling laws can be found in polymer\n",
-      "physics textbooks like [4\u20136].  \n",
-      "The reason for the different scaling law is the following: When being transported, every monomer creates a flow field that follows the direction of its motion. This flow field makes it easier for other monomers to follow its motion. This makes a polymer long enough diffuse more like compact object including the fluid inside it, although it does not have clear boundaries. It can be shown that its motion can be described by its\n",
-      "hydrodynamic radius. It is defined as:  \n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "\\begin{equation}\n",
-      "  \\langle \\frac{1}{R_h} \\rangle = \\langle \\frac{1}{N^2}\\sum_{i\\neq j} \\frac{1}{\\left| r_i - r_j \\right|} \\rangle\n",
-      "\\end{equation}"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This hydrodynamic radius exhibits the scaling law  $R_h \\propto N^{\\nu}$\n",
-      "and the diffusion coefficient of long polymer is proportional to its inverse.  \n",
-      "For shorter polymers there is a transition region. It can be described\n",
-      "by the Kirkwood-Zimm model:\n",
-      "\\begin{equation}\n",
-      "  D=\\frac{D_0}{N} + \\frac{k_B T}{6 \\pi \\eta } \\langle \\frac{1}{R_h} \\rangle\n",
-      "\\end{equation}"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Here $D_0$ is the monomer diffusion coefficient and $\\eta$ the \n",
-      "viscosity of the fluid. For a finite system size the second part of the\n",
-      "diffusion is subject of a $1/L$ finite size effect, because\n",
-      "hydrodynamic interactions are proportional to the inverse\n",
-      "distance and thus long ranged. It can be taken into account\n",
-      "by a correction:"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "\\begin{equation}\n",
-      "  D=\\frac{D_0}{N} + \\frac{k_B T}{6 \\pi \\eta } \\langle \\frac{1}{R_h} \\rangle \\left( 1- \\langle\\frac{R_h}{L} \\rangle \\right)\n",
-      "\\end{equation}\n",
-      "It is quite difficult to prove this formula with good accuracy. It will \n",
-      "need quite some computer time and a careful analysis. So please don't be\n",
-      "too disappointed if you don't manage to do so.  \n",
-      "We want to determine the diffusion coefficient from the mean square\n",
-      "distance that a particle travels in the time $t$. For large $t$ it is\n",
-      "be proportional to the time and the diffusion coefficient occurs as \n",
-      "prefactor: \n",
-      "\\begin{equation}\n",
-      "  \\frac{\\partial \\langle r^2 \\left(t\\right)\\rangle}{\\partial t} = 2 d D. \n",
-      "\\end{equation}\n",
-      "Here $d$ denotes the dimensionality of the system, in our case 3.This equation can be\n",
-      "found in virtually any simulation textbook, like [7]. We will therefore set up a polymer\n",
-      "in an LB fluid, simulate for an appropriate amount of time, calculate the mean square\n",
-      "displacement as a function of time and obtain the diffusion coefficient from a linear\n",
-      "fit. However we make a couple of steps in between and divide the full problem into\n",
-      "subproblems that allow to (hopefully) fully understand the process."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "###5.1 Step 1: Diffusion of a single particle"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Our first step is to investigate the diffusion of a single particle that is coupled to an LB fluid by the point coupling method. Take a look at the script <tt>single_particle_diffusion.py</tt>. The script takes the LB-friction coefficient as an argument. Start with an friction coefficient of 1.0:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# The friction coefficient has to be changed inside the code as sys.argv[1]\n",
-      "# does not work in iPython.\n",
-      "from espressomd import System, lb\n",
-      "from espressomd.observables import ParticlePositions\n",
-      "from espressomd.accumulators import Correlator\n",
-      "\n",
-      "import numpy as np\n",
-      "import sys\n",
-      "\n",
-      "# Constants\n",
-      "\n",
-      "loops = 400000\n",
-      "steps = 10\n",
-      "time_step = 0.01\n",
-      "runtime = loops*steps*time_step\n",
-      "box_l = 16\n",
-      "\n",
-      "lb_friction = 1.0 # The friction has been set to be 1.0 as default\n",
-      "                  # Change this value for further simulations\n",
-      "\n",
-      "\n",
-      "# System setup\n",
-      "system = System(box_l = [box_l] * 3)\n",
-      "system.set_random_state_PRNG()\n",
-      "np.random.seed(seed = system.seed)\n",
-      "system.time_step = time_step\n",
-      "system.cell_system.skin = 0.4\n",
-      "\n",
-      "\n",
-      "lbf = lb.LBFluidGPU(agrid=1, dens=1, visc=5, tau=0.01, fric=lb_friction)\n",
-      "system.actors.add(lbf)\n",
-      "system.thermostat.set_lb(kT=1)\n",
-      "\n",
-      "system.part.add(pos=[0, 0, 0])\n",
-      "\n",
-      "\n",
-      "## perform a couple of steps to come to equilbrium\n",
-      "print(\"Equilibrating the system.\")\n",
-      "system.integrator.run(1000)\n",
-      "print(\"Equlibration finished.\")\n",
-      "\n",
-      "# Setup observable correlator\n",
-      "pos = ParticlePositions(ids=(0,))\n",
-      "c = Correlator(obs1=pos, tau_lin = 16, tau_max = loops*steps, delta_N = loops*steps,\n",
-      "        corr_operation=\"square_distance_componentwise\", compress1=\"discard1\")\n",
-      "system.auto_update_accumulators.add(c)\n",
-      "\n",
-      "print(\"Sampling started.\")\n",
-      "for i in range(loops):\n",
-      "    system.integrator.run(steps)\n",
-      "\n",
-      "    if i % 1e2 == 0:\n",
-      "        sys.stdout.write(\"\\rSampling: %05i\"%i)\n",
-      "        sys.stdout.flush()\n",
-      "\n",
-      "print(\"Sampling finished.\")\n",
-      "\n",
-      "c.finalize()\n",
-      "corrdata = c.result()\n",
-      "corr = np.zeros((corrdata.shape[0],2))\n",
-      "corr[:,0] = corrdata[:,0]\n",
-      "corr[:,1] = (corrdata[:,2] + corrdata[:,3] + corrdata[:,4]) / 3\n",
-      "\n",
-      "np.savetxt(\"./msd_\"+str(lb_friction)+\".dat\", corr)\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In this script an LB fluid and a single particle are created and thermalized. The\n",
-      "random forces on the particle and within the LB fluid will cause the particle to move.\n",
-      "The mean squared displacement is calculated during the simulation via a multiple-tau\n",
-      "correlator. Run the simulation script and plot the output data <tt>msd_1.0.dat</tt>. To load the file into a numpy array, one can use <tt>numpy.loadtxt</tt>. Zoom in on the origin of the\n",
-      "plot. What do you see for short times? What do you see on a longer time scale? Produce\n",
-      "a double-logarithmic plot to assess the power law."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "<figure>\n",
-      "<img src='figures/msd.png', style=\"width: 500px;\"/>\n",
-      "<center>\n",
-      "<figcaption>*Mean squared displacement of a single particle for different values of LB friction\n",
-      "coefficient.*</figcaption>\n",
-      "</figure>"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Can you give an explanation for the quadratic time dependency for short times? Use the function <tt>curve_fit</tt> from the module <tt>scipy.optimize</tt> to produce a fit for the linear regime and determine the diffusion coefficient. Run the simulation again with different values for the friction coefficient, e.g., 1, 2, 4, and 10. Calculate the diffusion coefficient for all cases and plot them as a function of \u03b3. What relation do you observe?"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##References"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
-      "[2] B. D\u00fcnweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89\u2013166. Springer, 2009.  \n",
-      "[3] B. D\u00fcnweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
-      "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
-      "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
-      "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
-      "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
     }
    ],
-   "metadata": {}
+   "source": [
+    "# The friction coefficient has to be changed inside the code as sys.argv[1]\n",
+    "# does not work in iPython.\n",
+    "from espressomd import System, lb\n",
+    "from espressomd.observables import ParticlePositions\n",
+    "from espressomd.accumulators import Correlator\n",
+    "\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "\n",
+    "# Constants\n",
+    "\n",
+    "loops = 40000\n",
+    "steps = 10\n",
+    "time_step = 0.01\n",
+    "runtime = loops*steps*time_step\n",
+    "box_l = 16\n",
+    "\n",
+    "lb_friction = 1.0 # The friction has been set to be 1.0 as default\n",
+    "                  # Change this value for further simulations\n",
+    "\n",
+    "\n",
+    "# System setup\n",
+    "system = System(box_l = [box_l] * 3)\n",
+    "system.set_random_state_PRNG()\n",
+    "np.random.seed(seed = system.seed)\n",
+    "system.time_step = time_step\n",
+    "system.cell_system.skin = 0.4\n",
+    "\n",
+    "\n",
+    "lbf = lb.LBFluidGPU(agrid=1, dens=1, visc=5, tau=0.01, fric=lb_friction)\n",
+    "system.actors.add(lbf)\n",
+    "system.thermostat.set_lb(kT=1)\n",
+    "\n",
+    "system.part.add(pos=[0, 0, 0])\n",
+    "\n",
+    "\n",
+    "## perform a couple of steps to come to equilbrium\n",
+    "print(\"Equilibrating the system.\")\n",
+    "system.integrator.run(1000)\n",
+    "print(\"Equlibration finished.\")\n",
+    "\n",
+    "# Setup observable correlator\n",
+    "pos = ParticlePositions(ids=(0,))\n",
+    "c = Correlator(obs1=pos, tau_lin = 16, tau_max = 1000, delta_N = 1,\n",
+    "        corr_operation=\"square_distance_componentwise\", compress1=\"discard1\")\n",
+    "system.auto_update_accumulators.add(c)\n",
+    "\n",
+    "print(\"Sampling started.\")\n",
+    "for i in range(loops):\n",
+    "    system.integrator.run(steps)\n",
+    "\n",
+    "    if i % 1e2 == 0:\n",
+    "        sys.stdout.write(\"\\rSampling: %05i\"%i)\n",
+    "        sys.stdout.flush()\n",
+    "\n",
+    "print(\"Sampling finished.\")\n",
+    "\n",
+    "c.finalize()\n",
+    "corrdata = c.result()\n",
+    "corr = np.zeros((corrdata.shape[0],2))\n",
+    "corr[:,0] = corrdata[:,0]\n",
+    "corr[:,1] = (corrdata[:,2] + corrdata[:,3] + corrdata[:,4]) / 3\n",
+    "\n",
+    "np.savetxt(\"./msd_\"+str(lb_friction)+\".dat\", corr)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this script an LB fluid and a single particle are created and thermalized. The\n",
+    "random forces on the particle and within the LB fluid will cause the particle to move.\n",
+    "The mean squared displacement is calculated during the simulation via a multiple-tau\n",
+    "correlator. Run the simulation script and plot the output data <tt>msd_1.0.dat</tt>. To load the file into a numpy array, one can use <tt>numpy.loadtxt</tt>. Zoom in on the origin of the\n",
+    "plot. What do you see for short times? What do you see on a longer time scale? Produce\n",
+    "a double-logarithmic plot to assess the power law."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<figure>\n",
+    "<img src='figures/msd.png', style=\"width: 500px;\"/>\n",
+    "<center>\n",
+    "<figcaption>*Mean squared displacement of a single particle for different values of LB friction\n",
+    "coefficient.*</figcaption>\n",
+    "</figure>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Can you give an explanation for the quadratic time dependency for short times? Use the function <tt>curve_fit</tt> from the module <tt>scipy.optimize</tt> to produce a fit for the linear regime and determine the diffusion coefficient. Run the simulation again with different values for the friction coefficient, e.g., 1, 2, 4, and 10. Calculate the diffusion coefficient for all cases and plot them as a function of γ. What relation do you observe?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
+    "[2] B. Dünweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89–166. Springer, 2009.  \n",
+    "[3] B. Dünweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
+    "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
+    "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
+    "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
+    "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part3.ipynb
+++ b/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part3.ipynb
@@ -1,239 +1,263 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:5c70024694ce207ccfcdd0089dd35bdd23211a61a3dc1c3fc04610a8943bcd52"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial 4 : The Lattice Boltzmann Method in ESPResSo - Part 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Step 2: Diffusion of a polymer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One of the typical applications of **ESPResSo** is the simulation of polymer chains with a bead-spring-model. For this we need a repulsive interaction between all beads, for which one usually takes a shifted and truncated Lennard-Jones (so called Weeks-Chandler-Anderson) interaction, and additionally a bonded interaction between adjacent beads to hold the polymer together. You have already learned that the command"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "system.non_bonded_inter[0,0].lennard_jones.set_params(\n",
+    "      epsilon = 1.0, sigma = 1.0,\n",
+    "      shift = 0.25, cutof = 1.226)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "creates a Lennard-Jones interaction with $\\varepsilon=1.$, $\\sigma=1.$,\n",
+    "$r_\\text{cut} = 1.125$ and $\\varepsilon_\\text{shift}=0.25$ between particles\n",
+    "of type 0, which is the desired \n",
+    "repulsive interaction. The command"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "from espressomd import interactions\n",
+    "fene = interactions.FeneBond(k = 7,d_r_max = 2)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "creates a <tt>FeneBond</tt> object (see **ESPResSo** manual for the details). Still **ESPResSo** does not know between which beads this interaction should be applied. This can be either be specified explicitly or done with the <tt>polymer</tt> module. This creates a given number of beads, links them with the given bonded interaction and places them following a certain algorithm. We will use the pruned self-avoiding walk: The monomers are set according to a pruned self-avoiding walk (in 3D) with a fixed distance between adjacent bead positions. The syntax is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "from espressomd import polymer\n",
+    "# mpc: monomers per chain\n",
+    "mpc = 30\n",
+    "poly = polymer.Polymer(N_P=1, MPC = mpc, bond=fene, bond_length = 1)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using a random walk to create a polymer causes trouble: The random walk may \n",
+    "cross itself (or closely approach itself) and the LJ potential is very\n",
+    "steep. This would raise the potential energy enormously and would make\n",
+    "the monomers shoot through the simulation box. The pruned self-avoiding\n",
+    "walk should prevent that, but to be sure we perform some MD steps with a capped LJ potential, this means forces above a certain threshold will be set to the threshold in order to prevent the system from exploding. To see how this is done, look at the script <tt>polymer_diffusion.py</tt> (see the code below).\n",
+    "It contains a quite long warmup command so that also longer polymers\n",
+    "are possible. You can probably make it shorter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This allows to quickly change the number of monomers without editing the script. For the warmup a Langevin thermostat is used to keep the temperature constant. Furthermore we want to compute the diffusion constant of the polymer for different numbers of monomers. For this purpose we can again use the multiple tau correlator. Have a look at the **ESPResSo**-script for the single particle diffusion and add the adapted commands for the polymer. Find out how many integration steps are necessary to capture the long-time diffusion regime of the polymer. The script already computes the time averaged hydrodynamic radius and stores it in a file <tt>rh\\_out.dat</tt> whose first column denotes the number of monomers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Tutorial 4 : The Lattice Boltzmann Method in\n",
-      "ESPResSo - Part 3"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warming up the polymer chain.\n",
+      "Warmup finished.\n",
+      "Warming up the system with LB fluid.\n",
+      "LB fluid warming finished.\n",
+      "Sampling started.\n",
+      "Sampling: 00099"
      ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### 5.2 Step 2: Diffusion of a polymer"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "One of the typical applications of **ESPResSo** is the simulation of polymer chains with a bead-spring-model. For this we need a repulsive interaction between all beads, for which one usually takes a shifted and truncated Lennard-Jones (so called Weeks-Chandler-Anderson) interaction, and additionally a bonded interaction between adjacent beads to hold the polymer together. You have already learned that the command"
-     ]
-    },
-    {
-     "cell_type": "raw",
-     "metadata": {},
-     "source": [
-      "system.non_bonded_inter[0,0].lennard_jones.set_params(\n",
-      "      epsilon = 1.0, sigma = 1.0,\n",
-      "      shift = 0.25, cutof = 1.226)"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "creates a Lennard-Jones interaction with $\\varepsilon=1.$, $\\sigma=1.$,\n",
-      "$r_\\text{cut} = 1.125$ and $\\varepsilon_\\text{shift}=0.25$ between particles\n",
-      "of type 0, which is the desired \n",
-      "repulsive interaction. The command"
-     ]
-    },
-    {
-     "cell_type": "raw",
-     "metadata": {},
-     "source": [
-      "  from espressomd import interactions\n",
-      "  fene = interactions.FeneBond(k = 7,d_r_max = 2)"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "creates a <tt>FeneBond</tt> object (see **ESPResSo** manual for the details). Still **ESPResSo** does not know between which beads this interaction should be applied. This can be either be specified explicitly or done with the <tt>polymer</tt> module. This creates a given number of beads, links them with the given bonded interaction and places them following a certain algorithm. We will use the pruned self-avoiding walk: The monomers are set according to a pruned self-avoiding walk (in 3D) with a fixed distance between adjacent bead positions. The syntax is:"
-     ]
-    },
-    {
-     "cell_type": "raw",
-     "metadata": {},
-     "source": [
-      "  from espressomd import polymer\n",
-      "  # mpc: monomers per chain\n",
-      "  mpc = 30\n",
-      "  poly = polymer.Polymer(N_P=1, MPC = mpc, bond=fene, bond_length = 1)"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Using a random walk to create a polymer causes trouble: The random walk may \n",
-      "cross itself (or closely approach itself) and the LJ potential is very\n",
-      "steep. This would raise the potential energy enormously and would make\n",
-      "the monomers shoot through the simulation box. The pruned self-avoiding\n",
-      "walk should prevent that, but to be sure we perform some MD steps with a capped LJ potential, this means forces above a certain threshold will be set to the threshold in order to prevent the system from exploding. To see how this is done, look at the script <tt>polymer_diffusion.py</tt> (see the code below).\n",
-      "It contains a quite long warmup command so that also longer polymers\n",
-      "are possible. You can probably make it shorter."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This allows to quickly change the number of monomers without editing the script. For the warmup a Langevin thermostat is used to keep the temperature constant. Furthermore we want to compute the diffusion constant of the polymer for different numbers of monomers. For this purpose we can again use the multiple tau correlator. Have a look at the **ESPResSo**-script for the single particle diffusion and add the adapted commands for the polymer. Find out how many integration steps are necessary to capture the long-time diffusion regime of the polymer. The script already computes the time averaged hydrodynamic radius and stores it in a file <tt>rh\\_out.dat</tt> whose first column denotes the number of monomers."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from __future__ import print_function, division\n",
-      "from espressomd import System, interactions, lb, polymer\n",
-      "from espressomd.observables import ComPosition\n",
-      "from espressomd.accumulators import Correlator\n",
-      "\n",
-      "from numpy import savetxt, zeros\n",
-      "import numpy as np\n",
-      "import sys\n",
-      "\n",
-      "# Setup constant\n",
-      "time_step = 0.01\n",
-      "loops = 50000\n",
-      "step_per_loop = 100\n",
-      "\n",
-      "# System setup\n",
-      "system = System(box_l = [32.0, 32.0, 32.0])\n",
-      "system.set_random_state_PRNG()\n",
-      "np.random.seed(seed = system.seed)\n",
-      "system.cell_system.skin = 0.4\n",
-      "\n",
-      "mpc = 20 # The number of monomers has been set to be 20 as default\n",
-      "         # Change this value for further simulations\n",
-      "\n",
-      "# Lennard-Jones interaction\n",
-      "system.non_bonded_inter[0,0].lennard_jones.set_params(\n",
-      "    epsilon=1.0, sigma=1.0, \n",
-      "    shift=\"auto\", cutoff=2.0**(1.0/6.0))\n",
-      "\n",
-      "# Fene interaction\n",
-      "fene = interactions.FeneBond(k=7, d_r_max=2)\n",
-      "system.bonded_inter.add(fene)\n",
-      "\n",
-      "\n",
-      "# Setup polymer of part_id 0 with fene bond\n",
-      "\n",
-      "polymer.create_polymer(N_P=1, MPC=mpc, bond=fene, bond_length=1,\n",
-      "                       start_pos = [16.0, 16.0, 16.0])\n",
-      "\n",
-      "\n",
-      "print(\"Warming up the polymer chain.\")\n",
-      "## For longer chains (>100) an extensive \n",
-      "## warmup is neccessary ...\n",
-      "system.time_step = 0.002\n",
-      "system.thermostat.set_langevin(kT=1.0, gamma=10)\n",
-      "\n",
-      "for i in range(100):\n",
-      "    system.force_cap = float(i) + 1\n",
-      "    system.integrator.run(1000)\n",
-      "\n",
-      "print(\"Warmup finished.\")\n",
-      "system.force_cap = 0\n",
-      "system.integrator.run(10000)\n",
-      "system.time_step = time_step\n",
-      "system.integrator.run(50000)\n",
-      "\n",
-      "system.thermostat.turn_off()\n",
-      "\n",
-      "system.part[:].v = [0,0,0]\n",
-      "\n",
-      "lbf = lb.LBFluidGPU(agrid=1, dens=1, visc=5, tau=time_step, fric=5)\n",
-      "system.actors.add(lbf)\n",
-      "system.thermostat.set_lb(kT=1)\n",
-      "\n",
-      "print(\"Warming up the system with LB fluid.\")\n",
-      "system.integrator.run(1000)\n",
-      "print(\"LB fluid warming finished.\")\n",
-      "\n",
-      "\n",
-      "# configure correlators\n",
-      "com_pos = ComPosition(ids=(0,))\n",
-      "c = Correlator(obs1 = com_pos, tau_lin=16, tau_max=loops*step_per_loop, delta_N=1,\n",
-      "        corr_operation=\"square_distance_componentwise\", compress1=\"discard1\")\n",
-      "system.auto_update_accumulators.add(c)\n",
-      "\n",
-      "print(\"Sampling started.\")\n",
-      "for i in range(loops):\n",
-      "    system.integrator.run(step_per_loop)\n",
-      "    system.analysis.append()\n",
-      "    sys.stdout.write(\"\\rSampling: %05i\"%i)\n",
-      "    sys.stdout.flush()\n",
-      "\n",
-      "c.finalize()\n",
-      "corrdata = c.result()\n",
-      "corr = zeros((corrdata.shape[0],2))\n",
-      "corr[:,0] = corrdata[:,0]\n",
-      "corr[:,1] = (corrdata[:,2] + corrdata[:,3] + corrdata[:,4]) / 3\n",
-      "\n",
-      "savetxt(\"./msd_nom\"+str(mpc)+\".dat\", corr)\n",
-      "\n",
-      "with open(\"./rh_out.dat\",\"a\") as datafile:\n",
-      "    rh = system.analysis.calc_rh(chain_start=0, number_of_chains=1, chain_length=mpc-1)\n",
-      "    datafile.write(str(mpc)+ \"    \" + str(rh[0])+\"\\n\")\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Run the script for different numbers of monomers and determine the evolution of the diffusion coefficient as a function of the chain length. Compare the results of your ESPResSo simulations with the given Kirkwood-Zimm formula."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##References"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
-      "[2] B. D\u00fcnweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89\u2013166. Springer, 2009.  \n",
-      "[3] B. D\u00fcnweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
-      "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
-      "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
-      "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
-      "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
     }
    ],
-   "metadata": {}
+   "source": [
+    "from __future__ import print_function, division\n",
+    "from espressomd import System, interactions, lb, polymer\n",
+    "from espressomd.observables import ComPosition\n",
+    "from espressomd.accumulators import Correlator\n",
+    "\n",
+    "from numpy import savetxt, zeros\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "\n",
+    "# Setup constant\n",
+    "time_step = 0.01\n",
+    "loops = 100\n",
+    "step_per_loop = 100\n",
+    "\n",
+    "# System setup\n",
+    "system = System(box_l = [32.0, 32.0, 32.0])\n",
+    "system.set_random_state_PRNG()\n",
+    "np.random.seed(seed = system.seed)\n",
+    "system.cell_system.skin = 0.4\n",
+    "\n",
+    "mpc = 20 # The number of monomers has been set to be 20 as default\n",
+    "         # Change this value for further simulations\n",
+    "\n",
+    "# Lennard-Jones interaction\n",
+    "system.non_bonded_inter[0,0].lennard_jones.set_params(\n",
+    "    epsilon=1.0, sigma=1.0, \n",
+    "    shift=\"auto\", cutoff=2.0**(1.0/6.0))\n",
+    "\n",
+    "# Fene interaction\n",
+    "fene = interactions.FeneBond(k=7, d_r_max=2)\n",
+    "system.bonded_inter.add(fene)\n",
+    "\n",
+    "\n",
+    "# Setup polymer of part_id 0 with fene bond\n",
+    "\n",
+    "polymer.create_polymer(N_P=1, MPC=mpc, bond=fene, bond_length=1,\n",
+    "                       start_pos = [16.0, 16.0, 16.0])\n",
+    "\n",
+    "\n",
+    "print(\"Warming up the polymer chain.\")\n",
+    "## For longer chains (>100) an extensive \n",
+    "## warmup is neccessary ...\n",
+    "system.time_step = 0.002\n",
+    "system.thermostat.set_langevin(kT=1.0, gamma=10)\n",
+    "\n",
+    "for i in range(100):\n",
+    "    system.force_cap = float(i) + 1\n",
+    "    system.integrator.run(1000)\n",
+    "\n",
+    "print(\"Warmup finished.\")\n",
+    "system.force_cap = 0\n",
+    "system.integrator.run(10000)\n",
+    "system.time_step = time_step\n",
+    "system.integrator.run(50000)\n",
+    "\n",
+    "system.thermostat.turn_off()\n",
+    "\n",
+    "system.part[:].v = [0,0,0]\n",
+    "\n",
+    "lbf = lb.LBFluidGPU(agrid=1, dens=1, visc=5, tau=time_step, fric=5)\n",
+    "system.actors.add(lbf)\n",
+    "system.thermostat.set_lb(kT=1)\n",
+    "\n",
+    "print(\"Warming up the system with LB fluid.\")\n",
+    "system.integrator.run(1000)\n",
+    "print(\"LB fluid warming finished.\")\n",
+    "\n",
+    "\n",
+    "# configure correlators\n",
+    "com_pos = ComPosition(ids=(0,))\n",
+    "c = Correlator(obs1 = com_pos, tau_lin=16, tau_max=loops*step_per_loop, delta_N=1,\n",
+    "        corr_operation=\"square_distance_componentwise\", compress1=\"discard1\")\n",
+    "system.auto_update_accumulators.add(c)\n",
+    "\n",
+    "print(\"Sampling started.\")\n",
+    "for i in range(loops):\n",
+    "    system.integrator.run(step_per_loop)\n",
+    "    system.analysis.append()\n",
+    "    sys.stdout.write(\"\\rSampling: %05i\"%i)\n",
+    "    sys.stdout.flush()\n",
+    "\n",
+    "c.finalize()\n",
+    "corrdata = c.result()\n",
+    "corr = zeros((corrdata.shape[0],2))\n",
+    "corr[:,0] = corrdata[:,0]\n",
+    "corr[:,1] = (corrdata[:,2] + corrdata[:,3] + corrdata[:,4]) / 3\n",
+    "\n",
+    "savetxt(\"./msd_nom\"+str(mpc)+\".dat\", corr)\n",
+    "\n",
+    "with open(\"./rh_out.dat\",\"a\") as datafile:\n",
+    "    rh = system.analysis.calc_rh(chain_start=0, number_of_chains=1, chain_length=mpc-1)\n",
+    "    datafile.write(str(mpc)+ \"    \" + str(rh[0])+\"\\n\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the script for different numbers of monomers and determine the evolution of the diffusion coefficient as a function of the chain length. Compare the results of your ESPResSo simulations with the given Kirkwood-Zimm formula."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
+    "[2] B. Dünweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89–166. Springer, 2009.  \n",
+    "[3] B. Dünweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
+    "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
+    "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
+    "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
+    "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part4.ipynb
+++ b/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part4.ipynb
@@ -1,169 +1,176 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:683c9a601fd69262d891c9dedcb9c4901b96c54202c9e12b42d4c94e1dd8fbbd"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 4,
-     "metadata": {},
-     "source": [
-      "Tutorial 4 : The Lattice Boltzmann Method in\n",
-      "ESPResSo - Part 4"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### 6 Poiseuille flow ESPResSo"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Poisseuille flow is the flow through a pipe or (in our case) a slit\n",
-      "under a homogenous force density, e.g. gravity. In the limit of small Reynolds\n",
-      "numbers, the flow can be described with the Stokes equation. \n",
-      "We assume the slit being infinitely extended in $y$ and $z$ \n",
-      "direction and a force density $f$ on the fluid \n",
-      "in $y$ direction. No slip-boundary conditions  (i.e. $\\vec{u}=0$)\n",
-      "are located at $z = \\pm l/2$.\n",
-      "Assuming invariance in $y$ and $z$ direction and a steady state \n",
-      "the Stokes equation is simplified to:\n",
-      "\\begin{equation}\n",
-      "  \\eta \\partial_x^2 u_y = f\n",
-      "\\end{equation}\n",
-      "where $f$ denotes the force density and $\\eta$ the dynamic viscosity.\n",
-      "This can be integrated twice and the integration constants are chosen\n",
-      "so that $u_y=0$ at $z = \\pm l/2$ and we obtain:\n",
-      "\\begin{equation}\n",
-      "  u_y = \\frac{f}{2\\eta} \\left(l^2/4-x^2\\right)\n",
-      "\\end{equation}\n",
-      "With that knowledge investigate the script \\texttt{poisseuille.py}.\n",
-      "Note the use of the \\texttt{lbboundaries} module. Two walls are created\n",
-      "with normal vectors $\\left(\\pm 1, 0, 0 \\right)$. An external force\n",
-      "is applied to every node. After 5000 LB updates the steady state should\n",
-      "be reached."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Task: Write a loop that prints the fluid velocity at the nodes (0,0,0) to (16,0,0) and the node position to a file. Use the <tt>lbf.[node].quantity</tt> method for that. Hint: to write \n",
-      "to a file, first open a file and then use the <tt>write()</tt> method to write into it. Do not forget to close the file afterwards. Example:"
-     ]
-    },
-    {
-     "cell_type": "raw",
-     "metadata": {},
-     "source": [
-      "f = open(\"file.dat\", \"w\")\n",
-      "f.write(\"Hello world!\\n\")\n",
-      "f.close()"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Use the data to fit a parabolic function. Can you confirm the analytic solution?"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "## A script to simulate planar Poisseuille flow in Espresso\n",
-      "from espressomd import System, lb, shapes, lbboundaries\n",
-      "import numpy as np\n",
-      "\n",
-      "# System setup\n",
-      "box_l = 16.0\n",
-      "system = System(box_l = [box_l, box_l, box_l])\n",
-      "system.set_random_state_PRNG()\n",
-      "np.random.seed(seed = system.seed)\n",
-      "system.time_step = 0.01\n",
-      "system.cell_system.skin = 0.2\n",
-      "\n",
-      "lbf = lb.LBFluidGPU(agrid=1, dens=1, visc=1, tau=0.01, ext_force_density=[0, 0.001, 0])\n",
-      "system.actors.add(lbf)\n",
-      "system.thermostat.set_lb(kT=0)\n",
-      "\n",
-      "# Setup boundaries\n",
-      "walls = [lbboundaries.LBBoundary() for k in range(2)]\n",
-      "walls[0].set_params(shape=shapes.Wall(normal=[1,0,0], dist = 1.5))\n",
-      "walls[1].set_params(shape=shapes.Wall(normal=[-1,0,0], dist = -14.5))\n",
-      "\n",
-      "for wall in walls:\n",
-      "    system.lbboundaries.add(wall)\n",
-      "\n",
-      "## Perform enough iterations until the flow profile\n",
-      "## is static (5000 LB updates):\n",
-      "system.integrator.run(5000)\n",
-      "\n",
-      "## Part of the solution\n",
-      "node_v_list = []\n",
-      "for i in range(int(box_l)):\n",
-      "    node_v_list.append(lbf[i, 0, 0].velocity[1])\n",
-      "\n",
-      "with open(\"lb_fluid_velocity.dat\", \"w\") as f:\n",
-      "    for line in node_v_list:\n",
-      "        f.write(str(line)+\"\\n\")"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "<figure>\n",
-      "<img src='figures/poiseuille.png', style=\"width: 500px;\"/>\n",
-      "<center>\n",
-      "<figcaption>*Poisseuille Flow in a slit Geometry.*</figcaption>\n",
-      "</figure>"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "##References"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
-      "[2] B. D\u00fcnweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89\u2013166. Springer, 2009.  \n",
-      "[3] B. D\u00fcnweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
-      "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
-      "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
-      "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
-      "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial 4 : The Lattice Boltzmann Method in ESPResSo - Part 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6 Poiseuille flow ESPResSo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Poisseuille flow is the flow through a pipe or (in our case) a slit\n",
+    "under a homogenous force density, e.g. gravity. In the limit of small Reynolds\n",
+    "numbers, the flow can be described with the Stokes equation. \n",
+    "We assume the slit being infinitely extended in $y$ and $z$ \n",
+    "direction and a force density $f$ on the fluid \n",
+    "in $y$ direction. No slip-boundary conditions  (i.e. $\\vec{u}=0$)\n",
+    "are located at $z = \\pm l/2$.\n",
+    "Assuming invariance in $y$ and $z$ direction and a steady state \n",
+    "the Stokes equation is simplified to:\n",
+    "\\begin{equation}\n",
+    "  \\eta \\partial_x^2 u_y = f\n",
+    "\\end{equation}\n",
+    "where $f$ denotes the force density and $\\eta$ the dynamic viscosity.\n",
+    "This can be integrated twice and the integration constants are chosen\n",
+    "so that $u_y=0$ at $z = \\pm l/2$ and we obtain:\n",
+    "\\begin{equation}\n",
+    "  u_y = \\frac{f}{2\\eta} \\left(l^2/4-x^2\\right)\n",
+    "\\end{equation}\n",
+    "With that knowledge investigate the script \\texttt{poisseuille.py}.\n",
+    "Note the use of the \\texttt{lbboundaries} module. Two walls are created\n",
+    "with normal vectors $\\left(\\pm 1, 0, 0 \\right)$. An external force\n",
+    "is applied to every node. After 5000 LB updates the steady state should\n",
+    "be reached."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Task: Write a loop that prints the fluid velocity at the nodes (0,0,0) to (16,0,0) and the node position to a file. Use the <tt>lbf.[node].quantity</tt> method for that. Hint: to write \n",
+    "to a file, first open a file and then use the <tt>write()</tt> method to write into it. Do not forget to close the file afterwards. Example:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "f = open(\"file.dat\", \"w\")\n",
+    "f.write(\"Hello world!\\n\")\n",
+    "f.close()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the data to fit a parabolic function. Can you confirm the analytic solution?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## A script to simulate planar Poisseuille flow in Espresso\n",
+    "from espressomd import System, lb, shapes, lbboundaries\n",
+    "import numpy as np\n",
+    "\n",
+    "# System setup\n",
+    "box_l = 16.0\n",
+    "system = System(box_l = [box_l, box_l, box_l])\n",
+    "system.set_random_state_PRNG()\n",
+    "np.random.seed(seed = system.seed)\n",
+    "system.time_step = 0.01\n",
+    "system.cell_system.skin = 0.2\n",
+    "\n",
+    "lbf = lb.LBFluidGPU(agrid=1, dens=1, visc=1, tau=0.01, ext_force_density=[0, 0.001, 0])\n",
+    "system.actors.add(lbf)\n",
+    "system.thermostat.set_lb(kT=0)\n",
+    "\n",
+    "# Setup boundaries\n",
+    "walls = [lbboundaries.LBBoundary() for k in range(2)]\n",
+    "walls[0].set_params(shape=shapes.Wall(normal=[1,0,0], dist = 1.5))\n",
+    "walls[1].set_params(shape=shapes.Wall(normal=[-1,0,0], dist = -14.5))\n",
+    "\n",
+    "for wall in walls:\n",
+    "    system.lbboundaries.add(wall)\n",
+    "\n",
+    "## Perform enough iterations until the flow profile\n",
+    "## is static (5000 LB updates):\n",
+    "system.integrator.run(5000)\n",
+    "\n",
+    "## Part of the solution\n",
+    "node_v_list = []\n",
+    "for i in range(int(box_l)):\n",
+    "    node_v_list.append(lbf[i, 0, 0].velocity[1])\n",
+    "\n",
+    "with open(\"lb_fluid_velocity.dat\", \"w\") as f:\n",
+    "    for line in node_v_list:\n",
+    "        f.write(str(line)+\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<figure>\n",
+    "<img src='figures/poiseuille.png', style=\"width: 500px;\"/>\n",
+    "<center>\n",
+    "<figcaption>Poisseuille Flow in a slit Geometry.</figcaption>\n",
+    "</figure>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[1] S Succi. *The lattice Boltzmann equation for fluid dynamics and beyond. *Clarendon Press, Oxford, 2001.  \n",
+    "[2] B. Dünweg and A. J. C. Ladd. *Advanced Computer Simulation Approaches for Soft Matter Sciences III*, chapter II, pages 89–166. Springer, 2009.  \n",
+    "[3] B. Dünweg, U. Schiller, and A.J.C. Ladd. Statistical mechanics of the fluctuating lattice-boltzmann equation. *Phys. Rev. E*, 76:36704, 2007.  \n",
+    "[4] P. G. de Gennes. *Scaling Concepts in Polymer Physics*. Cornell University Press, Ithaca, NY, 1979.  \n",
+    "[5] M. Doi. *Introduction do Polymer Physics.* Clarendon Press, Oxford, 1996.  \n",
+    "[6] Michael Rubinstein and Ralph H. Colby. *Polymer Physics.* Oxford University Press, Oxford, UK, 2003.  \n",
+    "[7] Daan Frenkel and Berend Smit. *Understanding Molecular Simulation.* Academic Press, San Diego, second edition, 2002."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Raw cell types end up as python code for nbconvert, one shouldn't use them at all.
Pseudocode should be in markdown and triple backtics.
Also reduced the number of loops at some points.

However, looking at the diffs, jupyter did a lot of format changes (e.g. headings are now pure markdown).
I checked that the python scripts generated by nbconvert are still running, so this should be fine.

Also accidentally included the commit from PR #2193.