### PR TITLE
core: Moved obstrvable struct definitions to sep file

### DIFF
--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -1,0 +1,70 @@
+#ifndef ESPRESSO_OBSERVABLE_STAT_HPP
+#define ESPRESSO_OBSERVABLE_STAT_HPP
+
+#include <utils/List.hpp>
+
+struct Observable_stat {
+    /** Status flag for observable calculation.  For 'analyze energy': 0
+        re-initialize observable struct, else everything is fine,
+        calculation can start.  For 'analyze pressure' and 'analyze
+        p_inst': 0 or !(1+v_comp) re-initialize, else all OK. */
+    int init_status;
+
+    /** Array for observables on each node. */
+    Utils::List<double> data;
+
+    /** number of Coulomb interactions */
+    int n_coulomb;
+    /** number of dipolar interactions */
+    int n_dipolar;
+    /** number of non bonded interactions */
+    int n_non_bonded;
+    /** Number of virtual sites relative (rigid body) contributions */
+    int n_virtual_sites;
+    /** Number of external field contributions */
+    const static int n_external_field = 1;
+
+    /** start of bonded interactions. Right after the special ones */
+    double *bonded;
+    /** start of observables for non-bonded interactions. */
+    double *non_bonded;
+    /** start of observables for Coulomb interaction. */
+    double *coulomb;
+    /** start of observables for Coulomb interaction. */
+    double *dipolar;
+    /** Start of observables for virtual sites relative (rigid bodies) */
+    double *virtual_sites;
+    /** Start of observables for external fields */
+    double *external_fields;
+
+    /** number of doubles per data item */
+    int chunk_size;
+};
+
+/** Structure used only in the pressure and stress tensor calculation to
+   distinguish
+    non-bonded intra- and inter- molecular contributions. */
+typedef struct {
+    /** Status flag for observable calculation.
+        For 'analyze energy': 0 re-initialize observable struct, else every thing
+       is fine, calculation can start.
+        For 'analyze pressure' and 'analyze p_inst': 0 or !(1+v_comp)
+       re-initialize, else all OK. */
+    int init_status_nb;
+
+    /** Array for observables on each node. */
+    Utils::List<double> data_nb;
+
+    /** number of non bonded interactions */
+    int n_nonbonded;
+
+    /** start of observables for non-bonded intramolecular interactions. */
+    double *non_bonded_intra;
+    /** start of observables for non-bonded intermolecular interactions. */
+    double *non_bonded_inter;
+
+    /** number of doubles per data item */
+    int chunk_size_nb;
+} Observable_stat_non_bonded;
+
+#endif //ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -4,67 +4,67 @@
 #include <utils/List.hpp>
 
 struct Observable_stat {
-    /** Status flag for observable calculation.  For 'analyze energy': 0
-        re-initialize observable struct, else everything is fine,
-        calculation can start.  For 'analyze pressure' and 'analyze
-        p_inst': 0 or !(1+v_comp) re-initialize, else all OK. */
-    int init_status;
+  /** Status flag for observable calculation.  For 'analyze energy': 0
+      re-initialize observable struct, else everything is fine,
+      calculation can start.  For 'analyze pressure' and 'analyze
+      p_inst': 0 or !(1+v_comp) re-initialize, else all OK. */
+  int init_status;
 
-    /** Array for observables on each node. */
-    Utils::List<double> data;
+  /** Array for observables on each node. */
+  Utils::List<double> data;
 
-    /** number of Coulomb interactions */
-    int n_coulomb;
-    /** number of dipolar interactions */
-    int n_dipolar;
-    /** number of non bonded interactions */
-    int n_non_bonded;
-    /** Number of virtual sites relative (rigid body) contributions */
-    int n_virtual_sites;
-    /** Number of external field contributions */
-    const static int n_external_field = 1;
+  /** number of Coulomb interactions */
+  int n_coulomb;
+  /** number of dipolar interactions */
+  int n_dipolar;
+  /** number of non bonded interactions */
+  int n_non_bonded;
+  /** Number of virtual sites relative (rigid body) contributions */
+  int n_virtual_sites;
+  /** Number of external field contributions */
+  const static int n_external_field = 1;
 
-    /** start of bonded interactions. Right after the special ones */
-    double *bonded;
-    /** start of observables for non-bonded interactions. */
-    double *non_bonded;
-    /** start of observables for Coulomb interaction. */
-    double *coulomb;
-    /** start of observables for Coulomb interaction. */
-    double *dipolar;
-    /** Start of observables for virtual sites relative (rigid bodies) */
-    double *virtual_sites;
-    /** Start of observables for external fields */
-    double *external_fields;
+  /** start of bonded interactions. Right after the special ones */
+  double *bonded;
+  /** start of observables for non-bonded interactions. */
+  double *non_bonded;
+  /** start of observables for Coulomb interaction. */
+  double *coulomb;
+  /** start of observables for Coulomb interaction. */
+  double *dipolar;
+  /** Start of observables for virtual sites relative (rigid bodies) */
+  double *virtual_sites;
+  /** Start of observables for external fields */
+  double *external_fields;
 
-    /** number of doubles per data item */
-    int chunk_size;
+  /** number of doubles per data item */
+  int chunk_size;
 };
 
 /** Structure used only in the pressure and stress tensor calculation to
    distinguish
     non-bonded intra- and inter- molecular contributions. */
 typedef struct {
-    /** Status flag for observable calculation.
-        For 'analyze energy': 0 re-initialize observable struct, else every thing
-       is fine, calculation can start.
-        For 'analyze pressure' and 'analyze p_inst': 0 or !(1+v_comp)
-       re-initialize, else all OK. */
-    int init_status_nb;
+  /** Status flag for observable calculation.
+      For 'analyze energy': 0 re-initialize observable struct, else every thing
+     is fine, calculation can start.
+      For 'analyze pressure' and 'analyze p_inst': 0 or !(1+v_comp)
+     re-initialize, else all OK. */
+  int init_status_nb;
 
-    /** Array for observables on each node. */
-    Utils::List<double> data_nb;
+  /** Array for observables on each node. */
+  Utils::List<double> data_nb;
 
-    /** number of non bonded interactions */
-    int n_nonbonded;
+  /** number of non bonded interactions */
+  int n_nonbonded;
 
-    /** start of observables for non-bonded intramolecular interactions. */
-    double *non_bonded_intra;
-    /** start of observables for non-bonded intermolecular interactions. */
-    double *non_bonded_inter;
+  /** start of observables for non-bonded intramolecular interactions. */
+  double *non_bonded_intra;
+  /** start of observables for non-bonded intermolecular interactions. */
+  double *non_bonded_inter;
 
-    /** number of doubles per data item */
-    int chunk_size_nb;
+  /** number of doubles per data item */
+  int chunk_size_nb;
 } Observable_stat_non_bonded;
 
