### PR TITLE
Update energy.cpp

### DIFF
--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -200,7 +200,7 @@ void calc_long_range_energies() {
 
       energy.coulomb[1] -= 0.5 * p3m_calc_kspace_forces(0, 1);
 
-      // restore modified sums 
+      // restore modified sums
       ELC_P3M_restore_p3m_sums();
     }
     energy.coulomb[2] = ELC_energy();

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -199,6 +199,9 @@ void calc_long_range_energies() {
       ELC_P3M_modify_p3m_sums_image();
 
       energy.coulomb[1] -= 0.5 * p3m_calc_kspace_forces(0, 1);
+
+      // restore modified sums 
+      ELC_P3M_restore_p3m_sums();
     }
     energy.coulomb[2] = ELC_energy();
     break;


### PR DESCRIPTION
Restore p3m sums to only account for particle charges (without ELC contributions).
Cures ELC sanity check for charge neutrality that is called in the beginning of each integration step.

Fixes mailing list issue.