### PR TITLE
Bond angle refactor

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -1262,7 +1262,7 @@ PAPER_TYPE             = a4wide
 # The EXTRA_PACKAGES tag can be to specify one or more names of LaTeX
 # packages that should be included in the LaTeX output.
 
-EXTRA_PACKAGES         =
+EXTRA_PACKAGES         = amsmath
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for
 # the generated latex document. The header should contain everything until

--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -11,7 +11,7 @@ the following syntax to activate and assign a bonded interaction::
     system.bonded_inter.add(bond)
     system.part[pid1].add_bond((bond, pid2...))
 
-In general, one instantiates an interaction object *bond* and subsequently passes it
+In general, one instantiates an interaction object ``bond`` and subsequently passes it
 to :meth:`espressomd.interactions.BondedInteractions.add`. This will enable the
 bonded interaction and allows the user to assign bonds between particle ids *pidX*.
 Bonded interactions are identified by either their *bondid* or their appropriate object.
@@ -28,9 +28,13 @@ is provided in subsection :ref:`FENE bond`) between them using::
     system.part[12].add_bond((fene, 43))
 
 This will set up a FENE bond between particles 42 and 43, 42 and 12, and 12 and 43.
-Note that the *fene* object specifies the type of bond and its parameters,
-the specific bonds are stored within the particles. you can find more
+Note that the ``fene`` object specifies the type of bond and its parameters,
+the specific bonds are stored within the particles. You can find more
 information regarding particle properties in :ref:`Setting up particles`.
+
+To delete the FENE bond between particles 12 and 43::
+
+    system.part[12].delete_bond((fene, 43))
 
 .. _Distance-dependent bonds:
 
@@ -272,7 +276,7 @@ The potential is calculated as follows:
 -  ``type="dihedral"``: tabulates a torsional
    dihedral angle potential. It is assumed
    that the potential is tabulated for all angles between 0 and
-   :math:`2\pi`. *This potential is not tested yet! Use on own risk, and
+   :math:`2\pi`. *This potential is not tested yet! Use at your own risk, and
    please report your findings and eventually necessary fixes.*
 
 .. _Virtual bonds:
@@ -536,12 +540,9 @@ in the correct order. Command
 
 calculates the outward normal vector of triangle defined by particles 1,
 2, 3 (these should be selected in such a way that particle 0 lies
-approximately at its centroid - for OIF objects, this is automatically
-handled by oif_create_template command, see Section
-[ssec:oif-create-template]). In order for the direction to be outward
+approximately at its centroid). In order for the direction to be outward
 with respect to the underlying object, the triangle 123 needs to be
-properly oriented (as explained in the section on volume in
-oif_global_forces interaction).
+properly oriented (as explained in paragraph `Volume conservation`_).
 
 
 
@@ -549,8 +550,6 @@ oif_global_forces interaction).
 
 Bond-angle interactions
 -----------------------
-.. note::
-    Feature ``BOND_ANGLE`` required.
 
 Bond-angle interactions involve three particles forming the angle :math:`\phi`, as shown in the schematic below.
 
@@ -560,83 +559,99 @@ Bond-angle interactions involve three particles forming the angle :math:`\phi`, 
    :align: center
    :height: 12.00cm
 
-This allows for a bond type having an angle-dependent potential.
-This potential is defined between three particles.
-The particle for which the bond is created, is the central particle, and the
-angle :math:`\phi` between the vectors from this particle to the two
-others determines the interaction.
+This allows for a bond type having an angle-dependent potential. This potential
+is defined between three particles and depends on the angle :math:`\phi`
+between the vectors from the central particle to the two other particles.
 
-Similar to other bonded interactions, these are defined for every particle triplet and must be added to a particle (see :attr:`espressomd.particle_data.ParticleHandle.bonds`).
-For example, for the schematic with particles ``id=0``, ``1`` and ``2`` the bond was defined using ::
+Similar to other bonded interactions, these are defined for every particle triplet and must be added to a particle (see :attr:`espressomd.particle_data.ParticleHandle.bonds`), in this case the central one.
+For example, for the schematic with particles ``id=0``, ``1`` (central particle) and ``2`` the bond was defined using ::
 
     >>> system.part[1].add_bond((bond_angle, 0, 2))
 
-The parameter ``bond_angle`` is a bond type identifier of three possible bond-angle classes, described below.
+The parameter ``bond_angle`` is an instance of one of four possible bond-angle
+classes, described below.
 
+
+Harmonic angle potential
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 :class:`espressomd.interactions.AngleHarmonic`
 
-    A classical harmonic potential of the form:
+Equation:
 
-    .. math:: V(\phi) = \frac{K}{2} \left(\phi - \phi_0\right)^2.
+.. math:: V(\phi) = \frac{K}{2} \left(\phi - \phi_0\right)^2.
 
-    :math:`K` is the bending constant,
-    and the optional parameter :math:`\phi_0` is the equilibrium bond angle in
-    radians ranging from 0 to :math:`\pi`.
+:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
+angle in radians ranging from 0 to :math:`\pi`.
 
-    If this parameter is not given, it defaults to :math:`\phi_0 = \pi`,
-    which corresponds to a stretched conformation.
+Example::
 
-    Unlike the two other variants, this potential has a kink at
-    :math:`\phi=\phi_0+\pi` and accordingly a discontinuity in the
-    force, and should therefore be used with caution.
-
-    Example::
-
-        >>> angle_harmonic = AngleHarmonic(bend=1.0, phi0=np.pi)
-        >>> system.bonded_inter.add(angle_harmonic)
-        >>> system.part[1].add_bond((angle_harmonic, 0, 2))
+    >>> angle_harmonic = AngleHarmonic(bend=1.0, phi0=2 * np.pi / 3)
+    >>> system.bonded_inter.add(angle_harmonic)
+    >>> system.part[1].add_bond((angle_harmonic, 0, 2))
 
 
+Cosine angle potential
+~~~~~~~~~~~~~~~~~~~~~~
 
 :class:`espressomd.interactions.AngleCosine`
 
-    Cosine bond angle potential of the form:
+Equation:
 
-    .. math:: V(\phi) = K \left[1 - \cos(\phi - \phi_0)\right]
+.. math:: V(\phi) = K \left[1 - \cos(\phi - \phi_0)\right]
 
-    :math:`K` is the bending constant,
-    and the optional parameter :math:`\phi_0` is the equilibrium bond angle in
-    radians ranging from 0 to :math:`\pi`.
+:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
+angle in radians ranging from 0 to :math:`\pi`.
 
-    If this parameter is not given, it defaults to :math:`\phi_0 = \pi`,
-    which corresponds to a stretched conformation.
+Around :math:`\phi_0`, this potential is close to a harmonic one
+(both are :math:`1/2(\phi-\phi_0)^2` in leading order), but it is
+periodic and smooth for all angles :math:`\phi`.
 
-    Around :math:`\phi_0`, this potential is close to a harmonic one
-    (both are :math:`1/2(\phi-\phi_0)^2` in leading order), but it is
-    periodic and smooth for all angles :math:`\phi`.
+Example::
 
-    Example::
+    >>> angle_cosine = AngleCosine(bend=1.0, phi0=2 * np.pi / 3)
+    >>> system.bonded_inter.add(angle_cosine)
+    >>> system.part[1].add_bond((angle_cosine, 0, 2))
 
-        >>> angle_cosine = AngleCosine(bend=1.0, phi0=np.pi)
-        >>> system.bonded_inter.add(angle_cosine)
-        >>> system.part[1].add_bond((angle_cosine, 0, 2))
+
+Harmonic cosine potential
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :class:`espressomd.interactions.AngleCossquare`
 
-    Cosine square bond angle potential of the form:
+Equation:
 
-    .. math:: V(\phi) = \frac{K}{2} \left[\cos(\phi) - \cos(\phi_0)\right]^2
+.. math:: V(\phi) = \frac{K}{2} \left[\cos(\phi) - \cos(\phi_0)\right]^2
 
-    This form is used for example in the GROMOS96 force field. The
-    potential is :math:`1/8(\phi-\phi_0)^4` around :math:`\phi_0`, and
-    therefore much flatter than the two potentials before.
+:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
+angle in radians ranging from 0 to :math:`\pi`.
 
-    Example::
+This form is used for example in the GROMOS96 force field. The
+potential is :math:`1/8(\phi-\phi_0)^4` around :math:`\phi_0`, and
+therefore much flatter than the two aforementioned potentials.
 
-        >>> angle_cossquare = AngleCossquare(bend=1.0, phi0=np.pi)
-        >>> system.bonded_inter.add(angle_cossquare)
-        >>> system.part[1].add_bond((angle_cossquare, 0, 2))
+Example::
+
+    >>> angle_cossquare = AngleCossquare(bend=1.0, phi0=2 * np.pi / 3)
+    >>> system.bonded_inter.add(angle_cossquare)
+    >>> system.part[1].add_bond((angle_cossquare, 0, 2))
+
+
+Tabulated bond
+~~~~~~~~~~~~~~
+
+:class:`espressomd.interactions.Tabulated`
+
+Custom bond angle potential.
+
+Example::
+
+    >>> theta = np.linspace(0, np.pi, num=91, endpoint=True)
+    >>> angle_tabulated = Tabulated(type='angle', min=0, max=np.pi,
+    ...                             energy=0.5 * 10 * (theta - 2 * np.pi / 3)**2,
+    ...                             force=10 * (theta - 2 * np.pi / 3))
+    >>> system.bonded_inter.add(angle_tabulated)
+    >>> system.part[1].add_bond((angle_tabulated, 0, 2))
 
 
 .. _Dihedral interactions:
@@ -663,12 +678,14 @@ angle between the planes defined by the particle triples :math:`p_1`,
 :math:`p_2` and :math:`p_3` and :math:`p_2`, :math:`p_3` and
 :math:`p_4`:
 
-|image_dihedral|
+.. _inter_dihedral:
+.. figure:: figures/dihedral-angle.pdf
+   :alt: Dihedral interaction
+   :align: center
+   :height: 12.00cm
 
 Together with appropriate Lennard-Jones interactions, this potential can
 mimic a large number of atomic torsion potentials.
-
-.. |image_dihedral| image:: figures/dihedral-angle.pdf
 
 
 .. _Thermalized distance bond:

--- a/src/core/bonded_interactions/angle_common.hpp
+++ b/src/core/bonded_interactions/angle_common.hpp
@@ -131,9 +131,8 @@ calc_angle_generic_3body_forces(Vector3d const &r_mid, Vector3d const &r_left,
     if (cos_phi < -TINY_COS_VALUE)
       cos_phi = -TINY_COS_VALUE;
   }
-  auto sin_phi = sqrt(1.0 - Utils::sqr(cos_phi));
   /* force factor */
-  auto const fac = forceFactor(cos_phi, sin_phi);
+  auto const fac = forceFactor(cos_phi);
   /* force calculation */
   auto const fj = vec31 / (vec21_len * vec31_len) - cos_phi * vec21 / vec21_sqr;
   auto const fk = vec21 / (vec21_len * vec31_len) - cos_phi * vec31 / vec31_sqr;