-#endif //ESPRESSO_OBSERVABLE_STAT_HPP
+#endif // ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -26,13 +26,13 @@
  *  Implementation in statistics.cpp.
  */
 
+#include "Observable_stat.hpp"
 #include "PartCfg.hpp"
 #include "grid.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "particle_data.hpp"
 #include "topology.hpp"
 #include "utils.hpp"
-#include "Observable_stat.hpp"
 
 #include <map>
 #include <string>

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -32,6 +32,8 @@
 #include "particle_data.hpp"
 #include "topology.hpp"
 #include "utils.hpp"
+#include "Observable_stat.hpp"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -39,70 +41,6 @@
 /** \name Data Types */
 /************************************************************/
 /*@{*/
-
-struct Observable_stat {
-  /** Status flag for observable calculation.  For 'analyze energy': 0
-      re-initialize observable struct, else everything is fine,
-      calculation can start.  For 'analyze pressure' and 'analyze
-      p_inst': 0 or !(1+v_comp) re-initialize, else all OK. */
-  int init_status;
-
-  /** Array for observables on each node. */
-  DoubleList data;
-
-  /** number of Coulomb interactions */
-  int n_coulomb;
-  /** number of dipolar interactions */
-  int n_dipolar;
-  /** number of non bonded interactions */
-  int n_non_bonded;
-  /** Number of virtual sites relative (rigid body) contributions */
-  int n_virtual_sites;
-  /** Number of external field contributions */
-  const static int n_external_field = 1;
-
-  /** start of bonded interactions. Right after the special ones */
-  double *bonded;
-  /** start of observables for non-bonded interactions. */
-  double *non_bonded;
-  /** start of observables for Coulomb interaction. */
-  double *coulomb;
-  /** start of observables for Coulomb interaction. */
-  double *dipolar;
-  /** Start of observables for virtual sites relative (rigid bodies) */
-  double *virtual_sites;
-  /** Start of observables for external fields */
-  double *external_fields;
-
-  /** number of doubles per data item */
-  int chunk_size;
-};
-
-/** Structure used only in the pressure and stress tensor calculation to
-   distinguish
-    non-bonded intra- and inter- molecular contributions. */
-typedef struct {
-  /** Status flag for observable calculation.
-      For 'analyze energy': 0 re-initialize observable struct, else every thing
-     is fine, calculation can start.
-      For 'analyze pressure' and 'analyze p_inst': 0 or !(1+v_comp)
-     re-initialize, else all OK. */
-  int init_status_nb;
-
-  /** Array for observables on each node. */
-  DoubleList data_nb;
-
-  /** number of non bonded interactions */
-  int n_nonbonded;
-
-  /** start of observables for non-bonded intramolecular interactions. */
-  double *non_bonded_intra;
-  /** start of observables for non-bonded intermolecular interactions. */
-  double *non_bonded_inter;
-
-  /** number of doubles per data item */
-  int chunk_size_nb;
-} Observable_stat_non_bonded;
 
 /*@}*/
 


### PR DESCRIPTION
These need to be included to add energy or pressure contributions.

The corresponding functions should be cleaned up too, but is out of scope for me.
