### PR TITLE
Re-enable AMD GPU tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,7 +217,7 @@ rocm-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/rocm:latest
   script:
-    - export myconfig=maxset make_check=false
+    - export myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
   tags:
     - amdgpu


### PR DESCRIPTION
Fixes #2472 

This problem was probably caused by incorrect CPU pinning. I have now pinned Condor to 12 cores and Gitlab Runner to the remaining 4 cores, so they should not be competing anymore.