### PR TITLE
Fix tutorials and samples

### DIFF
--- a/doc/tutorials/02-charged_system/scripts/nacl.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl.py
@@ -61,11 +61,11 @@ system.thermostat.set_langevin(kT=temp, gamma=gamma)
 
 # Place particles
 for i in range(int(n_ionpairs)):
-    system.part.add(id=len(system.part), type=types["Anion"], pos=numpy.random.random(
-        3) * box_l, q=charges["Anion"])
+    system.part.add(id=len(system.part), type=types["Anion"],
+                    pos=numpy.random.random(3) * box_l, q=charges["Anion"])
 for i in range(int(n_ionpairs)):
-    system.part.add(id=len(system.part), type=types["Cation"], pos=numpy.random.random(
-        3) * box_l, q=charges["Cation"])
+    system.part.add(id=len(system.part), type=types["Cation"],
+                    pos=numpy.random.random(3) * box_l, q=charges["Cation"])
 
 
 def combination_rule_epsilon(rule, eps1, eps2):
@@ -103,8 +103,8 @@ system.thermostat.set_langevin(kT=temp * 0.1, gamma=gamma * 50.0)
 
 while min_dist < max_sigma:
     # Warmup Helper: Cap max. force, increase slowly for overlapping particles
-    min_dist = system.analysis.min_dist([types["Anion"], types["Cation"]], [
-        types["Anion"], types["Cation"]])
+    min_dist = system.analysis.min_dist([types["Anion"], types["Cation"]],
+                                        [types["Anion"], types["Cation"]])
     cap += min_dist
 # print min_dist, cap
     system.force_cap = cap
@@ -121,15 +121,10 @@ system.actors.add(p3m)
 print("\n--->Temperature Equilibration")
 system.time = 0.0
 for i in range(int(num_steps_equilibration / 100)):
-    temp_measured = system.analysis.energy(
-    )['kinetic'] / ((3.0 / 2.0) * n_part)
-    print(
-        "t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(system.time,
-                                                                              system.analysis.energy()[
-                                                                                  'total'],
-                                                                              system.analysis.energy()[
-                                                                                  'coulomb'],
-                                                                              temp_measured))
+    temp_measured = system.analysis.energy()['kinetic'] / ((3 / 2.0) * n_part)
+    print("t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(
+        system.time, system.analysis.energy()['total'],
+        system.analysis.energy()['coulomb'], temp_measured))
     system.integrator.run(100)
 
 print("\n--->Integration")
@@ -138,13 +133,9 @@ temp_measured = []
 for i in range(num_configs):
     temp_measured.append(system.analysis.energy()[
                          'kinetic'] / ((3.0 / 2.0) * n_part))
-    print(
-        "t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(system.time,
-                                                                              system.analysis.energy()[
-                                                                                  'total'],
-                                                                              system.analysis.energy()[
-                                                                                  'coulomb'],
-                                                                              temp_measured[-1]))
+    print("t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(
+        system.time, system.analysis.energy()['total'],
+        system.analysis.energy()['coulomb'], temp_measured[-1]))
     system.integrator.run(integ_steps_per_config)
 
     # Internally append particle configuration

--- a/doc/tutorials/02-charged_system/scripts/nacl_units.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import espressomd
 from espressomd import electrostatics, assert_features
 import numpy
 
@@ -112,7 +113,7 @@ for s in [["Cl", "Na"], ["Cl", "Cl"], ["Na", "Na"]]:
 print("\n--->Tuning Electrostatics")
 # p3m = electrostatics.P3M(bjerrum_length=l_bjerrum, accuracy=1e-2,
 # mesh=[84,84,84], cao=6)
-p3m = electrostatics.P3M(bjerrum_length=l_bjerrum, accuracy=1e-2)
+p3m = electrostatics.P3M(prefactor=l_bjerrum * temp, accuracy=1e-2)
 system.actors.add(p3m)
 
 print("\n--->Temperature Equilibration")

--- a/doc/tutorials/02-charged_system/scripts/nacl_units.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units.py
@@ -73,11 +73,19 @@ for i in range(n_ppside):
         for k in range(n_ppside):
             p = numpy.array([i, j, k]) * l
             if q < 0:
-                system.part.add(id=len(
-                    system.part), type=types["Cl"], pos=p, q=charges["Cl"], mass=masses["Cl"])
+                system.part.add(
+                    id=len(system.part),
+                    type=types["Cl"],
+                    pos=p,
+                    q=charges["Cl"],
+                    mass=masses["Cl"])
             else:
