### PR TITLE
LB: encapsulate defines into enums

### DIFF
--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -873,17 +873,17 @@ void mpi_sync_topo_part_info_slave(int, int) {
 
 /******************* REQ_BCAST_LBPAR ********************/
 
-void mpi_bcast_lb_params(int field, int value) {
+void mpi_bcast_lb_params(LBParam field, int value) {
 #ifdef LB
-  mpi_call(mpi_bcast_lb_params_slave, field, value);
-  mpi_bcast_lb_params_slave(field, value);
+  mpi_call(mpi_bcast_lb_params_slave, (int)field, value);
+  mpi_bcast_lb_params_slave((int)field, value);
 #endif
 }
 
 void mpi_bcast_lb_params_slave(int field, int) {
 #ifdef LB
   MPI_Bcast(&lbpar, sizeof(LB_Parameters), MPI_BYTE, 0, comm_cart);
-  lb_lbfluid_on_lb_params_change(field);
+  lb_lbfluid_on_lb_params_change((LBParam)field);
 #endif
 }
 

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -875,15 +875,15 @@ void mpi_sync_topo_part_info_slave(int, int) {
 
 void mpi_bcast_lb_params(LBParam field, int value) {
 #ifdef LB
-  mpi_call(mpi_bcast_lb_params_slave, (int)field, value);
-  mpi_bcast_lb_params_slave((int)field, value);
+  mpi_call(mpi_bcast_lb_params_slave, static_cast<int>(field), value);
+  mpi_bcast_lb_params_slave(static_cast<int>(field), value);
 #endif
 }
 
 void mpi_bcast_lb_params_slave(int field, int) {
 #ifdef LB
   MPI_Bcast(&lbpar, sizeof(LB_Parameters), MPI_BYTE, 0, comm_cart);
-  lb_lbfluid_on_lb_params_change((LBParam)field);
+  lb_lbfluid_on_lb_params_change(static_cast<LBParam>(field));
 #endif
 }
 

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -58,6 +58,7 @@
 
 /** Included needed by callbacks. */
 #include "cuda_init.hpp"
+#include "grid_based_algorithms/lb_constants.hpp"
 #include "particle_data.hpp"
 
 #include "utils/serialization/array.hpp"
@@ -289,7 +290,7 @@ int mpi_sync_topo_part_info(void);
  *                    The references are defined in lb.hpp
  *  @param[in] value  Dummy value
  */
-void mpi_bcast_lb_params(int field, int value = -1);
+void mpi_bcast_lb_params(LBParam field, int value = -1);
 
 void mpi_bcast_lb_particle_coupling();
 

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -154,7 +154,7 @@ void force_calc() {
 
 #if defined(LB_GPU) || defined(LB)
 #ifdef LB
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
 #ifdef ENGINE
     ghost_communicator(&cell_structure.exchange_ghosts_comm,
                        GHOSTTRANS_SWIMMING);

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -52,10 +52,7 @@
 /* TODO: get rid of this code duplication with lb-boundaries.h by solving the
          cuda-mpi incompatibility */
 
-#define LATTICE_OFF 0
-#define LATTICE_LB_CPU 1
-#define LATTICE_LB_GPU 2
-extern int lattice_switch;
+extern ActiveLB lattice_switch;
 extern bool ek_initialized;
 extern EK_parameters *lb_ek_parameters_gpu;
 
@@ -2476,7 +2473,7 @@ int ek_init() {
       ek_parameters.species_index[i] = -1;
     }
 
-    if (lattice_switch != LATTICE_OFF) {
+    if (lattice_switch != ActiveLB::NONE) {
       fprintf(stderr,
               "ERROR: Electrokinetics automatically intializes the LB on the "
               "GPU and can therefore not be used in conjunction with LB.\n");
@@ -2485,7 +2482,7 @@ int ek_init() {
       return 1;
     }
 
-    lattice_switch = LATTICE_LB_GPU;
+    lattice_switch = ActiveLB::GPU;
     ek_initialized = true;
 
     lbpar_gpu.agrid = ek_parameters.agrid;

--- a/src/core/grid_based_algorithms/lattice.cpp
+++ b/src/core/grid_based_algorithms/lattice.cpp
@@ -29,7 +29,7 @@
 #include "debug.hpp"
 #include "grid.hpp"
 
-int lattice_switch = LATTICE_OFF;
+ActiveLB lattice_switch = ActiveLB::NONE;
 
 int Lattice::init(double *agrid, double *offset, int halo_size, size_t dim) {
   /* determine the number of local lattice nodes */

--- a/src/core/grid_based_algorithms/lattice.hpp
+++ b/src/core/grid_based_algorithms/lattice.hpp
@@ -31,16 +31,11 @@
 
 #include "utils/Vector.hpp"
 
-/** Switch determining the type of lattice dynamics. A value of zero
- *  means that there is no lattice dynamics. Different types can be
- *  combined by or'ing the respective flags.
- *  So far, only \ref LATTICE_OFF and \ref LATTICE_LB exist.
- */
-extern int lattice_switch;
+/** @brief LB implementation currently active. */
+enum class ActiveLB { NONE, CPU, GPU };
 
-#define LATTICE_LB 1     /** Lattice Boltzmann */
-#define LATTICE_LB_GPU 2 /** Lattice Boltzmann */
-#define LATTICE_OFF 0    /** Lattice off */
+/** @brief Switch determining the type of lattice dynamics. */
+extern ActiveLB lattice_switch;
 
 class Lattice {
 public:

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -1263,7 +1263,7 @@ void lb_check_halo_regions(const LB_Fluid &lbfluid) {
 void lb_calc_local_fields(Lattice::index_t index, double *rho, double *j,
                           double *pi) {
 
-  if (!(lattice_switch & LATTICE_LB)) {
+  if (lattice_switch != ActiveLB::CPU) {
     runtimeErrorMsg() << "Error in lb_calc_local_fields in " << __FILE__
                       << __LINE__ << ": CPU LB not switched on.";
     *rho = 0;

--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -267,7 +267,7 @@ std::array<double, 19> lb_calc_modes(Lattice::index_t index);
  */
 inline void lb_calc_local_rho(Lattice::index_t index, double *rho) {
   // unit conversion: mass density
-  if (!(lattice_switch & LATTICE_LB)) {
+  if (lattice_switch != ActiveLB::CPU) {
     runtimeErrorMsg() << "Error in lb_calc_local_rho in " << __FILE__
                       << __LINE__ << ": CPU LB not switched on.";
     *rho = 0;
@@ -291,7 +291,7 @@ inline void lb_calc_local_rho(Lattice::index_t index, double *rho) {
  *  @retval The local fluid momentum.
  */
 inline Vector3d lb_calc_local_j(Lattice::index_t index) {
-  if (!(lattice_switch & LATTICE_LB)) {
+  if (lattice_switch != ActiveLB::CPU) {
     runtimeErrorMsg() << "Error in lb_calc_local_j in " << __FILE__ << __LINE__
                       << ": CPU LB not switched on.";
     return {};
@@ -325,7 +325,7 @@ void lb_calc_local_fields(Lattice::index_t index, double *rho, double *j,
 inline void lb_local_fields_get_boundary_flag(Lattice::index_t index,
                                               int *boundary) {
 
-  if (!(lattice_switch & LATTICE_LB)) {
+  if (lattice_switch != ActiveLB::CPU) {
     runtimeErrorMsg() << "Error in lb_local_fields_get_boundary_flag in "
                       << __FILE__ << __LINE__ << ": CPU LB not switched on.";
     *boundary = 0;

--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -31,6 +31,7 @@
 #include "config.hpp"
 
 #include "grid_based_algorithms/lattice.hpp"
+#include "grid_based_algorithms/lb_constants.hpp"
 
 void mpi_set_lb_fluid_counter(int high, int low);
 
@@ -46,23 +47,6 @@ void mpi_set_lb_fluid_counter(int high, int low);
 #include "utils/Counter.hpp"
 #include "utils/Span.hpp"
 
-/** \name Parameter fields for Lattice Boltzmann
- * The numbers are referenced in \ref mpi_bcast_lb_params
- * to determine what actions have to take place upon change
- * of the respective parameter.
- */
-/*@{*/
-#define LBPAR_DENSITY 0   /**< fluid density */
-#define LBPAR_VISCOSITY 1 /**< fluid kinematic viscosity */
-#define LBPAR_AGRID 2     /**< grid constant for fluid lattice */
-#define LBPAR_TAU 3       /**< time step for fluid propagation */
-/** friction coefficient for viscous coupling between particles and fluid */
-#define LBPAR_FRICTION 4
-#define LBPAR_EXTFORCE 5 /**< external force density acting on the fluid */
-#define LBPAR_BULKVISC 6 /**< fluid bulk viscosity */
-#define LBPAR_KT 7       /**< thermal energy */
-
-/*@}*/
 /** Some general remarks:
  *  This file implements the LB D3Q19 method to Espresso. The LB_Model
  *  construction is preserved for historical reasons and might be removed

--- a/src/core/grid_based_algorithms/lb_constants.hpp
+++ b/src/core/grid_based_algorithms/lb_constants.hpp
@@ -1,0 +1,43 @@
+/*
+   Copyright (C) 2019-2019 The ESPResSo project
+
+   This file is part of ESPResSo.
+
+   ESPResSo is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** \file
+ *  Constants and enumerators for LB.
+ */
+
+#ifndef LB_CONSTANTS_HPP
+#define LB_CONSTANTS_HPP
+
+/** @brief Parameter fields for lattice Boltzmann
+ *
+ *  Determine what actions have to take place upon change of the respective
+ *  parameter.
+ */
+enum class LBParam {
+  DENSITY,   /**< fluid density */
+  VISCOSITY, /**< fluid kinematic viscosity */
+  AGRID,     /**< grid constant for fluid lattice */
+  TAU,       /**< time step for fluid propagation */
+  /** friction coefficient for viscous coupling between particles and fluid */
+  FRICTION,
+  EXTFORCE, /**< external force density acting on the fluid */
+  BULKVISC, /**< fluid bulk viscosity */
+  KT        /**< thermal energy */
+};
+
+#endif /* LB_CONSTANTS_HPP */

--- a/src/core/grid_based_algorithms/lb_constants.hpp
+++ b/src/core/grid_based_algorithms/lb_constants.hpp
@@ -32,12 +32,9 @@ enum class LBParam {
   DENSITY,   /**< fluid density */
   VISCOSITY, /**< fluid kinematic viscosity */
   AGRID,     /**< grid constant for fluid lattice */
-  TAU,       /**< time step for fluid propagation */
-  /** friction coefficient for viscous coupling between particles and fluid */
-  FRICTION,
-  EXTFORCE, /**< external force density acting on the fluid */
-  BULKVISC, /**< fluid bulk viscosity */
-  KT        /**< thermal energy */
+  EXTFORCE,  /**< external force density acting on the fluid */
+  BULKVISC,  /**< fluid bulk viscosity */
+  KT         /**< thermal energy */
 };
 
 #endif /* LB_CONSTANTS_HPP */

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -417,7 +417,7 @@ double lb_lbfluid_get_tau() {
 
 void lb_lbfluid_set_lattice_switch(int local_lattice_switch) {
   assert(local_lattice_switch >= 0 && local_lattice_switch <= 2);
-  lattice_switch = (ActiveLB)local_lattice_switch;
+  lattice_switch = static_cast<ActiveLB>(local_lattice_switch);
   mpi_bcast_parameter(FIELD_LATTICE_SWITCH);
 }
 
@@ -1191,7 +1191,7 @@ void lb_lbnode_set_pop(const Vector3i &ind, const Vector19d &p_pop) {
 const Lattice &lb_lbfluid_get_lattice() { return lblattice; }
 #endif
 
-int lb_lbfluid_get_lattice_switch() { return (int)lattice_switch; }
+int lb_lbfluid_get_lattice_switch() { return static_cast<int>(lattice_switch); }
 
 void lb_lbfluid_on_lb_params_change(LBParam field) {
   if (field == LBParam::AGRID) {

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -146,12 +146,12 @@ void lb_lbfluid_set_density(double p_dens) {
   if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     lbpar_gpu.rho = static_cast<float>(p_dens);
-    lb_lbfluid_on_lb_params_change(LBPAR_DENSITY);
+    lb_lbfluid_on_lb_params_change(LBParam::DENSITY);
 #endif // LB_GPU
   } else {
 #ifdef LB
     lbpar.rho = p_dens;
-    mpi_bcast_lb_params(LBPAR_DENSITY);
+    mpi_bcast_lb_params(LBParam::DENSITY);
 #endif // LB
   }
 }
@@ -180,12 +180,12 @@ void lb_lbfluid_set_viscosity(double p_visc) {
   if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     lbpar_gpu.viscosity = static_cast<float>(p_visc);
-    lb_lbfluid_on_lb_params_change(LBPAR_VISCOSITY);
+    lb_lbfluid_on_lb_params_change(LBParam::VISCOSITY);
 #endif // LB_GPU
   } else {
 #ifdef LB
     lbpar.viscosity = p_visc;
-    mpi_bcast_lb_params(LBPAR_VISCOSITY);
+    mpi_bcast_lb_params(LBParam::VISCOSITY);
 #endif // LB
   }
 }
@@ -215,13 +215,13 @@ void lb_lbfluid_set_bulk_viscosity(double p_bulk_visc) {
 #ifdef LB_GPU
     lbpar_gpu.bulk_viscosity = static_cast<float>(p_bulk_visc);
     lbpar_gpu.is_TRT = false;
-    lb_lbfluid_on_lb_params_change(LBPAR_BULKVISC);
+    lb_lbfluid_on_lb_params_change(LBParam::BULKVISC);
 #endif // LB_GPU
   } else {
 #ifdef LB
     lbpar.bulk_viscosity = p_bulk_visc;
     lbpar.is_TRT = false;
-    mpi_bcast_lb_params(LBPAR_BULKVISC);
+    mpi_bcast_lb_params(LBParam::BULKVISC);
 #endif // LB
   }
 }
@@ -251,13 +251,13 @@ void lb_lbfluid_set_gamma_odd(double p_gamma_odd) {
 #ifdef LB_GPU
     lbpar_gpu.gamma_odd = static_cast<float>(p_gamma_odd);
     lbpar_gpu.is_TRT = false;
-    lb_lbfluid_on_lb_params_change(0);
+    lb_lbfluid_on_lb_params_change(LBParam::DENSITY);
 #endif // LB_GPU
   } else {
 #ifdef LB
     lbpar.gamma_odd = p_gamma_odd;
     lbpar.is_TRT = false;
-    mpi_bcast_lb_params(0);
+    mpi_bcast_lb_params(LBParam::DENSITY);
 #endif // LB
   }
 }
@@ -287,13 +287,13 @@ void lb_lbfluid_set_gamma_even(double p_gamma_even) {
 #ifdef LB_GPU
     lbpar_gpu.gamma_even = static_cast<float>(p_gamma_even);
     lbpar_gpu.is_TRT = false;
-    lb_lbfluid_on_lb_params_change(0);
+    lb_lbfluid_on_lb_params_change(LBParam::DENSITY);
 #endif // LB_GPU
   } else {
 #ifdef LB
     lbpar.gamma_even = p_gamma_even;
     lbpar.is_TRT = false;
-    mpi_bcast_lb_params(0);
+    mpi_bcast_lb_params(LBParam::DENSITY);
 #endif // LB
   }
 }
@@ -319,12 +319,12 @@ void lb_lbfluid_set_agrid(double agrid) {
   if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     lb_set_agrid_gpu(agrid);
-    lb_lbfluid_on_lb_params_change(LBPAR_AGRID);
+    lb_lbfluid_on_lb_params_change(LBParam::AGRID);
 #endif // LB_GPU
   } else {
 #ifdef LB
     lbpar.agrid = agrid;
-    mpi_bcast_lb_params(LBPAR_AGRID);
+    mpi_bcast_lb_params(LBParam::AGRID);
 #endif // LB
   }
 }
@@ -362,7 +362,7 @@ void lb_lbfluid_set_ext_force_density(const Vector3d &force_density) {
   } else {
 #ifdef LB
     lbpar.ext_force_density = force_density;
-    mpi_bcast_lb_params(LBPAR_EXTFORCE);
+    mpi_bcast_lb_params(LBParam::EXTFORCE);
 #endif // LB
   }
 }
@@ -387,12 +387,12 @@ void lb_lbfluid_set_tau(double p_tau) {
   if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     lbpar_gpu.tau = static_cast<float>(p_tau);
-    lb_lbfluid_on_lb_params_change(0);
+    lb_lbfluid_on_lb_params_change(LBParam::DENSITY);
 #endif // LB_GPU
   } else {
 #ifdef LB
     lbpar.tau = p_tau;
-    mpi_bcast_lb_params(0);
+    mpi_bcast_lb_params(LBParam::DENSITY);
 #endif // LB
   }
 }
@@ -429,7 +429,7 @@ void lb_lbfluid_set_kT(double kT) {
   } else if (lattice_switch == ActiveLB::CPU) {
 #ifdef LB
     lbpar.kT = kT;
-    mpi_bcast_lb_params(LBPAR_KT);
+    mpi_bcast_lb_params(LBParam::KT);
 #endif
   }
 }
@@ -850,7 +850,7 @@ void lb_lbfluid_load_checkpoint(const std::string &filename, int binary) {
     Vector3i ind;
 
     Vector3i gridsize;
-    mpi_bcast_lb_params(0);
+    mpi_bcast_lb_params(LBParam::DENSITY);
     gridsize[0] = box_l[0] / lbpar.agrid;
     gridsize[1] = box_l[1] / lbpar.agrid;
     gridsize[2] = box_l[2] / lbpar.agrid;
@@ -1193,8 +1193,8 @@ const Lattice &lb_lbfluid_get_lattice() { return lblattice; }
 
 int lb_lbfluid_get_lattice_switch() { return (int)lattice_switch; }
 
-void lb_lbfluid_on_lb_params_change(int field) {
-  if (field == LBPAR_AGRID) {
+void lb_lbfluid_on_lb_params_change(LBParam field) {
+  if (field == LBParam::AGRID) {
 #ifdef LB
     if (lattice_switch == ActiveLB::CPU)
       lb_init();
@@ -1207,7 +1207,7 @@ void lb_lbfluid_on_lb_params_change(int field) {
     LBBoundaries::lb_init_boundaries();
 #endif
   }
-  if (field == LBPAR_DENSITY) {
+  if (field == LBParam::DENSITY) {
     lb_lbfluid_reinit_fluid();
   }
   lb_lbfluid_reinit_parameters();

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -3,6 +3,7 @@
 
 #include "config.hpp"
 #include "grid_based_algorithms/lattice.hpp"
+#include "grid_based_algorithms/lb_constants.hpp"
 #include "utils/Vector.hpp"
 
 #if defined(LB) || defined(LB_GPU)
@@ -205,7 +206,7 @@ void lb_lbfluid_load_checkpoint(const std::string &filename, int binary);
  */
 bool lb_lbnode_is_index_valid(const Vector3i &ind);
 
-void lb_lbfluid_on_lb_params_change(int field);
+void lb_lbfluid_on_lb_params_change(LBParam field);
 
 Vector3d lb_lbfluid_calc_fluid_momentum();
 #endif

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -47,14 +47,12 @@ void lb_lbfluid_set_rng_state(uint64_t counter);
 const Lattice &lb_lbfluid_get_lattice();
 
 /**
- * @brief Get the global variable lattice_switch which defines wether NONE, CPU
- * or GPU LB is active.
+ * @brief Get the global variable @ref lattice_switch.
  */
 int lb_lbfluid_get_lattice_switch();
 
 /**
- * @brief Set the global variable lattice_switch which defines wether NONE, CPU
- * or GPU LB is active.
+ * @brief Set the global variable @ref lattice_switch.
  */
 void lb_lbfluid_set_lattice_switch(int local_lattice_switch);
 

--- a/src/core/grid_based_algorithms/lb_interpolation.cpp
+++ b/src/core/grid_based_algorithms/lb_interpolation.cpp
@@ -70,7 +70,7 @@ Vector3d node_u(Lattice::index_t index) {
 
 const Vector3d
 lb_lbinterpolation_get_interpolated_velocity(const Vector3d &pos) {
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
 #ifdef LB
     Vector3d interpolated_u{};
 
@@ -91,7 +91,7 @@ lb_lbinterpolation_get_interpolated_velocity(const Vector3d &pos) {
 const Vector3d
 lb_lbinterpolation_get_interpolated_velocity_global(const Vector3d &pos) {
   auto const folded_pos = folded_position(pos);
-  if (lattice_switch & LATTICE_LB_GPU) {
+  if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     Vector3d interpolated_u{};
     switch (interpolation_order) {
@@ -106,7 +106,7 @@ lb_lbinterpolation_get_interpolated_velocity_global(const Vector3d &pos) {
     }
     return interpolated_u;
 #endif
-  } else if (lattice_switch & LATTICE_LB) {
+  } else if (lattice_switch == ActiveLB::CPU) {
 #ifdef LB
     switch (interpolation_order) {
     case (InterpolationOrder::quadratic):

--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -46,11 +46,11 @@ uint64_t lb_coupling_get_rng_state_cpu() {
 }
 
 uint64_t lb_lbcoupling_get_rng_state() {
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
 #ifdef LB
     return lb_coupling_get_rng_state_cpu();
 #endif
-  } else if (lattice_switch & LATTICE_LB_GPU) {
+  } else if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     return lb_coupling_get_rng_state_gpu();
 #endif
@@ -59,13 +59,13 @@ uint64_t lb_lbcoupling_get_rng_state() {
 }
 
 void lb_lbcoupling_set_rng_state(uint64_t counter) {
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
 #ifdef LB
     lb_particle_coupling.rng_counter_coupling =
         Utils::Counter<uint64_t>(counter);
     mpi_bcast_lb_particle_coupling();
 #endif
-  } else if (lattice_switch & LATTICE_LB_GPU) {
+  } else if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     lb_coupling_set_rng_state_gpu(counter);
 #endif
@@ -166,7 +166,7 @@ void add_swimmer_force(Particle &p) {
 
 void lb_lbcoupling_calc_particle_lattice_ia(bool couple_virtual) {
   ESPRESSO_PROFILER_CXX_MARK_FUNCTION;
-  if (lattice_switch & LATTICE_LB_GPU) {
+  if (lattice_switch == ActiveLB::GPU) {
 #ifdef LB_GPU
     if (lb_particle_coupling.couple_to_md && this_node == 0) {
       switch (lb_lbinterpolation_get_interpolation_order()) {
@@ -181,7 +181,7 @@ void lb_lbcoupling_calc_particle_lattice_ia(bool couple_virtual) {
       }
     }
 #endif
-  } else if (lattice_switch & LATTICE_LB) {
+  } else if (lattice_switch == ActiveLB::CPU) {
 #ifdef LB
     if (lb_particle_coupling.couple_to_md) {
       switch (lb_lbinterpolation_get_interpolation_order()) {

--- a/src/core/grid_based_algorithms/lbboundaries.cpp
+++ b/src/core/grid_based_algorithms/lbboundaries.cpp
@@ -88,7 +88,7 @@ void lbboundary_mindist_position(const Vector3d &pos, double *mindist,
 
 /** Initialize boundary conditions for all constraints in the system. */
 void lb_init_boundaries() {
-  if (lattice_switch & LATTICE_LB_GPU) {
+  if (lattice_switch == ActiveLB::GPU) {
 #if defined(LB_GPU) && defined(LB_BOUNDARIES_GPU)
     int number_of_boundnodes = 0;
     int *host_boundary_node_list = (int *)Utils::malloc(sizeof(int));
@@ -339,7 +339,7 @@ int lbboundary_get_force(void *lbb, double *f) {
 
   std::vector<double> forces(3 * lbboundaries.size());
 
-  if (lattice_switch & LATTICE_LB_GPU) {
+  if (lattice_switch == ActiveLB::GPU) {
 #if defined(LB_BOUNDARIES_GPU) && defined(LB_GPU)
     lb_gpu_get_boundary_forces(forces.data());
 

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -37,23 +37,6 @@
  * thus making the code more efficient. */
 #define LBQ 19
 
-/** \name Parameter fields for lattice Boltzmann
- *  The numbers are referenced in \ref mpi_bcast_lb_params
- *  to determine what actions have to take place upon change
- *  of the respective parameter. */
-/*@{*/
-#define LBPAR_DENSITY 0   /**< fluid density */
-#define LBPAR_VISCOSITY 1 /**< fluid kinematic viscosity */
-#define LBPAR_AGRID 2     /**< grid constant for fluid lattice */
-#define LBPAR_TAU 3       /**< time step for fluid propagation */
-#define LBPAR_FRICTION                                                         \
-  4 /**< friction coefficient for viscous coupling between particles and fluid \
-     */
-#define LBPAR_EXTFORCE 5 /**< external force acting on the fluid */
-#define LBPAR_BULKVISC 6 /**< fluid bulk viscosity */
-#define LBPAR_BOUNDARY 7 /**< boundary parameters */
-/*@}*/
-
 #if defined(LB_DOUBLE_PREC) || defined(EK_DOUBLE_PREC)
 typedef double lbForceFloat;
 #else

--- a/src/core/initialize.cpp
+++ b/src/core/initialize.cpp
@@ -357,14 +357,14 @@ void on_lbboundary_change() {
   invalidate_obs();
 
 #ifdef LB_BOUNDARIES
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
     LBBoundaries::lb_init_boundaries();
   }
 #endif
 
 #ifdef LB_BOUNDARIES_GPU
   if (this_node == 0) {
-    if (lattice_switch & LATTICE_LB_GPU) {
+    if (lattice_switch == ActiveLB::GPU) {
       LBBoundaries::lb_init_boundaries();
     }
   }
@@ -452,7 +452,7 @@ void on_boxl_change() {
 #endif
 
 #ifdef LB
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
     lb_lbfluid_init();
 #ifdef LB_BOUNDARIES
     LBBoundaries::lb_init_boundaries();
@@ -509,7 +509,7 @@ void on_cell_structure_change() {
 #endif /* ifdef DIPOLES */
 
 #ifdef LB
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
     lb_lbfluid_init();
   }
 #endif
@@ -626,7 +626,7 @@ void on_ghost_flags_change() {
 
 /* DPD and LB need also ghost velocities */
 #ifdef LB
-  if (lattice_switch & LATTICE_LB)
+  if (lattice_switch == ActiveLB::CPU)
     ghosts_have_v = 1;
 #endif
 #ifdef BOND_CONSTRAINT

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -253,7 +253,7 @@ void integrate_vv(int n_steps, int reuse_forces) {
 
 #if defined(LB) || defined(LB_GPU)
     lb_lbcoupling_deactivate();
-    if (lattice_switch != LATTICE_OFF && this_node == 0 && n_part)
+    if (lattice_switch != ActiveLB::NONE && this_node == 0 && n_part)
       runtimeWarning("Recalculating forces, so the LB coupling forces are not "
                      "included in the particle force the first time step. This "
                      "only matters if it happens frequently during "

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -295,7 +295,7 @@ void convert_torques_propagate_omega() {
       fprintf(stderr, "%d: convert_torques_propagate_omega:\n", this_node));
 
 #if defined(LB_GPU) && defined(ENGINE)
-  if ((lattice_switch & LATTICE_LB_GPU) && swimming_particles_exist) {
+  if (lattice_switch == ActiveLB::GPU && swimming_particles_exist) {
     copy_v_cs_from_GPU(local_cells.particles());
   }
 #endif
@@ -308,7 +308,7 @@ void convert_torques_propagate_omega() {
     convert_torque_to_body_frame_apply_fix_and_thermostat(p);
 
 #if defined(ENGINE) && (defined(LB) || defined(LB_GPU))
-    if (p.swim.swimming && lattice_switch != 0) {
+    if (p.swim.swimming && lattice_switch != ActiveLB::NONE) {
 
       auto const dip = p.swim.dipole_length * p.r.calc_director();
 

--- a/src/core/virtual_sites/VirtualSitesInertialessTracers.cpp
+++ b/src/core/virtual_sites/VirtualSitesInertialessTracers.cpp
@@ -29,13 +29,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 void VirtualSitesInertialessTracers::after_force_calc() {
   // Now the forces are computed and need to go into the LB fluid
 #ifdef LB
-  if (lattice_switch & LATTICE_LB) {
+  if (lattice_switch == ActiveLB::CPU) {
     IBM_ForcesIntoFluid_CPU();
     return;
   }
 #endif
 #ifdef LB_GPU
-  if (lattice_switch & LATTICE_LB_GPU) {
+  if (lattice_switch == ActiveLB::GPU) {
     IBM_ForcesIntoFluid_GPU(local_cells.particles());
     return;
   }
@@ -55,9 +55,9 @@ void VirtualSitesInertialessTracers::after_lb_propagation() {
   IBM_UpdateParticlePositions(local_cells.particles());
 // We reset all since otherwise the halo nodes may not be reset
 // NB: the normal Espresso reset is also done after applying the forces
-//    if (lattice_switch & LATTICE_LB) IBM_ResetLBForces_CPU();
+//    if (lattice_switch == ActiveLB::CPU) IBM_ResetLBForces_CPU();
 #ifdef LB_GPU
-// if (lattice_switch & LATTICE_LB_GPU) IBM_ResetLBForces_GPU();
+// if (lattice_switch == ActiveLB::GPU) IBM_ResetLBForces_GPU();
 #endif
 
   // Ghost positions are now out-of-date

--- a/src/core/virtual_sites/lb_inertialess_tracers.cpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers.cpp
@@ -118,10 +118,10 @@ Interpolates LB velocity at the particle positions and propagates the particles
 
 void IBM_UpdateParticlePositions(ParticleRange particles) {
   // Get velocities
-  if (lattice_switch & LATTICE_LB)
+  if (lattice_switch == ActiveLB::CPU)
     ParticleVelocitiesFromLB_CPU();
 #ifdef LB_GPU
-  if (lattice_switch & LATTICE_LB_GPU)
+  if (lattice_switch == ActiveLB::GPU)
     ParticleVelocitiesFromLB_GPU(particles);
 #endif
 

--- a/src/python/espressomd/lb.pxd
+++ b/src/python/espressomd/lb.pxd
@@ -36,6 +36,11 @@ cdef class HydrodynamicInteraction(Actor):
 
 IF LB_GPU or LB:
 
+    cdef enum ActiveLB:
+        ActiveLB_NONE = 0
+        ActiveLB_CPU = 1
+        ActiveLB_GPU = 2
+
     ##############################################
     #
     # extern functions and structs

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -244,7 +244,7 @@ cdef class HydrodynamicInteraction(Actor):
     "Subclasses of HydrodynamicInteraction have to implement _activate_method.") 
 
         def _deactivate_method(self):
-            lb_lbfluid_set_lattice_switch(0)
+            lb_lbfluid_set_lattice_switch(ActiveLB_NONE)
 
 
 # LBFluid main class
@@ -257,7 +257,7 @@ IF LB:
         """
 
         def _set_lattice_switch(self):
-            lb_lbfluid_set_lattice_switch(1)
+            lb_lbfluid_set_lattice_switch(ActiveLB_CPU)
 
         def _activate_method(self):
             self.validate_params()
@@ -275,7 +275,7 @@ IF LB_GPU:
             lb_lbfluid_remove_total_momentum()
 
         def _set_lattice_switch(self):
-            lb_lbfluid_set_lattice_switch(2)
+            lb_lbfluid_set_lattice_switch(ActiveLB_GPU)
 
         def _activate_method(self):
             self.validate_params()

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -36,6 +36,7 @@ from .utils cimport numeric_limits
 if LB or LB_GPU:
     from .lb cimport lb_lbfluid_get_tau
     from .lb cimport lb_lbfluid_get_lattice_switch
+    from .lb cimport ActiveLB_NONE
 from .thermostat import Thermostat
 from .cellsystem import CellSystem
 from .minimize_energy import MinimizeEnergy
@@ -273,7 +274,7 @@ cdef class System(object):
                 raise ValueError("Time Step must be positive")
             IF LB or LB_GPU:
                 cdef double tau
-                if lb_lbfluid_get_lattice_switch() != 0:
+                if lb_lbfluid_get_lattice_switch() != ActiveLB_NONE:
                     tau = lb_lbfluid_get_tau()
                     if (tau >= 0.0 and
                             tau - _time_step > numeric_limits[float].epsilon() * abs(tau + _time_step)):


### PR DESCRIPTION
Hard-coded integer values and macros are confusing, not logically connected to each other and prone to accidental redefines and documentation decay. `enum class` puts everything in scopes. Fixes #2556