### PR TITLE
Fix unit test without SSE instructions

### DIFF
--- a/src/core/unit_tests/field_coupling_couplings_test.cpp
+++ b/src/core/unit_tests/field_coupling_couplings_test.cpp
@@ -78,10 +78,10 @@ BOOST_AUTO_TEST_CASE(scaled) {
       const int m_id;
     };
 
-    BOOST_CHECK((1.23 * 2.) == scaled_coupling(Particle(0), 2.));
-    BOOST_CHECK((default_val * 3.) == scaled_coupling(Particle(1), 3.));
-    BOOST_CHECK((3.45 * 4.) == scaled_coupling(Particle(2), 4.));
-    BOOST_CHECK((default_val * 5.) == scaled_coupling(Particle(3), 5.));
+    BOOST_CHECK_CLOSE(1.23 * 2., scaled_coupling(Particle(0), 2.), 1e-14);
+    BOOST_CHECK_CLOSE(default_val * 3., scaled_coupling(Particle(1), 3.), 1e-14);
+    BOOST_CHECK_CLOSE(3.45 * 4., scaled_coupling(Particle(2), 4.), 1e-14);
+    BOOST_CHECK_CLOSE(default_val * 5., scaled_coupling(Particle(3), 5.), 1e-14);
   }
 }
 

--- a/src/core/unit_tests/field_coupling_couplings_test.cpp
+++ b/src/core/unit_tests/field_coupling_couplings_test.cpp
@@ -79,9 +79,11 @@ BOOST_AUTO_TEST_CASE(scaled) {
     };
 
     BOOST_CHECK_CLOSE(1.23 * 2., scaled_coupling(Particle(0), 2.), 1e-14);
-    BOOST_CHECK_CLOSE(default_val * 3., scaled_coupling(Particle(1), 3.), 1e-14);
+    BOOST_CHECK_CLOSE(default_val * 3., scaled_coupling(Particle(1), 3.),
+                      1e-14);
     BOOST_CHECK_CLOSE(3.45 * 4., scaled_coupling(Particle(2), 4.), 1e-14);
-    BOOST_CHECK_CLOSE(default_val * 5., scaled_coupling(Particle(3), 5.), 1e-14);
+    BOOST_CHECK_CLOSE(default_val * 5., scaled_coupling(Particle(3), 5.),
+                      1e-14);
   }
 }
 


### PR DESCRIPTION
Reported in #2258 by @junghans.

This is due to SSE vs. i387 floating-point arithmetic. If I compile with `-msse -mfpmath=sse` on i586, the test succeeds. If I use `-mfpmath=387`, it fails. This is not an issue on amd64 as SSE is mandatory there.

Candidate for Espresso 4.0.1.