### PR TITLE
calc particle dipole vector and director on the fly

### DIFF
--- a/src/core/EspressoSystemInterface.hpp
+++ b/src/core/EspressoSystemInterface.hpp
@@ -96,16 +96,16 @@ public:
     return m_needsQGpu;
   };
 
-  float *quatuGpuBegin() override { return m_quatu_gpu_begin; };
-  float *quatuGpuEnd() override { return m_quatu_gpu_end; };
-  bool hasQuatuGpu() override { return true; };
-  bool requestQuatuGpu() override {
-    m_needsQuatuGpu = hasQuatuGpu();
-    m_splitParticleStructGpu |= m_needsQuatuGpu;
-    m_gpu |= m_needsQuatuGpu;
+  float *directorGpuBegin() override { return m_director_gpu_begin; };
+  float *directorGpuEnd() override { return m_director_gpu_end; };
+  bool hasDirectorGpu() override { return true; };
+  bool requestDirectorGpu() override {
+    m_needsDirectorGpu = hasDirectorGpu();
+    m_splitParticleStructGpu |= m_needsDirectorGpu;
+    m_gpu |= m_needsDirectorGpu;
     if (m_gpu)
       enableParticleCommunication();
-    return m_needsQuatuGpu;
+    return m_needsDirectorGpu;
   };
 
   bool requestParticleStructGpu() {
@@ -164,8 +164,8 @@ protected:
   EspressoSystemInterface()
       : m_gpu_npart(0), m_gpu(false), m_r_gpu_begin(0), m_r_gpu_end(0),
         m_dip_gpu_begin(0), m_dip_gpu_end(0), m_v_gpu_begin(0), m_v_gpu_end(0),
-        m_q_gpu_begin(0), m_q_gpu_end(0), m_quatu_gpu_begin(0),
-        m_quatu_gpu_end(0), m_needsParticleStructGpu(false),
+        m_q_gpu_begin(0), m_q_gpu_end(0), m_director_gpu_begin(0),
+        m_director_gpu_end(0), m_needsParticleStructGpu(false),
         m_splitParticleStructGpu(false){};
   virtual ~EspressoSystemInterface() {}
 
@@ -200,8 +200,8 @@ protected:
   float *m_q_gpu_begin;
   float *m_q_gpu_end;
 
-  float *m_quatu_gpu_begin;
-  float *m_quatu_gpu_end;
+  float *m_director_gpu_begin;
+  float *m_director_gpu_end;
 
   bool m_needsParticleStructGpu;
   bool m_splitParticleStructGpu;

--- a/src/core/EspressoSystemInterface_cuda.cu
+++ b/src/core/EspressoSystemInterface_cuda.cu
@@ -110,7 +110,7 @@ __global__ void split_kernel_dip(CUDA_particle_data *particles, float *dip,
 }
 #endif
 
-__global__ void split_kernel_quatu(CUDA_particle_data *particles, float *quatu,
+__global__ void split_kernel_director(CUDA_particle_data *particles, float *director,
                                    int n) {
 #ifdef ROTATION
   int idx = blockDim.x * blockIdx.x + threadIdx.x;
@@ -121,9 +121,9 @@ __global__ void split_kernel_quatu(CUDA_particle_data *particles, float *quatu,
 
   idx *= 3;
 
-  quatu[idx + 0] = p.quatu[0];
-  quatu[idx + 1] = p.quatu[1];
-  quatu[idx + 2] = p.quatu[2];
+  director[idx + 0] = p.director[0];
+  director[idx + 1] = p.director[1];
+  director[idx + 2] = p.director[2];
 #endif
 }
 
@@ -156,11 +156,11 @@ void EspressoSystemInterface::reallocDeviceMemory(int n) {
     m_q_gpu_end = m_q_gpu_begin + 3 * n;
   }
 
-  if (m_needsQuatuGpu && ((n != m_gpu_npart) || (m_quatu_gpu_begin == 0))) {
-    if (m_quatu_gpu_begin != 0)
-      cuda_safe_mem(cudaFree(m_quatu_gpu_begin));
-    cuda_safe_mem(cudaMalloc(&m_quatu_gpu_begin, 3 * n * sizeof(float)));
-    m_quatu_gpu_end = m_quatu_gpu_begin + 3 * n;
+  if (m_needsDirectorGpu && ((n != m_gpu_npart) || (m_director_gpu_begin == 0))) {
+    if (m_director_gpu_begin != 0)
+      cuda_safe_mem(cudaFree(m_director_gpu_begin));
+    cuda_safe_mem(cudaMalloc(&m_director_gpu_begin, 3 * n * sizeof(float)));
+    m_director_gpu_end = m_director_gpu_begin + 3 * n;
   }
 
   m_gpu_npart = n;
@@ -197,7 +197,7 @@ void EspressoSystemInterface::split_particle_struct() {
 
 #endif
 
-  if (m_needsQuatuGpu)
-    split_kernel_quatu<<<grid, block>>>(gpu_get_particle_pointer(),
-                                        m_quatu_gpu_begin, n);
+  if (m_needsDirectorGpu)
+    split_kernel_director<<<grid, block>>>(gpu_get_particle_pointer(),
+                                        m_director_gpu_begin, n);
 }

--- a/src/core/EspressoSystemInterface_cuda.cu
+++ b/src/core/EspressoSystemInterface_cuda.cu
@@ -110,8 +110,8 @@ __global__ void split_kernel_dip(CUDA_particle_data *particles, float *dip,
 }
 #endif
 
-__global__ void split_kernel_director(CUDA_particle_data *particles, float *director,
-                                   int n) {
+__global__ void split_kernel_director(CUDA_particle_data *particles,
+                                      float *director, int n) {
 #ifdef ROTATION
   int idx = blockDim.x * blockIdx.x + threadIdx.x;
   if (idx >= n)
@@ -156,7 +156,8 @@ void EspressoSystemInterface::reallocDeviceMemory(int n) {
     m_q_gpu_end = m_q_gpu_begin + 3 * n;
   }
 
-  if (m_needsDirectorGpu && ((n != m_gpu_npart) || (m_director_gpu_begin == 0))) {
+  if (m_needsDirectorGpu &&
+      ((n != m_gpu_npart) || (m_director_gpu_begin == 0))) {
     if (m_director_gpu_begin != 0)
       cuda_safe_mem(cudaFree(m_director_gpu_begin));
     cuda_safe_mem(cudaMalloc(&m_director_gpu_begin, 3 * n * sizeof(float)));
@@ -199,5 +200,5 @@ void EspressoSystemInterface::split_particle_struct() {
 
   if (m_needsDirectorGpu)
     split_kernel_director<<<grid, block>>>(gpu_get_particle_pointer(),
-                                        m_director_gpu_begin, n);
+                                           m_director_gpu_begin, n);
 }

--- a/src/core/SystemInterface.hpp
+++ b/src/core/SystemInterface.hpp
@@ -29,7 +29,7 @@ class SystemInterface {
 public:
   SystemInterface()
       : m_needsRGpu(false), m_needsVGpu(false), m_needsQGpu(false),
-        m_needsQuatuGpu(false), m_needsFGpu(false), m_needsDipGpu(false),
+        m_needsDirectorGpu(false), m_needsFGpu(false), m_needsDipGpu(false),
         m_needsTorqueGpu(false){};
   typedef Vector3d Vector3;
   typedef double Real;
@@ -86,12 +86,12 @@ public:
     return m_needsFGpu;
   }
 
-  virtual float *quatuGpuBegin() { return 0; };
-  virtual float *quatuGpuEnd() { return 0; };
-  virtual bool hasQuatuGpu() { return false; };
-  virtual bool requestQuatuGpu() {
-    m_needsQuatuGpu = hasQuatuGpu();
-    return m_needsQuatuGpu;
+  virtual float *directorGpuBegin() { return 0; };
+  virtual float *directorGpuEnd() { return 0; };
+  virtual bool hasDirectorGpu() { return false; };
+  virtual bool requestDirectorGpu() {
+    m_needsDirectorGpu = hasDirectorGpu();
+    return m_needsDirectorGpu;
   }
 
   virtual unsigned int npart_gpu() { return 0; };
@@ -100,7 +100,7 @@ public:
   virtual bool needsRGpu() { return m_needsRGpu; };
   virtual bool needsDipGpu() { return m_needsRGpu; };
   virtual bool needsQGpu() { return m_needsQGpu; };
-  virtual bool needsQuatuGpu() { return m_needsQuatuGpu; };
+  virtual bool needsDirectorGpu() { return m_needsDirectorGpu; };
   virtual bool needsFGpu() { return m_needsFGpu; };
   virtual bool needsTorqueGpu() { return m_needsTorqueGpu; };
   virtual ~SystemInterface() = default;
@@ -109,7 +109,7 @@ protected:
   bool m_needsRGpu;
   bool m_needsVGpu;
   bool m_needsQGpu;
-  bool m_needsQuatuGpu;
+  bool m_needsDirectorGpu;
   bool m_needsFGpu;
   bool m_needsDipGpu;
   bool m_needsTorqueGpu;

--- a/src/core/actor/HarmonicOrientationWell.cpp
+++ b/src/core/actor/HarmonicOrientationWell.cpp
@@ -26,8 +26,8 @@
 HarmonicOrientationWell::HarmonicOrientationWell(float x1, float x2, float x3,
                                                  float _k, SystemInterface &s)
     : x(x1), y(x2), z(x3), k(_k) {
-  if (!s.requestQuatuGpu())
-    std::cerr << "HarmonicOrientationWell needs access to quatu on GPU!"
+  if (!s.requestDirectorGpu())
+    std::cerr << "HarmonicOrientationWell needs access to director on GPU!"
               << std::endl;
 
   if (!s.requestTorqueGpu())

--- a/src/core/actor/HarmonicOrientationWell.hpp
+++ b/src/core/actor/HarmonicOrientationWell.hpp
@@ -29,7 +29,7 @@
 #include <iostream>
 
 void HarmonicOrientationWell_kernel_wrapper(float x, float y, float z, float k,
-                                            int n, float *quatu, float *torque);
+                                            int n, float *director, float *torque);
 
 class HarmonicOrientationWell : public Actor {
 public:
@@ -38,7 +38,7 @@ public:
 
   virtual void computeTorques(SystemInterface &s) {
     HarmonicOrientationWell_kernel_wrapper(
-        x, y, z, k, s.npart_gpu(), s.quatuGpuBegin(), s.torqueGpuBegin());
+        x, y, z, k, s.npart_gpu(), s.directorGpuBegin(), s.torqueGpuBegin());
   };
 
   virtual ~HarmonicOrientationWell() {}

--- a/src/core/actor/HarmonicOrientationWell.hpp
+++ b/src/core/actor/HarmonicOrientationWell.hpp
@@ -29,7 +29,8 @@
 #include <iostream>
 
 void HarmonicOrientationWell_kernel_wrapper(float x, float y, float z, float k,
-                                            int n, float *director, float *torque);
+                                            int n, float *director,
+                                            float *torque);
 
 class HarmonicOrientationWell : public Actor {
 public:

--- a/src/core/actor/HarmonicOrientationWell_cuda.cu
+++ b/src/core/actor/HarmonicOrientationWell_cuda.cu
@@ -26,7 +26,7 @@
 #endif
 
 __global__ void HarmonicOrientationWell_kernel(float x, float y, float z,
-                                               float k, int n, float *quatu,
+                                               float k, int n, float *director,
                                                float *torque) {
 
   int id = blockIdx.x * blockDim.x + threadIdx.x;
@@ -35,17 +35,17 @@ __global__ void HarmonicOrientationWell_kernel(float x, float y, float z,
     return;
 
   float normdir = 1.0f / sqrt(x * x + y * y + z * z);
-  float normori = 1.0f / sqrt(quatu[3 * id + 0] * quatu[3 * id + 0] +
-                              quatu[3 * id + 1] * quatu[3 * id + 1] +
-                              quatu[3 * id + 2] * quatu[3 * id + 2]);
+  float normori = 1.0f / sqrt(director[3 * id + 0] * director[3 * id + 0] +
+                              director[3 * id + 1] * director[3 * id + 1] +
+                              director[3 * id + 2] * director[3 * id + 2]);
 
   float xn = x * normdir;
   float yn = y * normdir;
   float zn = z * normdir;
 
-  float qn = quatu[3 * id + 0] * normori;
-  float rn = quatu[3 * id + 1] * normori;
-  float sn = quatu[3 * id + 2] * normori;
+  float qn = director[3 * id + 0] * normori;
+  float rn = director[3 * id + 1] * normori;
+  float sn = director[3 * id + 2] * normori;
 
   float sgndir = signbit(xn * qn + yn * rn + zn * sn);
 
@@ -59,7 +59,7 @@ __global__ void HarmonicOrientationWell_kernel(float x, float y, float z,
 }
 
 void HarmonicOrientationWell_kernel_wrapper(float x, float y, float z, float k,
-                                            int n, float *quatu,
+                                            int n, float *director,
                                             float *torque) {
   dim3 grid(1, 1, 1);
   dim3 block(1, 1, 1);
@@ -76,5 +76,5 @@ void HarmonicOrientationWell_kernel_wrapper(float x, float y, float z, float k,
   }
 
   KERNELCALL(HarmonicOrientationWell_kernel, grid, block,
-             (x, y, z, k, n, quatu, torque))
+             (x, y, z, k, n, director, torque))
 }

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -85,7 +85,7 @@ inline int calc_harmonic_dumbbell_pair_force(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  const Vector3d director1=p1->r.calc_director();
+  const Vector3d director1 = p1->r.calc_director();
   da[0] = dhat[1] * director1[2] - dhat[2] * director1[1];
   da[1] = dhat[2] * director1[0] - dhat[0] * director1[2];
   da[2] = dhat[0] * director1[1] - dhat[1] * director1[0];
@@ -126,7 +126,7 @@ inline int harmonic_dumbbell_pair_energy(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  const Vector3d director1=p1->r.calc_director();
+  const Vector3d director1 = p1->r.calc_director();
   da[0] = dhat[1] * director1[2] - dhat[2] * director1[1];
   da[1] = dhat[2] * director1[0] - dhat[0] * director1[2];
   da[2] = dhat[0] * director1[1] - dhat[1] * director1[0];

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -85,9 +85,10 @@ inline int calc_harmonic_dumbbell_pair_force(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  da[0] = dhat[1] * p1->r.quatu[2] - dhat[2] * p1->r.quatu[1];
-  da[1] = dhat[2] * p1->r.quatu[0] - dhat[0] * p1->r.quatu[2];
-  da[2] = dhat[0] * p1->r.quatu[1] - dhat[1] * p1->r.quatu[0];
+  const Vector3d quatu1=p1->r.calc_quatu();
+  da[0] = dhat[1] * quatu1[2] - dhat[2] * quatu1[1];
+  da[1] = dhat[2] * quatu1[0] - dhat[0] * quatu1[2];
+  da[2] = dhat[0] * quatu1[1] - dhat[1] * quatu1[0];
 
   p1->f.torque[0] += iaparams->p.harmonic_dumbbell.k2 * da[0];
   p1->f.torque[1] += iaparams->p.harmonic_dumbbell.k2 * da[1];
@@ -125,9 +126,10 @@ inline int harmonic_dumbbell_pair_energy(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  da[0] = dhat[1] * p1->r.quatu[2] - dhat[2] * p1->r.quatu[1];
-  da[1] = dhat[2] * p1->r.quatu[0] - dhat[0] * p1->r.quatu[2];
-  da[2] = dhat[0] * p1->r.quatu[1] - dhat[1] * p1->r.quatu[0];
+  const Vector3d quatu1=p1->r.calc_quatu();
+  da[0] = dhat[1] * quatu1[2] - dhat[2] * quatu1[1];
+  da[1] = dhat[2] * quatu1[0] - dhat[0] * quatu1[2];
+  da[2] = dhat[0] * quatu1[1] - dhat[1] * quatu1[0];
 
   double torque[3];
   torque[0] = iaparams->p.harmonic_dumbbell.k2 * da[0];
@@ -135,9 +137,9 @@ inline int harmonic_dumbbell_pair_energy(Particle *p1, Particle *p2,
   torque[2] = iaparams->p.harmonic_dumbbell.k2 * da[2];
 
   double diff[3];
-  diff[0] = dhat[0] - p1->r.quatu[0];
-  diff[1] = dhat[1] - p1->r.quatu[1];
-  diff[2] = dhat[2] - p1->r.quatu[2];
+  diff[0] = dhat[0] - quatu1[0];
+  diff[1] = dhat[1] - quatu1[1];
+  diff[2] = dhat[2] - quatu1[2];
 
   *_energy =
       0.5 * iaparams->p.harmonic_dumbbell.k1 *

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -85,7 +85,7 @@ inline int calc_harmonic_dumbbell_pair_force(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  const Vector3d quatu1=p1->r.calc_quatu();
+  const Vector3d quatu1=p1->r.calc_director();
   da[0] = dhat[1] * quatu1[2] - dhat[2] * quatu1[1];
   da[1] = dhat[2] * quatu1[0] - dhat[0] * quatu1[2];
   da[2] = dhat[0] * quatu1[1] - dhat[1] * quatu1[0];
@@ -126,7 +126,7 @@ inline int harmonic_dumbbell_pair_energy(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  const Vector3d quatu1=p1->r.calc_quatu();
+  const Vector3d quatu1=p1->r.calc_director();
   da[0] = dhat[1] * quatu1[2] - dhat[2] * quatu1[1];
   da[1] = dhat[2] * quatu1[0] - dhat[0] * quatu1[2];
   da[2] = dhat[0] * quatu1[1] - dhat[1] * quatu1[0];

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -85,10 +85,10 @@ inline int calc_harmonic_dumbbell_pair_force(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  const Vector3d quatu1=p1->r.calc_director();
-  da[0] = dhat[1] * quatu1[2] - dhat[2] * quatu1[1];
-  da[1] = dhat[2] * quatu1[0] - dhat[0] * quatu1[2];
-  da[2] = dhat[0] * quatu1[1] - dhat[1] * quatu1[0];
+  const Vector3d director1=p1->r.calc_director();
+  da[0] = dhat[1] * director1[2] - dhat[2] * director1[1];
+  da[1] = dhat[2] * director1[0] - dhat[0] * director1[2];
+  da[2] = dhat[0] * director1[1] - dhat[1] * director1[0];
 
   p1->f.torque[0] += iaparams->p.harmonic_dumbbell.k2 * da[0];
   p1->f.torque[1] += iaparams->p.harmonic_dumbbell.k2 * da[1];
@@ -126,10 +126,10 @@ inline int harmonic_dumbbell_pair_energy(Particle *p1, Particle *p2,
   dhat[2] = dx[2] / dist;
 
   double da[3];
-  const Vector3d quatu1=p1->r.calc_director();
-  da[0] = dhat[1] * quatu1[2] - dhat[2] * quatu1[1];
-  da[1] = dhat[2] * quatu1[0] - dhat[0] * quatu1[2];
-  da[2] = dhat[0] * quatu1[1] - dhat[1] * quatu1[0];
+  const Vector3d director1=p1->r.calc_director();
+  da[0] = dhat[1] * director1[2] - dhat[2] * director1[1];
+  da[1] = dhat[2] * director1[0] - dhat[0] * director1[2];
+  da[2] = dhat[0] * director1[1] - dhat[1] * director1[0];
 
   double torque[3];
   torque[0] = iaparams->p.harmonic_dumbbell.k2 * da[0];
@@ -137,9 +137,9 @@ inline int harmonic_dumbbell_pair_energy(Particle *p1, Particle *p2,
   torque[2] = iaparams->p.harmonic_dumbbell.k2 * da[2];
 
   double diff[3];
-  diff[0] = dhat[0] - quatu1[0];
-  diff[1] = dhat[1] - quatu1[1];
-  diff[2] = dhat[2] - quatu1[2];
+  diff[0] = dhat[0] - director1[0];
+  diff[1] = dhat[1] - director1[1];
+  diff[2] = dhat[2] - director1[2];
 
   *_energy =
       0.5 * iaparams->p.harmonic_dumbbell.k1 *

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -884,7 +884,8 @@ void mpi_send_dip(int pnode, int part, double dip[3]) {
 
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    convert_dip_to_quat(Vector3d({dip[0],dip[1],dip[2]}), p->r.quat, &p->p.dipm);
+    convert_dip_to_quat(Vector3d({dip[0], dip[1], dip[2]}), p->r.quat,
+                        &p->p.dipm);
   } else {
     MPI_Send(dip, 3, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
   }

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -885,8 +885,6 @@ void mpi_send_dip(int pnode, int part, double dip[3]) {
   if (pnode == this_node) {
     Particle *p = local_particles[part];
     convert_dip_to_quat(Vector3d({dip[0],dip[1],dip[2]}), p->r.quat, &p->p.dipm);
-    p->p.dipm = sqrt(p->calc_dip()[0] * p->calc_dip()[0] + p->calc_dip()[1] * p->calc_dip()[1] +
-                     p->calc_dip()[2] * p->calc_dip()[2]);
   } else {
     MPI_Send(dip, 3, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
   }
@@ -903,7 +901,6 @@ void mpi_send_dip_slave(int pnode, int part) {
     MPI_Recv(dip.data(), 3, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
              MPI_STATUS_IGNORE);
     convert_dip_to_quat(dip, p->r.quat, &p->p.dipm);
-    p->p.dipm = dip.norm();
   }
 
   on_particle_change();

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -793,10 +793,6 @@ void mpi_send_quat(int pnode, int part, double quat[4]) {
     p->r.quat[1] = quat[1];
     p->r.quat[2] = quat[2];
     p->r.quat[3] = quat[3];
-    convert_quat_to_quatu(p->r.quat, p->r.quatu);
-#ifdef DIPOLES
-    convert_quatu_to_dip(p->r.quatu, p->p.dipm, p->r.dip);
-#endif
   } else {
     MPI_Send(quat, 4, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
   }
@@ -811,10 +807,6 @@ void mpi_send_quat_slave(int pnode, int part) {
     Particle *p = local_particles[part];
     MPI_Recv(p->r.quat.data(), 4, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
              MPI_STATUS_IGNORE);
-    convert_quat_to_quatu(p->r.quat, p->r.quatu);
-#ifdef DIPOLES
-    convert_quatu_to_dip(p->r.quatu, p->p.dipm, p->r.dip);
-#endif
   }
 
   on_particle_change();
@@ -892,16 +884,9 @@ void mpi_send_dip(int pnode, int part, double dip[3]) {
 
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    p->r.dip[0] = dip[0];
-    p->r.dip[1] = dip[1];
-    p->r.dip[2] = dip[2];
-#ifdef ROTATION
-    convert_dip_to_quat(p->r.dip, p->r.quat, &p->p.dipm);
-    convert_quat_to_quatu(p->r.quat, p->r.quatu);
-#else
-    p->p.dipm = sqrt(p->r.dip[0] * p->r.dip[0] + p->r.dip[1] * p->r.dip[1] +
-                     p->r.dip[2] * p->r.dip[2]);
-#endif
+    convert_dip_to_quat(Vector3d({dip[0],dip[1],dip[2]}), p->r.quat, &p->p.dipm);
+    p->p.dipm = sqrt(p->calc_dip()[0] * p->calc_dip()[0] + p->calc_dip()[1] * p->calc_dip()[1] +
+                     p->calc_dip()[2] * p->calc_dip()[2]);
   } else {
     MPI_Send(dip, 3, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
   }
@@ -914,15 +899,11 @@ void mpi_send_dip_slave(int pnode, int part) {
 #ifdef DIPOLES
   if (pnode == this_node) {
     Particle *p = local_particles[part];
-    MPI_Recv(p->r.dip.data(), 3, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
+    Vector3d dip;
+    MPI_Recv(dip.data(), 3, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
              MPI_STATUS_IGNORE);
-#ifdef ROTATION
-    convert_dip_to_quat(p->r.dip, p->r.quat, &p->p.dipm);
-    convert_quat_to_quatu(p->r.quat, p->r.quatu);
-#else
-    p->p.dipm = sqrt(p->r.dip[0] * p->r.dip[0] + p->r.dip[1] * p->r.dip[1] +
-                     p->r.dip[2] * p->r.dip[2]);
-#endif
+    convert_dip_to_quat(dip, p->r.quat, &p->p.dipm);
+    p->p.dipm = dip.norm();
   }
 
   on_particle_change();
@@ -939,7 +920,6 @@ void mpi_send_dipm(int pnode, int part, double dipm) {
     Particle *p = local_particles[part];
     p->p.dipm = dipm;
 #ifdef ROTATION
-    convert_quatu_to_dip(p->r.quatu, p->p.dipm, p->r.dip);
 #endif
   } else {
     MPI_Send(&dipm, 1, MPI_DOUBLE, pnode, SOME_TAG, comm_cart);
@@ -955,9 +935,6 @@ void mpi_send_dipm_slave(int pnode, int part) {
     Particle *p = local_particles[part];
     MPI_Recv(&p->p.dipm, 1, MPI_DOUBLE, 0, SOME_TAG, comm_cart,
              MPI_STATUS_IGNORE);
-#ifdef ROTATION
-    convert_quatu_to_dip(p->r.quatu, p->p.dipm, p->r.dip);
-#endif
   }
 
   on_particle_change();

--- a/src/core/constraints/HomogeneousMagneticField.cpp
+++ b/src/core/constraints/HomogeneousMagneticField.cpp
@@ -24,7 +24,7 @@ namespace Constraints {
 ParticleForce HomogeneousMagneticField::force(const Particle &p,
                                               const Vector3d &folded_pos) {
 #if defined(ROTATION) && defined(DIPOLES)
-  return {Vector3d{}, Vector3d::cross(p.r.dip, m_field)};
+  return {Vector3d{}, Vector3d::cross(p.calc_dip(), m_field)};
 #else
   return {Vector3d{}};
 #endif
@@ -34,7 +34,7 @@ void HomogeneousMagneticField::add_energy(const Particle &p,
                                           const Vector3d &folded_pos,
                                           Observable_stat &energy) const {
 #ifdef DIPOLES
-  energy.dipolar[0] += -1.0 * m_field * p.r.dip;
+  energy.dipolar[0] += -1.0 * m_field * p.calc_dip();
 #endif
 }
 

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -101,18 +101,18 @@ static void pack_particles(ParticleRange particles,
 #endif
 
 #ifdef ROTATION
-    const Vector3d quatu=part.r.calc_director();
-    buffer[i].quatu[0] = static_cast<float>(quatu[0]);
-    buffer[i].quatu[1] = static_cast<float>(quatu[1]);
-    buffer[i].quatu[2] = static_cast<float>(quatu[2]);
+    const Vector3d director=part.r.calc_director();
+    buffer[i].director[0] = static_cast<float>(director[0]);
+    buffer[i].director[1] = static_cast<float>(director[1]);
+    buffer[i].director[2] = static_cast<float>(director[2]);
 #endif
 
 #ifdef ENGINE
     buffer[i].swim.v_swim = static_cast<float>(part.swim.v_swim);
     buffer[i].swim.f_swim = static_cast<float>(part.swim.f_swim);
-    buffer[i].swim.quatu[0] = static_cast<float>(quatu[0]);
-    buffer[i].swim.quatu[1] = static_cast<float>(quatu[1]);
-    buffer[i].swim.quatu[2] = static_cast<float>(quatu[2]);
+    buffer[i].swim.director[0] = static_cast<float>(director[0]);
+    buffer[i].swim.director[1] = static_cast<float>(director[1]);
+    buffer[i].swim.director[2] = static_cast<float>(director[2]);
 #if defined(LB) || defined(LB_GPU)
     buffer[i].swim.push_pull = part.swim.push_pull;
     buffer[i].swim.dipole_length = static_cast<float>(part.swim.dipole_length);

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -73,7 +73,7 @@ static void pack_particles(ParticleRange particles,
 #endif
 
 #ifdef DIPOLES
-    const Vector3d dip=part.calc_dip();
+    const Vector3d dip = part.calc_dip();
     buffer[i].dip[0] = static_cast<float>(dip[0]);
     buffer[i].dip[1] = static_cast<float>(dip[1]);
     buffer[i].dip[2] = static_cast<float>(dip[2]);
@@ -101,7 +101,7 @@ static void pack_particles(ParticleRange particles,
 #endif
 
 #ifdef ROTATION
-    const Vector3d director=part.r.calc_director();
+    const Vector3d director = part.r.calc_director();
     buffer[i].director[0] = static_cast<float>(director[0]);
     buffer[i].director[1] = static_cast<float>(director[1]);
     buffer[i].director[2] = static_cast<float>(director[2]);

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -101,7 +101,7 @@ static void pack_particles(ParticleRange particles,
 #endif
 
 #ifdef ROTATION
-    const Vector3d quatu=part.r.calc_quatu();
+    const Vector3d quatu=part.r.calc_director();
     buffer[i].quatu[0] = static_cast<float>(quatu[0]);
     buffer[i].quatu[1] = static_cast<float>(quatu[1]);
     buffer[i].quatu[2] = static_cast<float>(quatu[2]);

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -73,9 +73,10 @@ static void pack_particles(ParticleRange particles,
 #endif
 
 #ifdef DIPOLES
-    buffer[i].dip[0] = static_cast<float>(part.r.dip[0]);
-    buffer[i].dip[1] = static_cast<float>(part.r.dip[1]);
-    buffer[i].dip[2] = static_cast<float>(part.r.dip[2]);
+    const Vector3d dip=part.calc_dip();
+    buffer[i].dip[0] = static_cast<float>(dip[0]);
+    buffer[i].dip[1] = static_cast<float>(dip[1]);
+    buffer[i].dip[2] = static_cast<float>(dip[2]);
 #endif
 
 #ifdef SHANCHEN
@@ -100,17 +101,18 @@ static void pack_particles(ParticleRange particles,
 #endif
 
 #ifdef ROTATION
-    buffer[i].quatu[0] = static_cast<float>(part.r.quatu[0]);
-    buffer[i].quatu[1] = static_cast<float>(part.r.quatu[1]);
-    buffer[i].quatu[2] = static_cast<float>(part.r.quatu[2]);
+    const Vector3d quatu=part.r.calc_quatu();
+    buffer[i].quatu[0] = static_cast<float>(quatu[0]);
+    buffer[i].quatu[1] = static_cast<float>(quatu[1]);
+    buffer[i].quatu[2] = static_cast<float>(quatu[2]);
 #endif
 
 #ifdef ENGINE
     buffer[i].swim.v_swim = static_cast<float>(part.swim.v_swim);
     buffer[i].swim.f_swim = static_cast<float>(part.swim.f_swim);
-    buffer[i].swim.quatu[0] = static_cast<float>(part.r.quatu[0]);
-    buffer[i].swim.quatu[1] = static_cast<float>(part.r.quatu[1]);
-    buffer[i].swim.quatu[2] = static_cast<float>(part.r.quatu[2]);
+    buffer[i].swim.quatu[0] = static_cast<float>(quatu[0]);
+    buffer[i].swim.quatu[1] = static_cast<float>(quatu[1]);
+    buffer[i].swim.quatu[2] = static_cast<float>(quatu[2]);
 #if defined(LB) || defined(LB_GPU)
     buffer[i].swim.push_pull = part.swim.push_pull;
     buffer[i].swim.dipole_length = static_cast<float>(part.swim.dipole_length);

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -50,7 +50,7 @@ typedef struct {
   float v_cs[6];
   float v_swim;
   float f_swim;
-  float quatu[3];
+  float director[3];
   int push_pull;
   float dipole_length;
   bool swimming;
@@ -75,7 +75,7 @@ struct CUDA_particle_data {
 #endif
 
 #ifdef ROTATION
-  float quatu[3];
+  float director[3];
 #endif
 
 #ifdef SHANCHEN

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -43,7 +43,8 @@
 #ifdef DIPOLES
 
 // Calculates dipolar energy and/or force between two particles
-double calc_dipole_dipole_ia(Particle *p1, const Vector3d& dip1, Particle *p2, int force_flag) {
+double calc_dipole_dipole_ia(Particle *p1, const Vector3d &dip1, Particle *p2,
+                             int force_flag) {
   double u, r, pe1, pe2, pe3, pe4, r3, r5, r2, r7, a, b, cc, d, ab;
 #ifdef ROTATION
   double bx, by, bz, ax, ay, az;
@@ -51,14 +52,14 @@ double calc_dipole_dipole_ia(Particle *p1, const Vector3d& dip1, Particle *p2, i
   double ffx, ffy, ffz;
 
   // Cache dipole momente
-  const Vector3d dip2 =p2->calc_dip();
-  
+  const Vector3d dip2 = p2->calc_dip();
+
   // Distance between particles
   Vector3d dr;
   get_mi_vector(dr, p1->r.p, p2->r.p);
 
   // Powers of distance
-  r2 = dr*dr;
+  r2 = dr * dr;
   r = sqrt(r2);
   r3 = r2 * r;
   r5 = r3 * r2;
@@ -66,8 +67,8 @@ double calc_dipole_dipole_ia(Particle *p1, const Vector3d& dip1, Particle *p2, i
 
   // Dot products
   pe1 = dip1 * dip2;
-  pe2 = dip1*dr;
-  pe3 = dip2*dr;
+  pe2 = dip1 * dr;
+  pe3 = dip2 * dr;
   pe4 = 3.0 / r5;
 
   // Energy, if requested
@@ -151,7 +152,7 @@ double dawaanr_calculations(int force_flag, int energy_flag) {
     if (it->p.dipm == 0.0)
       continue;
 
-    const Vector3d dip1=it->calc_dip();
+    const Vector3d dip1 = it->calc_dip();
     auto jt = it;
     /* Skip diagonal */
     ++jt;
@@ -240,7 +241,7 @@ double magnetic_dipolar_direct_sum_calculations(int force_flag,
   dip_particles = 0;
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm != 0.0) {
-      const Vector3d dip=p.calc_dip();
+      const Vector3d dip = p.calc_dip();
 
       mx[dip_particles] = dip[0];
       my[dip_particles] = dip[1];

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -43,32 +43,31 @@
 #ifdef DIPOLES
 
 // Calculates dipolar energy and/or force between two particles
-double calc_dipole_dipole_ia(Particle *p1, const Vector3d dip1, Particle *p2, int force_flag) {
+double calc_dipole_dipole_ia(Particle *p1, const Vector3d& dip1, Particle *p2, int force_flag) {
   double u, r, pe1, pe2, pe3, pe4, r3, r5, r2, r7, a, b, cc, d, ab;
 #ifdef ROTATION
   double bx, by, bz, ax, ay, az;
 #endif
   double ffx, ffy, ffz;
-  double dr[3];
 
   // Cache dipole momente
   const Vector3d dip2 =p2->calc_dip();
   
   // Distance between particles
+  Vector3d dr;
   get_mi_vector(dr, p1->r.p, p2->r.p);
 
   // Powers of distance
-  r2 = dr[0] * dr[0] + dr[1] * dr[1] + dr[2] * dr[2];
+  r2 = dr*dr;
   r = sqrt(r2);
   r3 = r2 * r;
   r5 = r3 * r2;
   r7 = r5 * r2;
 
   // Dot products
-  pe1 = dip1[0] * dip2[0] + dip1[1] * dip2[1] +
-        dip1[2] * dip2[2];
-  pe2 = dip1[0] * dr[0] + dip1[1] * dr[1] + dip1[2] * dr[2];
-  pe3 = dip2[0] * dr[0] + dip2[1] * dr[1] + dip2[2] * dr[2];
+  pe1 = dip1 * dip2;
+  pe2 = dip1*dr;
+  pe3 = dip2*dr;
   pe4 = 3.0 / r5;
 
   // Energy, if requested
@@ -93,18 +92,6 @@ double calc_dipole_dipole_ia(Particle *p1, const Vector3d dip1, Particle *p2, in
     p2->f.f[0] -= coulomb.Dprefactor * ffx;
     p2->f.f[1] -= coulomb.Dprefactor * ffy;
     p2->f.f[2] -= coulomb.Dprefactor * ffz;
-//    if (p1->p.identity==248)
-//    {
-//      printf("xxx %g %g %g\n", dr[0],dr[1],dr[2]);
-//      printf("%d %g %g %g - %g %g
-//      %g\n",p2->p.identity,ffx,ffy,ffz,p2->r.p[0],p2->r.p[1],p2->r.p[2]);
-//     }
-//    if (p2->p.identity==248)
-//   {
-//      printf("xxx %g %g %g\n", dr[0],dr[1],dr[2]);
-//      printf("%d %g %g %g - %g %g
-//      %g\n",p1->p.identity,-ffx,-ffy,-ffz,p1->r.p[0],p1->r.p[1],p1->r.p[2]);
-//     }
 
 // Torques
 #ifdef ROTATION

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -93,7 +93,7 @@ double slab_dip_count_mu(double *mt, double *mx, double *my) {
 
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm != 0.0) {
-      auto const dip =p.calc_dip();
+      auto const dip = p.calc_dip();
       node_sums[0] += dip[0];
       node_sums[1] += dip[1];
       node_sums[2] += dip[2];
@@ -174,7 +174,7 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
 
         for (auto const &p : local_cells.particles()) {
           if (p.p.dipm > 0) {
-            const Vector3d dip=p.calc_dip();
+            const Vector3d dip = p.calc_dip();
 
             a = gx * dip[0] + gy * dip[1];
             b = gr * dip[2];
@@ -268,7 +268,7 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
   ip = 0;
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm > 0) {
-      const Vector3d dip=p.calc_dip();
+      const Vector3d dip = p.calc_dip();
       a = dip[1] * tz[ip] - dip[2] * ty[ip];
       b = dip[2] * tx[ip] - dip[0] * tz[ip];
       c = dip[0] * ty[ip] - dip[1] * tx[ip];
@@ -349,7 +349,7 @@ double get_DLC_energy_dipolar(int kcut) {
 
         for (auto const &p : local_cells.particles()) {
           if (p.p.dipm > 0) {
-            const Vector3d dip=p.calc_dip();
+            const Vector3d dip = p.calc_dip();
 
             a = gx * dip[0] + gy * dip[1];
             {
@@ -470,7 +470,7 @@ void add_mdlc_force_corrections() {
   ip = 0;
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
-      const Vector3d dip=p.calc_dip();
+      const Vector3d dip = p.calc_dip();
 
       p.f.f[0] += coulomb.Dprefactor * dip_DLC_f_x[ip];
       p.f.f[1] += coulomb.Dprefactor * dip_DLC_f_y[ip];
@@ -488,12 +488,12 @@ void add_mdlc_force_corrections() {
         dy = 0.0;
         dz = correc * (-1.0) * mz;
 
-        p.f.torque[0] += coulomb.Dprefactor *
-                         (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
-        p.f.torque[1] += coulomb.Dprefactor *
-                         (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
-        p.f.torque[2] += coulomb.Dprefactor *
-                         (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
+        p.f.torque[0] +=
+            coulomb.Dprefactor * (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
+        p.f.torque[1] +=
+            coulomb.Dprefactor * (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
+        p.f.torque[2] +=
+            coulomb.Dprefactor * (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
 
       } else {
 
@@ -502,12 +502,12 @@ void add_mdlc_force_corrections() {
         dy = correps * my;
         dz = correc * (-1.0 + 1. / (2.0 * dp3m.params.epsilon + 1.0)) * mz;
 
-        p.f.torque[0] += coulomb.Dprefactor *
-                         (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
-        p.f.torque[1] += coulomb.Dprefactor *
-                         (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
-        p.f.torque[2] += coulomb.Dprefactor *
-                         (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
+        p.f.torque[0] +=
+            coulomb.Dprefactor * (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
+        p.f.torque[1] +=
+            coulomb.Dprefactor * (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
+        p.f.torque[2] +=
+            coulomb.Dprefactor * (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
       }
 #endif
     }

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -92,8 +92,8 @@ double slab_dip_count_mu(double *mt, double *mx, double *my) {
   tot_sums[2] = 0.0;
 
   for (auto const &p : local_cells.particles()) {
-    const Vector3d dip=p.calc_dip();
     if (p.p.dipm != 0.0) {
+      auto const dip =p.calc_dip();
       node_sums[0] += dip[0];
       node_sums[1] += dip[1];
       node_sums[2] += dip[2];

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -92,10 +92,11 @@ double slab_dip_count_mu(double *mt, double *mx, double *my) {
   tot_sums[2] = 0.0;
 
   for (auto const &p : local_cells.particles()) {
+    const Vector3d dip=p.calc_dip();
     if (p.p.dipm != 0.0) {
-      node_sums[0] += p.r.dip[0];
-      node_sums[1] += p.r.dip[1];
-      node_sums[2] += p.r.dip[2];
+      node_sums[0] += dip[0];
+      node_sums[1] += dip[1];
+      node_sums[2] += dip[2];
     }
   }
 
@@ -173,9 +174,10 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
 
         for (auto const &p : local_cells.particles()) {
           if (p.p.dipm > 0) {
+            const Vector3d dip=p.calc_dip();
 
-            a = gx * p.r.dip[0] + gy * p.r.dip[1];
-            b = gr * p.r.dip[2];
+            a = gx * dip[0] + gy * dip[1];
+            b = gr * dip[2];
             er = gx * p.r.p[0] + gy * p.r.p[1];
             ez = gr * p.r.p[2];
             c = cos(er);
@@ -266,9 +268,10 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
   ip = 0;
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm > 0) {
-      a = p.r.dip[1] * tz[ip] - p.r.dip[2] * ty[ip];
-      b = p.r.dip[2] * tx[ip] - p.r.dip[0] * tz[ip];
-      c = p.r.dip[0] * ty[ip] - p.r.dip[1] * tx[ip];
+      const Vector3d dip=p.calc_dip();
+      a = dip[1] * tz[ip] - dip[2] * ty[ip];
+      b = dip[2] * tx[ip] - dip[0] * tz[ip];
+      c = dip[0] * ty[ip] - dip[1] * tx[ip];
       tx[ip] = a;
       ty[ip] = b;
       tz[ip] = c;
@@ -346,10 +349,11 @@ double get_DLC_energy_dipolar(int kcut) {
 
         for (auto const &p : local_cells.particles()) {
           if (p.p.dipm > 0) {
+            const Vector3d dip=p.calc_dip();
 
-            a = gx * p.r.dip[0] + gy * p.r.dip[1];
+            a = gx * dip[0] + gy * dip[1];
             {
-              b = gr * p.r.dip[2];
+              b = gr * dip[2];
               er = gx * p.r.p[0] + gy * p.r.p[1];
               ez = gr * p.r.p[2];
               c = cos(er);
@@ -466,6 +470,7 @@ void add_mdlc_force_corrections() {
   ip = 0;
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
+      const Vector3d dip=p.calc_dip();
 
       p.f.f[0] += coulomb.Dprefactor * dip_DLC_f_x[ip];
       p.f.f[1] += coulomb.Dprefactor * dip_DLC_f_y[ip];
@@ -484,11 +489,11 @@ void add_mdlc_force_corrections() {
         dz = correc * (-1.0) * mz;
 
         p.f.torque[0] += coulomb.Dprefactor *
-                         (dip_DLC_t_x[ip] + p.r.dip[1] * dz - p.r.dip[2] * dy);
+                         (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
         p.f.torque[1] += coulomb.Dprefactor *
-                         (dip_DLC_t_y[ip] + p.r.dip[2] * dx - p.r.dip[0] * dz);
+                         (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
         p.f.torque[2] += coulomb.Dprefactor *
-                         (dip_DLC_t_z[ip] + p.r.dip[0] * dy - p.r.dip[1] * dx);
+                         (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
 
       } else {
 
@@ -498,11 +503,11 @@ void add_mdlc_force_corrections() {
         dz = correc * (-1.0 + 1. / (2.0 * dp3m.params.epsilon + 1.0)) * mz;
 
         p.f.torque[0] += coulomb.Dprefactor *
-                         (dip_DLC_t_x[ip] + p.r.dip[1] * dz - p.r.dip[2] * dy);
+                         (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
         p.f.torque[1] += coulomb.Dprefactor *
-                         (dip_DLC_t_y[ip] + p.r.dip[2] * dx - p.r.dip[0] * dz);
+                         (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
         p.f.torque[2] += coulomb.Dprefactor *
-                         (dip_DLC_t_z[ip] + p.r.dip[0] * dy - p.r.dip[1] * dx);
+                         (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
       }
 #endif
     }

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -802,7 +802,7 @@ static void P3M_assign_torques(double prefac, int d_rs) {
 
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
-      Vector3d dip=p.calc_dip();
+      const Vector3d dip=p.calc_dip();
       q_ind = dp3m.ca_fmp[cp_cnt];
       for (int i0 = 0; i0 < dp3m.params.cao; i0++) {
         for (int i1 = 0; i1 < dp3m.params.cao; i1++) {
@@ -867,7 +867,7 @@ static void dp3m_assign_forces_dip(double prefac, int d_rs) {
 
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
-      Vector3d dip=p.calc_dip();
+      const Vector3d dip=p.calc_dip();
       q_ind = dp3m.ca_fmp[cp_cnt];
       for (int i0 = 0; i0 < dp3m.params.cao; i0++) {
         for (int i1 = 0; i1 < dp3m.params.cao; i1++) {
@@ -1184,7 +1184,7 @@ double calc_surface_term(int force_flag, int energy_flag) {
 
   int ip = 0;
   for (auto const &p : local_cells.particles()) {
-    Vector3d dip=p.calc_dip();
+    const Vector3d dip=p.calc_dip();
     mx[ip] = dip[0];
     my[ip] = dip[1];
     mz[ip] = dip[2];
@@ -2111,9 +2111,7 @@ void dp3m_count_magnetic_particles() {
 
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm != 0.0) {
-      Vector3d dip=p.calc_dip();
-      node_sums[0] += Utils::sqr(dip[0]) + Utils::sqr(dip[1]) +
-                      Utils::sqr(dip[2]);
+      node_sums[0] += p.calc_dip().norm2();
       node_sums[1] += 1.0;
     }
   }

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -2026,7 +2026,7 @@ int dp3m_adaptive_tune(char **logger) {
                                   "    Drs_err    Dks_err    time [ms]\n");
 
   /* mesh loop */
-  for (; tmp_mesh <= mesh_max; tmp_mesh *= 2) {
+  for (; tmp_mesh <= mesh_max; tmp_mesh +=2) {
     tmp_cao = cao;
     tmp_time =
         dp3m_m_time(logger, tmp_mesh, cao_min, cao_max, &tmp_cao, r_cut_iL_min,

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -644,7 +644,7 @@ void dp3m_dipole_assign(void) {
 
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm != 0.0) {
-      dp3m_assign_dipole(p.r.p.data(), p.p.dipm, p.r.dip.data(), cp_cnt);
+      dp3m_assign_dipole(p.r.p.data(), p.p.dipm, p.calc_dip().data(), cp_cnt);
       cp_cnt++;
     }
   }
@@ -802,6 +802,7 @@ static void P3M_assign_torques(double prefac, int d_rs) {
 
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
+      Vector3d dip=p.calc_dip();
       q_ind = dp3m.ca_fmp[cp_cnt];
       for (int i0 = 0; i0 < dp3m.params.cao; i0++) {
         for (int i1 = 0; i1 < dp3m.params.cao; i1++) {
@@ -817,21 +818,21 @@ static void P3M_assign_torques(double prefac, int d_rs) {
             */
             switch (d_rs) {
             case 0: // E_x
-              p.f.torque[1] -= p.r.dip[2] * prefac * dp3m.ca_frac[cf_cnt] *
+              p.f.torque[1] -= dip[2] * prefac * dp3m.ca_frac[cf_cnt] *
                                dp3m.rs_mesh[q_ind];
-              p.f.torque[2] += p.r.dip[1] * prefac * dp3m.ca_frac[cf_cnt] *
+              p.f.torque[2] += dip[1] * prefac * dp3m.ca_frac[cf_cnt] *
                                dp3m.rs_mesh[q_ind];
               break;
             case 1: // E_y
-              p.f.torque[0] += p.r.dip[2] * prefac * dp3m.ca_frac[cf_cnt] *
+              p.f.torque[0] += dip[2] * prefac * dp3m.ca_frac[cf_cnt] *
                                dp3m.rs_mesh[q_ind];
-              p.f.torque[2] -= p.r.dip[0] * prefac * dp3m.ca_frac[cf_cnt] *
+              p.f.torque[2] -= dip[0] * prefac * dp3m.ca_frac[cf_cnt] *
                                dp3m.rs_mesh[q_ind];
               break;
             case 2: // E_z
-              p.f.torque[0] -= p.r.dip[1] * prefac * dp3m.ca_frac[cf_cnt] *
+              p.f.torque[0] -= dip[1] * prefac * dp3m.ca_frac[cf_cnt] *
                                dp3m.rs_mesh[q_ind];
-              p.f.torque[1] += p.r.dip[0] * prefac * dp3m.ca_frac[cf_cnt] *
+              p.f.torque[1] += dip[0] * prefac * dp3m.ca_frac[cf_cnt] *
                                dp3m.rs_mesh[q_ind];
             }
             q_ind++;
@@ -866,14 +867,15 @@ static void dp3m_assign_forces_dip(double prefac, int d_rs) {
 
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
+      Vector3d dip=p.calc_dip();
       q_ind = dp3m.ca_fmp[cp_cnt];
       for (int i0 = 0; i0 < dp3m.params.cao; i0++) {
         for (int i1 = 0; i1 < dp3m.params.cao; i1++) {
           for (int i2 = 0; i2 < dp3m.params.cao; i2++) {
             p.f.f[d_rs] += prefac * dp3m.ca_frac[cf_cnt] *
-                           (dp3m.rs_mesh_dip[0][q_ind] * p.r.dip[0] +
-                            dp3m.rs_mesh_dip[1][q_ind] * p.r.dip[1] +
-                            dp3m.rs_mesh_dip[2][q_ind] * p.r.dip[2]);
+                           (dp3m.rs_mesh_dip[0][q_ind] * dip[0] +
+                            dp3m.rs_mesh_dip[1][q_ind] * dip[1] +
+                            dp3m.rs_mesh_dip[2][q_ind] * dip[2]);
             q_ind++;
             cf_cnt++;
           }
@@ -1182,9 +1184,10 @@ double calc_surface_term(int force_flag, int energy_flag) {
 
   int ip = 0;
   for (auto const &p : local_cells.particles()) {
-    mx[ip] = p.r.dip[0];
-    my[ip] = p.r.dip[1];
-    mz[ip] = p.r.dip[2];
+    Vector3d dip=p.calc_dip();
+    mx[ip] = dip[0];
+    my[ip] = dip[1];
+    mz[ip] = dip[2];
     ip++;
   }
 
@@ -2108,8 +2111,9 @@ void dp3m_count_magnetic_particles() {
 
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm != 0.0) {
-      node_sums[0] += Utils::sqr(p.r.dip[0]) + Utils::sqr(p.r.dip[1]) +
-                      Utils::sqr(p.r.dip[2]);
+      Vector3d dip=p.calc_dip();
+      node_sums[0] += Utils::sqr(dip[0]) + Utils::sqr(dip[1]) +
+                      Utils::sqr(dip[2]);
       node_sums[1] += 1.0;
     }
   }

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -802,7 +802,7 @@ static void P3M_assign_torques(double prefac, int d_rs) {
 
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
-      const Vector3d dip=p.calc_dip();
+      const Vector3d dip = p.calc_dip();
       q_ind = dp3m.ca_fmp[cp_cnt];
       for (int i0 = 0; i0 < dp3m.params.cao; i0++) {
         for (int i1 = 0; i1 < dp3m.params.cao; i1++) {
@@ -818,22 +818,22 @@ static void P3M_assign_torques(double prefac, int d_rs) {
             */
             switch (d_rs) {
             case 0: // E_x
-              p.f.torque[1] -= dip[2] * prefac * dp3m.ca_frac[cf_cnt] *
-                               dp3m.rs_mesh[q_ind];
-              p.f.torque[2] += dip[1] * prefac * dp3m.ca_frac[cf_cnt] *
-                               dp3m.rs_mesh[q_ind];
+              p.f.torque[1] -=
+                  dip[2] * prefac * dp3m.ca_frac[cf_cnt] * dp3m.rs_mesh[q_ind];
+              p.f.torque[2] +=
+                  dip[1] * prefac * dp3m.ca_frac[cf_cnt] * dp3m.rs_mesh[q_ind];
               break;
             case 1: // E_y
-              p.f.torque[0] += dip[2] * prefac * dp3m.ca_frac[cf_cnt] *
-                               dp3m.rs_mesh[q_ind];
-              p.f.torque[2] -= dip[0] * prefac * dp3m.ca_frac[cf_cnt] *
-                               dp3m.rs_mesh[q_ind];
+              p.f.torque[0] +=
+                  dip[2] * prefac * dp3m.ca_frac[cf_cnt] * dp3m.rs_mesh[q_ind];
+              p.f.torque[2] -=
+                  dip[0] * prefac * dp3m.ca_frac[cf_cnt] * dp3m.rs_mesh[q_ind];
               break;
             case 2: // E_z
-              p.f.torque[0] -= dip[1] * prefac * dp3m.ca_frac[cf_cnt] *
-                               dp3m.rs_mesh[q_ind];
-              p.f.torque[1] += dip[0] * prefac * dp3m.ca_frac[cf_cnt] *
-                               dp3m.rs_mesh[q_ind];
+              p.f.torque[0] -=
+                  dip[1] * prefac * dp3m.ca_frac[cf_cnt] * dp3m.rs_mesh[q_ind];
+              p.f.torque[1] +=
+                  dip[0] * prefac * dp3m.ca_frac[cf_cnt] * dp3m.rs_mesh[q_ind];
             }
             q_ind++;
             cf_cnt++;
@@ -867,7 +867,7 @@ static void dp3m_assign_forces_dip(double prefac, int d_rs) {
 
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
-      const Vector3d dip=p.calc_dip();
+      const Vector3d dip = p.calc_dip();
       q_ind = dp3m.ca_fmp[cp_cnt];
       for (int i0 = 0; i0 < dp3m.params.cao; i0++) {
         for (int i1 = 0; i1 < dp3m.params.cao; i1++) {
@@ -1184,7 +1184,7 @@ double calc_surface_term(int force_flag, int energy_flag) {
 
   int ip = 0;
   for (auto const &p : local_cells.particles()) {
-    const Vector3d dip=p.calc_dip();
+    const Vector3d dip = p.calc_dip();
     mx[ip] = dip[0];
     my[ip] = dip[1];
     mz[ip] = dip[2];
@@ -2029,7 +2029,7 @@ int dp3m_adaptive_tune(char **logger) {
                                   "    Drs_err    Dks_err    time [ms]\n");
 
   /* mesh loop */
-  for (; tmp_mesh <= mesh_max; tmp_mesh +=2) {
+  for (; tmp_mesh <= mesh_max; tmp_mesh += 2) {
     tmp_cao = cao;
     tmp_time =
         dp3m_m_time(logger, tmp_mesh, cao_min, cao_max, &tmp_cao, r_cut_iL_min,

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -170,8 +170,8 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
     return 0.;
 
   double coeff, exp_adist2;
-  const Vector3d dip1=p1->calc_dip();
-  const Vector3d dip2=p2->calc_dip();
+  const Vector3d dip1 = p1->calc_dip();
+  const Vector3d dip2 = p2->calc_dip();
   double B_r, C_r, D_r;
   double alpsq = dp3m.params.alpha * dp3m.params.alpha;
 #ifdef ROTATION
@@ -187,11 +187,10 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
 #endif
 
     // Calculate scalar multiplications for vectors mi, mj, rij
-    double mimj = dip1*dip2; 
-                 
-    double mir = dip1 * Vector3d{d[0],d[1],d[2]};
-    double mjr = dip2 * Vector3d{d[0],d[1],d[2]};
-    
+    double mimj = dip1 * dip2;
+
+    double mir = dip1 * Vector3d{d[0], d[1], d[2]};
+    double mjr = dip2 * Vector3d{d[0], d[1], d[2]};
 
     coeff = 2.0 * dp3m.params.alpha * wupii;
     double dist2i = 1 / dist2;
@@ -207,10 +206,9 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
 
     // Calculate real-space forces
     for (int j = 0; j < 3; j++)
-      force[j] +=
-          coulomb.Dprefactor *
-          ((mimj * d[j] + dip1[j] * mjr + dip2[j] * mir) * C_r -
-           mir * mjr * D_r * d[j]);
+      force[j] += coulomb.Dprefactor *
+                  ((mimj * d[j] + dip1[j] * mjr + dip2[j] * mir) * C_r -
+                   mir * mjr * D_r * d[j]);
 
 // Calculate vector multiplications for vectors mi, mj, rij
 #ifdef ROTATION
@@ -250,8 +248,8 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
 /** Calculate real space contribution of dipolar pair energy. */
 inline double dp3m_pair_energy(Particle *p1, Particle *p2, double *d,
                                double dist2, double dist) {
-  const Vector3d dip1=p1->calc_dip();
-  const Vector3d dip2=p2->calc_dip();
+  const Vector3d dip1 = p1->calc_dip();
+  const Vector3d dip2 = p2->calc_dip();
   double /* fac1,*/ adist, erfc_part_ri, coeff, exp_adist2, dist2i;
   double mimj, mir, mjr;
   double B_r, C_r;
@@ -271,9 +269,9 @@ inline double dp3m_pair_energy(Particle *p1, Particle *p2, double *d,
 #endif
 
     // Calculate scalar multiplications for vectors mi, mj, rij
-    mimj = dip1 *dip2;
-    mir = dip1 * Vector3d{d[0],d[1],d[2]};
-    mjr = dip2 * Vector3d{d[0],d[1],d[2]};
+    mimj = dip1 * dip2;
+    mir = dip1 * Vector3d{d[0], d[1], d[2]};
+    mjr = dip2 * Vector3d{d[0], d[1], d[2]};
 
     coeff = 2.0 * dp3m.params.alpha * wupii;
     dist2i = 1 / dist2;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -170,6 +170,8 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
     return 0.;
 
   double coeff, exp_adist2;
+  Vector3d dip1=p1->calc_dip();
+  Vector3d dip2=p2->calc_dip();
   double B_r, C_r, D_r;
   double alpsq = dp3m.params.alpha * dp3m.params.alpha;
 #ifdef ROTATION
@@ -185,12 +187,12 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
 #endif
 
     // Calculate scalar multiplications for vectors mi, mj, rij
-    double mimj = p1->r.dip[0] * p2->r.dip[0] + p1->r.dip[1] * p2->r.dip[1] +
-                  p1->r.dip[2] * p2->r.dip[2];
+    double mimj = dip1[0] * dip2[0] + dip1[1] * dip2[1] +
+                  dip1[2] * dip2[2];
     double mir =
-        p1->r.dip[0] * d[0] + p1->r.dip[1] * d[1] + p1->r.dip[2] * d[2];
+        dip1[0] * d[0] + dip1[1] * d[1] + dip1[2] * d[2];
     double mjr =
-        p2->r.dip[0] * d[0] + p2->r.dip[1] * d[1] + p2->r.dip[2] * d[2];
+        dip2[0] * d[0] + dip2[1] * d[1] + dip2[2] * d[2];
 
     coeff = 2.0 * dp3m.params.alpha * wupii;
     double dist2i = 1 / dist2;
@@ -208,22 +210,22 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
     for (int j = 0; j < 3; j++)
       force[j] +=
           coulomb.Dprefactor *
-          ((mimj * d[j] + p1->r.dip[j] * mjr + p2->r.dip[j] * mir) * C_r -
+          ((mimj * d[j] + dip1[j] * mjr + dip2[j] * mir) * C_r -
            mir * mjr * D_r * d[j]);
 
 // Calculate vector multiplications for vectors mi, mj, rij
 #ifdef ROTATION
-    mixmj[0] = p1->r.dip[1] * p2->r.dip[2] - p1->r.dip[2] * p2->r.dip[1];
-    mixmj[1] = p1->r.dip[2] * p2->r.dip[0] - p1->r.dip[0] * p2->r.dip[2];
-    mixmj[2] = p1->r.dip[0] * p2->r.dip[1] - p1->r.dip[1] * p2->r.dip[0];
+    mixmj[0] = dip1[1] * dip2[2] - dip1[2] * dip2[1];
+    mixmj[1] = dip1[2] * dip2[0] - dip1[0] * dip2[2];
+    mixmj[2] = dip1[0] * dip2[1] - dip1[1] * dip2[0];
 
-    mixr[0] = p1->r.dip[1] * d[2] - p1->r.dip[2] * d[1];
-    mixr[1] = p1->r.dip[2] * d[0] - p1->r.dip[0] * d[2];
-    mixr[2] = p1->r.dip[0] * d[1] - p1->r.dip[1] * d[0];
+    mixr[0] = dip1[1] * d[2] - dip1[2] * d[1];
+    mixr[1] = dip1[2] * d[0] - dip1[0] * d[2];
+    mixr[2] = dip1[0] * d[1] - dip1[1] * d[0];
 
-    mjxr[0] = p2->r.dip[1] * d[2] - p2->r.dip[2] * d[1];
-    mjxr[1] = p2->r.dip[2] * d[0] - p2->r.dip[0] * d[2];
-    mjxr[2] = p2->r.dip[0] * d[1] - p2->r.dip[1] * d[0];
+    mjxr[0] = dip2[1] * d[2] - dip2[2] * d[1];
+    mjxr[1] = dip2[2] * d[0] - dip2[0] * d[2];
+    mjxr[2] = dip2[0] * d[1] - dip2[1] * d[0];
 
     // Calculate real-space torques
     for (int j = 0; j < 3; j++) {
@@ -249,6 +251,8 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
 /** Calculate real space contribution of dipolar pair energy. */
 inline double dp3m_pair_energy(Particle *p1, Particle *p2, double *d,
                                double dist2, double dist) {
+  Vector3d dip1=p1->calc_dip();
+  Vector3d dip2=p2->calc_dip();
   double /* fac1,*/ adist, erfc_part_ri, coeff, exp_adist2, dist2i;
   double mimj, mir, mjr;
   double B_r, C_r;
@@ -268,10 +272,10 @@ inline double dp3m_pair_energy(Particle *p1, Particle *p2, double *d,
 #endif
 
     // Calculate scalar multiplications for vectors mi, mj, rij
-    mimj = p1->r.dip[0] * p2->r.dip[0] + p1->r.dip[1] * p2->r.dip[1] +
-           p1->r.dip[2] * p2->r.dip[2];
-    mir = p1->r.dip[0] * d[0] + p1->r.dip[1] * d[1] + p1->r.dip[2] * d[2];
-    mjr = p2->r.dip[0] * d[0] + p2->r.dip[1] * d[1] + p2->r.dip[2] * d[2];
+    mimj = dip1[0] * dip2[0] + dip1[1] * dip2[1] +
+           dip1[2] * dip2[2];
+    mir = dip1[0] * d[0] + dip1[1] * d[1] + dip1[2] * d[2];
+    mjr = dip2[0] * d[0] + dip2[1] * d[1] + dip2[2] * d[2];
 
     coeff = 2.0 * dp3m.params.alpha * wupii;
     dist2i = 1 / dist2;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -170,8 +170,8 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
     return 0.;
 
   double coeff, exp_adist2;
-  Vector3d dip1=p1->calc_dip();
-  Vector3d dip2=p2->calc_dip();
+  const Vector3d dip1=p1->calc_dip();
+  const Vector3d dip2=p2->calc_dip();
   double B_r, C_r, D_r;
   double alpsq = dp3m.params.alpha * dp3m.params.alpha;
 #ifdef ROTATION
@@ -187,12 +187,11 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
 #endif
 
     // Calculate scalar multiplications for vectors mi, mj, rij
-    double mimj = dip1[0] * dip2[0] + dip1[1] * dip2[1] +
-                  dip1[2] * dip2[2];
-    double mir =
-        dip1[0] * d[0] + dip1[1] * d[1] + dip1[2] * d[2];
-    double mjr =
-        dip2[0] * d[0] + dip2[1] * d[1] + dip2[2] * d[2];
+    double mimj = dip1*dip2; 
+                 
+    double mir = dip1 * Vector3d{d[0],d[1],d[2]};
+    double mjr = dip2 * Vector3d{d[0],d[1],d[2]};
+    
 
     coeff = 2.0 * dp3m.params.alpha * wupii;
     double dist2i = 1 / dist2;
@@ -251,8 +250,8 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2, double *d,
 /** Calculate real space contribution of dipolar pair energy. */
 inline double dp3m_pair_energy(Particle *p1, Particle *p2, double *d,
                                double dist2, double dist) {
-  Vector3d dip1=p1->calc_dip();
-  Vector3d dip2=p2->calc_dip();
+  const Vector3d dip1=p1->calc_dip();
+  const Vector3d dip2=p2->calc_dip();
   double /* fac1,*/ adist, erfc_part_ri, coeff, exp_adist2, dist2i;
   double mimj, mir, mjr;
   double B_r, C_r;
@@ -272,10 +271,9 @@ inline double dp3m_pair_energy(Particle *p1, Particle *p2, double *d,
 #endif
 
     // Calculate scalar multiplications for vectors mi, mj, rij
-    mimj = dip1[0] * dip2[0] + dip1[1] * dip2[1] +
-           dip1[2] * dip2[2];
-    mir = dip1[0] * d[0] + dip1[1] * d[1] + dip1[2] * d[2];
-    mjr = dip2[0] * d[0] + dip2[1] * d[1] + dip2[2] * d[2];
+    mimj = dip1 *dip2;
+    mir = dip1 * Vector3d{d[0],d[1],d[2]};
+    mjr = dip2 * Vector3d{d[0],d[1],d[2]};
 
     coeff = 2.0 * dp3m.params.alpha * wupii;
     dist2i = 1 / dist2;

--- a/src/core/electrostatics_magnetostatics/scafacos.cpp
+++ b/src/core/electrostatics_magnetostatics/scafacos.cpp
@@ -87,7 +87,7 @@ int ScafacosData::update_particle_data() {
       charges.push_back(p.p.q);
     } else {
 #ifdef SCAFACOS_DIPOLES
-    const Vector3d dip=p.calc_dip();
+      const Vector3d dip = p.calc_dip();
       dipoles.push_back(dip[0]);
       dipoles.push_back(dip[1]);
       dipoles.push_back(dip[2]);
@@ -122,7 +122,7 @@ void ScafacosData::update_particle_forces() const {
       // field
       // So, the torques are given by m \times B
       double t[3];
-      const Vector3d dip=p.calc_dip();
+      const Vector3d dip = p.calc_dip();
       Utils::cross_product(dip, &(potentials[it_p]), t);
       // The force is given by G m, where G is a matrix
       // which comes from the "fields" output of scafacos like this

--- a/src/core/electrostatics_magnetostatics/scafacos.cpp
+++ b/src/core/electrostatics_magnetostatics/scafacos.cpp
@@ -87,9 +87,10 @@ int ScafacosData::update_particle_data() {
       charges.push_back(p.p.q);
     } else {
 #ifdef SCAFACOS_DIPOLES
-      dipoles.push_back(p.r.dip[0]);
-      dipoles.push_back(p.r.dip[1]);
-      dipoles.push_back(p.r.dip[2]);
+    const Vector3d dip=p.calc_dip();
+      dipoles.push_back(dip[0]);
+      dipoles.push_back(dip[1]);
+      dipoles.push_back(dip[2]);
 #endif
     }
   }
@@ -121,7 +122,8 @@ void ScafacosData::update_particle_forces() const {
       // field
       // So, the torques are given by m \times B
       double t[3];
-      Utils::cross_product(p.r.dip, &(potentials[it_p]), t);
+      const Vector3d dip=p.calc_dip();
+      Utils::cross_product(dip, &(potentials[it_p]), t);
       // The force is given by G m, where G is a matrix
       // which comes from the "fields" output of scafacos like this
       // 0 1 2
@@ -130,12 +132,12 @@ void ScafacosData::update_particle_forces() const {
       // where the numbers refer to indices in the "field" output from
       // scafacos
       double f[3];
-      f[0] = fields[it_f + 0] * p.r.dip[0] + fields[it_f + 1] * p.r.dip[1] +
-             fields[it_f + 2] * p.r.dip[2];
-      f[1] = fields[it_f + 1] * p.r.dip[0] + fields[it_f + 3] * p.r.dip[1] +
-             fields[it_f + 4] * p.r.dip[2];
-      f[2] = fields[it_f + 2] * p.r.dip[0] + fields[it_f + 4] * p.r.dip[1] +
-             fields[it_f + 5] * p.r.dip[2];
+      f[0] = fields[it_f + 0] * dip[0] + fields[it_f + 1] * dip[1] +
+             fields[it_f + 2] * dip[2];
+      f[1] = fields[it_f + 1] * dip[0] + fields[it_f + 3] * dip[1] +
+             fields[it_f + 4] * dip[2];
+      f[2] = fields[it_f + 2] * dip[0] + fields[it_f + 4] * dip[1] +
+             fields[it_f + 5] * dip[2];
 
       // Add to particles
       for (int j = 0; j < 3; j++) {

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -153,7 +153,7 @@ inline void init_local_particle_force(Particle *part) {
     // apply a swimming force in the direction of
     // the particle's orientation axis
     if (part->swim.swimming) {
-      part->f.f += part->swim.f_swim * part->r.calc_quatu();
+      part->f.f += part->swim.f_swim * part->r.calc_director();
     }
 #endif
 

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -153,10 +153,7 @@ inline void init_local_particle_force(Particle *part) {
     // apply a swimming force in the direction of
     // the particle's orientation axis
     if (part->swim.swimming) {
-      const Vector3d quatu=part->r.calc_quatu();
-      part->f.f[0] += part->swim.f_swim * quatu[0];
-      part->f.f[1] += part->swim.f_swim * quatu[1];
-      part->f.f[2] += part->swim.f_swim * quatu[2];
+      part->f.f += part->swim.f_swim * part->r.calc_quatu();
     }
 #endif
 

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -153,9 +153,10 @@ inline void init_local_particle_force(Particle *part) {
     // apply a swimming force in the direction of
     // the particle's orientation axis
     if (part->swim.swimming) {
-      part->f.f[0] += part->swim.f_swim * part->r.quatu[0];
-      part->f.f[1] += part->swim.f_swim * part->r.quatu[1];
-      part->f.f[2] += part->swim.f_swim * part->r.quatu[2];
+      const Vector3d quatu=part->r.calc_quatu();
+      part->f.f[0] += part->swim.f_swim * quatu[0];
+      part->f.f[1] += part->swim.f_swim * quatu[1];
+      part->f.f[2] += part->swim.f_swim * quatu[2];
     }
 #endif
 

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -2684,12 +2684,12 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
                                          p->swim.v_source.data());
 
     // calculate and set force at source position
-    delta_j[0] =
-        -p->swim.f_swim * p->r.calc_director()[0] * time_step * lbpar.tau / lbpar.agrid;
-    delta_j[1] =
-        -p->swim.f_swim * p->r.calc_director()[1] * time_step * lbpar.tau / lbpar.agrid;
-    delta_j[2] =
-        -p->swim.f_swim * p->r.calc_director()[2] * time_step * lbpar.tau / lbpar.agrid;
+    delta_j[0] = -p->swim.f_swim * p->r.calc_director()[0] * time_step *
+                 lbpar.tau / lbpar.agrid;
+    delta_j[1] = -p->swim.f_swim * p->r.calc_director()[1] * time_step *
+                 lbpar.tau / lbpar.agrid;
+    delta_j[2] = -p->swim.f_swim * p->r.calc_director()[2] * time_step *
+                 lbpar.tau / lbpar.agrid;
 
     lattice_interpolation(lblattice, source_position,
                           [&delta_j](Lattice::index_t index, double w) {

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -2622,7 +2622,7 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
   Vector3d v_drift = {interpolated_u[0], interpolated_u[1], interpolated_u[2]};
 #ifdef ENGINE
   if (p->swim.swimming) {
-    v_drift += p->swim.v_swim * p->r.calc_quatu();
+    v_drift += p->swim.v_swim * p->r.calc_director();
     p->swim.v_center[0] = interpolated_u[0];
     p->swim.v_center[1] = interpolated_u[1];
     p->swim.v_center[2] = interpolated_u[2];
@@ -2673,9 +2673,9 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
     // calculate source position
     Vector3d source_position;
     double direction = double(p->swim.push_pull) * p->swim.dipole_length;
-    source_position[0] = p->r.p[0] + direction * p->r.calc_quatu()[0];
-    source_position[1] = p->r.p[1] + direction * p->r.calc_quatu()[1];
-    source_position[2] = p->r.p[2] + direction * p->r.calc_quatu()[2];
+    source_position[0] = p->r.p[0] + direction * p->r.calc_director()[0];
+    source_position[1] = p->r.p[1] + direction * p->r.calc_director()[1];
+    source_position[2] = p->r.p[2] + direction * p->r.calc_director()[2];
 
     int corner[3] = {0, 0, 0};
     fold_position(source_position, corner);
@@ -2685,11 +2685,11 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
 
     // calculate and set force at source position
     delta_j[0] =
-        -p->swim.f_swim * p->r.calc_quatu()[0] * time_step * lbpar.tau / lbpar.agrid;
+        -p->swim.f_swim * p->r.calc_director()[0] * time_step * lbpar.tau / lbpar.agrid;
     delta_j[1] =
-        -p->swim.f_swim * p->r.calc_quatu()[1] * time_step * lbpar.tau / lbpar.agrid;
+        -p->swim.f_swim * p->r.calc_director()[1] * time_step * lbpar.tau / lbpar.agrid;
     delta_j[2] =
-        -p->swim.f_swim * p->r.calc_quatu()[2] * time_step * lbpar.tau / lbpar.agrid;
+        -p->swim.f_swim * p->r.calc_director()[2] * time_step * lbpar.tau / lbpar.agrid;
 
     lattice_interpolation(lblattice, source_position,
                           [&delta_j](Lattice::index_t index, double w) {

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -2622,7 +2622,7 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
   Vector3d v_drift = {interpolated_u[0], interpolated_u[1], interpolated_u[2]};
 #ifdef ENGINE
   if (p->swim.swimming) {
-    v_drift += p->swim.v_swim * p->r.quatu;
+    v_drift += p->swim.v_swim * p->r.calc_quatu();
     p->swim.v_center[0] = interpolated_u[0];
     p->swim.v_center[1] = interpolated_u[1];
     p->swim.v_center[2] = interpolated_u[2];
@@ -2673,9 +2673,9 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
     // calculate source position
     Vector3d source_position;
     double direction = double(p->swim.push_pull) * p->swim.dipole_length;
-    source_position[0] = p->r.p[0] + direction * p->r.quatu[0];
-    source_position[1] = p->r.p[1] + direction * p->r.quatu[1];
-    source_position[2] = p->r.p[2] + direction * p->r.quatu[2];
+    source_position[0] = p->r.p[0] + direction * p->r.calc_quatu()[0];
+    source_position[1] = p->r.p[1] + direction * p->r.calc_quatu()[1];
+    source_position[2] = p->r.p[2] + direction * p->r.calc_quatu()[2];
 
     int corner[3] = {0, 0, 0};
     fold_position(source_position, corner);
@@ -2685,11 +2685,11 @@ inline void lb_viscous_coupling(Particle *p, double force[3]) {
 
     // calculate and set force at source position
     delta_j[0] =
-        -p->swim.f_swim * p->r.quatu[0] * time_step * lbpar.tau / lbpar.agrid;
+        -p->swim.f_swim * p->r.calc_quatu()[0] * time_step * lbpar.tau / lbpar.agrid;
     delta_j[1] =
-        -p->swim.f_swim * p->r.quatu[1] * time_step * lbpar.tau / lbpar.agrid;
+        -p->swim.f_swim * p->r.calc_quatu()[1] * time_step * lbpar.tau / lbpar.agrid;
     delta_j[2] =
-        -p->swim.f_swim * p->r.quatu[2] * time_step * lbpar.tau / lbpar.agrid;
+        -p->swim.f_swim * p->r.calc_quatu()[2] * time_step * lbpar.tau / lbpar.agrid;
 
     lattice_interpolation(lblattice, source_position,
                           [&delta_j](Lattice::index_t index, double w) {

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -2082,9 +2082,9 @@ __device__ void calc_viscous_force_three_point_couple(
                     particle_data[part_index].swim.dipole_length;
   // Extrapolate position by dipole length if we are at the centre of the
   // particle
-  position[0] += flag_cs * direction * particle_data[part_index].swim.quatu[0];
-  position[1] += flag_cs * direction * particle_data[part_index].swim.quatu[1];
-  position[2] += flag_cs * direction * particle_data[part_index].swim.quatu[2];
+  position[0] += flag_cs * direction * particle_data[part_index].swim.director[0];
+  position[1] += flag_cs * direction * particle_data[part_index].swim.director[1];
+  position[2] += flag_cs * direction * particle_data[part_index].swim.director[2];
 #endif
 
   // Do the velocity interpolation
@@ -2093,11 +2093,11 @@ __device__ void calc_viscous_force_three_point_couple(
 
 #ifdef ENGINE
   velocity[0] -= (particle_data[part_index].swim.v_swim) *
-                 particle_data[part_index].swim.quatu[0];
+                 particle_data[part_index].swim.director[0];
   velocity[1] -= (particle_data[part_index].swim.v_swim) *
-                 particle_data[part_index].swim.quatu[1];
+                 particle_data[part_index].swim.director[1];
   velocity[2] -= (particle_data[part_index].swim.v_swim) *
-                 particle_data[part_index].swim.quatu[2];
+                 particle_data[part_index].swim.director[2];
 
   // The first three components are v_center, the last three v_source
   // Do not use within LB, because these have already been converted back to MD
@@ -2198,13 +2198,13 @@ __device__ void calc_viscous_force_three_point_couple(
 #ifdef ENGINE
     // add swimming force to source position
     delta_j[0 + 3 * ii] -= flag_cs * particle_data[part_index].swim.f_swim *
-                           particle_data[part_index].swim.quatu[0] *
+                           particle_data[part_index].swim.director[0] *
                            para.time_step * para.tau / para.agrid;
     delta_j[1 + 3 * ii] -= flag_cs * particle_data[part_index].swim.f_swim *
-                           particle_data[part_index].swim.quatu[1] *
+                           particle_data[part_index].swim.director[1] *
                            para.time_step * para.tau / para.agrid;
     delta_j[2 + 3 * ii] -= flag_cs * particle_data[part_index].swim.f_swim *
-                           particle_data[part_index].swim.quatu[2] *
+                           particle_data[part_index].swim.director[2] *
                            para.time_step * para.tau / para.agrid;
 #endif
   }
@@ -2450,9 +2450,9 @@ __device__ void calc_viscous_force(
                     particle_data[part_index].swim.dipole_length;
   // Extrapolate position by dipole length if we are at the centre of the
   // particle
-  position[0] += flag_cs * direction * particle_data[part_index].swim.quatu[0];
-  position[1] += flag_cs * direction * particle_data[part_index].swim.quatu[1];
-  position[2] += flag_cs * direction * particle_data[part_index].swim.quatu[2];
+  position[0] += flag_cs * direction * particle_data[part_index].swim.director[0];
+  position[1] += flag_cs * direction * particle_data[part_index].swim.director[1];
+  position[2] += flag_cs * direction * particle_data[part_index].swim.director[2];
 #endif
 
   // Do the velocity interpolation
@@ -2461,11 +2461,11 @@ __device__ void calc_viscous_force(
 
 #ifdef ENGINE
   velocity[0] -= particle_data[part_index].swim.v_swim *
-                 particle_data[part_index].swim.quatu[0];
+                 particle_data[part_index].swim.director[0];
   velocity[1] -= particle_data[part_index].swim.v_swim *
-                 particle_data[part_index].swim.quatu[1];
+                 particle_data[part_index].swim.director[1];
   velocity[2] -= particle_data[part_index].swim.v_swim *
-                 particle_data[part_index].swim.quatu[2];
+                 particle_data[part_index].swim.director[2];
 
   // The first three components are v_center, the last three v_source
   // Do not use within LB, because these have already been converted back to MD
@@ -2702,13 +2702,13 @@ __device__ void calc_viscous_force(
 #ifdef ENGINE
     // add swimming force to source position
     delta_j[0 + 3 * ii] -= flag_cs * particle_data[part_index].swim.f_swim *
-                           particle_data[part_index].swim.quatu[0] *
+                           particle_data[part_index].swim.director[0] *
                            para.time_step * para.tau / para.agrid;
     delta_j[1 + 3 * ii] -= flag_cs * particle_data[part_index].swim.f_swim *
-                           particle_data[part_index].swim.quatu[1] *
+                           particle_data[part_index].swim.director[1] *
                            para.time_step * para.tau / para.agrid;
     delta_j[2 + 3 * ii] -= flag_cs * particle_data[part_index].swim.f_swim *
-                           particle_data[part_index].swim.quatu[2] *
+                           particle_data[part_index].swim.director[2] *
                            para.time_step * para.tau / para.agrid;
 #endif
   }

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -2082,9 +2082,12 @@ __device__ void calc_viscous_force_three_point_couple(
                     particle_data[part_index].swim.dipole_length;
   // Extrapolate position by dipole length if we are at the centre of the
   // particle
-  position[0] += flag_cs * direction * particle_data[part_index].swim.director[0];
-  position[1] += flag_cs * direction * particle_data[part_index].swim.director[1];
-  position[2] += flag_cs * direction * particle_data[part_index].swim.director[2];
+  position[0] +=
+      flag_cs * direction * particle_data[part_index].swim.director[0];
+  position[1] +=
+      flag_cs * direction * particle_data[part_index].swim.director[1];
+  position[2] +=
+      flag_cs * direction * particle_data[part_index].swim.director[2];
 #endif
 
   // Do the velocity interpolation
@@ -2450,9 +2453,12 @@ __device__ void calc_viscous_force(
                     particle_data[part_index].swim.dipole_length;
   // Extrapolate position by dipole length if we are at the centre of the
   // particle
-  position[0] += flag_cs * direction * particle_data[part_index].swim.director[0];
-  position[1] += flag_cs * direction * particle_data[part_index].swim.director[1];
-  position[2] += flag_cs * direction * particle_data[part_index].swim.director[2];
+  position[0] +=
+      flag_cs * direction * particle_data[part_index].swim.director[0];
+  position[1] +=
+      flag_cs * direction * particle_data[part_index].swim.director[1];
+  position[2] +=
+      flag_cs * direction * particle_data[part_index].swim.director[2];
 #endif
 
   // Do the velocity interpolation

--- a/src/core/nonbonded_interactions/gb.hpp
+++ b/src/core/nonbonded_interactions/gb.hpp
@@ -54,12 +54,12 @@ add_gb_pair_force(const Particle *const p1, const Particle *const p2,
       FikX, FikY, FikZ,           /*  help for forces        */
       Gx, Gy, Gz;                 /*  help for torques       */
 
-  u1x = p1->r.calc_quatu()[0];
-  u1y = p1->r.calc_quatu()[1];
-  u1z = p1->r.calc_quatu()[2];
-  u2x = p2->r.calc_quatu()[0];
-  u2y = p2->r.calc_quatu()[1];
-  u2z = p2->r.calc_quatu()[2];
+  u1x = p1->r.calc_director()[0];
+  u1y = p1->r.calc_director()[1];
+  u1z = p1->r.calc_director()[2];
+  u2x = p2->r.calc_director()[0];
+  u2y = p2->r.calc_director()[1];
+  u2z = p2->r.calc_director()[2];
 
   a = d[0] * u1x + d[1] * u1y + d[2] * u1z;
   b = d[0] * u2x + d[1] * u2y + d[2] * u2z;
@@ -169,12 +169,12 @@ inline double gb_pair_energy(const Particle *p1, const Particle *p2,
   double a, b, c, X, Xcut, Brack, BrackCut, u1x, u1y, u1z, u2x, u2y, u2z, E, E1,
       E2, Sigma, Plus1, Minus1, Plus2, Minus2;
 
-  u1x = p1->r.calc_quatu()[0];
-  u1y = p1->r.calc_quatu()[1];
-  u1z = p1->r.calc_quatu()[2];
-  u2x = p2->r.calc_quatu()[0];
-  u2y = p2->r.calc_quatu()[1];
-  u2z = p2->r.calc_quatu()[2];
+  u1x = p1->r.calc_director()[0];
+  u1y = p1->r.calc_director()[1];
+  u1z = p1->r.calc_director()[2];
+  u2x = p2->r.calc_director()[0];
+  u2y = p2->r.calc_director()[1];
+  u2z = p2->r.calc_director()[2];
 
   a = d[0] * u1x + d[1] * u1y + d[2] * u1z;
   b = d[0] * u2x + d[1] * u2y + d[2] * u2z;

--- a/src/core/nonbonded_interactions/gb.hpp
+++ b/src/core/nonbonded_interactions/gb.hpp
@@ -54,12 +54,12 @@ add_gb_pair_force(const Particle *const p1, const Particle *const p2,
       FikX, FikY, FikZ,           /*  help for forces        */
       Gx, Gy, Gz;                 /*  help for torques       */
 
-  u1x = p1->r.quatu[0];
-  u1y = p1->r.quatu[1];
-  u1z = p1->r.quatu[2];
-  u2x = p2->r.quatu[0];
-  u2y = p2->r.quatu[1];
-  u2z = p2->r.quatu[2];
+  u1x = p1->r.calc_quatu()[0];
+  u1y = p1->r.calc_quatu()[1];
+  u1z = p1->r.calc_quatu()[2];
+  u2x = p2->r.calc_quatu()[0];
+  u2y = p2->r.calc_quatu()[1];
+  u2z = p2->r.calc_quatu()[2];
 
   a = d[0] * u1x + d[1] * u1y + d[2] * u1z;
   b = d[0] * u2x + d[1] * u2y + d[2] * u2z;
@@ -169,12 +169,12 @@ inline double gb_pair_energy(const Particle *p1, const Particle *p2,
   double a, b, c, X, Xcut, Brack, BrackCut, u1x, u1y, u1z, u2x, u2y, u2z, E, E1,
       E2, Sigma, Plus1, Minus1, Plus2, Minus2;
 
-  u1x = p1->r.quatu[0];
-  u1y = p1->r.quatu[1];
-  u1z = p1->r.quatu[2];
-  u2x = p2->r.quatu[0];
-  u2y = p2->r.quatu[1];
-  u2z = p2->r.quatu[2];
+  u1x = p1->r.calc_quatu()[0];
+  u1y = p1->r.calc_quatu()[1];
+  u1z = p1->r.calc_quatu()[2];
+  u2x = p2->r.calc_quatu()[0];
+  u2y = p2->r.calc_quatu()[1];
+  u2z = p2->r.calc_quatu()[2];
 
   a = d[0] * u1x + d[1] * u1y + d[2] * u1z;
   b = d[0] * u2x + d[1] * u2y + d[2] * u2z;

--- a/src/core/observables/MagneticDipoleMoment.hpp
+++ b/src/core/observables/MagneticDipoleMoment.hpp
@@ -32,9 +32,9 @@ public:
     std::vector<double> res(n_values(), 0.0);
     for (int i = 0; i < ids().size(); i++) {
 #ifdef DIPOLES
-      res[0] += partCfg[ids()[i]].r.dip[0];
-      res[1] += partCfg[ids()[i]].r.dip[1];
-      res[2] += partCfg[ids()[i]].r.dip[2];
+      res[0] += partCfg[ids()[i]].calc_dip()[0];
+      res[1] += partCfg[ids()[i]].calc_dip()[1];
+      res[2] += partCfg[ids()[i]].calc_dip()[2];
 #endif
     }
     return res;

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1245,9 +1245,6 @@ void pointer_to_quat(Particle const *p, double const *&res) {
   res = p->r.quat.data();
 }
 
-void pointer_to_quatu(Particle const *p, double const *&res) {
-  res = p->r.quatu.data();
-}
 #endif
 
 void pointer_to_q(Particle const *p, double const *&res) { res = &(p->p.q); }
@@ -1272,9 +1269,6 @@ void pointer_to_vs_relative(Particle const *p, int const *&res1,
 #endif
 
 #ifdef DIPOLES
-void pointer_to_dip(Particle const *p, double const *&res) {
-  res = p->r.dip.data();
-}
 
 void pointer_to_dipm(Particle const *p, double const *&res) {
   res = &(p->p.dipm);

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -219,12 +219,12 @@ struct ParticlePosition {
   Vector<4, double> quat = {1., 0., 0., 0.};
   /** unit director calculated from the quaternions */
   inline
-  Vector3d calc_quatu() const {
-    return Vector3d({{2 * (quat[1] * quat[3] + quat[0] * quat[2]),
+  const Vector3d calc_quatu() const {
+    return {2 * (quat[1] * quat[3] + quat[0] * quat[2]),
            2 * (quat[2] * quat[3] - quat[0] * quat[1]),
            quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
-                         quat[3] * quat[3]}});
-                  }
+                         quat[3] * quat[3]};
+                         };
 #endif
 
 #ifdef BOND_CONSTRAINT
@@ -370,7 +370,7 @@ struct Particle {
   ///
   ParticlePosition r;
   #ifdef DIPOLES
-  inline Vector3d calc_dip() const {
+  inline const Vector3d calc_dip() const {
      return r.calc_quatu()*p.dipm;
   }
   #endif
@@ -1065,7 +1065,4 @@ bool particle_exists(int part);
 int get_particle_node(int id);
 
 
-struct pair_ia_lhs_cache {
-  Vector3d dip;
-};
 #endif

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -218,12 +218,13 @@ struct ParticlePosition {
   /** quaternions to define particle orientation */
   Vector<4, double> quat = {1., 0., 0., 0.};
   /** unit director calculated from the quaternions */
-  Vector3d quatu{0., 0., 1.};
-#endif
-
-#ifdef DIPOLES
-  /** dipole moment. This is synchronized with quatu and quat. */
-  Vector3d dip = {0., 0., 0.};
+  inline
+  Vector3d calc_quatu() const {
+    return Vector3d({{2 * (quat[1] * quat[3] + quat[0] * quat[2]),
+           2 * (quat[2] * quat[3] - quat[0] * quat[1]),
+           quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
+                         quat[3] * quat[3]}});
+                  }
 #endif
 
 #ifdef BOND_CONSTRAINT
@@ -368,6 +369,11 @@ struct Particle {
   ParticleProperties p;
   ///
   ParticlePosition r;
+  #ifdef DIPOLES
+  inline Vector3d calc_dip() const {
+     return r.calc_quatu()*p.dipm;
+  }
+  #endif
   ///
   ParticleMomentum m;
   ///
@@ -995,7 +1001,6 @@ void pointer_to_omega_body(Particle const *p, double const *&res);
 void pointer_to_torque_lab(Particle const *p, double const *&res);
 
 void pointer_to_quat(Particle const *p, double const *&res);
-void pointer_to_quatu(Particle const *p, double const *&res);
 
 #endif
 
@@ -1059,4 +1064,8 @@ bool particle_exists(int part);
  */
 int get_particle_node(int id);
 
+
+struct pair_ia_lhs_cache {
+  Vector3d dip;
+};
 #endif

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -218,13 +218,12 @@ struct ParticlePosition {
   /** quaternions to define particle orientation */
   Vector<4, double> quat = {1., 0., 0., 0.};
   /** unit director calculated from the quaternions */
-  inline
-  const Vector3d calc_director() const {
+  inline const Vector3d calc_director() const {
     return {2 * (quat[1] * quat[3] + quat[0] * quat[2]),
-           2 * (quat[2] * quat[3] - quat[0] * quat[1]),
-           quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
-                         quat[3] * quat[3]};
-                         };
+            2 * (quat[2] * quat[3] - quat[0] * quat[1]),
+            quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
+                quat[3] * quat[3]};
+  };
 #endif
 
 #ifdef BOND_CONSTRAINT
@@ -369,11 +368,9 @@ struct Particle {
   ParticleProperties p;
   ///
   ParticlePosition r;
-  #ifdef DIPOLES
-  inline const Vector3d calc_dip() const {
-     return r.calc_director()*p.dipm;
-  }
-  #endif
+#ifdef DIPOLES
+  inline const Vector3d calc_dip() const { return r.calc_director() * p.dipm; }
+#endif
   ///
   ParticleMomentum m;
   ///
@@ -1063,6 +1060,5 @@ bool particle_exists(int part);
  *  @brief Get the mpi rank which owns the particle with id.
  */
 int get_particle_node(int id);
-
 
 #endif

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -219,7 +219,7 @@ struct ParticlePosition {
   Vector<4, double> quat = {1., 0., 0., 0.};
   /** unit director calculated from the quaternions */
   inline
-  const Vector3d calc_quatu() const {
+  const Vector3d calc_director() const {
     return {2 * (quat[1] * quat[3] + quat[0] * quat[2]),
            2 * (quat[2] * quat[3] - quat[0] * quat[1]),
            quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
@@ -371,7 +371,7 @@ struct Particle {
   ParticlePosition r;
   #ifdef DIPOLES
   inline const Vector3d calc_dip() const {
-     return r.calc_quatu()*p.dipm;
+     return r.calc_director()*p.dipm;
   }
   #endif
   ///

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -323,15 +323,11 @@ void convert_torques_propagate_omega() {
     double omega_swim[3] = {0, 0, 0};
     double omega_swim_body[3] = {0, 0, 0};
     if (p.swim.swimming && lattice_switch != 0) {
-      double dip[3];
       double diff[3];
       double cross[3];
       double l_diff, l_cross;
 
-      const Vector3d quatu=p.r.calc_quatu();
-      dip[0] = p.swim.dipole_length * quatu[0];
-      dip[1] = p.swim.dipole_length * quatu[1];
-      dip[2] = p.swim.dipole_length * quatu[2];
+      auto const dip = p.swim.dipole_length * p.r.calc_quatu();
 
       diff[0] = (p.swim.v_center[0] - p.swim.v_source[0]);
       diff[1] = (p.swim.v_center[1] - p.swim.v_source[1]);

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -254,10 +254,8 @@ void propagate_omega_quat_particle(Particle *p) {
   p->r.quat[3] +=
       time_step * (Qd[3] + time_step_half * Qdd[3]) - lambda * p->r.quat[3];
   // Update the director
-  convert_quat_to_quatu(p->r.quat, p->r.quatu);
 #ifdef DIPOLES
   // When dipoles are enabled, update dipole moment
-  convert_quatu_to_dip(p->r.quatu, p->p.dipm, p->r.dip);
 #endif
 
   ONEPART_TRACE(if (p->p.identity == check_id)
@@ -330,9 +328,10 @@ void convert_torques_propagate_omega() {
       double cross[3];
       double l_diff, l_cross;
 
-      dip[0] = p.swim.dipole_length * p.r.quatu[0];
-      dip[1] = p.swim.dipole_length * p.r.quatu[1];
-      dip[2] = p.swim.dipole_length * p.r.quatu[2];
+      const Vector3d quatu=p.r.calc_quatu();
+      dip[0] = p.swim.dipole_length * quatu[0];
+      dip[1] = p.swim.dipole_length * quatu[1];
+      dip[2] = p.swim.dipole_length * quatu[2];
 
       diff[0] = (p.swim.v_center[0] - p.swim.v_source[0]);
       diff[1] = (p.swim.v_center[1] - p.swim.v_source[1]);
@@ -571,11 +570,6 @@ void local_rotate_particle(Particle *p, double *aSpaceFrame, double phi) {
   multiply_quaternions(p->r.quat, q, qn);
   for (int k = 0; k < 4; k++)
     p->r.quat[k] = qn[k];
-  convert_quat_to_quatu(p->r.quat, p->r.quatu);
-#ifdef DIPOLES
-  // When dipoles are enabled, update dipole moment
-  convert_quatu_to_dip(p->r.quatu, p->p.dipm, p->r.dip);
-#endif
 }
 
 #endif

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -72,7 +72,7 @@ static void define_Qdd(Particle *p, double Qd[4], double Qdd[4], double S[3],
 
 /** convert quaternions to the director */
 /** Convert director to quaternions */
-int convert_quatu_to_quat(const Vector3d &d, Vector<4, double> &quat) {
+int convert_director_to_quat(const Vector3d &d, Vector<4, double> &quat) {
   double d_xy, dm;
   double theta2, phi2;
 

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -327,7 +327,7 @@ void convert_torques_propagate_omega() {
       double cross[3];
       double l_diff, l_cross;
 
-      auto const dip = p.swim.dipole_length * p.r.calc_quatu();
+      auto const dip = p.swim.dipole_length * p.r.calc_director();
 
       diff[0] = (p.swim.v_center[0] - p.swim.v_source[0]);
       diff[1] = (p.swim.v_center[1] - p.swim.v_source[1]);

--- a/src/core/rotation.hpp
+++ b/src/core/rotation.hpp
@@ -69,12 +69,12 @@ void convert_vel_space_to_body(const Particle *p, double *vel_body);
 void define_rotation_matrix(Particle const &p, double A[9]);
 
 inline void convert_quat_to_director(const Vector<4, double> &quat,
-                                  Vector3d &director) {
+                                     Vector3d &director) {
   /* director */
   director[0] = 2 * (quat[1] * quat[3] + quat[0] * quat[2]);
   director[1] = 2 * (quat[2] * quat[3] - quat[0] * quat[1]);
   director[2] = (quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
-              quat[3] * quat[3]);
+                 quat[3] * quat[3]);
 }
 
 /** Multiply two quaternions */
@@ -106,7 +106,7 @@ inline int convert_dip_to_quat(const Vector3d &dip, Vector<4, double> &quat,
 
 /** convert quaternion director to the dipole moment */
 inline void convert_director_to_dip(const Vector3d &director, double dipm,
-                                 Vector3d &dip) {
+                                    Vector3d &dip) {
   /* dipole moment */
   dip[0] = director[0] * dipm;
   dip[1] = director[1] * dipm;

--- a/src/core/rotation.hpp
+++ b/src/core/rotation.hpp
@@ -68,12 +68,12 @@ void convert_vel_space_to_body(const Particle *p, double *vel_body);
     the body-fixed frames */
 void define_rotation_matrix(Particle const &p, double A[9]);
 
-inline void convert_quat_to_quatu(const Vector<4, double> &quat,
-                                  Vector3d &quatu) {
+inline void convert_quat_to_director(const Vector<4, double> &quat,
+                                  Vector3d &director) {
   /* director */
-  quatu[0] = 2 * (quat[1] * quat[3] + quat[0] * quat[2]);
-  quatu[1] = 2 * (quat[2] * quat[3] - quat[0] * quat[1]);
-  quatu[2] = (quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
+  director[0] = 2 * (quat[1] * quat[3] + quat[0] * quat[2]);
+  director[1] = 2 * (quat[2] * quat[3] - quat[0] * quat[1]);
+  director[2] = (quat[0] * quat[0] - quat[1] * quat[1] - quat[2] * quat[2] +
               quat[3] * quat[3]);
 }
 
@@ -88,7 +88,7 @@ void multiply_quaternions(const T1 &a, const T2 &b, T3 &result) {
 }
 
 /** Convert director to quaternions */
-int convert_quatu_to_quat(const Vector3d &d, Vector<4, double> &quat);
+int convert_director_to_quat(const Vector3d &d, Vector<4, double> &quat);
 
 #ifdef DIPOLES
 
@@ -99,18 +99,18 @@ inline int convert_dip_to_quat(const Vector3d &dip, Vector<4, double> &quat,
   // Calculate magnitude of dipole moment
   dm = sqrt(dip[0] * dip[0] + dip[1] * dip[1] + dip[2] * dip[2]);
   *dipm = dm;
-  convert_quatu_to_quat(dip, quat);
+  convert_director_to_quat(dip, quat);
 
   return 0;
 }
 
 /** convert quaternion director to the dipole moment */
-inline void convert_quatu_to_dip(const Vector3d &quatu, double dipm,
+inline void convert_director_to_dip(const Vector3d &director, double dipm,
                                  Vector3d &dip) {
   /* dipole moment */
-  dip[0] = quatu[0] * dipm;
-  dip[1] = quatu[1] * dipm;
-  dip[2] = quatu[2] * dipm;
+  dip[0] = director[0] * dipm;
+  dip[1] = director[1] * dipm;
+  dip[2] = director[2] * dipm;
 }
 
 #endif

--- a/src/core/swimmer_reaction.cpp
+++ b/src/core/swimmer_reaction.cpp
@@ -219,7 +219,7 @@ bool in_lower_half_space(Particle p1, Particle p2) {
   // This function determines whether the particle p2 is in the lower
   // half space of particle p1
   auto const distvec = get_mi_vector(p1.r.p, p2.r.p);
-  double dot = p1.r.quatu * distvec;
+  double dot = p1.r.calc_quatu() * distvec;
   int sgn = Utils::sgn(dot);
   return (sgn + 1) / 2;
 }

--- a/src/core/swimmer_reaction.cpp
+++ b/src/core/swimmer_reaction.cpp
@@ -219,7 +219,7 @@ bool in_lower_half_space(Particle p1, Particle p2) {
   // This function determines whether the particle p2 is in the lower
   // half space of particle p1
   auto const distvec = get_mi_vector(p1.r.p, p2.r.p);
-  double dot = p1.r.calc_quatu() * distvec;
+  double dot = p1.r.calc_director() * distvec;
   int sgn = Utils::sgn(dot);
   return (sgn + 1) / 2;
 }

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -223,7 +223,7 @@ inline void friction_thermo_langevin(Particle *p) {
 
   // Get velocity effective in the thermostatting
   Vector3d velocity;
-  const Vector3d quatu=p->r.calc_quatu();
+  const Vector3d quatu=p->r.calc_director();
   for (int i = 0; i < 3; i++) {
     // Particle velocity
     velocity[i] = p->m.v[i];

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -223,7 +223,7 @@ inline void friction_thermo_langevin(Particle *p) {
 
   // Get velocity effective in the thermostatting
   Vector3d velocity;
-  const Vector3d quatu=p->r.calc_director();
+  const Vector3d director=p->r.calc_director();
   for (int i = 0; i < 3; i++) {
     // Particle velocity
     velocity[i] = p->m.v[i];
@@ -231,7 +231,7 @@ inline void friction_thermo_langevin(Particle *p) {
     // In case of the engine feature, the velocity is relaxed
     // towards a swimming velocity oriented parallel to the
     // particles director
-    velocity[i] -= p->swim.v_swim * quatu[i];
+    velocity[i] -= p->swim.v_swim * director[i];
 #endif
 
   } // for

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -223,6 +223,7 @@ inline void friction_thermo_langevin(Particle *p) {
 
   // Get velocity effective in the thermostatting
   Vector3d velocity;
+  const Vector3d quatu=p->r.calc_quatu();
   for (int i = 0; i < 3; i++) {
     // Particle velocity
     velocity[i] = p->m.v[i];
@@ -230,7 +231,7 @@ inline void friction_thermo_langevin(Particle *p) {
     // In case of the engine feature, the velocity is relaxed
     // towards a swimming velocity oriented parallel to the
     // particles director
-    velocity[i] -= p->swim.v_swim * p->r.quatu[i];
+    velocity[i] -= p->swim.v_swim * quatu[i];
 #endif
 
   } // for

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -223,7 +223,9 @@ inline void friction_thermo_langevin(Particle *p) {
 
   // Get velocity effective in the thermostatting
   Vector3d velocity;
+#ifdef ENGINE
   const Vector3d director = p->r.calc_director();
+#endif
   for (int i = 0; i < 3; i++) {
     // Particle velocity
     velocity[i] = p->m.v[i];

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -223,7 +223,7 @@ inline void friction_thermo_langevin(Particle *p) {
 
   // Get velocity effective in the thermostatting
   Vector3d velocity;
-  const Vector3d director=p->r.calc_director();
+  const Vector3d director = p->r.calc_director();
   for (int i = 0; i < 3; i++) {
     // Particle velocity
     velocity[i] = p->m.v[i];

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -88,7 +88,7 @@ void calculate_vs_relate_to_params(const Particle &p_current,
 
     // Obtain quaternions from desired director
     Vector<4, double> quat_director;
-    convert_quatu_to_quat(d, quat_director);
+    convert_director_to_quat(d, quat_director);
 
     // Define quat as described above:
     double x = 0;

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -87,7 +87,7 @@ void VirtualSitesRelative::update_pos(Particle &p) const {
   multiply_quaternions(p_real->r.quat, p.p.vs_relative_rel_orientation, q);
   // Calculate the director resulting from the quaternions
   Vector3d director = {0, 0, 0};
-  convert_quat_to_quatu(q, director);
+  convert_quat_to_director(q, director);
   // normalize
   double l = sqrt(sqrlen(director));
   // Division comes in the loop below

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -52,10 +52,8 @@ void VirtualSitesRelative::update_virtual_particle_quaternion(
         "particle associated with virtual site.\n");
   }
   multiply_quaternions(p_real->r.quat, p.p.vs_quat, p.r.quat);
-  convert_quat_to_quatu(p.r.quat, p.r.quatu);
 #ifdef DIPOLES
   // When dipoles are enabled, update dipole moment
-  convert_quatu_to_dip(p.r.quatu, p.p.dipm, p.r.dip);
 #endif
 }
 

--- a/src/features.def
+++ b/src/features.def
@@ -43,7 +43,7 @@ _P3M_GPU_FLOAT                  requires CUDA and ELECTROSTATICS
 
 
 /* Magnetostatics */
-DIPOLES
+DIPOLES                         implies ROTATION
 DP3M                            equals DIPOLES and FFTW
 DIPOLAR_DIRECT_SUM              requires CUDA
 DIPOLAR_DIRECT_SUM              equals DIPOLES and ROTATION and CUDA

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -46,7 +46,6 @@ cdef extern from "particle_data.hpp":
         Vector3d p
         Vector3d calc_director()
 
-
     ctypedef struct particle_force "ParticleForce":
         Vector3d f
 
@@ -116,7 +115,7 @@ cdef extern from "particle_data.hpp":
 
     IF LB_ELECTROHYDRODYNAMICS:
         int set_particle_mu_E(int part, double mu_E[3])
-        void get_particle_mu_E(int part, double ( & mu_E)[3])
+        void get_particle_mu_E(int part, double (& mu_E)[3])
 
     int set_particle_type(int part, int type)
 
@@ -242,9 +241,9 @@ cdef class _ParticleSliceImpl:
     cdef int _chunk_size
 
 cdef extern from "grid.hpp":
-    Vector3d folded_position(const particle *)
-    Vector3d unfolded_position(const particle *)
-    cdef void fold_position(double *, int*)
+    Vector3d folded_position(const particle * )
+    Vector3d unfolded_position(const particle * )
+    cdef void fold_position(double * , int*)
     void unfold_position(double pos[3], int image_box[3])
 
 cdef make_array_locked(const Vector3d & v)

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -44,6 +44,8 @@ cdef extern from "particle_data.hpp":
 
     ctypedef struct particle_position "ParticlePosition":
         Vector3d p
+        Vector3d calc_quatu()
+
 
     ctypedef struct particle_force "ParticleForce":
         Vector3d f
@@ -62,6 +64,7 @@ cdef extern from "particle_data.hpp":
         particle_local l
         int_list bl
         int_list exclusions() except +
+        Vector3d calc_dip()
 
     IF ENGINE:
         IF LB or LB_GPU:
@@ -122,7 +125,6 @@ cdef extern from "particle_data.hpp":
     IF ROTATION:
         int set_particle_quat(int part, double quat[4])
         void pointer_to_quat(const particle * p, const double * & res)
-        void pointer_to_quatu(const particle * p, const double * & res)
         int set_particle_omega_lab(int part, double omega[3])
         int set_particle_omega_body(int part, double omega[3])
         int set_particle_torque_lab(int part, double torque[3])
@@ -143,7 +145,6 @@ cdef extern from "particle_data.hpp":
 
     IF DIPOLES:
         int set_particle_dip(int part, double dip[3])
-        void pointer_to_dip(const particle * P, const double * & res)
 
         int set_particle_dipm(int part, double dipm)
         void pointer_to_dipm(const particle * P, const double * & res)

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -44,7 +44,7 @@ cdef extern from "particle_data.hpp":
 
     ctypedef struct particle_position "ParticlePosition":
         Vector3d p
-        Vector3d calc_quatu()
+        Vector3d calc_director()
 
 
     ctypedef struct particle_force "ParticleForce":

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -464,9 +464,7 @@ cdef class ParticleHandle(object):
 
             def __get__(self):
                 self.update_particle_data()
-                cdef const double * x = NULL
-                pointer_to_quatu(self.particle_data, x)
-                return np.array([x[0], x[1], x[2]])
+                return make_array_locked(self.particle_data.r.calc_quatu())
 
     # ROTATIONAL_INERTIA
         property omega_body:
@@ -801,9 +799,7 @@ cdef class ParticleHandle(object):
             def __get__(self):
                 self.update_particle_data()
 
-                cdef const double * x = NULL
-                pointer_to_dip(self.particle_data, x)
-                return array_locked([x[0], x[1], x[2]])
+                return make_array_locked(self.particle_data.calc_dip())
 
         # Scalar magnitude of dipole moment
         property dipm:

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -464,7 +464,7 @@ cdef class ParticleHandle(object):
 
             def __get__(self):
                 self.update_particle_data()
-                return make_array_locked(self.particle_data.r.calc_quatu())
+                return make_array_locked(self.particle_data.r.calc_director())
 
     # ROTATIONAL_INERTIA
         property omega_body:

--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -305,7 +305,8 @@ class ArrayPropertyTest(ut.TestCase):
         # Check (allowed) setter
         # Particle
         self.system.part[0].dip = [2, 2, 2]
-        self.assertTrue((self.system.part[0].dip == [2, 2, 2]).all())
+        np.testing.assert_allclose([2,2,2],self.system.part[0].dip,atol=1E-15)
+        
 
         # Check if copy is settable
         # Particle

--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -305,9 +305,9 @@ class ArrayPropertyTest(ut.TestCase):
         # Check (allowed) setter
         # Particle
         self.system.part[0].dip = [2, 2, 2]
-        np.testing.assert_allclose([2,2,2],self.system.part[0].dip,atol=1E-15)
+        np.testing.assert_allclose(
+            [2, 2, 2], self.system.part[0].dip, atol=1E-15)
         
-
         # Check if copy is settable
         # Particle
         self.set_copy(self.system.part[0].dip)

--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -306,7 +306,7 @@ class ArrayPropertyTest(ut.TestCase):
         # Particle
         self.system.part[0].dip = [2, 2, 2]
         np.testing.assert_allclose(
-            [2, 2, 2], self.system.part[0].dip, atol=1E-15)
+            [2, 2, 2], np.copy(self.system.part[0].dip), atol=1E-15)
         
         # Check if copy is settable
         # Particle

--- a/testsuite/python/rotation_per_particle.py
+++ b/testsuite/python/rotation_per_particle.py
@@ -98,7 +98,7 @@ class Rotation(ut.TestCase):
 
         # Space and body frame co-incide?
         np.testing.assert_allclose(
-            p.director, p.convert_vector_body_to_space((0, 0, 1)), atol=1E-10)
+            np.copy(p.director), p.convert_vector_body_to_space((0, 0, 1)), atol=1E-10)
 
         # Random vector should still co-incide
         v = (1., 5.5, 17)


### PR DESCRIPTION
rather than storing them on the particle


The methods are called calc_dip() and calc_quatu() to make it clear that a calculation takes placed when caling them.

This is to reduce particle size and decrease the performance penalty for compiling in rotation and dipoles.
