### PR TITLE
use correct Maxwell-Boltzmann velocity distribution in reaction ensemble

### DIFF
--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -717,9 +717,9 @@ int ReactionAlgorithm::create_particle(int desired_type) {
   // for components
   double vel[3];
   // we use mass=1 for all particles, think about adapting this
-  vel[0] = std::pow(2 * PI * temperature, -3.0 / 2.0) * gaussian_random();
-  vel[1] = std::pow(2 * PI * temperature, -3.0 / 2.0) * gaussian_random();
-  vel[2] = std::pow(2 * PI * temperature, -3.0 / 2.0) * gaussian_random();
+  vel[0] = std::sqrt(temperature) * gaussian_random();
+  vel[1] = std::sqrt(temperature) * gaussian_random();
+  vel[2] = std::sqrt(temperature) * gaussian_random();
 #ifdef ELECTROSTATICS
   double charge = charges_of_types[desired_type];
 #endif

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -831,6 +831,12 @@ bool ReactionAlgorithm::do_global_mc_move_for_particles_of_type(
     p_id = p_id_s_changed_particles[i];
     // change particle position
     new_pos = get_random_position_in_box();
+    double vel[3];
+    // we use mass=1 for all particles, think about adapting this
+    vel[0] = std::sqrt(temperature) * gaussian_random();
+    vel[1] = std::sqrt(temperature) * gaussian_random();
+    vel[2] = std::sqrt(temperature) * gaussian_random();
+    set_particle_v(p_id, vel);
     // new_pos=get_random_position_in_box_enhanced_proposal_of_small_radii();
     // //enhanced proposal of small radii
     place_particle(p_id, new_pos.data());

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -832,10 +832,10 @@ bool ReactionAlgorithm::do_global_mc_move_for_particles_of_type(
     // change particle position
     new_pos = get_random_position_in_box();
     double vel[3];
-    // we use mass=1 for all particles, think about adapting this
-    vel[0] = std::sqrt(temperature) * gaussian_random();
-    vel[1] = std::sqrt(temperature) * gaussian_random();
-    vel[2] = std::sqrt(temperature) * gaussian_random();
+    auto const &p = get_particle_data(p_id);
+    vel[0] = std::sqrt(temperature / p.p.mass) * gaussian_random();
+    vel[1] = std::sqrt(temperature / p.p.mass) * gaussian_random();
+    vel[2] = std::sqrt(temperature / p.p.mass) * gaussian_random();
     set_particle_v(p_id, vel);
     // new_pos=get_random_position_in_box_enhanced_proposal_of_small_radii();
     // //enhanced proposal of small radii

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -16,9 +16,9 @@ cdef class ReactionAlgorithm(object):
     reaction algorithm by setting the standard pressure, temperature, and the
     exclusion radius.
 
-    Note: When creating particles the velocities the new particles are set
-    according the Maxwell distribution. In this step the mass of the new particle
-    is assumed to equal 1.
+    Note: When creating particles the velocities of the new particles are set
+    according the Maxwell-Boltzmann distribution. In this step the mass of the
+    new particle is assumed to equal 1.
 
 
     Parameters

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -16,6 +16,9 @@ cdef class ReactionAlgorithm(object):
     reaction algorithm by setting the standard pressure, temperature, and the
     exclusion radius.
 
+    Note: When setting the velocities of the particles according the the
+    Maxwell distribution the mass of all particles is assumed to equal 1.
+
 
     Parameters
     ----------

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -16,8 +16,9 @@ cdef class ReactionAlgorithm(object):
     reaction algorithm by setting the standard pressure, temperature, and the
     exclusion radius.
 
-    Note: When setting the velocities of the particles according the the
-    Maxwell distribution the mass of all particles is assumed to equal 1.
+    Note: When creating particles the velocities the new particles are set
+    according the Maxwell distribution. In this step the mass of the new particle
+    is assumed to equal 1.
 
 
     Parameters


### PR DESCRIPTION
Fixes #1770 and #2377 

The velocities of the particles inserted by the reaction ensemble did not follow the Maxwell-Boltzmann velocity distribution [1]. Even worse, with increasing temperature the mean squared velocity was decreasing. The effect of this PR on the velocity distribution function are shown in the following figure:

![maxwell_plot](https://user-images.githubusercontent.com/20684475/48563042-bff4f980-e8f3-11e8-8070-d7548b6152c7.png)

As you can see, now the measured velocity distribution from the simulation (marked as _Sim_ in the plots).becomes wider with increasing temperature and follows the Maxwell-Boltzmann distribution (marked as _Theo_ in the plots).

[1]: Atkins, P. W., and J. de Paula. Atkins’ Physical Chemistry. Oxford, UK: Oxford University Press, 2006.