### PR TITLE
Fix PARTIAL_PERIODIC on big-endian platforms

### DIFF
--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -147,7 +147,7 @@ const std::unordered_map<int, Datafield> fields{
      {&nptiso.piston, Datafield::Type::DOUBLE, 1,
       "npt_piston"}}, /* 27 from pressure.cpp */
     {FIELD_PERIODIC,
-     {&periodic, Datafield::Type::BOOL, 3,
+     {&periodic, Datafield::Type::INT, 1,
       "periodicity"}}, /* 28 from grid.cpp */
     {FIELD_SKIN,
      {&skin, Datafield::Type::DOUBLE, 1, "skin"}}, /* 29 from integrate.cpp */

--- a/src/core/utils/serialization/List.hpp
+++ b/src/core/utils/serialization/List.hpp
@@ -20,6 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CORE_UTILS_SERIALIZATION_LIST_HPP
 
 #include <boost/serialization/array.hpp>
+#if BOOST_VERSION >= 106400 && BOOST_VERSION < 106500
+#include <boost/serialization/array_wrapper.hpp>
+#endif
 #include <boost/serialization/split_free.hpp>
 
 #include "core/utils/List.hpp"


### PR DESCRIPTION
Problem reported by @junghans in #2258.

I spun up OpenSUSE Tumbleweed in a Docker container to emulate an IBM mainframe with s390x CPU in QEMU. The PARTIAL_PERIODIC tests were failing just like on the SUSE Build Service due to a byte-order issue. Also I needed to add one Boost header to make it work with Boost 1.64.0 (see https://github.com/boostorg/serialization/commit/1d86261581230e2dc5d617a9b16287d326f3e229).

I expect that this also fixes the ppc64 issue, but couldn't test that because there are no Docker images for it (only for ppc64le). ppc64 might still be somewhat relevant in HPC as there are a few IBM BlueGene/Q machines still in operation. I really can't imagine why anyone would run Espresso on s390x; IBM's zEnterprise mainframe architecture that just isn't optimized for this kind of workload.

Candidate for Espresso 4.0.1.