-                system.part.add(id=len(
-                    system.part), type=types["Na"], pos=p, q=charges["Na"], mass=masses["Na"])
+                system.part.add(
+                    id=len(system.part),
+                    type=types["Na"],
+                    pos=p,
+                    q=charges["Na"],
+                    mass=masses["Na"])
 
             q *= -1
         q *= -1
@@ -121,13 +129,8 @@ system.time = 0.0
 for i in range(int(num_steps_equilibration / 100)):
     energy = system.analysis.energy()
     temp_measured = energy['kinetic'] / ((3.0 / 2.0) * n_part)
-    print(
-        "t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(system.time,
-                                                                              energy[
-                                                                              'total'],
-                                                                              energy[
-                                                                              'coulomb'],
-                                                                              temp_measured))
+    print("t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(
+        system.time, energy['total'], energy['coulomb'], temp_measured))
     system.integrator.run(100)
 
 print("\n--->Integration")
@@ -135,13 +138,8 @@ system.time = 0.0
 for i in range(num_configs):
     energy = system.analysis.energy()
     temp_measured = energy['kinetic'] / ((3.0 / 2.0) * n_part)
-    print(
-        "t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(system.time,
-                                                                              energy[
-                                                                              'total'],
-                                                                              energy[
-                                                                              'coulomb'],
-                                                                              temp_measured))
+    print("t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(
+        system.time, energy['total'], energy['coulomb'], temp_measured))
     system.integrator.run(integ_steps_per_config)
 
     # Internally append particle configuration

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import espressomd
 from espressomd import electrostatics, electrostatic_extensions, assert_features
 from espressomd.shapes import Wall
 import numpy
@@ -127,7 +128,7 @@ energy = system.analysis.energy()
 print("After Minimization: E_total=", energy['total'])
 
 print("\n--->Tuning Electrostatics")
-p3m = electrostatics.P3M(bjerrum_length=l_bjerrum, accuracy=1e-2)
+p3m = electrostatics.P3M(prefactor=l_bjerrum * temp, accuracy=1e-2)
 system.actors.add(p3m)
 elc = electrostatic_extensions.ELC(gap_size=elc_gap, maxPWerror=1e-3)
 system.actors.add(elc)

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
@@ -23,7 +23,7 @@ from espressomd import electrostatics, electrostatic_extensions, assert_features
 from espressomd.shapes import Wall
 import numpy
 
-assert_features(["ELECTROSTATICS", "CONSTRAINTS", "MASS", "LENNARD_JONES"])
+assert_features(["ELECTROSTATICS", "MASS", "LENNARD_JONES"])
 
 system = espressomd.System(box_l=[1.0, 1.0, 1.0])
 system.seed = system.cell_system.get_state()['n_nodes'] * [1234]

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
@@ -74,22 +74,30 @@ system.cell_system.skin = 0.3
 system.thermostat.set_langevin(kT=temp, gamma=gamma)
 
 # Walls
-system.constraints.add(shape=Wall(
-    dist=0, normal=[0, 0, 1]), particle_type=types["Electrode"])
-system.constraints.add(shape=Wall(
-    dist=-box_z, normal=[0, 0, -1]), particle_type=types["Electrode"])
+system.constraints.add(shape=Wall(dist=0, normal=[0, 0, 1]),
+                       particle_type=types["Electrode"])
+system.constraints.add(shape=Wall(dist=-box_z, normal=[0, 0, -1]),
+                       particle_type=types["Electrode"])
 
 # Place particles
 for i in range(int(n_ionpairs)):
     p = numpy.random.random(3) * box_l
     p[2] += lj_sigmas["Electrode"]
-    system.part.add(id=len(system.part),
-                    type=types["Cl"], pos=p, q=charges["Cl"], mass=masses["Cl"])
+    system.part.add(
+        id=len(system.part),
+        type=types["Cl"],
+        pos=p,
+        q=charges["Cl"],
+        mass=masses["Cl"])
 for i in range(int(n_ionpairs)):
     p = numpy.random.random(3) * box_l
     p[2] += lj_sigmas["Electrode"]
-    system.part.add(id=len(system.part),
-                    type=types["Na"], pos=p, q=charges["Na"], mass=masses["Na"])
+    system.part.add(
+        id=len(system.part),
+        type=types["Na"],
+        pos=p,
+        q=charges["Na"],
+        mass=masses["Na"])
 
 # Lennard-Jones interactions parameters
 
@@ -108,7 +116,8 @@ def combination_rule_sigma(rule, sig1, sig2):
         return ValueError("No combination rule defined")
 
 
