### PR TITLE
Always define q

### DIFF
--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -602,7 +602,6 @@ int set_particle_q(int part, double q) {
 constexpr double ParticleProperties::q;
 #endif
 
-
 #ifdef LB_ELECTROHYDRODYNAMICS
 int set_particle_mu_E(int part, double mu_E[3]) {
   auto const pnode = get_particle_node(part);

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -598,6 +598,10 @@ int set_particle_q(int part, double q) {
   mpi_send_q(pnode, part, q);
   return ES_OK;
 }
+#ifndef ELECTROSTATICS
+const constexpr double ParticleProperties::q;
+#endif
+
 
 #ifdef LB_ELECTROHYDRODYNAMICS
 int set_particle_mu_E(int part, double mu_E[3]) {

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1247,9 +1247,7 @@ void pointer_to_quatu(Particle const *p, double const *&res) {
 }
 #endif
 
-#ifdef ELECTROSTATICS
 void pointer_to_q(Particle const *p, double const *&res) { res = &(p->p.q); }
-#endif
 
 #ifdef VIRTUAL_SITES
 void pointer_to_virtual(Particle const *p, int const *&res) {

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -599,7 +599,7 @@ int set_particle_q(int part, double q) {
   return ES_OK;
 }
 #ifndef ELECTROSTATICS
-const constexpr double ParticleProperties::q;
+constexpr double ParticleProperties::q;
 #endif
 
 

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -127,7 +127,7 @@ struct ParticleProperties {
 #ifdef ELECTROSTATICS
   double q = 0.0;
 #else
-  static constexpr double q = 0.0;
+  constexpr static double q{0.0};
 #endif
 
 #ifdef LB_ELECTROHYDRODYNAMICS

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -123,9 +123,11 @@ struct ParticleProperties {
   // integrated
   short int rotation = 0;
 
-#ifdef ELECTROSTATICS
   /** charge. */
+#ifdef ELECTROSTATICS
   double q = 0.0;
+#else
+  static constexpr double q = 0.0;
 #endif
 
 #ifdef LB_ELECTROHYDRODYNAMICS
@@ -991,9 +993,7 @@ void pointer_to_quatu(Particle const *p, double const *&res);
 
 #endif
 
-#ifdef ELECTROSTATICS
 void pointer_to_q(Particle const *p, double const *&res);
-#endif
 
 #ifdef VIRTUAL_SITES
 void pointer_to_virtual(Particle const *p, int const *&res);

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -109,8 +109,7 @@ cdef extern from "particle_data.hpp":
         int set_particle_rotation(int part, int rot)
         void pointer_to_rotation(const particle * p, const short int * & res)
 
-    IF ELECTROSTATICS:
-        int set_particle_q(int part, double q)
+    int set_particle_q(int part, double q)
 
     IF LB_ELECTROHYDRODYNAMICS:
         int set_particle_mu_E(int part, double mu_E[3])
@@ -178,8 +177,7 @@ cdef extern from "particle_data.hpp":
         int set_particle_vs_relative(int part, int vs_relative_to, double vs_distance, double * rel_ori)
         void set_particle_vs_quat(int part, double * vs_quat)
 
-    IF ELECTROSTATICS:
-        void pointer_to_q(const particle * P, const double * & res)
+    void pointer_to_q(const particle * P, const double * & res)
 
     IF EXTERNAL_FORCES:
         IF ROTATION:

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -609,31 +609,30 @@ cdef class ParticleHandle(object):
 
 
 # Charge
-    IF ELECTROSTATICS:
-        property q:
-            """
-            Particle charge.
+    property q:
+        """
+        Particle charge.
 
-            q : :obj:`float`
+        q : :obj:`float`
 
-            .. note::
-               This needs the feature ELECTROSTATICS.
+        .. note::
+           This needs the feature ELECTROSTATICS.
 
-            """
+        """
 
-            def __set__(self, _q):
-                cdef double myq
-                check_type_or_throw_except(
-                    _q, 1, float, "Charge has to be floats.")
-                myq = _q
-                if set_particle_q(self._id, myq) == 1:
-                    raise Exception("Set particle position first.")
+        def __set__(self, _q):
+            cdef double myq
+            check_type_or_throw_except(
+                _q, 1, float, "Charge has to be floats.")
+            myq = _q
+            if set_particle_q(self._id, myq) == 1:
+                raise Exception("Set particle position first.")
 
-            def __get__(self):
-                self.update_particle_data()
-                cdef const double * x = NULL
-                pointer_to_q(self.particle_data, x)
-                return x[0]
+        def __get__(self):
+            self.update_particle_data()
+            cdef const double * x = NULL
+            pointer_to_q(self.particle_data, x)
+            return x[0]
 
     IF LB_ELECTROHYDRODYNAMICS:
         property mu_E:


### PR DESCRIPTION
Fixes #2248 (tentative)

Description of changes:
 - remove preprocessor barriers to the definition of `q` as a particle propertpy
 - goal: avoid failure when a feature "blindly" accesses q (here, for the MDA sample)

I file the PR now to get an idea of the CI result, as I could only test a limited number of configurations.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