--- a/src/core/bonded_interactions/angle_common.hpp
+++ b/src/core/bonded_interactions/angle_common.hpp
@@ -30,26 +30,26 @@
 /** Compute the cosine of the angle between three particles.
  *
  *  Also return all intermediate quantities: normalized vectors
- *  @f$ \vec{r_{ji}} @f$ (from particle @f$ i @f$ to particle @f$ j @f$)
+ *  @f$ \vec{r_{ij}} @f$ (from particle @f$ j @f$ to particle @f$ i @f$)
  *  and @f$ \vec{r_{kj}} @f$, and their normalization constants.
  *
  *  @param[in]  r_mid            Position of second/middle particle.
  *  @param[in]  r_left           Position of first/left particle.
  *  @param[in]  r_right          Position of third/right particle.
  *  @param[in]  sanitize_cosine  Sanitize the cosine of the angle.
- *  @return @f$ \vec{r_{ji}} @f$, @f$ \vec{r_{kj}} @f$,
- *          @f$ \left\|\vec{r_{ji}}\right\|^{-1} @f$,
+ *  @return @f$ \vec{r_{ij}} @f$, @f$ \vec{r_{kj}} @f$,
+ *          @f$ \left\|\vec{r_{ij}}\right\|^{-1} @f$,
  *          @f$ \left\|\vec{r_{kj}}\right\|^{-1} @f$,
  *          @f$ \cos(\theta_{ijk}) @f$
  */
 inline std::tuple<Vector3d, Vector3d, double, double, double>
 calc_vectors_and_cosine(Vector3d const &r_mid, Vector3d const &r_left,
                         Vector3d const &r_right, bool sanitize_cosine = false) {
-  /* vector from p_left to p_mid */
-  auto vec1 = get_mi_vector(r_mid, r_left);
+  /* normalized vector from p_mid to p_left */
+  auto vec1 = get_mi_vector(r_left, r_mid);
   auto const d1i = 1.0 / vec1.norm();
   vec1 *= d1i;
-  /* vector from p_mid to p_right */
+  /* normalized vector from p_mid to p_right */
   auto vec2 = get_mi_vector(r_right, r_mid);
   auto const d2i = 1.0 / vec2.norm();
   vec2 *= d2i;
@@ -74,73 +74,26 @@ calc_vectors_and_cosine(Vector3d const &r_mid, Vector3d const &r_left,
  *  @param[in]  r_right          Position of third/right particle.
  *  @param[in]  forceFactor      Angle force term.
  *  @param[in]  sanitize_cosine  Sanitize the cosine of the angle.
- *  @param[out] f_mid            Force on the second/middle particle.
- *  @param[out] f_left           Force on the first/left particle.
- *  tparam      ForceFactor      Function evaluating the angle force term
- *                               for a given angle.
- */
-template <typename ForceFactor>
-void calc_angle_generic_force(Vector3d const &r_mid, Vector3d const &r_left,
-                              Vector3d const &r_right, ForceFactor forceFactor,
-                              double f_mid[3], double f_left[3],
-                              bool sanitize_cosine) {
-  Vector3d vec1, vec2;
-  double d1i, d2i, cosine;
-  std::tie(vec1, vec2, d1i, d2i, cosine) =
-      calc_vectors_and_cosine(r_mid, r_left, r_right, sanitize_cosine);
-  /* force factor */
-  auto const fac = forceFactor(cosine);
-  /* force calculation on particles 1 and 3 */
-  auto const f1 = fac * (cosine * vec1 - vec2) * d1i;
-  auto const f3 = fac * (cosine * vec2 - vec1) * d2i;
-  for (int j = 0; j < 3; j++) {
-    f_mid[j] = (f1 - f3)[j];
-    f_left[j] = -f1[j];
-  }
-}
-
-/** Compute the forces of a three-body bonded potential.
- *
- *  See the details in @ref bondedIA_angle_force. The @f$ K(\theta_{ijk}) @f$
- *  term is provided as a lambda function in @p forceFactor.
- *
- *  @param[in]  r_mid            Position of second/middle particle.
- *  @param[in]  r_left           Position of first/left particle.
- *  @param[in]  r_right          Position of third/right particle.
- *  @param[in]  forceFactor      Angle force term.
- *  @param[in]  sanitize_cosine  Sanitize the cosine of the angle.
  *  tparam      ForceFactor      Function evaluating the angle force term
  *                               for a given angle.
  *  @return Forces on the second, first and third particles, in that order.
  */
 template <typename ForceFactor>
 std::tuple<Vector3d, Vector3d, Vector3d>
-calc_angle_generic_3body_forces(Vector3d const &r_mid, Vector3d const &r_left,
-                                Vector3d const &r_right,
-                                ForceFactor forceFactor, bool sanitize_cosine) {
-  auto const vec21 = get_mi_vector(r_left, r_mid);
-  auto const vec31 = get_mi_vector(r_right, r_mid);
-  auto const vec21_sqr = vec21.norm2();
-  auto const vec31_sqr = vec31.norm2();
-  auto const vec21_len = sqrt(vec21_sqr);
-  auto const vec31_len = sqrt(vec31_sqr);
-  auto cos_phi = (vec21 * vec31) / (vec21_len * vec31_len);
-  if (sanitize_cosine) {
-    if (cos_phi > TINY_COS_VALUE)
-      cos_phi = TINY_COS_VALUE;
-    if (cos_phi < -TINY_COS_VALUE)
-      cos_phi = -TINY_COS_VALUE;
-  }
+calc_angle_generic_force(Vector3d const &r_mid, Vector3d const &r_left,
+                         Vector3d const &r_right, ForceFactor forceFactor,
+                         bool sanitize_cosine) {
+  Vector3d vec1, vec2;
+  double d1i, d2i, cosine;
+  std::tie(vec1, vec2, d1i, d2i, cosine) =
+      calc_vectors_and_cosine(r_mid, r_left, r_right, sanitize_cosine);
   /* force factor */
-  auto const fac = forceFactor(cos_phi);
-  /* force calculation */
-  auto const fj = vec31 / (vec21_len * vec31_len) - cos_phi * vec21 / vec21_sqr;
-  auto const fk = vec21 / (vec21_len * vec31_len) - cos_phi * vec31 / vec31_sqr;
-  // note that F1 = -(F2 + F3) in analytical case
-  auto force_mid = -fac * (fj + fk);
-  auto force_left = fac * fj;
-  auto force_right = fac * fk;
-  return std::make_tuple(force_mid, force_left, force_right);
+  auto const fac = forceFactor(cosine);
+  /* distribute forces */
+  auto f_left = (fac * d1i) * (vec1 * cosine - vec2);
+  auto f_right = (fac * d2i) * (vec2 * cosine - vec1);
+  auto f_mid = -(f_left + f_right);
+  return std::make_tuple(f_mid, f_left, f_right);
 }
 
 #endif /* ANGLE_COMMON_H */

--- a/src/core/bonded_interactions/angle_cosine.hpp
+++ b/src/core/bonded_interactions/angle_cosine.hpp
@@ -83,7 +83,8 @@ inline void calc_angle_cosine_3body_forces(Particle const *p_mid,
                                            Vector3d &f_mid, Vector3d &f_left,
                                            Vector3d &f_right) {
 
-  auto forceFactor = [&iaparams](double const cos_phi, double const sin_phi) {
+  auto forceFactor = [&iaparams](double const cos_phi) {
+    auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
     auto const K = iaparams->p.angle_cosine.bend;
     auto const sin_phi0 = iaparams->p.angle_cosine.sin_phi0;
     auto const cos_phi0 = iaparams->p.angle_cosine.cos_phi0;

--- a/src/core/bonded_interactions/angle_cosine.hpp
+++ b/src/core/bonded_interactions/angle_cosine.hpp
@@ -22,8 +22,8 @@
 #define ANGLE_COSINE_H
 /** \file
  *  Routines to calculate the angle energy or/and and force
- *  for a particle triple.
- *  \ref forces.cpp
+ *  for a particle triple using the potential described in
+ *  @ref bondedIA_angle_cosine.
  */
 
 #include "bonded_interaction_data.hpp"
@@ -33,25 +33,25 @@
 #include "grid.hpp"
 #include <tuple>
 
-/** set parameters for the angle potential. */
+/** Set parameters for the angle potential. */
 int angle_cosine_set_params(int bond_type, double bend, double phi0);
 
 /************************************************************/
 
-/** Computes the three-body angle interaction force.
+/** Compute the three-body angle interaction force.
  *  @param[in]  p_mid     Second/middle particle.
  *  @param[in]  p_left    First/left particle.
  *  @param[in]  p_right   Third/right particle.
  *  @param[in]  iaparams  Bonded parameters for the angle interaction.
- *  @param[out] force1    Force on particle 1.
- *  @param[out] force2    Force on particle 2.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
  *  @retval 0
  */
 inline int calc_angle_cosine_force(Particle const *p_mid,
                                    Particle const *p_left,
                                    Particle const *p_right,
                                    Bonded_ia_parameters const *iaparams,
-                                   double force1[3], double force2[3]) {
+                                   double f_mid[3], double f_left[3]) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
@@ -62,19 +62,26 @@ inline int calc_angle_cosine_force(Particle const *p_mid,
   };
 
   calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor,
-                           force1, force2, true);
+                           f_mid, f_left, true);
 
   return 0;
 }
 
-/* The force on each particle due to a three-body bonded potential
-   is computed. */
+/** Compute the three-body angle interaction force.
+ *  @param[in]  p_mid     Second/middle particle.
+ *  @param[in]  p_left    First/left particle.
+ *  @param[in]  p_right   Third/right particle.
+ *  @param[in]  iaparams  Bonded parameters for the angle interaction.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
+ *  @param[out] f_right   Force on @p p_right.
+ */
 inline void calc_angle_cosine_3body_forces(Particle const *p_mid,
                                            Particle const *p_left,
                                            Particle const *p_right,
                                            Bonded_ia_parameters const *iaparams,
-                                           Vector3d &force1, Vector3d &force2,
-                                           Vector3d &force3) {
+                                           Vector3d &f_mid, Vector3d &f_left,
+                                           Vector3d &f_right) {
 
   auto forceFactor = [&iaparams](double const cos_phi, double const sin_phi) {
     auto const K = iaparams->p.angle_cosine.bend;
@@ -85,7 +92,7 @@ inline void calc_angle_cosine_3body_forces(Particle const *p_mid,
     return K * (sin_phi * cos_phi0 - cos_phi * sin_phi0) / sin_phi;
   };
 
-  std::tie(force1, force2, force3) = calc_angle_generic_3body_forces(
+  std::tie(f_mid, f_left, f_right) = calc_angle_generic_3body_forces(
       p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor, false);
 }
 

--- a/src/core/bonded_interactions/angle_cosine.hpp
+++ b/src/core/bonded_interactions/angle_cosine.hpp
@@ -36,35 +36,30 @@
 /** Set parameters for the angle potential. */
 int angle_cosine_set_params(int bond_type, double bend, double phi0);
 
-/************************************************************/
-
 /** Compute the three-body angle interaction force.
  *  @param[in]  p_mid     Second/middle particle.
  *  @param[in]  p_left    First/left particle.
  *  @param[in]  p_right   Third/right particle.
  *  @param[in]  iaparams  Bonded parameters for the angle interaction.
- *  @param[out] f_mid     Force on @p p_mid.
- *  @param[out] f_left    Force on @p p_left.
- *  @retval 0
+ *  @return Forces on the second, first and third particles, in that order.
  */
-inline int calc_angle_cosine_force(Particle const *p_mid,
-                                   Particle const *p_left,
-                                   Particle const *p_right,
-                                   Bonded_ia_parameters const *iaparams,
-                                   double f_mid[3], double f_left[3]) {
+inline std::tuple<Vector3d, Vector3d, Vector3d>
+calc_angle_cosine_3body_forces(Particle const *p_mid, Particle const *p_left,
+                               Particle const *p_right,
+                               Bonded_ia_parameters const *iaparams) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
     auto const cos_phi0 = iaparams->p.angle_cosine.cos_phi0;
     auto const sin_phi0 = iaparams->p.angle_cosine.sin_phi0;
-    auto const K = iaparams->p.angle_cosine.bend;
-    return K * (sin_phi0 * (cos_phi / sin_phi) + cos_phi0);
+    auto const k = iaparams->p.angle_cosine.bend;
+    // angle force term: K(phi) = -k * sin(phi - phi0) / sin(phi)
+    // trig identity: sin(a - b) = sin(a)cos(b) - cos(a)sin(b)
+    return -k * (sin_phi * cos_phi0 - cos_phi * sin_phi0) / sin_phi;
   };
 
-  calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor,
-                           f_mid, f_left, true);
-
-  return 0;
+  return calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p,
+                                  forceFactor, false);
 }
 
 /** Compute the three-body angle interaction force.
@@ -75,26 +70,24 @@ inline int calc_angle_cosine_force(Particle const *p_mid,
  *  @param[out] f_mid     Force on @p p_mid.
  *  @param[out] f_left    Force on @p p_left.
  *  @param[out] f_right   Force on @p p_right.
+ *  @retval 0
  */
-inline void calc_angle_cosine_3body_forces(Particle const *p_mid,
-                                           Particle const *p_left,
-                                           Particle const *p_right,
-                                           Bonded_ia_parameters const *iaparams,
-                                           Vector3d &f_mid, Vector3d &f_left,
-                                           Vector3d &f_right) {
+inline int calc_angle_cosine_force(Particle const *p_mid,
+                                   Particle const *p_left,
+                                   Particle const *p_right,
+                                   Bonded_ia_parameters const *iaparams,
+                                   double f_mid[3], double f_left[3],
+                                   double f_right[3]) {
 
-  auto forceFactor = [&iaparams](double const cos_phi) {
-    auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
-    auto const K = iaparams->p.angle_cosine.bend;
-    auto const sin_phi0 = iaparams->p.angle_cosine.sin_phi0;
-    auto const cos_phi0 = iaparams->p.angle_cosine.cos_phi0;
-    // potential dependent term [dU/dphi = K * sin(phi - phi0)]
-    // trig identity: sin(a - b) = sin(a)cos(b) - cos(a)sin(b)
-    return K * (sin_phi * cos_phi0 - cos_phi * sin_phi0) / sin_phi;
-  };
-
-  std::tie(f_mid, f_left, f_right) = calc_angle_generic_3body_forces(
-      p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor, false);
+  Vector3d f_mid_v, f_left_v, f_right_v;
+  std::tie(f_mid_v, f_left_v, f_right_v) =
+      calc_angle_cosine_3body_forces(p_mid, p_left, p_right, iaparams);
+  for (int i = 0; i < 3; ++i) {
+    f_mid[i] = f_mid_v[i];
+    f_left[i] = f_left_v[i];
+    f_right[i] = f_right_v[i];
+  }
+  return 0;
 }
 
 /** Computes the three-body angle interaction energy.
@@ -115,8 +108,10 @@ inline int angle_cosine_energy(Particle const *p_mid, Particle const *p_left,
   auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
   auto const cos_phi0 = iaparams->p.angle_cosine.cos_phi0;
   auto const sin_phi0 = iaparams->p.angle_cosine.sin_phi0;
-  auto const K = iaparams->p.angle_cosine.bend;
-  *_energy = K * (cos_phi * cos_phi0 - sin_phi * sin_phi0 + 1);
+  auto const k = iaparams->p.angle_cosine.bend;
+  // potential: U(phi) = k * [1 - cos(phi - phi0)]
+  // trig identity: cos(phi - phi0) = cos(phi)cos(phi0) + sin(phi)sin(phi0)
+  *_energy = k * (1 - (cos_phi * cos_phi0 + sin_phi * sin_phi0));
   return 0;
 }
 

--- a/src/core/bonded_interactions/angle_cossquare.hpp
+++ b/src/core/bonded_interactions/angle_cossquare.hpp
@@ -22,8 +22,8 @@
 #define ANGLE_COSSQUARE_H
 /** \file
  *  Routines to calculate the angle energy or/and and force
- *  for a particle triple.
- *  \ref forces.cpp
+ *  for a particle triple using the potential described in
+ *  @ref bondedIA_angle_cossquare.
  */
 
 #include "bonded_interaction_data.hpp"
@@ -33,7 +33,7 @@
 #include "grid.hpp"
 #include <tuple>
 
-/** set parameters for the angle potential. */
+/** Set parameters for the angle potential. */
 int angle_cossquare_set_params(int bond_type, double bend, double phi0);
 
 /************************************************************/
@@ -43,15 +43,15 @@ int angle_cossquare_set_params(int bond_type, double bend, double phi0);
  *  @param[in]  p_left    First/left particle.
  *  @param[in]  p_right   Third/right particle.
  *  @param[in]  iaparams  Bonded parameters for the angle interaction.
- *  @param[out] force1    Force on particle 1.
- *  @param[out] force2    Force on particle 2.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
  *  @retval 0
  */
 inline int calc_angle_cossquare_force(Particle const *p_mid,
                                       Particle const *p_left,
                                       Particle const *p_right,
                                       Bonded_ia_parameters const *iaparams,
-                                      double force1[3], double force2[3]) {
+                                      double f_mid[3], double f_left[3]) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const K = iaparams->p.angle_cossquare.bend;
@@ -60,17 +60,24 @@ inline int calc_angle_cossquare_force(Particle const *p_mid,
   };
 
   calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor,
-                           force1, force2, false);
+                           f_mid, f_left, false);
 
   return 0;
 }
 
