### PR TITLE
Scriptinterface: Avoid cast to float

### DIFF
--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -161,7 +161,7 @@ cdef class PScriptInterface(object):
         elif np.issubdtype(np.dtype(type(value)), np.signedinteger):
             return make_variant[int](value)
         elif np.issubdtype(np.dtype(type(value)), np.floating):
-            return make_variant[float](value)
+            return make_variant[double](value)
         else:
             raise TypeError("Unkown type for conversion to Variant")
 

--- a/src/script_interface/VariantTester.hpp
+++ b/src/script_interface/VariantTester.hpp
@@ -93,6 +93,10 @@ public:
         return is_vector(par.at("value"));
       }
     }
+    
+    if (method == "mirror") {
+      return par.at("value");
+    }
 
     throw std::runtime_error("Unknown method");
   }

--- a/src/script_interface/VariantTester.hpp
+++ b/src/script_interface/VariantTester.hpp
@@ -93,7 +93,7 @@ public:
         return is_vector(par.at("value"));
       }
     }
-    
+
     if (method == "mirror") {
       return par.at("value");
     }

--- a/testsuite/python/collision_detection.py
+++ b/testsuite/python/collision_detection.py
@@ -733,7 +733,7 @@ class CollisionDetection(ut.TestCase):
         res = reduce[0](reduce[1][0])
         self.assertEqual(res.__class__.__name__, "CollisionDetection")
         self.assertEqual(res.mode, "bind_centers")
-        self.assertAlmostEqual(res.distance, 0.11, delta=1E-9)
+        self.assertAlmostEqual(res.distance, 0.11, delta=1E-12)
         self.assertEqual(res.bond_centers, self.H)
 
 

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -471,7 +471,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 offset=0.,
                 eps=1.0,
                 sig=1.0,
-                r=1.134228603),
+                r=hollowcone_constraint.min_dist()),
             places=9)
 
         # Reset

--- a/testsuite/python/variant_conversion.py
+++ b/testsuite/python/variant_conversion.py
@@ -46,6 +46,10 @@ class test_variant_conversion(ut.TestCase):
         self.assertTrue(self.vt.call_method("true"))
         self.assertFalse(self.vt.call_method("false"))
 
+    def test_mirror(self):
+        for v in 1.1, 0.6, 0.1232, 1, [1, 1.1], "blabla":
+            self.assertEqual(v, self.vt.call_method("mirror", value=v))
+    
     def test_default(self):
         """ Check that a default constructed Variant translates to None.
         """


### PR DESCRIPTION
Sorry for the late action. Fixes #2396 
It is not clear to me, why that didn't get caught by the clang checks.


Description of changes:
 - 


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
