### PR TITLE
Resolve Doxygen warnings

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -1402,18 +1402,6 @@ GENERATE_XML           = NO
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -382,7 +382,7 @@ EXTRACT_LOCAL_METHODS  = NO
 # name of the file that contains the anonymous namespace. By default
 # anonymous namespaces are hidden.
 
-EXTRACT_ANON_NSPACES   = NO
+EXTRACT_ANON_NSPACES   = YES
 
 # If the HIDE_UNDOC_MEMBERS tag is set to YES, Doxygen will hide all
 # undocumented members of documented classes, files or namespaces.

--- a/doc/sphinx/advanced_methods.rst
+++ b/doc/sphinx/advanced_methods.rst
@@ -1711,7 +1711,7 @@ In |es|, the basic ingredients to simulate such a system are split into three bo
 
 The system-wide thermostat has to be applied to the centre of mass and not to
 the core particle directly. Therefore, the particles have to be excluded from
-global thermostating.  With ``LANGEVIN_PER_PARTICLE`` enabled, we set the
+global thermostatting.  With ``LANGEVIN_PER_PARTICLE`` enabled, we set the
 temperature and friction coefficient of the Drude complex to zero, which allows
 to still use a global Langevin thermostat for non-polarizable particles.
 

--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -488,7 +488,7 @@ The short ranged part is given by:
 .. math :: p^\text{Coulomb, P3M, dir}_{(k,l)}= \frac{1}{4\pi \epsilon_0 \epsilon_r} \frac{1}{2V} \sum_{\vec{n}}^* \sum_{i,j=1}^N q_i q_j \left( \frac{ \mathrm{erfc}(\beta |\vec{r}_j-\vec{r}_i+\vec{n}|)}{|\vec{r}_j-\vec{r}_i+\vec{n}|^3} +\frac{2\beta \pi^{-1/2} \exp(-(\beta |\vec{r}_j-\vec{r}_i+\vec{n}|)^2)}{|\vec{r}_j-\vec{r}_i+\vec{n}|^2} \right) (\vec{r}_j-\vec{r}_i+\vec{n})_k (\vec{r}_j-\vec{r}_i+\vec{n})_l,
 
 where :math:`\beta` is the P3M splitting parameter, :math:`\vec{n}` identifies the periodic images, the asterix denotes that terms with :math:`\vec{n}=\vec{0}` and i=j are omitted.
-The long ranged (kspace) part is given by:
+The long ranged (k-space) part is given by:
 
 .. math :: p^\text{Coulomb, P3M, rec}_{(k,l)}= \frac{1}{4\pi \epsilon_0 \epsilon_r} \frac{1}{2 \pi V^2} \sum_{\vec{k} \neq \vec{0}} \frac{\exp(-\pi^2 \vec{k}^2/\beta^2)}{\vec{k}^2} |S(\vec{k})|^2 \cdot (\delta_{k,l}-2\frac{1+\pi^2\vec{k}^2/\beta^2}{\vec{k}^2} \vec{k}_k \vec{k}_l),
 

--- a/doc/sphinx/appendix.rst
+++ b/doc/sphinx/appendix.rst
@@ -378,8 +378,8 @@ ELC theory
 The ELC method differs from the other MMM algorithms in that it is not
 an algorithm for the calculation of the electrostatic interaction, but
 rather represents a correction term which allows to use any method for
-threedimensionally periodic systems with spherical summation order for
-twodimensional periodicity. The basic idea is to expand the two
+three-dimensionally periodic systems with spherical summation order for
+two-dimensional periodicity. The basic idea is to expand the two
 dimensional slab system of height h in the non-periodic z-coordinate to
 a system with periodicity in all three dimensions, with a period of
 :math:`\lambda_z>h`, which leaves an empty gap of height

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -869,7 +869,7 @@ simulation core which requires running the program in a debugger.  The
 which sets the Python path appropriately and starts the Python
 interpreter with your arguments.  Thus it is not possible to directly
 run ``pypresso`` in a debugger.  However, we provide some useful
-commandline options for the most common tools.
+command line options for the most common tools.
 
 .. code-block:: bash
 

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -510,7 +510,7 @@ particles of the types ``type1`` and ``type2``. The Hertzian potential is define
      \end{cases}
 
 The potential has no singularity and is defined everywhere; the
-potential has a nondifferentiable maximum at :math:`r=0`, where the force
+potential has a non-differentiable maximum at :math:`r=0`, where the force
 is undefined.
 
 .. _Gaussian:

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -413,7 +413,7 @@ and the parameters:
     * ``ext_pressure``:  (float) The external pressure as float variable.
     * ``piston``:        (float) The mass of the applied piston as float variable.
 