-/* The force on each particle due to a three-body bonded potential
-   is computed. */
+/** Compute the three-body angle interaction force.
+ *  @param[in]  p_mid     Second/middle particle.
+ *  @param[in]  p_left    First/left particle.
+ *  @param[in]  p_right   Third/right particle.
+ *  @param[in]  iaparams  Bonded parameters for the angle interaction.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
+ *  @param[out] f_right   Force on @p p_right.
+ */
 inline void calc_angle_cossquare_3body_forces(
     Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Vector3d &force1, Vector3d &force2,
-    Vector3d &force3) {
+    Bonded_ia_parameters const *iaparams, Vector3d &f_mid, Vector3d &f_left,
+    Vector3d &f_right) {
 
   auto forceFactor = [&iaparams](double const cos_phi, double const sin_phi) {
     auto const K = iaparams->p.angle_cossquare.bend;
@@ -80,7 +87,7 @@ inline void calc_angle_cossquare_3body_forces(
     return K * (sin_phi * cos_phi0 - cos_phi * sin_phi) / sin_phi;
   };
 
-  std::tie(force1, force2, force3) = calc_angle_generic_3body_forces(
+  std::tie(f_mid, f_left, f_right) = calc_angle_generic_3body_forces(
       p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor, false);
 }
 

--- a/src/core/bonded_interactions/angle_cossquare.hpp
+++ b/src/core/bonded_interactions/angle_cossquare.hpp
@@ -79,7 +79,8 @@ inline void calc_angle_cossquare_3body_forces(
     Bonded_ia_parameters const *iaparams, Vector3d &f_mid, Vector3d &f_left,
     Vector3d &f_right) {
 
-  auto forceFactor = [&iaparams](double const cos_phi, double const sin_phi) {
+  auto forceFactor = [&iaparams](double const cos_phi) {
+    auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
     auto const K = iaparams->p.angle_cossquare.bend;
     auto const cos_phi0 = iaparams->p.angle_cossquare.cos_phi0;
     // potential dependent term [dU/dphi = K * (sin_phi * cos_phi0 - cos_phi *

--- a/src/core/bonded_interactions/angle_harmonic.hpp
+++ b/src/core/bonded_interactions/angle_harmonic.hpp
@@ -36,35 +36,28 @@
 /** Set parameters for the angle potential. */
 int angle_harmonic_set_params(int bond_type, double bend, double phi0);
 
-/************************************************************/
-
 /** Compute the three-body angle interaction force.
- *  @param[in]  p_mid     Second/middle particle.
- *  @param[in]  p_left    First/left particle.
- *  @param[in]  p_right   Third/right particle.
- *  @param[in]  iaparams  Bonded parameters for the angle interaction.
- *  @param[out] f_mid     Force on @p p_mid.
- *  @param[out] f_left    Force on @p p_left.
- *  @retval 0
+ *  @param  p_mid     Second/middle particle.
+ *  @param  p_left    First/left particle.
+ *  @param  p_right   Third/right particle.
+ *  @param  iaparams  Bonded parameters for the angle interaction.
+ *  @return Forces on the second, first and third particles, in that order.
  */
-inline int calc_angle_harmonic_force(Particle const *p_mid,
-                                     Particle const *p_left,
-                                     Particle const *p_right,
-                                     Bonded_ia_parameters const *iaparams,
-                                     double f_mid[3], double f_left[3]) {
+inline std::tuple<Vector3d, Vector3d, Vector3d>
+calc_angle_harmonic_3body_forces(Particle const *p_mid, Particle const *p_left,
+                                 Particle const *p_right,
+                                 Bonded_ia_parameters const *iaparams) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
-    auto const phi = acos(-cos_phi);
+    auto const phi = acos(cos_phi);
     auto const phi0 = iaparams->p.angle_harmonic.phi0;
-    auto const K = iaparams->p.angle_harmonic.bend;
-    return K * (phi - phi0) / sin_phi;
+    auto const k = iaparams->p.angle_harmonic.bend;
+    return -k * (phi - phi0) / sin_phi;
   };
 
-  calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor,
-                           f_mid, f_left, true);
-
-  return 0;
+  return calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p,
+                                  forceFactor, true);
 }
 
 /** Compute the three-body angle interaction force.
@@ -75,23 +68,24 @@ inline int calc_angle_harmonic_force(Particle const *p_mid,
  *  @param[out] f_mid     Force on @p p_mid.
  *  @param[out] f_left    Force on @p p_left.
  *  @param[out] f_right   Force on @p p_right.
+ *  @retval 0
  */
-inline void calc_angle_harmonic_3body_forces(
-    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Vector3d &f_mid, Vector3d &f_left,
-    Vector3d &f_right) {
+inline int calc_angle_harmonic_force(Particle const *p_mid,
+                                     Particle const *p_left,
+                                     Particle const *p_right,
+                                     Bonded_ia_parameters const *iaparams,
+                                     double f_mid[3], double f_left[3],
+                                     double f_right[3]) {
 
-  auto forceFactor = [&iaparams](double const cos_phi) {
-    auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
-    auto const phi = acos(cos_phi);
-    auto const phi0 = iaparams->p.angle_harmonic.phi0;
-    auto const K = iaparams->p.angle_harmonic.bend;
-    // potential dependent term [dU/dphi = K * (phi - phi0)]
-    return K * (phi - phi0) / sin_phi;
-  };
-
-  std::tie(f_mid, f_left, f_right) = calc_angle_generic_3body_forces(
-      p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor, true);
+  Vector3d f_mid_v, f_left_v, f_right_v;
+  std::tie(f_mid_v, f_left_v, f_right_v) =
+      calc_angle_harmonic_3body_forces(p_mid, p_left, p_right, iaparams);
+  for (int i = 0; i < 3; ++i) {
+    f_mid[i] = f_mid_v[i];
+    f_left[i] = f_left_v[i];
+    f_right[i] = f_right_v[i];
+  }
+  return 0;
 }
 
 /** Compute the three-body angle interaction energy.
@@ -109,10 +103,10 @@ inline int angle_harmonic_energy(Particle const *p_mid, Particle const *p_left,
   auto const vectors =
       calc_vectors_and_cosine(p_mid->r.p, p_left->r.p, p_right->r.p, true);
   auto const cos_phi = std::get<4>(vectors);
-  auto const phi = acos(-cos_phi);
+  auto const phi = acos(cos_phi);
   auto const phi0 = iaparams->p.angle_harmonic.phi0;
-  auto const K = iaparams->p.angle_harmonic.bend;
-  *_energy = 0.5 * K * Utils::sqr(phi - phi0);
+  auto const k = iaparams->p.angle_harmonic.bend;
+  *_energy = 0.5 * k * Utils::sqr(phi - phi0);
   return 0;
 }
 

--- a/src/core/bonded_interactions/angle_harmonic.hpp
+++ b/src/core/bonded_interactions/angle_harmonic.hpp
@@ -81,7 +81,8 @@ inline void calc_angle_harmonic_3body_forces(
     Bonded_ia_parameters const *iaparams, Vector3d &f_mid, Vector3d &f_left,
     Vector3d &f_right) {
 
-  auto forceFactor = [&iaparams](double const cos_phi, double const sin_phi) {
+  auto forceFactor = [&iaparams](double const cos_phi) {
+    auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
     auto const phi = acos(cos_phi);
     auto const phi0 = iaparams->p.angle_harmonic.phi0;
     auto const K = iaparams->p.angle_harmonic.bend;

--- a/src/core/bonded_interactions/angle_harmonic.hpp
+++ b/src/core/bonded_interactions/angle_harmonic.hpp
@@ -22,8 +22,8 @@
 #define ANGLE_HARMONIC_H
 /** \file
  *  Routines to calculate the angle energy or/and and force
- *  for a particle triple.
- *  \ref forces.cpp
+ *  for a particle triple using the potential described in
+ *  @ref bondedIA_angle_harmonic.
  */
 
 #include "bonded_interaction_data.hpp"
@@ -33,25 +33,25 @@
 #include "grid.hpp"
 #include <tuple>
 
-/** set parameters for the angle potential. */
+/** Set parameters for the angle potential. */
 int angle_harmonic_set_params(int bond_type, double bend, double phi0);
 
 /************************************************************/
 
-/** Computes the three-body angle interaction force.
+/** Compute the three-body angle interaction force.
  *  @param[in]  p_mid     Second/middle particle.
  *  @param[in]  p_left    First/left particle.
  *  @param[in]  p_right   Third/right particle.
  *  @param[in]  iaparams  Bonded parameters for the angle interaction.
- *  @param[out] force1    Force on particle 1.
- *  @param[out] force2    Force on particle 2.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
  *  @retval 0
  */
 inline int calc_angle_harmonic_force(Particle const *p_mid,
                                      Particle const *p_left,
                                      Particle const *p_right,
                                      Bonded_ia_parameters const *iaparams,
-                                     double force1[3], double force2[3]) {
+                                     double f_mid[3], double f_left[3]) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
@@ -62,17 +62,24 @@ inline int calc_angle_harmonic_force(Particle const *p_mid,
   };
 
   calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor,
-                           force1, force2, true);
+                           f_mid, f_left, true);
 
   return 0;
 }
 
