### PR TITLE
Add support for gdb in ipypresso

### DIFF
--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -54,7 +54,7 @@ fi
 case $1 in
     --gdb)
         shift
-        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec /usr/bin/ipython \"$@\"'" --args /usr/bin/python $@
+        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" --args "@PYTHON_EXECUTABLE@" $@
         exec gdb --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb)
@@ -76,7 +76,7 @@ case $1 in
     --gdb=*)
         options="${1#*=}"
         shift
-        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec /usr/bin/ipython \"$@\"'" ${options} --args /usr/bin/python $@
+        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" ${options} --args "@PYTHON_EXECUTABLE@" $@
         exec gdb ${options} --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb=*)

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -54,6 +54,7 @@ fi
 case $1 in
     --gdb)
         shift
+        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec /usr/bin/ipython \"$@\"'" --args /usr/bin/python $@
         exec gdb --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb)
@@ -75,6 +76,7 @@ case $1 in
     --gdb=*)
         options="${1#*=}"
         shift
+        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec /usr/bin/ipython \"$@\"'" ${options} --args /usr/bin/python $@
         exec gdb ${options} --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb=*)

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -54,7 +54,7 @@ fi
 case $1 in
     --gdb)
         shift
-        [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" --args "@PYTHON_EXECUTABLE@" $@
+        [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"\$@\"'" --args "@PYTHON_EXECUTABLE@" $@
         exec gdb --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb)
@@ -76,7 +76,7 @@ case $1 in
     --gdb=*)
         options="${1#*=}"
         shift
-        [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" ${options} --args "@PYTHON_EXECUTABLE@" $@
+        [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"\$@\"'" ${options} --args "@PYTHON_EXECUTABLE@" $@
         exec gdb ${options} --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb=*)

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -54,7 +54,7 @@ fi
 case $1 in
     --gdb)
         shift
-        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" --args "@PYTHON_EXECUTABLE@" $@
+        [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" --args "@PYTHON_EXECUTABLE@" $@
         exec gdb --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb)
@@ -76,7 +76,7 @@ case $1 in
     --gdb=*)
         options="${1#*=}"
         shift
-        expr match @PYTHON_FRONTEND@ '.*ipython.*' && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" ${options} --args "@PYTHON_EXECUTABLE@" $@
+        [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"$@\"'" ${options} --args "@PYTHON_EXECUTABLE@" $@
         exec gdb ${options} --args @PYTHON_FRONTEND@ $@
         ;;
     --lldb=*)


### PR DESCRIPTION
Ipypresso's flag "--gdb" does not work on my system because ipypresso is just a wrapper script executing python with a bunch of parameters. Nevertheless, support of --gdb can be added to ipypresso by a slightly more complicated gdb setup.

This PR adds this support using gdb's exec-wrapper functionality. The implementation is quite hacky by inserting a check for ipython into pypresso.cmakein. Let me know if the functionality itself is something that you want to have upstream. If so, we also could figure out a less hacky solution.

Description of changes:
 - Use ipython as gdb's exec-wrapper, not directly as executable


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
