### PR TITLE
added deactivation method for dipolar p3m

### DIFF
--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -311,7 +311,7 @@ void dp3m_pre_init(void) {
   dfft_pre_init();
 }
 
-void dp3m_set_prefactor() {
+void dp3m_deactivate() {
   dp3m.params.alpha = 0.0;
   dp3m.params.alpha_L = 0.0;
   dp3m.params.r_cut = 0.0;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -122,8 +122,6 @@ int dp3m_set_eps(double eps);
  */
 void dp3m_init(void);
 
-void dp3m_set_prefactor(void);
-
 /** Updates \ref p3m_parameter_struct::alpha and \ref
  * p3m_parameter_struct::r_cut if \ref box_l changed. */
 void dp3m_scaleby_box_l();
@@ -137,8 +135,8 @@ int dp3m_sanity_checks();
     Dcur_ca_frac. */
 void dp3m_dipole_assign(void);
 
-/** set prefactor for dipolar p3m */
-void dp3m_set_prefactor(void);
+/** reset dipolar p3m core parameters */
+void dp3m_deactivate(void);
 
 int dp3m_adaptive_tune(char **log);
 

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -49,6 +49,7 @@ IF DP3M == 1:
         int dp3m_set_eps(double eps)
         int dp3m_set_ninterpol(int n)
         int dp3m_adaptive_tune(char ** log)
+        int dp3m_deactivate()
 
         ctypedef struct dp3m_data_struct:
             p3m_parameter_struct params

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -149,7 +149,7 @@ IF DP3M == 1:
                     "epsilon": 0.0,
                     "mesh_off": [-1, -1, -1],
                     "tune": True}
-
+        
         def _get_params_from_es_core(self):
             params = {}
             params.update(dp3m.params)
@@ -183,6 +183,10 @@ IF DP3M == 1:
 
             self._set_params_in_es_core()
             mpi_bcast_coulomb_params()
+        
+        def _deactivate_method(self):
+            dp3m_deactivate()
+            super(type(self), self)._deactivate_method()
 
         def python_dp3m_set_mesh_offset(self, mesh_off):
             cdef double mesh_offset[3]


### PR DESCRIPTION
Fixes #1937 

Description of changes:
 - Added deactivation method for dipolar p3m
- `dp3m_set_prefactor()` was unused, renamed to `dp3m_deactivate()`

Tested with the following snippet, which now forgets the tune-parameters:
```
dp3m = magnetostatics.DipolarP3M(prefactor=2, accuracy=1E-6, epsilon="metallic")
s.actors.add(dp3m)
s.integrator.run(0)
s.actors.remove(dp3m)
dp3m = magnetostatics.DipolarP3M(prefactor=2, accuracy=1E-6, epsilon="metallic")
s.actors.add(dp3m)
```
                                                                                    
