### PR TITLE
core: Work around another boost.mpi bug

### DIFF
--- a/src/core/unit_tests/sendrecv_test.cpp
+++ b/src/core/unit_tests/sendrecv_test.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(blocking) {
 
   /* Non-MPI datatype */
   {
-    const std::string send = std::to_string(right);
+    const std::string send = std::to_string(rank);
     std::string recv;
 
     sendrecv(world, left, 42, send, right, 42, recv);

--- a/src/core/utils/mpi/sendrecv.hpp
+++ b/src/core/utils/mpi/sendrecv.hpp
@@ -38,7 +38,8 @@ mpi::request isend(mpi::communicator const &comm, int dest, int tag,
   /* boost.mpi before that version has a broken implementation
      of isend for non-mpi data types, so we have to use our own. */
 #if BOOST_VERSION < 106800
-  auto archive = boost::make_shared<mpi::packed_oarchive>(comm);
+  auto archive =
+      boost::shared_ptr<mpi::packed_oarchive>(new mpi::packed_oarchive(comm));
   *archive << value;
   auto const size = archive->size();
   auto const data = const_cast<void *>(archive->address());

--- a/src/core/utils/mpi/sendrecv.hpp
+++ b/src/core/utils/mpi/sendrecv.hpp
@@ -42,13 +42,13 @@ mpi::request isend(mpi::communicator const &comm, int dest, int tag,
       boost::shared_ptr<mpi::packed_oarchive>(new mpi::packed_oarchive(comm));
   *archive << value;
   auto const size = archive->size();
-  auto const data = const_cast<void *>(archive->address());
   mpi::request result;
   BOOST_MPI_CHECK_RESULT(MPI_Isend,
                          (&size, 1, mpi::get_mpi_datatype<std::size_t>(size),
                           dest, tag, comm, &result.m_requests[0]));
-  BOOST_MPI_CHECK_RESULT(MPI_Isend, (data, size, MPI_PACKED, dest, tag, comm,
-                                     &result.m_requests[1]));
+  BOOST_MPI_CHECK_RESULT(MPI_Isend,
+                         (const_cast<void *>(archive->address()), size,
+                          MPI_PACKED, dest, tag, comm, &result.m_requests[1]));
 
   result.m_data = archive;
   return result;

--- a/src/core/utils/mpi/sendrecv.hpp
+++ b/src/core/utils/mpi/sendrecv.hpp
@@ -41,7 +41,7 @@ mpi::request isend(mpi::communicator const &comm, int dest, int tag,
   auto archive =
       boost::shared_ptr<mpi::packed_oarchive>(new mpi::packed_oarchive(comm));
   *archive << value;
-  auto const size = archive->size();
+  auto size = archive->size();
   mpi::request result;
   BOOST_MPI_CHECK_RESULT(MPI_Isend,
                          (&size, 1, mpi::get_mpi_datatype<std::size_t>(size),


### PR DESCRIPTION
Older versions of boost.mpi had a broken implementation of communicator::isend for non-mpi data types. This works around that.
