### PR TITLE
Vector

### DIFF
--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -65,7 +65,7 @@ calc_harmonic_dumbbell_pair_force(Particle *p1, Particle const *p2,
     force[i] = fac * dx[i];
 
   auto const dhat = Vector3d{dx[0], dx[1], dx[2]} * normalizer;
-  auto const da = dhat.cross(p1->r.calc_director());
+  auto const da = vector_product(dhat, p1->r.calc_director());
 
   p1->f.torque += iaparams->p.harmonic_dumbbell.k2 * da;
   return 0;

--- a/src/core/constraints/HomogeneousMagneticField.cpp
+++ b/src/core/constraints/HomogeneousMagneticField.cpp
@@ -25,7 +25,7 @@ ParticleForce HomogeneousMagneticField::force(const Particle &p,
                                               const Vector3d &folded_pos,
                                               double t) {
 #if defined(ROTATION) && defined(DIPOLES)
-  return {Vector3d{}, Vector3d::cross(p.calc_dip(), m_field)};
+  return {Vector3d{}, vector_product(p.calc_dip(), m_field)};
 #else
   return {Vector3d{}};
 #endif

--- a/src/core/immersed_boundary/ibm_tribend.cpp
+++ b/src/core/immersed_boundary/ibm_tribend.cpp
@@ -231,8 +231,8 @@ int IBM_Tribend_SetParams(const int bond_type, const int ind1, const int ind2,
 
       // Get normals on triangle; pointing outwards by definition of indices
       // sequence
-      auto const n1l = dx1.cross(dx2);
-      auto const n2l = -dx1.cross(dx3);
+      auto const n1l = vector_product(dx1, dx2);
+      auto const n2l = -vector_product(dx1, dx3);
 
       auto const n1 = n1l / n1l.norm();
       auto const n2 = n2l / n2l.norm();
@@ -244,7 +244,7 @@ int IBM_Tribend_SetParams(const int bond_type, const int ind1, const int ind2,
 
       theta0 = acos(sc);
 
-      auto const desc = dx1 * n1.cross(n2);
+      auto const desc = dx1 * vector_product(n1, n2);
       if (desc < 0)
         theta0 = 2.0 * PI - theta0;
 

--- a/src/core/immersed_boundary/ibm_triel.cpp
+++ b/src/core/immersed_boundary/ibm_triel.cpp
@@ -89,7 +89,7 @@ int IBM_Triel_CalcForce(Particle *p1, Particle *p2, Particle *p3,
 
   // angles between these vectors; calculated directly via the products
   const double cosPhi = (vec1 * vec2) / (lp * l);
-  auto const vecpro = vec1.cross(vec2);
+  auto const vecpro = vector_product(vec1, vec2);
   const double sinPhi = vecpro.norm() / (l * lp);
 
   // Check for sanity

--- a/src/core/object-in-fluid/membrane_collision.hpp
+++ b/src/core/object-in-fluid/membrane_collision.hpp
@@ -96,7 +96,7 @@ inline void add_membrane_collision_pair_force(const Particle *p1,
 
       // for very small angles the force should not be applied - these happen at
       // the crossing of the boundary and would result in oscillation
-      product = out1.dot(out2);
+      product = out1 * out2;
       angle = acos(product);
 
       if (fabs(angle) > SMALL_OIF_MEMBRANE_CUTOFF) {

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -889,7 +889,7 @@ void set_particle_rotational_inertia(int part, double *rinertia) {
       part, Vector3d(rinertia, rinertia + 3));
 }
 #else
-const constexpr double ParticleProperties::rinertia[3];
+constexpr Vector3d ParticleProperties::rinertia;
 #endif
 #ifdef ROTATION
 void set_particle_rotation(int part, int rot) {

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -299,14 +299,6 @@ struct ParticleLocal {
   int ghost = 0;
 };
 
-#ifdef LB
-/** Data related to the lattice Boltzmann hydrodynamic coupling */
-struct ParticleLatticeCoupling {
-  /** fluctuating part of the coupling force */
-  Vector3d f_random;
-};
-#endif
-
 struct ParticleParametersSwimming {
 // ifdef inside because we need this type for some MPI prototypes
 #ifdef ENGINE
@@ -388,9 +380,6 @@ struct Particle {
   ///
   ParticleLocal l;
 ///
-#ifdef LB
-  ParticleLatticeCoupling lc;
-#endif
   /** Bonded interactions list
    *
    *  The format is pretty simple: just the bond type, and then the particle

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -112,7 +112,7 @@ struct ParticleProperties {
   /** rotational inertia */
   Vector3d rinertia = {1., 1., 1.};
 #else
-  static const constexpr double rinertia[3] = {1., 1., 1.};
+  static constexpr Vector3d rinertia = {1., 1., 1.};
 #endif
 
 #ifdef AFFINITY

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -379,7 +379,7 @@ struct Particle {
   ParticleForce f;
   ///
   ParticleLocal l;
-///
+  ///
   /** Bonded interactions list
    *
    *  The format is pretty simple: just the bond type, and then the particle

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -356,9 +356,6 @@ struct Particle {
     ret.m = m;
     ret.f = f;
     ret.l = l;
-#ifdef LB
-    ret.lc = lc;
-#endif
 #ifdef ENGINE
     ret.swim = swim;
 #endif

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -315,7 +315,7 @@ void convert_torques_propagate_omega() {
 
       auto const diff = p.swim.v_center - p.swim.v_source;
 
-      const Vector3d cross = Vector3d::cross(diff, dip);
+      const Vector3d cross = vector_product(diff, dip);
       const double l_diff = diff.norm();
       const double l_cross = cross.norm();
 

--- a/src/core/shapes/HollowCone.cpp
+++ b/src/core/shapes/HollowCone.cpp
@@ -51,7 +51,7 @@ void HollowCone::calculate_dist(const Vector3d &pos, double *dist,
   // Calculate the point on position + mu * orientation,
   // where the difference segment is orthogonal
 
-  mu = (m_orientation.dot(point_3D) - m_position.dot(m_orientation)) /
+  mu = (m_orientation * point_3D - m_position * m_orientation) /
        m_orientation.norm2();
 
   // Then the closest point to the line is

--- a/src/core/shapes/Stomatocyte.cpp
+++ b/src/core/shapes/Stomatocyte.cpp
@@ -55,7 +55,7 @@ void Stomatocyte::calculate_dist(const Vector3d &pos, double *dist,
   // Calculate the point on position + mu * orientation,
   // where the difference segment is orthogonal
 
-  mu = (m_orientation.dot(pos) - m_position.dot(m_orientation)) /
+  mu = (m_orientation * pos - m_position * m_orientation) /
        m_orientation.norm2();
 
   // Then the closest point to the line is

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -292,12 +292,12 @@ void angularmomentum(PartCfg &partCfg, int type, double *com) {
 void momentofinertiamatrix(PartCfg &partCfg, int type, double *MofImatrix) {
   int i, count;
   double p1[3], massi;
-  std::vector<double> com(3);
   count = 0;
 
   for (i = 0; i < 9; i++)
     MofImatrix[i] = 0.;
-  com = centerofmass(partCfg, type);
+
+  auto const com = centerofmass(partCfg, type);
   for (auto const &p : partCfg) {
     if (type == p.p.type) {
       count++;

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -750,19 +750,19 @@ int calc_cylindrical_average(
 
         // Find the height of the particle above the axis (height) and
         // the distance from the center point (dist)
-        auto const hat = direction.cross(diff);
+        auto const hat = vector_product(direction, diff);
         auto const height = hat.norm();
-        auto const dist = direction.dot(diff) / norm_direction;
+        auto const dist = direction * diff / norm_direction;
 
         // Determine the components of the velocity parallel and
         // perpendicular to the direction vector
         double v_radial;
         if (height == 0)
-          v_radial = vel.cross(direction).norm() / norm_direction;
+          v_radial = vector_product(vel, direction).norm() / norm_direction;
         else
-          v_radial = vel.dot(hat) / height;
+          v_radial = vel * hat / height;
 
-        auto const v_axial = vel.dot(direction) / norm_direction;
+        auto const v_axial = vel * direction / norm_direction;
 
         // Work out relevant indices for x and y
         index_radial = static_cast<int>(floor(height / binwd_radial));

--- a/src/core/unit_tests/vec_rotate_test.cpp
+++ b/src/core/unit_tests/vec_rotate_test.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(rotation) {
 
   /* Rodrigues' formula from wikipedia */
   auto const expected =
-      cos(t) * v + sin(t) * k.cross(v) + (1. - cos(t)) * (k * v) * k;
+      cos(t) * v + sin(t) * vector_product(k, v) + (1. - cos(t)) * (k * v) * k;
 
   auto const is = vec_rotate(k, t, v);
   auto const rel_diff = (expected - is).norm() / expected.norm();

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -31,23 +31,23 @@
 
 #include "utils/Array.hpp"
 
-template <typename Scalar, std::size_t n>
-class Vector : public Utils::Array<Scalar, n> {
+template <typename T, std::size_t n>
+class Vector : public Utils::Array<T, n> {
 public:
-  using Utils::Array<Scalar, n>::at;
-  using Utils::Array<Scalar, n>::operator[];
-  using Utils::Array<Scalar, n>::front;
-  using Utils::Array<Scalar, n>::back;
-  using Utils::Array<Scalar, n>::data;
-  using Utils::Array<Scalar, n>::begin;
-  using Utils::Array<Scalar, n>::cbegin;
-  using Utils::Array<Scalar, n>::end;
-  using Utils::Array<Scalar, n>::cend;
-  using Utils::Array<Scalar, n>::empty;
-  using Utils::Array<Scalar, n>::size;
-  using Utils::Array<Scalar, n>::max_size;
-  using Utils::Array<Scalar, n>::fill;
-  using Utils::Array<Scalar, n>::broadcast;
+  using Utils::Array<T, n>::at;
+  using Utils::Array<T, n>::operator[];
+  using Utils::Array<T, n>::front;
+  using Utils::Array<T, n>::back;
+  using Utils::Array<T, n>::data;
+  using Utils::Array<T, n>::begin;
+  using Utils::Array<T, n>::cbegin;
+  using Utils::Array<T, n>::end;
+  using Utils::Array<T, n>::cend;
+  using Utils::Array<T, n>::empty;
+  using Utils::Array<T, n>::size;
+  using Utils::Array<T, n>::max_size;
+  using Utils::Array<T, n>::fill;
+  using Utils::Array<T, n>::broadcast;
   Vector() = default;
   Vector(Vector const &) = default;
   Vector &operator=(Vector const &) = default;
@@ -57,11 +57,11 @@ public:
   template <typename Container>
   explicit Vector(Container const &v) : Vector(std::begin(v), std::end(v)) {}
 
-  explicit Vector(Scalar const (&v)[n]) {
+  explicit Vector(T const (&v)[n]) {
     std::copy_n(std::begin(v), n, begin());
   }
 
-  Vector(std::initializer_list<Scalar> v)
+  Vector(std::initializer_list<T> v)
       : Vector(std::begin(v), std::end(v)) {}
 
   template <typename InputIterator>
@@ -78,27 +78,27 @@ public:
    * @brief Create a vector that has all entries set to
    *         one value.
    */
-  static Vector<Scalar, n> broadcast(const Scalar &s) {
-    Vector<Scalar, n> ret;
+  static Vector<T, n> broadcast(const T &s) {
+    Vector<T, n> ret;
     std::fill(ret.begin(), ret.end(), s);
 
     return ret;
   }
 
-  std::vector<Scalar> as_vector() const {
-    return std::vector<Scalar>(begin(), end());
+  std::vector<T> as_vector() const {
+    return std::vector<T>(begin(), end());
   }
 
-  operator std::vector<Scalar>() const { return as_vector(); }
+  operator std::vector<T>() const { return as_vector(); }
 
-  inline Scalar dot(const Vector<Scalar, n> &b) const { return *this * b; }
+  inline T dot(const Vector<T, n> &b) const { return *this * b; }
 
-  inline Scalar norm2() const { return (*this) * (*this); }
-  inline Scalar norm() const { return sqrt(norm2()); }
+  inline T norm2() const { return (*this) * (*this); }
+  inline T norm() const { return sqrt(norm2()); }
 
   inline Vector &normalize(void) {
     const auto N = norm();
-    if (N > Scalar(0)) {
+    if (N > T(0)) {
       for (int i = 0; i < n; i++)
         this->operator[](i) /= N;
     }
@@ -106,21 +106,21 @@ public:
     return *this;
   }
 
-  static void cross(const Vector<Scalar, 3> &a, const Vector<Scalar, 3> &b,
-                    Vector<Scalar, 3> &c) {
+  static void cross(const Vector<T, 3> &a, const Vector<T, 3> &b,
+                    Vector<T, 3> &c) {
     c[0] = a[1] * b[2] - a[2] * b[1];
     c[1] = a[2] * b[0] - a[0] * b[2];
     c[2] = a[0] * b[1] - a[1] * b[0];
   }
 
-  static Vector<Scalar, 3> cross(const Vector<Scalar, 3> &a,
-                                 const Vector<Scalar, 3> &b) {
-    Vector<Scalar, 3> c;
+  static Vector<T, 3> cross(const Vector<T, 3> &a,
+                                 const Vector<T, 3> &b) {
+    Vector<T, 3> c;
     cross(a, b, c);
     return c;
   }
 
-  inline Vector<Scalar, 3> cross(const Vector<Scalar, 3> &a) const {
+  inline Vector<T, 3> cross(const Vector<T, 3> &a) const {
     return cross(*this, a);
   }
 };

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -63,8 +63,7 @@ private:
 
 public:
   template <typename Container>
-  explicit Vector(const Container &v)
-      : Vector(std::begin(v), std::end(v)) {}
+  explicit Vector(const Container &v) : Vector(std::begin(v), std::end(v)) {}
   explicit constexpr Vector(T const (&v)[N]) {
     copy_init(std::begin(v), std::end(v));
   }

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -31,39 +31,53 @@
 
 #include "utils/Array.hpp"
 
-template <typename T, std::size_t n> class Vector : public Utils::Array<T, n> {
+template <typename T, std::size_t N> class Vector : public Utils::Array<T, N> {
 public:
-  using Utils::Array<T, n>::at;
-  using Utils::Array<T, n>::operator[];
-  using Utils::Array<T, n>::front;
-  using Utils::Array<T, n>::back;
-  using Utils::Array<T, n>::data;
-  using Utils::Array<T, n>::begin;
-  using Utils::Array<T, n>::cbegin;
-  using Utils::Array<T, n>::end;
-  using Utils::Array<T, n>::cend;
-  using Utils::Array<T, n>::empty;
-  using Utils::Array<T, n>::size;
-  using Utils::Array<T, n>::max_size;
-  using Utils::Array<T, n>::fill;
-  using Utils::Array<T, n>::broadcast;
+  using Utils::Array<T, N>::at;
+  using Utils::Array<T, N>::operator[];
+  using Utils::Array<T, N>::front;
+  using Utils::Array<T, N>::back;
+  using Utils::Array<T, N>::data;
+  using Utils::Array<T, N>::begin;
+  using Utils::Array<T, N>::cbegin;
+  using Utils::Array<T, N>::end;
+  using Utils::Array<T, N>::cend;
+  using Utils::Array<T, N>::empty;
+  using Utils::Array<T, N>::size;
+  using Utils::Array<T, N>::max_size;
+  using Utils::Array<T, N>::fill;
+  using Utils::Array<T, N>::broadcast;
   Vector() = default;
   Vector(Vector const &) = default;
   Vector &operator=(Vector const &) = default;
 
   void swap(Vector &rhs) { std::swap_ranges(begin(), end(), rhs.begin()); }
 
+private:
+    constexpr void copy_init(const T* first, const T* last) {
+      auto it = begin();
+      while(first != last) {
+          *it++ = *first++;
+      }
+  }
+
+public:
   template <typename Container>
   explicit constexpr Vector(Container &&v) : Vector(std::begin(v), std::end(v)) {}
+  explicit constexpr Vector(T const (&v)[N]) { copy_init(std::begin(v), std::end(v)); }
+  constexpr Vector(std::initializer_list<T> v) {
+      if(N != v.size()) {
+          throw std::length_error(
+                  "Construction of Vector from Container of wrong length.");
+      }
 
-  explicit constexpr Vector(T const (&v)[n]) { std::copy_n(std::begin(v), n, begin()); }
-
-  constexpr Vector(std::initializer_list<T> v) : Vector(std::begin(v), std::end(v)) {}
+      copy_init(v.begin(), v.end());
+  }
 
   template <typename InputIterator>
-  constexpr Vector(InputIterator first, InputIterator last) {
-    if (std::distance(first, last) == n) {
-      std::copy_n(first, n, begin());
+  Vector(InputIterator first, InputIterator last) {
+    if (std::distance(first, last) == N) {
+      std::copy_n(first, N, begin());
     } else {
       throw std::length_error(
           "Construction of Vector from Container of wrong length.");
@@ -74,8 +88,8 @@ public:
    * @brief Create a vector that has all entries set to
    *         one value.
    */
-  static Vector<T, n> broadcast(const T &s) {
-    Vector<T, n> ret;
+  static Vector<T, N> broadcast(const T &s) {
+    Vector<T, N> ret;
     std::fill(ret.begin(), ret.end(), s);
 
     return ret;
@@ -96,10 +110,10 @@ public:
    */
 
   inline Vector &normalize() {
-    const auto N = norm();
-    if (N > T(0)) {
-      for (int i = 0; i < n; i++)
-        this->operator[](i) /= N;
+    const auto l = norm();
+    if (l > T(0)) {
+      for (int i = 0; i < N; i++)
+        this->operator[](i) /= l;
     }
 
     return *this;

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -54,24 +54,27 @@ public:
   void swap(Vector &rhs) { std::swap_ranges(begin(), end(), rhs.begin()); }
 
 private:
-    constexpr void copy_init(const T* first, const T* last) {
-      auto it = begin();
-      while(first != last) {
-          *it++ = *first++;
-      }
+  constexpr void copy_init(const T *first, const T *last) {
+    auto it = begin();
+    while (first != last) {
+      *it++ = *first++;
+    }
   }
 
 public:
   template <typename Container>
-  explicit constexpr Vector(Container &&v) : Vector(std::begin(v), std::end(v)) {}
-  explicit constexpr Vector(T const (&v)[N]) { copy_init(std::begin(v), std::end(v)); }
+  explicit constexpr Vector(Container &&v)
+      : Vector(std::begin(v), std::end(v)) {}
+  explicit constexpr Vector(T const (&v)[N]) {
+    copy_init(std::begin(v), std::end(v));
+  }
   constexpr Vector(std::initializer_list<T> v) {
-      if(N != v.size()) {
-          throw std::length_error(
-                  "Construction of Vector from Container of wrong length.");
-      }
+    if (N != v.size()) {
+      throw std::length_error(
+          "Construction of Vector from Container of wrong length.");
+    }
 
-      copy_init(v.begin(), v.end());
+    copy_init(v.begin(), v.end());
   }
 
   template <typename InputIterator>

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -31,8 +31,7 @@
 
 #include "utils/Array.hpp"
 
-template <typename T, std::size_t n>
-class Vector : public Utils::Array<T, n> {
+template <typename T, std::size_t n> class Vector : public Utils::Array<T, n> {
 public:
   using Utils::Array<T, n>::at;
   using Utils::Array<T, n>::operator[];
@@ -55,17 +54,14 @@ public:
   void swap(Vector &rhs) { std::swap_ranges(begin(), end(), rhs.begin()); }
 
   template <typename Container>
-  explicit Vector(Container &&v) : Vector(std::begin(v), std::end(v)) {}
+  explicit constexpr Vector(Container &&v) : Vector(std::begin(v), std::end(v)) {}
 
-  explicit Vector(T const (&v)[n]) {
-    std::copy_n(std::begin(v), n, begin());
-  }
+  explicit constexpr Vector(T const (&v)[n]) { std::copy_n(std::begin(v), n, begin()); }
 
-  Vector(std::initializer_list<T> v)
-      : Vector(std::begin(v), std::end(v)) {}
+  constexpr Vector(std::initializer_list<T> v) : Vector(std::begin(v), std::end(v)) {}
 
   template <typename InputIterator>
-  Vector(InputIterator first, InputIterator last) {
+  constexpr Vector(InputIterator first, InputIterator last) {
     if (std::distance(first, last) == n) {
       std::copy_n(first, n, begin());
     } else {
@@ -85,16 +81,21 @@ public:
     return ret;
   }
 
-  std::vector<T> as_vector() const {
-    return std::vector<T>(begin(), end());
-  }
+  std::vector<T> as_vector() const { return std::vector<T>(begin(), end()); }
 
   operator std::vector<T>() const { return as_vector(); }
 
   inline T norm2() const { return (*this) * (*this); }
   inline T norm() const { return std::sqrt(norm2()); }
 
-  inline Vector &normalize(void) {
+  /*
+   * @brief Normalize the vector.
+   *
+   * Normalize the vector by its length,
+   * if not zero, otherwise the vector is unchanged.
+   */
+
+  inline Vector &normalize() {
     const auto N = norm();
     if (N > T(0)) {
       for (int i = 0; i < n; i++)
@@ -134,7 +135,7 @@ Vector<T, N> &binary_op_assign(Vector<T, N> &a, Vector<T, N> const &b, Op op) {
 }
 
 template <size_t N, typename T, typename Op>
-bool all_of(Vector<T, N> const &a, Vector<T, N> const &b, Op op) {
+constexpr bool all_of(Vector<T, N> const &a, Vector<T, N> const &b, Op op) {
   for (int i = 0; i < a.size(); i++) {
     /* Short circuit */
     if (!static_cast<bool>(op(a[i], b[i]))) {
@@ -147,32 +148,32 @@ bool all_of(Vector<T, N> const &a, Vector<T, N> const &b, Op op) {
 } // namespace detail
 
 template <size_t N, typename T>
-bool operator<(Vector<T, N> const &a, Vector<T, N> const &b) {
+constexpr bool operator<(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::less<T>());
 }
 
 template <size_t N, typename T>
-bool operator>(Vector<T, N> const &a, Vector<T, N> const &b) {
+constexpr bool operator>(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::greater<T>());
 }
 
 template <size_t N, typename T>
-bool operator<=(Vector<T, N> const &a, Vector<T, N> const &b) {
+constexpr bool operator<=(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::less_equal<T>());
 }
 
 template <size_t N, typename T>
-bool operator>=(Vector<T, N> const &a, Vector<T, N> const &b) {
+constexpr bool operator>=(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::greater_equal<T>());
 }
 
 template <size_t N, typename T>
-bool operator==(Vector<T, N> const &a, Vector<T, N> const &b) {
+constexpr bool operator==(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::equal_to<T>());
 }
 
 template <size_t N, typename T>
-bool operator!=(Vector<T, N> const &a, Vector<T, N> const &b) {
+constexpr bool operator!=(Vector<T, N> const &a, Vector<T, N> const &b) {
   return not(a == b);
 }
 
@@ -267,14 +268,10 @@ template <size_t N, typename T> Vector<T, N> sqrt(Vector<T, N> const &a) {
   return ret;
 }
 
-template<class T>
-Vector<T, 3> vector_product(const Vector<T, 3> &a,
-                   const Vector<T, 3> &b) {
-    return {
-            a[1] * b[2] - a[2] * b[1],
-            a[2] * b[0] - a[0] * b[2],
-            a[0] * b[1] - a[1] * b[0]
-    };
+template <class T>
+Vector<T, 3> vector_product(const Vector<T, 3> &a, const Vector<T, 3> &b) {
+  return {a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2],
+          a[0] * b[1] - a[1] * b[0]};
 }
 
 /**

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -63,7 +63,7 @@ private:
 
 public:
   template <typename Container>
-  explicit constexpr Vector(Container &&v)
+  explicit Vector(const Container &v)
       : Vector(std::begin(v), std::end(v)) {}
   explicit constexpr Vector(T const (&v)[N]) {
     copy_init(std::begin(v), std::end(v));

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -56,7 +56,7 @@ public:
   void swap(Vector &rhs) { std::swap_ranges(begin(), end(), rhs.begin()); }
 
 private:
-  constexpr void copy_init(const T *first, const T *last) {
+  constexpr void copy_init(T const *first, T const *last) {
     auto it = begin();
     while (first != last) {
       *it++ = *first++;
@@ -65,7 +65,7 @@ private:
 
 public:
   template <typename Container>
-  explicit Vector(const Container &v) : Vector(std::begin(v), std::end(v)) {}
+  explicit Vector(Container const &v) : Vector(std::begin(v), std::end(v)) {}
   explicit constexpr Vector(T const (&v)[N]) : Base() {
     copy_init(std::begin(v), std::end(v));
   }
@@ -93,7 +93,7 @@ public:
    * @brief Create a vector that has all entries set to
    *         one value.
    */
-  static Vector<T, N> broadcast(const T &s) {
+  static Vector<T, N> broadcast(T const &s) {
     Vector<T, N> ret;
     std::fill(ret.begin(), ret.end(), s);
 
@@ -115,7 +115,7 @@ public:
    */
 
   inline Vector &normalize() {
-    const auto l = norm();
+    auto const l = norm();
     if (l > T(0)) {
       for (int i = 0; i < N; i++)
         this->operator[](i) /= l;
@@ -124,8 +124,6 @@ public:
     return *this;
   }
 };
-
-// Useful typedefs
 
 template <size_t N> using VectorXd = Vector<double, N>;
 using Vector2d = VectorXd<2>;
@@ -288,7 +286,7 @@ template <size_t N, typename T> Vector<T, N> sqrt(Vector<T, N> const &a) {
 }
 
 template <class T>
-Vector<T, 3> vector_product(const Vector<T, 3> &a, const Vector<T, 3> &b) {
+Vector<T, 3> vector_product(Vector<T, 3> const &a, Vector<T, 3> const &b) {
   return {a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2],
           a[0] * b[1] - a[1] * b[0]};
 }

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -55,7 +55,7 @@ public:
   void swap(Vector &rhs) { std::swap_ranges(begin(), end(), rhs.begin()); }
 
   template <typename Container>
-  explicit Vector(Container const &v) : Vector(std::begin(v), std::end(v)) {}
+  explicit Vector(Container &&v) : Vector(std::begin(v), std::end(v)) {}
 
   explicit Vector(T const (&v)[n]) {
     std::copy_n(std::begin(v), n, begin());
@@ -91,10 +91,8 @@ public:
 
   operator std::vector<T>() const { return as_vector(); }
 
-  inline T dot(const Vector<T, n> &b) const { return *this * b; }
-
   inline T norm2() const { return (*this) * (*this); }
-  inline T norm() const { return sqrt(norm2()); }
+  inline T norm() const { return std::sqrt(norm2()); }
 
   inline Vector &normalize(void) {
     const auto N = norm();
@@ -104,24 +102,6 @@ public:
     }
 
     return *this;
-  }
-
-  static void cross(const Vector<T, 3> &a, const Vector<T, 3> &b,
-                    Vector<T, 3> &c) {
-    c[0] = a[1] * b[2] - a[2] * b[1];
-    c[1] = a[2] * b[0] - a[0] * b[2];
-    c[2] = a[0] * b[1] - a[1] * b[0];
-  }
-
-  static Vector<T, 3> cross(const Vector<T, 3> &a,
-                                 const Vector<T, 3> &b) {
-    Vector<T, 3> c;
-    cross(a, b, c);
-    return c;
-  }
-
-  inline Vector<T, 3> cross(const Vector<T, 3> &a) const {
-    return cross(*this, a);
   }
 };
 
@@ -285,6 +265,16 @@ template <size_t N, typename T> Vector<T, N> sqrt(Vector<T, N> const &a) {
                  [](T const &v) { return sqrt(v); });
 
   return ret;
+}
+
+template<class T>
+Vector<T, 3> vector_product(const Vector<T, 3> &a,
+                   const Vector<T, 3> &b) {
+    return {
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0]
+    };
 }
 
 /**

--- a/src/core/utils/Vector.hpp
+++ b/src/core/utils/Vector.hpp
@@ -32,6 +32,8 @@
 #include "utils/Array.hpp"
 
 template <typename T, std::size_t N> class Vector : public Utils::Array<T, N> {
+  using Base = Utils::Array<T, N>;
+
 public:
   using Utils::Array<T, N>::at;
   using Utils::Array<T, N>::operator[];
@@ -64,10 +66,11 @@ private:
 public:
   template <typename Container>
   explicit Vector(const Container &v) : Vector(std::begin(v), std::end(v)) {}
-  explicit constexpr Vector(T const (&v)[N]) {
+  explicit constexpr Vector(T const (&v)[N]) : Base() {
     copy_init(std::begin(v), std::end(v));
   }
-  constexpr Vector(std::initializer_list<T> v) {
+
+  constexpr Vector(std::initializer_list<T> v) : Base() {
     if (N != v.size()) {
       throw std::length_error(
           "Construction of Vector from Container of wrong length.");

--- a/src/core/utils/math/triangle_functions.hpp
+++ b/src/core/utils/math/triangle_functions.hpp
@@ -12,7 +12,7 @@ inline Vector3d get_n_triangle(const Vector3d &P1, const Vector3d &P2,
   auto const u = P2 - P1;
   auto const v = P3 - P1;
 
-  return u.cross(v);
+  return vector_product(u, v);
 }
 
 /** Computes the area of triangle between vectors P1,P2,P3,


### PR DESCRIPTION
- removed no longer needed `Vector::dot`
- renamed `Vector::cross` to `vector_product` and made a free function
- constexpr constructors from c-arrays and std::initializer_list
- constexpr relational operators