### PR TITLE
Label expected LB error messages

### DIFF
--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import itertools
 import unittest as ut
 import numpy as np
+import sys
 
 import espressomd
 import espressomd.lb
@@ -205,6 +206,7 @@ class TestLB(object):
         local_box_l aren't integer multiples of agrid.
         """
         self.system.actors.clear()
+        print("Testing LB error messages:", file=sys.stderr)
         self.lbf = self.lb_class(
             visc=self.params['viscosity'],
             dens=self.params['dens'],
@@ -213,6 +215,7 @@ class TestLB(object):
             ext_force_density=[0, 0, 0])
         with self.assertRaises(Exception):
             self.system.actors.add(self.lbf)
+        print("End of LB error messages", file=sys.stderr)
 
     @ut.skipIf(not espressomd.has_features("EXTERNAL_FORCES"),
                "Features not available, skipping test!")


### PR DESCRIPTION
When the `lb.py` test fails, all stderr messages are printed to the CI log. All `ERROR: Lattice spacing p_agrid= 0.50001` messages are perfectly normal (they're from the `test_incompatible_agrid()` case), but they can be a distraction when trying to decipher the cause of a failed `lb.py` test. The improved output now makes it clear these error statements can be ignored:
```
.WARNING: More than one GPU detected, please note ESPResSo uses device 0 by default regardless
 of usage or capability. The GPU to be used can be modified by setting System.cuda_init_handle.device.
..Testing LB error messages:
ERROR: Lattice spacing p_agrid= 0.50001 is incompatible with box_l[0]=6, factor=12 err= 0.00012
ERROR: Lattice spacing p_agrid= 0.50001 is incompatible with box_l[1]=6, factor=12 err= 0.00012
ERROR: Lattice spacing p_agrid= 0.50001 is incompatible with box_l[2]=6, factor=12 err= 0.00012
End of LB error messages
..WARNING: Recalculating forces, so the LB coupling forces are not included in the particle force the
 first time step. This only matters if it happens frequently during sampling.
```