### PR TITLE
Lb remove boundary interpolation

### DIFF
--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -115,6 +115,7 @@ struct LB_FluidNode {
 #ifdef LB_BOUNDARIES
   /** flag indicating whether this site belongs to a boundary */
   int boundary;
+  Vector3d slip_velocity = {};
 #endif // LB_BOUNDARIES
 
   /** local force density */

--- a/src/core/grid_based_algorithms/lbboundaries.cpp
+++ b/src/core/grid_based_algorithms/lbboundaries.cpp
@@ -322,7 +322,7 @@ void lb_init_boundaries() {
             node.boundary = the_boundary + 1;
             node.slip_velocity =
                 LBBoundaries::lbboundaries[the_boundary]->velocity() *
-                (lbpar.agrid / lbpar.tau);
+                (lbpar.tau / lbpar.agrid);
           } else {
             lbfields[get_linear_index(x, y, z, lblattice.halo_grid)].boundary =
                 0;
@@ -429,13 +429,10 @@ void lb_bounce_back(LB_Fluid &lbfluid) {
           for (i = 0; i < 19; i++) {
             population_shift = 0;
             for (l = 0; l < 3; l++) {
-              population_shift -=
-                  lbpar.agrid * lbpar.agrid * lbpar.agrid * lbpar.rho * 2 *
-                  lbmodel.c[i][l] * lbmodel.w[i] *
-                  (*LBBoundaries::lbboundaries[lbfields[k].boundary - 1])
-                      .velocity()[l] *
-                  (lbpar.tau / lbpar.agrid) / // TODO
-                  lbmodel.c_sound_sq;
+              population_shift -= lbpar.agrid * lbpar.agrid * lbpar.agrid *
+                                  lbpar.rho * 2 * lbmodel.c[i][l] *
+                                  lbmodel.w[i] * lbfields[k].slip_velocity[l] /
+                                  lbmodel.c_sound_sq;
             }
 
             if (x - lbmodel.c[i][0] > 0 &&

--- a/src/core/grid_based_algorithms/lbboundaries.cpp
+++ b/src/core/grid_based_algorithms/lbboundaries.cpp
@@ -317,8 +317,12 @@ void lb_init_boundaries() {
 
           if (dist <= 0 && the_boundary >= 0 &&
               LBBoundaries::lbboundaries.size() > 0) {
-            lbfields[get_linear_index(x, y, z, lblattice.halo_grid)].boundary =
-                the_boundary + 1;
+            auto const index = get_linear_index(x, y, z, lblattice.halo_grid);
+            auto &node = lbfields[index];
+            node.boundary = the_boundary + 1;
+            node.slip_velocity =
+                LBBoundaries::lbboundaries[the_boundary]->velocity() *
+                (lbpar.agrid / lbpar.tau);
           } else {
             lbfields[get_linear_index(x, y, z, lblattice.halo_grid)].boundary =
                 0;

--- a/src/core/lattice.cpp
+++ b/src/core/lattice.cpp
@@ -83,14 +83,14 @@ int Lattice::init(double *agrid, double *offset, int halo_size, size_t dim) {
 }
 
 void Lattice::map_position_to_lattice(const Vector3d &pos,
-                                      index_t node_index[8], double delta[6]) {
+                                      index_t node_index[8], double delta[6]) const {
   int ind[3];
 
   /* determine the elementary lattice cell containing the particle
      and the relative position of the particle in this cell */
   for (int dir = 0; dir < 3; dir++) {
-    double lpos = pos[dir] - my_left[dir];
-    double rel = lpos / this->agrid[dir] + 0.5; // +1 for halo offset
+    const double lpos = pos[dir] - my_left[dir];
+    const double rel = lpos / this->agrid[dir] + 0.5; // +1 for halo offset
     ind[dir] = (int)floor(rel);
 
     /* surrounding elementary cell is not completely inside this box,

--- a/src/core/lattice.cpp
+++ b/src/core/lattice.cpp
@@ -83,7 +83,8 @@ int Lattice::init(double *agrid, double *offset, int halo_size, size_t dim) {
 }
 
 void Lattice::map_position_to_lattice(const Vector3d &pos,
-                                      index_t node_index[8], double delta[6]) const {
+                                      index_t node_index[8],
+                                      double delta[6]) const {
   int ind[3];
 
   /* determine the elementary lattice cell containing the particle

--- a/src/core/lattice.hpp
+++ b/src/core/lattice.hpp
@@ -94,8 +94,7 @@ public:
    *                   elementary cell, 6 directions (Output)
    */
   void map_position_to_lattice(const Vector3d &pos, index_t node_index[8],
-                               double delta[6]);
-
+                               double delta[6]) const;
   /********************** Inline Functions **********************/
 
   /** Map a global lattice site to the node grid.

--- a/src/core/virtual_sites/lb_inertialess_tracers.cpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers.cpp
@@ -181,12 +181,6 @@ CPU
 void CoupleIBMParticleToFluid(Particle *p) {
   // Convert units from MD to LB
   double delta_j[3];
-  // Old version. Worked, but not when agrid != 1 and probably also required
-  // time_step = lbpar.tau
-  /*  delta_j[0] = p->f.f[0]*time_step*lbpar.tau/lbpar.agrid;
-    delta_j[1] = p->f.f[1]*time_step*lbpar.tau/lbpar.agrid;
-    delta_j[2] = p->f.f[2]*time_step*lbpar.tau/lbpar.agrid;*/
-
   delta_j[0] = p->f.f[0] * lbpar.tau * lbpar.tau / lbpar.agrid;
   delta_j[1] = p->f.f[1] * lbpar.tau * lbpar.tau / lbpar.agrid;
   delta_j[2] = p->f.f[2] * lbpar.tau * lbpar.tau / lbpar.agrid;
@@ -237,40 +231,6 @@ void GetIBMInterpolatedVelocity(double *p, double *const v,
   Vector3d pos;
 
 #ifdef LB_BOUNDARIES
-
-  // This is the interpolation scheme from lb_lbfluid_get_interpolated_velocity
-  // in lb.cpp
-  // It is buggy and has therefore been removed
-
-  /* int boundary_no;
-    int boundary_flag=-1; // 0 if more than agrid/2 away from the boundary, 1 if
-    0<dist<agrid/2, 2 if dist <0
-
-    LBBoundaries::lbboundary_mindist_position(p, &lbboundary_mindist, distvec,
-    &boundary_no);
-    if (lbboundary_mindist>lbpar.agrid/2) {
-      boundary_flag=0;
-      pos[0]=p[0];
-      pos[1]=p[1];
-      pos[2]=p[2];
-
-    } else if (lbboundary_mindist > 0 ) {
-      boundary_flag=1;
-      pos[0]=p[0] - distvec[0]+ distvec[0]/lbboundary_mindist*lbpar.agrid/2.;
-      pos[1]=p[1] - distvec[1]+ distvec[1]/lbboundary_mindist*lbpar.agrid/2.;
-      pos[2]=p[2] - distvec[2]+ distvec[2]/lbboundary_mindist*lbpar.agrid/2.;
-
-    } else {
-      boundary_flag=2;
-      v[0]=
-    (*LBBoundaries::lbboundaries[boundary_no]).velocity()[0]*lbpar.agrid/lbpar.tau;
-      v[1]=
-    (*LBBoundaries::lbboundaries[boundary_no]).velocity()[1]*lbpar.agrid/lbpar.tau;
-      v[2]=
-    (*LBBoundaries::lbboundaries[boundary_no]).velocity()[2]*lbpar.agrid/lbpar.tau;
-      return; // we can return without interpolating
-    }*/
-
   pos[0] = p[0];
   pos[1] = p[1];
   pos[2] = p[2];
@@ -363,20 +323,6 @@ void GetIBMInterpolatedVelocity(double *p, double *const v,
     }
   }
 #ifdef LB_BOUNDARIES
-  // Again the interpolation scheme has been removed
-  /*  if (boundary_flag==1) {
-      v[0]=lbboundary_mindist/(lbpar.agrid/2.)*interpolated_u[0]+(1-lbboundary_mindist/(lbpar.agrid/2.))*
-    (*LBBoundaries::lbboundaries[boundary_no]).velocity()[0];
-      v[1]=lbboundary_mindist/(lbpar.agrid/2.)*interpolated_u[1]+(1-lbboundary_mindist/(lbpar.agrid/2.))*
-    (*LBBoundaries::lbboundaries[boundary_no]).velocity()[1];
-      v[2]=lbboundary_mindist/(lbpar.agrid/2.)*interpolated_u[2]+(1-lbboundary_mindist/(lbpar.agrid/2.))*
-    (*LBBoundaries::lbboundaries[boundary_no]).velocity()[2];
-
-    } else {
-      v[0] = interpolated_u[0];
-      v[1] = interpolated_u[1];
-      v[2] = interpolated_u[2];
-    }*/
   v[0] = interpolated_u[0];
   v[1] = interpolated_u[1];
   v[2] = interpolated_u[2];


### PR DESCRIPTION
Description of changes:
 - Removed broken LB boundary interpolation scheme, the CPU viscous coupling is
   now the same as with the passive tracers.
- Factored out lattice interpolation
- Directly store boundary slip velocity instead of id, which is ill-defined if there are
  multiple boundaries intersecting.
