### PR TITLE
Improve constrainst visualization sample; directly set box_l where appropriate

### DIFF
--- a/samples/minimal-polymer.py
+++ b/samples/minimal-polymer.py
@@ -30,14 +30,13 @@ import numpy as np
 # System parameters
 #############################################################
 
-system = espressomd.System(box_l=[1.0, 1.0, 1.0])
+system = espressomd.System(box_l=[100, 100, 100])
 system.set_random_state_PRNG()
 #system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
 np.random.seed(seed=system.seed)
 
 system.time_step = 0.01
 system.cell_system.skin = 0.4
-system.box_l = [100, 100, 100]
 system.thermostat.set_langevin(kT=1.0, gamma=1.0)
 system.cell_system.set_n_square(use_verlet_lists=False)
 outfile = open('polymer.vtf', 'w')

--- a/samples/rigid_body.py
+++ b/samples/rigid_body.py
@@ -32,15 +32,14 @@ required_features = ["VIRTUAL_SITES_RELATIVE", "MASS", "ROTATIONAL_INERTIA"]
 espressomd.assert_features(required_features)
 
 
-system = espressomd.System(box_l=[1.0, 1.0, 1.0])
+box_l = 100
+system = espressomd.System(box_l=[box_l, box_l, box_l])
 system.set_random_state_PRNG()
 system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
 
 system.time_step = 0.01
 skin = 10.0
 system.cell_system.skin = skin
-box_l = 100
-system.box_l = [box_l, box_l, box_l]
 system.thermostat.set_langevin(kT=1.0, gamma=1.0)
 
 ### Particle types

--- a/samples/store_properties.py
+++ b/samples/store_properties.py
@@ -57,7 +57,7 @@ lj_cap = 20
 
 # Integration parameters
 #############################################################
-system = espressomd.System(box_l=[1.0, 1.0, 1.0])
+system = espressomd.System(box_l=[box_l, box_l, box_l])
 system.set_random_state_PRNG()
 #system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
 np.random.seed(seed=system.seed)
@@ -84,8 +84,6 @@ int_n_times = 10
 
 # Interaction setup
 #############################################################
