### PR TITLE
Early exit from pair force kernel

### DIFF
--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -270,18 +270,18 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
   double torque1[3] = {0., 0., 0.};
   double torque2[3] = {0., 0., 0.};
   int j;
-  
+
   // Early exit if there is no interactoin to calculate
   // The exception for MMM2d is there, because the method assumes that
   // pairs within a cell system layer but outside the cutoff are considered
-  
+
 #ifdef ELECTROSTATICS
-  if (!(coulomb.method==COULOMB_MMM2D))
+  if (!(coulomb.method == COULOMB_MMM2D))
 #endif
-{
-  if (dist > max_cut)
-    return;
-}
+  {
+    if (dist > max_cut)
+      return;
+  }
 
   /***********************************************/
   /* bond creation and breaking                  */

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -294,16 +294,20 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
   /***********************************************/
   /* non bonded pair potentials                  */
   /***********************************************/
+  if (dist > max_cut)
+    return;
 
+  if (dist < ia_params->max_cut) {
 #ifdef EXCLUSIONS
-  if (do_nonbonded(p1, p2))
+    if (do_nonbonded(p1, p2))
 #endif
-    calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, dist2, force.data(),
-                               torque1, torque2);
+      calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, dist2,
+                                 force.data(), torque1, torque2);
+  }
 
-    /***********************************************/
-    /* short range electrostatics                  */
-    /***********************************************/
+  /***********************************************/
+  /* short range electrostatics                  */
+  /***********************************************/
 
 #ifdef ELECTROSTATICS
   if (coulomb.method == COULOMB_DH)

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -270,6 +270,18 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
   double torque1[3] = {0., 0., 0.};
   double torque2[3] = {0., 0., 0.};
   int j;
+  
+  // Early exit if there is no interactoin to calculate
+  // The exception for MMM2d is there, because the method assumes that
+  // pairs within a cell system layer but outside the cutoff are considered
+  
+#ifdef ELECTROSTATICS
+  if (!(coulomb.method==COULOMB_MMM2D))
+#endif
+{
+  if (dist > max_cut)
+    return;
+}
 
   /***********************************************/
   /* bond creation and breaking                  */
@@ -294,8 +306,6 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
   /***********************************************/
   /* non bonded pair potentials                  */
   /***********************************************/
-  if (dist > max_cut)
-    return;
 
   if (dist < ia_params->max_cut) {
 #ifdef EXCLUSIONS

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
@@ -359,6 +359,11 @@ static void recalc_maximal_cutoff_nonbonded() {
       if (max_cut_current < data->REACTION_range)
         max_cut_current = data->REACTION_range;
 #endif
+#ifdef THOLE
+    // If THOLE is active, use p3m cutoff
+    if (data->THOLE_scaling_coeff!=0) 
+      max_cut_current = std::max(max_cut_current, p3m.params.r_cut);
+#endif
 
       IA_parameters *data_sym = get_ia_param(j, i);
 

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
@@ -360,9 +360,9 @@ static void recalc_maximal_cutoff_nonbonded() {
         max_cut_current = data->REACTION_range;
 #endif
 #ifdef THOLE
-    // If THOLE is active, use p3m cutoff
-    if (data->THOLE_scaling_coeff!=0) 
-      max_cut_current = std::max(max_cut_current, p3m.params.r_cut);
+      // If THOLE is active, use p3m cutoff
+      if (data->THOLE_scaling_coeff != 0)
+        max_cut_current = std::max(max_cut_current, p3m.params.r_cut);
 #endif
 
       IA_parameters *data_sym = get_ia_param(j, i);


### PR DESCRIPTION
This adds a cutoff check to the beginning of the pair force kernel. Performance improvement is 10-15% for an LJ fluid (phi=0.2 and 0.4 tested).
The performance improvement is larger when more features are compiled in.
