### PR TITLE
core: Fixed find_current_cell

### DIFF
--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -491,13 +491,11 @@ void cells_update_ghosts() {
 }
 
 Cell *find_current_cell(const Particle &p) {
-  auto c = cell_structure.position_to_cell(p.r.p);
-  if (c) {
-    return c;
-  } else if (!p.l.ghost) {
-    // Old pos must lie within the cell system
-    return cell_structure.position_to_cell(p.l.p_old);
-  } else {
+  assert(not resort_particles);
+
+  if (p.l.ghost) {
     return nullptr;
   }
+
+  return cell_structure.position_to_cell(p.l.p_old);
 }

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -306,33 +306,6 @@ void fold_and_reset(Particle &p) {
 
   p.l.p_old = p.r.p;
 }
-
-/**
- * @brief Extract an indexed particle from a list.
- *
- * Removes a particle from a particle list and
- * from the particle index.
- */
-Particle extract_indexed_particle(ParticleList *sl, int i) {
-  Particle *src = &sl->part[i];
-  Particle *end = &sl->part[sl->n - 1];
-
-  Particle p = std::move(*src);
-
-  assert(p.p.identity <= max_seen_particle);
-  local_particles[p.p.identity] = nullptr;
-
-  if (src != end) {
-    new (src) Particle(std::move(*end));
-  }
-
-  if (realloc_particlelist(sl, --sl->n)) {
-    update_local_particles(sl);
-  } else if (src != end) {
-    local_particles[src->p.identity] = src;
-  }
-  return p;
-}
 } // namespace
 
 /**

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -298,12 +298,11 @@ void check_resort_particles();
 
 /*@}*/
 
-/* @brief Finds the cell in which a particle is stored
-
-   Uses position_to_cell on p.r.p. If this is not on the node's domain,
-   uses position at last Verlet list rebuild (p.l.p_old).
-
-   @return pointer to the cell or nullptr if the particle is not on the node
+/**
+ * @brief Finds the cell in which a particle is stored
+ *
+ *
+ * @return pointer to the cell or nullptr if the particle is not on the node
 */
 Cell *find_current_cell(const Particle &p);
 

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -303,7 +303,7 @@ void check_resort_particles();
  *
  *
  * @return pointer to the cell or nullptr if the particle is not on the node
-*/
+ */
 Cell *find_current_cell(const Particle &p);
 
 #endif

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -884,10 +884,6 @@ void local_remove_particle(int part) {
     std::tie(cell, n) = find_particle(p, local_cells);
   }
 
-  if (not cell) {
-    std::tie(cell, n) = find_particle(p, ghost_cells);
-  }
-
   assert(cell);
 
   Particle p_destroy = extract_indexed_particle(cell, n);

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -845,12 +845,12 @@ int remove_particle(int p_id) {
 
 namespace {
 std::pair<Cell *, size_t> find_particle(Particle *p, Cell *c) {
-  const auto n = (c->n > 0) ? std::distance(c->part, p) : -1;
-  if ((n >= 0) && (n < c->n) && ((c->part + n) == p)) {
-    return {c, n};
-  } else {
-    return {nullptr, 0};
+  for (int i = 0; i < c->n; ++i) {
+    if ((c->part + i) == p) {
+      return {c, i};
+    }
   }
+  return {nullptr, 0};
 }
 
 std::pair<Cell *, size_t> find_particle(Particle *p, CellPList cells) {

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -844,16 +844,16 @@ int remove_particle(int p_id) {
 }
 
 namespace {
-std::pair<Cell *, size_t> find_particle(const Particle *p, Cell *c) {
-  const auto n = p - c->part;
-  if ((n >= 0) && (n < c->n)) {
+std::pair<Cell *, size_t> find_particle(Particle *p, Cell *c) {
+  const auto n = (c->n > 0) ? std::distance(c->part, p) : -1;
+  if ((n >= 0) && (n < c->n) && ((c->part + n) == p)) {
     return {c, n};
   } else {
     return {nullptr, 0};
   }
 }
 
-std::pair<Cell *, size_t> find_particle(const Particle *p, CellPList cells) {
+std::pair<Cell *, size_t> find_particle(Particle *p, CellPList cells) {
   for (auto &c : cells) {
     auto res = find_particle(p, c);
     if (res.first) {
@@ -866,7 +866,7 @@ std::pair<Cell *, size_t> find_particle(const Particle *p, CellPList cells) {
 } // namespace
 
 void local_remove_particle(int part) {
-  const Particle *p = local_particles[part];
+  Particle *p = local_particles[part];
   assert(p);
   assert(not p->l.ghost);
 
@@ -884,7 +884,7 @@ void local_remove_particle(int part) {
     std::tie(cell, n) = find_particle(p, local_cells);
   }
 
-  assert(cell);
+  assert(cell && cell->part && (n < cell->n) && ((cell->part + n) == p));
 
   Particle p_destroy = extract_indexed_particle(cell, n);
 }

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -562,6 +562,8 @@ Particle *move_unindexed_particle(ParticleList *destList,
 Particle *move_indexed_particle(ParticleList *destList,
                                 ParticleList *sourceList, int ind);
 
+Particle extract_indexed_particle(ParticleList *sl, int i);
+
 /*    Other Functions                           */
 /************************************************/
 


### PR DESCRIPTION
The old implementation could potentially return a ghost cell or no cell as cell for a local particle,
but neighbor search on ghost cells is no possible. (They do not have neighbors set).
It's correct to always use `pos_old` to find the cell: this is the position the particle
was last sorted with, and hence will find the cell the particle is actually in. From my understanding
of the collision detection this meant that in some corner cases pairs were missed, but
I am not sure about that.