### PR TITLE
Correct syntax for setting skin.

### DIFF
--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -151,7 +151,7 @@ concerning the simulation system such as box geometry, time step or :ref:`cell-s
 
     print("The box dimensions are {}".format(system.box_l))
     system.time_step = 0.01
-    system.cellsystem.skin = 0.4
+    system.cell_system.skin = 0.4
 
 .. rubric:: Particles
 


### PR DESCRIPTION
Shinx documentation:
Fixes the syntax in sample for setting `skin` in the introduction.
This line lead to some confusion at this year's SFB summer school. 
