### PR TITLE
Expose Shape.calc_distance() in Python

### DIFF
--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -163,7 +163,7 @@ cdef class PScriptInterface(object):
         elif np.issubdtype(np.dtype(type(value)), np.floating):
             return make_variant[double](value)
         else:
-            raise TypeError("Unkown type for conversion to Variant")
+            raise TypeError("Unknown type for conversion to Variant")
 
     cdef variant_to_python_object(self, Variant value) except +:
         cdef ObjectId oid
@@ -219,7 +219,7 @@ cdef class PScriptInterface(object):
 
             return res
 
-        raise Exception("Unkown type")
+        raise Exception("Unknown type")
 
     def get_parameter(self, name):
         cdef Variant value = self.sip.get().get_parameter(to_char_pointer(name))

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -18,7 +18,13 @@ from .script_interface import ScriptInterfaceHelper, script_interface_register
 
 
 @script_interface_register
-class Cylinder(ScriptInterfaceHelper):
+class Shape(ScriptInterfaceHelper):
+    _so_name = "Shapes::Shape"
+    _so_bind_methods = ("calc_distance",)
+
+
+@script_interface_register
+class Cylinder(Shape):
 
     """
     A cylinder shape.
@@ -41,11 +47,10 @@ class Cylinder(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Cylinder"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class Ellipsoid(ScriptInterfaceHelper):
+class Ellipsoid(Shape):
 
     """
     An ellipsoid.
@@ -66,11 +71,10 @@ class Ellipsoid(ScriptInterfaceHelper):
        out of the mantel, for -1 it points inward.
     """
     _so_name = "Shapes::Ellipsoid"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class HollowCone(ScriptInterfaceHelper):
+class HollowCone(Shape):
 
     """
     A hollow cone shape.
