### PR TITLE
Fix memory leaks in analyze_rdfchain

### DIFF
--- a/src/core/statistics_chain.cpp
+++ b/src/core/statistics_chain.cpp
@@ -681,14 +681,15 @@ void analyze_formfactor_av(double qmin, double qmax, int qbins, double **_ff) {
 }
 
 void analyze_rdfchain(PartCfg &partCfg, double r_min, double r_max, int r_bins,
-                      double **_f1, double **_f2, double **_f3) {
+                      std::vector<double> &f1, std::vector<double> &f2,
+                      std::vector<double> &f3) {
   int i, j, ind, c_i, c_j, mon;
   double bin_width, inv_bin_width, factor, r_in, r_out, bin_volume, dist,
-      chain_mass, *f1 = nullptr, *f2 = nullptr, *f3 = nullptr;
+      chain_mass;
 
-  *_f1 = f1 = Utils::realloc(f1, r_bins * sizeof(double));
-  *_f2 = f2 = Utils::realloc(f2, r_bins * sizeof(double));
-  *_f3 = f3 = Utils::realloc(f3, r_bins * sizeof(double));
+  f1.resize(r_bins);
+  f2.resize(r_bins);
+  f3.resize(r_bins);
   std::vector<double> cm(chain_n_chains * 3);
   std::vector<double> min_d(chain_n_chains * chain_n_chains);
   for (i = 0; i < r_bins; i++) {

--- a/src/core/statistics_chain.hpp
+++ b/src/core/statistics_chain.hpp
@@ -191,7 +191,8 @@ void analyze_formfactor_av(double qmin, double qmax, int qbins, double **_ff);
    chains
     */
 void analyze_rdfchain(PartCfg &, double r_min, double r_max, int r_bins,
-                      double **_rdf, double **_rdf_cm, double **_rdf_d);
+                      std::vector<double> &_rdf, std::vector<double> &_rdf_cm,
+                      std::vector<double> &_rdf_d);
 
 /** sets the particle mol_id according to the chain_structure info*/
 void update_mol_ids_setchains();

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -268,7 +268,7 @@ class Analysis(object):
 
         ids = c_analyze.nbhood(c_analyze.partCfg(), c_pos, r_catch, planedims)
 
-        return create_nparray_from_int_list(& ids)
+        return create_nparray_from_int_list( & ids)
 
     def cylindrical_average(self, center=None, axis=None,
                             length=None, radius=None,
@@ -417,8 +417,8 @@ class Analysis(object):
         total_bonded = 0
         for i in range(bonded_ia_params.size()):
             if (bonded_ia_params[i].type != BONDED_IA_NONE):
-                p["bonded", i] = c_analyze.obsstat_bonded(& c_analyze.total_pressure, i)[0]
-                total_bonded += c_analyze.obsstat_bonded(& c_analyze.total_pressure, i)[0]
+                p["bonded", i] = c_analyze.obsstat_bonded( & c_analyze.total_pressure, i)[0]
+                total_bonded += c_analyze.obsstat_bonded( & c_analyze.total_pressure, i)[0]
         p["bonded"] = total_bonded
 
         # Non-Bonded interactions, total as well as intra and inter molecular
@@ -433,12 +433,12 @@ class Analysis(object):
         for i in range(c_analyze.max_seen_particle_type):
             for j in range(i, c_analyze.max_seen_particle_type):
                 #      if checkIfParticlesInteract(i, j):
-                p["non_bonded", i, j] = c_analyze.obsstat_nonbonded(& c_analyze.total_pressure, i, j)[0]
-                total_non_bonded += c_analyze.obsstat_nonbonded(& c_analyze.total_pressure, i, j)[0]
-                total_intra += c_analyze.obsstat_nonbonded_intra(& c_analyze.total_pressure_non_bonded, i, j)[0]
-                p["non_bonded_intra", i, j] = c_analyze.obsstat_nonbonded_intra(& c_analyze.total_pressure_non_bonded, i, j)[0]
-                p["non_bonded_inter", i, j] = c_analyze.obsstat_nonbonded_inter(& c_analyze.total_pressure_non_bonded, i, j)[0]
-                total_inter += c_analyze.obsstat_nonbonded_inter(& c_analyze.total_pressure_non_bonded, i, j)[0]
+                p["non_bonded", i, j] = c_analyze.obsstat_nonbonded( & c_analyze.total_pressure, i, j)[0]
+                total_non_bonded += c_analyze.obsstat_nonbonded( & c_analyze.total_pressure, i, j)[0]
+                total_intra += c_analyze.obsstat_nonbonded_intra( & c_analyze.total_pressure_non_bonded, i, j)[0]
+                p["non_bonded_intra", i, j] = c_analyze.obsstat_nonbonded_intra( & c_analyze.total_pressure_non_bonded, i, j)[0]
+                p["non_bonded_inter", i, j] = c_analyze.obsstat_nonbonded_inter( & c_analyze.total_pressure_non_bonded, i, j)[0]
+                total_inter += c_analyze.obsstat_nonbonded_inter( & c_analyze.total_pressure_non_bonded, i, j)[0]
         p["non_bonded_intra"] = total_intra
         p["non_bonded_inter"] = total_inter
         p["non_bonded"] = total_non_bonded
@@ -525,7 +525,7 @@ class Analysis(object):
         for i in range(bonded_ia_params.size()):
             if (bonded_ia_params[i].type != BONDED_IA_NONE):
                 p["bonded", i] = np.reshape(create_nparray_from_double_array(
-                    c_analyze.obsstat_bonded(& c_analyze.total_p_tensor, i), 9),
+                    c_analyze.obsstat_bonded( & c_analyze.total_p_tensor, i), 9),
                     (3, 3))
                 total_bonded += p["bonded", i]
         p["bonded"] = total_bonded
@@ -695,7 +695,7 @@ class Analysis(object):
         e = OrderedDict()
 
         if c_analyze.total_energy.init_status == 0:
-            c_analyze.init_energies(& c_analyze.total_energy)
+            c_analyze.init_energies( & c_analyze.total_energy)
             c_analyze.master_energy_calc()
             handle_errors("calc_long_range_energies failed")
 
@@ -717,8 +717,8 @@ class Analysis(object):
         total_bonded = 0
         for i in range(bonded_ia_params.size()):
             if (bonded_ia_params[i].type != BONDED_IA_NONE):
-                e["bonded", i] = c_analyze.obsstat_bonded(& c_analyze.total_energy, i)[0]
-                total_bonded += c_analyze.obsstat_bonded(& c_analyze.total_energy, i)[0]
+                e["bonded", i] = c_analyze.obsstat_bonded( & c_analyze.total_energy, i)[0]
+                total_bonded += c_analyze.obsstat_bonded( & c_analyze.total_energy, i)[0]
         e["bonded"] = total_bonded
 
         # Non-Bonded interactions, total as well as intra and inter molecular
@@ -733,9 +733,9 @@ class Analysis(object):
         for i in range(c_analyze.max_seen_particle_type):
             for j in range(c_analyze.max_seen_particle_type):
                 #      if checkIfParticlesInteract(i, j):
-                e["non_bonded", i, j] = c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
+                e["non_bonded", i, j] = c_analyze.obsstat_nonbonded( & c_analyze.total_energy, i, j)[0]
                 if i <= j:
-                    total_non_bonded += c_analyze.obsstat_nonbonded(& c_analyze.total_energy, i, j)[0]
+                    total_non_bonded += c_analyze.obsstat_nonbonded( & c_analyze.total_energy, i, j)[0]
     #        total_intra +=c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
     #        e["non_bonded_intra",i,j] =c_analyze.obsstat_nonbonded_intra(&c_analyze.total_energy_non_bonded, i, j)[0]
     #        e["nonBondedInter",i,j] =c_analyze.obsstat_nonbonded_inter(&c_analyze.total_energy_non_bonded, i, j)[0]
@@ -1263,9 +1263,9 @@ class Analysis(object):
             [3] is the third rdf: from the shortest monomer-monomer distances.
 
         """
-        cdef double * f1
-        cdef double * f2
-        cdef double * f3
+        cdef vector[double] f1
+        cdef vector[double] f2
+        cdef vector[double] f3
 
         check_type_or_throw_except(r_min, 1, float, "r_min has to be a float")
         check_type_or_throw_except(r_max, 1, float, "r_max has to be a float")
@@ -1284,7 +1284,14 @@ class Analysis(object):
         if (r_max <= r_min):
             raise Exception("<r_max> has to be larger than <r_min>")
 
-        c_analyze.analyze_rdfchain(c_analyze.partCfg(), r_min, r_max, r_bins, & f1, & f2, & f3)
+        c_analyze.analyze_rdfchain(
+    c_analyze.partCfg(),
+     r_min,
+     r_max,
+     r_bins,
+     f1,
+     f2,
+     f3)
 
         rdfchain = np.empty((r_bins, 4))
         bin_width = (r_max - r_min) / float(r_bins)

--- a/src/python/espressomd/c_analyze.pxd
+++ b/src/python/espressomd/c_analyze.pxd
@@ -98,6 +98,7 @@ cdef extern from "statistics_chain.hpp":
     void calc_re(PartCfg & , double ** re)
     void calc_rg(PartCfg & , double ** rg)
     void calc_rh(PartCfg & , double ** rh)
+    void analyze_rdfchain(PartCfg & , double r_min, double r_max, int r_bins, vector[double] & f1, vector[double] & f2, vector[double] & f3)
 
 cdef extern from "statistics.hpp":
     void calc_rdf(PartCfg &, vector[int] p1_types, vector[int] p2_types,
@@ -108,7 +109,6 @@ cdef extern from "statistics.hpp":
 
     void angularmomentum(PartCfg &, int p_type, double * com)
     void momentofinertiamatrix(PartCfg &, int p_type, double * MofImatrix)
-    void analyze_rdfchain(PartCfg &, double r_min, double r_max, int r_bins, double ** f1, double ** f2, double ** f3)
 
 cdef extern from "statistics.hpp":
     int n_part


### PR DESCRIPTION
Fixes #2186 and/or #2187 

I have replaced the pointers by `std::vector` which should take care of the memory leaks.  I have also temporarily replaced all array accesses using `std::vector::operator[]` inside `analyze_rdfchain` by `std::vector::at()` for bounds checking and ran the test `analyze_chains.py` 100 times without failures.  I don't know if the sporadic failures are gone now because I couldn't even reproduce before my fix.