### PR TITLE
ci: Remove noise level of the ci build script

### DIFF
--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -16,7 +16,6 @@ abort()
 
 trap 'abort' 0
 set -e
-set -x
 
 # HELPER FUNCTIONS
 


### PR DESCRIPTION
The combination of `cmd` and `set -x` is not readable.