### PR TITLE
Re-enable exotic architectures and set time limit for tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -228,7 +228,7 @@ rocm-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
-    - export with_cuda=false
+    - export with_cuda=false test_timeout=900
     - export OMPI_MCA_btl_vader_single_copy_mechanism=none
     - export myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
@@ -236,7 +236,7 @@ rocm-maxset:
     - docker
     - linux
   only:
-    - scheduled
+    - schedules
 
 ubuntu:arm64:
   <<: *arch_definition

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ endif()
 option(WARNINGS_ARE_ERRORS "Treat warnings as errors during compilation" OFF)
 option(WITH_CCACHE "Use ccache compiler invocation." OFF)
 option(WITH_PROFILER "Enable profiler annotations." OFF)
+option(TEST_TIMEOUT "Timeout in seconds for each testsuite test" "300")
 
 if(WITH_CCACHE)
   find_program(CCACHE ccache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 option(WARNINGS_ARE_ERRORS "Treat warnings as errors during compilation" OFF)
 option(WITH_CCACHE "Use ccache compiler invocation." OFF)
 option(WITH_PROFILER "Enable profiler annotations." OFF)
-option(TEST_TIMEOUT "Timeout in seconds for each testsuite test" "300")
+set(TEST_TIMEOUT "300" CACHE STRING "Timeout in seconds for each testsuite test")
 
 if(WITH_CCACHE)
   find_program(CCACHE ccache)

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -66,6 +66,7 @@ function cmd {
 [ -z "$with_cuda" ] && with_cuda="true"
 [ -z "$build_type" ] && build_type="Debug"
 [ -z "$with_ccache" ] && with_ccache="false"
+[ -z "$test_timeout" ] && test_timeout="300"
 
 # If there are no user-provided flags they
 # are added according to with_coverage.
@@ -88,6 +89,7 @@ fi
 cmake_params="-DCMAKE_BUILD_TYPE=$build_type -DPYTHON_EXECUTABLE=$(which python$python_version) -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=$check_procs $cmake_params -DWITH_SCAFACOS=ON"
 cmake_params="$cmake_params -DCMAKE_CXX_FLAGS=$cxx_flags"
 cmake_params="$cmake_params -DCMAKE_INSTALL_PREFIX=/tmp/espresso-unit-tests"
+cmake_params="$cmake_params -DTEST_TIMEOUT=$test_timeout"
 if $with_ccache; then
   cmake_params="$cmake_params -DWITH_CCACHE=ON"
 fi
@@ -236,15 +238,15 @@ if $make_check; then
     if [ -z "$run_tests" ]; then
         if $check_odd_only; then
             cmd "make -j${build_procs} check_python_parallel_odd $make_params" || exit 1
-	elif $check_gpu_only; then
-	    cmd "make -j${build_procs} check_python_gpu $make_params" || exit 1
+        elif $check_gpu_only; then
+            cmd "make -j${build_procs} check_python_gpu $make_params" || exit 1
         else
             cmd "make -j${build_procs} check_python $make_params" || exit 1
         fi
     else
         cmd "make python_tests $make_params"
         for t in $run_tests; do
-            cmd "ctest --output-on-failure -R $t" || exit 1
+            cmd "ctest --timeout 60 --output-on-failure -R $t" || exit 1
         done
     fi
     cmd "make -j${build_procs} check_unit_tests $make_params" || exit 1

--- a/maintainer/benchmarks/CMakeLists.txt
+++ b/maintainer/benchmarks/CMakeLists.txt
@@ -78,10 +78,10 @@ python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=10000;--volume_fract
 python_benchmark(FILE p3m.py ARGUMENTS "--particles_per_core=1000;--volume_fraction=0.25;--bjerrum_length=4")
 python_benchmark(FILE p3m.py ARGUMENTS "--particles_per_core=10000;--volume_fraction=0.25;--bjerrum_length=4")
 
-add_custom_target(benchmark_python_serial COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) -C serial --output-on-failure)
+add_custom_target(benchmark_python_serial COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} $(ARGS) -C serial --output-on-failure)
 add_dependencies(benchmark_python_serial pypresso)
 
-add_custom_target(benchmark_python_parallel COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) -C parallel --output-on-failure)
+add_custom_target(benchmark_python_parallel COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} $(ARGS) -C parallel --output-on-failure)
 add_dependencies(benchmark_python_parallel pypresso)
 
 add_custom_target(benchmark_python)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@
 #
 
 # Target for the unit tests
-add_custom_target(check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS) --output-on-failure)
+add_custom_target(check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} $(ARGS) --output-on-failure)
 
 if(WITH_TESTS)
   # Run unit tests on check

--- a/testsuite/cmake/CMakeLists.txt
+++ b/testsuite/cmake/CMakeLists.txt
@@ -35,6 +35,6 @@ endif()
 
 cmake_test(FILE test_python_bindings.sh DEPENDENCIES BashUnitTests.sh)
 
-add_custom_target(check_cmake_install COMMAND ${CMAKE_CTEST_COMMAND} -C serial --output-on-failure)
+add_custom_target(check_cmake_install COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -C serial --output-on-failure)
 add_dependencies(check_cmake_install setup_install)
 

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -189,12 +189,12 @@ add_custom_target(python_test_data
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/ek_eof_one_species_base.py ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-add_custom_target(check_python_parallel_odd COMMAND ${CMAKE_CTEST_COMMAND} -j${TEST_NP} -L parallel_odd $(ARGS) --output-on-failure)
+add_custom_target(check_python_parallel_odd COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -j${TEST_NP} -L parallel_odd $(ARGS) --output-on-failure)
 add_dependencies(check_python_parallel_odd pypresso python_test_data)
-add_custom_target(check_python_gpu COMMAND ${CMAKE_CTEST_COMMAND} -j${TEST_NP} -L gpu $(ARGS) --output-on-failure)
+add_custom_target(check_python_gpu COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -j${TEST_NP} -L gpu $(ARGS) --output-on-failure)
 add_dependencies(check_python_gpu pypresso python_test_data)
 
-add_custom_target(check_python COMMAND ${CMAKE_CTEST_COMMAND} -j${TEST_NP} $(ARGS) --output-on-failure)
+add_custom_target(check_python COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -j${TEST_NP} $(ARGS) --output-on-failure)
 add_dependencies(check_python pypresso python_test_data)
 add_dependencies(check check_python)
 


### PR DESCRIPTION
Fixes #2475. I have also increased the timeout to 6h now.