### PR TITLE
cmake: Search also for clang-tidy-CLANG_MAJOR_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,12 +505,17 @@ endif()
 
 if(WITH_CLANG_TIDY)
   string(REGEX
-         REPLACE "^([1-9]+\\.[0-9]+).*$"
+          REPLACE "^([1-9]+)\\.[0-9]+.*$"
+          "\\1"
+          CLANG_MAJOR_VERSION
+          "${CMAKE_CXX_COMPILER_VERSION}")
+  string(REGEX
+         REPLACE "^[1-9]+\\.([0-9]+).*$"
                  "\\1"
                  CLANG_MINOR_VERSION
                  "${CMAKE_CXX_COMPILER_VERSION}")
   find_program(CLANG_TIDY_EXE
-               NAMES "clang-tidy-${CLANG_MINOR_VERSION}" "clang-tidy"
+               NAMES "clang-tidy-${CLANG_MAJOR_VERSION}.${CLANG_MINOR_VERSION}" "clang-tidy-${CLANG_MAJOR_VERSION}" "clang-tidy"
                DOC "Path to clang-tidy executable")
   if(NOT CLANG_TIDY_EXE)
     message(STATUS "clang-tidy not found.")


### PR DESCRIPTION
Ubuntu changed their naming scheme for clang, this is needed so that clang-tidy-7 is found.
