### PR TITLE
ctest: add ARGS option to custom 'make check'

### DIFF
--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -21,7 +21,7 @@
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL ON)
 
 # Target for the unit tests
-add_custom_target(check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
+add_custom_target(check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) --output-on-failure)
 
 # Run unit tests on check
 add_dependencies(check check_unit_tests)

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -178,13 +178,13 @@ add_custom_target(python_test_data
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/ek_eof_one_species_base.py ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-add_custom_target(check_python_serial COMMAND ${CMAKE_CTEST_COMMAND} -C serial --output-on-failure)
+add_custom_target(check_python_serial COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) -C serial --output-on-failure)
 add_dependencies(check_python_serial pypresso python_test_data)
 
-add_custom_target(check_python_parallel COMMAND ${CMAKE_CTEST_COMMAND} -C parallel --output-on-failure)
+add_custom_target(check_python_parallel COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) -C parallel --output-on-failure)
 add_dependencies(check_python_parallel pypresso python_test_data)
 
-add_custom_target(check_python_parallel_odd COMMAND ${CMAKE_CTEST_COMMAND} -C parallel_odd --output-on-failure)
+add_custom_target(check_python_parallel_odd COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) -C parallel_odd --output-on-failure)
 add_dependencies(check_python_parallel_odd pypresso python_test_data)
 
 add_custom_target(check_python)


### PR DESCRIPTION
The ARGS make variable is the default for the common ctest calls,
e.g. make test ARGS="-E some_test". This change adds the same
functionality to the custom "make check" of this project.

Related to question in https://github.com/espressomd/espresso/issues/2250#issuecomment-420062882