### PR TITLE
Suppress gcov output in CI

### DIFF
--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -279,9 +279,9 @@ if $with_coverage; then
     lcov -q --remove coverage.info '*/doc/*' --output-file coverage.info # filter out docs
     # Uploading report to CodeCov
     if [ -z "$CODECOV_TOKEN" ]; then
-        bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+        bash <(curl -s https://codecov.io/bash) -X gcovout || echo "Codecov did not collect coverage reports"
     else
-        bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" || echo "Codecov did not collect coverage reports"
+        bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -X gcovout || echo "Codecov did not collect coverage reports"
     fi
 fi
 


### PR DESCRIPTION
gcove produces thousands of lines of output so that the actual build output can only be seen in Gitlab CI after clicking the "Raw log" link. It seems like codecov finally updated to https://github.com/codecov/codecov-bash/issues/121, so we can use it now.