### PR TITLE
Remove wrong warning from mdlc

### DIFF
--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -441,10 +441,6 @@ void add_mdlc_force_corrections() {
   // See Brodka, Chem. Phys. Lett. 400, 62, (2004).
 
   mz = slab_dip_count_mu(&mtot, &mx, &my);
-  {
-    fprintf(stderr, "You are not using the P3M method, therefore p3m.epsilon "
-                    "is unknown, I assume metallic borders \n");
-  }
 
   // --- Transfer the computed corrections to the Forces, Energy and torques
   //	of the particles


### PR DESCRIPTION
Regression of 0195bde0bb62efecdfabc8c231191db86c55c575, as far as I can tell


@fweik 


 - 


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
