### PR TITLE
backport support for non-amd64 architectures to 4.0.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,14 +223,12 @@ ubuntu:wo-dependencies:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
     - export with_cuda=false
+    - export OMPI_MCA_btl_vader_single_copy_mechanism=none
     - export myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
-#  only:
-#    - tags
-#    - triggers
 
 ubuntu:arm64:
   <<: *arch_definition

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,11 @@ else()
   set(BOOST_MINIMUM_VERSION "1.53.0")
 endif()
 
+# old Boost.MPI versions contain a use-after-free bug that seems to only cause crashes on 32-bit architectures
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  set(BOOST_MINIMUM_VERSION "1.67.0")
+endif()
+
 find_package(Boost ${BOOST_MINIMUM_VERSION} REQUIRED ${BOOST_COMPONENTS})
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 list(APPEND LIBRARIES ${Boost_LIBRARIES})

--- a/src/core/unit_tests/field_coupling_fields_test.cpp
+++ b/src/core/unit_tests/field_coupling_fields_test.cpp
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(interpolated_scalar_field) {
         grid_spacing, origin, Vector3d{});
 
     BOOST_CHECK((interpolated_value - field_value).norm() <
-                std::numeric_limits<double>::epsilon());
+                2 * std::numeric_limits<double>::epsilon());
   }
 }
 

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -162,7 +162,7 @@ class DPDThermostat(ut.TestCase):
             v_stored[i*N:(i+1)*N,:] = s.part[:].v
         v_minmax = 5
         bins = 5
-        error_tol = 0.01
+        error_tol = 0.012
         self.check_velocity_distribution(
             v_stored, v_minmax, bins, error_tol, kT)
 
@@ -193,12 +193,12 @@ class DPDThermostat(ut.TestCase):
         s.integrator.run(0)
 
         # Only trans, so x component should be zero
-        self.assertTrue(s.part[0].f[0] == 0.)
+        self.assertLess(abs(s.part[0].f[0]), 1e-16)
         # f = gamma * v_ij
         self.assertTrue(abs(s.part[0].f[1] - gamma * v[1]) < 1e-11)
         self.assertTrue(abs(s.part[0].f[2] - gamma * v[2]) < 1e-11)
         # Momentum conservation
-        self.assertTrue(s.part[1].f[0] == 0.)
+        self.assertLess(abs(s.part[1].f[0]), 1e-16)
         self.assertTrue(abs(s.part[1].f[1] + gamma * v[1]) < 1e-11)
         self.assertTrue(abs(s.part[1].f[2] + gamma * v[2]) < 1e-11)
 
@@ -244,14 +244,14 @@ class DPDThermostat(ut.TestCase):
         s.integrator.run(0)
 
         # Only trans, so x component should be zero
-        self.assertTrue(s.part[0].f[0] == 0.)
+        self.assertLess(abs(s.part[0].f[0]), 1e-16)
         # f = gamma * v_ij
         self.assertTrue(
             abs(s.part[0].f[1] - omega(1.3, 1.4)**2*gamma*v[1]) < 1e-11)
         self.assertTrue(
             abs(s.part[0].f[2] - omega(1.3, 1.4)**2*gamma*v[2]) < 1e-11)
         # Momentum conservation
-        self.assertTrue(s.part[1].f[0] == 0.)
+        self.assertLess(abs(s.part[1].f[0]), 1e-16)
         self.assertTrue(
             abs(s.part[1].f[1] + omega(1.3, 1.4)**2*gamma*v[1]) < 1e-11)
         self.assertTrue(

--- a/testsuite/python/engine_lb.py
+++ b/testsuite/python/engine_lb.py
@@ -94,7 +94,7 @@ class SwimmerTest(ut.TestCase):
         else:
             lbm.print_vtk_velocity("engine_test_tmp.vtk")
             different, difference = tests_common.calculate_vtk_max_pointwise_difference(
-                vtk_name, "engine_test_tmp.vtk", tol=2.0e-7)
+                vtk_name, "engine_test_tmp.vtk", tol=1.5e-6)
             os.remove("engine_test_tmp.vtk")
             print(
                 "Maximum deviation to the reference point is: {}".format(difference))

--- a/testsuite/python/subt_lj.py
+++ b/testsuite/python/subt_lj.py
@@ -57,7 +57,7 @@ class SubtLjTest(ut.TestCase):
         print(s.analysis.energy())
 
         self.assertAlmostEqual(f, 0, places=10)
-        self.assertAlmostEqual(s.analysis.energy()['total'], 0, places=10)
+        self.assertAlmostEqual(s.analysis.energy()['total'], 0, places=9)
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
Backported from #2401

@RudolfWeeber