### PR TITLE
Fix Random123 on architectures that do not provide 128-bit integers

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,6 +1,4 @@
 add_library(Random123 INTERFACE)
 target_include_directories(Random123 SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Random123-1.09/include)
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-  target_compile_definitions(Random123 INTERFACE R123_USE_MULHILO64_C99)
-endif()
+target_compile_definitions(Random123 INTERFACE R123_USE_MULHILO64_C99)


### PR DESCRIPTION
Follow-up to #2562.

[s390x](https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/-/jobs/82214) and [arm64](https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/-/jobs/82210) were still failing. This pull request unconditionally enables `R123_USE_MULHILO64_C99`, which is used as a fallback if neither assembly instructions, intrinsics, nor 128-bit integers are available.