### PR TITLE
Correct LJ tutorial.

### DIFF
--- a/doc/tutorials/01-lennard_jones/01-lennard_jones.ipynb
+++ b/doc/tutorials/01-lennard_jones/01-lennard_jones.ipynb
@@ -215,8 +215,8 @@
     "# Importing other relevant python modules\n",
     "import numpy as np\n",
     "# System parameters\n",
-    "n_part = 50\n",
-    "density = 0.1442\n",
+    "n_part = 100\n",
+    "density = 0.5\n",
     "\n",
     "box_l=np.power(n_part/density, 1.0/3.0)*np.ones(3)"
    ]
@@ -256,7 +256,8 @@
     "eq_tstep = 0.001\n",
     "temperature = 0.728\n",
     "\n",
-    "system.time_step = time_step"
+    "system.time_step = time_step\n",
+    "system.cell_system.skin = skin"
    ]
   },
   {
@@ -488,7 +489,7 @@
     "system.auto_update_accumulators.add(msd_corr)\n",
     "\n",
     "# Set parameters for the radial distribution function\n",
-    "r_bins = 50\n",
+    "r_bins = 70\n",
     "r_min  = 0.0\n",
     "r_max  = system.box_l[0]/2.0\n",
     "\n",
@@ -531,7 +532,15 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "plt.ion()\n",
+    "plt.ion()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig1 = plt.figure(num=None, figsize=(10, 6), dpi=80, facecolor='w', edgecolor='k')\n",
     "fig1.set_tight_layout(False)\n",
     "plt.plot(r, avg_rdf,'-', color=\"#A60628\", linewidth=2, alpha=1)\n",
@@ -680,7 +689,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.15rc1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #2315

Description of changes:
 - Increase number of particles and density. The density was quite low (here, density is a number density -- with the current `sigma=1` this corresponds to the rather small volume fraction of ~0.07). Without that, the rdf is not relaxed, to such an extend that it does not capture the expected physical form (always above one ...)
![ljtut_bad_rdf](https://user-images.githubusercontent.com/12623404/47562661-81d16f00-d91f-11e8-99c3-1329bf1dbec5.png)
With this PR, we get
![ljtut_better_rdf](https://user-images.githubusercontent.com/12623404/47562688-a0d00100-d91f-11e8-9682-4d79203f04bc.png)
where also the number of bins for the rdf histogram is slightly increased.
 - `skin` was defined, but not set in `system`, now it is.
 - The first `matplotlib` plot did not show after fist cell evaluation. Fixed by giving the `import` its own cell.
 
PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [x] Docs?
