### PR TITLE
python: set exclusions after all particles are set.

### DIFF
--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1140,22 +1140,16 @@ cdef class ParticleHandle(object):
                 for e in self.exclusions:
                     self.delete_exclusion(e)
 
-            # Empty list? ony delete
-                if _partners:
+                nlvl = nesting_level(_partners)
 
-                    nlvl = nesting_level(_partners)
-
-                    if nlvl == 0:  # Single item
-                        self.add_exclusion(_partners)
-                    elif nlvl == 1:  # List of items
-                        for partner in _partners:
-                            self.add_exclusion(partner)
-                    else:
-                        raise ValueError(
-                            "Exclusions have to specified as a lists of partners or a single partner.")
-
-                    # Set new exclusion list
-                    # self.add_exclusion(_partners)
+                if nlvl == 0:  # Single item
+                    self.add_exclusion(_partners)
+                elif nlvl == 1:  # List of items
+                    for partner in _partners:
+                        self.add_exclusion(partner)
+                else:
+                    raise ValueError(
+                        "Exclusions have to be specified as a lists of partners or a single item.")
 
             def __get__(self):
                 self.update_particle_data()
@@ -1813,9 +1807,16 @@ cdef class ParticleList(object):
         return odict
 
     def __setstate__(self, params):
+        exclusions = collections.OrderedDict()
         for particle_number in params.keys():
             params[particle_number]["id"] = particle_number
+            IF EXCLUSIONS:
+                exclusions[particle_number] = params[particle_number]["exclusions"]
+                del params[particle_number]["exclusions"]
             self._place_new_particle(params[particle_number])
+        IF EXCLUSIONS:
+            for pid in exclusions:
+                self[pid].exclusions = exclusions[pid]
 
     def __len__(self):
         return n_part

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1811,7 +1811,10 @@ cdef class ParticleList(object):
         for particle_number in params.keys():
             params[particle_number]["id"] = particle_number
             IF EXCLUSIONS:
-                exclusions[particle_number] = params[particle_number]["exclusions"]
+                exclusions[
+                    particle_number] = params[
+                        particle_number][
+                            "exclusions"]
                 del params[particle_number]["exclusions"]
             self._place_new_particle(params[particle_number])
         IF EXCLUSIONS:

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -310,7 +310,7 @@ def nesting_level(obj):
 
     """
 
-    if not isinstance(obj, (list, tuple)):
+    if not isinstance(obj, (list, tuple, np.ndarray)):
         return 0
 
     obj = list(obj)

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -40,6 +40,7 @@ if espressomd.has_features('LB'):
 
 system.part.add(pos=[1.0] * 3)
 system.part.add(pos=[1.0, 1.0, 2.0])
+system.part.add(pos=[2.0]*3, exclusions=[0,1])
 if espressomd.has_features('ELECTROSTATICS'):
     system.part[0].q = 1
     system.part[1].q = -1

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -40,7 +40,7 @@ if espressomd.has_features('LB'):
 
 system.part.add(pos=[1.0] * 3)
 system.part.add(pos=[1.0, 1.0, 2.0])
-system.part.add(pos=[2.0]*3, exclusions=[0,1])
+system.part.add(pos=[2.0] * 3, exclusions=[0, 1])
 if espressomd.has_features('ELECTROSTATICS'):
     system.part[0].q = 1
     system.part[1].q = -1

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -40,7 +40,8 @@ if espressomd.has_features('LB'):
 
 system.part.add(pos=[1.0] * 3)
 system.part.add(pos=[1.0, 1.0, 2.0])
-system.part.add(pos=[2.0] * 3, exclusions=[0, 1])
+if espressomd.has_features('EXCLUSIONS'):
+    system.part.add(pos=[2.0] * 3, exclusions=[0, 1])
 if espressomd.has_features('ELECTROSTATICS'):
     system.part[0].q = 1
     system.part[1].q = -1

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -23,6 +23,7 @@ import espressomd.checkpointing
 import espressomd.virtual_sites
 import tests_common
 
+
 class CheckpointTest(ut.TestCase):
 
     @classmethod
@@ -122,9 +123,12 @@ class CheckpointTest(ut.TestCase):
 
     @ut.skipIf(not espressomd.has_features("EXCLUSIONS"), "Skipped because feature EXCLUSIONS missing.")
     def test_exclusions(self):
-        self.assertTrue(tests_common.lists_contain_same_elements(system.part[0].exclusions, [2]))
-        self.assertTrue(tests_common.lists_contain_same_elements(system.part[1].exclusions, [2]))
-        self.assertTrue(tests_common.lists_contain_same_elements(system.part[2].exclusions, [0,1]))
+        self.assertTrue(
+            tests_common.lists_contain_same_elements(system.part[0].exclusions, [2]))
+        self.assertTrue(
+            tests_common.lists_contain_same_elements(system.part[1].exclusions, [2]))
+        self.assertTrue(
+            tests_common.lists_contain_same_elements(system.part[2].exclusions, [0, 1]))
 
 
 if __name__ == '__main__':

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -21,7 +21,7 @@ import numpy as np
 import espressomd
 import espressomd.checkpointing
 import espressomd.virtual_sites
-
+import tests_common
 
 class CheckpointTest(ut.TestCase):
 
@@ -119,6 +119,12 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(coldet.mode, "bind_centers")
         self.assertAlmostEqual(coldet.distance, 0.11, delta=1E-9)
         self.assertTrue(coldet.bond_centers, system.bonded_inter[0])
+
+    @ut.skipIf(not espressomd.has_features("EXCLUSIONS"), "Skipped because feature EXCLUSIONS missing.")
+    def test_exclusions(self):
+        self.assertTrue(tests_common.lists_contain_same_elements(system.part[0].exclusions, [2]))
+        self.assertTrue(tests_common.lists_contain_same_elements(system.part[1].exclusions, [2]))
+        self.assertTrue(tests_common.lists_contain_same_elements(system.part[2].exclusions, [0,1]))
 
 
 if __name__ == '__main__':

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -595,5 +595,6 @@ def single_component_maxwell(x1, x2, kT):
     x = np.linspace(x1, x2, 1000)
     return np.trapz(np.exp(-x**2 / (2. * kT)), x) / np.sqrt(2. * np.pi * kT)
 
+
 def lists_contain_same_elements(list1, list2):
     return len(list1) == len(list2) and sorted(list1) == sorted(list2)

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -139,8 +139,8 @@ def lj_force_vector(v_d, d, lj_params):
 
 
 def verify_lj_forces(system, tolerance, ids_to_skip=[]):
-    """Goes over all pairs of paritcles in system and compares the forces on them
-       to what would be expected based on the systems lj parametes.
+    """Goes over all pairs of particles in system and compares the forces on them
+       to what would be expected based on the systems LJ parametes.
        Particle ids listed in ids_to_skip are not checked
        Do not run this with a thermostat enabled."""
 
@@ -594,3 +594,6 @@ def single_component_maxwell(x1, x2, kT):
     """Integrate the probability density from x1 to x2 using the trapezoidal rule"""
     x = np.linspace(x1, x2, 1000)
     return np.trapz(np.exp(-x**2 / (2. * kT)), x) / np.sqrt(2. * np.pi * kT)
+
+def lists_contain_same_elements(list1, list2):
+    return len(list1) == len(list2) and sorted(list1) == sorted(list2)


### PR DESCRIPTION
Fixes #2418

Description of changes:
 - the particle exclusions are stored on all participating particles, which leads to an error if one of the
    exclusion partners does not exist while setting the exclusion for a particle. Therefore the exclusion
    partners have to be set after setting up all particles