-for s in [["Cl", "Na"], ["Cl", "Cl"], ["Na", "Na"], ["Na", "Electrode"], ["Cl", "Electrode"]]:
+for s in [["Cl", "Na"], ["Cl", "Cl"], ["Na", "Na"],
+          ["Na", "Electrode"], ["Cl", "Electrode"]]:
     lj_sig = combination_rule_sigma(
         "Berthelot", lj_sigmas[s[0]], lj_sigmas[s[1]])
     lj_cut = combination_rule_sigma("Berthelot", lj_cuts[s[0]], lj_cuts[s[1]])
@@ -141,13 +150,8 @@ system.time = 0.0
 for i in range(int(num_steps_equilibration / 100)):
     energy = system.analysis.energy()
     temp_measured = energy['kinetic'] / ((3.0 / 2.0) * n_part)
-    print(
-        "t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(system.time,
-                                                                              energy[
-                                                                              'total'],
-                                                                              energy[
-                                                                              'coulomb'],
-                                                                              temp_measured))
+    print("t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(
+        system.time, energy['total'], energy['coulomb'], temp_measured))
     system.integrator.run(100)
 
 
@@ -159,15 +163,10 @@ system.time = 0.0
 cnt = 0
 
 for i in range(num_configs):
-    temp_measured = system.analysis.energy(
-    )['kinetic'] / ((3.0 / 2.0) * n_part)
-    print(
-        "t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(system.time,
-                                                                              system.analysis.energy()[
-                                                                              'total'],
-                                                                              system.analysis.energy()[
-                                                                              'coulomb'],
-                                                                              temp_measured))
+    temp_measured = system.analysis.energy()['kinetic'] / ((3 / 2.0) * n_part)
+    print("t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(
+        system.time, system.analysis.energy()['total'],
+        system.analysis.energy()['coulomb'], temp_measured))
     system.integrator.run(integ_steps_per_config)
 
     for p in system.part:

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
@@ -72,26 +72,41 @@ system.cell_system.skin = 0.3
 system.thermostat.set_langevin(kT=temp, gamma=gamma)
 
 # Visualizer
-visualizer = openGLLive(system, camera_position=[-3 * box_l, box_l * 0.5, box_l * 0.5], camera_right=[
-                        0, 0, 1], drag_force=5 * 298, background_color=[1, 1, 1], light_pos=[30, 30, 30], ext_force_arrows_type_scale=[0.0001], ext_force_arrows=False)
+visualizer = openGLLive(
+    system,
+    camera_position=[-3 * box_l, box_l * 0.5, box_l * 0.5],
+    camera_right=[0, 0, 1],
+    drag_force=5 * 298,
+    background_color=[1, 1, 1],
+    light_pos=[30, 30, 30],
+    ext_force_arrows_type_scale=[0.0001],
+    ext_force_arrows=False)
 
 # Walls
-system.constraints.add(shape=Wall(
-    dist=0, normal=[0, 0, 1]), particle_type=types["Electrode"])
-system.constraints.add(shape=Wall(
-    dist=-box_z, normal=[0, 0, -1]), particle_type=types["Electrode"])
+system.constraints.add(shape=Wall(dist=0, normal=[0, 0, 1]),
+                       particle_type=types["Electrode"])
+system.constraints.add(shape=Wall(dist=-box_z, normal=[0, 0, -1]),
+                       particle_type=types["Electrode"])
 
 # Place particles
 for i in range(int(n_ionpairs)):
     p = numpy.random.random(3) * box_l
     p[2] += lj_sigmas["Electrode"]
-    system.part.add(id=len(system.part),
-                    type=types["Cl"], pos=p, q=charges["Cl"], mass=masses["Cl"])
+    system.part.add(
+        id=len(system.part),
+        type=types["Cl"],
+        pos=p,
+        q=charges["Cl"],
+        mass=masses["Cl"])
 for i in range(int(n_ionpairs)):
     p = numpy.random.random(3) * box_l
     p[2] += lj_sigmas["Electrode"]
-    system.part.add(id=len(system.part),
-                    type=types["Na"], pos=p, q=charges["Na"], mass=masses["Na"])
+    system.part.add(
+        id=len(system.part),
+        type=types["Na"],
+        pos=p,
+        q=charges["Na"],
+        mass=masses["Na"])
 
 # Lennard-Jones interactions parameters
 
@@ -110,7 +125,8 @@ def combination_rule_sigma(rule, sig1, sig2):
         return ValueError("No combination rule defined")
 
 
