### PR TITLE
Add check dependency only if target is existent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,8 +21,10 @@
 # Target for the unit tests
 add_custom_target(check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) --output-on-failure)
 
-# Run unit tests on check
-add_dependencies(check check_unit_tests)
+if(WITH_TESTS)
+  # Run unit tests on check
+  add_dependencies(check check_unit_tests)
+endif(WITH_TESTS)
 
 # unit_test function
 function(UNIT_TEST)


### PR DESCRIPTION
Fixes build without tests on my machine (CMake 3.10.2).

On a freshly checked out ESPResSo if you invoke CMake with "-DWITH_TESTS=off", I get the following CMake error:

```
CMake Error at src/CMakeLists.txt:25 (add_dependencies):
  Cannot add target-level dependencies to non-existent target "check".

  The add_dependencies works for top-level logical targets created by the
  add_executable, add_library, or add_custom_target commands.  If you want to
  add file-level dependencies see the DEPENDS option of the add_custom_target
  and add_custom_command commands.
```

This commit fixes this problem: add_dependency is only executed if WITH_TESTS is set.

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
