### PR TITLE
cmake: install libH5mdCore

### DIFF
--- a/src/core/io/writer/CMakeLists.txt
+++ b/src/core/io/writer/CMakeLists.txt
@@ -7,4 +7,5 @@ target_include_directories(H5mdCore SYSTEM PUBLIC
 
 add_dependencies(H5mdCore EspressoConfig)
 target_include_directories(H5mdCore PRIVATE ${CMAKE_SOURCE_DIR}/src/core ${CMAKE_BINARY_DIR}/src/core)
+install(TARGETS H5mdCore LIBRARY DESTINATION ${LIBDIR})
 endif()


### PR DESCRIPTION
To prevent:
```
$ python3
Python 3.6.5 (default, May  2 2018, 16:08:17) 
[GCC 6.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import espressomd
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.6/site-packages/espressomd/__init__.py", line 23, in <module>
    import espressomd._init
ImportError: libH5mdCore.so: cannot open shared object file: No such file or directory
>>> 
```