@@ -95,11 +99,10 @@ class HollowCone(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::HollowCone"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class Rhomboid(ScriptInterfaceHelper):
+class Rhomboid(Shape):
 
     """
     An parallelepiped.
@@ -120,11 +123,10 @@ class Rhomboid(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Rhomboid"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class Slitpore(ScriptInterfaceHelper):
+class Slitpore(Shape):
 
     """
 
@@ -143,11 +145,10 @@ class Slitpore(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Slitpore"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class Sphere(ScriptInterfaceHelper):
+class Sphere(Shape):
 
     """
     A sphere.
@@ -164,11 +165,10 @@ class Sphere(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Sphere"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class SpheroCylinder(ScriptInterfaceHelper):
+class SpheroCylinder(Shape):
 
     """
     A cylinder with hemispheres as caps.
@@ -189,11 +189,10 @@ class SpheroCylinder(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::SpheroCylinder"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class Stomatocyte(ScriptInterfaceHelper):
+class Stomatocyte(Shape):
 
     """
     Attributes
@@ -215,11 +214,10 @@ class Stomatocyte(ScriptInterfaceHelper):
     """
 
     _so_name = "Shapes::Stomatocyte"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class Torus(ScriptInterfaceHelper):
+class Torus(Shape):
 
     """
     A torus shape.
@@ -239,11 +237,10 @@ class Torus(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Torus"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class Wall(ScriptInterfaceHelper):
+class Wall(Shape):
 
     """
     An infinite plane.
@@ -257,11 +254,10 @@ class Wall(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Wall"
-    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
-class SimplePore(ScriptInterfaceHelper):
+class SimplePore(Shape):
 
     """
     Two parallel infinite planes, and a cylindrical orfice connecting them.
@@ -283,4 +279,3 @@ class SimplePore(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::SimplePore"
-    _so_bind_methods = ['calc_distance']

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -17,14 +17,12 @@
 from .script_interface import ScriptInterfaceHelper, script_interface_register
 
 
-@script_interface_register
-class Shape(ScriptInterfaceHelper):
-    _so_name = "Shapes::Shape"
+class Shape(object):
     _so_bind_methods = ("calc_distance",)
 
 
 @script_interface_register
-class Cylinder(Shape):
+class Cylinder(Shape, ScriptInterfaceHelper):
 
     """
     A cylinder shape.
@@ -50,7 +48,7 @@ class Cylinder(Shape):
 
 
 @script_interface_register
-class Ellipsoid(Shape):
+class Ellipsoid(Shape, ScriptInterfaceHelper):
 
     """
     An ellipsoid.
@@ -74,7 +72,7 @@ class Ellipsoid(Shape):
 
 
 @script_interface_register
-class HollowCone(Shape):
+class HollowCone(Shape, ScriptInterfaceHelper):
 
     """
     A hollow cone shape.
@@ -102,7 +100,7 @@ class HollowCone(Shape):
 
 
 @script_interface_register
-class Rhomboid(Shape):
+class Rhomboid(Shape, ScriptInterfaceHelper):
 
     """
     An parallelepiped.
@@ -126,7 +124,7 @@ class Rhomboid(Shape):
 
 
 @script_interface_register
-class Slitpore(Shape):
+class Slitpore(Shape, ScriptInterfaceHelper):
 
     """
 
@@ -148,7 +146,7 @@ class Slitpore(Shape):
 
 
 @script_interface_register
-class Sphere(Shape):
+class Sphere(Shape, ScriptInterfaceHelper):
 
     """
     A sphere.
@@ -168,7 +166,7 @@ class Sphere(Shape):
 
 
 @script_interface_register
-class SpheroCylinder(Shape):
+class SpheroCylinder(Shape, ScriptInterfaceHelper):
 
     """
     A cylinder with hemispheres as caps.
@@ -192,7 +190,7 @@ class SpheroCylinder(Shape):
 
 
 @script_interface_register
-class Stomatocyte(Shape):
+class Stomatocyte(Shape, ScriptInterfaceHelper):
 
     """
     Attributes
@@ -217,7 +215,7 @@ class Stomatocyte(Shape):
 
 
 @script_interface_register
-class Torus(Shape):
+class Torus(Shape, ScriptInterfaceHelper):
 
     """
     A torus shape.
@@ -240,7 +238,7 @@ class Torus(Shape):
 
 
 @script_interface_register
-class Wall(Shape):
+class Wall(Shape, ScriptInterfaceHelper):
 
     """
     An infinite plane.
@@ -257,7 +255,7 @@ class Wall(Shape):
 
 
 @script_interface_register
-class SimplePore(Shape):
+class SimplePore(Shape, ScriptInterfaceHelper):
 
     """
     Two parallel infinite planes, and a cylindrical orfice connecting them.

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -241,6 +241,7 @@ class Torus(ScriptInterfaceHelper):
     _so_name = "Shapes::Torus"
     _so_bind_methods = ['calc_distance']
 
+
 @script_interface_register
 class Wall(ScriptInterfaceHelper):
 

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -41,6 +41,7 @@ class Cylinder(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Cylinder"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -65,6 +66,7 @@ class Ellipsoid(ScriptInterfaceHelper):
        out of the mantel, for -1 it points inward.
     """
     _so_name = "Shapes::Ellipsoid"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -93,6 +95,7 @@ class HollowCone(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::HollowCone"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -117,6 +120,7 @@ class Rhomboid(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Rhomboid"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -139,6 +143,7 @@ class Slitpore(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Slitpore"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -159,6 +164,7 @@ class Sphere(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Sphere"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -183,6 +189,7 @@ class SpheroCylinder(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::SpheroCylinder"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -208,6 +215,7 @@ class Stomatocyte(ScriptInterfaceHelper):
     """
 
     _so_name = "Shapes::Stomatocyte"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -231,7 +239,7 @@ class Torus(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Torus"
-
+    _so_bind_methods = ['calc_distance']
 
 @script_interface_register
 class Wall(ScriptInterfaceHelper):
@@ -248,6 +256,7 @@ class Wall(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::Wall"
+    _so_bind_methods = ['calc_distance']
 
 
 @script_interface_register
@@ -273,3 +282,4 @@ class SimplePore(ScriptInterfaceHelper):
 
     """
     _so_name = "Shapes::SimplePore"
+    _so_bind_methods = ['calc_distance']

--- a/src/script_interface/constraints/fields.hpp
+++ b/src/script_interface/constraints/fields.hpp
@@ -114,7 +114,7 @@ struct field_params_impl<Interpolated<T, codim>> {
     }
 
     if (*std::min_element(field_shape.begin(), field_shape.end()) < 1) {
-      throw std::runtime_error("Field is to small, needs to be at least "
+      throw std::runtime_error("Field is too small, needs to be at least "
                                "one in all directions.");
     }
 

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -163,22 +163,13 @@ class ShapeBasedConstraintTest(ut.TestCase):
         # check force calculation of cylinder constraint
         interaction_dir = -1  # constraint is directed inwards
         cylinder_shape = espressomd.shapes.Cylinder(
-            center=[
-                self.box_l /
-                2.0,
-                self.box_l /
-                2.0,
-                self.box_l /
-                2.0],
-            axis=[
-                0,
-                0,
-                1],
+            center=[self.box_l / 2.0,
+                    self.box_l / 2.0,
+                    self.box_l / 2.0],
+            axis=[0, 0, 1],
             direction=interaction_dir,
-            radius=self.box_l /
-            2.0,
-            length=self.box_l +
-            5)  # +5 in order to have no top or bottom
+            radius=self.box_l / 2.0,
+            length=self.box_l + 5)  # +5 in order to have no top or bottom
         penetrability = False  # impenetrable
         outer_cylinder_constraint = espressomd.constraints.ShapeBasedConstraint(
             shape=cylinder_shape, particle_type=1, penetrable=penetrability)

--- a/testsuite/python/simple_pore.py
+++ b/testsuite/python/simple_pore.py
@@ -35,10 +35,10 @@ class SimplePoreConstraint(ut.TestCase):
         pore = SimplePore(
             axis=[1., 0., 0.], radius=2., smoothing_radius=.1, length=2., center=[5., 5., 5.])
 
-        d, _ = pore.call_method("calc_distance", position=[.0, .0, .0])
+        d, _ = pore.calc_distance(position=[.0, .0, .0])
         self.assertGreater(d, 0.)
 
-        d, _ = pore.call_method("calc_distance", position=[5., 5., .0])
+        d, _ = pore.calc_distance(position=[5., 5., .0])
         self.assertLess(d, 0.)
 
     def test_stability(self):


### PR DESCRIPTION
Fixes #2495

There is unfortunately no Python docstring to document the `calc_distance` method. Maybe it could be added programmatically using the following logic in `/src/python/espressomd/script_interface.pyx`:

```python
class ScriptInterfaceHelper(PScriptInterface):
    _so_name = None
    _so_bind_methods = {}
    ...
    def generate_caller(self, method_name, docstring=""):
        def template_method(**kwargs):
            res = self.call_method(method_name, **kwargs)
            return res
        template_method.__doc__ = docstring
        return template_method

    def define_bound_methods(self):
        if not isinstance(self._so_bind_methods, dict):
            self._so_bind_methods = {x: "" for x in self._so_bind_methods}
        for method_name, method_doc in self._so_bind_methods.items():
            setattr(self, method_name, self.generate_caller(method_name, method_doc))
```
after which `help(shape.calc_distance)` generates:
```
Help on cython_function_or_method in module espressomd.script_interface:

template_method(**kwargs)
    Calculate the distance between a point and the shape surface.
```
which is not very helpful: the method name is shown as `template_method` and the docstring does not appear in the Sphinx documentation.

PR Checklist
------------
 - [x] Tests?
   - [x] Interface
   - [x] Core 
 - [x] Docs?
