### PR TITLE
utils: Removed DEVICE_QUALIFIER from defaulted special functions, as …

### DIFF
--- a/src/core/utils/Span.hpp
+++ b/src/core/utils/Span.hpp
@@ -72,11 +72,8 @@ private:
       typename std::enable_if<detail::has_data<T, U>::value, U>::type;
 
 public:
-  DEVICE_QUALIFIER
   Span() = default;
-  DEVICE_QUALIFIER
   Span(const Span &) = default;
-  DEVICE_QUALIFIER
   Span &operator=(const Span &) = default;
 
   DEVICE_QUALIFIER


### PR DESCRIPTION
…this causes a warning.


