### PR TITLE
Correct indentation of src/script_interface/CMakeLists.txt

### DIFF
--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -11,8 +11,8 @@ set(EspressoScriptInterface_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/mpiio/initialize.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ScriptInterfaceBase.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/shapes/initialize.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/ParallelScriptInterface.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/ScriptInterfaceBase.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ParallelScriptInterface.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ScriptInterfaceBase.cpp"
 )
 
 if(H5MD)


### PR DESCRIPTION
Reindent two lines of src/script_interface/CMakeLists.txt to fit the rest of the list.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
