### PR TITLE
core: silence compiler warning for non-const compare operator, namely…

### DIFF
--- a/src/core/PdbParser.hpp
+++ b/src/core/PdbParser.hpp
@@ -52,7 +52,7 @@ typedef struct {
 } itp_atomtype;
 
 struct itp_atomtype_compare {
-  bool operator() (const itp_atomtype &a, const itp_atomtype &b) const {
+  bool operator()(const itp_atomtype &a, const itp_atomtype &b) const {
     return a.id < b.id;
   }
 };

--- a/src/core/PdbParser.hpp
+++ b/src/core/PdbParser.hpp
@@ -52,7 +52,7 @@ typedef struct {
 } itp_atomtype;
 
 struct itp_atomtype_compare {
-  bool operator()(const itp_atomtype &a, const itp_atomtype &b) {
+  bool operator() (const itp_atomtype &a, const itp_atomtype &b) const {
     return a.id < b.id;
   }
 };


### PR DESCRIPTION
… 'warning: the specified comparator type does not provide a const call operator'.