-/* The force on each particle due to a three-body bonded potential
-   is computed. */
+/** Compute the three-body angle interaction force.
+ *  @param[in]  p_mid     Second/middle particle.
+ *  @param[in]  p_left    First/left particle.
+ *  @param[in]  p_right   Third/right particle.
+ *  @param[in]  iaparams  Bonded parameters for the angle interaction.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
+ *  @param[out] f_right   Force on @p p_right.
+ */
 inline void calc_angle_harmonic_3body_forces(
     Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Vector3d &force1, Vector3d &force2,
-    Vector3d &force3) {
+    Bonded_ia_parameters const *iaparams, Vector3d &f_mid, Vector3d &f_left,
+    Vector3d &f_right) {
 
   auto forceFactor = [&iaparams](double const cos_phi, double const sin_phi) {
     auto const phi = acos(cos_phi);
@@ -82,11 +89,11 @@ inline void calc_angle_harmonic_3body_forces(
     return K * (phi - phi0) / sin_phi;
   };
 
-  std::tie(force1, force2, force3) = calc_angle_generic_3body_forces(
+  std::tie(f_mid, f_left, f_right) = calc_angle_generic_3body_forces(
       p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor, true);
 }
 
-/** Computes the three-body angle interaction energy.
+/** Compute the three-body angle interaction energy.
  *  @param[in]  p_mid     Second/middle particle.
  *  @param[in]  p_left    First/left particle.
  *  @param[in]  p_right   Third/right particle.

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -1,0 +1,294 @@
+/*
+  Copyright (C) 2019 The ESPResSo project
+
+  This file is part of ESPResSo.
+
+  ESPResSo is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @page bondedIA Bonded interactions
+ * 
+ *  @section bondedIA_bond_angles Bond angle potentials
+ * 
+ *  @subsection bondedIA_angle_force General expressions for the forces
+ * 
+ *  This section uses the particle force expressions derived in
+ *  Swope, Ferguson *J. Comput. Chem.* **1992**, *13*(5): 585-594,
+ *  doi:[10.1002/jcc.540130508](https://doi.org/10.1002/jcc.540130508).
+ *
+ *  The force acting on particle @f$ i @f$ is given by the chain rule in
+ *  equation 6:
+ *
+ *  @f{equation}{
+ *      \label{eq:Swope-eq-6}
+ *      \vec{F_i}
+ *          = \nabla_i U(\theta_{ijk})
+ *          = \left(
+ *                  \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
+ *            \right)
+ *            \left(
+ *                  \frac{\mathrm{d}\theta_{ijk}}{\mathrm{d}\cos(\theta_{ijk})}
+ *            \right)
+ *            \left(
+ *                  \nabla_i \cos(\theta_{ijk})
+ *            \right)
+ *  @f}
+ *
+ *  with
+ *
+ *  @f[
+ *      \left(
+ *            \frac{\mathrm{d}\theta_{ijk}}{\mathrm{d}\cos(\theta_{ijk})}
+ *      \right)
+ *          = \left(
+ *                  \frac{-1}{\sin(\theta_{ijk})}
+ *            \right)
+ *  @f]
+ *
+ *  and @f$ \theta_{ijk} @f$ the angle formed by the three particles,
+ *  @f$ U(\theta_{ijk}) @f$ the bond angle potential, @f$ \vec{r_{ij}} @f$
+ *  the vector from particle @f$ j @f$ to particle @f$ i @f$ and
+ *  @f$ \nabla_i @f$ the gradient in the direction @f$ \vec{r_{ij}} @f$.
+ *
+ *  The expression for @f$ \cos(\theta_{ijk}) @f$ is given by equation 4:
+ *
+ *  @f{equation}{
+ *      \label{eq:Swope-eq-4}
+ *      \cos(\theta_{ijk})
+ *          = \frac{\vec{r_{ij}}\cdot\vec{r_{kj}}}
+ *                 {\left\|\vec{r_{ij}}\right\|\left\|\vec{r_{kj}}\right\|}
+ *  @f}
+ *
+ *  The expression for its gradient is given by equation 9:
+ *
+ *  @f{equation}{
+ *      \label{eq:Swope-eq-9}
+ *      \nabla_i \cos(\theta_{ijk})
+ *          = \vec{e_x}\frac{\partial\cos(\theta_{ijk})}{\partial x_{ij}}
+ *          + \vec{e_y}\frac{\partial\cos(\theta_{ijk})}{\partial y_{ij}}
+ *          + \vec{e_z}\frac{\partial\cos(\theta_{ijk})}{\partial z_{ij}}
+ *  @f}
+ *
+ *  with @f$ \left(\vec{e_x}, \vec{e_y}, \vec{e_z}\right) @f$ the unit vectors
+ *  of the reference coordinate system and
+ *  @f$ \vec{r_{ij}} = \left(x_{ij}, y_{ij}, z_{ij}\right) @f$.
+ *
+ *  Applying the quotient rule:
+ *
+ *  @f[
+ *      \frac{\partial\cos(\theta_{ijk})}{\partial x_{ij}}
+ *          = \frac{\partial}{\partial x_{ij}}
+ *            \left(
+ *                  \frac{\vec{r_{ij}}\cdot\vec{r_{kj}}}
+ *                       {\left\|\vec{r_{ij}}\right\|\left\|\vec{r_{kj}}\right\|}
+ *            \right)
+ *          = \frac{\left\|\vec{r_{ij}}\right\|\left\|\vec{r_{kj}}\right\|
+ *                  \partial \left(\vec{r_{ij}}\cdot\vec{r_{kj}}\right)
+ *                /\, \partial x_{ij}
+ *                - \vec{r_{ij}}\cdot\vec{r_{kj}}\cdot
+ *                  \partial
+ *                  \left(
+ *                       \left\|\vec{r_{ij}}\right\|\left\|\vec{r_{kj}}\right\|
+ *                  \right)
+ *                /\, \partial x_{ij}}
+ *                 {\left\|\vec{r_{ij}}\right\|^2\left\|\vec{r_{kj}}\right\|^2}
+ *            
+ *  @f]
+ *
+ *  with
+ *
+ *  @f[
+ *      \frac{\partial \left(\vec{r_{ij}}\cdot\vec{r_{kj}}\right)}
+ *           {\partial x_{ij}}
+ *          = \frac{\partial \left(x_{ij} \cdot x_{kj} + y_{ij} \cdot y_{kj} + z_{ij} \cdot z_{kj}\right)}
+ *           {\partial x_{ij}}
+ *          = x_{kj}
+ *  @f]
+ *
+ *  and
+ *
+ *  @f[
+ *      \frac{\partial \left(\left\|\vec{r_{ij}}\right\|\left\|\vec{r_{kj}}\right\|\right)}
+ *           {\partial x_{ij}}
+ *          = \left\|\vec{r_{kj}}\right\|
+ *            \frac{\partial}{\partial x_{ij}}
+ *            \sqrt{x_{ij}^2 + y_{ij}^2 + z_{ij}^2}
+ *          = \left\|\vec{r_{kj}}\right\|
+ *            \frac{0.5 \cdot 2 \cdot x_{ij}}
+ *                 {\sqrt{x_{ij}^2 + y_{ij}^2 + z_{ij}^2}}
+ *          = x_{ij}
+ *            \frac{\left\|\vec{r_{kj}}\right\|}
+ *                 {\left\|\vec{r_{ij}}\right\|}
+ *  @f]
+ *
+ *  leading to equation 12:
+ *
+ *  @f{align*}{
+ *      \label{eq:Swope-eq-12}
+ *      \frac{\partial\cos(\theta_{ijk})}{\partial x_{ij}}
+ *         &= \frac{\left\|\vec{r_{ij}}\right\|\left\|\vec{r_{kj}}\right\|x_{kj}
+ *                  - \vec{r_{ij}}\cdot\vec{r_{kj}}\cdot x_{ij}
+ *                    \left\|\vec{r_{kj}}\right\|\left\|\vec{r_{ij}}\right\|^{-1}}
+ *                 {\left\|\vec{r_{ij}}\right\|^2\left\|\vec{r_{kj}}\right\|^2}
+ *      \\
+ *         &= \frac{x_{kj}}
+ *                 {\left\|\vec{r_{ij}}\right\|\left\|\vec{r_{kj}}\right\|}
+ *          - \frac{\vec{r_{ij}}\cdot\vec{r_{kj}}\cdot x_{ij}}
+ *                 {\left\|\vec{r_{ij}}\right\|^3\left\|\vec{r_{kj}}\right\|}
+ *      \\
+ *         &= \frac{1}{\left\|\vec{r_{ij}}\right\|}
+ *                 \left(
+ *                    \frac{x_{kj}}{\left\|\vec{r_{kj}}\right\|}
+ *                  - \frac{x_{ij}}{\left\|\vec{r_{ij}}\right\|}
+ *                    \cos(\theta_{ijk})
+ *                 \right)
+ *  @f}
+ *
+ *  Applying these steps to equations 9-11 leads to the force equations
+ *  for all three particles:
+ *
+ *  @f{align*}{
+ *      \label{eq:Swope-eqs-9-final}
+ *      \vec{F_i}
+ *          &= K(\theta_{ijk})
+ *                 \frac{1}{\left\|\vec{r_{ij}}\right\|}
+ *                 \left(
+ *                    \frac{\vec{r_{kj}}}{\left\|\vec{r_{kj}}\right\|}
+ *                  - \frac{\vec{r_{ij}}}{\left\|\vec{r_{ij}}\right\|}
+ *                    \cos(\theta_{ijk})
+ *                 \right)
+ *      \\
+ *      \label{eq:Swope-eqs-10-final}
+ *      \vec{F_k}
+ *          &= K(\theta_{ijk})
+ *                 \frac{1}{\left\lVert\vec{r_{kj}}\right\rVert}
+ *                 \left(
+ *                    \frac{\vec{r_{ij}}}{\left\|\vec{r_{ij}}\right\|}
+ *                  - \frac{\vec{r_{kj}}}{\left\|\vec{r_{kj}}\right\|}
+ *                    \cos(\theta_{ijk})
+ *                 \right)
+ *      \\
+ *      \label{eq:Swope-eqs-11-final}
+ *      \vec{F_j} &= -\left(\vec{F_i} + \vec{F_k}\right)
+ *  @f}
+ *
+ *  with @f$ K(\theta_{ijk}) @f$ the angle force term, which depends on the
+ *  expression used for the angle potential.
+ *
+ *
+ *  @subsection bondedIA_angle_potentials Available potentials
+ *
+ *
+ *  @subsubsection bondedIA_angle_harmonic Harmonic angle potential
+ *
+ *  The harmonic angle potential takes the form:
+ *
+ *  @f{equation}{
+ *      \label{eq:harmonic-angle-pot}
+ *      U(\theta_{ijk})
+ *          = \frac{1}{2}k_{ijk}\left[\theta_{ijk} - \theta_{ijk}^0\right]^2
+ *  @f}
+ *
+ *  with @f$ \theta_{ijk} @f$ the angle formed by the three particles,
+ *  @f$ \theta_{ijk}^0 @f$ the equilibrium angle and @f$ k_{ijk} @f$
+ *  the bond angle force constant.
+ *
+ *  The derivative with respect to the angle is:
+ *
+ *  @f[
+ *      \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
+ *          = k_{ijk}\left[\theta_{ijk} - \theta_{ijk}^0\right]
+ *  @f]
+ *
+ *  resulting in the following angle force term:
+ *
+ *  @f{equation}{
+ *      \label{eq:harmonic-angle-pot-angle-term}
+ *      K(\theta_{ijk})
+ *          = -k_{ijk}\frac{\theta_{ijk} - \theta_{ijk}^0}
+ *                         {\sin(\theta_{ijk})}
+ *  @f}
+ *
+ *  which can lead to numerical instability at @f$ \theta_{ijk} = 0 @f$ and
+ *  @f$ \theta_{ijk} = \pi @f$.
+ *
+ *
+ *  @subsubsection bondedIA_angle_cossquare Harmonic cosine potential
+ *
+ *  The harmonic cosine potential takes the form:
+ *
+ *  @f{equation}{
+ *      \label{eq:harmonic-cosine-pot}
+ *      U(\theta_{ijk})
+ *          = \frac{1}{2}
+ *            k_{ijk}\left[\cos(\theta_{ijk}) - \cos(\theta_{ijk}^0)\right]^2
+ *  @f}
+ *
+ *  with @f$ \theta_{ijk} @f$ the angle formed by the three particles,
+ *  @f$ \theta_{ijk}^0 @f$ the equilibrium angle and @f$ k_{ijk} @f$
+ *  the bond angle force constant.
+ *
+ *  The derivative with respect to the angle is:
+ *
+ *  @f[
+ *      \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
+ *          = -k_{ijk}\sin(\theta_{ijk})
+ *            \left[\cos(\theta_{ijk}) - \cos(\theta_{ijk}^0)\right]
+ *  @f]
+ *
+ *  resulting in the following angle force term:
+ *
+ *  @f{equation}{
+ *      \label{eq:harmonic-cosine-pot-angle-term}
+ *      K(\theta_{ijk})
+ *          = k_{ijk}\left[\cos(\theta_{ijk}) - \cos(\theta_{ijk}^0)\right]
+ *  @f}
+ *
+ *  which does not suffer from numerical instability.
+ *
+ *
+ *  @subsubsection bondedIA_angle_cosine Cosine potential
+ *
+ *  The cosine potential takes the form:
+ *
+ *  @f{equation}{
+ *      \label{eq:cosine-pot}
+ *      U(\theta_{ijk})
+ *          = k_{ijk}\left[1 - \cos(\theta_{ijk} - \theta_{ijk}^0)\right]
+ *  @f}
+ *
+ *  with @f$ \theta_{ijk} @f$ the angle formed by the three particles,
+ *  @f$ \theta_{ijk}^0 @f$ the equilibrium angle and @f$ k_{ijk} @f$
+ *  the bond angle force constant.
+ *
+ *  The derivative with respect to the angle is:
+ *
+ *  @f[
+ *      \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
+ *          = k_{ijk}\sin(\theta_{ijk} - \theta_{ijk}^0)
+ *  @f]
+ *
+ *  resulting in the following angle force term:
+ *
+ *  @f{equation}{
+ *      \label{eq:cosine-pot-angle-term}
+ *      K(\theta_{ijk})
+ *          = -k_{ijk}\frac{\sin(\theta_{ijk} - \theta_{ijk}^0)}
+ *                         {\sin(\theta_{ijk})}
+ *  @f}
+ *
+ *  which can lead to numerical instability at @f$ \theta_{ijk} = 0 @f$ and
+ *  @f$ \theta_{ijk} = \pi @f$.
+ *
+ */

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -181,8 +181,24 @@
  *
  *  with @f$ K(\theta_{ijk}) @f$ the angle force term, which depends on the
  *  expression used for the angle potential. Forces @f$ \vec{F_i} @f$ and
- *  @f$ \vec{F_k} @f$ are perpendicular to the vectors @f$ \vec{r_{ij}} @f$
- *  resp. @f$ \vec{r_{kj}} @f$.
+ *  @f$ \vec{F_k} @f$ are perpendicular to the displacement vectors
+ *  @f$ \vec{r_{ij}} @f$ resp. @f$ \vec{r_{kj}} @f$ and their magnitude
+ *  are proportional to the potential gradient normalized by the displacement
+ *  vectors:
+ *
+ *  @f{align*}{
+ *      \left\|\vec{F_i}\right\|
+ *          &= \left(
+ *                  \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
+ *             \right)
+ *             \frac{1}{\left\|\vec{r_{ij}}\right\|}
+ *      \\
+ *      \left\|\vec{F_k}\right\|
+ *          &= \left(
+ *                  \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
+ *             \right)
+ *             \frac{1}{\left\|\vec{r_{kj}}\right\|}
+ *  @f}
  *
  *
  *  @subsection bondedIA_angle_potentials Available potentials

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -27,13 +27,12 @@
  *  Swope, Ferguson *J. Comput. Chem.* **1992**, *13*(5): 585-594,
  *  doi:[10.1002/jcc.540130508](https://doi.org/10.1002/jcc.540130508).
  *
- *  The force acting on particle @f$ i @f$ is given by the chain rule in
- *  equation 6:
+ *  The gradient of the potential at particle @f$ i @f$ is given by the chain
+ *  rule in equation 6:
  *
  *  @f{equation}{
  *      \label{eq:Swope-eq-6}
- *      \vec{F_i}
- *          = \nabla_i U(\theta_{ijk})
+ *      \nabla_i U(\theta_{ijk})
  *          = \left(
  *                  \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
  *            \right)
@@ -159,9 +158,8 @@
  *  for all three particles:
  *
  *  @f{align*}{
- *      \label{eq:Swope-eqs-9-final}
  *      \vec{F_i}
- *          &= K(\theta_{ijk})
+ *          &= - K(\theta_{ijk})
  *                 \frac{1}{\left\|\vec{r_{ij}}\right\|}
  *                 \left(
  *                    \frac{\vec{r_{kj}}}{\left\|\vec{r_{kj}}\right\|}
@@ -169,9 +167,8 @@
  *                    \cos(\theta_{ijk})
  *                 \right)
  *      \\
- *      \label{eq:Swope-eqs-10-final}
  *      \vec{F_k}
- *          &= K(\theta_{ijk})
+ *          &= - K(\theta_{ijk})
  *                 \frac{1}{\left\lVert\vec{r_{kj}}\right\rVert}
  *                 \left(
  *                    \frac{\vec{r_{ij}}}{\left\|\vec{r_{ij}}\right\|}
@@ -179,12 +176,13 @@
  *                    \cos(\theta_{ijk})
  *                 \right)
  *      \\
- *      \label{eq:Swope-eqs-11-final}
  *      \vec{F_j} &= -\left(\vec{F_i} + \vec{F_k}\right)
  *  @f}
  *
  *  with @f$ K(\theta_{ijk}) @f$ the angle force term, which depends on the
- *  expression used for the angle potential.
+ *  expression used for the angle potential. Forces @f$ \vec{F_i} @f$ and
+ *  @f$ \vec{F_k} @f$ are perpendicular to the vectors @f$ \vec{r_{ij}} @f$
+ *  resp. @f$ \vec{r_{kj}} @f$.
  *
  *
  *  @subsection bondedIA_angle_potentials Available potentials
@@ -286,6 +284,24 @@
  *      K(\theta_{ijk})
  *          = -k_{ijk}\frac{\sin(\theta_{ijk} - \theta_{ijk}^0)}
  *                         {\sin(\theta_{ijk})}
+ *  @f}
+ *
+ *  which can lead to numerical instability at @f$ \theta_{ijk} = 0 @f$ and
+ *  @f$ \theta_{ijk} = \pi @f$.
+ *
+ *
+ *  @subsubsection bondedIA_angle_tab Tabulated potential
+ *
+ *  The tabulated potential and its derivative with respect to the angle are
+ *  provided by the user. The angle force term takes the form:
+ *
+ *  @f{equation}{
+ *      \label{eq:tabulated-pot-angle-term}
+ *      K(\theta_{ijk})
+ *          = \frac{-1}{\sin(\theta_{ijk})}
+ *            \left(
+ *                  \frac{\mathrm{d}U(\theta_{ijk})}{\mathrm{d}\theta_{ijk}}
+ *            \right)
  *  @f}
  *
  *  which can lead to numerical instability at @f$ \theta_{ijk} = 0 @f$ and

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -163,7 +163,8 @@ inline void calc_angle_3body_tabulated_forces(
     Bonded_ia_parameters const *iaparams, Vector3d &force1, Vector3d &force2,
     Vector3d &force3) {
 
-  auto forceFactor = [&iaparams](double const cos_phi, double const sin_phi) {
+  auto forceFactor = [&iaparams](double const cos_phi) {
+    auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
 #ifdef TABANGLEMINUS
     auto const phi = acos(-cos_phi);
 #else

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -22,9 +22,8 @@
 #define CORE_BONDED_INTERACTIONS_TABULATED_HPP
 
 /** \file
- *  Routines to calculate the  energy and/or  force
- *  for a particle pair or bonds via interpolating from lookup tables.
- *  \ref forces.cpp
+ *  Routines to calculate the energy and/or force for particle bonds, angles
+ *  and dihedrals via interpolation of lookup tables.
  */
 
 #include "config.hpp"
@@ -118,50 +117,16 @@ inline int tab_bond_energy(Particle const *p1, Particle const *p2,
 }
 
 /** Compute the three-body angle interaction force.
- *
- *  The force on @p p_left and @p p_right acts perpendicular to the connecting
- *  vector between the particle and @p p_mid and in the plane defined by the
- *  three particles. The force on the middle particle balances the other two
- *  forces. The forces are scaled with the inverse length of the
- *  connecting vectors. It is assumed that the potential is tabulated
- *  for all angles between 0 and Pi.
- *
- *  @param[in]  p_mid     Second/middle particle.
- *  @param[in]  p_left    First/left particle.
- *  @param[in]  p_right   Third/right particle.
- *  @param[in]  iaparams  Bonded parameters for the angle interaction.
- *  @param[out] force1    Force on particle 1.
- *  @param[out] force2    Force on particle 2.
- *  @return 0
+ *  @param  p_mid     Second/middle particle.
+ *  @param  p_left    First/left particle.
+ *  @param  p_right   Third/right particle.
+ *  @param  iaparams  Bonded parameters for the angle interaction.
+ *  @return Forces on the second, first and third particles, in that order.
  */
-inline int calc_tab_angle_force(Particle const *p_mid, Particle const *p_left,
-                                Particle const *p_right,
-                                Bonded_ia_parameters const *iaparams,
-                                double force1[3], double force2[3]) {
-
-  auto forceFactor = [&iaparams](double const cos_phi) {
-    auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
-#ifdef TABANGLEMINUS
-    double const phi = acos(-cos_phi);
-#else
-    double const phi = acos(cos_phi);
-#endif
-    auto const dU = iaparams->p.tab.pot->force(phi);
-    return dU / sin_phi;
-  };
-
-  calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor,
-                           force1, force2, true);
-
-  return 0;
-}
-
-/* The force on each particle due to a three-body bonded tabulated
-   potential is computed. */
-inline void calc_angle_3body_tabulated_forces(
-    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Vector3d &force1, Vector3d &force2,
-    Vector3d &force3) {
+inline std::tuple<Vector3d, Vector3d, Vector3d>
+calc_angle_3body_tabulated_forces(Particle const *p_mid, Particle const *p_left,
+                                  Particle const *p_right,
+                                  Bonded_ia_parameters const *iaparams) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
@@ -171,12 +136,39 @@ inline void calc_angle_3body_tabulated_forces(
     auto const phi = acos(cos_phi);
 #endif
     auto const *tab_pot = iaparams->p.tab.pot;
-    auto const dU = tab_pot->force(phi);
-    return dU / sin_phi;
+    auto const gradient = tab_pot->force(phi);
+    return -gradient / sin_phi;
   };
 
-  std::tie(force1, force2, force3) = calc_angle_generic_3body_forces(
-      p_mid->r.p, p_left->r.p, p_right->r.p, forceFactor, true);
+  return calc_angle_generic_force(p_mid->r.p, p_left->r.p, p_right->r.p,
+                                  forceFactor, true);
+}
+
+/** Compute the three-body angle interaction force.
+ *  @param[in]  p_mid     Second/middle particle.
+ *  @param[in]  p_left    First/left particle.
+ *  @param[in]  p_right   Third/right particle.
+ *  @param[in]  iaparams  Bonded parameters for the angle interaction.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
+ *  @param[out] f_right   Force on @p p_right.
+ *  @retval 0
+ */
+inline int calc_tab_angle_force(Particle const *p_mid, Particle const *p_left,
+                                Particle const *p_right,
+                                Bonded_ia_parameters const *iaparams,
+                                double f_mid[3], double f_left[3],
+                                double f_right[3]) {
+
+  Vector3d f_mid_v, f_left_v, f_right_v;
+  std::tie(f_mid_v, f_left_v, f_right_v) =
+      calc_angle_3body_tabulated_forces(p_mid, p_left, p_right, iaparams);
+  for (int i = 0; i < 3; ++i) {
+    f_mid[i] = f_mid_v[i];
+    f_left[i] = f_left_v[i];
+    f_right[i] = f_right_v[i];
+  }
+  return 0;
 }
 
 /** Compute the three-body angle interaction energy.
@@ -188,7 +180,7 @@ inline void calc_angle_3body_tabulated_forces(
  *  @param[in]  p_right   Third/right particle.
  *  @param[in]  iaparams  Bonded parameters for the angle interaction.
  *  @param[out] _energy   Energy.
- *  @return 0
+ *  @retval 0
  */
 inline int tab_angle_energy(Particle const *p_mid, Particle const *p_left,
                             Particle const *p_right,

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -585,16 +585,16 @@ inline void add_bonded_force(Particle *p1) {
     else if (n_partners == 2) {
       switch (type) {
       case BONDED_IA_ANGLE_HARMONIC:
-        bond_broken =
-            calc_angle_harmonic_force(p1, p2, p3, iaparams, force, force2);
+        bond_broken = calc_angle_harmonic_force(p1, p2, p3, iaparams, force,
+                                                force2, force3);
         break;
       case BONDED_IA_ANGLE_COSINE:
-        bond_broken =
-            calc_angle_cosine_force(p1, p2, p3, iaparams, force, force2);
+        bond_broken = calc_angle_cosine_force(p1, p2, p3, iaparams, force,
+                                              force2, force3);
         break;
       case BONDED_IA_ANGLE_COSSQUARE:
-        bond_broken =
-            calc_angle_cossquare_force(p1, p2, p3, iaparams, force, force2);
+        bond_broken = calc_angle_cossquare_force(p1, p2, p3, iaparams, force,
+                                                 force2, force3);
         break;
 #ifdef OIF_GLOBAL_FORCES
       case BONDED_IA_OIF_GLOBAL_FORCES:
@@ -605,7 +605,7 @@ inline void add_bonded_force(Particle *p1) {
       case BONDED_IA_TABULATED:
         if (iaparams->num == 2)
           bond_broken =
-              calc_tab_angle_force(p1, p2, p3, iaparams, force, force2);
+              calc_tab_angle_force(p1, p2, p3, iaparams, force, force2, force3);
         break;
 #endif
 #ifdef IMMERSED_BOUNDARY
@@ -696,7 +696,7 @@ inline void add_bonded_force(Particle *p1) {
         default:
           p1->f.f[j] += force[j];
           p2->f.f[j] += force2[j];
-          p3->f.f[j] -= (force[j] + force2[j]);
+          p3->f.f[j] += force3[j];
         }
       }
       break;

--- a/src/core/observables/ParticleAngles.hpp
+++ b/src/core/observables/ParticleAngles.hpp
@@ -1,0 +1,65 @@
+/*
+Copyright (C) 2019 The ESPResSo project
+
+This file is part of ESPResSo.
+
+ESPResSo is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ESPResSo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OBSERVABLES_PARTICLEANGLES_HPP
+#define OBSERVABLES_PARTICLEANGLES_HPP
+
+#include "PidObservable.hpp"
+#include "utils/Vector.hpp"
+
+#include <cmath>
+#include <vector>
+
+namespace Observables {
+
+/** Calculate bond angles between particles in a polymer.
+ *  For \f$n\f$ bonded particles, return the \f$n-2\f$ angles along the chain,
+ *  in radians.
+ */
+class ParticleAngles : public PidObservable {
+public:
+  std::vector<double> operator()(PartCfg &partCfg) const override {
+    std::vector<double> res(n_values());
+    auto r1 = (partCfg[ids()[1]].r.p - partCfg[ids()[0]].r.p);
+    auto n1 = r1.norm();
+    for (int i = 0, end = n_values(); i < end; i++) {
+      auto r2 = (partCfg[ids()[i + 2]].r.p - partCfg[ids()[i + 1]].r.p);
+      auto n2 = r2.norm();
+      auto cosine = (r1 * r2) / (n1 * n2);
+      // sanitize cosine value
+      if (cosine > TINY_COS_VALUE)
+        cosine = TINY_COS_VALUE;
+      else if (cosine < -TINY_COS_VALUE)
+        cosine = -TINY_COS_VALUE;
+      /* to reduce computational time, after calculating an angle ijk, the
+       * vector r_ij takes the value r_jk, but to orient it correctly, it has
+       * to be multiplied -1; it's cheaper to do this operation on a double
+       * than on a vector of doubles
+       */
+      res[i] = acos(-cosine);
+      r1 = std::move(r2);
+      n1 = n2;
+    }
+    return res;
+  }
+  int n_values() const override { return ids().size() - 2; }
+};
+
+} // Namespace Observables
+
+#endif

--- a/src/core/observables/ParticleAngles.hpp
+++ b/src/core/observables/ParticleAngles.hpp
@@ -28,8 +28,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Observables {
 
 /** Calculate bond angles between particles in a polymer.
- *  For \f$n\f$ bonded particles, return the \f$n-2\f$ angles along the chain,
- *  in radians.
+ *  For @f$ n @f$ bonded particles, return the @f$ n-2 @f$ angles along the
+ *  chain, in radians.
  */
 class ParticleAngles : public PidObservable {
 public:

--- a/src/core/observables/ParticleAngles.hpp
+++ b/src/core/observables/ParticleAngles.hpp
@@ -53,7 +53,7 @@ public:
        * than on a vector of doubles
        */
       res[i] = acos(-cosine);
-      v1 = std::move(v2);
+      v1 = v2;
       n1 = n2;
     }
     return res;

--- a/src/core/observables/ParticleAngles.hpp
+++ b/src/core/observables/ParticleAngles.hpp
@@ -35,12 +35,13 @@ class ParticleAngles : public PidObservable {
 public:
   std::vector<double> operator()(PartCfg &partCfg) const override {
     std::vector<double> res(n_values());
-    auto r1 = (partCfg[ids()[1]].r.p - partCfg[ids()[0]].r.p);
-    auto n1 = r1.norm();
+    auto v1 = get_mi_vector(partCfg[ids()[1]].r.p, partCfg[ids()[0]].r.p);
+    auto n1 = v1.norm();
     for (int i = 0, end = n_values(); i < end; i++) {
-      auto r2 = (partCfg[ids()[i + 2]].r.p - partCfg[ids()[i + 1]].r.p);
-      auto n2 = r2.norm();
-      auto cosine = (r1 * r2) / (n1 * n2);
+      auto v2 =
+          get_mi_vector(partCfg[ids()[i + 2]].r.p, partCfg[ids()[i + 1]].r.p);
+      auto n2 = v2.norm();
+      auto cosine = (v1 * v2) / (n1 * n2);
       // sanitize cosine value
       if (cosine > TINY_COS_VALUE)
         cosine = TINY_COS_VALUE;
@@ -52,7 +53,7 @@ public:
        * than on a vector of doubles
        */
       res[i] = acos(-cosine);
-      r1 = std::move(r2);
+      v1 = std::move(v2);
       n1 = n2;
     }
     return res;

--- a/src/core/observables/ParticleDihedrals.hpp
+++ b/src/core/observables/ParticleDihedrals.hpp
@@ -28,8 +28,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Observables {
 
 /** Calculate dihedral angles between particles in a polymer.
- *  For \f$n\f$ bonded particles, return the \f$n-3\f$ signed dihedral angles
+ *  For @f$ n @f$ bonded particles, return the @f$ n-3 @f$ dihedral angles
  *  along the chain, in radians.
+ *
+ *  The sign of the dihedral angles follow the IUPAC nomenclature for the
+ *  Newman projection, specifically section "Torsion Angle" pages 2220-2221 in
+ *  G. P. Moss, *Basic Terminology of Stereochemistry* (IUPAC Recommendations
+ *  1996), *Pure and Applied Chemistry* **1996**, *68*(12): 2193-2222,
+ *  doi:[10.1351/pac199668122193](https://doi.org/10.1351%2Fpac199668122193)
+ *
  */
 class ParticleDihedrals : public PidObservable {
 public:

--- a/src/core/observables/ParticleDihedrals.hpp
+++ b/src/core/observables/ParticleDihedrals.hpp
@@ -35,17 +35,18 @@ class ParticleDihedrals : public PidObservable {
 public:
   std::vector<double> operator()(PartCfg &partCfg) const override {
     std::vector<double> res(n_values());
-    auto r1 = (partCfg[ids()[1]].r.p - partCfg[ids()[0]].r.p);
-    auto r2 = (partCfg[ids()[2]].r.p - partCfg[ids()[1]].r.p);
-    auto c1 = vector_product(r1, r2);
+    auto v1 = get_mi_vector(partCfg[ids()[1]].r.p, partCfg[ids()[0]].r.p);
+    auto v2 = get_mi_vector(partCfg[ids()[2]].r.p, partCfg[ids()[1]].r.p);
+    auto c1 = vector_product(v1, v2);
     for (int i = 0, end = n_values(); i < end; i++) {
-      auto r3 = (partCfg[ids()[i + 3]].r.p - partCfg[ids()[i + 2]].r.p);
-      auto c2 = vector_product(r2, r3);
+      auto v3 =
+          get_mi_vector(partCfg[ids()[i + 3]].r.p, partCfg[ids()[i + 2]].r.p);
+      auto c2 = vector_product(v2, v3);
       /* the 2-argument arctangent returns an angle in the range [-pi, pi] that
        * allows for an unambiguous determination of the 4th particle position */
-      res[i] = atan2(vector_product(c1, c2) * r2 / r2.norm(), c1 * c2);
-      r1 = std::move(r2);
-      r2 = std::move(r3);
+      res[i] = atan2((vector_product(c1, c2) * v2) / v2.norm(), c1 * c2);
+      v1 = std::move(v2);
+      v2 = std::move(v3);
       c1 = std::move(c2);
     }
     return res;

--- a/src/core/observables/ParticleDihedrals.hpp
+++ b/src/core/observables/ParticleDihedrals.hpp
@@ -52,9 +52,9 @@ public:
       /* the 2-argument arctangent returns an angle in the range [-pi, pi] that
        * allows for an unambiguous determination of the 4th particle position */
       res[i] = atan2((vector_product(c1, c2) * v2) / v2.norm(), c1 * c2);
-      v1 = std::move(v2);
-      v2 = std::move(v3);
-      c1 = std::move(c2);
+      v1 = v2;
+      v2 = v3;
+      c1 = c2;
     }
     return res;
   }

--- a/src/core/observables/ParticleDihedrals.hpp
+++ b/src/core/observables/ParticleDihedrals.hpp
@@ -1,0 +1,58 @@
+/*
+Copyright (C) 2019 The ESPResSo project
+
+This file is part of ESPResSo.
+
+ESPResSo is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ESPResSo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OBSERVABLES_PARTICLEDIHEDRALS_HPP
+#define OBSERVABLES_PARTICLEDIHEDRALS_HPP
+
+#include "PidObservable.hpp"
+#include "utils/Vector.hpp"
+
+#include <cmath>
+#include <vector>
+
+namespace Observables {
+
+/** Calculate dihedral angles between particles in a polymer.
+ *  For \f$n\f$ bonded particles, return the \f$n-3\f$ signed dihedral angles
+ *  along the chain, in radians.
+ */
+class ParticleDihedrals : public PidObservable {
+public:
+  std::vector<double> operator()(PartCfg &partCfg) const override {
+    std::vector<double> res(n_values());
+    auto r1 = (partCfg[ids()[1]].r.p - partCfg[ids()[0]].r.p);
+    auto r2 = (partCfg[ids()[2]].r.p - partCfg[ids()[1]].r.p);
+    auto c1 = vector_product(r1, r2);
+    for (int i = 0, end = n_values(); i < end; i++) {
+      auto r3 = (partCfg[ids()[i + 3]].r.p - partCfg[ids()[i + 2]].r.p);
+      auto c2 = vector_product(r2, r3);
+      /* the 2-argument arctangent returns an angle in the range [-pi, pi] that
+       * allows for an unambiguous determination of the 4th particle position */
+      res[i] = atan2(vector_product(c1, c2) * r2 / r2.norm(), c1 * c2);
+      r1 = std::move(r2);
+      r2 = std::move(r3);
+      c1 = std::move(c2);
+    }
+    return res;
+  }
+  int n_values() const override { return ids().size() - 3; }
+};
+
+} // Namespace Observables
+
+#endif

--- a/src/core/observables/ParticleDistances.hpp
+++ b/src/core/observables/ParticleDistances.hpp
@@ -35,7 +35,8 @@ public:
   std::vector<double> operator()(PartCfg &partCfg) const override {
     std::vector<double> res(n_values());
     for (int i = 0, end = n_values(); i < end; i++) {
-      res[i] = (partCfg[ids()[i]].r.p - partCfg[ids()[i + 1]].r.p).norm();
+      auto v = get_mi_vector(partCfg[ids()[i]].r.p, partCfg[ids()[i + 1]].r.p);
+      res[i] = v.norm();
     }
     return res;
   }

--- a/src/core/observables/ParticleDistances.hpp
+++ b/src/core/observables/ParticleDistances.hpp
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Observables {
 
 /** Calculate distances between particles in a polymer.
- *  For \f$n\f$ bonded particles, return the \f$n-1\f$ distances separating
+ *  For @f$ n @f$ bonded particles, return the @f$ n-1 @f$ distances separating
  *  them.
  */
 class ParticleDistances : public PidObservable {

--- a/src/core/observables/ParticleDistances.hpp
+++ b/src/core/observables/ParticleDistances.hpp
@@ -1,0 +1,47 @@
+/*
+Copyright (C) 2019 The ESPResSo project
+
+This file is part of ESPResSo.
+
+ESPResSo is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ESPResSo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OBSERVABLES_PARTICLEDISTANCES_HPP
+#define OBSERVABLES_PARTICLEDISTANCES_HPP
+
+#include "PidObservable.hpp"
+#include "utils/Vector.hpp"
+
+#include <vector>
+
+namespace Observables {
+
+/** Calculate distances between particles in a polymer.
+ *  For \f$n\f$ bonded particles, return the \f$n-1\f$ distances separating
+ *  them.
+ */
+class ParticleDistances : public PidObservable {
+public:
+  std::vector<double> operator()(PartCfg &partCfg) const override {
+    std::vector<double> res(n_values());
+    for (int i = 0, end = n_values(); i < end; i++) {
+      res[i] = (partCfg[ids()[i]].r.p - partCfg[ids()[i + 1]].r.p).norm();
+    }
+    return res;
+  }
+  int n_values() const override { return ids().size() - 1; }
+};
+
+} // Namespace Observables
+
+#endif

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -188,6 +188,7 @@ inline void calc_three_body_bonded_forces(Particle const *p_mid,
     default:
       runtimeErrorMsg() << "calc_bonded_force: tabulated bond type of atom "
                         << p_mid->p.identity << " unknown\n";
+      f_mid = f_left = f_right = Vector3d{};
       return;
     }
     break;

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -149,53 +149,54 @@ inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2, double d[3],
 #endif /*ifdef DIPOLES */
 }
 
-/* calc_three_body_bonded_forces is called by add_three_body_bonded_stress. This
-   routine is only entered for angular potentials. */
-inline void calc_three_body_bonded_forces(Particle *p1, Particle *p2,
-                                          Particle *p3,
-                                          Bonded_ia_parameters *iaparams,
-                                          Vector3d &force1, Vector3d &force2,
-                                          Vector3d &force3) {
-
-#ifdef TABULATED
-// char* errtxt;
-#endif
-
+/** Calculate bond angle forces.
+ *  This routine is only entered for angular potentials.
+ *  @param[in]  p_mid     Second/middle particle.
+ *  @param[in]  p_left    First/left particle.
+ *  @param[in]  p_right   Third/right particle.
+ *  @param[in]  iaparams  Bonded parameters for the angle interaction.
+ *  @param[out] f_mid     Force on @p p_mid.
+ *  @param[out] f_left    Force on @p p_left.
+ *  @param[out] f_right   Force on @p p_right.
+ */
+inline void calc_three_body_bonded_forces(Particle const *p_mid,
+                                          Particle const *p_left,
+                                          Particle const *p_right,
+                                          Bonded_ia_parameters const *iaparams,
+                                          Vector3d &f_mid, Vector3d &f_left,
+                                          Vector3d &f_right) {
   switch (iaparams->type) {
   case BONDED_IA_ANGLE_HARMONIC:
-    // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-    calc_angle_harmonic_3body_forces(p1, p2, p3, iaparams, force1, force2,
-                                     force3);
+    std::tie(f_mid, f_left, f_right) =
+        calc_angle_harmonic_3body_forces(p_mid, p_left, p_right, iaparams);
     break;
   case BONDED_IA_ANGLE_COSINE:
-    // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-    calc_angle_cosine_3body_forces(p1, p2, p3, iaparams, force1, force2,
-                                   force3);
+    std::tie(f_mid, f_left, f_right) =
+        calc_angle_cosine_3body_forces(p_mid, p_left, p_right, iaparams);
     break;
   case BONDED_IA_ANGLE_COSSQUARE:
-    // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-    calc_angle_cossquare_3body_forces(p1, p2, p3, iaparams, force1, force2,
-                                      force3);
+    std::tie(f_mid, f_left, f_right) =
+        calc_angle_cossquare_3body_forces(p_mid, p_left, p_right, iaparams);
     break;
 #ifdef TABULATED
   case BONDED_IA_TABULATED:
     switch (iaparams->p.tab.type) {
     case TAB_BOND_ANGLE:
-      // p1 is *p_mid, p2 is *p_left, p3 is *p_right
-      calc_angle_3body_tabulated_forces(p1, p2, p3, iaparams, force1, force2,
-                                        force3);
+      std::tie(f_mid, f_left, f_right) =
+          calc_angle_3body_tabulated_forces(p_mid, p_left, p_right, iaparams);
       break;
     default:
       runtimeErrorMsg() << "calc_bonded_force: tabulated bond type of atom "
-                        << p1->p.identity << " unknown\n";
+                        << p_mid->p.identity << " unknown\n";
       return;
     }
     break;
 #endif
   default:
     fprintf(stderr, "calc_three_body_bonded_forces: \
-            WARNING: Bond type %d , atom %d unhandled, Atom 2: %d\n",
-            iaparams->type, p1->p.identity, p2->p.identity);
+            WARNING: Bond type %d, atom %d unhandled, Atom 2: %d\n",
+            iaparams->type, p_mid->p.identity, p_left->p.identity);
+    f_mid = f_left = f_right = Vector3d{};
     break;
   }
 }
@@ -276,7 +277,7 @@ inline void add_three_body_bonded_stress(Particle *p1) {
     auto const dx21 = -get_mi_vector(p1->r.p, p2->r.p);
     auto const dx31 = get_mi_vector(p3->r.p, p1->r.p);
 
-    Vector3d force1{}, force2{}, force3{};
+    Vector3d force1, force2, force3;
     calc_three_body_bonded_forces(p1, p2, p3, iaparams, force1, force2, force3);
     /* three-body bonded interactions contribute to the stress but not the
      * scalar pressure */

--- a/src/core/utils.hpp
+++ b/src/core/utils.hpp
@@ -20,13 +20,9 @@
 */
 #ifndef UTILS_HPP
 #define UTILS_HPP
-/** \file utils.hpp
- *    Small functions that are useful not only for one modul.
-
- *  just some nice utilities...
- *  and some constants...
- *
-*/
+/** \file
+ *  Convenience functions for common operations on vectors.
+ */
 
 #include "utils/Vector.hpp"
 #include "utils/constants.hpp"
@@ -40,7 +36,7 @@
 /**************************************************************/
 /*@{*/
 
-/** calculates the scalar product of two vectors a and b */
+/** calculates the scalar product of two vectors @p a and @p b */
 template <typename T1, typename T2> double scalar(const T1 &a, const T2 &b) {
   double d2 = 0.0;
   for (int i = 0; i < 3; i++)
@@ -67,14 +63,12 @@ inline void vector_product(T const &a, U const &b, V &c) {
 /*************************************************************/
 /*@{*/
 
-/** get the linear index from the position (a,b,c) in a 3D grid
- *  of dimensions adim[]. returns linear index.
+/** get the linear index from the position (@p a,@p b,@p c) in a 3D grid
+ *  of dimensions @p adim.
  *
- * @return        the linear index
- * @param a       x position
- * @param b       y position
- * @param c       z position
- * @param adim    dimensions of the underlying grid
+ * @return           The linear index
+ * @param a , b , c  Position in 3D space
+ * @param adim       Dimensions of the underlying grid
  */
 inline int get_linear_index(int a, int b, int c, const Vector3i &adim) {
   assert((a >= 0) && (a < adim[0]));
@@ -88,14 +82,12 @@ inline int get_linear_index(const Vector3i &ind, const Vector3i &adim) {
   return get_linear_index(ind[0], ind[1], ind[2], adim);
 }
 
-/** get the position a[] from the linear index in a 3D grid
- *  of dimensions adim[].
+/** get the position (@p a,@p b,@p c) from the linear index in a 3D grid
+ *  of dimensions @p adim.
  *
- * @param i       linear index
- * @param a       x position (return value)
- * @param b       y position (return value)
- * @param c       z position (return value)
- * @param adim    dimensions of the underlying grid
+ * @param[in]  i          Linear index
+ * @param[out] a , b , c  Position in 3D space
+ * @param[in]  adim       Dimensions of the underlying grid
  */
 inline void get_grid_pos(int i, int *a, int *b, int *c, const Vector3i &adim) {
   *a = i % adim[0];
@@ -112,7 +104,7 @@ inline void get_grid_pos(int i, int *a, int *b, int *c, const Vector3i &adim) {
 /*************************************************************/
 /*@{*/
 
-/** Calculate the distance between two positions.
+/** Calculate the squared distance between two positions.
  *  \param a Position one.
  *  \param b Position two.
  */

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -347,6 +347,51 @@ class ParticleVelocities(Observable):
 
 
 @script_interface_register
+class ParticleDistances(Observable):
+
+    """Calculates the distances between particles with given ids along a
+    polymer chain.
+
+    Parameters
+    ----------
+    ids : array_like of :obj:`int`
+          The ids of (existing) particles to take into account.
+
+    """
+    _so_name = "Observables::ParticleDistances"
+
+
+@script_interface_register
+class ParticleAngles(Observable):
+
+    """Calculates the angles between particles with given ids along a
+    polymer chain.
+
+    Parameters
+    ----------
+    ids : array_like of :obj:`int`
+          The ids of (existing) particles to take into account.
+
+    """
+    _so_name = "Observables::ParticleAngles"
+
+
+@script_interface_register
+class ParticleDihedrals(Observable):
+
+    """Calculates the dihedrals between particles with given ids along a
+    polymer chain.
+
+    Parameters
+    ----------
+    ids : array_like of :obj:`int`
+          The ids of (existing) particles to take into account.
+
+    """
+    _so_name = "Observables::ParticleDihedrals"
+
+
+@script_interface_register
 class StressTensor(Observable):
     _so_name = "Observables::StressTensor"
 

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -393,11 +393,11 @@ class ParticleDihedrals(Observable):
 
 @script_interface_register
 class StressTensor(Observable):
-    _so_name = "Observables::StressTensor"
 
     """Calculates the total stress tensor. See :ref:`stress tensor`)
 
     """
+    _so_name = "Observables::StressTensor"
 
 
 @script_interface_register

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -288,7 +288,7 @@ cdef class ParticleHandle(object):
         See Also
         --------
         add_bond() : Method to add bonds to a `Particle`
-        delete_bond() : Method to add bonds to a `Particle`
+        delete_bond() : Method to remove bonds from a `Particle`
 
         .. note::
            Bond ids have to be an integer >= 0.

--- a/src/script_interface/observables/initialize.cpp
+++ b/src/script_interface/observables/initialize.cpp
@@ -36,9 +36,12 @@
 #include "core/observables/DipoleMoment.hpp"
 #include "core/observables/LBVelocityProfile.hpp"
 #include "core/observables/MagneticDipoleMoment.hpp"
+#include "core/observables/ParticleAngles.hpp"
 #include "core/observables/ParticleAngularVelocities.hpp"
 #include "core/observables/ParticleBodyAngularVelocities.hpp"
 #include "core/observables/ParticleBodyVelocities.hpp"
+#include "core/observables/ParticleDihedrals.hpp"
+#include "core/observables/ParticleDistances.hpp"
 #include "core/observables/ParticleForces.hpp"
 #include "core/observables/ParticlePositions.hpp"
 #include "core/observables/ParticleVelocities.hpp"
@@ -93,6 +96,9 @@ void initialize() {
   REGISTER_PID_OBS(ComPosition);
   REGISTER_PID_OBS(ComVelocity);
   REGISTER_PID_OBS(ComForce);
+  REGISTER_PID_OBS(ParticleDistances);
+  REGISTER_PID_OBS(ParticleAngles);
+  REGISTER_PID_OBS(ParticleDihedrals);
   REGISTER_PID_PROFILE_OBS(DensityProfile);
   REGISTER_PID_PROFILE_OBS(ForceDensityProfile);
   REGISTER_PID_PROFILE_OBS(FluxDensityProfile);

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -191,6 +191,7 @@ python_test(FILE lb_thermostat.py MAX_NUM_PROC 2 LABELS gpu)
 python_test(FILE p3m_electrostatic_pressure.py MAX_NUM_PROC 2)
 python_test(FILE sigint.py DEPENDENCIES sigint_child.py MAX_NUM_PROC 1)
 python_test(FILE lb_density.py MAX_NUM_PROC 1)
+python_test(FILE observable_chain.py MAX_NUM_PROC 4)
 
 if(PY_H5PY)
   python_test(FILE h5md.py MAX_NUM_PROC 2)

--- a/testsuite/python/interactions_bond_angle.py
+++ b/testsuite/python/interactions_bond_angle.py
@@ -107,13 +107,12 @@ class InteractionsAngleBondTest(ut.TestCase):
             phi_diff = i * d_phi - bond_instance.params['phi0']
             for p, sign in [[p1, -1], [p2, +1]]:
                 # Check that force is perpendicular
-                dot_prod_tol = 1E-12
                 self.assertAlmostEqual(
                     np.dot(p.f, self.system.distance_vec(p0, p)), 0,
-                    delta=dot_prod_tol, msg="The force is not perpendicular")
+                    delta=1E-12, msg="The force is not perpendicular")
                 # Check that force has correct magnitude
                 self.assertAlmostEqual(np.linalg.norm(p.f), np.abs(
-                    f_ref) / self.system.distance(p0, p), delta=1E-12)
+                    f_ref) / self.system.distance(p0, p), delta=1E-11)
                 # Check that force decreases the quantity abs(phi - phi0)
                 if np.abs(phi_diff) > 1E-12:  # sign undefined for phi = phi0
                     force_axis = np.cross(self.system.distance_vec(p, p0), p.f)

--- a/testsuite/python/interactions_bond_angle.py
+++ b/testsuite/python/interactions_bond_angle.py
@@ -31,6 +31,7 @@ class InteractionsAngleBondTest(ut.TestCase):
     axis /= np.linalg.norm(axis)
     rel_pos = np.cross(np.random.rand(3), axis)
     rel_pos /= np.linalg.norm(rel_pos)
+    N = 111  # number of angles to sample
 
     def setUp(self):
         self.system.box_l = [self.box_l] * 3
@@ -60,14 +61,14 @@ class InteractionsAngleBondTest(ut.TestCase):
         return vrot
 
     # Analytical expressions
-    # Forces aren't divided by sin(phi) to simplify the force magnitude check,
+    # Forces aren't divided by -sin(phi) to simplify the force magnitude check,
     # which only depends on the displacement vectors and potential gradient,
     # see "Bond angle potentials" in Doxygen
     def angle_harmonic_potential(self, phi, bend=1.0, phi0=np.pi):
         return 0.5 * bend * np.power(phi - phi0, 2)
 
     def angle_harmonic_force(self, phi, bend=1.0, phi0=np.pi):
-        return -bend * (phi - phi0)
+        return bend * (phi - phi0)
 
     def angle_cosine_potential(self, phi, bend=1.0, phi0=np.pi):
         return bend * (1 - np.cos(phi - phi0))
@@ -79,20 +80,20 @@ class InteractionsAngleBondTest(ut.TestCase):
         return 0.5 * bend * (np.cos(phi) - np.cos(phi0))**2
 
     def angle_cos_squared_force(self, phi, bend=1.0, phi0=np.pi):
-        return bend * (np.cos(phi) - np.cos(phi0)) * np.sin(phi)
+        return -bend * (np.cos(phi) - np.cos(phi0)) * np.sin(phi)
 
-    def run_test(self, bond_instance, force_func, energy_func):
+    def run_test(self, bond_instance, force_func, energy_func, phi0):
         self.system.bonded_inter.add(bond_instance)
-        self.system.part[0].add_bond((bond_instance, 1, 2))
-        # Add an extra (strength 0) pair bond, which should change nothing
-        self.system.part[0].add_bond((self.harmonic_bond, 1))
         p0 = self.system.part[0]
         p1 = self.system.part[1]
         p2 = self.system.part[2]
+        # Add bond angle
+        p0.add_bond((bond_instance, 1, 2))
+        # Add an extra (strength 0) pair bond, which should change nothing
+        p0.add_bond((self.harmonic_bond, 1))
 
-        N = 111
-        d_phi = np.pi / N
-        for i in range(1, N):  # avoid singularities at phi = 0 and phi = pi
+        d_phi = np.pi / self.N
+        for i in range(1, self.N):  # avoid corner cases at phi = 0 and phi = pi
             p2.pos = self.start_pos + \
                 self.rotate_vector(self.rel_pos, self.axis, i * d_phi)
             self.system.integrator.run(recalc_forces=True, steps=0)
@@ -104,7 +105,7 @@ class InteractionsAngleBondTest(ut.TestCase):
             np.testing.assert_almost_equal(E_sim, E_ref, decimal=4)
 
             f_ref = force_func(i * d_phi)
-            phi_diff = i * d_phi - bond_instance.params['phi0']
+            phi_diff = i * d_phi - phi0
             for p, sign in [[p1, -1], [p2, +1]]:
                 # Check that force is perpendicular
                 self.assertAlmostEqual(
@@ -116,7 +117,8 @@ class InteractionsAngleBondTest(ut.TestCase):
                 # Check that force decreases the quantity abs(phi - phi0)
                 if np.abs(phi_diff) > 1E-12:  # sign undefined for phi = phi0
                     force_axis = np.cross(self.system.distance_vec(p, p0), p.f)
-                    self.assertEqual(np.sign(phi_diff),
+                    self.assertEqual(
+                        np.sign(phi_diff),
                         np.sign(sign * np.dot(force_axis, self.axis)),
                         msg="The force moves particles in the wrong direction")
 
@@ -145,6 +147,11 @@ class InteractionsAngleBondTest(ut.TestCase):
                 self.system.analysis.stress_tensor()["bonded"],
                 p_tensor_expected, atol=1E-12)
 
+        # Remove bonds
+        p0.delete_bond((bond_instance, 1, 2))
+        p0.delete_bond((self.harmonic_bond, 1))
+        p0.delete_bond((self.harmonic_bond, 2))
+
     def test_angle_harmonic(self):
         ah_bend = 1.
         ah_phi0 = 0.4327 * np.pi
@@ -155,7 +162,8 @@ class InteractionsAngleBondTest(ut.TestCase):
                       lambda phi: self.angle_harmonic_force(
                       phi=phi, bend=ah_bend, phi0=ah_phi0),
                       lambda phi: self.angle_harmonic_potential(
-                      phi=phi, bend=ah_bend, phi0=ah_phi0))
+                      phi=phi, bend=ah_bend, phi0=ah_phi0),
+                      ah_phi0)
 
     def test_angle_cosine(self):
         ac_bend = 1
@@ -167,7 +175,8 @@ class InteractionsAngleBondTest(ut.TestCase):
                       lambda phi: self.angle_cosine_force(
                       phi=phi, bend=ac_bend, phi0=ac_phi0),
                       lambda phi: self.angle_cosine_potential(
-                      phi=phi, bend=ac_bend, phi0=ac_phi0))
+                      phi=phi, bend=ac_bend, phi0=ac_phi0),
+                      ac_phi0)
 
     def test_angle_cos_squared(self):
         acs_bend = 1
@@ -179,7 +188,30 @@ class InteractionsAngleBondTest(ut.TestCase):
                       lambda phi: self.angle_cos_squared_force(
                       phi=phi, bend=acs_bend, phi0=acs_phi0),
                       lambda phi: self.angle_cos_squared_potential(
-                      phi=phi, bend=acs_bend, phi0=acs_phi0))
+                      phi=phi, bend=acs_bend, phi0=acs_phi0),
+                      acs_phi0)
+
+    @ut.skipIf(not espressomd.has_features("TABULATED"),
+               "Skipped because feature is disabled")
+    def test_angle_tabulated(self):
+        """Check that we can reproduce the three other potentials."""
+        at_bend = 1
+        at_phi0 = 1
+        phi = np.linspace(0, np.pi, num=self.N + 1, endpoint=True)
+        for fun_pot, fun_force in [
+                (self.angle_cosine_potential, self.angle_cosine_force),
+                (self.angle_harmonic_potential, self.angle_harmonic_force),
+                (self.angle_cos_squared_potential, self.angle_cos_squared_force)]:
+            angle_tabulated = espressomd.interactions.Tabulated(
+                type='angle', min=0, max=np.pi,
+                energy=fun_pot(phi=phi, bend=at_bend, phi0=at_phi0),
+                force=fun_force(phi=phi, bend=at_bend, phi0=at_phi0))
+            self.run_test(angle_tabulated,
+                          lambda phi: fun_force(
+                          phi=phi, bend=at_bend, phi0=at_phi0),
+                          lambda phi: fun_pot(
+                          phi=phi, bend=at_bend, phi0=at_phi0),
+                          at_phi0)
 
 if __name__ == '__main__':
     print("Features: ", espressomd.features())

--- a/testsuite/python/observable_chain.py
+++ b/testsuite/python/observable_chain.py
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2019 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import print_function
+import unittest as ut
+import espressomd
+import numpy as np
+import espressomd.observables
+
+
+class Observables(ut.TestCase):
+    n_tries = 50
+    n_parts = 8
+    box_l = 5.
+    system = espressomd.System(box_l=3 * [box_l])
+    system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
+
+    @classmethod
+    def setUpClass(cls):
+        for i in range(cls.n_parts):
+            cls.system.part.add(pos=[1 + i, 1 + i, 1 + i], id=i)
+
+    def scatter_particles(self):
+        pos = np.random.uniform(low=-1.5 * self.box_l, high=1.5 * self.box_l,
+                                size=[self.n_parts, 3])
+        for i in range(self.n_parts):
+            self.system.part[i].pos = pos[i]
+        return pos
+
+    def test_ParticleDistances(self):
+        """
+        Check ParticleDistances for a single particle pair and a chain.
+        """
+        pids = list(range(self.n_parts))
+        obs_single = espressomd.observables.ParticleDistances(ids=[0, 1])
+        obs_chain = espressomd.observables.ParticleDistances(ids=pids)
+        for _ in range(self.n_tries):
+            pos = self.scatter_particles()
+            distances = []
+            for i in pids[:-1]:
+                distances.append(np.linalg.norm(pos[i + 1] - pos[i]))
+            res_obs_single = obs_single.calculate()
+            res_obs_chain = obs_chain.calculate()
+            self.assertEqual(obs_single.n_values(), 1)
+            self.assertEqual(obs_chain.n_values(), self.n_parts - 1)
+            self.assertAlmostEqual(res_obs_single[0], distances[0], places=9)
+            np.testing.assert_array_almost_equal(
+                res_obs_chain, distances, decimal=9,
+                err_msg="Data did not agree for observable ParticleDistances")
+
+    def test_ParticleAngles(self):
+        """
+        Check ParticleAngles for a single particle triple and a chain.
+        """
+        pids = list(range(self.n_parts))
+        obs_single = espressomd.observables.ParticleAngles(ids=[0, 1, 2])
+        obs_chain = espressomd.observables.ParticleAngles(ids=pids)
+        for _ in range(self.n_tries):
+            pos = self.scatter_particles()
+            vectors = pos[1:] - pos[:-1]
+            angles = []
+            for i in pids[:-2]:
+                v1 = vectors[i]
+                v2 = vectors[i + 1]
+                angles.append(np.arccos(
+                    -np.dot(v1, v2) / np.linalg.norm(v1) / np.linalg.norm(v2)))
+            res_obs_single = obs_single.calculate()
+            res_obs_chain = obs_chain.calculate()
+            self.assertEqual(obs_single.n_values(), 1)
+            self.assertEqual(obs_chain.n_values(), self.n_parts - 2)
+            self.assertAlmostEqual(res_obs_single[0], angles[0], places=9)
+            np.testing.assert_array_almost_equal(
+                res_obs_chain, angles, decimal=9,
+                err_msg="Data did not agree for observable ParticleAngles")
+
+    def test_ParticleDihedrals(self):
+        """
+        Check ParticleDihedrals, for a single particle quadruple and a chain.
+        """
+        pids = list(range(self.n_parts))
+        obs_single = espressomd.observables.ParticleDihedrals(ids=[0, 1, 2, 3])
+        obs_chain = espressomd.observables.ParticleDihedrals(ids=pids)
+        counter = 0
+        loops = 0
+        while counter < self.n_tries:
+            loops += 1
+            self.assertTrue(loops < self.n_tries + 5, "np.random.uniform() "
+                            "placed particles such that dihedral angles were undefined")
+            pos = self.scatter_particles()
+            vectors = pos[1:] - pos[:-1]
+            dihedrals = []
+            for i in pids[:-3]:
+                v1 = vectors[i]
+                v2 = vectors[i + 1]
+                v3 = vectors[i + 2]
+                c1 = np.cross(v1, v2)
+                c2 = np.cross(v2, v3)
+                # only carry out test if dihedral angle is defined
+                if np.linalg.norm(c1) < 1e-8 or np.linalg.norm(c2) < 1e-8:
+                    continue
+                dihedrals.append(np.arctan2(
+                    np.dot(np.cross(c1, c2), v2) / np.linalg.norm(v2),
+                    np.dot(c1, c2)))
+            res_obs_single = obs_single.calculate()
+            res_obs_chain = obs_chain.calculate()
+            self.assertEqual(obs_single.n_values(), 1)
+            self.assertEqual(obs_chain.n_values(), self.n_parts - 3)
+            self.assertAlmostEqual(res_obs_single[0], dihedrals[0], places=9)
+            np.testing.assert_array_almost_equal(
+                res_obs_chain, dihedrals, decimal=9,
+                err_msg="Data did not agree for observable ParticleDihedrals")
+            counter += 1
+
+if __name__ == "__main__":
+    ut.main()

--- a/testsuite/python/observable_chain.py
+++ b/testsuite/python/observable_chain.py
@@ -163,9 +163,10 @@ class Observables(ut.TestCase):
                     # place particles and keep list of unfolded positions
                     pos = place_particles(bond_length, 3 * [offset])
                     # rotate the 1st particle
-                    p[0].pos = pos[0] = rotate_particle(*pos[0:4,:][::-1], phi)
+                    p[0].pos = pos[0] = rotate_particle(*pos[0:4,:][::-1],
+                                                        phi=phi)
                     # rotate the 5th particle
-                    p[4].pos = pos[4] = rotate_particle(*pos[1:5,:], phi)
+                    p[4].pos = pos[4] = rotate_particle(*pos[1:5,:], phi=phi)
                     # expected values
                     dih1 = calculate_dihedral(*pos[0:4,:][::-1])
                     dih2 = calculate_dihedral(*pos[1:5,:])

--- a/testsuite/python/observable_chain.py
+++ b/testsuite/python/observable_chain.py
@@ -24,37 +24,46 @@ import espressomd.observables
 
 class Observables(ut.TestCase):
     n_tries = 50
-    n_parts = 8
+    n_parts = 5
     box_l = 5.
     system = espressomd.System(box_l=3 * [box_l])
     system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
+    system.periodicity = [1, 1, 1]
+    system.time_step = 0.01
+    system.cell_system.skin = 0.2 * box_l
 
     @classmethod
     def setUpClass(cls):
         for i in range(cls.n_parts):
             cls.system.part.add(pos=[1 + i, 1 + i, 1 + i], id=i)
 
-    def scatter_particles(self):
-        pos = np.random.uniform(low=-1.5 * self.box_l, high=1.5 * self.box_l,
-                                size=[self.n_parts, 3])
-        for i in range(self.n_parts):
-            self.system.part[i].pos = pos[i]
-        return pos
-
     def test_ParticleDistances(self):
         """
-        Check ParticleDistances for a single particle pair and a chain.
+        Check ParticleDistances, for a particle pair and for a chain.
         """
         pids = list(range(self.n_parts))
         obs_single = espressomd.observables.ParticleDistances(ids=[0, 1])
         obs_chain = espressomd.observables.ParticleDistances(ids=pids)
+        # take periodic boundaries into account: bond length cannot exceed
+        # half the box size along the smallest axis
+        min_dim = np.min(self.system.box_l)
+        max_bond_length = min_dim / 2.01
+        p = self.system.part
+
         for _ in range(self.n_tries):
-            pos = self.scatter_particles()
-            distances = []
-            for i in pids[:-1]:
-                distances.append(np.linalg.norm(pos[i + 1] - pos[i]))
+            # build polymer
+            pos = np.zeros((self.n_parts, 3), dtype=float)
+            pos[0] = p[0].pos = np.random.uniform(low=0, high=min_dim, size=3)
+            for i in range(self.n_parts):
+                pos[i] = p[i].pos = pos[i-1] + np.random.uniform(
+                    low=0, high=max_bond_length, size=3)
+            # expected values
+            distances = np.linalg.norm(pos[1:] - pos[:-1], axis=1)
+            # observed values
+            self.system.integrator.run(0)
             res_obs_single = obs_single.calculate()
             res_obs_chain = obs_chain.calculate()
+            # checks
             self.assertEqual(obs_single.n_values(), 1)
             self.assertEqual(obs_chain.n_values(), self.n_parts - 1)
             self.assertAlmostEqual(res_obs_single[0], distances[0], places=9)
@@ -64,22 +73,35 @@ class Observables(ut.TestCase):
 
     def test_ParticleAngles(self):
         """
-        Check ParticleAngles for a single particle triple and a chain.
+        Check ParticleAngles, for a particle triple and for a chain.
         """
         pids = list(range(self.n_parts))
         obs_single = espressomd.observables.ParticleAngles(ids=[0, 1, 2])
         obs_chain = espressomd.observables.ParticleAngles(ids=pids)
+        # take periodic boundaries into account: bond length cannot exceed
+        # half the box size along the smallest axis
+        min_dim = np.min(self.system.box_l)
+        max_bond_length = min_dim / 2.01
+        p = self.system.part
+
         for _ in range(self.n_tries):
-            pos = self.scatter_particles()
-            vectors = pos[1:] - pos[:-1]
-            angles = []
-            for i in pids[:-2]:
-                v1 = vectors[i]
-                v2 = vectors[i + 1]
-                angles.append(np.arccos(
-                    -np.dot(v1, v2) / np.linalg.norm(v1) / np.linalg.norm(v2)))
+            # build polymer
+            pos = np.zeros((self.n_parts, 3), dtype=float)
+            pos[0] = p[0].pos = np.random.uniform(low=0, high=min_dim, size=3)
+            for i in range(self.n_parts):
+                pos[i] = p[i].pos = pos[i-1] + np.random.uniform(
+                    low=0, high=max_bond_length, size=3)
+            # expected values
+            v1 = pos[:-2] - pos[1:-1]
+            v2 = pos[2:] - pos[1:-1]
+            l1 = np.linalg.norm(v1, axis=1)
+            l2 = np.linalg.norm(v2, axis=1)
+            angles = np.arccos((v1 * v2).sum(1) / l1 / l2)
+            # observed values
+            self.system.integrator.run(0)
             res_obs_single = obs_single.calculate()
             res_obs_chain = obs_chain.calculate()
+            # checks
             self.assertEqual(obs_single.n_values(), 1)
             self.assertEqual(obs_chain.n_values(), self.n_parts - 2)
             self.assertAlmostEqual(res_obs_single[0], angles[0], places=9)
@@ -89,41 +111,75 @@ class Observables(ut.TestCase):
 
     def test_ParticleDihedrals(self):
         """
-        Check ParticleDihedrals, for a single particle quadruple and a chain.
+        Check ParticleDihedrals, for a particle quadruple and for a chain.
         """
+        def rotate_vector(v, k, phi):
+            """Rotates vector v around unit vector k by angle phi.
+            Uses Rodrigues' rotation formula."""
+            vrot = v * np.cos(phi) + np.cross(k, v) * \
+                np.sin(phi) + k * np.dot(k, v) * (1.0 - np.cos(phi))
+            return vrot
+
+        def rotate_particle(p1, p2, p3, p4, phi):
+            """Rotates particle p4 around the axis formed by the bond
+            between p2 and p3."""
+            k = p3 - p2
+            k /= np.linalg.norm(k)
+            return p3 + rotate_vector(p4 - p3, k, phi)
+
+        def calculate_dihedral(a, b, c, d):
+            v1 = b - a
+            v2 = c - b
+            v3 = d - c
+            b1 = np.cross(v1, v2)
+            b2 = np.cross(v2, v3)
+            u2 = v2 / np.linalg.norm(v2)
+            return np.arctan2(np.dot(np.cross(b1, b2), u2), np.dot(b1, b2))
+
+        def place_particles(bl, offset):
+            """Place 5 particles in the XY plane with bond length `bl` and
+            bond angle = 120 degrees. The chain is then shifted by `offset`."""
+            phi = 2 * np.pi / 3
+            pos = np.zeros((self.n_parts, 3), dtype=float)
+            pos[0] = [bl * np.cos(phi), bl * np.sin(phi), 0.]
+            pos[1] = [0., 0., 0.]
+            pos[2] = [bl, 0., 0.]
+            pos[3] = pos[2] + [bl * np.cos(np.pi - phi), bl * np.sin(phi), 0.]
+            pos[4] = pos[3] + [bl, 0., 0.]
+            pos += offset
+            for i in range(self.n_parts):
+                self.system.part[i].pos = pos[i]
+            return pos
+
         pids = list(range(self.n_parts))
-        obs_single = espressomd.observables.ParticleDihedrals(ids=[0, 1, 2, 3])
+        obs_single = espressomd.observables.ParticleDihedrals(ids=pids[:4])
         obs_chain = espressomd.observables.ParticleDihedrals(ids=pids)
-        counter = 0
-        loops = 0
-        while counter < self.n_tries:
-            loops += 1
-            self.assertTrue(loops < self.n_tries + 5, "np.random.uniform() "
-                            "placed particles such that dihedral angles were undefined")
-            pos = self.scatter_particles()
-            vectors = pos[1:] - pos[:-1]
-            dihedrals = []
-            for i in pids[:-3]:
-                v1 = vectors[i]
-                v2 = vectors[i + 1]
-                v3 = vectors[i + 2]
-                c1 = np.cross(v1, v2)
-                c2 = np.cross(v2, v3)
-                # only carry out test if dihedral angle is defined
-                if np.linalg.norm(c1) < 1e-8 or np.linalg.norm(c2) < 1e-8:
-                    continue
-                dihedrals.append(np.arctan2(
-                    np.dot(np.cross(c1, c2), v2) / np.linalg.norm(v2),
-                    np.dot(c1, c2)))
-            res_obs_single = obs_single.calculate()
-            res_obs_chain = obs_chain.calculate()
-            self.assertEqual(obs_single.n_values(), 1)
-            self.assertEqual(obs_chain.n_values(), self.n_parts - 3)
-            self.assertAlmostEqual(res_obs_single[0], dihedrals[0], places=9)
-            np.testing.assert_array_almost_equal(
-                res_obs_chain, dihedrals, decimal=9,
-                err_msg="Data did not agree for observable ParticleDihedrals")
-            counter += 1
+
+        # test multiple angles, take periodic boundaries into account
+        p = self.system.part
+        for bond_length in [0.1, self.box_l / 2.0]:
+            for offset in [1.0, self.box_l / 2.0]:
+                for phi in np.arange(0, np.pi, np.pi / 6):
+                    # place particles and keep list of unfolded positions
+                    pos = place_particles(bond_length, 3 * [offset])
+                    # rotate the 1st particle
+                    p[0].pos = pos[0] = rotate_particle(*pos[0:4,:][::-1], phi)
+                    # rotate the 5th particle
+                    p[4].pos = pos[4] = rotate_particle(*pos[1:5,:], phi)
+                    # expected values
+                    dih1 = calculate_dihedral(*pos[0:4,:][::-1])
+                    dih2 = calculate_dihedral(*pos[1:5,:])
+                    # observed values
+                    self.system.integrator.run(0)
+                    res_obs_single = obs_single.calculate()
+                    res_obs_chain = obs_chain.calculate()
+                    # checks
+                    self.assertEqual(obs_single.n_values(), 1)
+                    self.assertEqual(obs_chain.n_values(), self.n_parts - 3)
+                    self.assertAlmostEqual(res_obs_single[0], dih1, places=9)
+                    np.testing.assert_array_almost_equal(
+                        res_obs_chain, [dih1, dih2], decimal=9,
+                        err_msg="Data did not agree for observable ParticleDihedrals")
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/observables.py
+++ b/testsuite/python/observables.py
@@ -15,8 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Tests particle property setters/getters
 from __future__ import print_function
 import unittest as ut
 import espressomd


### PR DESCRIPTION
Each of the 4 bond angle (harmonic, cosine, cossquare, tabulated) force functions was defined twice, once for `pressure_inline.hpp` (aka `calc_angle_..._3body_forces()`) using the external angle convention, and once for `forces_inline.hpp` (aka `calc_angle_..._force()`) using the internal angle convention. Since the angle convention changes the equations for the angle energy and angle forces, the duplicated functions ended up diverging significantly in coding style, causing severe readability issues, even though they gave the same numerical results.

Changes:
   - all angle energy/force functions now use the internal angle convention
   - force calculation is done in functions `calc_angle_..._3body_forces()`, while functions  `calc_angle_..._force()` are just wrappers (commit 0cc3904, the diff is hard to read)
   - new observables to monitor bond distances, angles, and dihedrals during integration
   - new Doxygen page dedicated to the bonded interactions and their equations
   - tabulated angle potentials are now unit tested
   - removed unused `TABANGLEMINUS` (old debug macro to switch from internal to external convention in tabulated angle functions, I suppose)

Remarks:
   - the wrapper functions `calc_angle_..._force()` still use double[3] instead of Vector3d; these wrapper functions will be removed in the future when Vector3d becomes more widespread (#2502)
   - the dihedral angle functions will be refactored in a future PR, which will cause an API change
   - the Doxygen page with equations will be supplemented with more interactions in the future (e.g. dihedrals); it shouldn't be moved to Sphinx since it is only relevant to maintainers who need to understand where the formula in the C++ code come from

Currently, when the bond angle is &pi;, the behavior of angle force functions is inconsistent: AngleCossquare sets the forces to zero, AngleCosine sets the force to NaN, AngleHarmonic makes the two outer particles slowly collapse on the central particle. This is confusing, should we instead set the force to zero regardless of the potential?