-for s in [["Cl", "Na"], ["Cl", "Cl"], ["Na", "Na"], ["Na", "Electrode"], ["Cl", "Electrode"]]:
+for s in [["Cl", "Na"], ["Cl", "Cl"], ["Na", "Na"],
+          ["Na", "Electrode"], ["Cl", "Electrode"]]:
     lj_sig = combination_rule_sigma(
         "Berthelot", lj_sigmas[s[0]], lj_sigmas[s[1]])
     lj_cut = combination_rule_sigma("Berthelot", lj_cuts[s[0]], lj_cuts[s[1]])
@@ -120,8 +136,8 @@ for s in [["Cl", "Na"], ["Cl", "Cl"], ["Na", "Na"], ["Na", "Electrode"], ["Cl", 
     system.non_bonded_inter[types[s[0]], types[s[1]]].lennard_jones.set_params(
         epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
-system.minimize_energy.init(
-    f_max=10, gamma=10, max_steps=2000, max_displacement=0.1)
+system.minimize_energy.init(f_max=10, gamma=10, max_steps=2000,
+                            max_displacement=0.1)
 system.minimize_energy.minimize()
 
 print("\n--->Tuning Electrostatics")
@@ -148,10 +164,10 @@ def decreaseElectricField():
 
 
 # Register buttons
-visualizer.keyboardManager.register_button(KeyboardButtonEvent(
-    'u', KeyboardFireEvent.Hold, increaseElectricField))
-visualizer.keyboardManager.register_button(KeyboardButtonEvent(
-    'j', KeyboardFireEvent.Hold, decreaseElectricField))
+visualizer.keyboardManager.register_button(
+    KeyboardButtonEvent('u', KeyboardFireEvent.Hold, increaseElectricField))
+visualizer.keyboardManager.register_button(
+    KeyboardButtonEvent('j', KeyboardFireEvent.Hold, decreaseElectricField))
 
 
 def main():

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
@@ -26,7 +26,7 @@ import numpy
 from threading import Thread
 from time import sleep
 
-assert_features(["ELECTROSTATICS", "CONSTRAINTS", "MASS", "LENNARD_JONES"])
+assert_features(["ELECTROSTATICS", "MASS", "LENNARD_JONES"])
 
 system = espressomd.System(box_l=[1.0, 1.0, 1.0])
 system.seed = system.cell_system.get_state()['n_nodes'] * [1234]

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import espressomd
 from espressomd import assert_features, electrostatics, electrostatic_extensions
 from espressomd.shapes import Wall
 from espressomd.visualization_opengl import *
@@ -72,7 +73,7 @@ system.thermostat.set_langevin(kT=temp, gamma=gamma)
 
 # Visualizer
 visualizer = openGLLive(system, camera_position=[-3 * box_l, box_l * 0.5, box_l * 0.5], camera_right=[
-                        0, 0, 1], drag_force=5 * 298, background_color=[1, 1, 1], light_pos=[30, 30, 30], ext_force_arrows_scale=[0.0001], ext_force_arrows=False)
+                        0, 0, 1], drag_force=5 * 298, background_color=[1, 1, 1], light_pos=[30, 30, 30], ext_force_arrows_type_scale=[0.0001], ext_force_arrows=False)
 
 # Walls
 system.constraints.add(shape=Wall(
@@ -124,7 +125,7 @@ system.minimize_energy.init(
 system.minimize_energy.minimize()
 
 print("\n--->Tuning Electrostatics")
-p3m = electrostatics.P3M(bjerrum_length=l_bjerrum, accuracy=1e-2)
+p3m = electrostatics.P3M(prefactor=l_bjerrum * temp, accuracy=1e-2)
 system.actors.add(p3m)
 elc = electrostatic_extensions.ELC(gap_size=elc_gap, maxPWerror=1e-3)
 system.actors.add(elc)
@@ -147,9 +148,9 @@ def decreaseElectricField():
 
 
 # Register buttons
-visualizer.keyboardManager.registerButton(KeyboardButtonEvent(
+visualizer.keyboardManager.register_button(KeyboardButtonEvent(
     'u', KeyboardFireEvent.Hold, increaseElectricField))
-visualizer.keyboardManager.registerButton(KeyboardButtonEvent(
+visualizer.keyboardManager.register_button(KeyboardButtonEvent(
     'j', KeyboardFireEvent.Hold, decreaseElectricField))
 
 

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_vis.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_vis.py
@@ -111,11 +111,11 @@ def main():
             for k in range(n_ppside):
                 p = numpy.array([i, j, k]) * l
                 if q < 0:
-                    system.part.add(id=len(
-                        system.part), type=types["Cl"], pos=p, q=charges["Cl"], mass=masses["Cl"])
+                    system.part.add(id=len(system.part), type=types["Cl"],
+                                    pos=p, q=charges["Cl"], mass=masses["Cl"])
                 else:
-                    system.part.add(id=len(
-                        system.part), type=types["Na"], pos=p, q=charges["Na"], mass=masses["Na"])
+                    system.part.add(id=len(system.part), type=types["Na"],
+                                    pos=p, q=charges["Na"], mass=masses["Na"])
 
                 q *= -1
             q *= -1
@@ -156,13 +156,9 @@ def main():
     for i in range(int(num_steps_equilibration / 100)):
         energy = system.analysis.energy()
         temp_measured = energy['kinetic'] / ((3.0 / 2.0) * n_part)
-        print(
-            "t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}".format(system.time,
-                                                                                  energy[
-                                                                                  'total'],
-                                                                                  energy[
-                                                                                  'coulomb'],
-                                                                                  temp_measured))
+        print("t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T_cur={3:.4f}"
+              .format(system.time, energy['total'], energy['coulomb'],
+                      temp_measured))
         system.integrator.run(100)
         visualizer.update()
 

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_vis.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_vis.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import espressomd
 from espressomd import assert_features, electrostatics, electrostatic_extensions
 from espressomd.visualization_opengl import *
 import numpy
@@ -57,9 +58,9 @@ def decreaseTemp():
 
 
 # Register buttons
-visualizer.keyboardManager.registerButton(
+visualizer.keyboardManager.register_button(
     KeyboardButtonEvent('t', KeyboardFireEvent.Hold, increaseTemp))
-visualizer.keyboardManager.registerButton(
+visualizer.keyboardManager.register_button(
     KeyboardButtonEvent('g', KeyboardFireEvent.Hold, decreaseTemp))
 
 
@@ -147,7 +148,7 @@ def main():
     print("\n--->Tuning Electrostatics")
     # p3m = electrostatics.P3M(bjerrum_length=l_bjerrum, accuracy=1e-2,
     # mesh=[84,84,84], cao=6)
-    p3m = electrostatics.P3M(bjerrum_length=l_bjerrum, accuracy=1e-2)
+    p3m = electrostatics.P3M(prefactor=l_bjerrum * temp, accuracy=1e-2)
     system.actors.add(p3m)
 
     print("\n--->Temperature Equilibration")

--- a/doc/tutorials/06-active_matter/SOLUTIONS/rectification_simulation.py
+++ b/doc/tutorials/06-active_matter/SOLUTIONS/rectification_simulation.py
@@ -35,7 +35,7 @@ from espressomd import assert_features
 from espressomd.shapes import Cylinder, Wall, HollowCone
 
 
-assert_features(["ENGINE", "CONSTRAINTS", "LENNARD_JONES", "ROTATION", "MASS"])
+assert_features(["ENGINE", "LENNARD_JONES", "ROTATION", "MASS"])
 
 # Quaternion procedure
 

--- a/doc/tutorials/10-reaction_ensemble/scripts/RE_vs_cpH_poly.py
+++ b/doc/tutorials/10-reaction_ensemble/scripts/RE_vs_cpH_poly.py
@@ -101,8 +101,16 @@ lj_shift = 0.0
 
 # setting up the polymer
 polymer.create_polymer(
-    N_P=N_P, bond_length=bond_l, MPC=MPC, start_id=0, bond=harmonic_bond,
-                       type_poly_neutral=type_HA, type_poly_charged=type_A, mode=0, val_poly=charges[type_A], start_pos=[0]*3)
+    N_P=N_P,
+    bond_length=bond_l,
+    MPC=MPC,
+    start_id=0,
+    bond=harmonic_bond,
+    type_poly_neutral=type_HA,
+    type_poly_charged=type_A,
+    mode=0,
+    val_poly=charges[type_A],
+    start_pos=[0] * 3)
 # setting up counterions
 for i in range(N0):
     system.part.add(pos=np.random.random(3) *
@@ -150,12 +158,27 @@ elif(mode == "constant_pH_ensemble"):
     RE.constant_pH = 0
 
 # HA <--> A- + H+
-RE.add_reaction(gamma=K_diss, reactant_types=[type_HA], reactant_coefficients=[1], product_types=[
-                type_A, type_H], product_coefficients=[1, 1], default_charges={type_HA: charges[type_HA], type_A: charges[type_A], type_H: charges[type_H]})
+RE.add_reaction(
+    gamma=K_diss,
+    reactant_types=[type_HA],
+    reactant_coefficients=[1],
+    product_types=[type_A, type_H],
+    product_coefficients=[1, 1],
+    default_charges={
+        type_HA: charges[type_HA],
+        type_A: charges[type_A],
+        type_H: charges[type_H]})
 
 # H2O autoprotolysis
-RE.add_reaction(gamma=(1 / K_w), reactant_types=[type_H, type_OH], reactant_coefficients=[
-                1, 1], product_types=[], product_coefficients=[], default_charges={type_H: charges[type_H], type_OH: charges[type_OH]})
+RE.add_reaction(
+    gamma=1 / K_w,
+    reactant_types=[type_H, type_OH],
+    reactant_coefficients=[1, 1],
+    product_types=[],
+    product_coefficients=[],
+    default_charges={
+        type_H: charges[type_H],
+        type_OH: charges[type_OH]})
 
 
 print(RE.get_status())
@@ -175,9 +198,20 @@ for i in range(12000):
     system.integrator.run(
         500)  # this is for tutorial only, too few integration steps
     print(
-        i, ") HA", system.number_of_particles(type=type_HA), "A-", system.number_of_particles(
-            type=type_A), "H+", system.number_of_particles(type=type_H),
-          'OH-', system.number_of_particles(type=type_OH), 'Cl-', system.number_of_particles(type=type_Cl), 'NA+', system.number_of_particles(type=type_Na))
+        i,
+        ") ",
+        "HA",
+        system.number_of_particles(type=type_HA),
+        "A-",
+        system.number_of_particles(type=type_A),
+        "H+",
+        system.number_of_particles(type=type_H),
+        'OH-',
+        system.number_of_particles(type=type_OH),
+        'Cl-',
+        system.number_of_particles(type=type_Cl),
+        'NA+',
+        system.number_of_particles(type=type_Na))
     if (i > 2000):  # just a bit of thermalization before starting to gain informations about the properties of the system
         alpha.append(system.number_of_particles(type=type_A) / N0)
         nHA.append(system.number_of_particles(type=type_HA))

--- a/doc/tutorials/10-reaction_ensemble/scripts/RE_vs_cpH_poly.py
+++ b/doc/tutorials/10-reaction_ensemble/scripts/RE_vs_cpH_poly.py
@@ -102,7 +102,7 @@ lj_shift = 0.0
 # setting up the polymer
 polymer.create_polymer(
     N_P=N_P, bond_length=bond_l, MPC=MPC, start_id=0, bond=harmonic_bond,
-                       type_poly_neutral=type_HA, type_poly_charged=type_A, mode=0, val_poly=charges[type_A])
+                       type_poly_neutral=type_HA, type_poly_charged=type_A, mode=0, val_poly=charges[type_A], start_pos=[0]*3)
 # setting up counterions
 for i in range(N0):
     system.part.add(pos=np.random.random(3) *

--- a/samples/ekboundaries.py
+++ b/samples/ekboundaries.py
@@ -23,7 +23,7 @@ import espressomd
 required_features = ["ELECTROKINETICS", "EK_BOUNDARIES", "EXTERNAL_FORCES"]
 espressomd.assert_features(required_features)
 
-from espressomd import System, shapes, electrokinetics
+from espressomd import System, shapes, electrokinetics, ekboundaries
 import sys
 
 system = System(box_l=[10, 10, 10])
@@ -51,9 +51,9 @@ print(neg.get_params())
 print(pos[5, 5, 5].density)
 
 
-ek_wall_left = electrokinetics.EKBoundary(
+ek_wall_left = ekboundaries.EKBoundary(
     shape=shapes.Wall(dist=1, normal=[1, 0, 0]), charge_density=-0.01)
-ek_wall_right = electrokinetics.EKBoundary(
+ek_wall_right = ekboundaries.EKBoundary(
     shape=shapes.Wall(dist=-9, normal=[-1, 0, 0]), charge_density=0.01)
 system.ekboundaries.add(ek_wall_left)
 system.ekboundaries.add(ek_wall_right)

--- a/samples/espresso_logo.py
+++ b/samples/espresso_logo.py
@@ -178,7 +178,7 @@ visualizer = openGLLive(system,
                         camera_position=[box_l / 2.0, box_l / 4.0, 20 * 3],
                         particle_sizes=[0.6, 0.75, 0.9, 0.2],
                         particle_type_materials=[
-                        'silver', 'gold', 'greenplastic', 'chrome'],
+                        'bright', 'bright', 'plastic', 'chrome'],
                         particle_type_colors=[[0.2, 0.2, 0.8, 1], [
                             0.8, 0.2, 0.2, 1], [
                                 1, 1, 1, 1], [0.8, 0.8, 0.8, 1]],
@@ -187,7 +187,7 @@ visualizer = openGLLive(system,
                         bond_type_colors=[[0.2, 0.2, 0.2, 0.5]],
                         bond_type_radius=[0.1],
                         constraint_type_colors=[[1, 1, 1, 0.5]],
-                        constraint_type_materials=['ruby'],
+                        constraint_type_materials=['chrome'],
                         spotlight_brightness=5.0,
                         spotlight_focus=100,
                         spotlight_angle=60,

--- a/samples/espresso_logo.py
+++ b/samples/espresso_logo.py
@@ -145,10 +145,12 @@ for i in range(n_steam):
 system.constraints.add(
     shape=Cylinder(
         center=[box_l / 2.0, 1.0, box_l / 2.0],
-            axis=[0, 1, 0],
-            direction=1,
-            radius=7.5,
-            length=1), particle_type=0, penetrable=True)
+        axis=[0, 1, 0],
+        direction=1,
+        radius=7.5,
+        length=1),
+    particle_type=0,
+    penetrable=True)
 
 
 system.time_step = 0.00022
@@ -173,17 +175,17 @@ for i in range(3):
         epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
 visualizer = openGLLive(system,
-                        background_color=[
-                        0.2, 0.2, 0.3],
+                        background_color=[0.2, 0.2, 0.3],
                         camera_position=[box_l / 2.0, box_l / 4.0, 20 * 3],
                         particle_sizes=[0.6, 0.75, 0.9, 0.2],
                         particle_type_materials=[
-                        'bright', 'bright', 'plastic', 'chrome'],
-                        particle_type_colors=[[0.2, 0.2, 0.8, 1], [
-                            0.8, 0.2, 0.2, 1], [
-                                1, 1, 1, 1], [0.8, 0.8, 0.8, 1]],
-                        bond_type_materials=[
-                        'chrome'],
+                            'bright', 'bright', 'plastic', 'chrome'],
+                        particle_type_colors=[
+                            [0.2, 0.2, 0.8, 1],
+                            [0.8, 0.2, 0.2, 1],
+                            [1, 1, 1, 1],
+                            [0.8, 0.8, 0.8, 1]],
+                        bond_type_materials=['chrome'],
                         bond_type_colors=[[0.2, 0.2, 0.2, 0.5]],
                         bond_type_radius=[0.1],
                         constraint_type_colors=[[1, 1, 1, 0.5]],
@@ -202,5 +204,6 @@ def rotate():
     visualizer.camera.rotateSystemXL()
 
 # visualizer.registerCallback(rotate, interval = 16)
+
 
 visualizer.run(1)

--- a/samples/load_properties.py
+++ b/samples/load_properties.py
@@ -102,16 +102,15 @@ if not system.non_bonded_inter[0, 0].lennard_jones.is_active():
     print(system.non_bonded_inter[0, 0].lennard_jones.get_params())
 
 
-# Import of particle properties and P3M parameters
+# Import P3M parameters
 #############################################################
-with open("particle_save", "rb") as particle_save:
-    pickle.load(particle_save)
 act_min_dist = system.analysis.min_dist()
 
 with open("p3m_save", "rb") as p3m_save:
     p3m = pickle.load(p3m_save)
 print(p3m.get_params())
 
+system.actors.clear()
 system.actors.add(p3m)
 
 # Check import

--- a/samples/store_properties.py
+++ b/samples/store_properties.py
@@ -169,9 +169,6 @@ try:
 except ImportError:
     import pickle
 
-with open("particle_save", "wb") as particle_save:
-    pickle.dump(system.part, particle_save, -1)
-
 with open("p3m_save", "wb") as p3m_save:
     pickle.dump(p3m, p3m_save, -1)
 

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -164,7 +164,6 @@ def create_polymer(**kwargs):
     default_params["MPC"] = 0
     default_params["bond_length"] = 0
     default_params["start_id"] = 0
-    default_params["start_pos"] = np.array([0, 0, 0])
     default_params["mode"] = 1
     default_params["shield"] = 0
     default_params["max_tries"] = 1000

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -40,7 +40,8 @@ def validate_params(_params, default):
     if _params["start_id"] < 0:
         raise ValueError(
             "start_id has to be a positive Integer")
-    if not hasattr(_params["start_pos"], "__getitem__") or len(_params["start_pos"]) != 3:
+    if not hasattr(_params["start_pos"], "__getitem__") \
+            or len(_params["start_pos"]) != 3:
         raise ValueError(
             "start_pos has to be an numpy array with 3 Elements")
     if not is_valid_type(_params["mode"], int):
@@ -52,7 +53,8 @@ def validate_params(_params, default):
     if _params["max_tries"] < 0 and default["max_tries"] != _params["max_tries"]:
         raise ValueError(
             "max_tries has to be a positive Integer")
-    if not is_valid_type(_params["val_poly"], float) and default["val_poly"] != _params["val_poly"]:
+    if not is_valid_type(_params["val_poly"], float) \
+            and default["val_poly"] != _params["val_poly"]:
         raise ValueError(
             "val_poly has to be a float")
     if _params["charge_distance"] < 0:
@@ -178,13 +180,28 @@ def create_polymer(**kwargs):
     params = default_params
 
     valid_keys = [
-        "N_P", "MPC", "bond_length", "bond", "start_id", "start_pos", "mode", "shield", "max_tries",
-        "val_poly", "charge_distance", "type_poly_neutral", "type_poly_charged", "angle", "angle2", "constraints", "pos2"]
+        "N_P",
+        "MPC",
+        "bond_length",
+        "bond",
+        "start_id",
+        "start_pos",
+        "mode",
+        "shield",
+        "max_tries",
+        "val_poly",
+        "charge_distance",
+        "type_poly_neutral",
+        "type_poly_charged",
+        "angle",
+        "angle2",
+        "constraints",
+        "pos2"]
 
     required_keys = ["N_P", "MPC", "bond_length", "bond", "start_pos"]
 
     for k in kwargs:
-        if not k in valid_keys:
+        if k not in valid_keys:
             raise ValueError("Unknown parameter '%s'" % k)
         params[k] = kwargs[k]
 
@@ -192,7 +209,8 @@ def create_polymer(**kwargs):
         if k not in kwargs:
             print(k)
             raise ValueError(
-                "At least the following keys have to be given as keyword arguments: " + required_keys.__str__())
+                "At least the following keys have to be given as keyword "
+                "arguments: " + required_keys.__str__())
 
     validate_params(params, default_params)
 
@@ -207,19 +225,16 @@ def create_polymer(**kwargs):
 
     if "pos2" in params:
         polymerC(
-            partCfg(), params["N_P"], params["MPC"], params[
-                "bond_length"], params["start_id"],
-             start_pos, params["mode"], params["shield"], params["max_tries"],
-             params["val_poly"], params[
-                 "charge_distance"], params["type_poly_neutral"],
-             params["type_poly_charged"], bond_id, params["angle"],
-             params["angle2"], start_pos2, params["constraints"])
+            partCfg(), params["N_P"], params["MPC"], params["bond_length"],
+            params["start_id"], start_pos, params["mode"], params["shield"],
+            params["max_tries"], params["val_poly"], params["charge_distance"],
+            params["type_poly_neutral"], params["type_poly_charged"], bond_id,
+            params["angle"], params["angle2"], start_pos2,
+            params["constraints"])
     else:
         polymerC(
-            partCfg(), params["N_P"], params["MPC"], params[
-                "bond_length"], params["start_id"],
-             start_pos, params["mode"], params["shield"], params["max_tries"],
-             params["val_poly"], params[
-                 "charge_distance"], params["type_poly_neutral"],
-             params["type_poly_charged"], bond_id, params["angle"],
-             params["angle2"], NULL, params["constraints"])
+            partCfg(), params["N_P"], params["MPC"], params["bond_length"],
+            params["start_id"], start_pos, params["mode"], params["shield"],
+            params["max_tries"], params["val_poly"], params["charge_distance"],
+            params["type_poly_neutral"], params["type_poly_charged"], bond_id,
+            params["angle"], params["angle2"], NULL, params["constraints"])


### PR DESCRIPTION
Fix broken samples and tutorials for the 4.0.1 release
@RudolfWeeber, @KaiSzuttor

Two samples don't run in my environment:

- `/samples/lj-demo.py` crashes when using Mayavi, but works fine with OpenGL
- `/samples/wang_landau_reaction_ensemble.py` does not seem to work (output: "Histogram is flat", "Refining: Wang-Landau parameter is now 1/t.")

@KonradBreitsprecher: could you please check that `/samples/espresso_logo.py` is now correctly using your new implementation of material types?