### PR TITLE
Revert "CI: add ccache stats output to ci build."

### DIFF
--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -258,7 +258,3 @@ if $with_coverage; then
         bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" || echo "Codecov did not collect coverage reports"
     fi
 fi
-
-if $with_ccache; then
-    ccache -s
-fi


### PR DESCRIPTION
Reverts espressomd/espresso#2260