### PR TITLE
ci: Limit tests with non-standard architectures to scheduled pipeline…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,8 +239,8 @@ rocm-maxset:
   tags:
     - docker
     - linux
-  except:
-    - /^PR-.*/
+  only:
+    - scheduled
 
 ubuntu:arm64:
   <<: *arch_definition


### PR DESCRIPTION
… runs. Because they take to long.