### PR TITLE
Remove forces and boundaries from the GPU checkpoint file

### DIFF
--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -997,7 +997,6 @@ inline void lb_collide_stream() {
 /** \name Update step for the lattice Boltzmann fluid                  */
 /***********************************************************************/
 /*@{*/
-/*@}*/
 
 /** Update the lattice Boltzmann fluid.
  *
@@ -1015,6 +1014,8 @@ void lattice_boltzmann_update() {
     lb_collide_stream();
   }
 }
+
+/*@}*/
 
 /***********************************************************************/
 /** \name Coupling part */
@@ -1433,5 +1434,7 @@ void lb_collect_boundary_forces(double *result) {
              MPI_SUM, 0, comm_cart);
 #endif
 }
+
+/*@}*/
 
 #endif // LB

--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -311,4 +311,7 @@ void lb_calc_fluid_mass(double *result);
 void lb_calc_fluid_momentum(double *result);
 void lb_calc_fluid_temp(double *result);
 void lb_collect_boundary_forces(double *result);
+
+/*@}*/
+
 #endif /* _LB_H */

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -259,12 +259,8 @@ void lb_reinit_extern_nodeforce_GPU(LB_parameters_gpu *lbpar_gpu);
 void lb_reinit_GPU(LB_parameters_gpu *lbpar_gpu);
 int lb_lbnode_set_extforce_density_GPU(int ind[3], double f[3]);
 void lb_gpu_get_boundary_forces(double *forces);
-void lb_save_checkpoint_GPU(float *host_checkpoint_vd,
-                            unsigned int *host_checkpoint_boundary,
-                            lbForceFloat *host_checkpoint_force);
-void lb_load_checkpoint_GPU(float *host_checkpoint_vd,
-                            unsigned int *host_checkpoint_boundary,
-                            lbForceFloat *host_checkpoint_force);
+void lb_save_checkpoint_GPU(float *const host_checkpoint_vd);
+void lb_load_checkpoint_GPU(float const *const host_checkpoint_vd);
 
 void lb_lbfluid_remove_total_momentum();
 void lb_lbfluid_fluid_add_momentum(float momentum[3]);

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -115,7 +115,7 @@ static int *gpu_check = nullptr;
 static int *h_gpu_check = nullptr;
 /*@}*/
 
-static unsigned int intflag = 1;
+static bool intflag = true;
 LB_nodes_gpu *current_nodes = nullptr;
 /** @name defining size values for allocating global memory */
 /*@{*/
@@ -2493,7 +2493,7 @@ void lb_init_GPU(LB_parameters_gpu *lbpar_gpu) {
   KERNELCALL(calc_n_from_rho_j_pi, dim_grid, threads_per_block, nodes_a,
              device_rho_v, node_f, gpu_check);
 
-  intflag = 1;
+  intflag = true;
   current_nodes = &nodes_a;
   h_gpu_check[0] = 0;
   cuda_safe_mem(
@@ -2898,7 +2898,7 @@ void lb_save_checkpoint_GPU(float *const host_checkpoint_vd) {
  */
 void lb_load_checkpoint_GPU(float const *const host_checkpoint_vd) {
   current_nodes = &nodes_a;
-  intflag = 1;
+  intflag = true;
 
   cuda_safe_mem(cudaMemcpy(current_nodes->vd, host_checkpoint_vd,
                            lbpar_gpu.number_of_nodes * 19 * sizeof(float),
@@ -2990,18 +2990,18 @@ void lb_integrate_GPU() {
 #endif
 
   /**call of fluid step*/
-  if (intflag == 1) {
+  if (intflag) {
     KERNELCALL(integrate, dim_grid, threads_per_block, nodes_a, nodes_b,
                device_rho_v, node_f, lb_ek_parameters_gpu,
                rng_counter_fluid_gpu.value());
     current_nodes = &nodes_b;
-    intflag = 0;
+    intflag = false;
   } else {
     KERNELCALL(integrate, dim_grid, threads_per_block, nodes_b, nodes_a,
                device_rho_v, node_f, lb_ek_parameters_gpu,
                rng_counter_fluid_gpu.value());
     current_nodes = &nodes_a;
-    intflag = 1;
+    intflag = true;
   }
 
 #ifdef LB_BOUNDARIES_GPU

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -2885,45 +2885,23 @@ void lb_calc_fluid_temperature_GPU(double *host_temp) {
 }
 
 /** Setup and call kernel for getting macroscopic fluid values of all nodes
- *  @param host_checkpoint_vd         struct to save the gpu populations
- *  @param host_checkpoint_boundary   struct to save the boundary nodes
- *  @param host_checkpoint_force      struct to save the forces on the nodes
+ *  @param host_checkpoint_vd[out]   LB populations
  */
-void lb_save_checkpoint_GPU(float *host_checkpoint_vd,
-                            unsigned int *host_checkpoint_boundary,
-                            lbForceFloat *host_checkpoint_force) {
+void lb_save_checkpoint_GPU(float *const host_checkpoint_vd) {
   cuda_safe_mem(cudaMemcpy(host_checkpoint_vd, current_nodes->vd,
                            lbpar_gpu.number_of_nodes * 19 * sizeof(float),
-                           cudaMemcpyDeviceToHost));
-  cuda_safe_mem(cudaMemcpy(host_checkpoint_boundary, current_nodes->boundary,
-                           lbpar_gpu.number_of_nodes * sizeof(unsigned int),
-                           cudaMemcpyDeviceToHost));
-  cuda_safe_mem(cudaMemcpy(host_checkpoint_force, node_f.force_density,
-                           lbpar_gpu.number_of_nodes * 3 * sizeof(lbForceFloat),
                            cudaMemcpyDeviceToHost));
 }
 
 /** Setup and call kernel for getting macroscopic fluid values of all nodes
- *  @param host_checkpoint_vd         struct to save the GPU populations
- *  @param host_checkpoint_boundary   struct to save the boundary nodes
- *  @param host_checkpoint_force      struct to save the forces on the nodes
- *  @param host_checkpoint_philox_counter
+ *  @param host_checkpoint_vd[in]    LB populations
  */
-void lb_load_checkpoint_GPU(float *host_checkpoint_vd,
-                            unsigned int *host_checkpoint_boundary,
-                            lbForceFloat *host_checkpoint_force) {
+void lb_load_checkpoint_GPU(float const *const host_checkpoint_vd) {
   current_nodes = &nodes_a;
   intflag = 1;
 
   cuda_safe_mem(cudaMemcpy(current_nodes->vd, host_checkpoint_vd,
                            lbpar_gpu.number_of_nodes * 19 * sizeof(float),
-                           cudaMemcpyHostToDevice));
-
-  cuda_safe_mem(cudaMemcpy(current_nodes->boundary, host_checkpoint_boundary,
-                           lbpar_gpu.number_of_nodes * sizeof(unsigned int),
-                           cudaMemcpyHostToDevice));
-  cuda_safe_mem(cudaMemcpy(node_f.force_density, host_checkpoint_force,
-                           lbpar_gpu.number_of_nodes * 3 * sizeof(lbForceFloat),
                            cudaMemcpyHostToDevice));
 }
 


### PR DESCRIPTION
As discussed in https://github.com/espressomd/espresso/issues/2555#issuecomment-471959923.

Doxygen warnings reduced from 29 to 20.