### PR TITLE
Fix relocation error on s390x emulation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -326,6 +326,8 @@ ubuntu:ppc64le:
 
 ubuntu:s390x:
   <<: *arch_definition
+  variables:
+    LD_BIND_NOW: none
 
 ### Builds with OS X
 


### PR DESCRIPTION
Fixes #2766

I don't know why this helps, but it looks like a dynamic linker bug. I actually don't know either whether the bug is fully resolved, but previously it would occur every few hundred times when running any test, and now I haven't seen it in a few thousand times.