### PR TITLE
Lb density setters are broken

### DIFF
--- a/src/python/espressomd/lb.pxd
+++ b/src/python/espressomd/lb.pxd
@@ -97,6 +97,7 @@ IF LB_GPU or LB:
         bool lb_lbnode_is_index_valid(const Vector3i & ind)
         int lb_lbnode_get_u(const Vector3i & ind, double * double_return)
         int lb_lbnode_set_u(const Vector3i & ind, double * u);
+        int lb_lbnode_set_rho(const Vector3i & ind, double * u);
         int lb_lbnode_get_rho(const Vector3i & ind, double * double_return)
         int lb_lbnode_get_pi(const Vector3i & ind, double * double_return)
         int lb_lbnode_get_pi_neq(const Vector3i & ind, double * double_return)

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -350,11 +350,11 @@ IF LB or LB_GPU:
 
             def __set__(self, value):
                 cdef double dens
-                if not (hasattr(value,"__getitem__") and len(value) != 1 and \
+                if not (hasattr(value, "__getitem__") and len(value) != 1 and
                     is_valid_type(value[0], float)):
                     print(value)
-                    dens=float(value[0])
-                    lb_lbnode_set_rho(self.node, &dens)
+                    dens = float(value[0])
+                    lb_lbnode_set_rho(self.node, & dens)
                 else:
                     raise ValueError(
                         "Density has to be a list/tuple containing a single float.")

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -344,13 +344,20 @@ IF LB or LB_GPU:
                         "Velocity has to be of shape 3 and type float.")
         property density:
             def __get__(self):
-                cdef double[3] double_return
+                cdef double[1] double_return
                 lb_lbnode_get_rho(self.node, double_return)
-                return array_locked(double_return)
+                return array_locked((double_return[0],))
 
             def __set__(self, value):
-                raise NotImplementedError
-
+                cdef double dens
+                if not (hasattr(value,"__getitem__") and len(value) != 1 and \
+                    is_valid_type(value[0], float)):
+                    print(value)
+                    dens=float(value[0])
+                    lb_lbnode_set_rho(self.node, &dens)
+                else:
+                    raise ValueError(
+                        "Density has to be a list/tuple containing a single float.")
         property pi:
             def __get__(self):
                 cdef double[6] pi

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -168,14 +168,13 @@ class TestLB(object):
             fric=self.params['friction'], ext_force_density=[0, 0, 0])
         self.system.actors.add(self.lbf)
         v_fluid = np.array([1.2, 4.3, 0.2])
-        rho=3.2
+        rho = 3.2
         self.lbf[0, 0, 0].velocity = v_fluid
         self.lbf[0, 0, 0].density = [rho]
         np.testing.assert_allclose(
             np.copy(self.lbf[0, 0, 0].velocity), v_fluid, atol=1e-4)
         np.testing.assert_allclose(
             np.copy(self.lbf[0, 0, 0].density), rho, atol=1e-4)
-
 
     def test_grid_index(self):
         self.system.actors.clear()

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -158,7 +158,7 @@ class TestLB(object):
         self.assertAlmostEqual(
             np.mean(all_temp_particle), self.params["temp"], delta=temp_prec_particle)
 
-    def test_set_get_u(self):
+    def test_set_get_u_rho(self):
         self.system.actors.clear()
         self.lbf = self.lb_class(
             visc=self.params['viscosity'],
@@ -168,9 +168,14 @@ class TestLB(object):
             fric=self.params['friction'], ext_force_density=[0, 0, 0])
         self.system.actors.add(self.lbf)
         v_fluid = np.array([1.2, 4.3, 0.2])
+        rho=3.2
         self.lbf[0, 0, 0].velocity = v_fluid
+        self.lbf[0, 0, 0].density = [rho]
         np.testing.assert_allclose(
             np.copy(self.lbf[0, 0, 0].velocity), v_fluid, atol=1e-4)
+        np.testing.assert_allclose(
+            np.copy(self.lbf[0, 0, 0].density), rho, atol=1e-4)
+
 
     def test_grid_index(self):
         self.system.actors.clear()


### PR DESCRIPTION
This PR adds Python support for setting lb node densities.
It works, when first setting density, then veloicyt but not the other way round.
For lbcpu, the velocity is rescaled by setting the density on the node, on lbgpu, the velocity is set to 0.
I think both setters in the core are likely incorrect.