### PR TITLE
Remove duplicate import in cellsystem.pxd

### DIFF
--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -21,8 +21,6 @@
 from __future__ import print_function, absolute_import
 
 from libcpp.vector cimport vector
-
-from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 
 from .utils cimport Vector3i


### PR DESCRIPTION
Removes duplicate libcpp.vector import statement in cellsystem.pxd.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
