### PR TITLE
CI: make errors in the build script visible.

### DIFF
--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -74,7 +74,6 @@ if [ -z "$cxx_flags" ]; then
     else
         if $make_check; then
             cxx_flags="-O3"
-            fdsasdf
         else
             cxx_flags="-O0"
         fi

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -7,6 +7,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+abort()
+{
+    echo "An error occurred. Exiting..." >&2
+    echo "Command that failed: $BASH_COMMAND" >&2
+    exit 1
+}
+
+trap 'abort' 0
 set -e
 
 # HELPER FUNCTIONS
@@ -66,6 +74,7 @@ if [ -z "$cxx_flags" ]; then
     else
         if $make_check; then
             cxx_flags="-O3"
+            fdsasdf
         else
             cxx_flags="-O0"
         fi

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -268,3 +268,5 @@ if $with_coverage; then
         bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" || echo "Codecov did not collect coverage reports"
     fi
 fi
+
+trap : 0

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -7,6 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+set -e
+
 # HELPER FUNCTIONS
 
 # output value of env variables


### PR DESCRIPTION
man bash:
```
Exit immediately if a simple command (see SHELL GRAMMAR above) exits with a non-zero status.  The shell does not exit if the command that fails is part of the command  list  immediately  following a while or until keyword, part of the test in an if statement, part of a && or || list, or if the command's return value is being inverted via !.  A trap on ERR, if set, is executed before the shell exits.
```