### PR TITLE
CI: Don't override number of build processes on cuda builds

### DIFF
--- a/maintainer/cuda_build.sh
+++ b/maintainer/cuda_build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 nvidia-smi
-srcdir="${CI_PROJECT_DIR}" build_procs=4 maintainer/CI/build_cmake.sh
+srcdir="${CI_PROJECT_DIR}" maintainer/CI/build_cmake.sh
 


### PR DESCRIPTION
This resulted in an over-subscription of available cores.