-
-system.box_l = [box_l, box_l, box_l]
 
 system.non_bonded_inter[0, 0].lennard_jones.set_params(
     epsilon=lj_eps, sigma=lj_sig,

--- a/samples/visualization_constraints.py
+++ b/samples/visualization_constraints.py
@@ -40,44 +40,44 @@ visualizer = espressomd.visualization_opengl.openGLLive(
     rasterize_pointsize=5, camera_position=[150, 25, 25], camera_right=[0, 0, -1])
 
 # Wall
-#system.constraints.add(shape=espressomd.shapes.Wall(
-#    dist=20, normal=[0.1, 0.0, 1]), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Wall(  # nopep8
+#    dist=20, normal=[0.1, 0.0, 1]), particle_type=0, penetrable=True)  # nopep8
 
 # Sphere
-#system.constraints.add(shape=espressomd.shapes.Sphere(
-#    center=[25, 25, 25], radius=15, direction=1), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Sphere(  # nopep8
+#    center=[25, 25, 25], radius=15, direction=1), particle_type=0, penetrable=True)  # nopep8
 
 # Ellipsoid
-#system.constraints.add(shape=espressomd.shapes.Ellipsoid(
-#    center=[25, 25, 25], a=25, b=15, direction=1), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Ellipsoid(  # nopep8
+#    center=[25, 25, 25], a=25, b=15, direction=1), particle_type=0, penetrable=True)  # nopep8
 
 # Cylinder
-#system.constraints.add(shape=espressomd.shapes.Cylinder(center=[25, 25, 25], axis=[
-#                       1, 0, 0], direction=1, radius=10, length=30), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Cylinder(center=[25, 25, 25], axis=[  # nopep8
+#                       1, 0, 0], direction=1, radius=10, length=30), particle_type=0, penetrable=True)  # nopep8
 
 # SpheroCylinder
-#system.constraints.add(shape=espressomd.shapes.SpheroCylinder(center=[25, 25, 25], axis=[
-#                       1, 0, 0], direction=1, radius=10, length=30), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.SpheroCylinder(center=[25, 25, 25], axis=[  # nopep8
+#                       1, 0, 0], direction=1, radius=10, length=30), particle_type=0, penetrable=True)  # nopep8
 
 # Maze
-#system.constraints.add(shape=espressomd.shapes.Maze(
-#    cylrad=3, dim=2, nsphere=2, sphrad=8), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Maze(  # nopep8
+#    cylrad=3, dim=2, nsphere=2, sphrad=8), particle_type=0, penetrable=True)  # nopep8
 
 # Stomatocyte
-#system.constraints.add(shape=espressomd.shapes.Stomatocyte(inner_radius=3, outer_radius=7, axis=[
-#                       1.0, 0.0, 0.0], center=[25, 25, 25], layer_width=3, direction=1), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Stomatocyte(inner_radius=3, outer_radius=7, axis=[  # nopep8
+#                       1.0, 0.0, 0.0], center=[25, 25, 25], layer_width=3, direction=1), particle_type=0, penetrable=True)  # nopep8
 
 # SimplePore
-system.constraints.add(shape=espressomd.shapes.SimplePore(center=[25, 25, 25], axis=[
-                       1, 0, 0], length=15, radius=12.5, smoothing_radius=2), particle_type=0, penetrable=True)
+system.constraints.add(shape=espressomd.shapes.SimplePore(center=[25, 25, 25], axis=[  # nopep8
+                       1, 0, 0], length=15, radius=12.5, smoothing_radius=2), particle_type=0, penetrable=True)  # nopep8
 
 # Slitpore
-#system.constraints.add(shape=espressomd.shapes.Slitpore(channel_width=15, lower_smoothing_radius=3,
-#                                                        upper_smoothing_radius=3, pore_length=20, pore_mouth=30, pore_width=5), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Slitpore(channel_width=15, lower_smoothing_radius=3,  # nopep8
+#                                                        upper_smoothing_radius=3, pore_length=20, pore_mouth=30, pore_width=5), particle_type=0, penetrable=True)  # nopep8
 
 # HollowCone
-#system.constraints.add(shape=espressomd.shapes.HollowCone(inner_radius=5, outer_radius=20, opening_angle=np.pi /
-#                                                          4.0, axis=[1.0, 0.0, 0.0], center=[25, 25, 25], width=2, direction=1), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.HollowCone(inner_radius=5, outer_radius=20, opening_angle=np.pi /  # nopep8
+#                                                          4.0, axis=[1.0, 0.0, 0.0], center=[25, 25, 25], width=2, direction=1), particle_type=0, penetrable=True)  # nopep8
 
 system.thermostat.set_langevin(kT=10.0, gamma=10)
 

--- a/samples/visualization_constraints.py
+++ b/samples/visualization_constraints.py
@@ -10,8 +10,7 @@
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
+# GNU General Public License for more details.  #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """ Visualization of shape-based constraints with test particles.
@@ -29,7 +28,7 @@ required_features = ["LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 box_l = 50
-system = espressomd.System(box_l=[50.0] * 3)
+system = espressomd.System(box_l=[box_l] * 3)
 system.set_random_state_PRNG()
 np.random.seed(seed=system.seed)
 
@@ -38,53 +37,47 @@ system.cell_system.skin = 0.3
 
 visualizer = espressomd.visualization_opengl.openGLLive(
     system, background_color=[1, 1, 1], drag_enabled=True, rasterize_resolution=50.0,
-                        rasterize_pointsize=5, camera_position=[150, 25, 25], camera_right=[0, 0, -1])
+    rasterize_pointsize=5, camera_position=[150, 25, 25], camera_right=[0, 0, -1])
 
 # Wall
-# system.constraints.add(shape=espressomd.shapes.Wall(dist=20, normal=[0.1, 0.0, 1]),
-# particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Wall(
+#    dist=20, normal=[0.1, 0.0, 1]), particle_type=0, penetrable=True)
 
 # Sphere
-# system.constraints.add(shape=espressomd.shapes.Sphere(center=[25, 25, 25], radius=15,
-# direction=1), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Sphere(
+#    center=[25, 25, 25], radius=15, direction=1), particle_type=0, penetrable=True)
 
 # Ellipsoid
-# system.constraints.add(shape=espressomd.shapes.Ellipsoid(center=[25, 25, 25], a=25, b=15,
-# direction=1), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Ellipsoid(
+#    center=[25, 25, 25], a=25, b=15, direction=1), particle_type=0, penetrable=True)
 
 # Cylinder
-# system.constraints.add(shape=espressomd.shapes.Cylinder(center=[25, 25, 25], axis=[1, 0,
-# 0], direction=1, radius=10, length=30), particle_type=0,
-# penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Cylinder(center=[25, 25, 25], axis=[
+#                       1, 0, 0], direction=1, radius=10, length=30), particle_type=0, penetrable=True)
 
 # SpheroCylinder
-# system.constraints.add(shape=espressomd.shapes.SpheroCylinder(center=[25, 25, 25],
-# axis=[1, 0, 0], direction=1, radius=10, length=30), particle_type=0,
-# penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.SpheroCylinder(center=[25, 25, 25], axis=[
+#                       1, 0, 0], direction=1, radius=10, length=30), particle_type=0, penetrable=True)
 
 # Maze
-# system.constraints.add(shape=espressomd.shapes.Maze(cylrad=3, dim=2, nsphere=2, sphrad=8),
-# particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Maze(
+#    cylrad=3, dim=2, nsphere=2, sphrad=8), particle_type=0, penetrable=True)
 
 # Stomatocyte
-# system.constraints.add(shape=espressomd.shapes.Stomatocyte(inner_radius=3, outer_radius=7,
-# axis=[1.0, 0.0, 0.0], center=[25, 25, 25], layer_width=3, direction=1),
-# particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Stomatocyte(inner_radius=3, outer_radius=7, axis=[
+#                       1.0, 0.0, 0.0], center=[25, 25, 25], layer_width=3, direction=1), particle_type=0, penetrable=True)
 
 # SimplePore
 system.constraints.add(shape=espressomd.shapes.SimplePore(center=[25, 25, 25], axis=[
                        1, 0, 0], length=15, radius=12.5, smoothing_radius=2), particle_type=0, penetrable=True)
 
 # Slitpore
-# system.constraints.add(shape=espressomd.shapes.Slitpore(channel_width=15,
-# lower_smoothing_radius=3, upper_smoothing_radius=3, pore_length=20,
-# pore_mouth=30, pore_width=5), particle_type=0, penetrable=True)
+#system.constraints.add(shape=espressomd.shapes.Slitpore(channel_width=15, lower_smoothing_radius=3,
+#                                                        upper_smoothing_radius=3, pore_length=20, pore_mouth=30, pore_width=5), particle_type=0, penetrable=True)
 
 # HollowCone
-# system.constraints.add(shape=espressomd.shapes.HollowCone(inner_radius=5, outer_radius=20,
-# opening_angle=np.pi/4.0, axis=[1.0, 0.0, 0.0], center=[25, 25, 25],
-# width=2, direction=1), particle_type=0, penetrable=True)
-
+#system.constraints.add(shape=espressomd.shapes.HollowCone(inner_radius=5, outer_radius=20, opening_angle=np.pi /
+#                                                          4.0, axis=[1.0, 0.0, 0.0], center=[25, 25, 25], width=2, direction=1), particle_type=0, penetrable=True)
 
 system.thermostat.set_langevin(kT=10.0, gamma=10)
 


### PR DESCRIPTION
In `visualization_constraints.py`:
  - Variable `box_l` was defined but not used.
  - Commented out code was formatted as if descriptive comment. As a result you could **not** just comment in and run -- which is the desired behaviour here.

In the other samples, `System` was set up with some randomly chosen `box_l`, which a few lines later was just overwritten by a different `box_l`. This didn't really make sense.