### PR TITLE
WIP: Ci speedup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ debian:9:
   script:
     - export with_cuda=false
     - export myconfig=maxset make_check=false
-    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
+    - export cmake_params="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG='-g -DNDEBUG'"
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -88,7 +88,7 @@ opensuse:42.3:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
     - export with_cuda=false myconfig=maxset make_check=false
-    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
+    - export cmake_params="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG='-g -DNDEBUG'"
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -99,7 +99,7 @@ opensuse:15.0:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
     - export with_cuda=false myconfig=maxset make_check=false
-    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
+    - export cmake_params="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG='-g -DNDEBUG'"
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -110,7 +110,7 @@ centos:7:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
     - export with_cuda=false myconfig=maxset make_check=false
-    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
+    - export cmake_params="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG='-g -DNDEBUG'"
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -121,7 +121,7 @@ fedora:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/centos:next
   script:
     - export with_cuda=false myconfig=maxset make_check=false
-    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
+    - export cmake_params="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG='-g -DNDEBUG'"
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,7 @@ debian:9:
   script:
     - export with_cuda=false
     - export myconfig=maxset make_check=false
+    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -87,6 +88,7 @@ opensuse:42.3:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
     - export with_cuda=false myconfig=maxset make_check=false
+    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -97,6 +99,7 @@ opensuse:15.0:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
     - export with_cuda=false myconfig=maxset make_check=false
+    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -107,6 +110,7 @@ centos:7:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
     - export with_cuda=false myconfig=maxset make_check=false
+    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -117,6 +121,7 @@ fedora:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/centos:next
   script:
     - export with_cuda=false myconfig=maxset make_check=false
+    - export cmake_params=-DCMAKE_BUILD_TYPE=Debug
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,8 +370,8 @@ if(WARNINGS_ARE_ERRORS)
   endif()
 endif(WARNINGS_ARE_ERRORS)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -Wno-unused-function -Wno-unused-variable")
-if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  # G++ doesn't know this flag
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  # G++ and Intel don't know this flag
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
 endif()
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.8.5")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,11 @@ if(WARNINGS_ARE_ERRORS)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -Werror")
   endif()
 endif(WARNINGS_ARE_ERRORS)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -Wno-unused-function -Wno-unused-private-field -Wno-unused-variable")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -Wno-unused-function -Wno-unused-variable")
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # G++ doesn't know this flag
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
+endif()
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.8.5")
   # older versions don't support -Wno-pedantic which we need in src/python
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")

--- a/src/core/utils/Span.hpp
+++ b/src/core/utils/Span.hpp
@@ -78,7 +78,8 @@ public:
   constexpr reverse_iterator rend() const { return reverse_iterator(begin()); }
 
   constexpr reference operator[](size_type i) const {
-    return assert(i < size()), m_ptr[i];
+    assert(i < size());
+    return m_ptr[i];
   }
 
   constexpr reference at(size_type i) const {

--- a/src/core/utils/Span.hpp
+++ b/src/core/utils/Span.hpp
@@ -78,8 +78,7 @@ public:
   constexpr reverse_iterator rend() const { return reverse_iterator(begin()); }
 
   constexpr reference operator[](size_type i) const {
-    assert(i < size());
-    return m_ptr[i];
+    return assert(i < size()), m_ptr[i];
   }
 
   constexpr reference at(size_type i) const {


### PR DESCRIPTION
* disable compile-time optimizations for builds that don't run the testsuite (gives a factor of 2 on ICP machines with -j2)

* Don't run the full test suite for intel compiler buidls, but keep the mpirun of testsuite/particle.py as it is.
