### PR TITLE
Enable AMD GPU testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,11 +211,10 @@ rocm-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/rocm:latest
   script:
-    - export myconfig=maxset make_check=false HIP_PLATFORM=hcc HCC_AMDGPU_TARGET=gfx900
+    - export myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
-    - linux
+    - amdgpu
 
 ### Builds with OS X
 

--- a/src/core/cufft_wrapper.hpp
+++ b/src/core/cufft_wrapper.hpp
@@ -13,7 +13,6 @@
 #define cufftExecR2C hipfftExecR2C
 #define cufftExecZ2D hipfftExecZ2D
 #define cufftHandle hipfftHandle
-#define cufftPlan hipfftPlan
 #define cufftPlan3d hipfftPlan3d
 #define cufftReal hipfftReal
 #define cufftSetStream hipfftSetStream

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -737,10 +737,12 @@ void p3m_gpu_init(int cao, int mesh[3], double alpha) {
       cuda_safe_mem(cudaMalloc((void **)&(p3m_gpu_data.G_hat),
                                cmesh_size * sizeof(REAL_TYPE)));
 
-      cufftPlan3d(&(p3m_gpu_fft_plans.forw_plan), mesh[0], mesh[1], mesh[2],
-                  FFT_PLAN_FORW_FLAG);
-      cufftPlan3d(&(p3m_gpu_fft_plans.back_plan), mesh[0], mesh[1], mesh[2],
-                  FFT_PLAN_BACK_FLAG);
+      if (cufftPlan3d(&(p3m_gpu_fft_plans.forw_plan), mesh[0], mesh[1], mesh[2],
+                      FFT_PLAN_FORW_FLAG) != CUFFT_SUCCESS ||
+          cufftPlan3d(&(p3m_gpu_fft_plans.back_plan), mesh[0], mesh[1], mesh[2],
+                      FFT_PLAN_BACK_FLAG) != CUFFT_SUCCESS) {
+        throw std::string("Unable to create fft plan");
+      }
     }
 
     if (((reinit_if == 1) || (p3m_gpu_data_initialized == 0)) &&

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -24,6 +24,7 @@ import unittest as ut
 import numpy as np
 
 import espressomd
+import espressomd.cuda_init
 import espressomd.electrostatics
 from espressomd import scafacos
 import tests_common
@@ -86,14 +87,14 @@ class CoulombCloudWall(ut.TestCase):
             self.assertLessEqual(
                 energy_abs_diff,
                 self.tolerance,
-                "Absolte energy difference " +
+                "Absolute energy difference " +
                 str(energy_abs_diff) +
                 " too large for " +
                 method_name)
         self.assertLessEqual(
             force_abs_diff,
             self.tolerance,
-            "Asbolute force difference " +
+            "Absolute force difference " +
             str(force_abs_diff) +
             " too large for method " +
             method_name)
@@ -109,7 +110,8 @@ class CoulombCloudWall(ut.TestCase):
             self.S.integrator.run(0)
             self.compare("p3m", energy=True, prefactor=3)
 
-    if espressomd.has_features(["ELECTROSTATICS", "CUDA"]):
+    if espressomd.has_features(["ELECTROSTATICS", "CUDA"]) and not \
+       "Radeon" in ", ".join(espressomd.cuda_init.CudaInitHandle().device_list.values()):
         def test_p3m_gpu(self):
             self.S.actors.add(
                 espressomd.electrostatics.P3MGPU(

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -111,7 +111,7 @@ class CoulombCloudWall(ut.TestCase):
             self.compare("p3m", energy=True, prefactor=3)
 
     if espressomd.has_features(["ELECTROSTATICS", "CUDA"]) and not \
-       "Radeon" in ", ".join(espressomd.cuda_init.CudaInitHandle().device_list.values()):
+       str(espressomd.cuda_init.CudaInitHandle().device_list[0]) == "Device 687f":
         def test_p3m_gpu(self):
             self.S.actors.add(
                 espressomd.electrostatics.P3MGPU(

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -95,7 +95,7 @@ class CoulombCloudWall(ut.TestCase):
                 self.compare("p3m", energy=True)
 
         if espressomd.has_features(["ELECTROSTATICS", "CUDA"]) and not \
-           "Radeon" in ", ".join(espressomd.cuda_init.CudaInitHandle().device_list.values()):
+           str(espressomd.cuda_init.CudaInitHandle().device_list[0]) == "Device 687f":
             def test_p3m_gpu(self):
                 self.S.actors.add(
                     espressomd.electrostatics.P3MGPU(

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -23,6 +23,7 @@ import unittest as ut
 import numpy as np
 
 import espressomd
+import espressomd.cuda_init
 import espressomd.electrostatics
 from espressomd import scafacos
 from tests_common import abspath
@@ -77,9 +78,9 @@ class CoulombCloudWall(ut.TestCase):
             if energy:
                 energy_abs_diff = abs(
                     self.S.analysis.energy()["total"] - self.reference_energy)
-                self.assertTrue(energy_abs_diff <= self.tolerance, "Absolte energy difference " +
+                self.assertTrue(energy_abs_diff <= self.tolerance, "Absolute energy difference " +
                                 str(energy_abs_diff) + " too large for " + method_name)
-            self.assertTrue(force_abs_diff <= self.tolerance, "Asbolute force difference " +
+            self.assertTrue(force_abs_diff <= self.tolerance, "Absolute force difference " +
                             str(force_abs_diff) + " too large for method " + method_name)
 
         # Tests for individual methods
@@ -93,7 +94,8 @@ class CoulombCloudWall(ut.TestCase):
                 self.S.integrator.run(0)
                 self.compare("p3m", energy=True)
 
-        if espressomd.has_features(["ELECTROSTATICS", "CUDA"]):
+        if espressomd.has_features(["ELECTROSTATICS", "CUDA"]) and not \
+           "Radeon" in ", ".join(espressomd.cuda_init.CudaInitHandle().device_list.values()):
             def test_p3m_gpu(self):
                 self.S.actors.add(
                     espressomd.electrostatics.P3MGPU(

--- a/testsuite/python/coulomb_mixed_periodicity.py
+++ b/testsuite/python/coulomb_mixed_periodicity.py
@@ -89,14 +89,14 @@ class CoulombMixedPeriodicity(ut.TestCase):
             self.assertLessEqual(
                 energy_abs_diff,
                 self.tolerance_energy,
-                "Absolte energy difference " +
+                "Absolute energy difference " +
                 str(energy_abs_diff) +
                 " too large for " +
                 method_name)
         self.assertLessEqual(
             rms_force_diff,
             self.tolerance_force,
-            "Asbolute force difference " +
+            "Absolute force difference " +
             str(rms_force_diff) +
             " too large for method " +
             method_name)

--- a/testsuite/python/coulomb_tuning.py
+++ b/testsuite/python/coulomb_tuning.py
@@ -85,7 +85,7 @@ class CoulombCloudWallTune(ut.TestCase):
             self.compare("p3m")
 
     if espressomd.has_features(["ELECTROSTATICS", "CUDA"]) and not \
-       "Radeon" in ", ".join(espressomd.cuda_init.CudaInitHandle().device_list.values()):
+       str(espressomd.cuda_init.CudaInitHandle().device_list[0]) == "Device 687f":
         def test_p3m_gpu(self):
             # We have to add some tolerance here, because the reference
             # system is not homogeneous

--- a/testsuite/python/coulomb_tuning.py
+++ b/testsuite/python/coulomb_tuning.py
@@ -25,6 +25,7 @@ import numpy as np
 import unittest as ut
 
 import espressomd
+import espressomd.cuda_init
 import espressomd.electrostatics
 from espressomd import scafacos
 import tests_common
@@ -67,7 +68,7 @@ class CoulombCloudWallTune(ut.TestCase):
         self.assertLessEqual(
             force_abs_diff,
             self.tolerance,
-            "Asbolute force difference " +
+            "Absolute force difference " +
             str(force_abs_diff) +
             " too large for method " +
             method_name)
@@ -83,7 +84,8 @@ class CoulombCloudWallTune(ut.TestCase):
             self.system.integrator.run(0)
             self.compare("p3m")
 
-    if espressomd.has_features(["ELECTROSTATICS", "CUDA"]):
+    if espressomd.has_features(["ELECTROSTATICS", "CUDA"]) and not \
+       "Radeon" in ", ".join(espressomd.cuda_init.CudaInitHandle().device_list.values()):
         def test_p3m_gpu(self):
             # We have to add some tolerance here, because the reference
             # system is not homogeneous

--- a/testsuite/python/dawaanr-and-bh-gpu.py
+++ b/testsuite/python/dawaanr-and-bh-gpu.py
@@ -25,6 +25,7 @@ from numpy.random import random, seed
 import espressomd
 import espressomd.magnetostatics
 import espressomd.analyze
+import espressomd.cuda_init
 import tests_common
 
 
@@ -35,6 +36,12 @@ def stopAll(system):
 
 @ut.skipIf(not espressomd.has_features(["DIPOLAR_BARNES_HUT"]),
            "Features not available, skipping test!")
+@ut.skipIf(espressomd.has_features(["CUDA"]) and
+           "Radeon" in ", ".join(
+           espressomd.cuda_init.CudaInitHandle(
+           ).device_list.values(
+           )),
+           "Feature not yet supported on AMD GPU, skipping test!")
 class BHGPUTest(ut.TestCase):
     system = espressomd.System(box_l=[1, 1, 1])
     system.seed = system.cell_system.get_state()['n_nodes'] * [1234]

--- a/testsuite/python/dawaanr-and-bh-gpu.py
+++ b/testsuite/python/dawaanr-and-bh-gpu.py
@@ -37,10 +37,8 @@ def stopAll(system):
 @ut.skipIf(not espressomd.has_features(["DIPOLAR_BARNES_HUT"]),
            "Features not available, skipping test!")
 @ut.skipIf(espressomd.has_features(["CUDA"]) and
-           "Radeon" in ", ".join(
-           espressomd.cuda_init.CudaInitHandle(
-           ).device_list.values(
-           )),
+           str(espressomd.cuda_init.CudaInitHandle().device_list[0]) ==
+           "Device 687f",
            "Feature not yet supported on AMD GPU, skipping test!")
 class BHGPUTest(ut.TestCase):
     system = espressomd.System(box_l=[1, 1, 1])


### PR DESCRIPTION
Follow-up to #2302.

This depends on https://github.com/ROCmSoftwarePlatform/rocFFT/pull/141 and 
https://github.com/espressomd/docker/pull/45.

Right now all the important stuff (LB, EK) works. Barnes-Hut (@psci2195) and P3M GPU (@fweik) don't work; perhaps the original authors can have a look. Until that happens, I have disabled just these tests on AMD GPUs inside CI. They probably depended on some Nvidia implementation detail. The former method gets caught in an infinite loop in `sortKernel`, while the latter simply gives wrong results.