### PR TITLE
Use the implementation-defined EOF value

### DIFF
--- a/src/core/PdbParser.cpp
+++ b/src/core/PdbParser.cpp
@@ -79,8 +79,6 @@ bool PdbParser::parse_pdb_file(const string &filename) {
 bool PdbParser::parse_itp_file(const string &filename) {
   ifstream file(filename.c_str());
   string tmp, buf;
-  const decltype(buf)::value_type EOF_value =
-      std::char_traits<decltype(buf)::value_type>::eof();
   itp_atom atom;
   std::size_t pos;
 
@@ -118,7 +116,7 @@ bool PdbParser::parse_itp_file(const string &filename) {
             buf = char(file.get());
 
             /* Ignore leading whitespace, check for end of file */
-            if (std::isspace(buf[0]) || (buf[0] == EOF_value)) {
+            if (std::isspace(buf[0]) || file.eof()) {
               continue;
             }
             /* End of atoms section */
@@ -158,7 +156,7 @@ bool PdbParser::parse_itp_file(const string &filename) {
             }
 
             /* Ignore leading whitespace, check for end of file */
-            if (std::isspace(buf[0]) || (buf[0] == EOF_value)) {
+            if (std::isspace(buf[0]) || file.eof()) {
               continue;
             }
 

--- a/src/core/PdbParser.cpp
+++ b/src/core/PdbParser.cpp
@@ -79,6 +79,8 @@ bool PdbParser::parse_pdb_file(const string &filename) {
 bool PdbParser::parse_itp_file(const string &filename) {
   ifstream file(filename.c_str());
   string tmp, buf;
+  const decltype(buf)::value_type EOF_value =
+      std::char_traits<decltype(buf)::value_type>::eof();
   itp_atom atom;
   std::size_t pos;
 
@@ -87,7 +89,7 @@ bool PdbParser::parse_itp_file(const string &filename) {
 
   while (file.good()) {
     try {
-      buf = char(file.get());
+      buf = file.get();
       /* Skip leading whitespace */
       if (std::isspace(buf[0]))
         continue;
@@ -113,11 +115,10 @@ bool PdbParser::parse_itp_file(const string &filename) {
 
         if (section == "atoms") {
           while (file.good()) {
-            buf = char(file.get());
+            buf = file.get();
 
-            /* Ignore leading whitespace, check for end of file (standard says
-             * EOF is "generally" -1) */
-            if (std::isspace(buf[0]) || (buf[0] == -1)) {
+            /* Ignore leading whitespace, check for end of file */
+            if (std::isspace(buf[0]) || (buf[0] == EOF_value)) {
               continue;
             }
             /* End of atoms section */
@@ -144,7 +145,7 @@ bool PdbParser::parse_itp_file(const string &filename) {
           itp_atomtype type;
           std::string type_name;
           while (file.good()) {
-            buf = char(file.get());
+            buf = file.get();
 
             /* Ignore leading whitespace */
             if (std::isspace(buf[0])) {
@@ -156,9 +157,8 @@ bool PdbParser::parse_itp_file(const string &filename) {
               break;
             }
 
-            /* Ignore leading whitespace, check for end of file (standard says
-             * EOF is "generally" -1) */
-            if (std::isspace(buf[0]) || (buf[0] == -1)) {
+            /* Ignore leading whitespace, check for end of file */
+            if (std::isspace(buf[0]) || (buf[0] == EOF_value)) {
               continue;
             }
 

--- a/src/core/PdbParser.cpp
+++ b/src/core/PdbParser.cpp
@@ -89,7 +89,7 @@ bool PdbParser::parse_itp_file(const string &filename) {
 
   while (file.good()) {
     try {
-      buf = file.get();
+      buf = char(file.get());
       /* Skip leading whitespace */
       if (std::isspace(buf[0]))
         continue;
@@ -115,7 +115,7 @@ bool PdbParser::parse_itp_file(const string &filename) {
 
         if (section == "atoms") {
           while (file.good()) {
-            buf = file.get();
+            buf = char(file.get());
 
             /* Ignore leading whitespace, check for end of file */
             if (std::isspace(buf[0]) || (buf[0] == EOF_value)) {
@@ -145,7 +145,7 @@ bool PdbParser::parse_itp_file(const string &filename) {
           itp_atomtype type;
           std::string type_name;
           while (file.good()) {
-            buf = file.get();
+            buf = char(file.get());
 
             /* Ignore leading whitespace */
             if (std::isspace(buf[0])) {

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -68,4 +68,4 @@ unit_test(NAME field_coupling_force_field SRC field_coupling_force_field_test.cp
 unit_test(NAME Span_test SRC Span_test.cpp)
 unit_test(NAME periodic_fold_test SRC periodic_fold_test.cpp)
 unit_test(NAME sendrecv_test SRC sendrecv_test.cpp DEPENDS Boost::mpi MPI::MPI_CXX)
-unit_test(NAME PdbParser_test SRC PdbParser_test.cpp DEPENDS EspressoCore)
+unit_test(NAME PdbParser_test SRC PdbParser_test.cpp ../PdbParser.cpp)

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -68,3 +68,4 @@ unit_test(NAME field_coupling_force_field SRC field_coupling_force_field_test.cp
 unit_test(NAME Span_test SRC Span_test.cpp)
 unit_test(NAME periodic_fold_test SRC periodic_fold_test.cpp)
 unit_test(NAME sendrecv_test SRC sendrecv_test.cpp DEPENDS Boost::mpi MPI::MPI_CXX)
+unit_test(NAME PdbParser_test SRC PdbParser_test.cpp DEPENDS EspressoCore)

--- a/src/core/unit_tests/PdbParser_test.cpp
+++ b/src/core/unit_tests/PdbParser_test.cpp
@@ -1,0 +1,93 @@
+/*
+  Copyright (C) 2019-2019 The ESPResSo project
+
+  This file is part of ESPResSo.
+
+  ESPResSo is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** \file
+ *  Unit tests for the PdbParser class.
+ */
+
+#define BOOST_TEST_MODULE PdbParser test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <fstream>
+
+#include "PdbParser.hpp"
+
+BOOST_AUTO_TEST_CASE(parser) {
+  // create input files
+  const std::string pdb_filepath("PdbParser.pdb");
+  const std::string itp_filepath("PdbParser.itp");
+  std::ofstream file;
+  file.open(pdb_filepath);
+  file << "ATOM      1 O    LIG A   1       1.000   1.000   1.000  1.00\n";
+  file << "ATOM      2 C    LIG A   1       2.000  -0.500   1.000  1.00";
+  file.close();
+  file.open(itp_filepath);
+  file << "[ atomtypes ]\n";
+  file << ";name   bond_type   mass   charge  ptype   sigma       epsilon\n";
+  file << " c        c        12.010  0.7700   A     1.000e-01   2.000e-01\n";
+  file << "\n";
+  file << "[ atoms ]\n";
+  file << ";   nr     type  resnr residue  atom   cgnr    charge     mass\n";
+  file << "     1        O      1    LIG     O1      1   -0.7700       16\n";
+  file << "     2        c      1    LIG     C1      2    0.7700    12.01";
+  file.close();
+
+  PdbParser::PdbParser topology{};
+  // check file parser
+  const bool success = topology.parse_file(pdb_filepath, itp_filepath);
+  BOOST_CHECK(success);
+  // check bounding box
+  const auto box = topology.calc_bounding_box();
+  BOOST_CHECK(box.llx == 1.0);
+  BOOST_CHECK(box.lly == -0.5);
+  BOOST_CHECK(box.llz == 1.0);
+  BOOST_CHECK(box.urx == 2.0);
+  BOOST_CHECK(box.ury == 1.0);
+  BOOST_CHECK(box.urz == 1.0);
+  // check itp atomtypes
+  const auto O_atomtype = topology.itp_atomtypes["O"];
+  BOOST_CHECK(O_atomtype.id == 0);
+  BOOST_CHECK(O_atomtype.sigma == 0.0f);
+  BOOST_CHECK(O_atomtype.epsilon == 0.0f);
+  const auto c_atomtype = topology.itp_atomtypes["c"];
+  BOOST_CHECK(c_atomtype.id == 1);
+  BOOST_CHECK(c_atomtype.sigma == 0.1f);
+  BOOST_CHECK(c_atomtype.epsilon == 0.2f);
+  // check itp atoms
+  const auto O_itp_atom = topology.itp_atoms[1];
+  BOOST_CHECK(O_itp_atom.i == 1);
+  BOOST_CHECK(O_itp_atom.type == "O");
+  BOOST_CHECK(O_itp_atom.charge == -0.77f);
+  const auto c_itp_atom = topology.itp_atoms[0];
+  BOOST_CHECK(c_itp_atom.i == 0);
+  BOOST_CHECK(c_itp_atom.type == "");
+  BOOST_CHECK(c_itp_atom.charge == 0.0f);
+  // check pdb atoms
+  const auto O_pdbatom = topology.pdb_atoms[0];
+  BOOST_CHECK(O_pdbatom.i == 1);
+  BOOST_CHECK(O_pdbatom.x == 1.0f);
+  BOOST_CHECK(O_pdbatom.y == 1.0f);
+  BOOST_CHECK(O_pdbatom.z == 1.0f);
+  const auto c_pdbatom = topology.pdb_atoms[1];
+  BOOST_CHECK(c_pdbatom.i == 2);
+  BOOST_CHECK(c_pdbatom.x == 2.0f);
+  BOOST_CHECK(c_pdbatom.y == -0.5f);
+  BOOST_CHECK(c_pdbatom.z == 1.0f);
+}

--- a/src/core/unit_tests/PdbParser_test.cpp
+++ b/src/core/unit_tests/PdbParser_test.cpp
@@ -35,8 +35,8 @@ BOOST_AUTO_TEST_CASE(parser) {
   const std::string itp_filepath("PdbParser.itp");
   std::ofstream file;
   file.open(pdb_filepath);
-  file << "ATOM      1 O    LIG A   1       1.000   1.000   1.000  1.00\n";
-  file << "ATOM      2 C    LIG A   1       2.000  -0.500   1.000  1.00";
+  file << "ATOM      1 O1   LIG A   1       1.000   1.000   1.000  1.00\n";
+  file << "ATOM      2 C1   LIG A   1       2.000  -0.500   1.000  1.00";
   file.close();
   file.open(itp_filepath);
   file << "[ atomtypes ]\n";


### PR DESCRIPTION
Fixes the broken pipeline.

The following error message appeared in containers `ubuntu:s390x`, `ubuntu:arm64`, `ubuntu:armhf`, `ubuntu:ppc64le`:
```
[  1%] Building CXX object src/core/CMakeFiles/EspressoCore.dir/PdbParser.cpp.o
/builds/espressomd/espresso/src/core/PdbParser.cpp: In member function 'bool PdbParser::PdbParser::parse_itp_file(const string&)':
/builds/espressomd/espresso/src/core/PdbParser.cpp:120:49: error: comparison is always false due to limited range of data type [-Werror=type-limits]
             if (std::isspace(buf[0]) || (buf[0] == -1)) {
```

The cause is a mismatch between signed/unsigned types: the `EOF` value is implementation-dependent (typically -1 or 255), and the `buf` string's value_type `char` can or cannot be cast to a signed integer depending on the implementation. One solution is to cast `EOF` (or the result of `std::char_traits::eof()`) to the string's value_type.