### PR TITLE
Speedup back assignment of forces/torques from gpu methods

### DIFF
--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -266,7 +266,7 @@ void gpu_change_number_of_part_to_comm() {
           cudaHostAlloc((void **)&particle_data_host,
                         global_part_vars_host.number_of_particles *
                             sizeof(CUDA_particle_data),
-                        cudaHostAllocWriteCombined | cudaHostAllocMapped));
+                        cudaHostAllocWriteCombined ));
       particle_forces_host = (float *)malloc(
           3 * global_part_vars_host.number_of_particles * sizeof(float));
 

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -154,8 +154,9 @@ void cuda_mpi_get_particles(ParticleRange particles,
  * @param torques The torques as flat array of size 3 * particles.size(),
  *                this is only touched if ROTATION is active.
  */
-static void add_forces_and_torques(ParticleRange particles, float *forces,
-                                   float *torques) {
+static void add_forces_and_torques(ParticleRange particles,
+                                   const std::vector<float> &forces,
+                                   const std::vector<float> &torques) {
   int i = 0;
   for (auto &part : particles) {
     for (int j = 0; j < 3; j++) {
@@ -168,8 +169,9 @@ static void add_forces_and_torques(ParticleRange particles, float *forces,
   }
 }
 
-void cuda_mpi_send_forces(ParticleRange particles, float *host_forces,
-                          float *host_torques = nullptr) {
+void cuda_mpi_send_forces(ParticleRange particles,
+                          std::vector<float> &host_forces,
+                          std::vector<float> &host_torques) {
   auto const n_elements = 3 * particles.size();
 
   if (this_node > 0) {
@@ -186,13 +188,12 @@ void cuda_mpi_send_forces(ParticleRange particles, float *host_forces,
     Utils::Mpi::scatter_buffer(buffer_torques.data(), n_elements, comm_cart);
 #endif
 
-    add_forces_and_torques(particles, buffer_forces.data(),
-                           buffer_torques.data());
+    add_forces_and_torques(particles, buffer_forces, buffer_torques);
   } else {
     /* Scatter forces to slaves */
-    Utils::Mpi::scatter_buffer(host_forces, n_elements, comm_cart);
+    Utils::Mpi::scatter_buffer(host_forces.data(), n_elements, comm_cart);
 #ifdef ROTATION
-    Utils::Mpi::scatter_buffer(host_torques, n_elements, comm_cart);
+    Utils::Mpi::scatter_buffer(host_torques.data(), n_elements, comm_cart);
 #endif
 
     add_forces_and_torques(particles, host_forces, host_torques);
@@ -230,18 +231,20 @@ void cuda_mpi_send_composition(ParticleRange particles,
 
 #if defined(ENGINE) && defined(LB_GPU)
 namespace {
-void set_v_cs(ParticleRange particles, CUDA_v_cs *v_cs) {
+void set_v_cs(ParticleRange particles, const std::vector<CUDA_v_cs> &v_cs) {
+  int ind = 0;
   for (auto &p : particles) {
     for (int i = 0; i < 3; i++) {
-      p.swim.v_center[i] = v_cs->v_cs[0 + i];
-      p.swim.v_source[i] = v_cs->v_cs[3 + i];
+      p.swim.v_center[i] = v_cs[ind].v_cs[0 + i];
+      p.swim.v_source[i] = v_cs[ind].v_cs[3 + i];
     }
-    v_cs++;
+    ind++;
   }
 }
 } // namespace
 
-void cuda_mpi_send_v_cs(ParticleRange particles, CUDA_v_cs *host_v_cs) {
+void cuda_mpi_send_v_cs(ParticleRange particles,
+                        std::vector<CUDA_v_cs> host_v_cs) {
   // first collect number of particles on each node
   auto const n_part = particles.size();
 
@@ -250,9 +253,9 @@ void cuda_mpi_send_v_cs(ParticleRange particles, CUDA_v_cs *host_v_cs) {
     std::vector<CUDA_v_cs> buffer(n_part);
 
     Utils::Mpi::scatter_buffer(buffer.data(), n_part, comm_cart);
-    set_v_cs(particles, buffer.data());
+    set_v_cs(particles, buffer);
   } else {
-    Utils::Mpi::scatter_buffer(host_v_cs, n_part, comm_cart);
+    Utils::Mpi::scatter_buffer(host_v_cs.data(), n_part, comm_cart);
     set_v_cs(particles, host_v_cs);
   }
   COMM_TRACE(fprintf(stderr, "%d: finished send\n", this_node));

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -168,8 +168,9 @@ void copy_part_data_to_gpu(ParticleRange particles);
  *
  * This is a collective call.
  */
-void cuda_mpi_send_forces(ParticleRange particles, float *host_forces,
-                          float *host_torques);
+void cuda_mpi_send_forces(ParticleRange particles,
+                          std::vector<float> &host_forces,
+                          std::vector<float> &host_torques);
 void cuda_bcast_global_part_params();
 void cuda_copy_to_device(void *host_data, void *device_data, size_t n);
 void cuda_copy_to_host(void *host_device, void *device_host, size_t n);
@@ -180,7 +181,8 @@ void cuda_mpi_send_composition(ParticleRange, CUDA_fluid_composition *);
 
 #ifdef ENGINE
 void copy_v_cs_from_GPU(ParticleRange particles);
-void cuda_mpi_send_v_cs(ParticleRange particles, CUDA_v_cs *host_v_cs);
+void cuda_mpi_send_v_cs(ParticleRange particles,
+                        std::vector<CUDA_v_cs> host_v_cs);
 #endif
 
 #endif /* ifdef CUDA */


### PR DESCRIPTION
By not using cuda pinned memory. 
In lj+lb fluids with n=1000, phi=0.1, agrid=sigma, this increases performance by a third.
