### PR TITLE
Use a single build script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,8 +175,8 @@ cuda-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   script:
-    - export myconfig=maxset with_coverage=true python_version=3 test_timeout=900
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=maxset with_coverage=true python_version=3 test_timeout=900
+    - bash maintainer/CI/build_cmake.sh
   artifacts:
     paths:
     - build/
@@ -191,8 +191,8 @@ tutorials-samples-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=maxset with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=maxset with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
@@ -203,8 +203,8 @@ tutorials-samples-default:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=default with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=default with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
@@ -217,8 +217,8 @@ tutorials-samples-empty:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=empty with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=empty with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
@@ -231,8 +231,8 @@ tutorials-samples-no-gpu:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=maxset with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200 hide_gpu=true
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=maxset with_coverage=false python_version=3 make_check=false make_check_tutorials=true make_check_samples=true test_timeout=1200 hide_gpu=true
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
@@ -247,8 +247,8 @@ cuda-no-gpu:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   script:
-    - export myconfig=maxset hide_gpu=true python_version=3 test_timeout=900
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=maxset hide_gpu=true python_version=3 test_timeout=900
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
@@ -359,8 +359,8 @@ clang:6.0:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
-    - export myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
@@ -372,9 +372,9 @@ intel:18:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
-    - export myconfig=maxset with_coverage=false I_MPI_SHM_LMT=shm
+    - export cuda_job=true myconfig=maxset with_coverage=false I_MPI_SHM_LMT=shm
     - export cxx_flags=-O2
-    - bash maintainer/cuda_build.sh
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
@@ -424,8 +424,8 @@ check_with_odd_no_of_processors:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   when: on_success
   script:
-    - export myconfig=maxset with_coverage=true python_version=3 build_procs=3 check_procs=3 check_odd_only=true
-    - bash maintainer/cuda_build.sh
+    - export cuda_job=true myconfig=maxset with_coverage=true python_version=3 build_procs=3 check_procs=3 check_odd_only=true
+    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -87,7 +87,7 @@ if [ -z "$cxx_flags" ]; then
     fi
 fi
 
-if [[ ! -z ${with_coverage+x} ]]; then
+if [ ! -z ${with_coverage+x} ]; then
   bash <(curl -s https://codecov.io/env) &> /dev/null;
 fi
 
@@ -102,9 +102,8 @@ fi
 if [ $cuda_job = "true" ]; then
   nvidia-smi
 fi
-if [[ "$hide_gpu" == "true" ]]
-then
-  echo Hiding gpu from Cuda via CUDA_VISIBLE_DEVICES
+if [ $hide_gpu = "true" ]; then
+  echo "Hiding gpu from Cuda via CUDA_VISIBLE_DEVICES"
   export CUDA_VISIBLE_DEVICES=
 fi
 

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -42,6 +42,8 @@ function end {
 
 # execute and output a command
 # handle environment variables
+[ -z "$cuda_job" ] && cuda_job="false"
+[ $cuda_job = "true" ] && [ -n "${CI_PROJECT_DIR}" ] && srcdir="${CI_PROJECT_DIR}"
 [ -z "$insource" ] && insource="false"
 [ -z "$srcdir" ] && srcdir=`pwd`
 [ -z "$cmake_params" ] && cmake_params=""
@@ -97,6 +99,9 @@ if $with_ccache; then
   cmake_params="$cmake_params -DWITH_CCACHE=ON"
 fi
 
+if [ $cuda_job = "true" ]; then
+  nvidia-smi
+fi
 if [[ "$hide_gpu" == "true" ]]
 then
   echo Hiding gpu from Cuda via CUDA_VISIBLE_DEVICES

--- a/maintainer/cuda_build.sh
+++ b/maintainer/cuda_build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-nvidia-smi
-srcdir="${CI_PROJECT_DIR}" maintainer/CI/build_cmake.sh
-


### PR DESCRIPTION
The `cuda_build.sh` used to be a separate build script for GPU jobs, but it is now just a two-line wrapper for `build_cmake.sh`. It has been in that state for almost 2 years and keeps getting thinned out, to the point where it would make more sense to merge both files.