-This thermostat is based on the Anderson thermostat (see
+This thermostat is based on the Andersen thermostat (see
 :cite:`andersen80a,mann05d`) and will thermalize the box
 geometry. It will only do isotropic changes of the box.
 See this code snippet for the two commands::

--- a/doc/tutorials/09-swimmer_reactions/SOLUTIONS/reaction.py
+++ b/doc/tutorials/09-swimmer_reactions/SOLUTIONS/reaction.py
@@ -273,7 +273,7 @@ system.integrator.set_vv()
 
 ## Answer 6 ##
 # Because of the use of minimize_energy. Had we instead used force
-# capping, a separate integration loop with thermostating would have
+# capping, a separate integration loop with thermostatting would have
 # been used to remove offending configurations.
 
 system.thermostat.set_langevin(kT=temp, gamma=frict_trans_colloid)

--- a/doc/tutorials/Readme.rst
+++ b/doc/tutorials/Readme.rst
@@ -55,7 +55,7 @@ To view the tutorials, first change to the tutorials directory and then run the 
     /path_to_espresso_build/ipypresso notebook
 
 This will launch a web browser in which the notebooks for the tutorials can be viewed and run.
-For more details, please see: hppt://jupyter.readthedocs.io/en/latest/running.html
+For more details, please see: http://jupyter.readthedocs.io/en/latest/running.html
 Note that `Jupyter` is the successor of IPython.
 
 

--- a/src/core/EspressoSystemInterface_cuda.cu
+++ b/src/core/EspressoSystemInterface_cuda.cu
@@ -27,7 +27,7 @@
 #error CU-file includes mpi.h! This should not happen!
 #endif
 
-// These functions will split the paritlce data structure into individual arrays
+// These functions will split the particle data structure into individual arrays
 // for each property
 
 // Position and charge

--- a/src/core/accumulators/Correlator.hpp
+++ b/src/core/accumulators/Correlator.hpp
@@ -71,7 +71,7 @@
  * Correlations are only calculated on each level: For
  * tau=1,2,..,tau_lin the values are taken from level 1.
  * For tau=tau_lin, tau_lin+2, .., 2*tau_lin we take the values
- * from level 2. On level 2 we halso have values for 0,..tau_lin-2,
+ * from level 2. On level 2 we also have values for 0,..tau_lin-2,
  * but these are discarded as we have "better" estimates on level 1.
  *
  * The functions A and B can get extra arguments. This can e.g. be an

--- a/src/core/accumulators/Correlator.hpp
+++ b/src/core/accumulators/Correlator.hpp
@@ -155,23 +155,19 @@ public:
    * correlation class
    * has to be fed with correct data from the very beginning.
    *
-   * @param _delta_N: The number of time steps between subsequent updates
-   * @param _tau_lin: The linear part of the correlation function.
-   * @param _tau_max: maximal time delay tau to sample
-   * @param _window_distance: The distance in time domain between update of the
+   * @param delta_N The number of time steps between subsequent updates
+   * @param tau_lin The linear part of the correlation function.
+   * @param tau_max maximal time delay tau to sample
+   * @param window_distance: The distance in time domain between update of the
    * correlation estimate
-   * @param _dim_A: The dimension of the A vector
-   * @param _dim_B: The dimension of the B vector
-   * @param _A: First observable to correlate
-   * @param _B: Second observable to correlate
-   * @param _dim_corr: The dimension of the correlation to be calculated
-   * @param _corr_operation_name: how to correlate the two observables A and B
+   * @param obs1 First observable to correlate
+   * @param obs2 Second observable to correlate
+   * @param corr_operation how to correlate the two observables A and B
    *     (this has no default)
-   * @param _compressA_name: how the A values should be compressed (usually
+   * @param compress1_ how the A values should be compressed (usually
    *     the linear compression method)
-   * @param _compressB_name: how the B values should be compressed (usually
+   * @param compress2_ how the B values should be compressed (usually
    *     the linear compression method)
-   * @param _args: the parameters of the observables
    *
    */
   Correlator(int tau_lin, double tau_max, int delta_N,

--- a/src/core/actor/DipolarBarnesHut_cuda.cu
+++ b/src/core/actor/DipolarBarnesHut_cuda.cu
@@ -839,7 +839,7 @@ __global__ __launch_bounds__(THREADS5, FACTOR5) void forceCalculationKernel(
             }
           } else {
             // Early out because all remaining children are also zero.
-            // We shuld move to the next octant or to the next depth if other
+            // We should move to the next octant or to the next depth if other
             // threads already checked other octants:
             depth = max(j, depth - 1);
           }
@@ -1075,7 +1075,7 @@ void summarizeBH(int blocks) {
 }
 
 // Sort particle indexes according to the BH tree representation.
-// Crucial for the per-warp perfomance tuning of forceCalculationKernel and
+// Crucial for the per-warp performance tuning of forceCalculationKernel and
 // energyCalculationKernel.
 void sortBH(int blocks) {
   dim3 grid(1, 1, 1);

--- a/src/core/actor/Mmm1dgpuForce_cuda.cu
+++ b/src/core/actor/Mmm1dgpuForce_cuda.cu
@@ -219,14 +219,14 @@ void Mmm1dgpuForce::tune(SystemInterface &s, mmm1dgpu_real _maxPWerror,
   mmm1dgpu_real maxrad = host_boxz;
 
   if (_far_switch_radius < 0 && _bessel_cutoff < 0)
-  // autodetermine switching radius and bessel cutoff
+  // autodetermine switching radius and Bessel cutoff
   {
     mmm1dgpu_real bestrad = 0, besttime = INFINITY;
 
     for (far_switch_radius = 0.05 * maxrad; far_switch_radius < maxrad;
          far_switch_radius += 0.05 * maxrad) {
       set_params(0, 0, _maxPWerror, far_switch_radius, bessel_cutoff);
-      tune(s, _maxPWerror, far_switch_radius, -2); // tune bessel cutoff
+      tune(s, _maxPWerror, far_switch_radius, -2); // tune Bessel cutoff
       int runtime = force_benchmark(s);
       if (runtime < besttime) {
         besttime = runtime;
@@ -236,11 +236,11 @@ void Mmm1dgpuForce::tune(SystemInterface &s, mmm1dgpu_real _maxPWerror,
     far_switch_radius = bestrad;
 
     set_params(0, 0, _maxPWerror, far_switch_radius, bessel_cutoff);
-    tune(s, _maxPWerror, far_switch_radius, -2); // tune bessel cutoff
+    tune(s, _maxPWerror, far_switch_radius, -2); // tune Bessel cutoff
   }
 
   else if (_bessel_cutoff < 0)
-  // autodetermine bessel cutoff
+  // autodetermine Bessel cutoff
   {
     int *dev_cutoff;
     int maxCut = 30;

--- a/src/core/algorithm/verlet_ia.hpp
+++ b/src/core/algorithm/verlet_ia.hpp
@@ -84,9 +84,9 @@ void kernel(CellIterator first, CellIterator last,
 
 /**
  * @brief Iterates over all particles in the cell range
- *        and all pairs in the verlet list of the cells.
+ *        and all pairs in the Verlet list of the cells.
  *        If rebuild is true, all neighbor cells are iterated
- *        and the verlet lists are updated with the so found pairs.
+ *        and the Verlet lists are updated with the so found pairs.
  */
 template <typename CellIterator, typename ParticleKernel, typename PairKernel,
           typename DistanceFunction, typename VerletCriterion>

--- a/src/core/bonded_interactions/angle_cosine.cpp
+++ b/src/core/bonded_interactions/angle_cosine.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file angle_cosine.cpp
+/** \file
  *
  *  Implementation of \ref angle_cosine.hpp
  */

--- a/src/core/bonded_interactions/angle_cosine.hpp
+++ b/src/core/bonded_interactions/angle_cosine.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef ANGLE_COSINE_H
 #define ANGLE_COSINE_H
-/** \file angle_cosine.hpp
+/** \file
  *  Routines to calculate the angle energy or/and and force
  *  for a particle triple.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/angle_cossquare.cpp
+++ b/src/core/bonded_interactions/angle_cossquare.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file angle_cossquare.cpp
+/** \file
  *
  *  Implementation of \ref angle_cossquare.hpp
  */

--- a/src/core/bonded_interactions/angle_cossquare.cpp
+++ b/src/core/bonded_interactions/angle_cossquare.cpp
@@ -20,7 +20,7 @@
 */
 /** \file angle_cossquare.cpp
  *
- *  Implementation of \ref angle.hpp
+ *  Implementation of \ref angle_cossquare.hpp
  */
 #include "angle_cossquare.hpp"
 

--- a/src/core/bonded_interactions/angle_cossquare.hpp
+++ b/src/core/bonded_interactions/angle_cossquare.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef ANGLE_COSSQUARE_H
 #define ANGLE_COSSQUARE_H
-/** \file angle_cossquare.hpp
+/** \file
  *  Routines to calculate the angle energy or/and and force
  *  for a particle triple.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/angle_dist.cpp
+++ b/src/core/bonded_interactions/angle_dist.cpp
@@ -18,9 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file angledist.cpp
+/** \file angle_dist.cpp
  *
- *  Implementation of \ref angledist.hpp
+ *  Implementation of \ref angle_dist.hpp
  */
 #include "angle_dist.hpp"
 

--- a/src/core/bonded_interactions/angle_dist.cpp
+++ b/src/core/bonded_interactions/angle_dist.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file angle_dist.cpp
+/** \file
  *
  *  Implementation of \ref angle_dist.hpp
  */

--- a/src/core/bonded_interactions/angle_dist.hpp
+++ b/src/core/bonded_interactions/angle_dist.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _ANGLEDIST_H
 #define _ANGLEDIST_H
-/** \file angle_dist.hpp
+/** \file
  *  Routines to calculate the angle and distance dependent (from a constraint)
  * energy or/and and force
  *  for a particle triple.

--- a/src/core/bonded_interactions/angle_dist.hpp
+++ b/src/core/bonded_interactions/angle_dist.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _ANGLEDIST_H
 #define _ANGLEDIST_H
-/** \file angledist.hpp
+/** \file angle_dist.hpp
  *  Routines to calculate the angle and distance dependent (from a constraint)
  * energy or/and and force
  *  for a particle triple.

--- a/src/core/bonded_interactions/angle_harmonic.cpp
+++ b/src/core/bonded_interactions/angle_harmonic.cpp
@@ -20,7 +20,7 @@
 */
 /** \file angle_harmonic.cpp
  *
- *  Implementation of \ref angle.hpp
+ *  Implementation of \ref angle_harmonic.hpp
  */
 #include "angle_harmonic.hpp"
 

--- a/src/core/bonded_interactions/angle_harmonic.cpp
+++ b/src/core/bonded_interactions/angle_harmonic.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file angle_harmonic.cpp
+/** \file
  *
  *  Implementation of \ref angle_harmonic.hpp
  */

--- a/src/core/bonded_interactions/angle_harmonic.hpp
+++ b/src/core/bonded_interactions/angle_harmonic.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef ANGLE_HARMONIC_H
 #define ANGLE_HARMONIC_H
-/** \file angle_harmonic.hpp
+/** \file
  *  Routines to calculate the angle energy or/and and force
  *  for a particle triple.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/bonded_coulomb.cpp
+++ b/src/core/bonded_interactions/bonded_coulomb.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file bonded_coulomb.cpp
+/** \file
  *
  *  Implementation of \ref bonded_coulomb.hpp
  */

--- a/src/core/bonded_interactions/bonded_coulomb.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb.hpp
@@ -41,11 +41,11 @@
 int bonded_coulomb_set_params(int bond_type, double prefactor);
 
 /** Computes the BONDED_COULOMB pair force and adds this
-    force to the particle forces (see \ref interaction_data.cpp).
+    force to the particle forces (see \ref nonbonded_interaction_data.cpp).
     @param p1        Pointer to first particle.
     @param p2        Pointer to second/middle particle.
     @param iaparams  bond type number of the angle interaction (see \ref
-   interaction_data.cpp).
+   nonbonded_interaction_data.cpp).
     @param dx        particle distance vector
     @param force     returns force of particle 1
     @return 0.

--- a/src/core/bonded_interactions/bonded_coulomb.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _BONDED_COULOMB_HPP
 #define _BONDED_COULOMB_HPP
-/** \file bonded_coulomb.hpp
+/** \file
  *  Routines to calculate the BONDED_COULOMB Energy or/and BONDED_COULOMB force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/bonded_coulomb_p3m_sr.cpp
+++ b/src/core/bonded_interactions/bonded_coulomb_p3m_sr.cpp
@@ -18,9 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file bonded_coulomb.cpp
+/** \file bonded_coulomb_p3m_sr.cpp
  *
- *  Implementation of \ref bonded_coulomb.hpp
+ *  Implementation of \ref bonded_coulomb_p3m_sr.hpp
  */
 #include "bonded_coulomb_p3m_sr.hpp"
 #include "communication.hpp"

--- a/src/core/bonded_interactions/bonded_coulomb_p3m_sr.cpp
+++ b/src/core/bonded_interactions/bonded_coulomb_p3m_sr.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file bonded_coulomb_p3m_sr.cpp
+/** \file
  *
  *  Implementation of \ref bonded_coulomb_p3m_sr.hpp
  */

--- a/src/core/bonded_interactions/bonded_coulomb_p3m_sr.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb_p3m_sr.hpp
@@ -24,7 +24,7 @@
  *  Routines to calculate the BONDED_COULOMB_P3M_SR Energy or/and
  * BONDED_COULOMB_P3M_SR force for a particle pair. This is only the shortrange
  * part of P3M and first used to subtract certain intramolecular interactions in
- * combination with thole damping \ref forces.cpp
+ * combination with Thole damping \ref forces.cpp
  */
 
 /************************************************************/

--- a/src/core/bonded_interactions/bonded_coulomb_p3m_sr.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb_p3m_sr.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _BONDED_COULOMB_P3M_SR_HPP
 #define _BONDED_COULOMB_P3M_SR_HPP
-/** \file bonded_coulomb_p3m_sr.hpp
+/** \file
  *  Routines to calculate the BONDED_COULOMB_P3M_SR Energy or/and
  * BONDED_COULOMB_P3M_SR force for a particle pair. This is only the shortrange
  * part of P3M and first used to subtract certain intramolecular interactions in

--- a/src/core/bonded_interactions/bonded_coulomb_p3m_sr.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb_p3m_sr.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _BONDED_COULOMB_P3M_SR_HPP
 #define _BONDED_COULOMB_P3M_SR_HPP
-/** \file bonded_coulomb.hpp
+/** \file bonded_coulomb_p3m_sr.hpp
  *  Routines to calculate the BONDED_COULOMB_P3M_SR Energy or/and
  * BONDED_COULOMB_P3M_SR force for a particle pair. This is only the shortrange
  * part of P3M and first used to subtract certain intramolecular interactions in

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -13,7 +13,7 @@ enum BondedInteraction {
   /** This bonded interaction was not set. */
   BONDED_IA_NONE = -1,
   /** Type of bonded interaction is a FENE potential
-      (to be combined with Lennard Jones). */
+      (to be combined with Lennard-Jones). */
   BONDED_IA_FENE,
   /** Type of bonded interaction is a HARMONIC potential. */
   BONDED_IA_HARMONIC,
@@ -78,7 +78,7 @@ enum TabulatedBondedInteraction {
 /*@}*/
 /** Parameters for FENE bond Potential.
 k - spring constant.
-drmax - maximal bond streching.
+drmax - maximal bond stretching.
 r0 - equilibrium bond length.
 drmax2 - square of drmax (internal parameter).
 */
@@ -350,7 +350,7 @@ struct Bonded_ia_parameters {
   Bond_parameters p;
 };
 
-/** Field containing the paramters of the bonded ia types */
+/** Field containing the parameters of the bonded ia types */
 extern std::vector<Bonded_ia_parameters> bonded_ia_params;
 
 /** Maximal interaction cutoff (real space/short range bonded interactions). */

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -148,13 +148,13 @@ struct Quartic_bond_parameters {
   double r_cut;
 };
 
-/** Parameters for coulomb bond Potential */
+/** Parameters for Coulomb bond Potential */
 struct Bonded_coulomb_bond_parameters {
   double prefactor;
 };
 
 #ifdef P3M
-/** Parameters for coulomb bond p3m shortrange Potential */
+/** Parameters for Coulomb bond p3m shortrange Potential */
 struct Bonded_coulomb_p3m_sr_bond_parameters {
   double q1q2;
 };

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -365,7 +365,6 @@ void make_bond_type_exist(int type);
 /** @brief Checks if particle has a pair bond with a given partner
  *  Note that bonds are stored only on one of the two particles in Espresso
  *
- * @param P
  * @param p          particle on which the bond may be stored
  * @param partner    bond partner
  * @param bond_type  numerical bond type */
@@ -390,9 +389,8 @@ inline bool pair_bond_exists_on(const Particle *const p,
 /** @brief Checks both particle for a specific bond. Needs GHOSTS_HAVE_BONDS if
  * particles are ghosts.
  *
- * @param P
- * @param p1          particle on which the bond may be stored
- * @param p2    	     bond partner
+ * @param p_bond      particle on which the bond may be stored
+ * @param p_partner   bond partner
  * @param bond        enum bond type */
 inline bool pair_bond_enum_exists_on(const Particle *const p_bond,
                                      const Particle *const p_partner,
@@ -414,10 +412,9 @@ inline bool pair_bond_enum_exists_on(const Particle *const p_bond,
 /** @brief Checks both particle for a specific bond. Needs GHOSTS_HAVE_BONDS if
  * particles are ghosts.
  *
- * @param P
- * @param p1          particle on which the bond may be stored
- * @param p2    	     particle on which the bond may be stored
- * @param bond_type   numerical bond type */
+ * @param p1     particle on which the bond may be stored
+ * @param p2     particle on which the bond may be stored
+ * @param bond   numerical bond type */
 inline bool pair_bond_enum_exists_between(const Particle *const p1,
                                           const Particle *const p2,
                                           BondedInteraction bond) {

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -21,7 +21,7 @@
 #ifndef CORE_BONDED_INTERACTIONS_TABULATED_HPP
 #define CORE_BONDED_INTERACTIONS_TABULATED_HPP
 
-/** \file tab.hpp
+/** \file bonded_tab.hpp
  *  Routines to calculate the  energy and/or  force
  *  for a particle pair or bonds via interpolating from lookup tables.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -43,7 +43,6 @@
 
     @param part_type_a particle type for which the interaction is defined
     @param part_type_b particle type for which the interaction is defined
-    @param filename from which file to fetch the data
 
     @return <ul>
     <li> 0 on success
@@ -66,7 +65,6 @@ int tabulated_set_params(int part_type_a, int part_type_b, double min,
     @param bond_type bond type for which the interaction is defined
     @param tab_type table type, TAB_BOND_LENGTH, TAB_BOND_ANGLE,
    TAB_BOND_DIHEDRAL
-    @param filename from which file to fetch the data
 
     @return <ul>
     <li> 0 on success

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -21,7 +21,7 @@
 #ifndef CORE_BONDED_INTERACTIONS_TABULATED_HPP
 #define CORE_BONDED_INTERACTIONS_TABULATED_HPP
 
-/** \file bonded_tab.hpp
+/** \file
  *  Routines to calculate the  energy and/or  force
  *  for a particle pair or bonds via interpolating from lookup tables.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/dihedral.cpp
+++ b/src/core/bonded_interactions/dihedral.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file dihedral.cpp
+/** \file
  *
  *  Implementation of \ref dihedral.hpp
  */

--- a/src/core/bonded_interactions/dihedral.hpp
+++ b/src/core/bonded_interactions/dihedral.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef DIHEDRAL_H
 #define DIHEDRAL_H
-/** \file dihedral.hpp Routines to calculate the dihedral energy or/and
+/** \file
+ *  Routines to calculate the dihedral energy or/and
  *  and force for a particle quadruple.  Note that usage of dihedrals
  *  increases the interaction range of bonded interactions to 2 times
  *  the maximal bond length!  \ref forces.cpp

--- a/src/core/bonded_interactions/dihedral.hpp
+++ b/src/core/bonded_interactions/dihedral.hpp
@@ -22,7 +22,7 @@
 #define DIHEDRAL_H
 /** \file
  *  Routines to calculate the dihedral energy or/and
- *  and force for a particle quadruple.  Note that usage of dihedrals
+ *  force for a particle quadruple.  Note that usage of dihedrals
  *  increases the interaction range of bonded interactions to 2 times
  *  the maximal bond length!  \ref forces.cpp
  */

--- a/src/core/bonded_interactions/fene.cpp
+++ b/src/core/bonded_interactions/fene.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file fene.cpp
+/** \file
  *
  *  Implementation of \ref fene.hpp
  */

--- a/src/core/bonded_interactions/fene.hpp
+++ b/src/core/bonded_interactions/fene.hpp
@@ -39,11 +39,11 @@
 int fene_set_params(int bond_type, double k, double drmax, double r0);
 
 /** Computes the FENE pair force and adds this
-    force to the particle forces (see \ref interaction_data.cpp).
+    force to the particle forces (see \ref bonded_interaction_data.cpp).
     @param p1        Pointer to first particle.
     @param p2        Pointer to second/middle particle.
     @param iaparams  bond type number of the angle interaction (see \ref
-   interaction_data.cpp).
+   bonded_interaction_data.cpp).
     @param dx        particle distance vector
     @param force     returns force of particle 1
     @return true if the bond is broken

--- a/src/core/bonded_interactions/fene.hpp
+++ b/src/core/bonded_interactions/fene.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _FENE_HPP
 #define _FENE_HPP
-/** \file fene.hpp
+/** \file
  *  Routines to calculate the FENE Energy or/and FENE force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/harmonic.cpp
+++ b/src/core/bonded_interactions/harmonic.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file harmonic.cpp
+/** \file
  *
  *  Implementation of \ref harmonic.hpp
  */

--- a/src/core/bonded_interactions/harmonic.hpp
+++ b/src/core/bonded_interactions/harmonic.hpp
@@ -38,11 +38,11 @@
 int harmonic_set_params(int bond_type, double k, double r, double r_cut);
 
 /** Computes the HARMONIC pair force and adds this
-    force to the particle forces (see \ref interaction_data.cpp).
+    force to the particle forces (see \ref bonded_interaction_data.cpp).
     @param p1        Pointer to first particle.
     @param p2        Pointer to second/middle particle.
     @param iaparams  bond type number of the angle interaction (see \ref
-   interaction_data.cpp).
+   bonded_interaction_data.cpp).
     @param dx        particle distance vector
     @param force     returns force of particle 1
     @return 0.

--- a/src/core/bonded_interactions/harmonic.hpp
+++ b/src/core/bonded_interactions/harmonic.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _HARMONIC_HPP
 #define _HARMONIC_HPP
-/** \file harmonic.hpp
+/** \file
  *  Routines to calculate the HARMONIC Energy or/and HARMONIC force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/harmonic_dumbbell.cpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file harmonic_dumbbell.cpp
+/** \file
  *
  *  Implementation of \ref harmonic_dumbbell.hpp
  */

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _HARMONIC_DUMBBELL_HPP
 #define _HARMONIC_DUMBBELL_HPP
-/** \file harmonic_dumbbell.hpp
+/** \file
  *  Routines to calculate the HARMONIC Energy or/and HARMONIC force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -41,11 +41,11 @@ int harmonic_dumbbell_set_params(int bond_type, double k1, double k2, double r,
                                  double r_cut);
 
 /** Computes the HARMONIC pair force and adds this
-    force to the particle forces (see \ref interaction_data.cpp).
+    force to the particle forces (see \ref bonded_interaction_data.cpp).
     @param p1        Pointer to first particle.
     @param p2        Pointer to second/middle particle.
     @param iaparams  bond type number of the angle interaction (see \ref
-   interaction_data.cpp).
+   bonded_interaction_data.cpp).
     @param dx        particle distance vector
     @param force     returns force of particle 1
     @return 0.

--- a/src/core/bonded_interactions/quartic.cpp
+++ b/src/core/bonded_interactions/quartic.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file quartic.cpp
+/** \file
  *
  *  Implementation of \ref quartic.hpp
  */

--- a/src/core/bonded_interactions/quartic.hpp
+++ b/src/core/bonded_interactions/quartic.hpp
@@ -39,11 +39,11 @@ int quartic_set_params(int bond_type, double k0, double k1, double r,
                        double r_cut);
 
 /** Computes the QUARTIC pair force and adds this
-    force to the particle forces (see \ref interaction_data.cpp).
+    force to the particle forces (see \ref bonded_interaction_data.cpp).
     @param p1        Pointer to first particle.
     @param p2        Pointer to second/middle particle.
     @param iaparams  bond type number of the angle interaction (see \ref
-   interaction_data.cpp).
+   bonded_interaction_data.cpp).
     @param dx        particle distance vector
     @param force     returns force of particle 1
     @return 0.

--- a/src/core/bonded_interactions/quartic.hpp
+++ b/src/core/bonded_interactions/quartic.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _QUARTIC_HPP
 #define _QUARTIC_HPP
-/** \file quartic.hpp
+/** \file
  *  Routines to calculate the HARMONIC Energy or/and HARMONIC force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/subt_lj.cpp
+++ b/src/core/bonded_interactions/subt_lj.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file subt_lj.cpp
+/** \file
  *
  *  Implementation of \ref subt_lj.hpp
  */

--- a/src/core/bonded_interactions/subt_lj.hpp
+++ b/src/core/bonded_interactions/subt_lj.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef SUBT_LJ_H
 #define SUBT_LJ_H
-/** \file subt_lj.hpp
+/** \file
  *  Routines to subtract the LENNARD-JONES Energy and/or the LENNARD-JONES force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/bonded_interactions/thermalized_bond.cpp
+++ b/src/core/bonded_interactions/thermalized_bond.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file thermalized_bond.cpp
+/** \file
  *
  *  Implementation of \ref thermalized_bond.hpp
  */

--- a/src/core/bonded_interactions/thermalized_bond.hpp
+++ b/src/core/bonded_interactions/thermalized_bond.hpp
@@ -24,7 +24,7 @@
 #define THERMALIZED_DIST_H
 /** \file thermalized_bond.hpp
  *  Routines to thermalize the com and distance of a particle pair.
- *  \ref forces.c
+ *  \ref forces.cpp
  */
 
 /** number of thermalized bonds */

--- a/src/core/bonded_interactions/thermalized_bond.hpp
+++ b/src/core/bonded_interactions/thermalized_bond.hpp
@@ -22,7 +22,7 @@
 
 #ifndef THERMALIZED_DIST_H
 #define THERMALIZED_DIST_H
-/** \file thermalized_bond.hpp
+/** \file
  *  Routines to thermalize the com and distance of a particle pair.
  *  \ref forces.cpp
  */

--- a/src/core/bonded_interactions/umbrella.cpp
+++ b/src/core/bonded_interactions/umbrella.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file umbrella.cpp
+/** \file
  *
  *  Implementation of \ref umbrella.hpp
  */

--- a/src/core/bonded_interactions/umbrella.hpp
+++ b/src/core/bonded_interactions/umbrella.hpp
@@ -24,7 +24,7 @@
 /** \file
  *  Routines to calculate the umbrella energy and/or  force
  *  for a particle pair: harmonic interaction in only one
- *  cartesian direction. Useful for umbrella sampling simulations.
+ *  Cartesian direction. Useful for umbrella sampling simulations.
  *  \ref forces.cpp
  */
 

--- a/src/core/bonded_interactions/umbrella.hpp
+++ b/src/core/bonded_interactions/umbrella.hpp
@@ -21,7 +21,7 @@
 #ifndef umbrella_H
 #define umbrella_H
 
-/** \file umbrella.hpp
+/** \file
  *  Routines to calculate the umbrella energy and/or  force
  *  for a particle pair: harmonic interaction in only one
  *  cartesian direction. Useful for umbrella sampling simulations.

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file cells.cpp
+/** \file
  *
  *  This file contains functions for the cell system.
  *

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -185,7 +185,7 @@ static void topology_release(int cs) {
 /** Switch for choosing the topology init function of a certain
     cell system. */
 void topology_init(int cs, CellPList *local) {
-  /** broadcast the flag for using verlet list */
+  /** broadcast the flag for using Verlet list */
   boost::mpi::broadcast(comm_cart, cell_structure.use_verlet_list, 0);
 
   switch (cs) {
@@ -333,7 +333,7 @@ void cells_resort_particles(int global_flag) {
   ghost_communicator(&cell_structure.ghost_cells_comm);
   ghost_communicator(&cell_structure.exchange_ghosts_comm);
 
-  /* Particles are now sorted, but verlet lists are invalid
+  /* Particles are now sorted, but Verlet lists are invalid
      and p_old has to be reset. */
   resort_particles = Cells::RESORT_NONE;
   rebuild_verletlist = 1;

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _CELLS_H
 #define _CELLS_H
-/** \file cells.hpp
+/** \file
     This file contains everything related to the cell structure / cell
     system.
 

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -57,7 +57,7 @@ Collision_parameters collision_params;
  * needs to be placed. At this point, all modes need this */
 inline bool bind_centers() {
   // Note that the glue to surface mode adds bonds between the centers
-  // but does so later in the process. This is needed to gaurantee that
+  // but does so later in the process. This is needed to guarantee that
   // a particle can only be glued once, even if queued twice in a single
   // time step
   return collision_params.mode != COLLISION_MODE_OFF &&
@@ -549,7 +549,7 @@ void handle_collisions() {
   }
 
   // Note that the glue to surface mode adds bonds between the centers
-  // but does so later in the process. This is needed to gaurantee that
+  // but does so later in the process. This is needed to guarantee that
   // a particle can only be glued once, even if queued twice in a single
   // time step
   if (bind_centers()) {

--- a/src/core/comfixed_global.cpp
+++ b/src/core/comfixed_global.cpp
@@ -16,7 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file comfixed_global.cpp
+/** \file
  *
  *  Implementation of \ref comfixed_global.hpp
  */

--- a/src/core/comfixed_global.cpp
+++ b/src/core/comfixed_global.cpp
@@ -16,9 +16,9 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file comfixed.cpp
+/** \file comfixed_global.cpp
  *
- *  Implementation of \ref comfixed.hpp
+ *  Implementation of \ref comfixed_global.hpp
  */
 #include "comfixed_global.hpp"
 

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _COMMUNICATION_HPP
 #define _COMMUNICATION_HPP
-/** \file communication.hpp
+/** \file
     This file contains the asynchronous MPI communication.
 
     It is the header file for \ref communication.cpp "communication.cpp".

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -23,7 +23,7 @@
 /** \file communication.hpp
     This file contains the asynchronous MPI communication.
 
-    It is the header file for \ref communication.cpp "communication.c".
+    It is the header file for \ref communication.cpp "communication.cpp".
 
     The asynchronous MPI communication is used during the script
     evaluation. Except for the master node that interprets the Tcl

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -370,7 +370,6 @@ void mpi_remove_particle(int node, int id);
     and exclusions are left over.
     \param part the particle.
     \param node the node it is attached to.
-    \param part_data where to store the received data.
     \note Gets a copy of the particle data not a pointer to the actual particle
     used in integration
 */

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -465,7 +465,7 @@ void mpi_local_stress_tensor(DoubleList *TensorInBin, int bins[3],
 */
 void mpi_set_time_step(double time_step);
 
-/** Issue REQ_BCAST_COULOMB: send new coulomb parameters. */
+/** Issue REQ_BCAST_COULOMB: send new Coulomb parameters. */
 void mpi_bcast_coulomb_params();
 
 /** send new collision parameters. */

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -137,7 +137,7 @@ extern const char *ESPRESSO_VERSION;
 #define MAX_OBJECTS_IN_FLUID 10000
 #endif
 
-/** number of fluid components for lattice boltzmann  */
+/** number of fluid components for lattice Boltzmann  */
 #ifndef LB_COMPONENTS
 #ifdef SHANCHEN
 #define LB_COMPONENTS 2

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -21,7 +21,7 @@
 #ifndef _CONFIG_HPP
 #define _CONFIG_HPP
 
-/** \file config.hpp
+/** \file
 
     This file contains the defaults for Espresso. To modify them, add
     an appropriate line in myconfig.hpp. To find a list of features that

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -39,7 +39,7 @@ static __device__ __constant__ CUDA_global_part_vars global_part_vars_device;
 static float *particle_forces_device = nullptr;
 static float *particle_torques_device = nullptr;
 
-/** struct for particle position and veloctiy */
+/** struct for particle position and velocity */
 static CUDA_particle_data *particle_data_device = nullptr;
 /** struct for storing particle rn seed */
 static CUDA_particle_seed *particle_seeds_device = nullptr;
@@ -115,7 +115,7 @@ __device__ unsigned int getThreadIndex() {
          threadIdx.x;
 }
 
-/** kernel for the initalisation of the particle force array
+/** kernel for the initialisation of the particle force array
  * @param *particle_forces_device	    Pointer to local particle force
  * (Output)
  * @param *particle_seeds_device			Pointer to the particle
@@ -145,7 +145,7 @@ __global__ void init_particle_force(float *particle_forces_device,
   }
 }
 
-/** kernel for the initalisation of the fluid composition
+/** kernel for the initialisation of the fluid composition
  * @param *fluid_composition_device Pointer to local fluid composition (Output)
  */
 __global__ void
@@ -163,7 +163,7 @@ init_fluid_composition(CUDA_fluid_composition *fluid_composition_device) {
   }
 }
 
-/** kernel for the initalisation of the partikel force array
+/** kernel for the initialisation of the particle force array
  * @param *particle_forces_device	pointer to local particle force (Input)
  */
 __global__ void reset_particle_force(float *particle_forces_device,

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file debug.cpp
+/** \file
     Implements the malloc replacements as described in \ref debug.hpp
    "debug.hpp".
 */

--- a/src/core/debug.hpp
+++ b/src/core/debug.hpp
@@ -22,7 +22,7 @@
  This file controls debug facilities.
 
  The implementation is found in
- \ref debug.cpp "debug.c".
+ \ref debug.cpp "debug.cpp".
 
  For every define there exists a macro that can be used to encapsulate short
  lines (like printf("...",...);)

--- a/src/core/debug.hpp
+++ b/src/core/debug.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file debug.hpp
+/** \file
  This file controls debug facilities.
 
  The implementation is found in

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -492,7 +492,7 @@ void dd_update_communicators_w_boxl() {
 
 /** Init cell interactions for cell system domain decomposition.
  * initializes the interacting neighbor cell list of a cell The
- * created list of interacting neighbor cells is used by the verlet
+ * created list of interacting neighbor cells is used by the Verlet
  * algorithm (see verlet.cpp) to build the verlet lists.
  */
 void dd_init_cell_interactions() {

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file domain_decomposition.cpp
+/** \file
  *
  *  This file contains everything related to the cell system: domain
  * decomposition.

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -21,7 +21,7 @@
 #ifndef _DOMAIN_DECOMPOSITION_H
 #define _DOMAIN_DECOMPOSITION_H
 
-/** \file domain_decomposition.hpp
+/** \file
  *
  *  This file contains everything related to the cell system: domain
  * decomposition.

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -27,14 +27,14 @@
  * decomposition.
  *
  *  The simulation box is split into spatial domains for each node
- *  according to a cartesian node grid (\ref node_grid).
+ *  according to a Cartesian node grid (\ref node_grid).
  *
  *  The domain of a node is split into a 3D cell grid with dimension
  *  \ref DomainDecomposition::cell_grid. Together with one ghost cell
  *  layer on each side the overall dimension of the ghost cell grid is
  *  \ref DomainDecomposition::ghost_cell_grid. The domain
  *  decomposition enables one the use of the linked cell algorithm
- *  which is in turn used for setting up the verlet list for the
+ *  which is in turn used for setting up the Verlet list for the
  *  system. You can see a 2D graphical representation of the linked
  *  cell grid below.
  *

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file dpd.cpp
+/** \file
     Implementation of \ref dpd.hpp "dpd.hpp"
  */
 #include "dpd.hpp"

--- a/src/core/dpd.hpp
+++ b/src/core/dpd.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef CORE_DPD_HPP
 #define CORE_DPD_HPP
-/** \file dpd.hpp
+/** \file
  *  Routines to use dpd as thermostat or pair force
  *  T. Soddemann, B. Duenweg and K. Kremer, Phys. Rev. E 68, 046702 (2003)
  *  \ref forces.cpp

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file debye_hueckel.cpp
+/** \file
  *
  *  Implementation of \ref debye_hueckel.hpp
  */

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
@@ -68,7 +68,7 @@ inline void add_dh_coulomb_pair_force(Particle *p1, Particle *p2, double d[3],
       fac = coulomb.prefactor * p1->p.q * p2->p.q *
             (exp(-kappa_dist) / (dist * dist * dist)) * (1.0 + kappa_dist);
     } else {
-      /* pure coulomb case: */
+      /* pure Coulomb case: */
       fac = coulomb.prefactor * p1->p.q * p2->p.q / (dist * dist * dist);
     }
     for (int j = 0; j < 3; j++)

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef DEBYE_HUECKEL_H
 #define DEBYE_HUECKEL_H
-/** \file debye_hueckel.hpp
+/** \file
  *  Routines to calculate the Debye_Hueckel  Energy or/and Debye_Hueckel force
  *  for a particle pair.
  */

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file elc.cpp
+/** \file
  *
  *  For more information about ELC, see \ref
  * electrostatics_magnetostatics/elc.hpp

--- a/src/core/electrostatics_magnetostatics/elc.hpp
+++ b/src/core/electrostatics_magnetostatics/elc.hpp
@@ -20,7 +20,7 @@
 */
 /** \file
    ELC algorithm for long range
-   coulomb interactions. Implementation of the ELC method for the calculation of
+   Coulomb interactions. Implementation of the ELC method for the calculation of
    the electrostatic interaction in two dimensional periodic systems. For
     details on the method see MMM in general. The ELC method works
     together with any three dimensional method, which in Espresso is

--- a/src/core/electrostatics_magnetostatics/elc.hpp
+++ b/src/core/electrostatics_magnetostatics/elc.hpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file electrostatics_magnetostatics/elc.hpp ELC algorithm for long range
+/** \file
+   ELC algorithm for long range
    coulomb interactions. Implementation of the ELC method for the calculation of
    the electrostatic interaction in two dimensional periodic systems. For
     details on the method see MMM in general. The ELC method works

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -19,9 +19,9 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** \file iccp3m.cpp
+/** \file icc.cpp
   Detailed Information about the method is included in the corresponding header
-  file \ref iccp3m.hpp.
+  file \ref icc.hpp.
 */
 
 #include <cmath>

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -19,7 +19,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** \file icc.cpp
+/** \file
   Detailed Information about the method is included in the corresponding header
   file \ref icc.hpp.
 */

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -75,7 +75,7 @@ inline void init_ghost_force_iccp3m(Particle *part);
  */
 void force_calc_iccp3m();
 
-/** Variant of add_non_bonded_pair_force where only coulomb
+/** Variant of add_non_bonded_pair_force where only Coulomb
  *  contributions are calculated   */
 inline void add_non_bonded_pair_force_iccp3m(Particle *p1, Particle *p2,
                                              double d[3], double dist,
@@ -90,7 +90,7 @@ inline void add_non_bonded_pair_force_iccp3m(Particle *p1, Particle *p2,
   /* long range electrostatics                   */
   /***********************************************/
 
-  /* real space coulomb */
+  /* real space Coulomb */
   auto const q1q2 = p1->p.q * p2->p.q;
   switch (coulomb.method) {
 #ifdef P3M

--- a/src/core/electrostatics_magnetostatics/icc.hpp
+++ b/src/core/electrostatics_magnetostatics/icc.hpp
@@ -20,7 +20,7 @@
 */
 //
 
-/** \file icc.hpp
+/** \file
 
     ICCP3M is a method that allows to take into account the influence
     of arbitrarily shaped dielectric interfaces.  The dielectric

--- a/src/core/electrostatics_magnetostatics/icc.hpp
+++ b/src/core/electrostatics_magnetostatics/icc.hpp
@@ -20,7 +20,7 @@
 */
 //
 
-/** \file iccp3m.hpp
+/** \file icc.hpp
 
     ICCP3M is a method that allows to take into account the influence
     of arbitrarily shaped dielectric interfaces.  The dielectric

--- a/src/core/electrostatics_magnetostatics/icc.hpp
+++ b/src/core/electrostatics_magnetostatics/icc.hpp
@@ -43,7 +43,7 @@
     it can be tolerated.
 
     For the determination of the induced charges only the forces
-    acting on the induced charges has to be determined. As P3M an the
+    acting on the induced charges has to be determined. As P3M and the
     other coulomb solvers calculate all mutual forces, the force
     calculation was modified to avoid the calculation of the short
     range part of the source-source force calculation.  For different

--- a/src/core/electrostatics_magnetostatics/icc.hpp
+++ b/src/core/electrostatics_magnetostatics/icc.hpp
@@ -44,7 +44,7 @@
 
     For the determination of the induced charges only the forces
     acting on the induced charges has to be determined. As P3M and the
-    other coulomb solvers calculate all mutual forces, the force
+    other Coulomb solvers calculate all mutual forces, the force
     calculation was modified to avoid the calculation of the short
     range part of the source-source force calculation.  For different
     particle data organisation schemes this is performed differently.

--- a/src/core/electrostatics_magnetostatics/maggs.cpp
+++ b/src/core/electrostatics_magnetostatics/maggs.cpp
@@ -20,7 +20,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file maggs.cpp
+/** \file
  *  Maxwell Equations Molecular Dynamics (MEMD) method for electrostatic
  *  interactions.
  *

--- a/src/core/electrostatics_magnetostatics/maggs.hpp
+++ b/src/core/electrostatics_magnetostatics/maggs.hpp
@@ -20,7 +20,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** \file maggs.hpp
+/** \file
  *  Maxwell Equations Molecular Dynamics (MEMD) method for electrostatic
  *  interactions.
  *

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file magnetic_non_p3m_methods.cpp  All 3d non P3M methods to deal with the
+/** \file
+ * All 3d non P3M methods to deal with the
  * magnetic dipoles
  *
  *  DAWAANR => DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.hpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef MAG_NON_P3M_H
 #define MAG_NON_P3M_H
-/** \file electrostatics_magnetostatics/magnetic_non_p3m_methods.hpp   Header of
+/** \file
+ * Header of
  * all 3d non P3M methods to deal with the magnetic dipoles
  *
  *  DAWAANR => DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -576,12 +576,12 @@ double add_mdlc_energy_corrections() {
    same
    value of the dipolar momentum modulus (mu_max). mu_max is taken as the
    largest value of
-   mu inside the system. If we assum the gap has a width gap_size (within which
+   mu inside the system. If we assume the gap has a width gap_size (within which
    there is no particles)
 
    Lz=h+gap_size
 
-   BE CAREFUL:  (1) We assum the short distance for the slab to be in the Z
+   BE CAREFUL:  (1) We assume the short distance for the slab to be in the Z
    direction
    (2) You must also tune the other 3D method to the same accuracy, otherwise
    it has no sense to have a good accurate result for DLC-dipolar.

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file p3m.hpp  code for calculating the MDLC (magnetic dipolar layer
+/** \file
+ * code for calculating the MDLC (magnetic dipolar layer
  *correction).
  *  Purpose:   get the corrections for dipolar 3D algorithms
  *             when applied to a slab geometry and dipolar

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.hpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.hpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file p3m.hpp   main header-file for MDLC (magnetic dipolar layer
+/** \file
+ * main header-file for MDLC (magnetic dipolar layer
  *correction).
  *
  *  Developer: Joan J. Cerda.

--- a/src/core/electrostatics_magnetostatics/mmm-common.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm-common.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mmm-common.cpp
+/** \file
     Common parts of the MMM family of methods for the
     electrostatic interaction, MMM1D, MMM2D and ELC.  This file contains the
    code for the polygamma expansions used for the near formulas of MMM1D and

--- a/src/core/electrostatics_magnetostatics/mmm-common.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm-common.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mmm-common.hpp
+/** \file
     modified polygamma functions. See Arnold,Holm 2002
 */
 #ifndef MMM_COMMON_H

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -20,7 +20,7 @@
 */
 /** \file mmm1d.cpp  MMM1D algorithm for long range coulomb interaction.
  *
- *  For more information about MMM1D, see \ref mmm1d.hpp "mmm1d.h".
+ *  For more information about MMM1D, see \ref mmm1d.hpp "mmm1d.hpp".
  */
 
 #include "electrostatics_magnetostatics/mmm1d.hpp"

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file
- *  MMM1D algorithm for long range coulomb interaction.
+ *  MMM1D algorithm for long range Coulomb interaction.
  *
  *  For more information about MMM1D, see \ref mmm1d.hpp "mmm1d.hpp".
  */
@@ -64,7 +64,7 @@ static double uz, L2, uz2, prefuz2, prefL3_i;
 /*@}*/
 
 MMM1D_struct mmm1d_params = {0.05, 1e-5};
-/** From which distance a certain bessel cutoff is valid. Can't be part of the
+/** From which distance a certain Bessel cutoff is valid. Can't be part of the
     params since these get broadcasted. */
 static double *bessel_radii;
 

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mmm1d.cpp  MMM1D algorithm for long range coulomb interaction.
+/** \file
+ *  MMM1D algorithm for long range coulomb interaction.
  *
  *  For more information about MMM1D, see \ref mmm1d.hpp "mmm1d.hpp".
  */

--- a/src/core/electrostatics_magnetostatics/mmm1d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.hpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mmm1d.hpp MMM1D algorithm for long range coulomb interactions.
+/** \file
+    MMM1D algorithm for long range coulomb interactions.
     Implementation of the MMM1D method for the calculation of the electrostatic
     interaction in one dimensionally periodic systems. For details on the
     method see MMM in general. The MMM1D method works only with the nsquared,

--- a/src/core/electrostatics_magnetostatics/mmm1d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.hpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file
-    MMM1D algorithm for long range coulomb interactions.
+    MMM1D algorithm for long range Coulomb interactions.
     Implementation of the MMM1D method for the calculation of the electrostatic
     interaction in one dimensionally periodic systems. For details on the
     method see MMM in general. The MMM1D method works only with the nsquared,
@@ -40,7 +40,7 @@ typedef struct {
   double far_switch_radius_2;
   /** required accuracy */
   double maxPWerror;
-  /** cutoff of the bessel sum. only used by the GPU implementation */
+  /** cutoff of the Bessel sum. only used by the GPU implementation */
   int bessel_cutoff;
 } MMM1D_struct;
 extern MMM1D_struct mmm1d_params;

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mmm2d.cpp  MMM2D algorithm for long range coulomb interaction.
+/** \file
+ *  MMM2D algorithm for long range coulomb interaction.
  *
  *  For more information about MMM2D, see \ref mmm2d.hpp "mmm2d.hpp".
  */

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file
- *  MMM2D algorithm for long range coulomb interaction.
+ *  MMM2D algorithm for long range Coulomb interaction.
  *
  *  For more information about MMM2D, see \ref mmm2d.hpp "mmm2d.hpp".
  */
@@ -107,7 +107,7 @@ char const *mmm2d_errors[] = {
 /** up to that error the sums in the NF are evaluated */
 static double part_error;
 
-/** cutoffs for the bessel sum */
+/** cutoffs for the Bessel sum */
 static IntList besselCutoff;
 
 /** cutoffs for the complex sum */
@@ -121,7 +121,7 @@ static double ux, ux2, uy, uy2, uz;
 /*@}*/
 
 /** maximal z for near formula, minimal z for far formula.
-    Is identical in the theory, but with the verlet tricks
+    Is identical in the theory, but with the Verlet tricks
     this is no longer true, the skin has to be added/subtracted */
 /*@{*/
 static double max_near, min_far;
@@ -138,7 +138,7 @@ MMM2D_struct mmm2d_params = {1e100, 10, 1, 0, 0, 0, 0, 1, 1, 1};
 #define ERROR_LARGE 1
 /** box too large */
 #define ERROR_BOXL 2
-/** no reasonable bessel cutoff found */
+/** no reasonable Bessel cutoff found */
 #define ERROR_BESSEL 3
 /** no reasonable polygamma cutoff found */
 #define ERROR_POLY 4
@@ -1308,7 +1308,7 @@ static int MMM2D_tune_near(double error) {
     return ERROR_BOXL;
 
   /* error is split into three parts:
-     one part for bessel, one for complex
+     one part for Bessel, one for complex
      and one for polygamma cutoff */
   part_error = error / 3;
 
@@ -1384,7 +1384,7 @@ static void prepareBernoulliNumbers(int bon_order) {
 
   bon.resize(bon_order);
 
-  /* the ux is multiplied in to bessel, complex and psi at once, not here,
+  /* the ux is multiplied in to Bessel, complex and psi at once, not here,
      and we use uy*(z + iy), so the uy is also treated below */
   for (l = 1; (l <= bon_order) && (l < 34); l++)
     bon[l - 1] = 2 * uy * bon_table[l];
@@ -1458,7 +1458,7 @@ void add_mmm2d_coulomb_pair_force(double charge_factor, double d[3], double dl2,
         k1ySum += k1 * ypl;
       }
 
-      /* the ux is multiplied in to bessel, complex and psi at once, not here */
+      /* the ux is multiplied in to Bessel, complex and psi at once, not here */
       c = 4 * freq * cos(freq * d[0]);
       s = 4 * freq * sin(freq * d[0]);
       F[0] += s * k0Sum;
@@ -1514,7 +1514,7 @@ void add_mmm2d_coulomb_pair_force(double charge_factor, double d[3], double dl2,
     double mpe, mpo;
 
     /* n = 0 inflicts only Fx and pot */
-    /* one ux is multiplied in to bessel, complex and psi at once, not here */
+    /* one ux is multiplied in to Bessel, complex and psi at once, not here */
     F[0] += ux * mod_psi_odd(0, uxx);
 
     uxrho_2nm2 = 1.0;
@@ -1599,7 +1599,7 @@ inline double calc_mmm2d_copy_pair_energy(double d[3]) {
         k0Sum += K0(freq * rho_l);
       }
 
-      /* the ux is multiplied in to bessel, complex and psi at once, not here */
+      /* the ux is multiplied in to Bessel, complex and psi at once, not here */
       c = 4 * cos(freq * d[0]);
       eng += c * k0Sum;
     }
@@ -1649,7 +1649,7 @@ inline double calc_mmm2d_copy_pair_energy(double d[3]) {
     double uxrho_2n;
 
     /* n = 0 inflicts only Fx and pot */
-    /* one ux is multiplied in to bessel, complex and psi at once, not here */
+    /* one ux is multiplied in to Bessel, complex and psi at once, not here */
     eng -= mod_psi_even(0, uxx);
 
     uxrho_2n = uxrho2;

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -20,7 +20,7 @@
 */
 /** \file mmm2d.cpp  MMM2D algorithm for long range coulomb interaction.
  *
- *  For more information about MMM2D, see \ref mmm2d.hpp "mmm2d.h".
+ *  For more information about MMM2D, see \ref mmm2d.hpp "mmm2d.hpp".
  */
 
 #include "electrostatics_magnetostatics/mmm2d.hpp"

--- a/src/core/electrostatics_magnetostatics/mmm2d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.hpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mmm2d.hpp MMM2D algorithm for long range coulomb interaction
+/** \file
+    MMM2D algorithm for long range coulomb interaction
     in 2d+h geometries.  Implementation of the MMM2D method for the calculation
     of the electrostatic interaction for two dimensionally periodic systems.
     For details on the method see MMM general. The MMM2D method works only with

--- a/src/core/electrostatics_magnetostatics/mmm2d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.hpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file
-    MMM2D algorithm for long range coulomb interaction
+    MMM2D algorithm for long range Coulomb interaction
     in 2d+h geometries.  Implementation of the MMM2D method for the calculation
     of the electrostatic interaction for two dimensionally periodic systems.
     For details on the method see MMM general. The MMM2D method works only with

--- a/src/core/electrostatics_magnetostatics/p3m-common.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file p3m-common.cpp P3M main file.
+/** \file
+ *  P3M main file.
  */
 #include "p3m-common.hpp"
 

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef _P3M_COMMON_H
 #define _P3M_COMMON_H
-/** \file p3m-common.hpp   common functions for dipolar and charge p3m.
+/** \file
+ *  common functions for dipolar and charge p3m.
  *
  *  We use here a P3M (Particle-Particle Particle-Mesh) method based
  *  on the Ewald summation. Details of the used method can be found in

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -1782,7 +1782,8 @@ static double dp3m_m_time(char **log, int mesh, int cao_min, int cao_max,
                           double *_accuracy) {
   double best_time = -1, tmp_time, tmp_r_cut_iL, tmp_alpha_L = 0.0,
          tmp_accuracy = 0.0;
-  /* in which direction improvement is possible. Initially, we don't know it yet.
+  /* in which direction improvement is possible. Initially, we don't know it
+   * yet.
    */
   int final_dir = 0;
   int cao = *_cao;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -1586,7 +1586,7 @@ double dp3m_perform_aliasing_sums_energy(int n[3], double nominator[1]) {
     error contributions of real and reciprocal space should be equal.
 
     After checking if the total error fulfills the accuracy goal the
-    time needed for one force calculation (including verlet list
+    time needed for one force calculation (including Verlet list
     update) is measured via \ref mpi_integrate (0).
 
     The function returns a log of the performed tuning.

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -1782,7 +1782,7 @@ static double dp3m_m_time(char **log, int mesh, int cao_min, int cao_max,
                           double *_accuracy) {
   double best_time = -1, tmp_time, tmp_r_cut_iL, tmp_alpha_L = 0.0,
          tmp_accuracy = 0.0;
-  /* in which direction improvement is possible. Initially, we dont know it yet.
+  /* in which direction improvement is possible. Initially, we don't know it yet.
    */
   int final_dir = 0;
   int cao = *_cao;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file p3m-dipolar.cpp  P3M algorithm for long range magnetic dipole-dipole
+/** \file
+ *  P3M algorithm for long range magnetic dipole-dipole
  interaction.
  *
  NB: In general the magnetic dipole-dipole functions bear the same

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef _P3M_MAGNETOSTATICS_H
 #define _P3M_MAGNETOSTATICS_H
-/** \file p3m-dipolar.hpp P3M algorithm for long range magnetic dipole-dipole
+/** \file
+ * P3M algorithm for long range magnetic dipole-dipole
  * interaction.
  *
  *  We use here a P3M (Particle-Particle Particle-Mesh) method based

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -207,11 +207,11 @@ double p3m_perform_aliasing_sums_energy(int n[3]);
 /** Calculates the real space contribution to the rms error in the force (as
    described
    by Kolafa and Perram).
-   \param prefac   Prefactor of coulomb interaction.
+   \param prefac   Prefactor of Coulomb interaction.
    \param r_cut_iL rescaled real space cutoff for p3m method.
    \param n_c_part number of charged particles in the system.
    \param sum_q2   sum of square of charges in the system
-   \param alpha_L  rescaled ewald splitting parameter.
+   \param alpha_L  rescaled Ewald splitting parameter.
    \return real space error
 */
 static double p3m_real_space_error(double prefac, double r_cut_iL, int n_c_part,
@@ -221,12 +221,12 @@ static double p3m_real_space_error(double prefac, double r_cut_iL, int n_c_part,
     P3M method in the book of Hockney and Eastwood (Eqn. 8.23) in
     order to obtain the rms error in the force for a system of N
     randomly distributed particles in a cubic box (k space part).
-    \param prefac   Prefactor of coulomb interaction.
+    \param prefac   Prefactor of Coulomb interaction.
     \param mesh     number of mesh points in one direction.
     \param cao      charge assignment order.
     \param n_c_part number of charged particles in the system.
     \param sum_q2   sum of square of charges in the system
-    \param alpha_L  rescaled ewald splitting parameter.
+    \param alpha_L  rescaled Ewald splitting parameter.
     \return reciprocal (k) space error
 */
 static double p3m_k_space_error(double prefac, int mesh[3], int cao,
@@ -2332,7 +2332,7 @@ void p3m_calc_kspace_stress(double *stress) {
     double force_prefac, node_k_space_energy, sqk, vterm, kx, ky, kz;
 
     int j[3], i, ind = 0;
-    // ordering after fourier transform
+    // ordering after Fourier transform
     node_k_space_stress = (double *)Utils::malloc(9 * sizeof(double));
     k_space_stress = (double *)Utils::malloc(9 * sizeof(double));
 

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -1576,7 +1576,7 @@ static double p3m_m_time(char **log, int mesh[3], int cao_min, int cao_max,
                          double *_accuracy) {
   double best_time = -1, tmp_time, tmp_r_cut_iL = 0.0, tmp_alpha_L = 0.0,
          tmp_accuracy = 0.0;
-  /* in which direction improvement is possible. Initially, we dont know it
+  /* in which direction improvement is possible. Initially, we don't know it
    * yet.
    */
   int final_dir = 0;

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -21,7 +21,7 @@
 #ifndef _P3M_H
 #define _P3M_H
 /** \file
- *  P3M algorithm for long range coulomb interaction.
+ *  P3M algorithm for long range Coulomb interaction.
  *
  *  We use a P3M (Particle-Particle Particle-Mesh) method based on the
  *  Ewald summation. Details of the used method can be found in
@@ -191,7 +191,7 @@ enum P3M_TUNE_ERROR {
    that the error contributions of real and reciprocal space should be equal.
 
     After checking if the total error fulfills the accuracy goal the
-    time needed for one force calculation (including verlet list
+    time needed for one force calculation (including Verlet list
     update) is measured via \ref mpi_integrate (0).
 
     The function returns a log of the performed tuning.
@@ -214,7 +214,7 @@ void p3m_assign_charge(double q, Vector3d &real_pos, int cp_cnt);
 /** shrink wrap the charge grid */
 void p3m_shrink_wrap_charge_grid(int n_charges);
 
-/** Calculate real space contribution of coulomb pair forces.
+/** Calculate real space contribution of Coulomb pair forces.
     If NPT is compiled in, it returns the energy, which is needed for NPT. */
 inline double p3m_add_pair_force(double chgfac, double *d, double dist2,
                                  double dist, double force[3]) {
@@ -259,7 +259,7 @@ int p3m_set_eps(double eps);
 
 int p3m_set_ninterpol(int n);
 
-/** Calculate real space contribution of coulomb pair energy. */
+/** Calculate real space contribution of Coulomb pair energy. */
 inline double p3m_pair_energy(double chgfac, double dist) {
   if (dist < p3m.params.r_cut && dist != 0) {
     double adist = p3m.params.alpha * dist;

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef _P3M_H
 #define _P3M_H
-/** \file p3m.hpp P3M algorithm for long range coulomb interaction.
+/** \file
+ *  P3M algorithm for long range coulomb interaction.
  *
  *  We use a P3M (Particle-Particle Particle-Mesh) method based on the
  *  Ewald summation. Details of the used method can be found in

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -17,7 +17,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file p3m_gpu_cuda.cu
+/** \file
  *
  * Cuda (.cu) file for the P3M electrostatics method.
  * Header file \ref p3m_gpu.hpp .

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_error_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_error_cuda.cu
@@ -12,7 +12,7 @@
 #error CU-file includes mpi.h! This should not happen!
 #endif
 
-/** @TODO: Extend to hight order. This comes from some 1/sin expansion in
+/** @todo Extend to higher order. This comes from some 1/sin expansion in
  * Hockney/Eastwood */
 
 template <int cao>

--- a/src/core/electrostatics_magnetostatics/scafacos.cpp
+++ b/src/core/electrostatics_magnetostatics/scafacos.cpp
@@ -314,7 +314,7 @@ void tune() {
   /** Check if there is a user supplied cutoff */
   if ((scafacos->has_near) && (scafacos->r_cut() <= 0.0)) {
     // Tuning of r_cut needs to run on the master node because it relies on
-    // master-slve mode communication
+    // master-slave mode communication
     if (this_node == 0) {
       tune_r_cut();
     } else {

--- a/src/core/electrostatics_magnetostatics/scafacos.cpp
+++ b/src/core/electrostatics_magnetostatics/scafacos.cpp
@@ -273,7 +273,7 @@ double time_r_cut(double r_cut) {
 /** Determine the optimal cutoff by bisection */
 void tune_r_cut() {
   const double tune_limit = 1e-3;
-  /** scafacos p3m and ewald do not accept r_cut 0 for no good reason */
+  /** scafacos p3m and Ewald do not accept r_cut 0 for no good reason */
   double r_min = 1.0;
   double r_max = std::min(min_local_box_l, min_box_l / 2.0) - skin;
   double t_min = 0;

--- a/src/core/electrostatics_magnetostatics/scafacos.hpp
+++ b/src/core/electrostatics_magnetostatics/scafacos.hpp
@@ -19,7 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file scafacos.hpp This file contains the c-type wrapper interface to the (oop-) scafacos
+/** \file
+ * This file contains the c-type wrapper interface to the (oop-) scafacos
  * interface. */
 
 #ifndef __SCAFACOS_HPP

--- a/src/core/electrostatics_magnetostatics/scafacos.hpp
+++ b/src/core/electrostatics_magnetostatics/scafacos.hpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file This file contains the c-type wrapper interface to the (oop-) scafacos
+/** \file scafacos.hpp This file contains the c-type wrapper interface to the (oop-) scafacos
  * interface. */
 
 #ifndef __SCAFACOS_HPP

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file energy.cpp
+/** \file
     Implementation of \ref energy.hpp "energy.hpp".
 */
 

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file energy.hpp
+/** \file
     Implementation of the energy calculation.
 */
 

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file energy_inline.hpp
+/** \file
     Implementation of the energy calculation.
 */
 #ifndef ENERGY_INLINE_HPP

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -97,12 +97,12 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef LENNARD_JONES
-  /* lennard jones */
+  /* lennard-jones */
   ret += lj_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
 #ifdef LENNARD_JONES_GENERIC
-  /* Generic lennard jones */
+  /* Generic lennard-jones */
   ret += ljgen_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
@@ -132,7 +132,7 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef BUCKINGHAM
-  /* lennard jones */
+  /* Buckingham */
   ret += buck_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
@@ -147,7 +147,7 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef LJCOS2
-  /* lennard jones */
+  /* lennard-jones */
   ret += ljcos2_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
@@ -162,7 +162,7 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef LJCOS
-  /* lennard jones cosine */
+  /* lennard-jones cosine */
   ret += ljcos_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -97,12 +97,12 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef LENNARD_JONES
-  /* lennard-jones */
+  /* Lennard-Jones */
   ret += lj_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
 #ifdef LENNARD_JONES_GENERIC
-  /* Generic lennard-jones */
+  /* Generic Lennard-Jones */
   ret += ljgen_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
@@ -127,7 +127,7 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef MORSE
-  /* morse */
+  /* Morse */
   ret += morse_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
@@ -147,12 +147,12 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef LJCOS2
-  /* lennard-jones */
+  /* Lennard-Jones */
   ret += ljcos2_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
 #ifdef THOLE
-  /* thole damping */
+  /* Thole damping */
   ret += thole_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
@@ -162,7 +162,7 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
 #endif
 
 #ifdef LJCOS
-  /* lennard-jones cosine */
+  /* Lennard-Jones cosine */
   ret += ljcos_pair_energy(p1, p2, ia_params, d, dist);
 #endif
 
@@ -178,7 +178,7 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
   return ret;
 }
 
-/** Add non bonded energies and short range coulomb between a pair of particles.
+/** Add non bonded energies and short range Coulomb between a pair of particles.
     @param p1        pointer to particle 1.
     @param p2        pointer to particle 2.
     @param d         vector between p1 and p2.
@@ -201,7 +201,7 @@ inline void add_non_bonded_pair_energy(Particle *p1, Particle *p2, double d[3],
 
 #ifdef ELECTROSTATICS
   if (coulomb.method != COULOMB_NONE) {
-    /* real space coulomb */
+    /* real space Coulomb */
     switch (coulomb.method) {
 #ifdef P3M
     case COULOMB_P3M_GPU:

--- a/src/core/errorhandling.cpp
+++ b/src/core/errorhandling.cpp
@@ -44,7 +44,7 @@ void mpi_gather_runtime_errors_slave(int node, int parm);
 namespace {
 /** RuntimeErrorCollector instance.
  *  This is a weak pointer so we don't
- *  leak on repeated calls of @f init_error_handling.
+ *  leak on repeated calls of init_error_handling.
  */
 unique_ptr<RuntimeErrorCollector> runtimeErrorCollector;
 

--- a/src/core/errorhandling.cpp
+++ b/src/core/errorhandling.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file errorhandling.cpp
+/** \file
     Implementation of \ref errorhandling.hpp.
 */
 #include <csignal>

--- a/src/core/errorhandling.hpp
+++ b/src/core/errorhandling.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file errorhandling.hpp
+/** \file
     This file contains the errorhandling code for severe errors, like
     a broken bond or illegal parameter combinations. See section
     "Errorhandling for developers" for details on the error format and

--- a/src/core/fft-common.cpp
+++ b/src/core/fft-common.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file fft-common.cpp
+/** \file
  *
  *  Routines, row decomposition, data structures and communication for the
  * 3D-FFT.

--- a/src/core/fft-dipolar.cpp
+++ b/src/core/fft-dipolar.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file fft-dipolar.cpp
+/** \file
  *
  *  Routines, row decomposition, data structures and communication for the
  * 3D-FFT.

--- a/src/core/fft-dipolar.cpp
+++ b/src/core/fft-dipolar.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file fft.cpp
+/** \file fft-dipolar.cpp
  *
  *  Routines, row decomposition, data structures and communication for the
  * 3D-FFT.

--- a/src/core/fft-dipolar.hpp
+++ b/src/core/fft-dipolar.hpp
@@ -22,7 +22,7 @@
 #ifndef _FFT_MAGNETOSTATICS_H
 #define _FFT_MAGNETOSTATICS_H
 
-/** \file fft-dipolar.hpp
+/** \file
  *
  *  Routines, row decomposition, data structures and communication for the
  * 3D-FFT.

--- a/src/core/fft.cpp
+++ b/src/core/fft.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file fft.cpp
+/** \file
  *
  *  Routines, row decomposition, data structures and communication for the
  * 3D-FFT.

--- a/src/core/fft.hpp
+++ b/src/core/fft.hpp
@@ -39,7 +39,7 @@
  *  \todo The packing routines could be moved to utils.hpp when they are needed
  * elsewhere.
  *
- *  For more information about FFT usage, see \ref fft.cpp "fft.c".
+ *  For more information about FFT usage, see \ref fft.cpp "fft.cpp".
  */
 
 #include "config.hpp"

--- a/src/core/fft.hpp
+++ b/src/core/fft.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _FFT_H
 #define _FFT_H
-/** \file fft.hpp
+/** \file
  *
  *  Routines, row decomposition, data structures and communication for the
  * 3D-FFT.

--- a/src/core/forcecap.cpp
+++ b/src/core/forcecap.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file forcecap.cpp force cap calculation.
+/** \file
+ *  force cap calculation.
  *
  *  For more information see \ref forcecap.hpp "forcecap.hpp".
  */

--- a/src/core/forcecap.cpp
+++ b/src/core/forcecap.cpp
@@ -20,7 +20,7 @@
 */
 /** \file forcecap.cpp force cap calculation.
  *
- *  For more information see \ref forcecap.hpp "forcecap.h".
+ *  For more information see \ref forcecap.hpp "forcecap.hpp".
  */
 
 #include "forcecap.hpp"

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -53,7 +53,7 @@ void init_forces() {
     nptiso.p_vir[0] = nptiso.p_vir[1] = nptiso.p_vir[2] = 0.0;
 #endif
 
-  /* initialize forces with langevin thermostat forces
+  /* initialize forces with Langevin thermostat forces
      or zero depending on the thermostat
      set torque to zero for all and rescale quaternions
   */

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -19,7 +19,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file forces.cpp Force calculation.
+/** \file
+ *  Force calculation.
  *
  *  For more information see \ref forces.hpp "forces.hpp".
  */

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -21,7 +21,7 @@
 */
 /** \file forces.cpp Force calculation.
  *
- *  For more information see \ref forces.hpp "forces.h".
+ *  For more information see \ref forces.hpp "forces.hpp".
  */
 
 #include "EspressoSystemInterface.hpp"

--- a/src/core/forces.hpp
+++ b/src/core/forces.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef CORE_FORCES_HPP
 #define CORE_FORCES_HPP
-/** \file forces.hpp Force calculation.
+/** \file
+ *  Force calculation.
  *
  *  \todo Preprocessor switches for all forces (Default: everything is turned
  * on). \todo Implement more flexible thermostat, %e.g. which thermostat to use.

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -181,11 +181,11 @@ inline void calc_non_bonded_pair_force_parts(
   if (p1->p.mol_id == p2->p.mol_id)
     return;
 #endif
-/* lennard-jones */
+/* Lennard-Jones */
 #ifdef LENNARD_JONES
   add_lj_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* lennard-jones generic */
+/* Lennard-Jones generic */
 #ifdef LENNARD_JONES_GENERIC
   add_ljgen_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
@@ -205,11 +205,11 @@ inline void calc_non_bonded_pair_force_parts(
 #ifdef BMHTF_NACL
   add_BMHTF_pair_force(p1, p2, ia_params, d, dist, dist2, force);
 #endif
-/* buckingham*/
+/* Buckingham*/
 #ifdef BUCKINGHAM
   add_buck_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* morse*/
+/* Morse*/
 #ifdef MORSE
   add_morse_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
@@ -225,15 +225,15 @@ inline void calc_non_bonded_pair_force_parts(
 #ifdef HAT
   add_hat_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* lennard-jones cosine */
+/* Lennard-Jones cosine */
 #ifdef LJCOS
   add_ljcos_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* lennard-jones cosine */
+/* Lennard-Jones cosine */
 #ifdef LJCOS2
   add_ljcos2_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* thole damping */
+/* Thole damping */
 #ifdef THOLE
   add_thole_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
@@ -346,7 +346,7 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
   /***********************************************/
 
 #ifdef ELECTROSTATICS
-  /* real space coulomb */
+  /* real space Coulomb */
   const double q1q2 = p1->p.q * p2->p.q;
 
   switch (coulomb.method) {

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -181,11 +181,11 @@ inline void calc_non_bonded_pair_force_parts(
   if (p1->p.mol_id == p2->p.mol_id)
     return;
 #endif
-/* lennard jones */
+/* lennard-jones */
 #ifdef LENNARD_JONES
   add_lj_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* lennard jones generic */
+/* lennard-jones generic */
 #ifdef LENNARD_JONES_GENERIC
   add_ljgen_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
@@ -225,11 +225,11 @@ inline void calc_non_bonded_pair_force_parts(
 #ifdef HAT
   add_hat_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* lennard jones cosine */
+/* lennard-jones cosine */
 #ifdef LJCOS
   add_ljcos_pair_force(p1, p2, ia_params, d, dist, force);
 #endif
-/* lennard jones cosine */
+/* lennard-jones cosine */
 #ifdef LJCOS2
   add_ljcos2_pair_force(p1, p2, ia_params, d, dist, force);
 #endif

--- a/src/core/galilei.cpp
+++ b/src/core/galilei.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file galilei.cpp
+/** \file
  *
  */
 

--- a/src/core/galilei.hpp
+++ b/src/core/galilei.hpp
@@ -27,7 +27,7 @@
 #include "particle_data.hpp"
 
 /** broadcasts reaction parameters and sets up an entry in the ia_params, so
-    that the verlet radius is equal or bigger than the reaction range.
+    that the Verlet radius is equal or bigger than the reaction range.
 **/
 void local_kill_particle_motion(int);
 void local_kill_particle_forces(int);

--- a/src/core/galilei.hpp
+++ b/src/core/galilei.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef GALILEI_H
 #define GALILEI_H
-/** \file galilei.hpp
+/** \file
  *
  */
 

--- a/src/core/ghmc.cpp
+++ b/src/core/ghmc.cpp
@@ -19,7 +19,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file ghmc.cpp
+/** \file
 
     For more information see \ref ghmc.hpp
  */

--- a/src/core/ghmc.cpp
+++ b/src/core/ghmc.cpp
@@ -371,7 +371,7 @@ void ghmc_close() {
   ghmc_acc += ghmcdata.acc;
 }
 
-/* monte carlo step of ghmc - evaluation stage */
+/* Monte Carlo step of ghmc - evaluation stage */
 void ghmc_mc() {
   INTEG_TRACE(fprintf(stderr, "%d: ghmc_mc:\n", this_node));
 
@@ -383,7 +383,7 @@ void ghmc_mc() {
 
     ghmcdata.att++;
 
-    // metropolis algorithm
+    // Metropolis algorithm
     double boltzmann = ghmcdata.hmlt_new - ghmcdata.hmlt_old;
     if (boltzmann < 0)
       boltzmann = 1.0;

--- a/src/core/ghmc.hpp
+++ b/src/core/ghmc.hpp
@@ -21,7 +21,7 @@
 */
 #ifndef GHMC_H
 #define GHMC_H
-/** \file ghmc.hpp
+/** \file
 
     This file contains the implementation of the GHMC (Generalized
     Hybrid Monte Carlo) thermostat.

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file ghosts.cpp   Ghost particles and particle exchange.
+/** \file
+ *  Ghost particles and particle exchange.
  *
  *  For more information on ghosts,
  *  see \ref ghosts.hpp "ghosts.hpp"

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef _GHOSTS_H
 #define _GHOSTS_H
-/** \file ghosts.hpp    Ghost particles and particle exchange.
+/** \file
+ *  Ghost particles and particle exchange.
 
 In this file you find everything concerning the exchange of
 particle data (particles, ghosts, positions and forces) for short

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file global.cpp
-    Implementation of \ref global.hpp "global.h".
+    Implementation of \ref global.hpp "global.hpp".
 */
 #include "global.hpp"
 

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file global.cpp
+/** \file
     Implementation of \ref global.hpp "global.hpp".
 */
 #include "global.hpp"

--- a/src/core/global.hpp
+++ b/src/core/global.hpp
@@ -50,109 +50,108 @@ void check_global_consistency();
 
 /** \name Field Enumeration
     These numbers identify the variables given in
-    \ref #fields for use with \ref mpi_bcast_parameter.
+    \ref anonymous_namespace{global.cpp}::fields "fields"
+    for use with \ref mpi_bcast_parameter.
 */
-/*@{*/
 enum Fields {
-  /** index of \ref box_l in \ref #fields */
+  /** index of \ref box_l */
   FIELD_BOXL = 0,
-  /** index of \ref DomainDecomposition::cell_grid in  \ref #fields */
+  /** index of \ref DomainDecomposition::cell_grid */
   FIELD_CELLGRID,
-  /** index of \ref DomainDecomposition::cell_size in  \ref #fields */
+  /** index of \ref DomainDecomposition::cell_size */
   FIELD_CELLSIZE,
-  /** index of \ref langevin_gamma in  \ref #fields */
+  /** index of \ref langevin_gamma */
   FIELD_LANGEVIN_GAMMA,
-  /** index of \ref integ_switch in \ref #fields */
+  /** index of \ref integ_switch */
   FIELD_INTEG_SWITCH,
-  /** index of \ref local_box_l in \ref #fields */
+  /** index of \ref local_box_l */
   FIELD_LBOXL,
-  /** index of \ref max_cut in \ref #fields */
+  /** index of \ref max_cut */
   FIELD_MCUT,
-  /** index of \ref max_num_cells  in \ref #fields */
+  /** index of \ref max_num_cells  */
   FIELD_MAXNUMCELLS,
-  /** index of \ref max_seen_particle in \ref #fields */
+  /** index of \ref max_seen_particle */
   FIELD_MAXPART,
-  /** index of \ref max_range in \ref #fields */
+  /** index of \ref max_range */
   FIELD_MAXRANGE,
-  /** index of \ref max_skin in  \ref #fields */
+  /** index of \ref max_skin */
   FIELD_MAXSKIN,
-  /** index of \ref min_num_cells  in \ref #fields */
+  /** index of \ref min_num_cells  */
   FIELD_MINNUMCELLS,
-  /** index of \ref n_layers in  \ref #fields */
+  /** index of \ref n_layers */
   FIELD_NLAYERS,
-  /** index of \ref n_nodes in \ref #fields */
+  /** index of \ref n_nodes */
   FIELD_NNODES,
-  /** index of \ref n_part in  \ref #fields */
+  /** index of \ref n_part */
   FIELD_NPART,
-  /** index of \ref max_seen_particle_type in \ref #fields */
+  /** index of \ref max_seen_particle_type */
   FIELD_NPARTTYPE,
-  /** index of \ref n_rigidbonds in \ref #fields */
+  /** index of \ref n_rigidbonds */
   FIELD_RIGIDBONDS,
-  /** index of \ref node_grid in \ref #fields */
+  /** index of \ref node_grid */
   FIELD_NODEGRID,
-  /** index of \ref nptiso_gamma in \ref #fields */
+  /** index of \ref nptiso_gamma0 */
   FIELD_NPTISO_G0,
-  /** index of \ref nptiso_gammav in \ref #fields */
+  /** index of \ref nptiso_gammav */
   FIELD_NPTISO_GV,
-  /** index of \ref nptiso_struct::p_ext in \ref #fields */
+  /** index of \ref nptiso_struct::p_ext */
   FIELD_NPTISO_PEXT,
-  /** index of \ref nptiso_struct::p_inst in \ref #fields */
+  /** index of \ref nptiso_struct::p_inst */
   FIELD_NPTISO_PINST,
-  /** index of \ref nptiso_struct::p_inst_av in \ref #fields */
+  /** index of \ref nptiso_struct::p_inst_av */
   FIELD_NPTISO_PINSTAV,
-  /** index of \ref nptiso_struct::p_diff in \ref #fields */
+  /** index of \ref nptiso_struct::p_diff */
   FIELD_NPTISO_PDIFF,
-  /** index of \ref nptiso_struct::piston in \ref #fields */
+  /** index of \ref nptiso_struct::piston */
   FIELD_NPTISO_PISTON,
-  /** index of \ref #periodic in \ref #fields */
+  /** index of \ref #periodic */
   FIELD_PERIODIC,
-  /** index of \ref #skin in \ref #fields */
+  /** index of \ref #skin */
   FIELD_SKIN,
-  /** index of \ref #temperature in \ref #fields */
+  /** index of \ref #temperature */
   FIELD_TEMPERATURE,
-  /** index of \ref thermo_switch in \ref #fields */
+  /** index of \ref thermo_switch */
   FIELD_THERMO_SWITCH,
-  /** index of \ref sim_time in  \ref #fields */
+  /** index of \ref sim_time */
   FIELD_SIMTIME,
-  /** index of \ref time_step in \ref #fields */
+  /** index of \ref time_step */
   FIELD_TIMESTEP,
-  /** index of \ref timing_samples in  \ref #fields */
+  /** index of \ref timing_samples */
   FIELD_TIMINGSAMP,
-  /** index of \ref max_cut_nonbonded in \ref #fields */
+  /** index of \ref max_cut_nonbonded */
   FIELD_MCUT_NONBONDED,
-  /** index of \ref verlet_reuse in  \ref #fields */
+  /** index of \ref verlet_reuse */
   FIELD_VERLETREUSE,
-  /** index of \ref lattice_switch in \ref #fields */
+  /** index of \ref lattice_switch */
   FIELD_LATTICE_SWITCH,
-  /** index of \ref max_cut_bonded in \ref #fields */
+  /** index of \ref max_cut_bonded */
   FIELD_MCUT_BONDED,
-  /** index of \ref min_global_cut in \ref #fields */
+  /** index of \ref min_global_cut */
   FIELD_MIN_GLOBAL_CUT,
-  /** index of \ref ghmc_nmd in \ref #fields */
+  /** index of \ref ghmc_nmd */
   FIELD_GHMC_NMD,
-  /** index of \ref ghmc_phi in \ref #fields */
+  /** index of \ref ghmc_phi */
   FIELD_GHMC_PHI,
-  /** index of \ref ghmc_phi in \ref #fields */
+  /** index of \ref ghmc_phi */
   FIELD_GHMC_RES,
-  /** index of \ref ghmc_phi in \ref #fields */
+  /** index of \ref ghmc_phi */
   FIELD_GHMC_FLIP,
-  /** index of \ref ghmc_phi in \ref #fields */
+  /** index of \ref ghmc_phi */
   FIELD_GHMC_SCALE,
-  /** index of \ref warnings in \ref #fields */
+  /** index of \ref warnings */
   FIELD_WARNINGS,
-  /** index of \ref langevin_trans in \ref #fields */
+  /** index of \ref langevin_trans */
   FIELD_LANGEVIN_TRANS_SWITCH,
-  /** index of \ref langevin_rotate in \ref #fields */
+  /** index of \ref langevin_rotate */
   FIELD_LANGEVIN_ROT_SWITCH,
-  /** index of \ref langevin_gamma_rotation in  \ref #fields */
+  /** index of \ref langevin_gamma_rotation */
   FIELD_LANGEVIN_GAMMA_ROTATION,
   FIELD_MAX_OIF_OBJECTS, // soft objects as per the object-in-fluid method
-  /** index of \ref n_thermalized_bonds in \ref #fields */
+  /** index of \ref n_thermalized_bonds */
   FIELD_THERMALIZEDBONDS,
   FIELD_FORCE_CAP,
   FIELD_THERMO_VIRTUAL
 };
-/*@}*/
 
 /** bool: whether to write out warnings or not */
 extern int warnings;

--- a/src/core/global.hpp
+++ b/src/core/global.hpp
@@ -21,7 +21,8 @@
 #ifndef _GLOBAL_HPP
 #define _GLOBAL_HPP
 
-/** \file global.hpp This file contains the code for access to globally
+/** \file
+    This file contains the code for access to globally
     defined variables using the script command setmd. Please refer to
     the Developer's guide, section "Adding global variables", for
     details on how to add new variables in the interpreter's

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file grid.cpp   Domain decomposition for parallel computing.
+/** \file
+ *  Domain decomposition for parallel computing.
  *
  *  For more information on the domain decomposition,
  *  see \ref grid.hpp "grid.hpp".

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -21,7 +21,7 @@
 /** \file grid.cpp   Domain decomposition for parallel computing.
  *
  *  For more information on the domain decomposition,
- *  see \ref grid.hpp "grid.h".
+ *  see \ref grid.hpp "grid.hpp".
  */
 
 #include "grid.hpp"

--- a/src/core/grid.hpp
+++ b/src/core/grid.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef _GRID_H
 #define _GRID_H
-/** \file grid.hpp   Domain decomposition for parallel computing.
+/** \file
+ *  Domain decomposition for parallel computing.
  *
  *  The primary simulation box is divided into orthogonal rectangular
  *  subboxes which are assigned to the different nodes (or processes

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -1534,7 +1534,7 @@ __global__ void ek_calculate_quantities(unsigned int species_index,
 
     /* Calculate the diffusive fluxes between this node and its neighbors. Only
        the 9 fluxes along the directions of the LB velocities c_i with i odd are
-       stored with a node to avoid redundencies. */
+       stored with a node to avoid redundancies. */
 
     neighborindex[EK_LINK_U00] = rhoindex_cartesian2linear(
         (coord[0] + 1) % ek_parameters_gpu.dim_x, coord[1], coord[2]);

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -2791,7 +2791,7 @@ int ek_node_print_density(int species, int x, int y, int z, double *density) {
 int ek_node_print_flux(int species, int x, int y, int z, double *flux) {
 
   ekfloat flux_local_cartesian[3]; // temporary variable for converting fluxes
-                                   // into cartesian coordinates for output
+                                   // into Cartesian coordinates for output
   unsigned int coord[3];
 
   coord[0] = x;
@@ -3017,7 +3017,7 @@ int ek_print_vtk_flux(int species, char *filename) {
 
   FILE *fp = fopen(filename, "w");
   ekfloat flux_local_cartesian[3]; // temporary variable for converting fluxes
-                                   // into cartesian coordinates for output
+                                   // into Cartesian coordinates for output
 
   unsigned int coord[3];
 

--- a/src/core/grid_based_algorithms/electrokinetics_pdb_parse.cpp
+++ b/src/core/grid_based_algorithms/electrokinetics_pdb_parse.cpp
@@ -258,7 +258,7 @@ int populate_lattice(PdbParser::PdbParser &parser, double scale) {
         (lowernode[1] + 1) % ek_parameters.dim_y,
         (lowernode[2] + 1) % ek_parameters.dim_z)] +=
         b.charge * cellpos[0] * cellpos[1] * cellpos[2];
-    // Interpolate lennard-jones parameters to boundary
+    // Interpolate Lennard-Jones parameters to boundary
     float r = pow(2, 1. / 6.) * c.sigma * 10 / scale;
 
     a_x_shifted = (a_x_scaled + shift[0]) / ek_parameters.agrid - 0.5f;

--- a/src/core/grid_based_algorithms/fd-electrostatics_cuda.cu
+++ b/src/core/grid_based_algorithms/fd-electrostatics_cuda.cu
@@ -129,7 +129,7 @@ __global__ void createGreensfcn() {
                   (fde_parameters_gpu.dim_x / 2 + 1)) {
 
     if (index == 0) {
-      // setting 0th fourier mode to 0 enforces charge neutrality
+      // setting 0th Fourier mode to 0 enforces charge neutrality
       fde_parameters_gpu.greensfcn[index] = 0.0f;
     } else {
       fde_parameters_gpu.greensfcn[index] =

--- a/src/core/grid_based_algorithms/lb-d3q19.hpp
+++ b/src/core/grid_based_algorithms/lb-d3q19.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lb-d3q19.hpp
+/** \file
  * Header file for the lattice Boltzmann D3Q19 model.
  *
  * This header file contains the definition of the D3Q19 model.

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -126,7 +126,7 @@ HaloCommunicator update_halo_comm = {0, nullptr};
 
 /** amplitude of the fluctuations in the viscous coupling */
 static double lb_coupl_pref = 0.0;
-/** amplitude of the fluctuations in the viscous coupling with gaussian random
+/** amplitude of the fluctuations in the viscous coupling with Gaussian random
  * numbers */
 static double lb_coupl_pref2 = 0.0;
 /*@}*/

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lb.cpp
+/** \file
  *
  * Lattice Boltzmann algorithm for hydrodynamic degrees of freedom.
  *

--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lb.hpp
+/** \file
  * Header file for lb.cpp
  *
  * This is the header file for the Lattice Boltzmann implementation in lb.cpp

--- a/src/core/grid_based_algorithms/lbboundaries.cpp
+++ b/src/core/grid_based_algorithms/lbboundaries.cpp
@@ -18,10 +18,10 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lb-boundaries.cpp
+/** \file lbboundaries.cpp
  *
  * Boundary conditions for Lattice Boltzmann fluid dynamics.
- * Header file for \ref lb-boundaries.hpp.
+ * Header file for \ref lbboundaries.hpp.
  *
  */
 

--- a/src/core/grid_based_algorithms/lbboundaries.cpp
+++ b/src/core/grid_based_algorithms/lbboundaries.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lbboundaries.cpp
+/** \file
  *
  * Boundary conditions for Lattice Boltzmann fluid dynamics.
  * Header file for \ref lbboundaries.hpp.

--- a/src/core/grid_based_algorithms/lbboundaries.hpp
+++ b/src/core/grid_based_algorithms/lbboundaries.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lbboundaries.hpp
+/** \file
  *
  * Boundary conditions for Lattice Boltzmann fluid dynamics.
  * Header file for \ref lbboundaries.cpp.

--- a/src/core/grid_based_algorithms/lbboundaries.hpp
+++ b/src/core/grid_based_algorithms/lbboundaries.hpp
@@ -18,10 +18,10 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lb-boundaries.hpp
+/** \file lbboundaries.hpp
  *
  * Boundary conditions for Lattice Boltzmann fluid dynamics.
- * Header file for \ref lb-boundaries.cpp.
+ * Header file for \ref lbboundaries.cpp.
  *
  * In the current version only simple bounce back walls are implemented. Thus
  * after the streaming step, in all wall nodes all populations are bounced

--- a/src/core/grid_based_algorithms/lbboundaries/LBBoundary.hpp
+++ b/src/core/grid_based_algorithms/lbboundaries/LBBoundary.hpp
@@ -92,7 +92,7 @@ private:
 
   /** Private data members */
   std::shared_ptr<Shapes::Shape>
-      m_shape; // TODO: I dont like this being a pointer just to get around the
+      m_shape; // TODO: I don't like this being a pointer just to get around the
                // virtual limitations
   Vector3d m_velocity;
   Vector3d m_force;

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -17,7 +17,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file lbgpu.cpp
+/** \file
  *
  * C file for the Lattice Boltzmann implementation on GPUs.
  * Header file for \ref lbgpu.hpp.

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -204,7 +204,7 @@ void lattice_boltzmann_calc_shanchen_gpu(void) {
 }
 #endif // SHANCHEN
 
-/** lattice boltzmann update gpu called from integrate.cpp
+/** lattice Boltzmann update gpu called from integrate.cpp
  */
 
 void lattice_boltzmann_update_gpu() {

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -38,7 +38,7 @@
 #define D3Q19
 #define LBQ 19
 
-/** Note these are usef for binary logic so should be powers of 2 */
+/** Note these are used for binary logic so should be powers of 2 */
 #define LB_COUPLE_NULL 1
 #define LB_COUPLE_TWO_POINT 2
 #define LB_COUPLE_THREE_POINT 4

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -17,7 +17,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file lbgpu.hpp
+/** \file
  * Header file for lbgpu.cpp
  *
  * This is the header file for the Lattice Boltzmann implementation in

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -18,9 +18,8 @@
 */
 
 /** \file
- *
- * Cuda (.cu) file for the Lattice Boltzmann implementation on GPUs.
- * Header file for \ref lbgpu.hpp.
+ *  Cuda (.cu) file for the Lattice Boltzmann implementation on GPUs.
+ *  Header file for \ref lbgpu.hpp.
  */
 
 #include "config.hpp"
@@ -59,26 +58,29 @@ int extended_values_flag = 0; /* TODO: this has to be set to one by
                                  the need to compute pi at every
                                  step (e.g. moving boundaries)*/
 
-/**defining structures residing in global memory */
+/** defining structures residing in global memory */
 
 /** device_rho_v: struct for hydrodynamic fields: this is for internal use
-    (i.e. stores values in LB units) and should not used for
-    printing values  */
+ *  (i.e. stores values in LB units) and should not used for
+ *  printing values
+ */
 static LB_rho_v_gpu *device_rho_v = nullptr;
 
 /** device_rho_v_pi: extended struct for hydrodynamic fields: this is the
-   interface and stores values in MD units. It should not be used as an input
-   for any LB calculations. TODO: This structure is not yet used, and it is here
-   to allow access to the stress tensor at any timestep, e.g. for future
-   implementations of moving boundary codes */
+ *  interface and stores values in MD units. It should not be used as an input
+ *  for any LB calculations. TODO: This structure is not yet used, and it is
+ *  here to allow access to the stress tensor at any timestep, e.g. for future
+ *  implementations of moving boundary codes
+ */
 static LB_rho_v_pi_gpu *device_rho_v_pi = nullptr;
 
 /** print_rho_v_pi: struct for hydrodynamic fields: this is the interface
-    and stores values in MD units. It should not used
-    as an input for any LB calculations. TODO: in the future,
-    one might want to have several structures for printing
-    separately rho, v, pi without having to compute/store
-    the complete set. */
+ *  and stores values in MD units. It should not used
+ *  as an input for any LB calculations. TODO: in the future,
+ *  one might want to have several structures for printing
+ *  separately rho, v, pi without having to compute/store
+ *  the complete set.
+ */
 static LB_rho_v_pi_gpu *print_rho_v_pi = nullptr;
 
 /** structs for velocity densities */
@@ -952,7 +954,8 @@ __device__ void thermalize_modes(float *mode, unsigned int index,
 }
 
 /*-------------------------------------------------------*/
-/**normalization of the modes need before back-transformation into velocity space
+/**normalization of the modes need before back-transformation into velocity
+ * space
  * @param mode    Pointer to the local register values mode (Input/Output)
  */
 __device__ void normalize_modes(float *mode) {
@@ -982,8 +985,8 @@ __device__ void normalize_modes(float *mode) {
 }
 
 /*-------------------------------------------------------*/
-/**back-transformation from modespace to densityspace and streaming with the push
- * method using pbc
+/**back-transformation from modespace to densityspace and streaming with the
+ * push method using pbc
  * @param index   node index / thread index (Input)
  * @param mode    Pointer to the local register values mode (Input)
  * @param *n_b    Pointer to local node residing in array b (Output)
@@ -2208,13 +2211,13 @@ __device__ void calc_viscous_force_three_point_couple(
 }
 
 /**calculation of the node force caused by the particles, with atomicadd due to
- avoiding race conditions (Eq. (14) Ahlrichs and Duenweg, JCP 111(17):8225
- (1999))
+ * avoiding race conditions (Eq. (14) Ahlrichs and Duenweg, JCP 111(17):8225
+ * (1999))
  * @param *delta    Pointer for the weighting of particle position (Input)
  * @param *delta_j    Pointer for the weighting of particle momentum (Input)
  * @param node_index    node index around (8) particle (Input)
  * @param node_f        Pointer to the node force (Output).
-*/
+ */
 __device__ void
 calc_node_force_three_point_couple(float *delta, float *delta_j,
                                    unsigned int *node_index,

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -178,7 +178,7 @@ __device__ void random_01(LB_randomnr_gpu *rn) {
 __device__ void gaussian_random_cut(LB_randomnr_gpu *rn) {
   float x1, x2;
   float r2, fac;
-  /** On every second call two gaussian random numbers are calculated
+  /** On every second call two Gaussian random numbers are calculated
    via the Box-Muller transformation.*/
   /** draw two uniform random numbers in the unit circle */
   do {
@@ -220,13 +220,13 @@ __device__ void gaussian_random_cut(LB_randomnr_gpu *rn) {
   }
 }
 
-/** gaussian random number generator for thermalisation
+/** Gaussian random number generator for thermalisation
  * @param *rn Pointer to random number array of the local node node or particle
  */
 __device__ void gaussian_random(LB_randomnr_gpu *rn) {
   float x1, x2;
   float r2, fac;
-  /** On every second call two gaussian random numbers are calculated
+  /** On every second call two Gaussian random numbers are calculated
    via the Box-Muller transformation.*/
   /** draw two uniform random numbers in the unit circle */
   do {
@@ -826,7 +826,7 @@ __device__ void relax_modes(float *mode, unsigned int index,
   }
 }
 
-/**thermalization of the modes with gaussian random numbers
+/**thermalization of the modes with Gaussian random numbers
  * @param index   node index / thread index (Input)
  * @param mode    Pointer to the local register values mode (Input/Output)
  * @param *rn     Pointer to random number array of the local node
@@ -3959,7 +3959,7 @@ void lb_init_GPU(LB_parameters_gpu *lbpar_gpu) {
 
 #ifdef SHANCHEN
 // TODO FIXME:
-/* We must add shan-chen forces, which are zero only if the densities are
+/* We must add Shan-Chen forces, which are zero only if the densities are
  * uniform*/
 #endif
 

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -273,7 +273,6 @@ template <typename T> __device__ void index_to_xyz(T index, T *xyz) {
 
 /**transformation from xyz to 1d array-index
  * @param xyz     Pointer xyz array (Input)
- * @param index   Calculated node index / thread index (Output)
  */
 template <typename T> __device__ T xyz_to_index(T *xyz) {
   T x = (xyz[0] + para.dim_x) % para.dim_x;
@@ -1930,15 +1929,14 @@ __device__ void calc_mode(float *mode, LB_nodes_gpu n_a,
 /** \name interpolation_three_point_coupling */
 /*********************************************************/
 /**(Eq. (12) Ahlrichs and Duenweg, JCP 111(17):8225 (1999))
- * @param n_a             Pointer to local node residing in array a (Input)
- * @param *delta          Pointer for the weighting of particle position
- * (Output)
- * @param *particle_data  Pointer to the particle position and velocity (Input)
- * @param *particle_force Pointer to the particle force (Input)
- * @param part_index      particle id / thread id (Input)
- * @param node_index      node index around (8) particle (Output)
- * @param *d_v            Pointer to local device values
- * @param *interpolated_u Pointer to the interpolated velocity (Output)
+ * @param[in]  n_a                Local node residing in array a
+ * @param[out] delta              Weighting of particle position
+ * @param[in]  particle_position  Particle position and velocity
+ * @param[in]  particle_force     Particle force
+ * @param[in]  part_index         Particle id / thread id
+ * @param[out] node_index         Node index around (8) particle
+ * @param      d_v                Local device values
+ * @param[out] interpolated_u     Interpolated velocity
  */
 __device__ __inline__ void
 interpolation_three_point_coupling(LB_nodes_gpu n_a, float *particle_position,
@@ -4694,7 +4692,7 @@ __global__ void lb_lbfluid_set_population_kernel(LB_nodes_gpu n_a,
 
 /**interface to set the populations of a specific node for the GPU
  * @param xyz            coordinates of node (Input)
- * @param population     Pointer to population (Input)
+ * @param population_host     Pointer to population (Input)
  * @param c              LB component (for SHANCHEN) (Input)
  */
 void lb_lbfluid_set_population(int xyz[3], float population_host[LBQ], int c) {
@@ -4731,7 +4729,7 @@ __global__ void lb_lbfluid_get_population_kernel(LB_nodes_gpu n_a,
 
 /**interface to get the populations of a specific node for the GPU
  * @param xyz            coordinates of node (Input)
- * @param population     Pointer to population (Output)
+ * @param population_host     Pointer to population (Output)
  * @param c              LB component (for SHANCHEN) (Input)
  */
 void lb_lbfluid_get_population(int xyz[3], float population_host[LBQ], int c) {

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -127,7 +127,7 @@ static const float c_sound_sq = 1.0f / 3.0f;
 
 /*-------------------------------------------------------*/
 
-/** atomic add function for sveral cuda architectures
+/** atomic add function for several cuda architectures
  */
 __device__ inline void atomicadd(float *address, float value) {
 #if !defined __CUDA_ARCH__ ||                                                  \
@@ -156,8 +156,8 @@ __device__ inline void atomicadd(double *address, double value) {
   }
 }
 
-/**randomgenerator which generates numbers [0,1]
- * @param *rn Pointer to randomnumber array of the local node or particle
+/**random generator which generates numbers [0,1]
+ * @param *rn Pointer to random number array of the local node or particle
  */
 __device__ void random_01(LB_randomnr_gpu *rn) {
   const float mxi = 1.0f / (float)(1ul << 31);
@@ -170,10 +170,10 @@ __device__ void random_01(LB_randomnr_gpu *rn) {
   rn->seed = curr;
 }
 
-/**randomgenerator which generates numbers between -2 sigma and 2 sigma in the
+/**random generator which generates numbers between -2 sigma and 2 sigma in the
  * form of a Gaussian with standard deviation sigma=1.118591404 resulting in an
  * actual standard deviation of 1.
- * @param *rn Pointer to randomnumber array of the local node or particle
+ * @param *rn Pointer to random number array of the local node or particle
  */
 __device__ void gaussian_random_cut(LB_randomnr_gpu *rn) {
   float x1, x2;
@@ -220,8 +220,8 @@ __device__ void gaussian_random_cut(LB_randomnr_gpu *rn) {
   }
 }
 
-/** gaussian random nummber generator for thermalisation
- * @param *rn Pointer to randomnumber array of the local node node or particle
+/** gaussian random number generator for thermalisation
+ * @param *rn Pointer to random number array of the local node node or particle
  */
 __device__ void gaussian_random(LB_randomnr_gpu *rn) {
   float x1, x2;
@@ -259,7 +259,7 @@ __device__ void random_wrapper(LB_randomnr_gpu *rn) {
 #endif
 }
 
-/**tranformation from 1d array-index to xyz
+/**transformation from 1d array-index to xyz
  * @param index   node index / thread index (Input)
  * @param xyz     Pointer to calculated xyz array (Output)
  */
@@ -271,7 +271,7 @@ template <typename T> __device__ void index_to_xyz(T index, T *xyz) {
   xyz[2] = index;
 }
 
-/**tranformation from xyz to 1d array-index
+/**transformation from xyz to 1d array-index
  * @param xyz     Pointer xyz array (Input)
  * @param index   Calculated node index / thread index (Output)
  */
@@ -715,7 +715,7 @@ __device__ void update_rho_v(float *mode, unsigned int index,
     u_tot[2] += mode[3 + ii * LBQ];
 
     /** if forces are present, the momentum density is redefined to
-     * inlcude one half-step of the force action.  See the
+     * include one half-step of the force action.  See the
      * Chapman-Enskog expansion in [Ladd & Verberg]. */
 
     u_tot[0] +=
@@ -829,7 +829,7 @@ __device__ void relax_modes(float *mode, unsigned int index,
 /**thermalization of the modes with gaussian random numbers
  * @param index   node index / thread index (Input)
  * @param mode    Pointer to the local register values mode (Input/Output)
- * @param *rn     Pointer to randomnumber array of the local node
+ * @param *rn     Pointer to random number array of the local node
  */
 __device__ void thermalize_modes(float *mode, unsigned int index,
                                  LB_randomnr_gpu *rn) {
@@ -953,7 +953,7 @@ __device__ void thermalize_modes(float *mode, unsigned int index,
 }
 
 /*-------------------------------------------------------*/
-/**normalization of the modes need befor backtransformation into velocity space
+/**normalization of the modes need before back-transformation into velocity space
  * @param mode    Pointer to the local register values mode (Input/Output)
  */
 __device__ void normalize_modes(float *mode) {
@@ -983,7 +983,7 @@ __device__ void normalize_modes(float *mode) {
 }
 
 /*-------------------------------------------------------*/
-/**backtransformation from modespace to desityspace and streaming with the push
+/**back-transformation from modespace to densityspace and streaming with the push
  * method using pbc
  * @param index   node index / thread index (Input)
  * @param mode    Pointer to the local register values mode (Input)
@@ -1599,7 +1599,7 @@ calc_values_in_MD_units(LB_nodes_gpu n_a, float *mode, LB_rho_v_pi_gpu *d_p_v,
          m8 = pi_xz
          m9 = pi_yz */
 
-      // and pluggin in the Euler stress for the equilibrium:
+      // and plugging in the Euler stress for the equilibrium:
       // pi_eq = rho_0*c_s^2*I3 + (j \otimes j)/rho
       // with I3 the 3D identity matrix and
       // rho = \trace(rho_0*c_s^2*I3), which yields
@@ -1697,7 +1697,7 @@ __device__ void calc_values_from_m_in_LB_units(float *mode_single,
   // stress calculation
 
   for (int ii = 0; ii < LB_COMPONENTS; ii++) {
-    // Set the rho ouput value
+    // Set the rho output value
 
     Rho = d_v_single->rho[ii];
     rho_out[ii] = Rho;
@@ -1804,7 +1804,7 @@ __device__ void calc_values(LB_nodes_gpu n_a, float *mode, LB_rho_v_gpu *d_v,
       u_tot[2] += mode[3 + ii * 4];
 
       /** if forces are present, the momentum density is redefined to
-       * inlcude one half-step of the force action.  See the
+       * include one half-step of the force action.  See the
        * Chapman-Enskog expansion in [Ladd & Verberg]. */
 
       u_tot[0] +=
@@ -2033,7 +2033,7 @@ interpolation_three_point_coupling(LB_nodes_gpu n_a, float *particle_position,
  * @param *delta_j           Pointer for the weighting of particle momentum
  * (Output)
  * @param *particle_position Pointer to the particle position (Input)
- * @param *rn_part           Pointer to randomnumber array of the particle
+ * @param *rn_part           Pointer to random number array of the particle
  * @param node_index         node index around (8) particle (Output)
  * @param *d_v               Pointer to local device values
  * @param flag_cs            Determine if we are at the centre (0, typical) or
@@ -2209,7 +2209,7 @@ __device__ void calc_viscous_force_three_point_couple(
   }
 }
 
-/**calcutlation of the node force caused by the particles, with atomicadd due to
+/**calculation of the node force caused by the particles, with atomicadd due to
  avoiding race conditions (Eq. (14) Ahlrichs and Duenweg, JCP 111(17):8225
  (1999))
  * @param *delta    Pointer for the weighting of particle position (Input)
@@ -2386,7 +2386,7 @@ __device__ __inline__ void interpolation_two_point_coupling(
  * @param *particle_force       Pointer to the particle force (Input)
  * @param *fluid_composition    Pointer to the fluid composition (Input)
  * @param part_index            particle id / thread id (Input)
- * @param *rn_part              Pointer to randomnumber array of the particle
+ * @param *rn_part              Pointer to random number array of the particle
  * @param node_index            node index around (8) particle (Output)
  * @param *d_v                  Pointer to local device values
  * @param flag_cs               Determine if we are at the centre (0, typical)
@@ -3529,7 +3529,7 @@ __global__ void reset_boundaries(LB_nodes_gpu n_a, LB_nodes_gpu n_b) {
     n_a.boundary[index] = n_b.boundary[index] = 0;
 }
 
-/** integrationstep of the lb-fluid-solver
+/** integration step of the lb-fluid-solver
  * @param n_a     Pointer to local node residing in array a (Input)
  * @param n_b     Pointer to local node residing in array b (Input)
  * @param *d_v    Pointer to local device values (Input)
@@ -3899,7 +3899,7 @@ void lb_init_GPU(LB_parameters_gpu *lbpar_gpu) {
   size_of_rho_v_pi = lbpar_gpu->number_of_nodes * sizeof(LB_rho_v_pi_gpu);
 
   /** Allocate structs in device memory*/
-  /* see the notes to the stucture device_rho_v_pi above...*/
+  /* see the notes to the structure device_rho_v_pi above...*/
   if (extended_values_flag == 0) {
     free_realloc_and_clear(device_rho_v, size_of_rho_v);
   } else {
@@ -4241,7 +4241,7 @@ void lb_print_node_GPU(int single_nodeindex,
 }
 
 /** setup and call kernel to calculate the total momentum of the hole fluid
- * @param *mass value of the mass calcutated on the GPU
+ * @param *mass value of the mass calculated on the GPU
  */
 void lb_calc_fluid_mass_GPU(double *mass) {
   float *tot_mass;
@@ -4269,7 +4269,7 @@ void lb_calc_fluid_mass_GPU(double *mass) {
 }
 
 /** setup and call kernel to calculate the total momentum of the whole fluid
- *  @param host_mom value of the momentum calcutated on the GPU
+ *  @param host_mom value of the momentum calculated on the GPU
  */
 void lb_calc_fluid_momentum_GPU(double *host_mom) {
   float *tot_momentum;
@@ -4328,7 +4328,7 @@ void lb_remove_fluid_momentum_GPU(void) {
 }
 
 /** setup and call kernel to calculate the temperature of the hole fluid
- *  @param host_temp value of the temperatur calcutated on the GPU
+ *  @param host_temp value of the temperature calculated on the GPU
  */
 void lb_calc_fluid_temperature_GPU(double *host_temp) {
   int host_number_of_non_boundary_nodes = 0;
@@ -4518,7 +4518,7 @@ void lb_set_node_velocity_GPU(int single_nodeindex, float *host_velocity) {
 }
 
 /** reinit of params
- * @param *lbpar_gpu struct containing the paramters of the fluid
+ * @param *lbpar_gpu struct containing the parameters of the fluid
  */
 void reinit_parameters_GPU(LB_parameters_gpu *lbpar_gpu) {
   /**write parameters in const memory*/
@@ -4613,7 +4613,7 @@ void lb_lbfluid_remove_total_momentum() {
 
   /* Momentum fraction of the particles */
   auto const part_frac = particles_mass / (fluid_mass + particles_mass);
-  /* Mometum per particle */
+  /* Momentum per particle */
   float momentum_particles[3] = {-total_momentum[0] * part_frac,
                                  -total_momentum[1] * part_frac,
                                  -total_momentum[2] * part_frac};

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -17,7 +17,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file lbgpu_cuda.cu
+/** \file
  *
  * Cuda (.cu) file for the Lattice Boltzmann implementation on GPUs.
  * Header file for \ref lbgpu.hpp.

--- a/src/core/halo.cpp
+++ b/src/core/halo.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file halo.cpp
+/** \file
  *
  * Halo scheme for parallelization of lattice algorithms.
  * Implementation of file \ref halo.hpp.

--- a/src/core/halo.cpp
+++ b/src/core/halo.cpp
@@ -233,7 +233,7 @@ void halo_dtcopy(char *r_buffer, char *s_buffer, int count, Fieldtype type) {
 
 /** Preparation of the halo parallelization scheme. Sets up the
  *  necessary datastructures for \ref halo_communication
- * @param hc         halo communicator beeing created (Input/Output)
+ * @param hc         halo communicator being created (Input/Output)
  * @param lattice    lattice the communication is created for (Input)
  * @param fieldtype  field layout of the lattice data (Input)
  * @param datatype   MPI datatype for the lattice data (Input)

--- a/src/core/halo.hpp
+++ b/src/core/halo.hpp
@@ -98,8 +98,8 @@ typedef struct {
   unsigned long s_offset; /**< offset for send buffer */
   unsigned long r_offset; /**< offset for receive buffer */
 
-  Fieldtype fieldtype;   /**< type layout of the data beeing exchanged */
-  MPI_Datatype datatype; /**< MPI datatype of data beeing communicated */
+  Fieldtype fieldtype;   /**< type layout of the data being exchanged */
+  MPI_Datatype datatype; /**< MPI datatype of data being communicated */
 
 } HaloInfo;
 
@@ -142,7 +142,7 @@ void halo_free_fieldtype(Fieldtype *ftype);
 
 /** Preparation of a certain halo parallelizations scheme. Sets up the
  *  necessary datastructures for \ref halo_communication
- * @param hc         halo communicator beeing created (Input/Output)
+ * @param hc         halo communicator being created (Input/Output)
  * @param lattice    lattice the communication is created for (Input)
  * @param fieldtype  field layout of the lattice data (Input)
  * @param datatype   MPI datatype for the lattice data (Input)

--- a/src/core/halo.hpp
+++ b/src/core/halo.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file halo.hpp
+/** \file
  *
  * Halo scheme for parallelization of lattice algorithms.
  * Header file for \ref halo.cpp.

--- a/src/core/initialize.cpp
+++ b/src/core/initialize.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file initialize.cpp
+/** \file
     Implementation of \ref initialize.hpp "initialize.hpp"
 */
 #include "initialize.hpp"

--- a/src/core/initialize.hpp
+++ b/src/core/initialize.hpp
@@ -68,7 +68,7 @@ void on_particle_charge_change();
 /** called every time the particles are resorted from node to node. */
 void on_resort_particles();
 
-/** called every time the coulomb parameters are changed. */
+/** called every time the Coulomb parameters are changed. */
 void on_coulomb_change();
 
 /** called every time short ranged interaction parameters are changed. */

--- a/src/core/initialize.hpp
+++ b/src/core/initialize.hpp
@@ -20,7 +20,8 @@
 */
 #ifndef INITIALZE_H
 #define INITIALZE_H
-/** \file initialize.hpp This file contains the hook procedures. These
+/** \file
+    This file contains the hook procedures. These
     are the ones with names on_* and are called whenever something is
     changed in Espresso which might influence other parts. For
     example, the P3M code has to be reinitialized whenever the box

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -836,7 +836,7 @@ void force_and_velocity_display() {
 #endif
 }
 
-/** @TODO: This needs to go!! */
+/** @todo This needs to go!! */
 
 int python_integrate(int n_steps, bool recalc_forces, bool reuse_forces_par) {
   int reuse_forces = 0;

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -736,7 +736,7 @@ void propagate_pos() {
   if (integ_switch == INTEG_METHOD_NPT_ISO)
     /* Special propagator for NPT ISOTROPIC */
     /* Propagate pressure, box_length (2 times) and positions, rescale
-       positions and velocities and check verlet list criterion (only NPT) */
+       positions and velocities and check Verlet list criterion (only NPT) */
     propagate_press_box_pos_and_rescale_npt();
   else {
     for (auto &p : local_cells.particles()) {

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -19,7 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file integrate.cpp   Molecular dynamics integrator.
+/** \file
+ *  Molecular dynamics integrator.
  *
  *  For more information about the integrator
  *  see \ref integrate.hpp "integrate.hpp".

--- a/src/core/integrate.hpp
+++ b/src/core/integrate.hpp
@@ -61,7 +61,7 @@ extern bool skin_set;
 
 /** If non-zero, the forces will be recalculated before the next integration. */
 extern int recalc_forces;
-/** Average number of integration steps the verlet list has been re
+/** Average number of integration steps the Verlet list has been re
     used. */
 extern double verlet_reuse;
 
@@ -80,7 +80,7 @@ void integrator_npt_sanity_checks();
 /** Initialize the used thermodynamic Ensemble (NVT or NPT) */
 void integrate_ensemble_init();
 
-/** integrate with velocity verlet integrator.
+/** integrate with velocity Verlet integrator.
     \param n_steps number of steps to integrate.
     \param reuse_forces if nonzero, blindly trust
     the forces still stored with the particles for the first time step.

--- a/src/core/integrate.hpp
+++ b/src/core/integrate.hpp
@@ -23,7 +23,7 @@
 
 /** \file integrate.hpp    Molecular dynamics integrator.
  *
- *  For more information see \ref integrate.cpp "integrate.c".
+ *  For more information see \ref integrate.cpp "integrate.cpp".
  */
 
 #define INTEG_METHOD_NPT_ISO 0

--- a/src/core/integrate.hpp
+++ b/src/core/integrate.hpp
@@ -21,7 +21,8 @@
 #ifndef INTEGRATE_H
 #define INTEGRATE_H
 
-/** \file integrate.hpp    Molecular dynamics integrator.
+/** \file
+ *  Molecular dynamics integrator.
  *
  *  For more information see \ref integrate.cpp "integrate.cpp".
  */

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mpiio.cpp
+/** \file
  *
  * Concerning the file layouts.
  * - Scalar arrays are written like this:

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -298,7 +298,7 @@ static void mpiio_read_array(const std::string &fn, T *arr, size_t len,
  *
  * \param fn Filename of the head file
  * \param rank The rank of the current process in MPI_COMM_WORLD
- * \param file Pointer to store the fields to
+ * \param fields Pointer to store the fields to
  */
 static void read_head(const std::string &fn, int rank, unsigned *fields) {
   FILE *f = nullptr;
@@ -325,7 +325,7 @@ static void read_head(const std::string &fn, int rank, unsigned *fields) {
  * \param rank The rank of the current process in MPI_COMM_WORLD
  * \param size The size of MPI_COMM_WORLD
  * \param nglobalpart The global amount of particles
- * \param prefs Pointer to store the prefix to
+ * \param pref Pointer to store the prefix to
  * \param nlocalpart Pointer to store the amount of local particles to
  */
 static void read_prefs(const std::string &fn, int rank, int size,

--- a/src/core/io/mpiio/mpiio.hpp
+++ b/src/core/io/mpiio/mpiio.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file mpiio.hpp
+/** \file
  *  Implements binary output using MPI-IO.
  */
 

--- a/src/core/io/reader/readpdb.hpp
+++ b/src/core/io/reader/readpdb.hpp
@@ -34,12 +34,12 @@ struct PdbLJInteraction {
 
 /** Call only on the master node: Parse pdb file and add contained particles.
     @param pdb_file Filename of the pdb file.
-    @first_id Id of the first particle to add.
-    @type Type for the particles.
-    @lennard_jones Should lj interactions be added from the itp file.
-    @fit Should the box be rescaled to hold the particles.
-    @lj_internal Should LJ interactions within the molecule be added.
-    @lj_diagonal Just the diagonal interaction terms oh lj_internal.
+    @param first_id Id of the first particle to add.
+    @param type Type for the particles.
+    @param lennard_jones Should lj interactions be added from the itp file.
+    @param fit Should the box be rescaled to hold the particles.
+    @param lj_internal Should LJ interactions within the molecule be added.
+    @param lj_diagonal Just the diagonal interaction terms of lj_internal.
     @return Number of particles that were added.
  */
 

--- a/src/core/io/writer/h5md_core.hpp
+++ b/src/core/io/writer/h5md_core.hpp
@@ -55,7 +55,7 @@ class File {
 public:
   /**
    * Constructor/destructor without arguments (due to script_interface).
-   * @brief Constructor of the "File" class.
+   * @brief Constructor of the File class.
    */
   File();
   ~File();
@@ -80,13 +80,14 @@ public:
   /**
    * @brief General method to write to the datasets which calls more specific
    * write methods.
-   * @param Boolean values for position, velocity, force and mass.
+   * Boolean values for position, velocity, force and mass.
    */
   void Write(int write_dat, PartCfg &partCfg);
 
   /**
    * @brief Method to write the energy contributions to the H5MD file.
-   * @param Boolean values for total, kinetic.
+   * @param total Boolean values for total energy
+   * @param kinetic Boolean values for kinetic energy
    * \todo Implement this method.
    */
   void WriteEnergy(bool total = true, bool kinetic = true);

--- a/src/core/lattice.cpp
+++ b/src/core/lattice.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lattice.cpp
+/** \file
  *
  * Lattice class definition
  *

--- a/src/core/lattice.hpp
+++ b/src/core/lattice.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file lattice.hpp
+/** \file
  *
  * Lattice class definition
  * Contains the lattice layout and pointers to the data fields.

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file layered.cpp
+/** \file
     Implementation of \ref layered.hpp "layered.hpp".
  */
 #include "layered.hpp"

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file layered.cpp
-    Implementation of \ref layered.hpp "layered.h".
+    Implementation of \ref layered.hpp "layered.hpp".
  */
 #include "layered.hpp"
 #include "cells.hpp"

--- a/src/core/layered.hpp
+++ b/src/core/layered.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file layered.hpp
+/** \file
     The layered cellsystem. This cellsystem is a combination of a single
    processor n-squared method along x and y, and a multiprocessor domain
    decomposition along z. Therefore only \f$1\times 1\times N\f$ processors

--- a/src/core/layered.hpp
+++ b/src/core/layered.hpp
@@ -23,7 +23,7 @@
    processor n-squared method along x and y, and a multiprocessor domain
    decomposition along z. Therefore only \f$1\times 1\times N\f$ processors
    grids are allowed for this cellsystem. The implementation is pretty similar
-   to \ref domain_decomposition.hpp "domain_decomposition.h".
+   to \ref domain_decomposition.hpp "domain_decomposition.hpp".
 */
 #ifndef LAYERED_H
 #define LAYERED_H

--- a/src/core/metadynamics.cpp
+++ b/src/core/metadynamics.cpp
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "errorhandling.hpp"
 #include "grid.hpp"
 
-/** \file metadynamics.hpp
+/** \file metadynamics.cpp
  *
  *  This file contains routines to perform metadynamics.  Right now, the
  *  reaction coordinate is defined between two particles (either distance

--- a/src/core/metadynamics.cpp
+++ b/src/core/metadynamics.cpp
@@ -85,7 +85,7 @@ void meta_init() {
                          sizeof *meta_acc_fprofile);
   }
 
-  /* Check that the simulation uses onle a single processor. Otherwise exit.
+  /* Check that the simulation uses only a single processor. Otherwise exit.
    *  MPI interface *not* implemented. */
   if (n_nodes != 1) {
     runtimeErrorMsg() << "Can't use metadynamics on more than one processor.\n";
@@ -141,7 +141,7 @@ void meta_perform() {
 
   /* Now update free energy profile
    * Here, we're following the functional form of
-   * Marsili etal., J Comp. Chem, 31 (2009).
+   * Marsili et al., J Comp Chem, 31 (2009).
    * Instead of gaussians, we use so-called Lucy's functions */
 
   for (int i = 0; i < meta_xi_num_bins; ++i) {

--- a/src/core/metadynamics.cpp
+++ b/src/core/metadynamics.cpp
@@ -142,7 +142,7 @@ void meta_perform() {
   /* Now update free energy profile
    * Here, we're following the functional form of
    * Marsili et al., J Comp Chem, 31 (2009).
-   * Instead of gaussians, we use so-called Lucy's functions */
+   * Instead of Gaussians, we use so-called Lucy's functions */
 
   for (int i = 0; i < meta_xi_num_bins; ++i) {
     if (meta_switch == META_DIST) {

--- a/src/core/metadynamics.cpp
+++ b/src/core/metadynamics.cpp
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "errorhandling.hpp"
 #include "grid.hpp"
 
-/** \file metadynamics.cpp
+/** \file
  *
  *  This file contains routines to perform metadynamics.  Right now, the
  *  reaction coordinate is defined between two particles (either distance

--- a/src/core/metadynamics.hpp
+++ b/src/core/metadynamics.hpp
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <cmath>
 #include <cstring>
 
-/** \file metadynamics.hpp
+/** \file
  *
  *  This file contains routines to perform metadynamics.  Right now, the
  *  reaction coordinate is defined between two particles. Note that these

--- a/src/core/nemd.cpp
+++ b/src/core/nemd.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file nemd.cpp
+/** \file
 
     For more information see \ref nemd.hpp
  */

--- a/src/core/nemd.hpp
+++ b/src/core/nemd.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef NEMD_H
 #define NEMD_H
-/** \file nemd.hpp
+/** \file
 
     This file contains the implementation of the NEMD (Non Equilibrium
     Molecular Dynamics) algorithm. It allows one to shear a system

--- a/src/core/nonbonded_interactions/bmhtf-nacl.cpp
+++ b/src/core/nonbonded_interactions/bmhtf-nacl.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file bmhtf-nacl.cpp
+/** \file
  *
  *  Implementation of \ref bmhtf-nacl.hpp
  */

--- a/src/core/nonbonded_interactions/bmhtf-nacl.hpp
+++ b/src/core/nonbonded_interactions/bmhtf-nacl.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef BMHTF_NACL_H
 #define BMHTF_NACL_H
-/** \file bmhtf-nacl.hpp
+/** \file
  *  Routines to calculate the Born-Meyer-Huggins-Tosi-Fumi energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/buckingham.cpp
+++ b/src/core/nonbonded_interactions/buckingham.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file buckingham.cpp
+/** \file
  *
  *  Implementation of \ref buckingham.hpp
  */

--- a/src/core/nonbonded_interactions/buckingham.cpp
+++ b/src/core/nonbonded_interactions/buckingham.cpp
@@ -43,7 +43,7 @@ int buckingham_set_params(int part_type_a, int part_type_b, double A, double B,
   data->BUCK_discont = discont;
   data->BUCK_shift = shift;
 
-  /* Replace the buckingham potential for interatomic dist. less
+  /* Replace the Buckingham potential for interatomic dist. less
      than or equal to discontinuity by a straight line (F1+F2*r) */
   double F1;
   double F2;

--- a/src/core/nonbonded_interactions/buckingham.hpp
+++ b/src/core/nonbonded_interactions/buckingham.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef BUCKINGHAM_H
 #define BUCKINGHAM_H
-/** \file buckingham.hpp
+/** \file
  *  Routines to calculate the Buckingham energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/buckingham.hpp
+++ b/src/core/nonbonded_interactions/buckingham.hpp
@@ -37,12 +37,12 @@ int buckingham_set_params(int part_type_a, int part_type_b, double A, double B,
                           double C, double D, double cut, double discont,
                           double shift);
 
-/**Resultant Force due to a buckingham potential between two particles at
+/**Resultant Force due to a Buckingham potential between two particles at
  * interatomic separation r greater than or equal to discont*/
 inline double buck_force_r(double A, double B, double C, double D, double r) {
   return (A * B * exp(-B * r) - 6.0 * C / pow(r, 7) - 4.0 * D / pow(r, 5));
 }
-/**Potential Energy due to a buckingham potential between two particles at
+/**Potential Energy due to a Buckingham potential between two particles at
  * interatomic separation r greater than or equal to discont*/
 inline double buck_energy_r(double A, double B, double C, double D,
                             double shift, double r) {
@@ -57,7 +57,7 @@ inline void add_buck_pair_force(const Particle *const p1,
                                 double dist, double force[3]) {
   if ((dist < ia_params->BUCK_cut)) {
     /* case: resulting force/energy greater than discontinuity and
-             less than cutoff (true buckingham region) */
+             less than cutoff (true Buckingham region) */
     double fac;
     if (dist > ia_params->BUCK_discont) {
       fac = buck_force_r(ia_params->BUCK_A, ia_params->BUCK_B,
@@ -105,7 +105,7 @@ inline double buck_pair_energy(const Particle *p1, const Particle *p2,
                                const double d[3], double dist) {
   if ((dist < ia_params->BUCK_cut)) {
     /* case: resulting force/energy greater than discont and
-             less than cutoff (true buckingham region) */
+             less than cutoff (true Buckingham region) */
     if (dist > ia_params->BUCK_discont)
       return buck_energy_r(ia_params->BUCK_A, ia_params->BUCK_B,
                            ia_params->BUCK_C, ia_params->BUCK_D,

--- a/src/core/nonbonded_interactions/cos2.cpp
+++ b/src/core/nonbonded_interactions/cos2.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file cos2.hpp
+/** \file cos2.cpp
  *  Routines to calculate a flat potential with cosine tail energy and/or  force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp
  *  Used for attractive tail/tail interactions in lipid bilayer calculations.

--- a/src/core/nonbonded_interactions/cos2.cpp
+++ b/src/core/nonbonded_interactions/cos2.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file cos2.cpp
+/** \file
  *  Routines to calculate a flat potential with cosine tail energy and/or  force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp
  *  Used for attractive tail/tail interactions in lipid bilayer calculations.

--- a/src/core/nonbonded_interactions/cos2.hpp
+++ b/src/core/nonbonded_interactions/cos2.hpp
@@ -21,7 +21,7 @@
 #ifndef _COS2_H
 #define _COS2_H
 
-/** \file cos2.hpp
+/** \file
  *  Routines to calculate a flat potential with cosine tail energy and/or  force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp
  *  Used for attractive tail/tail interactions in lipid bilayer calculations.

--- a/src/core/nonbonded_interactions/gaussian.cpp
+++ b/src/core/nonbonded_interactions/gaussian.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file gaussian.cpp
+/** \file
  *
  *  Implementation of \ref gaussian.hpp
  */

--- a/src/core/nonbonded_interactions/gaussian.hpp
+++ b/src/core/nonbonded_interactions/gaussian.hpp
@@ -21,7 +21,7 @@
 #ifndef GAUSSIAN_H
 #define GAUSSIAN_H
 
-/** \file gaussian.hpp
+/** \file
  *  Routines to calculate the Gaussian energy and/or force
  *  for a particle pair.
  */

--- a/src/core/nonbonded_interactions/gaussian.hpp
+++ b/src/core/nonbonded_interactions/gaussian.hpp
@@ -53,7 +53,7 @@ inline void add_gaussian_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard-jones energy between particle p1 and p2. */
+/** calculate Lennard-Jones energy between particle p1 and p2. */
 inline double gaussian_pair_energy(const Particle *p1, const Particle *p2,
                                    const IA_parameters *ia_params,
                                    const double d[3], double dist,

--- a/src/core/nonbonded_interactions/gaussian.hpp
+++ b/src/core/nonbonded_interactions/gaussian.hpp
@@ -53,7 +53,7 @@ inline void add_gaussian_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard jones energy between particle p1 and p2. */
+/** calculate Lennard-jones energy between particle p1 and p2. */
 inline double gaussian_pair_energy(const Particle *p1, const Particle *p2,
                                    const IA_parameters *ia_params,
                                    const double d[3], double dist,

--- a/src/core/nonbonded_interactions/gb.cpp
+++ b/src/core/nonbonded_interactions/gb.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file gb.cpp
+/** \file
  *
  *  Implementation of \ref gb.hpp
  */

--- a/src/core/nonbonded_interactions/gb.hpp
+++ b/src/core/nonbonded_interactions/gb.hpp
@@ -21,7 +21,7 @@
 #ifndef _GB_HPP
 #define _GB_HPP
 
-/** \file gb.hpp
+/** \file
  *  Routines to calculate the Gay-Berne energy and force
  *  for a pair of particles.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/hat.cpp
+++ b/src/core/nonbonded_interactions/hat.cpp
@@ -18,9 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file soft_sphere.cpp
+/** \file hat.cpp
  *
- *  Implementation of \ref soft_sphere.hpp
+ *  Implementation of \ref hat.hpp
  */
 
 #include "config.hpp"

--- a/src/core/nonbonded_interactions/hat.cpp
+++ b/src/core/nonbonded_interactions/hat.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file hat.cpp
+/** \file
  *
  *  Implementation of \ref hat.hpp
  */

--- a/src/core/nonbonded_interactions/hat.hpp
+++ b/src/core/nonbonded_interactions/hat.hpp
@@ -21,7 +21,7 @@
 #ifndef hat_H
 #define hat_H
 
-/** \file hat.hpp
+/** \file
  *  Routines to calculate the soft-sphere energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/hat.hpp
+++ b/src/core/nonbonded_interactions/hat.hpp
@@ -21,7 +21,7 @@
 #ifndef hat_H
 #define hat_H
 
-/** \file soft_sphere.hpp
+/** \file hat.hpp
  *  Routines to calculate the soft-sphere energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/hertzian.cpp
+++ b/src/core/nonbonded_interactions/hertzian.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file hertzian.cpp
+/** \file
  *
  *  Implementation of \ref hertzian.hpp
  */

--- a/src/core/nonbonded_interactions/hertzian.hpp
+++ b/src/core/nonbonded_interactions/hertzian.hpp
@@ -21,7 +21,7 @@
 #ifndef HERTZIAN_H
 #define HERTZIAN_H
 
-/** \file hertzian.hpp
+/** \file
  *  Routines to calculate the Hertzian energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/hertzian.hpp
+++ b/src/core/nonbonded_interactions/hertzian.hpp
@@ -52,7 +52,7 @@ inline void add_hertzian_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard jones energy between particle p1 and p2. */
+/** calculate Lennard-jones energy between particle p1 and p2. */
 inline double hertzian_pair_energy(const Particle *p1, const Particle *p2,
                                    const IA_parameters *ia_params,
                                    const double d[3], double dist,

--- a/src/core/nonbonded_interactions/hertzian.hpp
+++ b/src/core/nonbonded_interactions/hertzian.hpp
@@ -52,7 +52,7 @@ inline void add_hertzian_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard-jones energy between particle p1 and p2. */
+/** calculate Lennard-Jones energy between particle p1 and p2. */
 inline double hertzian_pair_energy(const Particle *p1, const Particle *p2,
                                    const IA_parameters *ia_params,
                                    const double d[3], double dist,

--- a/src/core/nonbonded_interactions/lj.hpp
+++ b/src/core/nonbonded_interactions/lj.hpp
@@ -26,7 +26,7 @@
 #ifdef LENNARD_JONES
 
 /** \file
- *  Routines to calculate the lennard jones energy and/or  force
+ *  Routines to calculate the lennard-jones energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp
  */
@@ -40,7 +40,7 @@ int lennard_jones_set_params(int part_type_a, int part_type_b, double eps,
                              double sig, double cut, double shift,
                              double offset, double min);
 
-/** Calculate lennard Jones force between particle p1 and p2 */
+/** Calculate lennard-Jones force between particle p1 and p2 */
 inline void add_lj_pair_force(const Particle *const p1,
                               const Particle *const p2,
                               IA_parameters *ia_params, double const d[3],
@@ -102,7 +102,7 @@ inline void add_lj_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard jones energy between particle p1 and p2. */
+/** calculate Lennard-jones energy between particle p1 and p2. */
 inline double lj_pair_energy(const Particle *p1, const Particle *p2,
                              const IA_parameters *ia_params, const double d[3],
                              double dist) {

--- a/src/core/nonbonded_interactions/lj.hpp
+++ b/src/core/nonbonded_interactions/lj.hpp
@@ -26,7 +26,7 @@
 #ifdef LENNARD_JONES
 
 /** \file
- *  Routines to calculate the lennard-jones energy and/or  force
+ *  Routines to calculate the Lennard-Jones energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp
  */
@@ -40,7 +40,7 @@ int lennard_jones_set_params(int part_type_a, int part_type_b, double eps,
                              double sig, double cut, double shift,
                              double offset, double min);
 
-/** Calculate lennard-Jones force between particle p1 and p2 */
+/** Calculate Lennard-Jones force between particle p1 and p2 */
 inline void add_lj_pair_force(const Particle *const p1,
                               const Particle *const p2,
                               IA_parameters *ia_params, double const d[3],
@@ -102,7 +102,7 @@ inline void add_lj_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard-jones energy between particle p1 and p2. */
+/** calculate Lennard-Jones energy between particle p1 and p2. */
 inline double lj_pair_energy(const Particle *p1, const Particle *p2,
                              const IA_parameters *ia_params, const double d[3],
                              double dist) {

--- a/src/core/nonbonded_interactions/lj.hpp
+++ b/src/core/nonbonded_interactions/lj.hpp
@@ -25,7 +25,7 @@
 
 #ifdef LENNARD_JONES
 
-/** \file lj.hpp
+/** \file
  *  Routines to calculate the lennard jones energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/ljcos.hpp
+++ b/src/core/nonbonded_interactions/ljcos.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _LJCOS_H
 #define _LJCOS_H
-/** \file ljcos.hpp
+/** \file
  *  Routines to calculate the lennard jones+cosine energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/ljcos.hpp
+++ b/src/core/nonbonded_interactions/ljcos.hpp
@@ -21,7 +21,7 @@
 #ifndef _LJCOS_H
 #define _LJCOS_H
 /** \file
- *  Routines to calculate the lennard-jones+cosine energy and/or force
+ *  Routines to calculate the Lennard-Jones+cosine energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp
  */

--- a/src/core/nonbonded_interactions/ljcos.hpp
+++ b/src/core/nonbonded_interactions/ljcos.hpp
@@ -21,7 +21,7 @@
 #ifndef _LJCOS_H
 #define _LJCOS_H
 /** \file
- *  Routines to calculate the lennard jones+cosine energy and/or force
+ *  Routines to calculate the lennard-jones+cosine energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp
  */
@@ -53,7 +53,7 @@ inline void add_ljcos_pair_force(const Particle *const p1,
       for (int j = 0; j < 3; j++)
         force[j] += fac * d[j];
     }
-    /* lennard-jones part of the potential. */
+    /* Lennard-Jones part of the potential. */
     else if (dist > 0) {
       double frac2 = Utils::sqr(ia_params->LJCOS_sig / r_off);
       double frac6 = frac2 * frac2 * frac2;
@@ -77,7 +77,7 @@ inline double ljcos_pair_energy(const Particle *p1, const Particle *p2,
                                 const double d[3], double dist) {
   if ((dist < ia_params->LJCOS_cut + ia_params->LJCOS_offset)) {
     double r_off = dist - ia_params->LJCOS_offset;
-    /* lennard-jones part of the potential. */
+    /* Lennard-Jones part of the potential. */
     if (dist < (ia_params->LJCOS_rmin + ia_params->LJCOS_offset)) {
       double frac2 = Utils::sqr(ia_params->LJCOS_sig / r_off);
       double frac6 = frac2 * frac2 * frac2;

--- a/src/core/nonbonded_interactions/ljcos2.cpp
+++ b/src/core/nonbonded_interactions/ljcos2.cpp
@@ -21,7 +21,7 @@
 
 /** \file
  *
- *  Routines to calculate the lennard-jones with cosine tail energy and/or force
+ *  Routines to calculate the Lennard-Jones with cosine tail energy and/or force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp
  *  Used for attractive tail/tail interactions in lipid bilayer calculations
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/ljcos2.cpp
+++ b/src/core/nonbonded_interactions/ljcos2.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file ljcos2.cpp
+/** \file
  *
  *  Routines to calculate the lennard-jones with cosine tail energy and/or force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp

--- a/src/core/nonbonded_interactions/ljcos2.cpp
+++ b/src/core/nonbonded_interactions/ljcos2.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file ljcos2.hpp
+/** \file ljcos2.cpp
  *
  *  Routines to calculate the lennard-jones with cosine tail energy and/or force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp

--- a/src/core/nonbonded_interactions/ljcos2.hpp
+++ b/src/core/nonbonded_interactions/ljcos2.hpp
@@ -21,7 +21,7 @@
 #ifndef _LJCOS2_H
 #define _LJCOS2_H
 
-/** \file ljcos2.hpp
+/** \file
  *  Routines to calculate the lennard-jones with cosine tail energy and/or force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp
  *  Used for attractive tail/tail interactions in lipid bilayer calculations

--- a/src/core/nonbonded_interactions/ljcos2.hpp
+++ b/src/core/nonbonded_interactions/ljcos2.hpp
@@ -22,7 +22,7 @@
 #define _LJCOS2_H
 
 /** \file
- *  Routines to calculate the lennard-jones with cosine tail energy and/or force
+ *  Routines to calculate the Lennard-Jones with cosine tail energy and/or force
  *  for a particle pair.  Cosine tail is different from that in ljcos.hpp
  *  Used for attractive tail/tail interactions in lipid bilayer calculations
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/ljgen.cpp
+++ b/src/core/nonbonded_interactions/ljgen.cpp
@@ -20,7 +20,7 @@
 */
 
 /** \file
- *  Routines to calculate the generalized lennard-jones
+ *  Routines to calculate the generalized Lennard-Jones
  *  energy and/or force for a particle pair. "Generalized" here means
  *  that the LJ energy is of the form
  *

--- a/src/core/nonbonded_interactions/ljgen.cpp
+++ b/src/core/nonbonded_interactions/ljgen.cpp
@@ -20,7 +20,7 @@
 */
 
 /** \file
- *  Routines to calculate the generalized lennard jones
+ *  Routines to calculate the generalized lennard-jones
  *  energy and/or force for a particle pair. "Generalized" here means
  *  that the LJ energy is of the form
  *

--- a/src/core/nonbonded_interactions/ljgen.cpp
+++ b/src/core/nonbonded_interactions/ljgen.cpp
@@ -19,7 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file ljgen.cpp Routines to calculate the generalized lennard jones
+/** \file
+ *  Routines to calculate the generalized lennard jones
  *  energy and/or force for a particle pair. "Generalized" here means
  *  that the LJ energy is of the form
  *

--- a/src/core/nonbonded_interactions/ljgen.hpp
+++ b/src/core/nonbonded_interactions/ljgen.hpp
@@ -26,7 +26,7 @@
 #ifdef LENNARD_JONES_GENERIC
 
 /** \file
- *  Routines to calculate the generalized lennard jones
+ *  Routines to calculate the generalized lennard-jones
  *  energy and/or force for a particle pair. "Generalized" here means
  *  that the LJ energy is of the form
  *
@@ -50,7 +50,7 @@ int ljgen_set_params(int part_type_a, int part_type_b, double eps, double sig,
 #endif
 );
 
-/** Calculate lennard Jones force between particle p1 and p2 */
+/** Calculate lennard-Jones force between particle p1 and p2 */
 inline void add_ljgen_pair_force(const Particle *const p1,
                                  const Particle *const p2,
                                  IA_parameters *ia_params, double d[3],
@@ -108,7 +108,7 @@ inline void add_ljgen_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard jones energy between particle p1 and p2. */
+/** calculate Lennard-jones energy between particle p1 and p2. */
 inline double ljgen_pair_energy(const Particle *p1, const Particle *p2,
                                 const IA_parameters *ia_params,
                                 const double d[3], double dist) {

--- a/src/core/nonbonded_interactions/ljgen.hpp
+++ b/src/core/nonbonded_interactions/ljgen.hpp
@@ -25,7 +25,8 @@
 
 #ifdef LENNARD_JONES_GENERIC
 
-/** \file ljgen.hpp Routines to calculate the generalized lennard jones
+/** \file
+ *  Routines to calculate the generalized lennard jones
  *  energy and/or force for a particle pair. "Generalized" here means
  *  that the LJ energy is of the form
  *

--- a/src/core/nonbonded_interactions/ljgen.hpp
+++ b/src/core/nonbonded_interactions/ljgen.hpp
@@ -26,7 +26,7 @@
 #ifdef LENNARD_JONES_GENERIC
 
 /** \file
- *  Routines to calculate the generalized lennard-jones
+ *  Routines to calculate the generalized Lennard-Jones
  *  energy and/or force for a particle pair. "Generalized" here means
  *  that the LJ energy is of the form
  *
@@ -50,7 +50,7 @@ int ljgen_set_params(int part_type_a, int part_type_b, double eps, double sig,
 #endif
 );
 
-/** Calculate lennard-Jones force between particle p1 and p2 */
+/** Calculate Lennard-Jones force between particle p1 and p2 */
 inline void add_ljgen_pair_force(const Particle *const p1,
                                  const Particle *const p2,
                                  IA_parameters *ia_params, double d[3],
@@ -108,7 +108,7 @@ inline void add_ljgen_pair_force(const Particle *const p1,
   }
 }
 
-/** calculate Lennard-jones energy between particle p1 and p2. */
+/** calculate Lennard-Jones energy between particle p1 and p2. */
 inline double ljgen_pair_energy(const Particle *p1, const Particle *p2,
                                 const IA_parameters *ia_params,
                                 const double d[3], double dist) {

--- a/src/core/nonbonded_interactions/morse.cpp
+++ b/src/core/nonbonded_interactions/morse.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file morse.cpp
+/** \file
  *
  *  Implementation of \ref morse.hpp
  */

--- a/src/core/nonbonded_interactions/morse.hpp
+++ b/src/core/nonbonded_interactions/morse.hpp
@@ -22,7 +22,7 @@
 #define _MORSE_H
 
 /** \file
- *  Routines to calculate the lennard jones energy and/or  force
+ *  Routines to calculate the lennard-jones energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp
  */

--- a/src/core/nonbonded_interactions/morse.hpp
+++ b/src/core/nonbonded_interactions/morse.hpp
@@ -21,7 +21,7 @@
 #ifndef _MORSE_H
 #define _MORSE_H
 
-/** \file morse.hpp
+/** \file
  *  Routines to calculate the lennard jones energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/morse.hpp
+++ b/src/core/nonbonded_interactions/morse.hpp
@@ -22,7 +22,7 @@
 #define _MORSE_H
 
 /** \file
- *  Routines to calculate the lennard-jones energy and/or  force
+ *  Routines to calculate the Lennard-Jones energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp
  */

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file nonbonded_interaction_data.cpp
+/** \file
     Implementation of nonbonded_interaction_data.hpp
  */
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
@@ -218,8 +218,8 @@ static void recalc_global_maximal_nonbonded_and_long_range_cutoff() {
    for the relative virtual sites algorithm. */
   max_cut_global = min_global_cut;
 
-  // global cutoff without dipolar and coulomb methods is needed
-  // for more selective addition of particle pairs to verlet lists
+  // global cutoff without dipolar and Coulomb methods is needed
+  // for more selective addition of particle pairs to Verlet lists
   max_cut_global_without_coulomb_and_dipolar = max_cut_global;
 
   // Electrostatics and magnetostatics

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
@@ -130,7 +130,7 @@ double dipolar_cutoff;
 static void recalc_global_maximal_nonbonded_cutoff();
 
 /*****************************************
- * general lowlevel functions
+ * general low-level functions
  *****************************************/
 
 IA_parameters *get_ia_param_safe(int i, int j) {

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file interaction_data.cpp
+/** \file nonbonded_interaction_data.cpp
     Implementation of nonbonded_interaction_data.hpp
  */
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _INTERACTION_DATA_H
 #define _INTERACTION_DATA_H
-/** \file nonbonded_interaction_data.hpp
+/** \file
     Various procedures concerning interactions between particles.
 */
 

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.hpp
@@ -353,14 +353,14 @@ extern std::vector<IA_parameters> ia_params;
 /*@{*/
 
 /** field containing the interaction parameters for
- *  the coulomb  interaction.  */
+ *  the Coulomb  interaction.  */
 struct Coulomb_parameters {
 
 #ifdef ELECTROSTATICS
   /** bjerrum length times temperature. */
   double prefactor;
 
-  /** Method to treat coulomb interaction. */
+  /** Method to treat Coulomb interaction. */
   CoulombMethod method;
 #endif
 
@@ -386,7 +386,7 @@ extern double field_applied;
 /** Maximal particle type seen so far. */
 extern int max_seen_particle_type;
 
-/** Structure containing the coulomb parameters. */
+/** Structure containing the Coulomb parameters. */
 extern Coulomb_parameters coulomb;
 
 /** Maximal interaction cutoff (real space/short range interactions). */
@@ -394,7 +394,7 @@ extern double max_cut;
 /** Maximal interaction cutoff (real space/short range non-bonded interactions).
  */
 extern double max_cut_nonbonded;
-/** Cutoff of coulomb real space part */
+/** Cutoff of Coulomb real space part */
 extern double coulomb_cutoff;
 /** Cutoff of dipolar real space part */
 extern double dipolar_cutoff;
@@ -465,7 +465,7 @@ void realloc_ia_params(int nsize);
     electrostatics. The result is stored in the global variable
     max_cut. The maximal cutoff of the non-bonded + real space
     electrostatic interactions is stored in max_cut_non_bonded. This
-    value is used in the verlet pair list algorithm. */
+    value is used in the Verlet pair list algorithm. */
 void recalc_maximal_cutoff();
 
 /** check whether all force calculation routines are properly initialized. */

--- a/src/core/nonbonded_interactions/nonbonded_tab.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_tab.cpp
@@ -18,9 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file tab.cpp
+/** \file nonbonded_tab.cpp
  *
- *  Implementation of \ref tab.hpp
+ *  Implementation of \ref nonbonded_tab.hpp
  */
 #include "nonbonded_interactions/nonbonded_tab.hpp"
 

--- a/src/core/nonbonded_interactions/nonbonded_tab.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_tab.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file nonbonded_tab.cpp
+/** \file
  *
  *  Implementation of \ref nonbonded_tab.hpp
  */

--- a/src/core/nonbonded_interactions/nonbonded_tab.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_tab.hpp
@@ -21,7 +21,7 @@
 #ifndef CORE_TABULATED_HPP
 #define CORE_TABULATED_HPP
 
-/** \file tab.hpp
+/** \file nonbonded_tab.hpp
  *  Routines to calculate the  energy and/or  force
  *  for a particle pair or bonds via interpolating from lookup tables.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/nonbonded_tab.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_tab.hpp
@@ -21,7 +21,7 @@
 #ifndef CORE_TABULATED_HPP
 #define CORE_TABULATED_HPP
 
-/** \file nonbonded_tab.hpp
+/** \file
  *  Routines to calculate the  energy and/or  force
  *  for a particle pair or bonds via interpolating from lookup tables.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/reaction_field.cpp
+++ b/src/core/nonbonded_interactions/reaction_field.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file reaction_field.cpp
+/** \file
  *
  *  Implementation of \ref reaction_field.hpp
  */

--- a/src/core/nonbonded_interactions/reaction_field.hpp
+++ b/src/core/nonbonded_interactions/reaction_field.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef REACTION_FIELD_H
 #define REACTION_FIELD_H
-/** \file reaction_field.hpp
+/** \file
  *  Routines to calculate the Reaction Field Energy or/and force
  *  for a particle pair.
  *  M. Neumann, J. Chem. Phys 82, 5663 (1985)

--- a/src/core/nonbonded_interactions/soft_sphere.cpp
+++ b/src/core/nonbonded_interactions/soft_sphere.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file soft_sphere.cpp
+/** \file
  *
  *  Implementation of \ref soft_sphere.hpp
  */

--- a/src/core/nonbonded_interactions/soft_sphere.hpp
+++ b/src/core/nonbonded_interactions/soft_sphere.hpp
@@ -21,7 +21,7 @@
 #ifndef soft_H
 #define soft_H
 
-/** \file soft_sphere.hpp
+/** \file
  *  Routines to calculate the soft-sphere energy and/or  force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/steppot.cpp
+++ b/src/core/nonbonded_interactions/steppot.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file steppot.cpp
+/** \file
  *
  *  Implementation of \ref steppot.hpp
  */

--- a/src/core/nonbonded_interactions/steppot.hpp
+++ b/src/core/nonbonded_interactions/steppot.hpp
@@ -21,7 +21,7 @@
 #ifndef STEPPOT_H
 #define STEPPOT_H
 
-/** \file steppot.hpp
+/** \file
  *  Routines to calculate the smooth step potential energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/thole.hpp
+++ b/src/core/nonbonded_interactions/thole.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _THOLE_H
 #define _THOLE_H
-/** \file thole.hpp
+/** \file
  *  Routines to calculate the thole damping energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/nonbonded_interactions/thole.hpp
+++ b/src/core/nonbonded_interactions/thole.hpp
@@ -21,7 +21,7 @@
 #ifndef _THOLE_H
 #define _THOLE_H
 /** \file
- *  Routines to calculate the thole damping energy and/or force
+ *  Routines to calculate the Thole damping energy and/or force
  *  for a particle pair.
  *  \ref forces.cpp
  */
@@ -53,7 +53,7 @@ inline void add_thole_pair_force(const Particle *const p1,
     double dist2 = dist * dist;
 
     // Subtract p3m shortrange (dipole-dipole charge portion) to add damped
-    // coulomb later
+    // Coulomb later
     p3m_add_pair_force(-thole_q1q2, d, dist2, dist, force);
 
     // Calc damping function (see doi.org/10.1016/0301-0104(81)85176-2)

--- a/src/core/npt.hpp
+++ b/src/core/npt.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file npt.hpp
+/** \file
     exports for the NPT code, which otherwise is really spread all over...
 */
 

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file nsquare.cpp
+/** \file
  *
  *  Implementation of  \ref nsquare.hpp "nsquare.hpp".
  */

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -20,7 +20,7 @@
 */
 /** \file nsquare.cpp
  *
- *  Implementation of  \ref nsquare.hpp "nsquare.h".
+ *  Implementation of  \ref nsquare.hpp "nsquare.hpp".
  */
 
 #include "nsquare.hpp"

--- a/src/core/nsquare.hpp
+++ b/src/core/nsquare.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef NSQUARE_H
 #define NSQUARE_H
-/** \file nsquare.hpp
+/** \file
     This file contains the code for a simple n^2 particle loop.
 
     The nsquare cell system performs a full n^2 particle interaction

--- a/src/core/object-in-fluid/affinity.cpp
+++ b/src/core/object-in-fluid/affinity.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file affinity.cpp
+/** \file
  *
  *  Implementation of \ref affinity.hpp
  */

--- a/src/core/object-in-fluid/affinity.hpp
+++ b/src/core/object-in-fluid/affinity.hpp
@@ -70,7 +70,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 2. Then I check whether there exists a bond from the current particle:
      *?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will brake or not.
+     *decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
      *in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
@@ -80,7 +80,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * comments:
      * 	strength of the force is proportional to the difference of actual bond
      *length and relaxed bond length bond is always created, no probability is
-     *involved if bondlength reaches maxBond, the bond immediately ruptures. No
+     *involved if bond length reaches maxBond, the bond immediately ruptures. No
      *probability is involved
      *********************/
     int j;
@@ -150,7 +150,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 2. Then I check whether there exists a bond from the current particle:
      *?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will brake or not.
+     *decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
      *in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
@@ -162,7 +162,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 	strength of the force is proportional to the difference of actual bond
      *length and relaxed bond length bond is created with probability
      *1-exp(-Kon*timestep) maxBond is not used, we use probability
-     *1-exp(-Koff*timestep) to brake the bond Koff depends on the bondlenth via
+     *1-exp(-Koff*timestep) to break the bond Koff depends on the bond length via
      *Koff = K0*exp(F/Fd) = K0*exp(kappa(r-r0)/Fd) here, ia_params->Koff gives
      *us K_0, off rate when bond is relaxed. here, maxBond is used as detachment
      *force F_d. The original check for ensuring, that particle flows out of the
@@ -292,7 +292,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 2. Then I check whether there exists a bond from the current particle:
      *?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will brake or not.
+     *decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
      *in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
@@ -304,7 +304,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 	strength of the force is proportional to the difference of actual bond
      *length and relaxed bond length bond is created with probability
      *1-exp(-Kon*timestep) bond is ruptured with probability
-     *1-exp(-Koff*timestep) to brake the bond Koff is given as parameter, is not
+     *1-exp(-Koff*timestep) to break the bond Koff is given as parameter, is not
      *dependent on the force nor the bond length here, maxBond stands for
      *ensuring, that particle flows out of the cut-off radius and the bond
      *remains active. maxBond should be always less than cut_off radius
@@ -404,7 +404,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 2. Then I check whether there exists a bond from the current particle:
      *?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will brake or not.
+     *decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
      *in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
@@ -415,8 +415,8 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * comments:
      * 	strength of the force is proportional to the actual bond length
      * 	bond is created with probability 1-exp(-Kon*timestep)
-     * 	maxBond is not used, we use probability 1-exp(-Koff*timestep) to brake
-     *the bond Koff depends on the bondlength via Koff = K0*exp(F/Fd) =
+     * 	maxBond is not used, we use probability 1-exp(-Koff*timestep) to break
+     *the bond Koff depends on the bond length via Koff = K0*exp(F/Fd) =
      *K0*exp(kappa*r/Fd) here, ia_params->Koff gives us K_0, off rate when bond
      *is relaxed. here, maxBond is used as detachment force F_d. The original
      *check for ensuring, that particle flows out of the cut-off radius and the
@@ -534,7 +534,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 2. Then I check whether there exists a bond from the current particle:
      *?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will brake or not.
+     *decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
      *in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
@@ -546,7 +546,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 	strength of the force is proportional to the difference of actual bond
      *length and 75% of the relaxed bond length bond is created with probability
      *1-exp(-Kon*timestep) maxBond is not used, we use probability
-     *1-exp(-Koff*timestep) to brake the bond Koff depends on the bondlenth via
+     *1-exp(-Koff*timestep) to break the bond Koff depends on the bond length via
      *Koff = K0*exp(F/Fd) = K0*exp(kappa(r-0.75*r0)/Fd) here, ia_params->Koff
      *gives us K_0, off rate when bond is relaxed. here, maxBond is used as
      *detachment force F_d. The original check for ensuring, that particle flows
@@ -674,7 +674,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 2. Then I check whether there exists a bond from the current particle:
      *?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will brake or not.
+     *decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
      *in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
@@ -686,7 +686,7 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      * 	strength of the force is proportional to the difference of actual bond
      *length and the relaxed bond length bond is created with probability
      *1-exp(-Kon*timestep) maxBond is not used, we use probability
-     *1-exp(-Koff*timestep) to brake the bond Koff depends on the bondlenth via
+     *1-exp(-Koff*timestep) to break the bond Koff depends on the bond length via
      *Koff = K0*exp(F/Fd) = K0*exp(kappa(r-0.75*r0)/Fd) here, ia_params->Koff
      *gives us K_0, off rate when bond is relaxed. here, maxBond is used as
      *detachment force F_d. The original check for ensuring, that particle flows

--- a/src/core/object-in-fluid/affinity.hpp
+++ b/src/core/object-in-fluid/affinity.hpp
@@ -22,8 +22,7 @@
 #define AFFINITY_H
 
 /** \file
- *  Routines to calculate the affinity  force
- *  for a particle pair.
+ *  Routines to calculate the affinity force for a particle pair.
  *  \ref forces.cpp
  */
 
@@ -60,28 +59,29 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      *
      * Here I can implement the affinity force.
      * I have the position of the particle - p1, and under p1->p.bond_site I
-     *have the coordinate of the bond_site. Also, under d[3] I have the vector
-     *towards the constraint meaning that force on p1 should be in the direction
-     *of d[3].
+     * have the coordinate of the bond_site. Also, under d[3] I have the vector
+     * towards the constraint meaning that force on p1 should be in the
+     * direction of d[3].
      *
      * Algorithm:
      * 1. First check is, whether I am in the cut-off radius: ?dist <
-     *affinity_cut?.
+     *    affinity_cut?.
      * 2. Then I check whether there exists a bond from the current particle:
-     *?bond_site != -1?
+     *    ?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will break or not.
+     *    decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
-     *in the area of possible bond creation: ?dist < affinity_r0?
+     *    in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
-     *create or does not create the bond.
+     *    create or does not create the bond.
      * 6. If I am not in the area of possible bond creation I do nothing
      *
      * comments:
-     * 	strength of the force is proportional to the difference of actual bond
-     *length and relaxed bond length bond is always created, no probability is
-     *involved if bond length reaches maxBond, the bond immediately ruptures. No
-     *probability is involved
+     * - strength of the force is proportional to the difference of
+     *   actual bond length and relaxed bond length
+     * - bond is always created, no probability is involved
+     * - if bond length reaches maxBond, the bond immediately ruptures,
+     *   no probability is involved
      *********************/
     int j;
     double fac = 0.0;
@@ -111,11 +111,11 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
             // printf("len %f r0 %f\n",len, ia_params->affinity_r0);
           } else
             fac = 0.0;
-          //				double ftemp = 0;
+          // double ftemp = 0;
           for (j = 0; j < 3; j++) {
             force[j] += fac * vec[j] / len;
           }
-          //				printf("%f ",ftemp);
+          // printf("%f ",ftemp);
           // Decision whether I should break the bond: if the bond length is
           // greater than maxBond, it breaks.
           if (len > ia_params->affinity_maxBond) {
@@ -124,9 +124,9 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
           }
         } else if (dist <
                    ia_params
-                       ->affinity_r0) { // Bond does not exist, we are inside of
-                                        // possible bond creation area, lets
-                                        // talk about creating a bond
+                       ->affinity_r0) { // Bond does not exist, we are inside
+                                        // of possible bond creation area,
+                                        // lets talk about creating a bond
           // This implementation creates bond always
           Vector3d unfolded_pos = unfolded_position(p1);
           for (j = 0; j < 3; j++)
@@ -140,34 +140,37 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      *
      * Here I can implement the affinity force.
      * I have the position of the particle - p1, and under p1->p.bond_site I
-     *have the coordinate of the bond_site. Also, under d[3] I have the vector
-     *towards the constraint meaning that force on p1 should be in the direction
-     *of d[3].
+     * have the coordinate of the bond_site. Also, under d[3] I have the vector
+     * towards the constraint meaning that force on p1 should be in the
+     * direction of d[3].
      *
      * Algorithm:
      * 1. First check is whether I am in the cut-off radius: ?dist <
-     *affinity_cut?.
+     *    affinity_cut?.
      * 2. Then I check whether there exists a bond from the current particle:
-     *?bond_site != -1?
+     *    ?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will break or not.
+     *    decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
-     *in the area of possible bond creation: ?dist < affinity_r0?
+     *    in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
-     *create or does not create the bond.
+     *    create or does not create the bond.
      * 6. If I am not in the area of possible bond creation I do nothing
      *
      *
      * comments:
-     * 	strength of the force is proportional to the difference of actual bond
-     *length and relaxed bond length bond is created with probability
-     *1-exp(-Kon*timestep) maxBond is not used, we use probability
-     *1-exp(-Koff*timestep) to break the bond Koff depends on the bond length via
-     *Koff = K0*exp(F/Fd) = K0*exp(kappa(r-r0)/Fd) here, ia_params->Koff gives
-     *us K_0, off rate when bond is relaxed. here, maxBond is used as detachment
-     *force F_d. The original check for ensuring, that particle flows out of the
-     *cut-off radius and the bond remains active is replaced with fixed check,
-     *that bond length must not be greater that 0.8 cut_off
+     * - strength of the force is proportional to the difference of actual
+     *   bond length and relaxed bond length
+     * - bond is created with probability 1-exp(-Kon*timestep)
+     * - maxBond is not used, we use probability 1-exp(-Koff*timestep) to
+     *   break the bond
+     * - Koff depends on the bond length via Koff = K0*exp(F/Fd) =
+     *   K0*exp(kappa(r-r0)/Fd)
+     * - here, ia_params->Koff gives us K_0, off rate when bond is relaxed
+     * - here, maxBond is used as detachment force F_d
+     * - the original check for ensuring, that particle flows out of the
+     *   cut-off radius and the bond remains active is replaced with fixed
+     *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     int j;
     double fac = 0.0;
@@ -250,9 +253,9 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
             }
         } else if (dist <
                    ia_params
-                       ->affinity_r0) { // Bond does not exist, we are inside of
-                                        // possible bond creation area, lets
-                                        // talk about creating a bond
+                       ->affinity_r0) { // Bond does not exist, we are inside
+                                        // of possible bond creation area,
+                                        // lets talk about creating a bond
           double Pon = 1.0 - exp(-ia_params->affinity_Kon * time_step);
           // The probability is given by function Pon(x)= 1 - e^(-x) where x is
           // Kon*dt.
@@ -282,37 +285,39 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      *
      * Here I can implement the affinity force.
      * I have the position of the particle - p1, and under p1->p.bond_site I
-     *have the coordinate of the bond_site. Also, under d[3] I have the vector
-     *towards the constraint meaning that force on p1 should be in the direction
-     *of d[3].
+     * have the coordinate of the bond_site. Also, under d[3] I have the vector
+     * towards the constraint meaning that force on p1 should be in the
+     * direction of d[3].
      *
      * Algorithm:
      * 1. First check is whether I am in the cut-off radius: ?dist <
-     *affinity_cut?.
+     *    affinity_cut?.
      * 2. Then I check whether there exists a bond from the current particle:
-     *?bond_site != -1?
+     *    ?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will break or not.
+     *    decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
-     *in the area of possible bond creation: ?dist < affinity_r0?
+     *    in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
-     *create or does not create the bond.
+     *    create or does not create the bond.
      * 6. If I am not in the area of possible bond creation I do nothing
      *
      *
      * comments:
-     * 	strength of the force is proportional to the difference of actual bond
-     *length and relaxed bond length bond is created with probability
-     *1-exp(-Kon*timestep) bond is ruptured with probability
-     *1-exp(-Koff*timestep) to break the bond Koff is given as parameter, is not
-     *dependent on the force nor the bond length here, maxBond stands for
-     *ensuring, that particle flows out of the cut-off radius and the bond
-     *remains active. maxBond should be always less than cut_off radius
+     * - strength of the force is proportional to the difference of
+     *   actual bond length and relaxed bond length
+     * - bond is created with probability 1-exp(-Kon*timestep)
+     * - bond is ruptured with probability 1-exp(-Koff*timestep)
+     * - to break the bond Koff is given as parameter, is not
+     *   dependent on the force nor the bond length
+     * - here, maxBond stands for ensuring, that particle flows out of the
+     *   cut-off radius and the bond remains active
+     * - maxBond should be always less than cut_off radius
      *********************/
     int j;
     double fac = 0.0;
-    if ((dist < ia_params->affinity_cut)) { // Checking whether I am inside the
-                                            // interaction cut-off radius.
+    if ((dist < ia_params->affinity_cut)) { // Checking whether I am inside
+                                            // the interaction cut-off radius.
       if (dist > 0.0) {
         // printf("bond_site: %f %f
         // %f\n",p1->p.bond_site[0],p1->p.bond_site[1],p1->p.bond_site[2]);
@@ -336,11 +341,11 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
             // printf("len %f r0 %f\n",len, ia_params->affinity_r0);
           } else
             fac = 0.0;
-          //				double ftemp = 0;
+          // double ftemp = 0;
           for (j = 0; j < 3; j++) {
             force[j] += fac * vec[j];
           }
-          //				printf("%f ",ftemp);
+          // printf("%f ",ftemp);
           // Decision whether I should break the bond:
           // The random decision algorithm is much more complicated with Fd
           // detachment force etc. Here, I use much simpler rule, the same as
@@ -362,9 +367,9 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
           }
         } else if (dist <
                    ia_params
-                       ->affinity_r0) { // Bond does not exist, we are inside of
-                                        // possible bond creation area, lets
-                                        // talk about creating a bond
+                       ->affinity_r0) { // Bond does not exist, we are inside
+                                        // of possible bond creation area,
+                                        // lets talk about creating a bond
           double Pon = 1.0 - exp(-ia_params->affinity_Kon * time_step);
           // The probability is given by function Pon(x)= 1 - e^(-x) where x is
           // Kon*dt.
@@ -394,34 +399,36 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      *
      * Here I can implement the affinity force.
      * I have the position of the particle - p1, and under p1->p.bond_site I
-     *have the coordinate of the bond_site. Also, under d[3] I have the vector
-     *towards the constraint meaning that force on p1 should be in the direction
-     *of d[3].
+     * have the coordinate of the bond_site. Also, under d[3] I have the vector
+     * towards the constraint meaning that force on p1 should be in the
+     * direction of d[3].
      *
      * Algorithm:
      * 1. First check is whether I am in the cut-off radius: ?dist <
-     *affinity_cut?.
+     *    affinity_cut?.
      * 2. Then I check whether there exists a bond from the current particle:
-     *?bond_site != -1?
+     *    ?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will break or not.
+     *    decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
-     *in the area of possible bond creation: ?dist < affinity_r0?
+     *    in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
-     *create or does not create the bond.
+     *    create or does not create the bond.
      * 6. If I am not in the area of possible bond creation I do nothing
      *
      *
      * comments:
-     * 	strength of the force is proportional to the actual bond length
-     * 	bond is created with probability 1-exp(-Kon*timestep)
-     * 	maxBond is not used, we use probability 1-exp(-Koff*timestep) to break
-     *the bond Koff depends on the bond length via Koff = K0*exp(F/Fd) =
-     *K0*exp(kappa*r/Fd) here, ia_params->Koff gives us K_0, off rate when bond
-     *is relaxed. here, maxBond is used as detachment force F_d. The original
-     *check for ensuring, that particle flows out of the cut-off radius and the
-     *bond remains active is replaced with fixed check, that bond length must
-     *not be greater that 0.8 cut_off
+     * - strength of the force is proportional to the actual bond length
+     * - bond is created with probability 1-exp(-Kon*timestep)
+     * - maxBond is not used, we use probability 1-exp(-Koff*timestep) to
+     *   break the bond
+     * - Koff depends on the bond length via Koff = K0*exp(F/Fd) =
+     *   K0*exp(kappa*r/Fd)
+     * - here, ia_params->Koff gives us K_0, off rate when bond is relaxed
+     * - here, maxBond is used as detachment force F_d
+     * - the original check for ensuring, that particle flows out of the
+     *   cut-off radius and the bond remains active is replaced with fixed
+     *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     int j;
     double fac = 0.0;
@@ -495,9 +502,9 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
             }
         } else if (dist <
                    ia_params
-                       ->affinity_r0) { // Bond does not exist, we are inside of
-                                        // possible bond creation area, lets
-                                        // talk about creating a bond
+                       ->affinity_r0) { // Bond does not exist, we are inside
+                                        // of possible bond creation area,
+                                        // lets talk about creating a bond
           double Pon = 1.0 - exp(-ia_params->affinity_Kon * time_step);
           // The probability is given by function Pon(x)= 1 - e^(-x) where x is
           // Kon*dt.
@@ -524,34 +531,37 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      *
      * Here I can implement the affinity force.
      * I have the position of the particle - p1, and under p1->p.bond_site I
-     *have the coordinate of the bond_site. Also, under d[3] I have the vector
-     *towards the constraint meaning that force on p1 should be in the direction
-     *of d[3].
+     * have the coordinate of the bond_site. Also, under d[3] I have the vector
+     * towards the constraint meaning that force on p1 should be in the
+     * direction of d[3].
      *
      * Algorithm:
      * 1. First check is whether I am in the cut-off radius: ?dist <
-     *affinity_cut?.
+     *    affinity_cut?.
      * 2. Then I check whether there exists a bond from the current particle:
-     *?bond_site != -1?
+     *    ?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will break or not.
+     *    decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
-     *in the area of possible bond creation: ?dist < affinity_r0?
+     *    in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
-     *create or does not create the bond.
+     *    create or does not create the bond.
      * 6. If I am not in the area of possible bond creation I do nothing
      *
      *
      * comments:
-     * 	strength of the force is proportional to the difference of actual bond
-     *length and 75% of the relaxed bond length bond is created with probability
-     *1-exp(-Kon*timestep) maxBond is not used, we use probability
-     *1-exp(-Koff*timestep) to break the bond Koff depends on the bond length via
-     *Koff = K0*exp(F/Fd) = K0*exp(kappa(r-0.75*r0)/Fd) here, ia_params->Koff
-     *gives us K_0, off rate when bond is relaxed. here, maxBond is used as
-     *detachment force F_d. The original check for ensuring, that particle flows
-     *out of the cut-off radius and the bond remains active is replaced with
-     *fixed check, that bond length must not be greater that 0.8 cut_off
+     * - strength of the force is proportional to the difference of actual
+     *   bond length and 75% of the relaxed bond length
+     * - bond is created with probability 1-exp(-Kon*timestep)
+     * - maxBond is not used, we use probability 1-exp(-Koff*timestep) to
+     *   break the bond
+     * - Koff depends on the bond length via Koff = K0*exp(F/Fd) =
+     *   K0*exp(kappa(r-0.75*r0)/Fd)
+     * - here, ia_params->Koff gives us K_0, off rate when bond is relaxed
+     * - here, maxBond is used as detachment force F_d
+     * - the original check for ensuring, that particle flows out of the
+     *   cut-off radius and the bond remains active is replaced with fixed
+     *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     int j;
     double fac = 0.0;
@@ -632,9 +642,9 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
             }
         } else if (dist <
                    ia_params
-                       ->affinity_r0) { // Bond does not exist, we are inside of
-                                        // possible bond creation area, lets
-                                        // talk about creating a bond
+                       ->affinity_r0) { // Bond does not exist, we are inside
+                                        // of possible bond creation area,
+                                        // lets talk about creating a bond
           double Pon = 1.0 - exp(-ia_params->affinity_Kon * time_step);
           // The probability is given by function Pon(x)= 1 - e^(-x) where x is
           // Kon*dt.
@@ -664,34 +674,37 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
      *
      * Here I can implement the affinity force.
      * I have the position of the particle - p1, and under p1->p.bond_site I
-     *have the coordinate of the bond_site. Also, under d[3] I have the vector
-     *towards the constraint meaning that force on p1 should be in the direction
-     *of d[3].
+     * have the coordinate of the bond_site. Also, under d[3] I have the vector
+     * towards the constraint meaning that force on p1 should be in the
+     * direction of d[3].
      *
      * Algorithm:
      * 1. First check is whether I am in the cut-off radius: ?dist <
-     *affinity_cut?.
+     *    affinity_cut?.
      * 2. Then I check whether there exists a bond from the current particle:
-     *?bond_site != -1?
+     *    ?bond_site != -1?
      * 3. If yes, then I maintain the bond. I put the forces and afterwards I
-     *decide whether the bond will break or not.
+     *    decide whether the bond will break or not.
      * 4. If no, I maintain the creation of a bond. First I check whether I am
-     *in the area of possible bond creation: ?dist < affinity_r0?
+     *    in the area of possible bond creation: ?dist < affinity_r0?
      * 5. If yes, I run the decision algorithm for bond creation and I either
-     *create or does not create the bond.
+     *    create or does not create the bond.
      * 6. If I am not in the area of possible bond creation I do nothing
      *
      *
      * comments:
-     * 	strength of the force is proportional to the difference of actual bond
-     *length and the relaxed bond length bond is created with probability
-     *1-exp(-Kon*timestep) maxBond is not used, we use probability
-     *1-exp(-Koff*timestep) to break the bond Koff depends on the bond length via
-     *Koff = K0*exp(F/Fd) = K0*exp(kappa(r-0.75*r0)/Fd) here, ia_params->Koff
-     *gives us K_0, off rate when bond is relaxed. here, maxBond is used as
-     *detachment force F_d. The original check for ensuring, that particle flows
-     *out of the cut-off radius and the bond remains active is replaced with
-     *fixed check, that bond length must not be greater that 0.8 cut_off
+     * - strength of the force is proportional to the difference of
+     *   actual bond length and the relaxed bond length
+     * - bond is created with probability 1-exp(-Kon*timestep)
+     * - maxBond is not used, we use probability 1-exp(-Koff*timestep) to
+     *   break the bond
+     * - Koff depends on the bond length via Koff = K0*exp(F/Fd) =
+     *   K0*exp(kappa(r-0.75*r0)/Fd)
+     * - here, ia_params->Koff gives us K_0, off rate when bond is relaxed
+     * - here, maxBond is used as detachment force F_d
+     * - the original check for ensuring, that particle flows out of the
+     *   cut-off radius and the bond remains active is replaced with fixed
+     *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     int j;
     double fac = 0.0;
@@ -774,9 +787,9 @@ inline void add_affinity_pair_force(Particle *p1, Particle *p2,
             }
         } else if (dist <
                    ia_params
-                       ->affinity_r0) { // Bond does not exist, we are inside of
-                                        // possible bond creation area, lets
-                                        // talk about creating a bond
+                       ->affinity_r0) { // Bond does not exist, we are inside
+                                        // of possible bond creation area,
+                                        // lets talk about creating a bond
           double Pon = 1.0 - exp(-ia_params->affinity_Kon * time_step);
           // The probability is given by function Pon(x)= 1 - e^(-x) where x is
           // Kon*dt.

--- a/src/core/object-in-fluid/affinity.hpp
+++ b/src/core/object-in-fluid/affinity.hpp
@@ -21,7 +21,7 @@
 #ifndef AFFINITY_H
 #define AFFINITY_H
 
-/** \file affinity.hpp
+/** \file
  *  Routines to calculate the affinity  force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/object-in-fluid/membrane_collision.cpp
+++ b/src/core/object-in-fluid/membrane_collision.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file membrane_collision.cpp
+/** \file
  *
  *  Implementation of \ref membrane_collision.hpp
  */

--- a/src/core/object-in-fluid/membrane_collision.hpp
+++ b/src/core/object-in-fluid/membrane_collision.hpp
@@ -21,7 +21,7 @@
 #ifndef MEMBRANE_COLLISION_H
 #define MEMBRANE_COLLISION_H
 
-/** \file membrane_collision.hpp
+/** \file
  *  Routines to calculate the membrane collision force
  *  for a particle pair.
  *  \ref forces.cpp

--- a/src/core/object-in-fluid/oif_global_forces.cpp
+++ b/src/core/object-in-fluid/oif_global_forces.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file oif_global_forces.hpp
+/** \file oif_global_forces.cpp
  *  Routines to calculate the OIF_GLOBAL_FORCES energy or/and and force
  *  for a particle triple (triangle from mesh). (Dupin2007)
  *  \ref forces.cpp

--- a/src/core/object-in-fluid/oif_global_forces.cpp
+++ b/src/core/object-in-fluid/oif_global_forces.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file oif_global_forces.cpp
+/** \file
  *  Routines to calculate the OIF_GLOBAL_FORCES energy or/and and force
  *  for a particle triple (triangle from mesh). (Dupin2007)
  *  \ref forces.cpp

--- a/src/core/object-in-fluid/oif_global_forces.hpp
+++ b/src/core/object-in-fluid/oif_global_forces.hpp
@@ -18,7 +18,7 @@
 */
 #ifndef _OBJECT_IN_FLUID_OIF_GLOBAL_FORCES_H
 #define _OBJECT_IN_FLUID_OIF_GLOBAL_FORCES_H
-/** \file oif_global_forces.hpp
+/** \file
  *  Routines to calculate the OIF_GLOBAL_FORCES energy or/and and force
  *  for a particle triple (triangle from mesh). (Dupin2007)
  *  \ref forces.cpp

--- a/src/core/object-in-fluid/oif_local_forces.cpp
+++ b/src/core/object-in-fluid/oif_local_forces.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file oif_local_forces.hpp
+/** \file oif_local_forces.cpp
  *  Routines to calculate the OIF_LOCAL_FORCES
  *  for a particle quadruple (two neighboring triangles with common edge).
  * (Dupin2007) \ref forces.cpp

--- a/src/core/object-in-fluid/oif_local_forces.cpp
+++ b/src/core/object-in-fluid/oif_local_forces.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file oif_local_forces.cpp
+/** \file
  *  Routines to calculate the OIF_LOCAL_FORCES
  *  for a particle quadruple (two neighboring triangles with common edge).
  * (Dupin2007) \ref forces.cpp

--- a/src/core/object-in-fluid/oif_local_forces.hpp
+++ b/src/core/object-in-fluid/oif_local_forces.hpp
@@ -19,7 +19,7 @@
 #ifndef _OBJECT_IN_FLUID_OIF_LOCAL_FORCES_H
 #define _OBJECT_IN_FLUID_OIF_LOCAL_FORCES_H
 
-/** \file oif_local_forces.hpp
+/** \file
  *  Routines to calculate the OIF_LOCAL_FORCES
  *  for a particle quadruple (two neighboring triangles with common edge).
  * (Dupin2007) \ref forces.cpp

--- a/src/core/object-in-fluid/out_direction.cpp
+++ b/src/core/object-in-fluid/out_direction.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file out_direction.hpp Routines to calculate the outward direction of the
+/** \file out_direction.cpp Routines to calculate the outward direction of the
  * membrane using a particle quadruple (one particle and its 3 strategically
  * placed neighbors)
  */

--- a/src/core/object-in-fluid/out_direction.cpp
+++ b/src/core/object-in-fluid/out_direction.cpp
@@ -17,7 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file out_direction.cpp Routines to calculate the outward direction of the
+/** \file
+ * Routines to calculate the outward direction of the
  * membrane using a particle quadruple (one particle and its 3 strategically
  * placed neighbors)
  */

--- a/src/core/object-in-fluid/out_direction.hpp
+++ b/src/core/object-in-fluid/out_direction.hpp
@@ -18,7 +18,8 @@
 */
 #ifndef _OBJECT_IN_FLUID_OUT_DIRECTION_H
 #define _OBJECT_IN_FLUID_OUT_DIRECTION_H
-/** \file out_direction.hpp Routines to calculate the outward direction of the
+/** \file
+ * Routines to calculate the outward direction of the
  * membrane using a particle quadruple (one particle and its 3 strategically
  * placed neighbors)
  */

--- a/src/core/observables/not_yet_implemented/StructureFactor.hpp
+++ b/src/core/observables/not_yet_implemented/StructureFactor.hpp
@@ -69,7 +69,7 @@ int ObservableStructureFactor::actual_calculate(PartCfg &partCfg) {
   }
   l = 0;
   for (int k = 0; k < n; k++) {
-    // devide by the sqrt(number_of_particle) due to complex product and no
+    // divide by the sqrt(number_of_particle) due to complex product and no
     // k-vector averaging so far
     A[k] /= sqrt(n_part);
   }

--- a/src/core/observables/not_yet_implemented/StructureFactorFast.hpp
+++ b/src/core/observables/not_yet_implemented/StructureFactorFast.hpp
@@ -196,7 +196,7 @@ int ObservableStructureFactorFast::actual_calculate(PartCfg &partCfg) {
     }
   }
   for (int l = 0; l < n; l++) {
-    // devide by the sqrt of number_of_particle, average later
+    // divide by the sqrt of number_of_particle, average later
     A[l] /= sqrt(n_part);
   }
   return 0;

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file particle_data.cpp
+/** \file
     This file contains everything related to particle storage. If you want to
    add a new property to the particles, it is probably a good idea to modify
    \ref Particle to give scripts access to that property. You always have to

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -22,7 +22,7 @@
 #define _PARTICLE_DATA_H
 /** \file particle_data.hpp
     For more information on particle_data,
-    see \ref particle_data.cpp "particle_data.c"
+    see \ref particle_data.cpp "particle_data.cpp"
 */
 
 #include "Vector.hpp"
@@ -52,20 +52,20 @@
 #define WITH_BONDS 1
 
 #ifdef EXTERNAL_FORCES
-/** \ref ParticleLocal::ext_flag "ext_flag" value for particle subject to an
+/** \ref ParticleProperties::ext_flag "ext_flag" value for particle subject to an
  * external force. */
 #define PARTICLE_EXT_FORCE 1
-/** \ref ParticleLocal::ext_flag "ext_flag" value for fixed coordinate coord. */
+/** \ref ParticleProperties::ext_flag "ext_flag" value for fixed coordinate coord. */
 #define COORD_FIXED(coord) (2L << coord)
-/** \ref ParticleLocal::ext_flag "ext_flag" mask to check whether any of the
+/** \ref ParticleProperties::ext_flag "ext_flag" mask to check whether any of the
  * coordinates is fixed. */
 #define COORDS_FIX_MASK (COORD_FIXED(0) | COORD_FIXED(1) | COORD_FIXED(2))
-/** \ref ParticleLocal::ext_flag "ext_flag" mask to check whether all of the
+/** \ref ParticleProperties::ext_flag "ext_flag" mask to check whether all of the
  * coordinates are fixed. */
 #define COORDS_ALL_FIXED (COORD_FIXED(0) & COORD_FIXED(1) & COORD_FIXED(2))
 
 #ifdef ROTATION
-/** \ref ParticleLocal::ext_flag "ext_flag" value for particle subject to an
+/** \ref ParticleProperties::ext_flag "ext_flag" value for particle subject to an
  * external torque. */
 #define PARTICLE_EXT_TORQUE 16
 #endif
@@ -186,17 +186,17 @@ struct ParticleProperties {
   /** flag whether to fix a particle in space.
       Values:
       <ul> <li> 0 no external influence
-           <li> 1 apply external force \ref ParticleLocal::ext_force
+           <li> 1 apply external force \ref ParticleProperties::ext_force
            <li> 2,3,4 fix particle coordinate 0,1,2
-           <li> 5 apply external torque \ref ParticleLocal::ext_torque
+           <li> 5 apply external torque \ref ParticleProperties::ext_torque
       </ul>
   */
   int ext_flag = 0;
-  /** External force, apply if \ref ParticleLocal::ext_flag == 1. */
+  /** External force, apply if \ref ParticleProperties::ext_flag == 1. */
   Vector3d ext_force = {0, 0, 0};
 
 #ifdef ROTATION
-  /** External torque, apply if \ref ParticleLocal::ext_flag == 16. */
+  /** External torque, apply if \ref ParticleProperties::ext_flag == 16. */
   Vector3d ext_torque = {0, 0, 0};
 #endif
 #endif

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _PARTICLE_DATA_H
 #define _PARTICLE_DATA_H
-/** \file particle_data.hpp
+/** \file
     For more information on particle_data,
     see \ref particle_data.cpp "particle_data.cpp"
 */

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -587,7 +587,7 @@ const Particle &get_particle_data(int part);
  */
 void prefetch_particle_data(std::vector<int> ids);
 
-/** @brief Invalidate the fetch cache for @f get_particle_data. */
+/** @brief Invalidate the fetch cache for get_particle_data. */
 void invalidate_fetch_cache();
 
 /** Call only on the master node.

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -514,7 +514,7 @@ Particle *got_particle(ParticleList *plist, int id);
 /** Append a particle at the end of a particle List.
     reallocates particles if necessary!
     This procedure does not care for \ref local_particles.
-    \param plist List to append the particle to.
+    \param l List to append the particle to.
     \param part  Particle to append. */
 void append_unindexed_particle(ParticleList *l, Particle &&part);
 
@@ -699,7 +699,7 @@ void get_particle_mu_E(int part, double (&mu_E)[3]);
 #endif
 
 /** Call only on the master node: set particle type.
-    @param part the particle.
+    @param p_id the particle.
     @param type its new type.
     @return ES_OK if particle existed
 */

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -412,9 +412,9 @@ struct Particle {
 /**
  * These functions cause a compile time error if
  * Particles are copied by memmove or memcpy,
- * which does not keep class invariants.
+ * which do not keep class invariants.
  *
- * These are templates so that the error is cause
+ * These are templates so that the error is caused
  * at the place they are used.
  */
 template <typename Size> void memmove(Particle *, Particle *, Size) {

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -21,9 +21,9 @@
 #ifndef _PARTICLE_DATA_H
 #define _PARTICLE_DATA_H
 /** \file
-    For more information on particle_data,
-    see \ref particle_data.cpp "particle_data.cpp"
-*/
+ *  For more information on particle_data,
+ *  see \ref particle_data.cpp "particle_data.cpp"
+ */
 
 #include "Vector.hpp"
 #include "config.hpp"
@@ -44,29 +44,33 @@
 /// ok code for \ref place_particle, particle is new
 #define ES_PART_CREATED 1
 
-/**  bonds_flag "bonds_flag" value for updating particle config without bonding
- * information */
+/** bonds_flag "bonds_flag" value for updating particle config without bonding
+ *  information
+ */
 #define WITHOUT_BONDS 0
-/**  bonds_flag "bonds_flag" value for updating particle config with bonding
- * information */
+/** bonds_flag "bonds_flag" value for updating particle config with bonding
+ *  information
+ */
 #define WITH_BONDS 1
 
 #ifdef EXTERNAL_FORCES
-/** \ref ParticleProperties::ext_flag "ext_flag" value for particle subject to an
- * external force. */
+/** \ref ParticleProperties::ext_flag "ext_flag" value for particle subject to
+ *  an external force
+ */
 #define PARTICLE_EXT_FORCE 1
-/** \ref ParticleProperties::ext_flag "ext_flag" value for fixed coordinate coord. */
+/** \ref ParticleProperties::ext_flag "ext_flag" value for fixed coordinate
+ *  coord. */
 #define COORD_FIXED(coord) (2L << coord)
-/** \ref ParticleProperties::ext_flag "ext_flag" mask to check whether any of the
- * coordinates is fixed. */
+/** \ref ParticleProperties::ext_flag "ext_flag" mask to check whether any of
+ *  the coordinates is fixed. */
 #define COORDS_FIX_MASK (COORD_FIXED(0) | COORD_FIXED(1) | COORD_FIXED(2))
-/** \ref ParticleProperties::ext_flag "ext_flag" mask to check whether all of the
- * coordinates are fixed. */
+/** \ref ParticleProperties::ext_flag "ext_flag" mask to check whether all of
+ *  the coordinates are fixed. */
 #define COORDS_ALL_FIXED (COORD_FIXED(0) & COORD_FIXED(1) & COORD_FIXED(2))
 
 #ifdef ROTATION
-/** \ref ParticleProperties::ext_flag "ext_flag" value for particle subject to an
- * external torque. */
+/** \ref ParticleProperties::ext_flag "ext_flag" value for particle subject to
+ *  an external torque. */
 #define PARTICLE_EXT_TORQUE 16
 #endif
 
@@ -77,11 +81,11 @@
  ************************************************/
 
 /** Properties of a particle which are not supposed to
-    change during the integration, but have to be known
-    for all ghosts. Ghosts are particles which are
-    needed in the interaction calculation, but are just copies of
-    particles stored on different nodes.
-*/
+ *  change during the integration, but have to be known
+ *  for all ghosts. Ghosts are particles which are
+ *  needed in the interaction calculation, but are just copies of
+ *  particles stored on different nodes.
+ */
 struct ParticleProperties {
   /** unique identifier for the particle. */
   int identity = -1;
@@ -372,10 +376,12 @@ struct Particle {
 #ifdef LB
   ParticleLatticeCoupling lc;
 #endif
-  /** bonded interactions list. The format is pretty simple:
-      Just the bond type, and then the particle ids. The number of particle ids
-     can be determined
-      easily from the bonded_ia_params entry for the type. */
+  /** Bonded interactions list
+   *
+   *  The format is pretty simple: just the bond type, and then the particle
+   *  ids. The number of particle ids can be determined easily from the
+   *  bonded_ia_params entry for the type.
+   */
   IntList bl;
 
   IntList &bonds() { return bl; }
@@ -399,7 +405,7 @@ struct Particle {
 
 #ifdef EXCLUSIONS
   /** list of particles, with which this particle has no nonbonded
-   * interactions
+   *  interactions
    */
   IntList el;
 #endif
@@ -442,9 +448,9 @@ void MPI_Send(Particle const *, Size, Ts...) {
 }
 
 /** List of particles. The particle array is resized using a sophisticated
-    (we hope) algorithm to avoid unnecessary resizes.
-    Access using \ref realloc_particlelist, \ref got_particle,...
-*/
+ *  (we hope) algorithm to avoid unnecessary resizes.
+ *  Access using \ref realloc_particlelist, \ref got_particle, ...
+ */
 struct ParticleList {
   ParticleList() : part{nullptr}, n{0}, max{0} {}
   /** The particles payload */

--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file polymer.cpp
+/** \file
     This file contains everything needed to create a start-up configuration
     of (partially charged) polymer chains with counterions and salt molecules,
     assigning velocities to the particles and crosslinking the polymers if

--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -21,7 +21,7 @@
 /** \file
     This file contains everything needed to create a start-up configuration
     of (partially charged) polymer chains with counterions and salt molecules,
-    assigning velocities to the particles and crosslinking the polymers if
+    assigning velocities to the particles and cross-linking the polymers if
    necessary.
 
     The corresponding header file is polymer.hpp.

--- a/src/core/polymer.hpp
+++ b/src/core/polymer.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef POLYMER_H
 #define POLYMER_H
-/** \file polymer.hpp
+/** \file
 
     This file contains everything needed to create a start-up
     configuration of (partially charged) polymer chains with

--- a/src/core/polymer.hpp
+++ b/src/core/polymer.hpp
@@ -27,7 +27,7 @@
     counterions and salt molecules, assigning velocities to the
     particles and crosslinking the polymers if necessary.
 
-    For more information on polymer, see \ref polymer.cpp "polymer.c"
+    For more information on polymer, see \ref polymer.cpp "polymer.cpp"
 */
 
 #include "PartCfg.hpp"

--- a/src/core/polymer.hpp
+++ b/src/core/polymer.hpp
@@ -25,7 +25,7 @@
     This file contains everything needed to create a start-up
     configuration of (partially charged) polymer chains with
     counterions and salt molecules, assigning velocities to the
-    particles and crosslinking the polymers if necessary.
+    particles and cross-linking the polymers if necessary.
 
     For more information on polymer, see \ref polymer.cpp "polymer.cpp"
 */
@@ -98,7 +98,7 @@ int constraint_collision(double *p1, double *p2);
  *  @param  constr      = shall constraints be respected when setting up
  *  polymer?  (0=no, 1=yes, default: 0)
  *  @return Returns how often the attempt to place a monomer failed in the
- *  worstcase. <br>
+ *  worst case. <br>
  *  If val_cM \< 1e-10, the charge is assumed to be zero, and type_cM = type_nM.
  */
 int polymerC(PartCfg &, int N_P, int MPC, double bond_length, int part_id,

--- a/src/core/polynom.hpp
+++ b/src/core/polynom.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file polynom.hpp
+/** \file
     Datatypes and functions for polynomials.
     Evaluation possible both as Taylor and Chebychev series. Note that the
    length of the double list is equal to the order of the polynomial plus 1, so

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file pressure.cpp
+/** \file
     Implementation of \ref pressure.hpp "pressure.hpp".
 */
 

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file pressure.cpp
-    Implementation of \ref pressure.hpp "pressure.h".
+    Implementation of \ref pressure.hpp "pressure.hpp".
 */
 
 #include "cells.hpp"

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -254,7 +254,7 @@ void calc_long_range_virials() {
 /************************************************************/
 void init_virials(Observable_stat *stat) {
   // Determine number of contribution for different interaction types
-  // bonded, nonbonded, coulomb, dipolar, rigid bodies
+  // bonded, nonbonded, Coulomb, dipolar, rigid bodies
   int n_pre, n_non_bonded, n_coulomb, n_dipolar, n_vs;
 
   n_pre = 1;
@@ -320,7 +320,7 @@ void init_virials_non_bonded(Observable_stat_non_bonded *stat_nb) {
 /***************************/
 void init_p_tensor(Observable_stat *stat) {
   // Determine number of contribution for different interaction types
-  // bonded, nonbonded, coulomb, dipolar, rigid bodies
+  // bonded, nonbonded, Coulomb, dipolar, rigid bodies
   int n_pre, n_non_bonded, n_coulomb, n_dipolar, n_vs;
 
   n_pre = 1;

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file pressure.hpp
+/** \file
     Pressure calculation. Really similar to \ref energy.hpp "energy.hpp".
 */
 

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file pressure.hpp
-    Pressure calculation. Really similar to \ref energy.hpp "energy.h".
+    Pressure calculation. Really similar to \ref energy.hpp "energy.hpp".
 */
 
 #ifndef CORE_PRESSURE_HPP

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file pressure_inline.hpp
+/** \file
     Pressure calculation. Really similar to \ref energy.hpp "energy.hpp".
 */
 

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -81,7 +81,7 @@ inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2, double d[3],
   }
 
 #ifdef ELECTROSTATICS
-  /* real space coulomb */
+  /* real space Coulomb */
   if (coulomb.method != COULOMB_NONE) {
     switch (coulomb.method) {
 #ifdef P3M

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file pressure_inline.hpp
-    Pressure calculation. Really similar to \ref energy.hpp "energy.h".
+    Pressure calculation. Really similar to \ref energy.hpp "energy.hpp".
 */
 
 #ifndef CORE_PRESSURE_INLINE_HPP

--- a/src/core/random.cpp
+++ b/src/core/random.cpp
@@ -64,7 +64,7 @@ void set_state(const string &s) {
  * @brief Get the state size of the PRNG
  */
 int get_state_size_of_generator() {
-  return generator.state_size; // this only works for the mersenne twister
+  return generator.state_size; // this only works for the Mersenne twister
                                // generator, other generators do not provide
                                // this member variable
 }

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -22,7 +22,7 @@
 #ifndef RANDOM_H
 #define RANDOM_H
 
-/** \file random.hpp
+/** \file
 
     A random generator
 */

--- a/src/core/rattle.hpp
+++ b/src/core/rattle.hpp
@@ -21,7 +21,8 @@
 #ifndef RATTLE_H
 #define RATTLE_H
 
-/** \file rattle.hpp    RATTLE Algorithm (Rattle: A "Velocity" Version of the
+/** \file
+ * RATTLE Algorithm (Rattle: A "Velocity" Version of the
  * Shake Algorithm for Molecular Dynamics Calculations, H.C Andersen, J Comp
  * Phys, 52, 24-34, 1983)
  *

--- a/src/core/rattle.hpp
+++ b/src/core/rattle.hpp
@@ -25,7 +25,7 @@
  * Shake Algorithm for Molecular Dynamics Calculations, H.C Andersen, J Comp
  * Phys, 52, 24-34, 1983)
  *
- *  For more information see \ref rattle.cpp "rattle.c".
+ *  For more information see \ref rattle.cpp "rattle.cpp".
  */
 
 /** number of rigid bonds */

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -409,7 +409,7 @@ void WangLandauReactionEnsemble::on_reaction_entry(int &old_state_index) {
 void WangLandauReactionEnsemble::on_reaction_rejection_directly_after_entry(
     int &old_state_index) {
   update_wang_landau_potential_and_histogram(
-      old_state_index); // increase the wang landau potential and histogram at
+      old_state_index); // increase the wang-landau potential and histogram at
                         // the current nbar (this case covers the cases nbar=0
                         // or nbar=1)
 }
@@ -500,7 +500,7 @@ bool ReactionAlgorithm::generic_oneway_reaction(int reaction_id) {
     // accept
     accepted_state = new_state_index;
 
-    // delete hidden reactant_particles (remark: dont delete changed particles)
+    // delete hidden reactant_particles (remark: don't delete changed particles)
     // extract ids of to be deleted particles
     int len_hidden_particles_properties =
         static_cast<int>(hidden_particles_properties.size());
@@ -1095,7 +1095,7 @@ int WangLandauReactionEnsemble::get_num_needed_bins() {
 }
 
 void WangLandauReactionEnsemble::invalidate_bins() {
-  // make values in histogram and wang landau potential negative if they are not
+  // make values in histogram and wang-landau potential negative if they are not
   // allowed at the given degree of association, because the energy boundaries
   // prohibit them
 
@@ -1205,7 +1205,7 @@ double WangLandauReactionEnsemble::calculate_acceptance_probability(
     std::map<int, int> &old_particle_numbers, int old_state_index,
     int new_state_index, bool only_make_configuration_changing_move) {
   /**determine the acceptance probabilities of the reaction move
-   * in wang landau reaction ensemble
+   * in wang-landau reaction ensemble
    */
   double beta = 1.0 / temperature;
   double bf;
@@ -1277,7 +1277,7 @@ double WangLandauReactionEnsemble::calculate_acceptance_probability(
  *  no-energy-reweighting case, or with the functions
  *  do_global_mc_move_for_particles_of_type
  *
- *  perform additional Monte-carlo moves to to sample configurational
+ *  perform additional Monte carlo moves to to sample configurational
  *  partition function according to "Density-of-states Monte Carlo method
  *  for simulation of fluids"
  *
@@ -1304,7 +1304,7 @@ int WangLandauReactionEnsemble::do_reaction(int reaction_steps) {
       refine_wang_landau_parameter_one_over_t();
     }
   }
-  // shift wang landau potential minimum to zero
+  // shift wang-landau potential minimum to zero
   if (m_WL_tries % (std::max(90000, 9 * reaction_steps)) == 0) {
     // for numerical stability here we also subtract the minimum positive value
     // of the wang_landau_potential from the wang_landau potential, allowed
@@ -1327,7 +1327,7 @@ int WangLandauReactionEnsemble::do_reaction(int reaction_steps) {
 
 void WangLandauReactionEnsemble::update_wang_landau_potential_and_histogram(
     int index_of_state_after_acceptance_or_rejection) {
-  /**increase the wang landau potential and histogram at the current nbar */
+  /**increase the wang-landau potential and histogram at the current nbar */
   if (index_of_state_after_acceptance_or_rejection >= 0) {
     if (histogram[index_of_state_after_acceptance_or_rejection] >= 0) {
       histogram[index_of_state_after_acceptance_or_rejection] += 1;
@@ -1426,7 +1426,7 @@ void WangLandauReactionEnsemble::write_wang_landau_results_to_file(
                // double_fill_value. This if ensures
                // that for the energy observable not allowed energies (energies
                // in the interval [global_E_min, global_E_max]) in the
-               // multidimensional wang landau potential are printed out, since
+               // multidimensional wang-landau potential are printed out, since
                // the range [E_min(nbar), E_max(nbar)] for each nbar may be a
                // different one
         std::vector<int> unraveled_index(collective_variables.size());
@@ -1568,7 +1568,7 @@ int WangLandauReactionEnsemble::
 /** remove bins from the range of to be sampled values if they have not been
  *  sampled.
  *  use with caution otherwise you produce unphysical results, do only use
- *  when you know what you want to do. This can make wang landau converge on a
+ *  when you know what you want to do. This can make wang-landau converge on a
  *  reduced set gamma. use this function e.g. in do_reaction_wang_landau() for
  *  the diprotonic acid compare "Wang-Landau sampling with self-adaptive range"
  *  by Troester and Dellago
@@ -1599,7 +1599,7 @@ int WangLandauReactionEnsemble::write_wang_landau_checkpoint(
     const std::string &identifier) {
   std::ofstream outfile;
 
-  // write current wang landau parameters (wang_landau_parameter,
+  // write current wang-landau parameters (wang_landau_parameter,
   // monte_carlo_trial_moves, flat_index_of_current_state)
   outfile.open(std::string("checkpoint_wang_landau_parameters_") + identifier);
   outfile << wang_landau_parameter << " " << monte_carlo_trial_moves << " "
@@ -1612,7 +1612,7 @@ int WangLandauReactionEnsemble::write_wang_landau_checkpoint(
     outfile << histogram[i] << "\n";
   }
   outfile.close();
-  // write wang landau potential
+  // write wang-landau potential
   outfile.open(std::string("checkpoint_wang_landau_potential_") + identifier);
   for (int i = 0; i < wang_landau_potential.size(); i++) {
     outfile << wang_landau_potential[i] << "\n";
@@ -1628,7 +1628,7 @@ int WangLandauReactionEnsemble::load_wang_landau_checkpoint(
     const std::string &identifier) {
   std::ifstream infile;
 
-  // restore wang landau parameters
+  // restore wang-landau parameters
   infile.open(std::string("checkpoint_wang_landau_parameters_") + identifier);
   if (infile.is_open()) {
 
@@ -1666,7 +1666,7 @@ int WangLandauReactionEnsemble::load_wang_landau_checkpoint(
                              identifier);
   }
 
-  // restore wang landau potential
+  // restore wang-landau potential
   infile.open(std::string("checkpoint_wang_landau_potential_") + identifier);
   if (infile.is_open()) {
     double wang_landau_potential_entry;

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -376,7 +376,7 @@ double ReactionEnsemble::calculate_acceptance_probability(
       calculate_factorial_expression(current_reaction, old_particle_numbers);
 
   const double beta = 1.0 / temperature;
-  // calculate boltzmann factor
+  // calculate Boltzmann factor
   return std::pow(volume, current_reaction.nu_bar) * current_reaction.gamma *
          factorial_expr * exp(-beta * (E_pot_new - E_pot_old));
 }
@@ -409,7 +409,7 @@ void WangLandauReactionEnsemble::on_reaction_entry(int &old_state_index) {
 void WangLandauReactionEnsemble::on_reaction_rejection_directly_after_entry(
     int &old_state_index) {
   update_wang_landau_potential_and_histogram(
-      old_state_index); // increase the wang-landau potential and histogram at
+      old_state_index); // increase the Wang-Landau potential and histogram at
                         // the current nbar (this case covers the cases nbar=0
                         // or nbar=1)
 }
@@ -676,7 +676,7 @@ std::vector<double> ReactionAlgorithm::
   double random_radius =
       cyl_radius *
       d_random(); // for enhanced proposal of small radii, needs correction
-                  // within metropolis hasting algorithm, proposal density is
+                  // within Metropolis hasting algorithm, proposal density is
                   // p(x,y)=1/(2*pi*cyl_radius*r(x,y)), that means small radii
                   // are proposed more often
   double phi = 2.0 * PI * d_random();
@@ -871,7 +871,7 @@ bool ReactionAlgorithm::do_global_mc_move_for_particles_of_type(
                                                                    // symmetric
   }
 
-  //	//correct for enhanced proposal of small radii by using the metropolis
+  //	//correct for enhanced proposal of small radii by using the Metropolis
   // hastings algorithm for asymmetric proposal densities.
   //	double
   // old_radius=std::sqrt(std::pow(particle_positions[0]-cyl_x,2)+std::pow(particle_positions[1]-cyl_y,2));
@@ -1095,7 +1095,7 @@ int WangLandauReactionEnsemble::get_num_needed_bins() {
 }
 
 void WangLandauReactionEnsemble::invalidate_bins() {
-  // make values in histogram and wang-landau potential negative if they are not
+  // make values in histogram and Wang-Landau potential negative if they are not
   // allowed at the given degree of association, because the energy boundaries
   // prohibit them
 
@@ -1178,13 +1178,13 @@ int WangLandauReactionEnsemble::initialize_wang_landau() {
       1; //+1 for collective variables which are of type degree of association
 
   // construct (possibly higher dimensional) histogram over gamma (the room
-  // which should be equally sampled when the wang-landau algorithm has
+  // which should be equally sampled when the Wang-Landau algorithm has
   // converged)
   int needed_bins = get_num_needed_bins();
   histogram.resize(needed_bins, 0); // initialize new values with 0
 
   // construct (possibly higher dimensional) wang_landau potential over gamma
-  // (the room which should be equally sampled when the wang-landau algorithm
+  // (the room which should be equally sampled when the Wang-Landau algorithm
   // has converged)
   wang_landau_potential.resize(needed_bins, 0); // initialize new values with 0
 
@@ -1205,7 +1205,7 @@ double WangLandauReactionEnsemble::calculate_acceptance_probability(
     std::map<int, int> &old_particle_numbers, int old_state_index,
     int new_state_index, bool only_make_configuration_changing_move) {
   /**determine the acceptance probabilities of the reaction move
-   * in wang-landau reaction ensemble
+   * in Wang-Landau reaction ensemble
    */
   double beta = 1.0 / temperature;
   double bf;
@@ -1233,9 +1233,9 @@ double WangLandauReactionEnsemble::calculate_acceptance_probability(
       bf = std::min(1.0,
                     bf * exp(wang_landau_potential[old_state_index] -
                              wang_landau_potential[new_state_index])); // modify
-      // boltzmann
+      // Boltzmann
       // factor
-      // according to wang-landau
+      // according to Wang-Landau
       // algorithm, according to
       // grand canonical simulation
       // paper "Density-of-states
@@ -1277,7 +1277,7 @@ double WangLandauReactionEnsemble::calculate_acceptance_probability(
  *  no-energy-reweighting case, or with the functions
  *  do_global_mc_move_for_particles_of_type
  *
- *  perform additional Monte carlo moves to to sample configurational
+ *  perform additional Monte Carlo moves to to sample configurational
  *  partition function according to "Density-of-states Monte Carlo method
  *  for simulation of fluids"
  *
@@ -1304,7 +1304,7 @@ int WangLandauReactionEnsemble::do_reaction(int reaction_steps) {
       refine_wang_landau_parameter_one_over_t();
     }
   }
-  // shift wang-landau potential minimum to zero
+  // shift Wang-Landau potential minimum to zero
   if (m_WL_tries % (std::max(90000, 9 * reaction_steps)) == 0) {
     // for numerical stability here we also subtract the minimum positive value
     // of the wang_landau_potential from the wang_landau potential, allowed
@@ -1317,7 +1317,7 @@ int WangLandauReactionEnsemble::do_reaction(int reaction_steps) {
                                          // variable
         wang_landau_potential[i] -= minimum_wang_landau_potential;
     }
-    // write out preliminary wang-landau potential results
+    // write out preliminary Wang-Landau potential results
     write_wang_landau_results_to_file(output_filename);
   }
   return 0;
@@ -1327,7 +1327,7 @@ int WangLandauReactionEnsemble::do_reaction(int reaction_steps) {
 
 void WangLandauReactionEnsemble::update_wang_landau_potential_and_histogram(
     int index_of_state_after_acceptance_or_rejection) {
-  /**increase the wang-landau potential and histogram at the current nbar */
+  /**increase the Wang-Landau potential and histogram at the current nbar */
   if (index_of_state_after_acceptance_or_rejection >= 0) {
     if (histogram[index_of_state_after_acceptance_or_rejection] >= 0) {
       histogram[index_of_state_after_acceptance_or_rejection] += 1;
@@ -1426,7 +1426,7 @@ void WangLandauReactionEnsemble::write_wang_landau_results_to_file(
                // double_fill_value. This if ensures
                // that for the energy observable not allowed energies (energies
                // in the interval [global_E_min, global_E_max]) in the
-               // multidimensional wang-landau potential are printed out, since
+               // multidimensional Wang-Landau potential are printed out, since
                // the range [E_min(nbar), E_max(nbar)] for each nbar may be a
                // different one
         std::vector<int> unraveled_index(collective_variables.size());
@@ -1568,7 +1568,7 @@ int WangLandauReactionEnsemble::
 /** remove bins from the range of to be sampled values if they have not been
  *  sampled.
  *  use with caution otherwise you produce unphysical results, do only use
- *  when you know what you want to do. This can make wang-landau converge on a
+ *  when you know what you want to do. This can make Wang-Landau converge on a
  *  reduced set gamma. use this function e.g. in do_reaction_wang_landau() for
  *  the diprotonic acid compare "Wang-Landau sampling with self-adaptive range"
  *  by Troester and Dellago
@@ -1599,7 +1599,7 @@ int WangLandauReactionEnsemble::write_wang_landau_checkpoint(
     const std::string &identifier) {
   std::ofstream outfile;
 
-  // write current wang-landau parameters (wang_landau_parameter,
+  // write current Wang-Landau parameters (wang_landau_parameter,
   // monte_carlo_trial_moves, flat_index_of_current_state)
   outfile.open(std::string("checkpoint_wang_landau_parameters_") + identifier);
   outfile << wang_landau_parameter << " " << monte_carlo_trial_moves << " "
@@ -1612,7 +1612,7 @@ int WangLandauReactionEnsemble::write_wang_landau_checkpoint(
     outfile << histogram[i] << "\n";
   }
   outfile.close();
-  // write wang-landau potential
+  // write Wang-Landau potential
   outfile.open(std::string("checkpoint_wang_landau_potential_") + identifier);
   for (int i = 0; i < wang_landau_potential.size(); i++) {
     outfile << wang_landau_potential[i] << "\n";
@@ -1628,7 +1628,7 @@ int WangLandauReactionEnsemble::load_wang_landau_checkpoint(
     const std::string &identifier) {
   std::ifstream infile;
 
-  // restore wang-landau parameters
+  // restore Wang-Landau parameters
   infile.open(std::string("checkpoint_wang_landau_parameters_") + identifier);
   if (infile.is_open()) {
 
@@ -1666,7 +1666,7 @@ int WangLandauReactionEnsemble::load_wang_landau_checkpoint(
                              identifier);
   }
 
-  // restore wang-landau potential
+  // restore Wang-Landau potential
   infile.open(std::string("checkpoint_wang_landau_potential_") + identifier);
   if (infile.is_open()) {
     double wang_landau_potential_entry;

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -18,7 +18,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file rotation.cpp  Molecular dynamics integrator for rotational motion.
+/** \file
+ *  Molecular dynamics integrator for rotational motion.
  *
  *  A velocity Verlet <a
  * HREF="http://ciks.cbt.nist.gov/~garbocz/dpd1/dpd.html">algorithm</a>

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -28,7 +28,7 @@
  * all particles are
  *  treated as 3D objects with 3 translational and 3 rotational degrees of
  * freedom if ROTATION
- *  flag is set in \ref config.hpp "config.h".
+ *  flag is set in \ref config.hpp "config.hpp".
  */
 
 #include "rotation.hpp"

--- a/src/core/rotation.hpp
+++ b/src/core/rotation.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef ROTATION_H
 #define ROTATION_H
-/** \file rotation.hpp
+/** \file
     This file contains all subroutines required to process rotational motion.
 
 */

--- a/src/core/specfunc.cpp
+++ b/src/core/specfunc.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file specfunc.cpp
-    Special functions, see \ref specfunc.hpp "specfunc.h"
+    Special functions, see \ref specfunc.hpp "specfunc.hpp"
 */
 #include "specfunc.hpp"
 #include "polynom.hpp"

--- a/src/core/specfunc.cpp
+++ b/src/core/specfunc.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file specfunc.cpp
+/** \file
     Special functions, see \ref specfunc.hpp "specfunc.hpp"
 */
 #include "specfunc.hpp"

--- a/src/core/specfunc.hpp
+++ b/src/core/specfunc.hpp
@@ -19,23 +19,23 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file
-    This file contains implementations for some special functions which are
-   needed by the MMM family of algorithms. This are the modified Hurwitz zeta
-   function and the modified Bessel functions of first and second kind. The
-   implementations are based on the GSL code (see \ref specfunc.cpp "specfunc.cpp"
-    for the original GSL header).
-
-    The Hurwitz zeta function is evaluated using the Euler-MacLaurin summation
-   formula, the Bessel functions are evaluated using several different Chebychev
-   expansions. Both achieve a precision of nearly machine precision, which is no
-   problem for the Hurwitz zeta function, which is only used when determining
-   the coefficients for the modified polygamma functions (see \ref
-   mmm-common.hpp "mmm-common.h"). However, the Bessel functions are actually
-   used in the near formula of MMM2D, which is therefore slightly slower than
-    necessary. On the other hand, the number of terms in the Bessel sum is quite
-   small normally, so that a less precise version will probably not generate a
-   huge computational speed improvement.
-*/
+ *  This file contains implementations for some special functions which are
+ *  needed by the MMM family of algorithms. This are the modified Hurwitz zeta
+ *  function and the modified Bessel functions of first and second kind. The
+ *  implementations are based on the GSL code (see \ref specfunc.cpp
+ *  "specfunc.cpp" for the original GSL header).
+ *
+ *  The Hurwitz zeta function is evaluated using the Euler-MacLaurin summation
+ *  formula, the Bessel functions are evaluated using several different
+ *  Chebychev expansions. Both achieve a precision of nearly machine precision,
+ *  which is no problem for the Hurwitz zeta function, which is only used when
+ *  determining the coefficients for the modified polygamma functions (see \ref
+ *  mmm-common.hpp "mmm-common.h"). However, the Bessel functions are actually
+ *  used in the near formula of MMM2D, which is therefore slightly slower than
+ *  necessary. On the other hand, the number of terms in the Bessel sum is
+ *  quite small normally, so that a less precise version will probably not
+ *  generate a huge computational speed improvement.
+ */
 #ifndef SPECFUNC_H
 #define SPECFUNC_H
 
@@ -43,36 +43,40 @@
 double hzeta(double order, double x);
 
 /** Modified Bessel function of first kind, order 0. This function was taken
-   from the GSL code. Precise roughly up to machine precision. */
+ *  from the GSL code. Precise roughly up to machine precision.
+ */
 double I0(double x);
 /** Modified Bessel function of first kind, order 1. This function was taken
-   from the GSL code. Precise roughly up to machine precision. */
+ *  from the GSL code. Precise roughly up to machine precision.
+ */
 double I1(double x);
 /** Modified Bessel function of second kind, order 0. This function was taken
-   from the GSL code. Precise roughly up to machine precision. */
+ *  from the GSL code. Precise roughly up to machine precision.
+ */
 double K0(double x);
 /** Modified Bessel function of second kind, order 1. This function was taken
-   from the GSL code. Precise roughly up to machine precision. */
+ *  from the GSL code. Precise roughly up to machine precision.
+ */
 double K1(double x);
 
 /** Besselfunctions K0 at x.
-    The implementation has an absolute precision of around 10^(-14), which is
-    comparable to the relative precision sqrt implementation of current
-   hardware.
-*/
+ *  The implementation has an absolute precision of around 10^(-14), which is
+ *  comparable to the relative precision sqrt implementation of current
+ *  hardware.
+ */
 double LPK0(double x);
 
 /** Besselfunctions K1 at x.
-    The implementation has an absolute precision of around 10^(-14), which is
-    comparable to the relative precision sqrt implementation of current
-   hardware.
-*/
+ *  The implementation has an absolute precision of around 10^(-14), which is
+ *  comparable to the relative precision sqrt implementation of current
+ *  hardware.
+ */
 double LPK1(double x);
 
 /** Besselfunctions K0 and K1 at x.
-    The implementation has an absolute precision of around 10^(-14), which is
-    comparable to the relative precision sqrt implementation of current
-   hardware.
-*/
+ *  The implementation has an absolute precision of around 10^(-14), which is
+ *  comparable to the relative precision sqrt implementation of current
+ *  hardware.
+ */
 void LPK01(double x, double *K0, double *K1);
 #endif

--- a/src/core/specfunc.hpp
+++ b/src/core/specfunc.hpp
@@ -22,7 +22,7 @@
     This file contains implementations for some special functions which are
    needed by the MMM family of algorithms. This are the modified Hurwitz zeta
    function and the modified Bessel functions of first and second kind. The
-   implementations are based on the GSL code (see \ref specfunc.cpp "specfunc.c"
+   implementations are based on the GSL code (see \ref specfunc.cpp "specfunc.cpp"
     for the original GSL header).
 
     The Hurwitz zeta function is evaluated using the Euler-MacLaurin summation

--- a/src/core/specfunc.hpp
+++ b/src/core/specfunc.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file specfunc.hpp
+/** \file
     This file contains implementations for some special functions which are
    needed by the MMM family of algorithms. This are the modified Hurwitz zeta
    function and the modified Bessel functions of first and second kind. The

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -216,7 +216,7 @@ void predict_momentum_particles(double *result) {
 /** Calculate total momentum of the system (particles & LB fluid)
  * inputs are bools to include particles and fluid in the linear momentum
  * calculation
- * @param momentum Result for this processor (Output)
+ * @return Result for this processor (Output)
  */
 std::vector<double> calc_linear_momentum(int include_particles,
                                          int include_lbfluid) {

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file statistics.cpp
+/** \file
     This is the place for analysis (so far...).
     Implementation of statistics.hpp
 */

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _STATISTICS_H
 #define _STATISTICS_H
-/** \file statistics.hpp
+/** \file
     This file contains the code for statistics on the data.
 */
 

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -355,8 +355,7 @@ double min_distance(T1 const pos1, T2 const pos2) {
 }
 
 /** calculate the center of mass of a special type of the current configuration
- *  \param type  type of the particle
- *  \param com   center of mass position
+ *  \param part_type  type of the particle
  */
 std::vector<double> centerofmass(PartCfg &, int part_type);
 
@@ -374,7 +373,7 @@ void angularmomentum(PartCfg &, int type, double *com);
 
 /** calculate the center of mass of a special type of a saved configuration
  *  \param k       number of the saved configuration
- *  \param type_1  type of the particle, -1 for all
+ *  \param type    type of the particle, -1 for all
  *  \param com     center of mass position
  */
 

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -48,7 +48,7 @@ struct Observable_stat {
   /** Array for observables on each node. */
   DoubleList data;
 
-  /** number of coulomb interactions */
+  /** number of Coulomb interactions */
   int n_coulomb;
   /** number of dipolar interactions */
   int n_dipolar;
@@ -63,9 +63,9 @@ struct Observable_stat {
   double *bonded;
   /** start of observables for non-bonded interactions. */
   double *non_bonded;
-  /** start of observables for coulomb interaction. */
+  /** start of observables for Coulomb interaction. */
   double *coulomb;
-  /** start of observables for coulomb interaction. */
+  /** start of observables for Coulomb interaction. */
   double *dipolar;
   /** Start of observables for virtual sites relative (rigid bodies) */
   double *virtual_sites;
@@ -271,7 +271,7 @@ void calc_rdf_av(PartCfg &partCfg, std::vector<int> &p1_types,
     Calculates the van Hove auto correlation function (acf)  G(r,t) which is the
    probability that a particle has moved
     a distance r after time t. In the case of a random walk G(r,t)/(4 pi r*r) is
-   a gaussian. The mean square
+   a Gaussian. The mean square
     displacement (msd) is connected to the van Hove acf via sqrt(msd(t)) = int
    G(r,t) dr. This is very useful for
     the investigation of diffusion processes.

--- a/src/core/statistics_chain.cpp
+++ b/src/core/statistics_chain.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file statistics_chain.cpp
+/** \file
     Implementation of \ref statistics_chain.hpp "statistics_chain.hpp".
 */
 #include "PartCfg.hpp"

--- a/src/core/statistics_chain.hpp
+++ b/src/core/statistics_chain.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef STATISTICS_CHAIN_H
 #define STATISTICS_CHAIN_H
-/** \file statistics_chain.hpp
+/** \file
 
     This file contains the code for statistics on the data using the
     molecule information set with analyse set chains.

--- a/src/core/statistics_cluster.hpp
+++ b/src/core/statistics_cluster.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef STATISTICS_CLUSTER_H
 #define STATISTICS_CLUSTER_H
-/** \file statistics_cluster.hpp
+/** \file
  *
  *  mesh based cluster algorithm to identify hole spaces
  *  (see thesis chapter 3 of H. Schmitz for details)

--- a/src/core/statistics_fluid.cpp
+++ b/src/core/statistics_fluid.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file statistics_fluid.cpp
+/** \file
  *
  * Fluid related analysis functions.
  * Implementation of \ref statistics_fluid.hpp.

--- a/src/core/statistics_fluid.hpp
+++ b/src/core/statistics_fluid.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file statistics_fluid.hpp
+/** \file
  *
  * Fluid related analysis functions.
  * Header file for \ref statistics_fluid.cpp.

--- a/src/core/swimmer_reaction.cpp
+++ b/src/core/swimmer_reaction.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file swimmer_reaction.cpp
+/** \file
  *
  */
 

--- a/src/core/swimmer_reaction.cpp
+++ b/src/core/swimmer_reaction.cpp
@@ -78,7 +78,7 @@ void local_setup_reaction() {
   IA_parameters *data =
       get_ia_param_safe(reaction.reactant_type, reaction.catalyzer_type);
 
-  /* Used for the range of the verlet lists */
+  /* Used for the range of the Verlet lists */
   data->REACTION_range = reaction.range;
 
   /* Broadcast interaction parameters */

--- a/src/core/swimmer_reaction.cpp
+++ b/src/core/swimmer_reaction.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file reaction.cpp
+/** \file swimmer_reaction.cpp
  *
  */
 

--- a/src/core/swimmer_reaction.hpp
+++ b/src/core/swimmer_reaction.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef SWIMMER_REACTION_H
 #define SWIMMER_REACTION_H
-/** \file swimmer_reaction.hpp
+/** \file
  *
  */
 

--- a/src/core/swimmer_reaction.hpp
+++ b/src/core/swimmer_reaction.hpp
@@ -44,7 +44,7 @@ extern reaction_struct reaction;
 /** sanity checks for the reaction code */
 void reactions_sanity_checks();
 /** broadcasts reaction parameters and sets up an entry in the ia_params, so
-    that the verlet radius is equal or bigger than the reaction range.
+    that the Verlet radius is equal or bigger than the reaction range.
 **/
 void local_setup_reaction();
 void integrate_reaction();

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file thermostat.cpp
+/** \file
     Implementation of \ref thermostat.hpp "thermostat.hpp"
  */
 #include "thermostat.hpp"

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file thermostat.cpp
-    Implementation of \ref thermostat.hpp "thermostat.h"
+    Implementation of \ref thermostat.hpp "thermostat.hpp"
  */
 #include "thermostat.hpp"
 #include "bonded_interactions/thermalized_bond.hpp"

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -45,7 +45,7 @@ using Thermostat::GammaType;
 
 namespace {
 /* These functions return the sentinel value for the
-   langevin params, indicating that they have not been
+   Langevin params, indicating that they have not been
    set yet. */
 constexpr double sentinel(double) { return -1.0; }
 Vector3d sentinel(Vector3d) { return {-1.0, -1.0, -1.0}; }

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef _THERMOSTAT_H
 #define _THERMOSTAT_H
-/** \file thermostat.hpp
+/** \file
 
 */
 

--- a/src/core/topology.cpp
+++ b/src/core/topology.cpp
@@ -19,7 +19,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file topology.cpp
+/** \file
  *
  *  This file contains functions for handling the system topology.
  *

--- a/src/core/topology.hpp
+++ b/src/core/topology.hpp
@@ -21,7 +21,7 @@
 #ifndef CORE_TOPOLOGY_HPP
 #define CORE_TOPOLOGY_HPP
 
-/** \file topology.hpp
+/** \file
  *
  *  This file contains functions for handling the system topology.
  */

--- a/src/core/tuning.cpp
+++ b/src/core/tuning.cpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file tuning.cpp
+/** \file
     Implementation of tuning.hpp .
 */
 #include "communication.hpp"

--- a/src/core/tuning.cpp
+++ b/src/core/tuning.cpp
@@ -37,7 +37,7 @@ int timing_samples = 10;
  * \brief Time the force calculation.
  * This times the force calculation without
  * propagating the system. It therefore does
- * not include e.g. verlet list updates.
+ * not include e.g. Verlet list updates.
  *
  * @return Time per integration in ms.
  */

--- a/src/core/tuning.hpp
+++ b/src/core/tuning.hpp
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** \file tuning.hpp
+/** \file
     This contains a timing loop for the force calculation. Via the global
    variable timings you can specify how many
     force evaluations are sampled. Via \ref markTime and \ref diffTime you can

--- a/src/core/unit_tests/Batch_test.cpp
+++ b/src/core/unit_tests/Batch_test.cpp
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file Batch_test.cpp Unit tests for the
- * Utils::Batch class.
+/** \file
+ * Unit tests for the Utils::Batch class.
  *
  */
 

--- a/src/core/unit_tests/Batch_test.cpp
+++ b/src/core/unit_tests/Batch_test.cpp
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file NumeratedContainer_test.cpp Unit tests for the
- * Utils::NumeratedContainer class.
+/** \file Batch_test.cpp Unit tests for the
+ * Utils::Batch class.
  *
  */
 

--- a/src/core/unit_tests/Factory_test.cpp
+++ b/src/core/unit_tests/Factory_test.cpp
@@ -17,7 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file Factory_test.cpp Unit tests for the Utils::Factory class.
+/** \file
+ * Unit tests for the Utils::Factory class.
  * The factory is tested by registering different types of classes
  * with it (first test), and then checking if instances of those classes can be
  * made via the Factory (second test).

--- a/src/core/unit_tests/List_test.cpp
+++ b/src/core/unit_tests/List_test.cpp
@@ -17,7 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file List_test.cpp Unit tests for the Utils::List class.
+/** \file
+ * Unit tests for the Utils::List class.
  *
  */
 

--- a/src/core/unit_tests/List_test.cpp
+++ b/src/core/unit_tests/List_test.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file Vector_test.cpp Unit tests for the Utils::Vector class.
+/** \file List_test.cpp Unit tests for the Utils::List class.
  *
  */
 

--- a/src/core/unit_tests/MpiCallbacks_test.cpp
+++ b/src/core/unit_tests/MpiCallbacks_test.cpp
@@ -18,7 +18,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file MpiCallbacks_test.cpp Unit tests for the MpiCallbacks class.
+/** \file
+ * Unit tests for the MpiCallbacks class.
  *
  */
 

--- a/src/core/unit_tests/None_test.cpp
+++ b/src/core/unit_tests/None_test.cpp
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file None_test.cpp Unit tests for the
- * ScriptInterface::None class.
+/** \file
+ * Unit tests for the ScriptInterface::None class.
  *
  */
 

--- a/src/core/unit_tests/NumeratedContainer_test.cpp
+++ b/src/core/unit_tests/NumeratedContainer_test.cpp
@@ -19,8 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file NumeratedContainer_test.cpp Unit tests for the
- * Utils::NumeratedContainer class.
+/** \file
+ * Unit tests for the Utils::NumeratedContainer class.
  *
  */
 

--- a/src/core/unit_tests/ParticleCache_test.cpp
+++ b/src/core/unit_tests/ParticleCache_test.cpp
@@ -18,7 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file MpiCallbacks_test.cpp Unit tests for the MpiCallbacks class.
+/** \file ParticleCache_test.cpp Unit tests for the MpiCallbacks class.
  *
  */
 

--- a/src/core/unit_tests/ParticleCache_test.cpp
+++ b/src/core/unit_tests/ParticleCache_test.cpp
@@ -18,7 +18,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file ParticleCache_test.cpp Unit tests for the MpiCallbacks class.
+/** \file
+ * Unit tests for the MpiCallbacks class.
  *
  */
 

--- a/src/core/unit_tests/Particle_test.cpp
+++ b/src/core/unit_tests/Particle_test.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file Vector_test.cpp Unit tests for the Utils::Vector class.
+/** \file Particle_test.cpp Unit tests for the Particle struct.
  *
  */
 

--- a/src/core/unit_tests/Particle_test.cpp
+++ b/src/core/unit_tests/Particle_test.cpp
@@ -17,7 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file Particle_test.cpp Unit tests for the Particle struct.
+/** \file
+ * Unit tests for the Particle struct.
  *
  */
 

--- a/src/core/unit_tests/Range_test.cpp
+++ b/src/core/unit_tests/Range_test.cpp
@@ -15,8 +15,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file Range_test.cpp Unit tests for the
- * Utils::Range class.
+/** \file
+ * Unit tests for the Utils::Range class.
  *
  */
 

--- a/src/core/unit_tests/Range_test.cpp
+++ b/src/core/unit_tests/Range_test.cpp
@@ -15,8 +15,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file NumeratedContainer_test.cpp Unit tests for the
- * Utils::NumeratedContainer class.
+/** \file Range_test.cpp Unit tests for the
+ * Utils::Range class.
  *
  */
 

--- a/src/core/unit_tests/RuntimeErrorCollector_test.cpp
+++ b/src/core/unit_tests/RuntimeErrorCollector_test.cpp
@@ -19,8 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file RuntimeErrorCollector_test.cpp Unit tests for the
- * ErrorHandling::RuntimeErrorCollector class.
+/** \file
+ * Unit tests for the ErrorHandling::RuntimeErrorCollector class.
  *
  */
 

--- a/src/core/unit_tests/RuntimeError_test.cpp
+++ b/src/core/unit_tests/RuntimeError_test.cpp
@@ -19,8 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file RuntimeError_test.cpp Unit tests for the ErrorHandling::RuntimeError
- * class.
+/** \file
+ * Unit tests for the ErrorHandling::RuntimeError class.
  *
  */
 

--- a/src/core/unit_tests/Vector_test.cpp
+++ b/src/core/unit_tests/Vector_test.cpp
@@ -19,7 +19,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file Vector_test.cpp Unit tests for the Utils::Vector class.
+/** \file
+ * Unit tests for the Utils::Vector class.
  *
  */
 

--- a/src/core/unit_tests/Wall_test.cpp
+++ b/src/core/unit_tests/Wall_test.cpp
@@ -65,4 +65,4 @@ BOOST_AUTO_TEST_CASE(dist_function) {
   BOOST_CHECK(check_distance_function(w));
 }
 
-/* @TODO: Functional unit test of the distance function */
+/* @todo  Functional unit test of the distance function */

--- a/src/core/unit_tests/for_each_pair_test.cpp
+++ b/src/core/unit_tests/for_each_pair_test.cpp
@@ -17,7 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file for_each_pair_test.cpp Unit tests for the Utils::for_each_pair.
+/** \file
+ * Unit tests for the Utils::for_each_pair.
  *
  */
 

--- a/src/core/unit_tests/tensor_product_test.cpp
+++ b/src/core/unit_tests/tensor_product_test.cpp
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file tensor_product_test.cpp Unit tests for the
- * Utils::tensor_product class.
+/** \file
+ * Unit tests for the Utils::tensor_product class.
  *
  */
 

--- a/src/core/unit_tests/tensor_product_test.cpp
+++ b/src/core/unit_tests/tensor_product_test.cpp
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** \file None_test.cpp Unit tests for the
- * ScriptInterface::None class.
+/** \file tensor_product_test.cpp Unit tests for the
+ * Utils::tensor_product class.
  *
  */
 

--- a/src/core/unit_tests/verlet_ia_test.cpp
+++ b/src/core/unit_tests/verlet_ia_test.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(verlet_ia) {
   pairs.clear();
   std::fill(id_counts.begin(), id_counts.end(), 0);
 
-  /* Now check the verlet lists */
+  /* Now check the Verlet lists */
   Algorithm::verlet_ia(
       cells.begin(), cells.end(),
       [&id_counts](Particle const &p) { id_counts[p.p.identity]++; },

--- a/src/core/utils.hpp
+++ b/src/core/utils.hpp
@@ -20,7 +20,7 @@
 */
 #ifndef UTILS_HPP
 #define UTILS_HPP
-/** \file utils.hpp
+/** \file
  *    Small functions that are useful not only for one modul.
 
  *  just some nice utilities...

--- a/src/core/utils.hpp
+++ b/src/core/utils.hpp
@@ -21,7 +21,7 @@
 #ifndef UTILS_HPP
 #define UTILS_HPP
 /** \file
- *    Small functions that are useful not only for one modul.
+ *    Small functions that are useful not only for one module.
 
  *  just some nice utilities...
  *  and some constants...

--- a/src/core/utils/Histogram.hpp
+++ b/src/core/utils/Histogram.hpp
@@ -53,9 +53,10 @@ inline size_t ravel_index(std::vector<size_t> unravelled_indices,
  * \brief Returns the unraveled index of the provided flat index.
  *        Therefore is the inversion of flattening an ndims dimensional index.
  * \param len_dims an int array of length ndims containing the lengths of the
- * dimensions. (Input) \param ndims int denoting the number of dimensions.
- * (Input) \flattened_index an int denoting the flat index. (Input)
- * \unravelled_index_out an int array with length ndims where the unflat indices
+ * dimensions. (Input)
+ * \param ndims int denoting the number of dimensions. (Input)
+ * \param flattened_index an int denoting the flat index. (Input)
+ * \param unravelled_index_out an int array with length ndims where the unflat indices
  * are written to. (Output)
  */
 inline void unravel_index(const int *const len_dims, const int ndims,

--- a/src/core/utils/Histogram.hpp
+++ b/src/core/utils/Histogram.hpp
@@ -56,8 +56,8 @@ inline size_t ravel_index(std::vector<size_t> unravelled_indices,
  * dimensions. (Input)
  * \param ndims int denoting the number of dimensions. (Input)
  * \param flattened_index an int denoting the flat index. (Input)
- * \param unravelled_index_out an int array with length ndims where the unflat indices
- * are written to. (Output)
+ * \param unravelled_index_out an int array with length ndims where the unflat
+ * indices are written to. (Output)
  */
 inline void unravel_index(const int *const len_dims, const int ndims,
                           const int flattened_index,

--- a/src/core/utils/mpi/gather_buffer.hpp
+++ b/src/core/utils/mpi/gather_buffer.hpp
@@ -48,7 +48,7 @@ namespace Mpi {
           large enough to hold all elements and has the local
           part in the beginning. On the slaves the local buffer.
  * @param n_elem The number of elements in the local buffer.
- * @param The rank where the data should be gathered.
+ * @param root The rank where the data should be gathered.
  * @return On rank root, the total number of elements in the buffer,
  *         on the other ranks 0.
  */
@@ -87,7 +87,7 @@ int gather_buffer(T *buffer, int n_elem, boost::mpi::communicator comm,
  *
  * @param buffer On the master the target buffer that has the local
           part in the beginning. On the slaves the local buffer.
- * @param The rank where the data should be gathered.
+ * @param root The rank where the data should be gathered.
  * @return On rank root, the total number of elements in the buffer,
  *         on the other ranks 0.
  */

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -72,7 +72,7 @@ void calculate_vs_relate_to_params(const Particle &p_current,
   // the quaternions representing the orientation of the real particle
   // with those in the virtual particle. The re quulting quaternion is then
   // converted to a director.
-  // Whe have quat_(real particle) *quat_(virtual particle)
+  // We have quat_(real particle) *quat_(virtual particle)
   // = quat_(obtained from desired director)
   // Resolving this for the quat_(virtual particle)
 
@@ -130,7 +130,7 @@ void calculate_vs_relate_to_params(const Particle &p_current,
 // Setup the virtual_sites_relative properties of a particle so that the given
 // virtual particle will follow the given real particle
 int vs_relate_to(int part_num, int relate_to) {
-  // Get the data for the particle we act on and the one we wnat to relate
+  // Get the data for the particle we act on and the one we want to relate
   // it to.
   auto const &p_current = get_particle_data(part_num);
   auto const &p_relate_to = get_particle_data(relate_to);

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -42,7 +42,7 @@ public:
   /** @brief Update positions and/or velocities of virtual sites
 
   * Velocities are only updated if have_velocity() returns true.
-  * @param recalc_positions can be used to skip the reculation of positions.
+  * @param recalc_positions can be used to skip the recalculation of positions.
   */
   virtual void update(bool recalc_positions = true) const = 0;
   /** Back-transfer forces (and torques) to non-virtual particles. */

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -21,7 +21,7 @@
 #ifndef VIRTUAL_SITES_VIRTUAL_SITES_HPP
 #define VIRTUAL_SITES_VIRTUAL_SITES_HPP
 
-/** \file virtual_sites.hpp
+/** \file
  *  This file contains routine to handle virtual sites
  *  Virtual sites are like particles, but they will be not integrated.
  *  Step performed for virtual sites:

--- a/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
+++ b/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
@@ -31,7 +31,7 @@ class VirtualSitesInertialessTracers : public VirtualSites {
   /** @brief Update positions and/or velocities of virtual sites
 
   * Velocities are only updated update_velocities() return true
-  * @param recalc_positions can be used to skip the reculation of positions
+  * @param recalc_positions can be used to skip the recalculation of positions
   */
   void update(bool recalc_positions = true) const override{};
   /** Back-transfer forces (and torques) to non-virtual particles */

--- a/src/core/virtual_sites/VirtualSitesOff.hpp
+++ b/src/core/virtual_sites/VirtualSitesOff.hpp
@@ -28,7 +28,7 @@ class VirtualSitesOff : public VirtualSites {
   /** @brief Update positions and/or velocities of virtual sites
 
   * Velocities are only updated update_velocities() return true
-  * @param recalc_positions can be used to skip the reculation of positions
+  * @param recalc_positions can be used to skip the recalculation of positions
   */
   void update(bool recalc_positions = true) const override{};
   /** Back-transfer forces (and torques) to non-virtual particles */

--- a/src/core/virtual_sites/VirtualSitesRelative.hpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.hpp
@@ -34,7 +34,7 @@ public:
   /** @brief Update positions and/or velocities of virtual sites
 
   * Velocities are only updated have_velocity() return true
-  * @param recalc_positions can be used to skip the reculation of positions
+  * @param recalc_positions can be used to skip the recalculation of positions
   */
   void update(bool recalc_positions = true) const override;
   /** Back-transfer forces (and torques) to non-virtual particles */

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -902,7 +902,7 @@ class Analysis(object):
         spherically averaged structure factor of particles specified in
         `types`.  The structure factor is calculated for all possible wave
         vectors q up to `order` Do not choose parameter `order` too large
-        because the number of calculations gros as `order` to the third power.
+        because the number of calculations grows as `order` to the third power.
 
         Parameters
         ----------

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -52,7 +52,7 @@ cdef class CellSystem(object):
         Parameters
         ----------
         'use_verlet_lists' : :obj:`bool`, optional
-                             Activates or deactivates the usage of the verlet
+                             Activates or deactivates the usage of the Verlet
                              lists for this algorithm.
 
         """
@@ -73,7 +73,7 @@ cdef class CellSystem(object):
         'n_layers': :obj:`int`, optional, positive
                     Sets the number of layers in the z-direction.
         'use_verlet_lists' : :obj:`bool`, optional
-                             Activates or deactivates the usage of the verlet
+                             Activates or deactivates the usage of the Verlet
                              lists for this algorithm.
 
         """

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -18,12 +18,12 @@ from __future__ import print_function
 import espressomd.interactions
 from espressomd import has_features
 
-# Dict with drude type infos
+# Dict with Drude type infos
 drude_dict = {}
-# Lists with unique drude and core types
+# Lists with unique Drude and core types
 core_type_list = []
 drude_type_list = []
-# Get core id from drude id
+# Get core id from Drude id
 core_id_from_drude_id = {}
 # Drude IDs
 drude_id_list = []
@@ -34,7 +34,7 @@ def add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
                                mass_drude, coulomb_prefactor,
                                thole_damping=2.6, verbose=False):
     """
-    Adds a drude particle with specified id, type, and mass to the system.
+    Adds a Drude particle with specified id, type, and mass to the system.
     Checks if different Drude particles have different types.
     Collects types/charges/polarizations/Thole factors for intramol. core-Drude short-range exclusion and Thole interaction.
 
@@ -42,21 +42,21 @@ def add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
     ----------
 
     system : Instance of :attr:`espressomd.System`
-    harmonic_bond: This method adds this harmonic bond to between drude particle and core
-    thermalized_bond: This method adds this thermalizerd_bond to between drude particle and core
+    harmonic_bond: This method adds this harmonic bond to between Drude particle and core
+    thermalized_bond: This method adds this thermalizerd_bond to between Drude particle and core
     p_core: The existing core particle
     id_drude: :obj:`int`
-              This method creates the drude particle and assigns this id.
+              This method creates the Drude particle and assigns this id.
     type_drude: :obj:`int`
-                The type of the newly created drude particle
+                The type of the newly created Drude particle
     alpha : :obj:`float`
-            The polarizability in units of inverse volume. Related to the charge of the drude particle.
+            The polarizability in units of inverse volume. Related to the charge of the Drude particle.
     mass_drude : :obj:`float`
-                 The mass of the newly created drude particle
+                 The mass of the newly created Drude particle
     coulomb_prefactor : :obj:`float`
-                        Required to calculate the charge of the drude particle.
+                        Required to calculate the charge of the Drude particle.
     thole_damping : :obj:`float`
-                    Thole damping factor of the drude pair. Comes to effect if add_all_thole() method is used.
+                    Thole damping factor of the Drude pair. Comes to effect if add_all_thole() method is used.
     verbose : :obj:`bool`
              Turns on verbosity.
 
@@ -92,8 +92,8 @@ def add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
 
     core_id_from_drude_id[id_drude] = p_core.id
 
-    # Add new thole nonbonded interaction for D-D, D-C, C-C for all existing
-    # drude types if this type is seen for the first time
+    # Add new Thole nonbonded interaction for D-D, D-C, C-C for all existing
+    # Drude types if this type is seen for the first time
     if not type_drude in drude_dict:
 
         # Bookkeeping of q, alphas and damping parameter
@@ -111,7 +111,7 @@ def add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
         drude_dict[p_core.type]["thole_damping"] = thole_damping
         drude_dict[p_core.type]["drude_type"] = type_drude
 
-    # Collect unique drude types
+    # Collect unique Drude types
     if not type_drude in drude_type_list:
         drude_type_list.append(type_drude)
 
@@ -119,7 +119,7 @@ def add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
     if not p_core.type in core_type_list:
         core_type_list.append(p_core.type)
 
-    # Collect unique drude ids
+    # Collect unique Drude ids
     if not id_drude in drude_id_list:
         drude_id_list.append(id_drude)
 
@@ -166,7 +166,7 @@ def add_all_thole(system, verbose=False):
 
     """
 
-    # drude <-> drude
+    # Drude <-> Drude
     for i in range(len(drude_type_list)):
         for j in range(i, len(drude_type_list)):
             add_thole_pair_damping(
@@ -176,7 +176,7 @@ def add_all_thole(system, verbose=False):
         for j in range(i, len(core_type_list)):
             add_thole_pair_damping(
                 system, core_type_list[i], core_type_list[j], verbose)
-    # drude <-> core
+    # Drude <-> core
     for i in drude_type_list:
         for j in core_type_list:
             add_thole_pair_damping(system, i, j, verbose)
@@ -197,7 +197,7 @@ def setup_and_add_drude_exclusion_bonds(system, verbose=False):
 
     """
 
-    # All drude types need...
+    # All Drude types need...
     for td in drude_type_list:
 
         #...exclusions with core
@@ -233,7 +233,7 @@ def setup_intramol_exclusion_bonds(system, mol_drude_types, mol_core_types,
     ----------
 
     system : Instance of :attr:`espressomd.System`
-    mol_drude_types : List of types of drude particles within the molecule
+    mol_drude_types : List of types of Drude particles within the molecule
     mol_core_types : List of types of core particles within the molecule
     mol_core_partial_charges : List of partial charges of core particles within the molecule
     verbose : :obj:`bool`
@@ -241,13 +241,13 @@ def setup_intramol_exclusion_bonds(system, mol_drude_types, mol_core_types,
 
     """
 
-    # All drude types need...
+    # All Drude types need...
     for td in mol_drude_types:
         drude_dict[td]["subtr_p3m_sr_bonds_intramol"] = {}
 
         #...p3m sr exclusion bond with other partial core charges...
         for tc, qp in zip(mol_core_types, mol_core_partial_charges):
-            #...excluding the drude core partner
+            #...excluding the Drude core partner
             if drude_dict[td]["core_type"] != tc:
                 qd = drude_dict[td]["q"]  # Drude charge
                 subtr_p3m_sr_bond = espressomd.interactions.BondedCoulombP3MSRBond(

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -298,7 +298,7 @@ ELSE:
 
 IF P3M:
     cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
-        #* Parameters for Bonded coulomb p3m sr */
+        #* Parameters for Bonded Coulomb p3m sr */
         cdef struct Bonded_coulomb_p3m_sr_bond_parameters:
             double q1q2
 ELSE:
@@ -348,7 +348,7 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
         double gamma_distance
         double r_cut
 
-#* Parameters for Bonded coulomb */
+#* Parameters for Bonded Coulomb */
     cdef struct Bonded_coulomb_bond_parameters:
         double prefactor
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -31,7 +31,7 @@ from globals cimport immersed_boundaries
 
 cdef class NonBondedInteraction(object):
     """
-    Represents an instance of a non-bonded interaction, such as lennard jones
+    Represents an instance of a non-bonded interaction, such as lennard-jones
     Either called with two particle type id, in which case, the interaction
     will represent the bonded interaction as it is defined in Espresso core
     Or called with keyword arguments describing a new interaction.
@@ -292,7 +292,7 @@ IF LENNARD_JONES == 1:
                     self._params["shift"],
                     self._params["offset"],
                     self._params["min"]):
-                raise Exception("Could not set Lennard Jones parameters")
+                raise Exception("Could not set Lennard-Jones parameters")
 
         def default_params(self):
             """Python dictionary of default parameters.
@@ -324,7 +324,7 @@ IF LENNARD_JONES == 1:
             """
             return "epsilon", "sigma", "cutoff", "shift"
 
-# Generic Lennard Jones
+# Generic Lennard-Jones
 
 IF LENNARD_JONES_GENERIC == 1:
 
@@ -391,7 +391,7 @@ IF LENNARD_JONES_GENERIC == 1:
                                     self._params["lam"],
                                     self._params["delta"]):
                     raise Exception(
-                        "Could not set Generic Lennard Jones parameters")
+                        "Could not set Generic Lennard-Jones parameters")
             ELSE:
                 if ljgen_set_params(self._part_types[0], self._part_types[1],
                                     self._params["epsilon"],
@@ -405,7 +405,7 @@ IF LENNARD_JONES_GENERIC == 1:
                                     self._params["b2"],
                                     ):
                     raise Exception(
-                        "Could not set Generic Lennard Jones parameters")
+                        "Could not set Generic Lennard-Jones parameters")
 
         def default_params(self):
             """Python dictionary of default parameters.
@@ -527,7 +527,7 @@ IF LJCOS:
                                 self._params["cutoff"],
                                 self._params["offset"]):
                 raise Exception(
-                    "Could not set Lennard Jones Cosine parameters")
+                    "Could not set Lennard-Jones Cosine parameters")
 
         def default_params(self):
             return {
@@ -608,7 +608,7 @@ IF LJCOS2:
                                  self._params["offset"],
                                  self._params["width"]):
                 raise Exception(
-                    "Could not set Lennard Jones Cosine2 parameters")
+                    "Could not set Lennard-Jones Cosine2 parameters")
 
         def default_params(self):
             return {
@@ -2226,7 +2226,7 @@ IF THOLE:
             Parameters
             ----------
             scaling_coeff : :obj:`float`
-                            The facor used in the thole damping function between
+                            The factor used in the thole damping function between
                             polarizable particles i and j. Usually calculated by
                             the polarizabilities alpha_i, alpha_j and damping
                             parameters  a_i, a_j via

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -31,7 +31,7 @@ from globals cimport immersed_boundaries
 
 cdef class NonBondedInteraction(object):
     """
-    Represents an instance of a non-bonded interaction, such as lennard-jones
+    Represents an instance of a non-bonded interaction, such as Lennard-Jones
     Either called with two particle type id, in which case, the interaction
     will represent the bonded interaction as it is defined in Espresso core
     Or called with keyword arguments describing a new interaction.
@@ -2077,7 +2077,7 @@ if ELECTROSTATICS:
             ----------
 
             prefactor : :obj:`float`
-                        Sets the coulomb prefactor of the bonded coulomb interaction.
+                        Sets the Coulomb prefactor of the bonded Coulomb interaction.
             """
             super(BondedCoulomb, self).__init__(*args, **kwargs)
 
@@ -2226,14 +2226,14 @@ IF THOLE:
             Parameters
             ----------
             scaling_coeff : :obj:`float`
-                            The factor used in the thole damping function between
+                            The factor used in the Thole damping function between
                             polarizable particles i and j. Usually calculated by
                             the polarizabilities alpha_i, alpha_j and damping
                             parameters  a_i, a_j via
                             scaling_coeff = (a_i+a_j)/2 / ((alpha_i*alpha_j)^(1/2))^(1/3)
             q1q2: :obj:`float`
                   charge factor of the involved charges. Has to be set because
-                  it acts only on the portion of the drude core charge that is
+                  it acts only on the portion of the Drude core charge that is
                   associated to the dipole of the atom. For charged, polarizable
                   atoms that charge is not equal to the particle charge property.
 

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -424,7 +424,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
         Performs reaction_steps reactions. Sets the number of reaction steps which are
         performed at once. Do not use too many reaction steps
         steps consecutively without having conformation
-        changing steps in between (especially important for the Wang Landau reaction ensemble). Providing a number for the parameter reaction steps reduces the need for the interpreter to be
+        changing steps in between (especially important for the Wang-Landau reaction ensemble). Providing a number for the parameter reaction steps reduces the need for the interpreter to be
         called between consecutive reactions.
 
         """
@@ -478,7 +478,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
     def add_collective_variable_potential_energy(self, *args, **kwargs):
         """
-        Adds the potential energy as a collective variable (reaction coordinate) for the Wang Landau Reaction Ensemble.
+        Adds the potential energy as a collective variable (reaction coordinate) for the Wang-Landau Reaction Ensemble.
         Several collective variables can be set simultaneously.
 
         Parameters
@@ -571,7 +571,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
     def load_wang_landau_checkpoint(self):
         """
-        Loads the dumped wang landau potential file.
+        Loads the dumped wang-landau potential file.
 
         """
         checkpoint_name = "checkpoint".encode("utf-8")
@@ -579,7 +579,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
     def write_wang_landau_checkpoint(self):
         """
-        Dumps the wang landau potential to a checkpoint file. Can be used to
+        Dumps the wang-landau potential to a checkpoint file. Can be used to
         checkpoint the Wang-Landau histogram, potential, parameter and the
         number of executed trial moves.
 
@@ -613,7 +613,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
     def write_wang_landau_results_to_file(self, filename):
         """
-        This writes out the wang landau potential as a function of the used
+        This writes out the wang-landau potential as a function of the used
         collective variables.
 
         """

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -571,7 +571,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
     def load_wang_landau_checkpoint(self):
         """
-        Loads the dumped wang-landau potential file.
+        Loads the dumped Wang-Landau potential file.
 
         """
         checkpoint_name = "checkpoint".encode("utf-8")
@@ -579,7 +579,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
     def write_wang_landau_checkpoint(self):
         """
-        Dumps the wang-landau potential to a checkpoint file. Can be used to
+        Dumps the Wang-Landau potential to a checkpoint file. Can be used to
         checkpoint the Wang-Landau histogram, potential, parameter and the
         number of executed trial moves.
 
@@ -613,7 +613,7 @@ cdef class WangLandauReactionEnsemble(ReactionAlgorithm):
 
     def write_wang_landau_results_to_file(self, filename):
         """
-        This writes out the wang-landau potential as a function of the used
+        This writes out the Wang-Landau potential as a function of the used
         collective variables.
 
         """

--- a/src/python/espressomd/scafacos.pyx
+++ b/src/python/espressomd/scafacos.pyx
@@ -72,7 +72,7 @@ IF SCAFACOS == 1:
                 if len(pvalues) == 1:
                     pvalues = pvalues[0]
                 else:
-                    # Cast array elements to strings and join them by commata
+                    # Cast array elements to strings and join them by commas
                     # to achieve consistency with setting array-likes
                     # such as "pnfft_n":"128,128,128"
                     for j in range(len(pvalues)):

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -1383,7 +1383,7 @@ class openGLLive(object):
             return
 
         def redraw_on_idle():
-            # DONT REPOST FASTER THAN 60 FPS
+            # DON'T REPOST FASTER THAN 60 FPS
             self.draw_elapsed += (time.time() - self.draw_timer)
             if self.draw_elapsed > 1.0 / 60.0:
                 self.draw_elapsed = 0

--- a/src/script_interface/Parameter.hpp
+++ b/src/script_interface/Parameter.hpp
@@ -25,7 +25,7 @@
 namespace ScriptInterface {
 
 /**
- * Possible parameter type. Corresponds to the template parameters of @type
+ * Possible parameter type. Corresponds to the template parameters of type
  * Variant.
  */
 using ParameterType = VariantType;

--- a/src/script_interface/ScriptInterfaceBase.cpp
+++ b/src/script_interface/ScriptInterfaceBase.cpp
@@ -110,7 +110,7 @@ void ScriptInterfaceBase::set_state(Variant const &state) {
 
 /**
  * @brief Returns a binary representation of the state often
- *        the instance, as returned by @f get_state().
+ *        the instance, as returned by get_state().
  */
 std::string ScriptInterfaceBase::serialize() const {
   std::stringstream ss;
@@ -123,7 +123,7 @@ std::string ScriptInterfaceBase::serialize() const {
 
 /**
  * @brief Creates a new instance from a binary state,
- *        as returned by @f serialize().
+ *        as returned by serialize().
  */
 std::shared_ptr<ScriptInterfaceBase>
 ScriptInterfaceBase::unserialize(std::string const &state) {

--- a/src/script_interface/ScriptInterfaceBase.hpp
+++ b/src/script_interface/ScriptInterfaceBase.hpp
@@ -48,7 +48,7 @@ template <typename T> Variant make_variant(const T &x) { return Variant(x); }
 /**
  * @brief Base class for generic script interface.
  *
- * @TODO Add extensive documentation.
+ * @todo Add extensive documentation.
  *
  */
 class ScriptInterfaceBase : public Utils::AutoObjectId<ScriptInterfaceBase> {

--- a/src/script_interface/ScriptInterfaceBase.hpp
+++ b/src/script_interface/ScriptInterfaceBase.hpp
@@ -141,7 +141,7 @@ public:
    * @brief Get single parameter.
    *
    * @param name Name of the parameter
-   * @return Value of parameter @param name.
+   * @return Value of parameter @p name
    */
   virtual Variant get_parameter(const std::string &name) const {
     return get_parameters().at(name);
@@ -161,7 +161,7 @@ public:
    * every
    * element of the map.
    *
-   * @param Parameters Parameters to set.
+   * @param parameters Parameters to set.
    */
   virtual void set_parameters(const VariantMap &parameters) {
     for (auto const &it : parameters) {

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -71,7 +71,7 @@ typedef std::map<std::string, Variant> VariantMap;
 
 namespace detail {
 /**
- * @brief Implementation of @f infer_type.
+ * @brief Implementation of infer_type.
  *
  * Helper struct is needed because particle specialization
  * of functions is not allowed. Every specialization deals


### PR DESCRIPTION
Before: 562 warnings
After: 105 warnings

The bulk of the warnings came from broken links. When a file is moved/renamed/split, it's easy to forget to update all `@ref` commands linking to it. Doxygen will complain about it, but the message will be lost among all other warnings. The same goes for links to functions/members/variables that change name or namespace during code refactoring. Each broken `@param` could also generate 2 or 4 warnings.

The `@file <filename>` commands often had an incorrect filename (usually due to copy-pasting) and always provided the basename instead of the full path. Basenames and incorrect filenames are problematic, because two files may end up with the same `@file <filename>` command. For example, if `utils.cpp` and `boost/utils.cpp` are given the same `@file utils.cpp` command (instead of `@file boost/utils.cpp` for the latter), Doxygen will overwrite the documentation of the first file with the documentation of the second file. I propose we write `@file` without the optional argument from now on; Doxygen will use the full path of the source files by default.

Doxygen logs were stored with `make doxygen 2>&1 | tee doxy-[...].log` and analyzed with `diff --color doxy-XXX.log doxy-YYY.log` after each operation on the files to make sure the number of warnings decreased without side-effects. `git diff -U0 --word-diff` was helpful in reviewing individual commits.