### PR TITLE
Make has_features throw if testing for a not-feature

### DIFF
--- a/src/python/espressomd/__init__.py
+++ b/src/python/espressomd/__init__.py
@@ -39,10 +39,12 @@ def has_features(*args):
 
     if len(args) == 1 and not isinstance(args[0], str) and hasattr(args[0], "__iter__"):
         check_set = set(args[0])
-    else: check_set = set(args)
+    else:
+        check_set = set(args)
 
     if not check_set < all_features():
-        raise RuntimeError("'{}' is not a feature".format(','.join(check_set - all_features())))
+        raise RuntimeError(
+            "'{}' is not a feature".format(','.join(check_set - all_features())))
 
     return check_set < set(features())
 

--- a/src/python/espressomd/__init__.py
+++ b/src/python/espressomd/__init__.py
@@ -23,7 +23,7 @@
 import espressomd._init
 
 from espressomd.system import System
-from espressomd.code_info import features
+from espressomd.code_info import features, all_features
 from espressomd.cuda_init import gpu_available
 
 
@@ -38,16 +38,20 @@ def has_features(*args):
     """Tests whether a list of features is a subset of the compiled-in features"""
 
     if len(args) == 1 and not isinstance(args[0], str) and hasattr(args[0], "__iter__"):
-        return set(args[0]) < set(features())
+        check_set = set(args[0])
+    else: check_set = set(args)
 
-    return set(args) < set(features())
+    if not check_set < all_features():
+        raise RuntimeError("'{}' is not a feature".format(','.join(check_set - all_features())))
+
+    return check_set < set(features())
 
 
 def missing_features(*args):
     """Returns a list of the missing features in the argument"""
 
     if len(args) == 1 and not isinstance(args[0], str) and hasattr(args[0], "__iter__"):
-            return set(args[0]) - set(features())
+        return set(args[0]) - set(features())
 
     return set(args) - set(features())
 

--- a/src/python/espressomd/gen_code_info.py
+++ b/src/python/espressomd/gen_code_info.py
@@ -63,7 +63,10 @@ for feature in defs.allfeatures:
 
 cfile.write("""
     return sorted(f)
-""")
+
+def all_features():
+    return {}
+""".format(defs.allfeatures))
 
 cfile.close()
 print("Done.")

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -195,6 +195,7 @@ python_test(FILE lb_density.py MAX_NUM_PROC 1)
 python_test(FILE observable_chain.py MAX_NUM_PROC 4)
 python_test(FILE mpiio.py MAX_NUM_PROC 4)
 python_test(FILE gpu_availability.py MAX_NUM_PROC 1 LABELS gpu)
+python_test(FILE features.py MAX_NUM_PROC 1)
 
 if(PY_H5PY)
   python_test(FILE h5md.py MAX_NUM_PROC 2)

--- a/testsuite/python/analyze_itensor.py
+++ b/testsuite/python/analyze_itensor.py
@@ -40,7 +40,7 @@ class AnalyzeITensor(ut.TestCase):
         for i in range(20, 30, 1):
             self.system.part.add(
                 id=i, pos=np.random.random(3) * self.box_l, type=1)
-        if espressomd.has_features("mass"):
+        if espressomd.has_features("MASS"):
             s.part[:].mass = 0.5 + np.random.random(20)
 
     def i_tensor(self, ids):

--- a/testsuite/python/analyze_itensor.py
+++ b/testsuite/python/analyze_itensor.py
@@ -41,7 +41,7 @@ class AnalyzeITensor(ut.TestCase):
             self.system.part.add(
                 id=i, pos=np.random.random(3) * self.box_l, type=1)
         if espressomd.has_features("MASS"):
-            s.part[:].mass = 0.5 + np.random.random(20)
+            self.system.part[:].mass = 0.5 + np.random.random(20)
 
     def i_tensor(self, ids):
         pslice = self.system.part[ids]

--- a/testsuite/python/features.py
+++ b/testsuite/python/features.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2019 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest as ut
+from espressomd import has_features, code_info
+
+class Features(ut.TestCase):
+    def test_has_features(self):
+        for feature in code_info.features():
+            self.assertTrue(has_features(feature))
+
+        with self.assertRaises(RuntimeError) as _:
+            has_features("NotAFeature")
+
+if __name__ == '__main__':
+    ut.main()
+

--- a/testsuite/python/features.py
+++ b/testsuite/python/features.py
@@ -18,7 +18,9 @@
 import unittest as ut
 from espressomd import has_features, code_info
 
+
 class Features(ut.TestCase):
+
     def test_has_features(self):
         for feature in code_info.features():
             self.assertTrue(has_features(feature))
@@ -31,4 +33,3 @@ class Features(ut.TestCase):
 
 if __name__ == '__main__':
     ut.main()
-

--- a/testsuite/python/features.py
+++ b/testsuite/python/features.py
@@ -23,6 +23,9 @@ class Features(ut.TestCase):
         for feature in code_info.features():
             self.assertTrue(has_features(feature))
 
+        for feature in code_info.all_features() - set(code_info.features()):
+            self.assertFalse(has_features(feature))
+
         with self.assertRaises(RuntimeError) as _:
             has_features("NotAFeature")
 

--- a/testsuite/python/langevin_thermostat.py
+++ b/testsuite/python/langevin_thermostat.py
@@ -27,9 +27,6 @@ from espressomd.accumulators import Correlator
 from espressomd.observables import ParticleVelocities, ParticleBodyAngularVelocities
 from tests_common import single_component_maxwell
 
-
-@ut.skipIf(espressomd.has_features("THERMOSTAT_IGNORE_NON_VIRTUAL"),
-           "Skipped because of THERMOSTAT_IGNORE_NON_VIRTUAL")
 class LangevinThermostat(ut.TestCase):
 
     """Tests the velocity distribution created by the Langevin thermostat against

--- a/testsuite/python/virtual_sites_relative.py
+++ b/testsuite/python/virtual_sites_relative.py
@@ -299,9 +299,6 @@ class VirtualSites(ut.TestCase):
         system.non_bonded_inter[0, 0].lennard_jones.set_params(
             epsilon=0, sigma=0, cutoff=0, shift=0)
 
-    @ut.skipIf(
-        espressomd.has_features("VIRTUAL_SITES_THERMOSTAT"),
-        "LJ fluid test only works when VIRTUAL_SITES_THERMOSTAT is not compiled in.")
     def test_lj(self):
         """Run LJ fluid test for different cell systems."""
         system = self.system


### PR DESCRIPTION
- Made has_features throw if checking for features that do not exist
- Fixed dead code paths in tests caused by wrong feature checks

Fixes #2784.