### PR TITLE
Remove thermalized bond center of mass feature

### DIFF
--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -682,17 +682,13 @@ temperature and friction coefficient.
 The bond is configured with::
 
     from espressomd.interactions import ThermalizedBond
-    thermalized_bond = ThermalizedBond(temp_com=<float>, gamma_com=<float>,
-                                       temp_distance=<float>, gamma_distance=<float>,
-                                       r_cut=<float>)
+    thermalized_bond = ThermalizedBond(temp, gamma, r_cut=<float>)
     system.bonded_inter.add(thermalized_bond)
 
 The parameters are:
 
-    * ``temp_com``: Temperature of the Langevin thermostat for the COM of the particle pair.
-    * ``gamma_com``: Friction coefficient of the Langevin thermostat for the COM of the particle pair.
-    * ``temp_distance``: Temperature of the Langevin thermostat for the distance vector of the particle pair.
-    * ``gamma_distance``: Friction coefficient of the Langevin thermostat for the distance vector of the particle pair.
+    * ``temp``: Temperature of the Langevin thermostat for the distance vector of the particle pair.
+    * ``gamma``: Friction coefficient of the Langevin thermostat for the distance vector of the particle pair.
     * ``r_cut``:  Specifies maximum distance beyond which the bond is considered broken.
 
 The bond is closely related to simulating :ref:`Particle polarizability with

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -117,15 +117,11 @@ struct Harmonic_bond_parameters {
 
 /** Parameters for Thermalized bond **/
 struct Thermalized_bond_parameters {
-  double temp_com;
-  double gamma_com;
-  double temp_distance;
-  double gamma_distance;
+  double temp;
+  double gamma;
   double r_cut;
-  double pref1_com;
-  double pref2_com;
-  double pref1_dist;
-  double pref2_dist;
+  double pref1;
+  double pref2;
 };
 
 #ifdef ROTATION

--- a/src/core/bonded_interactions/thermalized_bond.cpp
+++ b/src/core/bonded_interactions/thermalized_bond.cpp
@@ -30,14 +30,15 @@
 
 int n_thermalized_bonds = 0;
 
-int thermalized_bond_set_params(int bond_type, double temp, double gamma, double r_cut) {
+int thermalized_bond_set_params(int bond_type, double temp, double gamma,
+                                double r_cut) {
   if (bond_type < 0)
     return ES_ERROR;
 
   make_bond_type_exist(bond_type);
 
   bonded_ia_params[bond_type].p.thermalized_bond.temp = temp;
-  bonded_ia_params[bond_type].p.thermalized_bond.gamma =gamma;
+  bonded_ia_params[bond_type].p.thermalized_bond.gamma = gamma;
   bonded_ia_params[bond_type].p.thermalized_bond.r_cut = r_cut;
   bonded_ia_params[bond_type].p.thermalized_bond.pref1 = gamma;
   bonded_ia_params[bond_type].p.thermalized_bond.pref2 =
@@ -67,8 +68,7 @@ void thermalized_bond_init() {
     if (bonded_ia_params[i].type == BONDED_IA_THERMALIZED_DIST) {
       Thermalized_bond_parameters &t = bonded_ia_params[i].p.thermalized_bond;
       t.pref1 = t.gamma;
-      t.pref2 =
-          sqrt(24.0 * t.gamma / time_step * t.temp);
+      t.pref2 = sqrt(24.0 * t.gamma / time_step * t.temp);
     }
   }
 }

--- a/src/core/bonded_interactions/thermalized_bond.cpp
+++ b/src/core/bonded_interactions/thermalized_bond.cpp
@@ -30,30 +30,19 @@
 
 int n_thermalized_bonds = 0;
 
-int thermalized_bond_set_params(int bond_type, double temp_com,
-                                double gamma_com, double temp_distance,
-                                double gamma_distance, double r_cut) {
+int thermalized_bond_set_params(int bond_type, double temp, double gamma, double r_cut) {
   if (bond_type < 0)
     return ES_ERROR;
 
   make_bond_type_exist(bond_type);
 
-  bonded_ia_params[bond_type].p.thermalized_bond.temp_com = temp_com;
-  bonded_ia_params[bond_type].p.thermalized_bond.gamma_com = gamma_com;
-  bonded_ia_params[bond_type].p.thermalized_bond.temp_distance = temp_distance;
-  bonded_ia_params[bond_type].p.thermalized_bond.gamma_distance =
-      gamma_distance;
+  bonded_ia_params[bond_type].p.thermalized_bond.temp = temp;
+  bonded_ia_params[bond_type].p.thermalized_bond.gamma =gamma;
   bonded_ia_params[bond_type].p.thermalized_bond.r_cut = r_cut;
-
-  bonded_ia_params[bond_type].p.thermalized_bond.pref1_com = gamma_com;
-  bonded_ia_params[bond_type].p.thermalized_bond.pref2_com =
-      sqrt(24.0 * gamma_com / time_step * temp_com);
-  bonded_ia_params[bond_type].p.thermalized_bond.pref1_dist = gamma_distance;
-  bonded_ia_params[bond_type].p.thermalized_bond.pref2_dist =
-      sqrt(24.0 * gamma_distance / time_step * temp_distance);
-
+  bonded_ia_params[bond_type].p.thermalized_bond.pref1 = gamma;
+  bonded_ia_params[bond_type].p.thermalized_bond.pref2 =
+      sqrt(24.0 * gamma / time_step * temp);
   bonded_ia_params[bond_type].type = BONDED_IA_THERMALIZED_DIST;
-
   bonded_ia_params[bond_type].num = 1;
 
   n_thermalized_bonds += 1;
@@ -74,26 +63,21 @@ void thermalized_bond_cool_down() {
 }
 
 void thermalized_bond_init() {
-
   for (int i = 0; i < bonded_ia_params.size(); i++) {
     if (bonded_ia_params[i].type == BONDED_IA_THERMALIZED_DIST) {
       Thermalized_bond_parameters &t = bonded_ia_params[i].p.thermalized_bond;
-      t.pref1_com = t.gamma_com;
-      t.pref2_com = sqrt(24.0 * t.gamma_com / time_step * t.temp_com);
-      t.pref1_dist = t.gamma_distance;
-      t.pref2_dist =
-          sqrt(24.0 * t.gamma_distance / time_step * t.temp_distance);
+      t.pref1 = t.gamma;
+      t.pref2 =
+          sqrt(24.0 * t.gamma / time_step * t.temp);
     }
   }
 }
 
 void thermalized_bond_update_params(double pref_scale) {
-
   for (int i = 0; i < bonded_ia_params.size(); i++) {
     if (bonded_ia_params[i].type == BONDED_IA_THERMALIZED_DIST) {
       Thermalized_bond_parameters &t = bonded_ia_params[i].p.thermalized_bond;
-      t.pref2_com *= pref_scale;
-      t.pref2_dist *= pref_scale;
+      t.pref2 *= pref_scale;
     }
   }
 }

--- a/src/core/bonded_interactions/thermalized_bond.hpp
+++ b/src/core/bonded_interactions/thermalized_bond.hpp
@@ -37,9 +37,7 @@ extern int n_thermalized_bonds;
 #include "utils.hpp"
 
 // Set the parameters for the thermalized bond
-int thermalized_bond_set_params(int bond_type, double temp_com,
-                                double gamma_com, double temp_distance,
-                                double gamma_distance, double r_cut);
+int thermalized_bond_set_params(int bond_type, double temp, double gamma, double r_cut);
 
 void thermalized_bond_heat_up();
 void thermalized_bond_cool_down();
@@ -67,45 +65,24 @@ inline int calc_thermalized_bond_forces(const Particle *p1, const Particle *p2,
     return 1;
   }
 
-  double force_lv_com, force_lv_dist, com_vel, dist_vel;
+  double force_lv_dist, dist_vel;
   double mass_tot = p1->p.mass + p2->p.mass;
-  double mass_tot_inv = 1.0 / mass_tot;
-  double sqrt_mass_tot = sqrt(mass_tot);
   double sqrt_mass_red = sqrt(p1->p.mass * p2->p.mass / mass_tot);
 
   for (int i = 0; i < 3; i++) {
-
-    // Langevin thermostat for center of mass
-    com_vel =
-        mass_tot_inv * (p1->p.mass * p1->m.v[i] + p2->p.mass * p2->m.v[i]);
-    if (iaparams->p.thermalized_bond.pref2_com > 0.0) {
-      force_lv_com = -iaparams->p.thermalized_bond.pref1_com * com_vel +
-                     sqrt_mass_tot * iaparams->p.thermalized_bond.pref2_com *
-                         (d_random() - 0.5);
-    } else {
-      force_lv_com = -iaparams->p.thermalized_bond.pref1_com * com_vel;
-    }
-
     // Langevin thermostat for distance p1->p2
     dist_vel = p2->m.v[i] - p1->m.v[i];
-    if (iaparams->p.thermalized_bond.pref2_dist > 0.0) {
-      force_lv_dist = -iaparams->p.thermalized_bond.pref1_dist * dist_vel +
-                      sqrt_mass_red * iaparams->p.thermalized_bond.pref2_dist *
+    if (iaparams->p.thermalized_bond.pref2 > 0.0) {
+      force_lv_dist = -iaparams->p.thermalized_bond.pref1 * dist_vel +
+                      sqrt_mass_red * iaparams->p.thermalized_bond.pref2 *
                           (d_random() - 0.5);
     } else {
-      force_lv_dist = -iaparams->p.thermalized_bond.pref1_dist * dist_vel;
+      force_lv_dist = -iaparams->p.thermalized_bond.pref1 * dist_vel;
     }
     // Add forces
-    force1[i] = p1->p.mass * mass_tot_inv * force_lv_com - force_lv_dist;
-    force2[i] = p2->p.mass * mass_tot_inv * force_lv_com + force_lv_dist;
+    force1[i] = - force_lv_dist;
+    force2[i] = + force_lv_dist;
   }
-
-  ONEPART_TRACE(if (p1->p.identity == check_id) fprintf(
-      stderr, "%d: OPT: THERMALIZED BOND f = (%.3e,%.3e,%.3e)\n", this_node,
-      p1->f.f[0] + force1[0], p1->f.f[1] + force1[1], p1->f.f[2] + force1[2]));
-  ONEPART_TRACE(if (p2->p.identity == check_id) fprintf(
-      stderr, "%d: OPT: THERMALIZED BOND f = (%.3e,%.3e,%.3e)\n", this_node,
-      p2->f.f[0] + force2[0], p2->f.f[1] + force2[1], p2->f.f[2] + force2[2]));
   return 0;
 }
 

--- a/src/core/bonded_interactions/thermalized_bond.hpp
+++ b/src/core/bonded_interactions/thermalized_bond.hpp
@@ -37,7 +37,8 @@ extern int n_thermalized_bonds;
 #include "utils.hpp"
 
 // Set the parameters for the thermalized bond
-int thermalized_bond_set_params(int bond_type, double temp, double gamma, double r_cut);
+int thermalized_bond_set_params(int bond_type, double temp, double gamma,
+                                double r_cut);
 
 void thermalized_bond_heat_up();
 void thermalized_bond_cool_down();
@@ -80,8 +81,8 @@ inline int calc_thermalized_bond_forces(const Particle *p1, const Particle *p2,
       force_lv_dist = -iaparams->p.thermalized_bond.pref1 * dist_vel;
     }
     // Add forces
-    force1[i] = - force_lv_dist;
-    force2[i] = + force_lv_dist;
+    force1[i] = -force_lv_dist;
+    force2[i] = +force_lv_dist;
   }
   return 0;
 }

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -447,6 +447,62 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
   }
 }
 
+inline int calc_bond_pair_force(Particle *p1, Particle *p2, Bonded_ia_parameters *iaparams, double *dx, double *force) {
+    int bond_broken = 0;
+
+    switch (iaparams->type) {
+        case BONDED_IA_FENE:
+            bond_broken = calc_fene_pair_force(p1, p2, iaparams, dx, force);
+            break;
+#ifdef ROTATION
+        case BONDED_IA_HARMONIC_DUMBBELL:
+            bond_broken =
+                    calc_harmonic_dumbbell_pair_force(p1, p2, iaparams, dx, force);
+            break;
+#endif
+        case BONDED_IA_HARMONIC:
+            bond_broken = calc_harmonic_pair_force(p1, p2, iaparams, dx, force);
+            break;
+        case BONDED_IA_QUARTIC:
+            bond_broken = calc_quartic_pair_force(p1, p2, iaparams, dx, force);
+            break;
+#ifdef ELECTROSTATICS
+        case BONDED_IA_BONDED_COULOMB:
+            bond_broken =
+                    calc_bonded_coulomb_pair_force(p1, p2, iaparams, dx, force);
+            break;
+#endif
+#ifdef P3M
+        case BONDED_IA_BONDED_COULOMB_P3M_SR:
+            bond_broken =
+                    calc_bonded_coulomb_p3m_sr_pair_force(p1, p2, iaparams, dx, force);
+            break;
+#endif
+#ifdef LENNARD_JONES
+        case BONDED_IA_SUBT_LJ:
+            bond_broken = calc_subt_lj_pair_force(p1, p2, iaparams, dx, force);
+            break;
+#endif
+#ifdef TABULATED
+        case BONDED_IA_TABULATED:
+            if (iaparams->num == 1)
+                bond_broken = calc_tab_bond_force(p1, p2, iaparams, dx, force);
+            break;
+#endif
+#ifdef UMBRELLA
+        case BONDED_IA_UMBRELLA:
+                bond_broken = calc_umbrella_pair_force(p1, p2, iaparams, dx, force);
+                break;
+#endif
+        default:
+            bond_broken = 0;
+            break;
+
+    } // switch type
+
+    return bond_broken;
+}
+
 /** Calculate bonded forces for one particle.
  *  @param p1   particle for which to calculate forces
  */
@@ -512,85 +568,24 @@ inline void add_bonded_force(Particle *p1) {
          not needed,
          and the pressure calculation not yet clear. */
       get_mi_vector(dx, p1->r.p, p2->r.p);
-    }
+      bond_broken = calc_bond_pair_force(p1, p2, iaparams, dx, force);
 
-    if (n_partners == 1) {
-      switch (type) {
-      case BONDED_IA_FENE:
-        bond_broken = calc_fene_pair_force(p1, p2, iaparams, dx, force);
-        break;
-#ifdef ROTATION
-      case BONDED_IA_HARMONIC_DUMBBELL:
-        bond_broken =
-            calc_harmonic_dumbbell_pair_force(p1, p2, iaparams, dx, force);
-        break;
+#ifdef NPT
+        if (integ_switch == INTEG_METHOD_NPT_ISO)
+            for(int j = 0; j < 3; j++)
+                nptiso.p_vir[j] += force[j] * dx[j];
 #endif
-      case BONDED_IA_HARMONIC:
-        bond_broken = calc_harmonic_pair_force(p1, p2, iaparams, dx, force);
-        break;
-      case BONDED_IA_QUARTIC:
-        bond_broken = calc_quartic_pair_force(p1, p2, iaparams, dx, force);
-        break;
-      case BONDED_IA_THERMALIZED_DIST:
-        bond_broken =
-            calc_thermalized_bond_forces(p1, p2, iaparams, dx, force, force2);
-        break;
-#ifdef ELECTROSTATICS
-      case BONDED_IA_BONDED_COULOMB:
-        bond_broken =
-            calc_bonded_coulomb_pair_force(p1, p2, iaparams, dx, force);
-        break;
-#endif
-#ifdef P3M
-      case BONDED_IA_BONDED_COULOMB_P3M_SR:
-        bond_broken =
-            calc_bonded_coulomb_p3m_sr_pair_force(p1, p2, iaparams, dx, force);
-        break;
-#endif
-#ifdef LENNARD_JONES
-      case BONDED_IA_SUBT_LJ:
-        bond_broken = calc_subt_lj_pair_force(p1, p2, iaparams, dx, force);
-        break;
-#endif
-#ifdef TABULATED
-      case BONDED_IA_TABULATED:
-        if (iaparams->num == 1)
-          bond_broken = calc_tab_bond_force(p1, p2, iaparams, dx, force);
-        break;
-#endif
-#ifdef IMMERSED_BOUNDARY
-      case BONDED_IA_IBM_VOLUME_CONSERVATION:
-        bond_broken = 0;
-        // Don't do anything here. We calculate and add the global volume forces
-        // in IBM_VolumeConservation. They cannot be calculated on a per-bond
-        // basis
-        force[0] = force2[0] = force3[0] = 0;
-        force[1] = force2[1] = force3[1] = 0;
-        force[2] = force2[2] = force3[2] = 0;
-        break;
-#endif
-#ifdef BOND_CONSTRAINT
-      case BONDED_IA_RIGID_BOND:
-        // add_rigid_bond_pair_force(p1,p2, iaparams, force, force2);
-        bond_broken = 0;
-        force[0] = force[1] = force[2] = 0.0;
-        break;
-#endif
-#ifdef UMBRELLA
-      case BONDED_IA_UMBRELLA:
-        bond_broken = calc_umbrella_pair_force(p1, p2, iaparams, dx, force);
-        break;
-#endif
-      case BONDED_IA_VIRTUAL_BOND:
-        bond_broken = 0;
-        force[0] = force[1] = force[2] = 0.0;
-        break;
-      default:
-        runtimeErrorMsg() << "add_bonded_force: bond type of atom "
-                          << p1->p.identity << " unknown " << type << ","
-                          << n_partners << "\n";
-        return;
-      } // switch type
+      
+      switch(type)
+        {
+            case BONDED_IA_THERMALIZED_DIST:
+                bond_broken =
+                        calc_thermalized_bond_forces(p1, p2, iaparams, dx, force, force2);
+            break;
+
+            default:
+                break;
+        }
     }   // 1 partner
     else if (n_partners == 2) {
       switch (type) {
@@ -722,11 +717,6 @@ inline void add_bonded_force(Particle *p1) {
           p2->f.torque[j] += torque2[j];
 #endif
         }
-
-#ifdef NPT
-        if (integ_switch == INTEG_METHOD_NPT_ISO)
-          nptiso.p_vir[j] += force[j] * dx[j];
-#endif
       }
       break;
     case 2:

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -447,60 +447,61 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
   }
 }
 
-inline int calc_bond_pair_force(Particle *p1, Particle *p2, Bonded_ia_parameters *iaparams, double *dx, double *force) {
-    int bond_broken = 0;
+inline int calc_bond_pair_force(Particle *p1, Particle *p2,
+                                Bonded_ia_parameters *iaparams, double *dx,
+                                double *force) {
+  int bond_broken = 0;
 
-    switch (iaparams->type) {
-        case BONDED_IA_FENE:
-            bond_broken = calc_fene_pair_force(p1, p2, iaparams, dx, force);
-            break;
+  switch (iaparams->type) {
+  case BONDED_IA_FENE:
+    bond_broken = calc_fene_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #ifdef ROTATION
-        case BONDED_IA_HARMONIC_DUMBBELL:
-            bond_broken =
-                    calc_harmonic_dumbbell_pair_force(p1, p2, iaparams, dx, force);
-            break;
+  case BONDED_IA_HARMONIC_DUMBBELL:
+    bond_broken =
+        calc_harmonic_dumbbell_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
-        case BONDED_IA_HARMONIC:
-            bond_broken = calc_harmonic_pair_force(p1, p2, iaparams, dx, force);
-            break;
-        case BONDED_IA_QUARTIC:
-            bond_broken = calc_quartic_pair_force(p1, p2, iaparams, dx, force);
-            break;
+  case BONDED_IA_HARMONIC:
+    bond_broken = calc_harmonic_pair_force(p1, p2, iaparams, dx, force);
+    break;
+  case BONDED_IA_QUARTIC:
+    bond_broken = calc_quartic_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #ifdef ELECTROSTATICS
-        case BONDED_IA_BONDED_COULOMB:
-            bond_broken =
-                    calc_bonded_coulomb_pair_force(p1, p2, iaparams, dx, force);
-            break;
+  case BONDED_IA_BONDED_COULOMB:
+    bond_broken = calc_bonded_coulomb_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
 #ifdef P3M
-        case BONDED_IA_BONDED_COULOMB_P3M_SR:
-            bond_broken =
-                    calc_bonded_coulomb_p3m_sr_pair_force(p1, p2, iaparams, dx, force);
-            break;
+  case BONDED_IA_BONDED_COULOMB_P3M_SR:
+    bond_broken =
+        calc_bonded_coulomb_p3m_sr_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
 #ifdef LENNARD_JONES
-        case BONDED_IA_SUBT_LJ:
-            bond_broken = calc_subt_lj_pair_force(p1, p2, iaparams, dx, force);
-            break;
+  case BONDED_IA_SUBT_LJ:
+    bond_broken = calc_subt_lj_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
 #ifdef TABULATED
-        case BONDED_IA_TABULATED:
-            if (iaparams->num == 1)
-                bond_broken = calc_tab_bond_force(p1, p2, iaparams, dx, force);
-            break;
+  case BONDED_IA_TABULATED:
+    if (iaparams->num == 1)
+      bond_broken = calc_tab_bond_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
 #ifdef UMBRELLA
-        case BONDED_IA_UMBRELLA:
-                bond_broken = calc_umbrella_pair_force(p1, p2, iaparams, dx, force);
-                break;
+  case BONDED_IA_UMBRELLA:
+    bond_broken = calc_umbrella_pair_force(p1, p2, iaparams, dx, force);
+    break;
 #endif
-        default:
-            bond_broken = 0;
-            break;
+  default:
+    bond_broken = 0;
+    break;
 
-    } // switch type
+  } // switch type
 
-    return bond_broken;
+  return bond_broken;
 }
 
 /** Calculate bonded forces for one particle.
@@ -571,22 +572,21 @@ inline void add_bonded_force(Particle *p1) {
       bond_broken = calc_bond_pair_force(p1, p2, iaparams, dx, force);
 
 #ifdef NPT
-        if (integ_switch == INTEG_METHOD_NPT_ISO)
-            for(int j = 0; j < 3; j++)
-                nptiso.p_vir[j] += force[j] * dx[j];
+      if (integ_switch == INTEG_METHOD_NPT_ISO)
+        for (int j = 0; j < 3; j++)
+          nptiso.p_vir[j] += force[j] * dx[j];
 #endif
-      
-      switch(type)
-        {
-            case BONDED_IA_THERMALIZED_DIST:
-                bond_broken =
-                        calc_thermalized_bond_forces(p1, p2, iaparams, dx, force, force2);
-            break;
 
-            default:
-                break;
-        }
-    }   // 1 partner
+      switch (type) {
+      case BONDED_IA_THERMALIZED_DIST:
+        bond_broken =
+            calc_thermalized_bond_forces(p1, p2, iaparams, dx, force, force2);
+        break;
+
+      default:
+        break;
+      }
+    } // 1 partner
     else if (n_partners == 2) {
       switch (type) {
 #ifdef BOND_ANGLE

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -150,93 +150,6 @@ inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2, double d[3],
 #endif /*ifdef DIPOLES */
 }
 
-inline void calc_bonded_force(Particle *p1, Particle *p2,
-                              Bonded_ia_parameters *iaparams, int *i,
-                              double dx[3], double force[3]) {
-#ifdef TABULATED
-// char* errtxt;
-#endif
-
-  /* Calculates the bonded force between two particles */
-  switch (iaparams->type) {
-  case BONDED_IA_FENE:
-    calc_fene_pair_force(p1, p2, iaparams, dx, force);
-    break;
-#ifdef ROTATION
-  case BONDED_IA_HARMONIC_DUMBBELL:
-    calc_harmonic_dumbbell_pair_force(p1, p2, iaparams, dx, force);
-    break;
-#endif
-  case BONDED_IA_HARMONIC:
-    calc_harmonic_pair_force(p1, p2, iaparams, dx, force);
-    break;
-#ifdef LENNARD_JONES
-  case BONDED_IA_SUBT_LJ:
-    calc_subt_lj_pair_force(p1, p2, iaparams, dx, force);
-    break;
-#endif
-    /* since it is not clear at the moment how to handle a many body interaction
-     * here, I skip it */
-  case BONDED_IA_ANGLE_HARMONIC:
-    (*i)++;
-    force[0] = force[1] = force[2] = 0;
-    break;
-  case BONDED_IA_ANGLE_COSINE:
-    (*i)++;
-    force[0] = force[1] = force[2] = 0;
-    break;
-  case BONDED_IA_ANGLE_COSSQUARE:
-    (*i)++;
-    force[0] = force[1] = force[2] = 0;
-    break;
-  case BONDED_IA_DIHEDRAL:
-    (*i) += 2;
-    force[0] = force[1] = force[2] = 0;
-    break;
-
-#ifdef TABULATED
-  case BONDED_IA_TABULATED:
-    // printf("BONDED TAB, Particle: %d, P2: %d TYPE_TAB:
-    // %d\n",p1->p.identity,p2->p.identity,iparams->p.tab.type);
-    switch (iaparams->p.tab.type) {
-    case 1:
-      calc_tab_bond_force(p1, p2, iaparams, dx, force);
-      break;
-    case 2:
-      (*i)++;
-      force[0] = force[1] = force[2] = 0;
-      break;
-    case 3:
-      (*i) += 2;
-      force[0] = force[1] = force[2] = 0;
-      break;
-    default:
-      runtimeErrorMsg() << "calc_bonded_force: tabulated bond type of atom "
-                        << p1->p.identity << " unknown\n";
-      return;
-    }
-    break;
-#endif
-#ifdef BOND_CONSTRAINT
-  case BONDED_IA_RIGID_BOND:
-    force[0] = force[1] = force[2] = 0;
-    break;
-#endif
-  case BONDED_IA_VIRTUAL_BOND:
-    force[0] = force[1] = force[2] = 0;
-    break;
-  default:
-    //      fprintf(stderr,"add_bonded_virials: WARNING: Bond type %d of atom %d
-    //      unhandled\n",bonded_ia_params[type_num].type,p1->p.identity);
-    fprintf(stderr,
-            "add_bonded_virials: WARNING: Bond type %d , atom %d unhandled, "
-            "Atom 2: %d\n",
-            iaparams->type, p1->p.identity, p2->p.identity);
-    force[0] = force[1] = force[2] = 0;
-    break;
-  }
-}
-
 /* calc_three_body_bonded_forces is called by add_three_body_bonded_stress. This
    routine is only entered for angular potentials. */
 inline void calc_three_body_bonded_forces(Particle *p1, Particle *p2,
@@ -333,7 +246,7 @@ inline void add_bonded_virials(Particle *p1) {
     double a[3] = {p1->r.p[0], p1->r.p[1], p1->r.p[2]};
     double b[3] = {p2->r.p[0], p2->r.p[1], p2->r.p[2]};
     auto dx = get_mi_vector(a, b);
-    calc_bonded_force(p1, p2, iaparams, &i, dx.data(), force);
+    calc_bond_pair_force(p1, p2, iaparams, dx.data(), force);
     *obsstat_bonded(&virials, type_num) +=
         dx[0] * force[0] + dx[1] * force[1] + dx[2] * force[2];
 

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -351,16 +351,13 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
 
 #* Parameters for thermalized  bond */
     cdef struct Thermalized_bond_parameters:
-        double temp_com
-        double gamma_com
-        double temp_distance
-        double gamma_distance
+        double temp
+        double gamma
         double r_cut
 
 #* Parameters for Bonded Coulomb */
     cdef struct Bonded_coulomb_bond_parameters:
         double prefactor
-
 
 #* Parameters for three body angular potential (bond-angle potentials).
     cdef struct Angle_bond_parameters:
@@ -517,7 +514,7 @@ cdef extern from "object-in-fluid/oif_local_forces.hpp":
 cdef extern from "object-in-fluid/out_direction.hpp":
     int oif_out_direction_set_params(int bond_type)
 cdef extern from "bonded_interactions/thermalized_bond.hpp":
-    int thermalized_bond_set_params(int bond_type, double temp_com, double gamma_com, double temp_distance, double gamma_distance, double r_cut)
+    int thermalized_bond_set_params(int bond_type, double temp, double gamma, double r_cut)
 cdef extern from "bonded_interactions/bonded_coulomb.hpp":
     int bonded_coulomb_set_params(int bond_type, double prefactor)
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -2244,15 +2244,11 @@ class ThermalizedBond(BondedInteraction):
         Parameters
         ----------
 
-        temp_com : :obj:`float`
-                    Sets the temperature of the Langevin thermostat for the com of the particle pair.
-        gamma_com: :obj:`float`
-                    Sets the friction coefficient of the Langevin thermostat for the com of the particle pair.
-        temp_distance: :obj:`float`
+        temp : :obj:`float`
                     Sets the temperature of the Langevin thermostat for the distance vector of the particle pair.
-        gamma_distance: :obj:`float`
+        gamma : :obj:`float`
                      Sets the friction coefficient of the Langevin thermostat for the distance vector of the particle pair.
-        r_cut: :obj:`float`, optional
+        r_cut : :obj:`float`, optional
                 Specifies maximum distance beyond which the bond is considered broken.
         """
         super(ThermalizedBond, self).__init__(*args, **kwargs)
@@ -2264,31 +2260,25 @@ class ThermalizedBond(BondedInteraction):
         return "THERMALIZED_DIST"
 
     def valid_keys(self):
-        return "temp_com", "gamma_com", "temp_distance", "gamma_distance", "r_cut"
+        return "temp", "gamma", "r_cut"
 
     def required_keys(self):
-        return "temp_com", "gamma_com", "temp_distance", "gamma_distance"
+        return "temp", "gamma"
 
     def set_default_params(self):
-        self._params = {"temp_com": 1., "gamma_com": 1.,
-                        "temp_distance": 1., "gamma_distance": 1., "r_cut": 0.}
+        self._params = {"temp": 0., "gamma": 1., "r_cut": 0.}
 
     def _get_params_from_es_core(self):
         return \
-            {"temp_com": bonded_ia_params[self._bond_id].p.thermalized_bond.temp_com,
-             "gamma_com":
-                 bonded_ia_params[self._bond_id].p.thermalized_bond.gamma_com,
-             "temp_distance":
+            {"temp": bonded_ia_params[self._bond_id].p.thermalized_bond.temp,
+             "gamma":
                  bonded_ia_params[
-                     self._bond_id].p.thermalized_bond.temp_distance,
-             "gamma_distance":
-                 bonded_ia_params[
-                     self._bond_id].p.thermalized_bond.gamma_distance,
+                     self._bond_id].p.thermalized_bond.gamma,
              "r_cut": bonded_ia_params[self._bond_id].p.thermalized_bond.r_cut}
 
     def _set_params_in_es_core(self):
         thermalized_bond_set_params(
-            self._bond_id, self._params["temp_com"], self._params["gamma_com"], self._params["temp_distance"], self._params["gamma_distance"], self._params["r_cut"])
+            self._bond_id, self._params["temp"], self._params["gamma"], self._params["r_cut"])
 
 IF THOLE:
     cdef class TholeInteraction(NonBondedInteraction):

--- a/testsuite/python/thermalized_bond.py
+++ b/testsuite/python/thermalized_bond.py
@@ -55,52 +55,6 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
                     bins[j], bins[j + 1], kT)
                 self.assertLessEqual(abs(found - expected), error_tol)
 
-    def test_com_langevin(self):
-        """Test for COM thermalization."""
-
-        N = 200
-        N2 = int(N/2)
-        self.system.part.clear()
-        self.system.time_step = 0.02
-        
-        if espressomd.has_features("PARTIAL_PERIODIC"):
-            self.system.periodicity = 0, 0, 0
-        
-        m1 = 1.0
-        m2 = 10.0
-        # Place particles
-        for i in range(0, N, 2):
-            self.system.part.add(pos=np.random.random(3), mass = m1)
-            self.system.part.add(pos=np.random.random(3), mass = m2)
-
-        t_dist = 0
-        g_dist = 0
-        t_com = 2.0
-        g_com = 4.0
-       
-        thermalized_dist_bond = espressomd.interactions.ThermalizedBond(temp_com = t_com, gamma_com = g_com, temp_distance = t_dist, gamma_distance = g_dist, r_cut = 2.0)
-        self.system.bonded_inter.add(thermalized_dist_bond)
-
-        for i in range(0, N, 2):
-            self.system.part[i].add_bond((thermalized_dist_bond, i+1))
-        
-        # Warmup
-        self.system.integrator.run(50)
-        
-        # Sampling
-        loops = 200
-        v_stored = np.zeros((N2 * loops, 3))
-        for i in range(loops):
-            self.system.integrator.run(12)
-            v_com = 1.0/(m1+m2)*(m1*self.system.part[::2].v+m2*self.system.part[1::2].v)
-            v_stored[i * N2:(i + 1) * N2,:] = v_com 
-
-        v_minmax = 5
-        bins = 50
-        error_tol = 0.017
-        self.check_velocity_distribution(
-            v_stored, v_minmax, bins, error_tol, t_com)
-
     def test_dist_langevin(self):
         """Test for dist thermalization."""
 
@@ -119,10 +73,8 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
 
         t_dist = 2.0
         g_dist = 4.0
-        t_com = 0.0
-        g_com = 0.0
        
-        thermalized_dist_bond = espressomd.interactions.ThermalizedBond(temp_com = t_com, gamma_com = g_com, temp_distance = t_dist, gamma_distance = g_dist, r_cut = 9)
+        thermalized_dist_bond = espressomd.interactions.ThermalizedBond(temp = t_dist, gamma = g_dist, r_cut = 9)
         self.system.bonded_inter.add(thermalized_dist_bond)
 
         for i in range(0, N, 2):

--- a/testsuite/python/thermalized_bond.py
+++ b/testsuite/python/thermalized_bond.py
@@ -25,13 +25,15 @@ import unittest as ut
 import espressomd
 from tests_common import single_component_maxwell
 
+
 @ut.skipIf(not espressomd.has_features(["MASS"]), "Features not available, skipping test!")
 class ThermalizedBond(ut.TestCase):
-    """Tests the two velocity distributions for COM and distance created by the thermalized bond independently against 
+
+    """Tests the two velocity distributions for COM and distance created by the thermalized bond independently against
 the single component Maxwell distribution. Adapted from langevin_thermostat testcase."""
 
     box_l = 10.0
-    system = espressomd.System(box_l=[box_l]*3)
+    system = espressomd.System(box_l=[box_l] * 3)
     system.cell_system.set_n_square()
     system.cell_system.skin = 0.3
     system.seed = range(system.cell_system.get_state()["n_nodes"])
@@ -48,7 +50,7 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
                 vel[:, i], range=(-minmax, minmax), bins=n_bins, normed=False)
             data = hist[0] / float(vel.shape[0])
             bins = hist[1]
-            
+
             for j in range(n_bins):
                 found = data[j]
                 expected = single_component_maxwell(
@@ -59,44 +61,45 @@ the single component Maxwell distribution. Adapted from langevin_thermostat test
         """Test for dist thermalization."""
 
         N = 100
-        N2 = int(N/2)
+        N2 = int(N / 2)
         self.system.part.clear()
         self.system.time_step = 0.02
         self.system.periodicity = 1, 1, 1
-        
+
         m1 = 1.0
         m2 = 10.0
         # Place particles
         for i in range(0, N, 2):
-            self.system.part.add(pos=np.random.random(3), mass = m1)
-            self.system.part.add(pos=np.random.random(3), mass = m2)
+            self.system.part.add(pos=np.random.random(3), mass=m1)
+            self.system.part.add(pos=np.random.random(3), mass=m2)
 
         t_dist = 2.0
         g_dist = 4.0
-       
-        thermalized_dist_bond = espressomd.interactions.ThermalizedBond(temp = t_dist, gamma = g_dist, r_cut = 9)
+
+        thermalized_dist_bond = espressomd.interactions.ThermalizedBond(
+            temp=t_dist, gamma=g_dist, r_cut=9)
         self.system.bonded_inter.add(thermalized_dist_bond)
 
         for i in range(0, N, 2):
-            self.system.part[i].add_bond((thermalized_dist_bond, i+1))
-        
+            self.system.part[i].add_bond((thermalized_dist_bond, i + 1))
+
         # Warmup
         self.system.integrator.run(50)
-        
+
         # Sampling
         loops = 200
         v_stored = np.zeros((N2 * loops, 3))
         for i in range(loops):
             self.system.integrator.run(12)
-            v_dist = self.system.part[1::2].v - self.system.part[::2].v 
-            v_stored[i * N2:(i + 1) * N2,:] = v_dist 
+            v_dist = self.system.part[1::2].v - self.system.part[::2].v
+            v_stored[i * N2:(i + 1) * N2, :] = v_dist
 
         v_minmax = 5
         bins = 50
         error_tol = 0.015
         self.check_velocity_distribution(
             v_stored, v_minmax, bins, error_tol, t_dist)
-        
+
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
Description of changes:
 - Removed the center-of-mass thermalization from the thermalized bond

This does not gain anything and causes problems with reintroducing Lees-
Edwards.

Depends of #2542 