### PR TITLE
Boost patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,14 @@ find_package(Boost ${BOOST_MINIMUM_VERSION} REQUIRED ${BOOST_COMPONENTS})
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 
+if(BOOST_VERSION VERSION_LESS 106700)
+  add_library(boost_patch SHARED ${CMAKE_SOURCE_DIR}/src/boost_patch.cpp)
+  set(BOOST_LD_PRELOAD $<TARGET_FILE_NAME:${boost_patch}>)
+else()
+  set(BOOST_LD_PRELOAD "")
+endif()
+  message(STATUS "BOOST_LD_PRELOAD ${BOOST_LD_PRELOAD}")
+
 if(Boost_VERSION VERSION_GREATER 106399 AND Boost_VERSION VERSION_LESS 106500)
   # Boost 1.64 has incompatible Serialization and MPI modules, see https://svn.boost.org/trac10/ticket/12723 .
   # Some distributions, like Fedora, have backported the patch.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,12 +363,10 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 
 if(BOOST_VERSION VERSION_LESS 106700)
-  add_library(boost_patch SHARED ${CMAKE_SOURCE_DIR}/src/boost_patch.cpp)
-  set(BOOST_LD_PRELOAD $<TARGET_FILE_NAME:${boost_patch}>)
+  set(BOOST_LD_PRELOAD $<TARGET_FILE:boost_patch>)
 else()
   set(BOOST_LD_PRELOAD "")
 endif()
-  message(STATUS "BOOST_LD_PRELOAD ${BOOST_LD_PRELOAD}")
 
 if(Boost_VERSION VERSION_GREATER 106399 AND Boost_VERSION VERSION_LESS 106500)
   # Boost 1.64 has incompatible Serialization and MPI modules, see https://svn.boost.org/trac10/ticket/12723 .

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,11 @@ add_custom_target(check_myconfig
           myconfig
   )
 
+if(BOOST_VERSION VERSION_LESS 106700)
+  add_library(boost_patch SHARED boost_patch.cpp)
+  target_link_libraries(boost_patch PRIVATE Boost::mpi)
+endif()
+
 add_subdirectory(core)
 
 if(WITH_SCRIPT_INTERFACE)

--- a/src/boost_patch.cpp
+++ b/src/boost_patch.cpp
@@ -27,16 +27,14 @@ template <>
 boost::mpi::request
 boost::mpi::communicator::isend<boost::mpi::packed_oarchive>(
     int dest, int tag, boost::mpi::packed_oarchive const &ar) const {
-  std::size_t const& size = ar.size();
+  std::size_t const &size = ar.size();
   request req;
+  BOOST_MPI_CHECK_RESULT(MPI_Isend, (&const_cast<std::size_t &>(size), 1,
+                                     get_mpi_datatype(size), dest, tag, *this,
+                                     &req.m_requests[0]));
   BOOST_MPI_CHECK_RESULT(MPI_Isend,
-                         (&const_cast<std::size_t &>(size), 1,
-                                 get_mpi_datatype(size),
-                                 dest, tag, *this, &req.m_requests[0]));
-  BOOST_MPI_CHECK_RESULT(MPI_Isend,
-                         (const_cast<void *>(ar.address()), size,
-                                 MPI_PACKED,
-                                 dest, tag, *this, &req.m_requests[1]));
+                         (const_cast<void *>(ar.address()), size, MPI_PACKED,
+                          dest, tag, *this, &req.m_requests[1]));
 
   return req;
 }

--- a/src/boost_patch.cpp
+++ b/src/boost_patch.cpp
@@ -1,0 +1,42 @@
+// Copyright 2005 Douglas Gregor.
+
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// Message Passing Interface 1.1 -- Section 3. MPI Point-to-point
+
+/* There is the potential for optimization here. We could keep around
+   a "small message" buffer of size N that we just receive into by
+   default. If the message is N - sizeof(int) bytes or smaller, it can
+   just be sent with that buffer. If it's larger, we send the first N
+   - sizeof(int) bytes in the first packet followed by another
+   packet. The size of the second packet will be stored in an integer
+   at the end of the first packet.
+
+   We will introduce this optimization later, when we have more
+   performance test cases and have met our functionality goals. */
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/datatype.hpp>
+#include <boost/mpi/detail/point_to_point.hpp>
+#include <boost/mpi/exception.hpp>
+#include <boost/mpi/request.hpp>
+
+template <>
+boost::mpi::request
+boost::mpi::communicator::isend<boost::mpi::packed_oarchive>(
+    int dest, int tag, boost::mpi::packed_oarchive const &ar) const {
+  std::size_t const& size = ar.size();
+  request req;
+  BOOST_MPI_CHECK_RESULT(MPI_Isend,
+                         (&const_cast<std::size_t &>(size), 1,
+                                 get_mpi_datatype(size),
+                                 dest, tag, *this, &req.m_requests[0]));
+  BOOST_MPI_CHECK_RESULT(MPI_Isend,
+                         (const_cast<void *>(ar.address()), size,
+                                 MPI_PACKED,
+                                 dest, tag, *this, &req.m_requests[1]));
+
+  return req;
+}

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -5,10 +5,12 @@ set(PYTHON_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 set(PYTHON_FRONTEND ${PYTHON_EXECUTABLE})
 configure_file(pypresso.cmakein ${CMAKE_BINARY_DIR}/pypresso @ONLY)
+file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/pypresso INPUT ${CMAKE_BINARY_DIR}/pypresso)
 
 if( IPYTHON_EXECUTABLE )
   set(PYTHON_FRONTEND ${IPYTHON_EXECUTABLE})
   configure_file(pypresso.cmakein ${CMAKE_BINARY_DIR}/ipypresso @ONLY)
+  file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/ipypresso INPUT ${CMAKE_BINARY_DIR}/ipypresso)
 endif( )
 
 # Configure pypresso for install dir
@@ -21,7 +23,6 @@ if( IPYTHON_EXECUTABLE )
   set(PYTHON_FRONTEND ${IPYTHON_EXECUTABLE})
   configure_file(pypresso.cmakein ${CMAKE_CURRENT_BINARY_DIR}/ipypresso @ONLY)
 endif( )
-
 
 option(INSTALL_PYPRESSO "Install pypresso script, not needed when Espresso is installed in /usr" ON)
 if(INSTALL_PYPRESSO)

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -7,6 +7,8 @@
 # without any warranty.
 #
 
+export LD_PRELOAD=@BOOST_LD_PRELOAD@:$LD_PRELOAD
+
 if test -n "$PYTHONPATH"; then
   PYTHONPATH=@PYTHON_DIR@:$PYTHONPATH
 else


### PR DESCRIPTION
If a broken boost.mpi version is used, a shared object is preloaded which containes a fixed version of the offending function in boost. This only works on posix, and currently not for installed versions of pypresso.
