### PR TITLE
CI: remove timestamp manipulation.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -323,7 +323,8 @@ check_sphinx:
   - cuda8-maxset
   when: on_success
   script:
-    - cd ${CI_PROJECT_DIR}; cd build && find ./ -exec touch -c -t 203901010000 {} \; && make sphinx
+    - cd ${CI_PROJECT_DIR}/build
+    - make sphinx
   tags:
     - docker
     - linux


### PR DESCRIPTION
This removes the cluttered output in the CI log.
