### PR TITLE
Performance improvements

### DIFF
--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -372,6 +372,11 @@ inline bool pair_bond_exists_on(const Particle *const p,
 inline bool pair_bond_enum_exists_on(const Particle *const p_bond,
                                      const Particle *const p_partner,
                                      BondedInteraction bond) {
+  #ifdef ADDITIONAL_CHECKS
+  extern int ghosts_have_bonds;
+  assert(ghosts_have_bonds);
+  #endif
+  
   int i = 0;
   while (i < p_bond->bl.n) {
     int type_num = p_bond->bl.e[i];

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -372,11 +372,11 @@ inline bool pair_bond_exists_on(const Particle *const p,
 inline bool pair_bond_enum_exists_on(const Particle *const p_bond,
                                      const Particle *const p_partner,
                                      BondedInteraction bond) {
-  #ifdef ADDITIONAL_CHECKS
+#ifdef ADDITIONAL_CHECKS
   extern int ghosts_have_bonds;
   assert(ghosts_have_bonds);
-  #endif
-  
+#endif
+
   int i = 0;
   while (i < p_bond->bl.n) {
     int type_num = p_bond->bl.e[i];

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -228,6 +228,7 @@ bool validate_collision_parameters() {
 
   recalc_forces = 1;
   rebuild_verletlist = 1;
+  on_ghost_flags_change();
 
   return true;
 }

--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -66,6 +66,9 @@ public:
   const_iterator end() const { return m_constraints.end(); }
 
   void add_forces(ParticleRange &particles) const {
+    if (m_constraints.empty())
+      return;
+
     reset_foces();
 
     for (auto &p : particles) {

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -281,7 +281,10 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
 
 /*affinity potential*/
 #ifdef AFFINITY
-  add_affinity_pair_force(p1, p2, ia_params, d, dist, force.data());
+  // Prevent jump to non-inlined function
+  if (dist < ia_params->affinity_cut) {
+    add_affinity_pair_force(p1, p2, ia_params, d, dist, force.data());
+  }
 #endif
 
   FORCE_TRACE(fprintf(stderr, "%d: interaction %d<->%d dist %f\n", this_node,
@@ -781,6 +784,10 @@ inline void check_particle_force(Particle *part) {
 #endif
 }
 
-inline void add_single_particle_force(Particle *p) { add_bonded_force(p); }
+inline void add_single_particle_force(Particle *p) { 
+  if (p->bl.n) {
+    add_bonded_force(p); 
+  }
+}
 
 #endif

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -92,9 +92,9 @@ inline void init_ghost_force(Particle *part) {
   part->f.f[2] = 0;
 
 #ifdef ROTATION
-    part->f.torque[0] = 0;
-    part->f.torque[1] = 0;
-    part->f.torque[2] = 0;
+  part->f.torque[0] = 0;
+  part->f.torque[1] = 0;
+  part->f.torque[2] = 0;
 #endif
 }
 
@@ -784,9 +784,9 @@ inline void check_particle_force(Particle *part) {
 #endif
 }
 
-inline void add_single_particle_force(Particle *p) { 
+inline void add_single_particle_force(Particle *p) {
   if (p->bl.n) {
-    add_bonded_force(p); 
+    add_bonded_force(p);
   }
 }
 

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -245,7 +245,10 @@ inline void calc_non_bonded_pair_force_parts(
 #endif
 /* Gay-Berne */
 #ifdef GAY_BERNE
-  add_gb_pair_force(p1, p2, ia_params, d, dist, force, torque1, torque2);
+  // The gb force function isn't inlined, probably due to its size
+  if (dist < ia_params->GB_cut) {
+    add_gb_pair_force(p1, p2, ia_params, d, dist, force, torque1, torque2);
+  }
 #endif
 #ifdef INTER_RF
   add_interrf_pair_force(p1, p2, ia_params, d, dist, force);

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -92,25 +92,9 @@ inline void init_ghost_force(Particle *part) {
   part->f.f[2] = 0;
 
 #ifdef ROTATION
-  {
-    double scale;
-    /* set torque to zero */
     part->f.torque[0] = 0;
     part->f.torque[1] = 0;
     part->f.torque[2] = 0;
-
-    /* and rescale quaternion, so it is exactly of unit length */
-    scale = sqrt(Utils::sqr(part->r.quat[0]) + Utils::sqr(part->r.quat[1]) +
-                 Utils::sqr(part->r.quat[2]) + Utils::sqr(part->r.quat[3]));
-    if (scale == 0) {
-      part->r.quat[0] = 1;
-    } else {
-      part->r.quat[0] /= scale;
-      part->r.quat[1] /= scale;
-      part->r.quat[2] /= scale;
-      part->r.quat[3] /= scale;
-    }
-  }
 #endif
 }
 

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -184,7 +184,7 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
           /* ok, this is not nice, but perhaps fast */
           ParticlePosition *pp = reinterpret_cast<ParticlePosition *>(insert);
           int i;
-          memcpy(pp, &pt->r, sizeof(ParticlePosition));
+          *pp = pt->r;
           for (i = 0; i < 3; i++)
             pp->p[i] += gc->shift[i];
           insert += sizeof(ParticlePosition);
@@ -411,7 +411,7 @@ void cell_cell_transfer(GhostCommunication *gc, int data_parts) {
         pt1 = &part1[p];
         pt2 = &part2[p];
         if (data_parts & GHOSTTRANS_PROPRTS) {
-          memcpy(&pt2->p, &pt1->p, sizeof(ParticleProperties));
+          pt2->p =pt1->p;
 #ifdef GHOSTS_HAVE_BONDS
           pt2->bl = pt1->bl;
 #ifdef EXCLUSIONS
@@ -422,24 +422,24 @@ void cell_cell_transfer(GhostCommunication *gc, int data_parts) {
         if (data_parts & GHOSTTRANS_POSSHFTD) {
           /* ok, this is not nice, but perhaps fast */
           int i;
-          memcpy(&pt2->r, &pt1->r, sizeof(ParticlePosition));
+          pt2->r= pt1->r;
           for (i = 0; i < 3; i++)
             pt2->r.p[i] += gc->shift[i];
         } else if (data_parts & GHOSTTRANS_POSITION)
-          memcpy(&pt2->r, &pt1->r, sizeof(ParticlePosition));
+          pt2->r =pt1->r;
         if (data_parts & GHOSTTRANS_MOMENTUM) {
-          memcpy(&pt2->m, &pt1->m, sizeof(ParticleMomentum));
+          pt2->m = pt1->m;
         }
         if (data_parts & GHOSTTRANS_FORCE)
           pt2->f += pt1->f;
 
 #ifdef LB
         if (data_parts & GHOSTTRANS_COUPLING)
-          memcpy(&pt2->lc, &pt1->lc, sizeof(ParticleLatticeCoupling));
+          pt2->lc =pt1->lc;
 #endif
 #ifdef ENGINE
         if (data_parts & GHOSTTRANS_SWIMMING)
-          memcpy(&pt2->swim, &pt1->swim, sizeof(ParticleParametersSwimming));
+          pt2->swim =pt1->swim;
 #endif
       }
     }

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -105,12 +105,12 @@ int calc_transmit_size(GhostCommunication *gc, int data_parts) {
     if (data_parts & GHOSTTRANS_PROPRTS) {
       n_buffer_new += sizeof(ParticleProperties);
       // sending size of bond/exclusion lists
-if (ghosts_have_bonds) {
-      n_buffer_new += sizeof(int);
+      if (ghosts_have_bonds) {
+        n_buffer_new += sizeof(int);
 #ifdef EXCLUSIONS
-      n_buffer_new += sizeof(int);
+        n_buffer_new += sizeof(int);
 #endif
-}
+      }
     }
     if (data_parts & GHOSTTRANS_POSITION)
       n_buffer_new += sizeof(ParticlePosition);
@@ -164,22 +164,22 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
         if (data_parts & GHOSTTRANS_PROPRTS) {
           memcpy(insert, &pt->p, sizeof(ParticleProperties));
           insert += sizeof(ParticleProperties);
-if (ghosts_have_bonds) {
-          *(int *)insert = pt->bl.n;
-          insert += sizeof(int);
-          if (pt->bl.n) {
-            s_bondbuffer.insert(s_bondbuffer.end(), pt->bl.e,
-                                pt->bl.e + pt->bl.n);
-          }
+          if (ghosts_have_bonds) {
+            *(int *)insert = pt->bl.n;
+            insert += sizeof(int);
+            if (pt->bl.n) {
+              s_bondbuffer.insert(s_bondbuffer.end(), pt->bl.e,
+                                  pt->bl.e + pt->bl.n);
+            }
 #ifdef EXCLUSIONS
-          *(int *)insert = pt->el.n;
-          insert += sizeof(int);
-          if (pt->el.n) {
-            s_bondbuffer.insert(s_bondbuffer.end(), pt->el.e,
-                                pt->el.e + pt->el.n);
-          }
+            *(int *)insert = pt->el.n;
+            insert += sizeof(int);
+            if (pt->el.n) {
+              s_bondbuffer.insert(s_bondbuffer.end(), pt->el.e,
+                                  pt->el.e + pt->el.n);
+            }
 #endif
-}
+          }
         }
         if (data_parts & GHOSTTRANS_POSSHFTD) {
           /* ok, this is not nice, but perhaps fast */
@@ -233,16 +233,16 @@ if (ghosts_have_bonds) {
 }
 
 static void prepare_ghost_cell(Cell *cell, int size) {
-if (ghosts_have_bonds) {
-  // free all allocated information, will be resent
-  {
-    int np = cell->n;
-    Particle *part = cell->part;
-    for (int p = 0; p < np; p++) {
-      free_particle(part + p);
+  if (ghosts_have_bonds) {
+    // free all allocated information, will be resent
+    {
+      int np = cell->n;
+      Particle *part = cell->part;
+      for (int p = 0; p < np; p++) {
+        free_particle(part + p);
+      }
     }
   }
-}
   cell->resize(size);
   // invalidate pointers etc
   {
@@ -291,26 +291,26 @@ void put_recv_buffer(GhostCommunication *gc, int data_parts) {
         if (data_parts & GHOSTTRANS_PROPRTS) {
           memcpy(&pt->p, retrieve, sizeof(ParticleProperties));
           retrieve += sizeof(ParticleProperties);
-if (ghosts_have_bonds) {
-          int n_bonds;
-          memcpy(&n_bonds, retrieve, sizeof(int));
-          retrieve += sizeof(int);
-          if (n_bonds) {
-            pt->bl.resize(n_bonds);
-            std::copy_n(bond_retrieve, n_bonds, pt->bl.begin());
-            bond_retrieve += n_bonds;
-          }
+          if (ghosts_have_bonds) {
+            int n_bonds;
+            memcpy(&n_bonds, retrieve, sizeof(int));
+            retrieve += sizeof(int);
+            if (n_bonds) {
+              pt->bl.resize(n_bonds);
+              std::copy_n(bond_retrieve, n_bonds, pt->bl.begin());
+              bond_retrieve += n_bonds;
+            }
 #ifdef EXCLUSIONS
-          int n_exclusions;
-          memcpy(&n_exclusions, retrieve, sizeof(int));
-          retrieve += sizeof(int);
-          if (n_exclusions) {
-            pt->el.resize(n_exclusions);
-            std::copy_n(bond_retrieve, n_exclusions, pt->el.begin());
-            bond_retrieve += n_exclusions;
-          }
+            int n_exclusions;
+            memcpy(&n_exclusions, retrieve, sizeof(int));
+            retrieve += sizeof(int);
+            if (n_exclusions) {
+              pt->el.resize(n_exclusions);
+              std::copy_n(bond_retrieve, n_exclusions, pt->el.begin());
+              bond_retrieve += n_exclusions;
+            }
 #endif
-}
+          }
           if (local_particles[pt->p.identity] == nullptr) {
             local_particles[pt->p.identity] = pt;
           }
@@ -412,22 +412,22 @@ void cell_cell_transfer(GhostCommunication *gc, int data_parts) {
         pt1 = &part1[p];
         pt2 = &part2[p];
         if (data_parts & GHOSTTRANS_PROPRTS) {
-          pt2->p =pt1->p;
-if (ghosts_have_bonds) {
-          pt2->bl = pt1->bl;
+          pt2->p = pt1->p;
+          if (ghosts_have_bonds) {
+            pt2->bl = pt1->bl;
 #ifdef EXCLUSIONS
-          pt2->el = pt1->el;
+            pt2->el = pt1->el;
 #endif
-}
+          }
         }
         if (data_parts & GHOSTTRANS_POSSHFTD) {
           /* ok, this is not nice, but perhaps fast */
           int i;
-          pt2->r= pt1->r;
+          pt2->r = pt1->r;
           for (i = 0; i < 3; i++)
             pt2->r.p[i] += gc->shift[i];
         } else if (data_parts & GHOSTTRANS_POSITION)
-          pt2->r =pt1->r;
+          pt2->r = pt1->r;
         if (data_parts & GHOSTTRANS_MOMENTUM) {
           pt2->m = pt1->m;
         }
@@ -436,11 +436,11 @@ if (ghosts_have_bonds) {
 
 #ifdef LB
         if (data_parts & GHOSTTRANS_COUPLING)
-          pt2->lc =pt1->lc;
+          pt2->lc = pt1->lc;
 #endif
 #ifdef ENGINE
         if (data_parts & GHOSTTRANS_SWIMMING)
-          pt2->swim =pt1->swim;
+          pt2->swim = pt1->swim;
 #endif
       }
     }

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -161,7 +161,7 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
       for (int p = 0; p < np; p++) {
         Particle *pt = &part[p];
         if (data_parts & GHOSTTRANS_PROPRTS) {
-          memmove(insert, &pt->p, sizeof(ParticleProperties));
+          memcpy(insert, &pt->p, sizeof(ParticleProperties));
           insert += sizeof(ParticleProperties);
 #ifdef GHOSTS_HAVE_BONDS
           *(int *)insert = pt->bl.n;
@@ -184,31 +184,31 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
           /* ok, this is not nice, but perhaps fast */
           ParticlePosition *pp = reinterpret_cast<ParticlePosition *>(insert);
           int i;
-          memmove(pp, &pt->r, sizeof(ParticlePosition));
+          memcpy(pp, &pt->r, sizeof(ParticlePosition));
           for (i = 0; i < 3; i++)
             pp->p[i] += gc->shift[i];
           insert += sizeof(ParticlePosition);
         } else if (data_parts & GHOSTTRANS_POSITION) {
-          memmove(insert, &pt->r, sizeof(ParticlePosition));
+          memcpy(insert, &pt->r, sizeof(ParticlePosition));
           insert += sizeof(ParticlePosition);
         }
         if (data_parts & GHOSTTRANS_MOMENTUM) {
-          memmove(insert, &pt->m, sizeof(ParticleMomentum));
+          memcpy(insert, &pt->m, sizeof(ParticleMomentum));
           insert += sizeof(ParticleMomentum);
         }
         if (data_parts & GHOSTTRANS_FORCE) {
-          memmove(insert, &pt->f, sizeof(ParticleForce));
+          memcpy(insert, &pt->f, sizeof(ParticleForce));
           insert += sizeof(ParticleForce);
         }
 #ifdef LB
         if (data_parts & GHOSTTRANS_COUPLING) {
-          memmove(insert, &pt->lc, sizeof(ParticleLatticeCoupling));
+          memcpy(insert, &pt->lc, sizeof(ParticleLatticeCoupling));
           insert += sizeof(ParticleLatticeCoupling);
         }
 #endif
 #ifdef ENGINE
         if (data_parts & GHOSTTRANS_SWIMMING) {
-          memmove(insert, &pt->swim, sizeof(ParticleParametersSwimming));
+          memcpy(insert, &pt->swim, sizeof(ParticleParametersSwimming));
           insert += sizeof(ParticleParametersSwimming);
         }
 #endif
@@ -288,11 +288,11 @@ void put_recv_buffer(GhostCommunication *gc, int data_parts) {
       for (int p = 0; p < np; p++) {
         Particle *pt = &part[p];
         if (data_parts & GHOSTTRANS_PROPRTS) {
-          memmove(&pt->p, retrieve, sizeof(ParticleProperties));
+          memcpy(&pt->p, retrieve, sizeof(ParticleProperties));
           retrieve += sizeof(ParticleProperties);
 #ifdef GHOSTS_HAVE_BONDS
           int n_bonds;
-          memmove(&n_bonds, retrieve, sizeof(int));
+          memcpy(&n_bonds, retrieve, sizeof(int));
           retrieve += sizeof(int);
           if (n_bonds) {
             pt->bl.resize(n_bonds);
@@ -301,7 +301,7 @@ void put_recv_buffer(GhostCommunication *gc, int data_parts) {
           }
 #ifdef EXCLUSIONS
           int n_exclusions;
-          memmove(&n_exclusions, retrieve, sizeof(int));
+          memcpy(&n_exclusions, retrieve, sizeof(int));
           retrieve += sizeof(int);
           if (n_exclusions) {
             pt->el.resize(n_exclusions);
@@ -315,26 +315,26 @@ void put_recv_buffer(GhostCommunication *gc, int data_parts) {
           }
         }
         if (data_parts & GHOSTTRANS_POSITION) {
-          memmove(&pt->r, retrieve, sizeof(ParticlePosition));
+          memcpy(&pt->r, retrieve, sizeof(ParticlePosition));
           retrieve += sizeof(ParticlePosition);
         }
         if (data_parts & GHOSTTRANS_MOMENTUM) {
-          memmove(&pt->m, retrieve, sizeof(ParticleMomentum));
+          memcpy(&pt->m, retrieve, sizeof(ParticleMomentum));
           retrieve += sizeof(ParticleMomentum);
         }
         if (data_parts & GHOSTTRANS_FORCE) {
-          memmove(&pt->f, retrieve, sizeof(ParticleForce));
+          memcpy(&pt->f, retrieve, sizeof(ParticleForce));
           retrieve += sizeof(ParticleForce);
         }
 #ifdef LB
         if (data_parts & GHOSTTRANS_COUPLING) {
-          memmove(&pt->lc, retrieve, sizeof(ParticleLatticeCoupling));
+          memcpy(&pt->lc, retrieve, sizeof(ParticleLatticeCoupling));
           retrieve += sizeof(ParticleLatticeCoupling);
         }
 #endif
 #ifdef ENGINE
         if (data_parts & GHOSTTRANS_SWIMMING) {
-          memmove(&pt->swim, retrieve, sizeof(ParticleParametersSwimming));
+          memcpy(&pt->swim, retrieve, sizeof(ParticleParametersSwimming));
           retrieve += sizeof(ParticleParametersSwimming);
         }
 #endif
@@ -411,7 +411,7 @@ void cell_cell_transfer(GhostCommunication *gc, int data_parts) {
         pt1 = &part1[p];
         pt2 = &part2[p];
         if (data_parts & GHOSTTRANS_PROPRTS) {
-          memmove(&pt2->p, &pt1->p, sizeof(ParticleProperties));
+          memcpy(&pt2->p, &pt1->p, sizeof(ParticleProperties));
 #ifdef GHOSTS_HAVE_BONDS
           pt2->bl = pt1->bl;
 #ifdef EXCLUSIONS
@@ -422,24 +422,24 @@ void cell_cell_transfer(GhostCommunication *gc, int data_parts) {
         if (data_parts & GHOSTTRANS_POSSHFTD) {
           /* ok, this is not nice, but perhaps fast */
           int i;
-          memmove(&pt2->r, &pt1->r, sizeof(ParticlePosition));
+          memcpy(&pt2->r, &pt1->r, sizeof(ParticlePosition));
           for (i = 0; i < 3; i++)
             pt2->r.p[i] += gc->shift[i];
         } else if (data_parts & GHOSTTRANS_POSITION)
-          memmove(&pt2->r, &pt1->r, sizeof(ParticlePosition));
+          memcpy(&pt2->r, &pt1->r, sizeof(ParticlePosition));
         if (data_parts & GHOSTTRANS_MOMENTUM) {
-          memmove(&pt2->m, &pt1->m, sizeof(ParticleMomentum));
+          memcpy(&pt2->m, &pt1->m, sizeof(ParticleMomentum));
         }
         if (data_parts & GHOSTTRANS_FORCE)
           pt2->f += pt1->f;
 
 #ifdef LB
         if (data_parts & GHOSTTRANS_COUPLING)
-          memmove(&pt2->lc, &pt1->lc, sizeof(ParticleLatticeCoupling));
+          memcpy(&pt2->lc, &pt1->lc, sizeof(ParticleLatticeCoupling));
 #endif
 #ifdef ENGINE
         if (data_parts & GHOSTTRANS_SWIMMING)
-          memmove(&pt2->swim, &pt1->swim, sizeof(ParticleParametersSwimming));
+          memcpy(&pt2->swim, &pt1->swim, sizeof(ParticleParametersSwimming));
 #endif
       }
     }

--- a/src/core/immersed_boundary/ImmersedBoundaries.cpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.cpp
@@ -70,7 +70,7 @@ void ImmersedBoundaries::init_volume_conservation() {
         // This check is important because InitVolumeConservation may be called
         // accidentally during the integration. Then we must not reset the
         // reference
-        BoundariesFound=true;
+        BoundariesFound = true;
         if (bonded_ia_params[i].p.ibmVolConsParameters.volRef == 0) {
           const int softID = bonded_ia_params[i].p.ibmVolConsParameters.softID;
           bonded_ia_params[i].p.ibmVolConsParameters.volRef =

--- a/src/core/immersed_boundary/ImmersedBoundaries.cpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.cpp
@@ -35,6 +35,9 @@ This function is called from integrate_vv
  **************/
 
 void ImmersedBoundaries::volume_conservation() {
+  if (VolumeInitDone && !BoundariesFound) {
+    return;
+  }
   // Calculate volumes
   calc_volumes();
 
@@ -67,6 +70,7 @@ void ImmersedBoundaries::init_volume_conservation() {
         // This check is important because InitVolumeConservation may be called
         // accidentally during the integration. Then we must not reset the
         // reference
+        BoundariesFound=true;
         if (bonded_ia_params[i].p.ibmVolConsParameters.volRef == 0) {
           const int softID = bonded_ia_params[i].p.ibmVolConsParameters.softID;
           bonded_ia_params[i].p.ibmVolConsParameters.volRef =

--- a/src/core/immersed_boundary/ImmersedBoundaries.hpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.hpp
@@ -41,6 +41,7 @@ private:
   const int MaxNumIBM;
   std::vector<double> VolumesCurrent;
   bool VolumeInitDone = false;
+  bool BoundariesFound = false;
 };
 
 #endif

--- a/src/core/initialize.cpp
+++ b/src/core/initialize.cpp
@@ -746,7 +746,9 @@ void on_ghost_flags_change() {
     ghosts_have_v = 1;
     ghosts_have_bonds = 1;
   }
+#ifdef COLLISION_DETECTION
   if (collision_params.mode) {
     ghosts_have_bonds = 1;
   }
+#endif
 }

--- a/src/core/initialize.cpp
+++ b/src/core/initialize.cpp
@@ -24,6 +24,7 @@
 #include "initialize.hpp"
 #include "bonded_interactions/thermalized_bond.hpp"
 #include "cells.hpp"
+#include "collision.hpp"
 #include "communication.hpp"
 #include "cuda_init.hpp"
 #include "cuda_interface.hpp"
@@ -67,7 +68,6 @@
 #include "thermostat.hpp"
 #include "utils.hpp"
 #include "virtual_sites.hpp"
-#include "collision.hpp"
 
 #include "utils/mpi/all_compare.hpp"
 /** whether the thermostat has to be reinitialized before integration */

--- a/src/core/initialize.cpp
+++ b/src/core/initialize.cpp
@@ -67,6 +67,7 @@
 #include "thermostat.hpp"
 #include "utils.hpp"
 #include "virtual_sites.hpp"
+#include "collision.hpp"
 
 #include "utils/mpi/all_compare.hpp"
 /** whether the thermostat has to be reinitialized before integration */
@@ -709,8 +710,10 @@ void on_ghost_flags_change() {
   EVENT_TRACE(fprintf(stderr, "%d: on_ghost_flags_change\n", this_node));
   /* that's all we change here */
   extern int ghosts_have_v;
+  extern int ghosts_have_bonds;
 
   ghosts_have_v = 0;
+  ghosts_have_bonds = 0;
 
 /* DPD and LB need also ghost velocities */
 #ifdef LB
@@ -739,6 +742,11 @@ void on_ghost_flags_change() {
   };
 #endif
   // THERMALIZED_DIST_BOND needs v to calculate v_com and v_dist for thermostats
-  if (n_thermalized_bonds)
+  if (n_thermalized_bonds) {
     ghosts_have_v = 1;
+    ghosts_have_bonds = 1;
+  }
+  if (collision_params.mode) {
+    ghosts_have_bonds = 1;
+  }
 }

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1071,7 +1071,9 @@ void try_add_exclusion(Particle *part, int part2) {
 void try_delete_exclusion(Particle *part, int part2) {
   IntList &el = part->el;
 
-  el.erase(std::remove(el.begin(), el.end(), part2), el.end());
+  if (!el.empty()) {
+    el.erase(std::remove(el.begin(), el.end(), part2), el.end());
+  };
 }
 #endif
 

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -39,6 +39,10 @@ extern std::mt19937 generator;
 extern std::normal_distribution<double> normal_distribution;
 extern std::uniform_real_distribution<double> uniform_real_distribution;
 extern bool user_has_seeded;
+inline void unseeded_error() {
+    runtimeErrorMsg() << "Please seed the random number generator.\nESPResSo "
+                         "can choose one for you with set_random_state_PRNG().";
+}
 
 /**
  * @brief checks the seeded state and throws error if unseeded
@@ -48,11 +52,11 @@ inline void check_user_has_seeded() {
   static bool unseeded_error_thrown = false;
   if (!user_has_seeded && !unseeded_error_thrown) {
     unseeded_error_thrown = true;
-    runtimeErrorMsg() << "Please seed the random number generator.\nESPResSo "
-                         "can choose one for you with set_random_state_PRNG().";
+    unseeded_error();
   }
   return;
 }
+
 
 /**
  * @brief Set seed of random number generators on each node.

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -40,8 +40,8 @@ extern std::normal_distribution<double> normal_distribution;
 extern std::uniform_real_distribution<double> uniform_real_distribution;
 extern bool user_has_seeded;
 inline void unseeded_error() {
-    runtimeErrorMsg() << "Please seed the random number generator.\nESPResSo "
-                         "can choose one for you with set_random_state_PRNG().";
+  runtimeErrorMsg() << "Please seed the random number generator.\nESPResSo "
+                       "can choose one for you with set_random_state_PRNG().";
 }
 
 /**
@@ -56,7 +56,6 @@ inline void check_user_has_seeded() {
   }
   return;
 }
-
 
 /**
  * @brief Set seed of random number generators on each node.

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -162,13 +162,13 @@ inline void friction_thermo_langevin(Particle *p) {
   }
 
   // Get velocity effective in the thermostatting
-  Vector3d velocity=p->m.v;
+  Vector3d velocity = p->m.v;
 #ifdef ENGINE
-  if (p->swim.v_swim!=0) {
-      // In case of the engine feature, the velocity is relaxed
-      // towards a swimming velocity oriented parallel to the
-      // particles director
-      velocity -= p->swim.v_swim * p->r.calc_director();
+  if (p->swim.v_swim != 0) {
+    // In case of the engine feature, the velocity is relaxed
+    // towards a swimming velocity oriented parallel to the
+    // particles director
+    velocity -= p->swim.v_swim * p->r.calc_director();
   }
 #endif
 
@@ -217,7 +217,7 @@ inline void friction_thermo_langevin(Particle *p) {
   if (aniso_flag) {
     velocity_body =
         (aniso_flag) ? convert_vector_space_to_body(*p, velocity) : Vector3d{};
-    }
+  }
 #endif
 
   // Do the actual thermostatting

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -213,11 +213,8 @@ inline void friction_thermo_langevin(Particle *p) {
                     (langevin_pref1_temp[1] != langevin_pref1_temp[2]) ||
                     (langevin_pref2_temp[0] != langevin_pref2_temp[1]) ||
                     (langevin_pref2_temp[1] != langevin_pref2_temp[2]);
-  Vector3d velocity_body;
-  if (aniso_flag) {
-    velocity_body =
-        (aniso_flag) ? convert_vector_space_to_body(*p, velocity) : Vector3d{};
-  }
+  auto const velocity_body =
+      (aniso_flag) ? convert_vector_space_to_body(*p, velocity) : Vector3d{};
 #endif
 
   // Do the actual thermostatting

--- a/src/features.def
+++ b/src/features.def
@@ -20,7 +20,7 @@ MASS
 EXCLUSIONS
 BOND_CONSTRAINT
 LANGEVIN_PER_PARTICLE
-COLLISION_DETECTION             implies GHOSTS_HAVE_BONDS
+COLLISION_DETECTION
 METADYNAMICS
 NEMD
 NPT
@@ -105,7 +105,6 @@ UMBRELLA                           requires EXPERIMENTAL_FEATURES
 GAY_BERNE                       implies ROTATION
 GAY_BERNE                       requires EXPERIMENTAL_FEATURES
 OVERLAPPED
-THOLE                           implies GHOSTS_HAVE_BONDS
 THOLE                           requires P3M
 
 /* Fluid-Structure Interactions (object in fluid) */
@@ -137,8 +136,6 @@ GAUSSRANDOMCUT                  requires not GAUSSRANDOM and not FLATNOISE
 OLD_DIHEDRAL                    notest
 /* turn off certain nonbonded interactions within molecules */
 NO_INTRA_NB                     notest
-/* ghost particles also have the bond information. */
-GHOSTS_HAVE_BONDS               notest
 
 
 /* Debugging */


### PR DESCRIPTION
Mainly relevant for (nearly) maxset myconfigs 
wihtout ghmc, metadynamics, nemd (no py interface) and additional checks.
There, this pr improves performance of lj liquids with 5%, 10% and 40% volume fraction and 1000 - 4000 particles on 1-4 cpus by some 15-25%.

See commit titles for individual changes

One relevant thing still missing is the possibility to switch ghosts_have_bonds at runtime.