### PR TITLE
Fix dp3m ifdefs; dawaanr-and-bh-gpu testcase requirements

### DIFF
--- a/src/core/electrostatics_magnetostatics/fft.cpp
+++ b/src/core/electrostatics_magnetostatics/fft.cpp
@@ -27,7 +27,7 @@
 
 #include "fft.hpp"
 
-#ifdef P3M
+#if defined(P3M) || defined(DP3M)
 #include "communication.hpp"
 #include "debug.hpp"
 #include "fft-common.hpp"

--- a/src/core/electrostatics_magnetostatics/fft.hpp
+++ b/src/core/electrostatics_magnetostatics/fft.hpp
@@ -43,7 +43,7 @@
  */
 
 #include "config.hpp"
-#ifdef P3M
+#if defined(P3M) || defined(DP3M)
 
 #include "fft-common.hpp"
 

--- a/testsuite/python/dawaanr-and-bh-gpu.py
+++ b/testsuite/python/dawaanr-and-bh-gpu.py
@@ -34,7 +34,8 @@ def stopAll(system):
     system.part[:].omega_body = np.zeros(3)
 
 
-@ut.skipIf(not espressomd.has_features(["DIPOLAR_BARNES_HUT"]),
+@ut.skipIf(not espressomd.has_features(["DIPOLAR_BARNES_HUT",
+                                        "PARTIAL_PERIODIC"]),
            "Features not available, skipping test!")
 @ut.skipIf(espressomd.has_features(["CUDA"]) and
            str(espressomd.cuda_init.CudaInitHandle().device_list[0]) ==


### PR DESCRIPTION
1.) Due to wrong `#ifdef`s, ESPResSo build failed when trying to build with `DIPOLES` **and** without `ELECTROSTATICS` feature:
```
In file included from /tikhome/pkreissl/git/espresso/src/core/initialize.cpp:40:0:
/tikhome/pkreissl/git/espresso/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp:102:3: error: ‘fft_data_struct’ does not name a type; did you mean ‘MPI_Type_struct’?
   fft_data_struct fft;
   ^~~~~~~~~~~~~~~
   MPI_Type_struct
```
This issue was introduced in  PR #2455.

2.) The testcase `dawaanr-and-bh-gpu.py` requires both `DIPOLES` and `PARTIAL_PERIODIC` feature. However, as it didn't check for the latter, the testcase failed when building with `DIPOLES` and without `PARTIAL_PERIODIC` feature.

Description of changes:
 - Described issues are fixed by this PR
