### PR TITLE
Tutorials: give regular feedback on long-running cells

### DIFF
--- a/doc/latexit.sh.in
+++ b/doc/latexit.sh.in
@@ -24,7 +24,7 @@ BIBINPUTS=.:$SRCDIR:
 export TEXINPUTS BIBINPUTS
 echo "TEXINPUTS=$TEXINPUTS"
 
-ESPRESSO_VERSION=`cd @abs_top_srcdir@; sh config/genversion.sh -rd`
+ESPRESSO_VERSION="@PROJECT_VERSION@"
 echo "ESPRESSO_VERSION=$ESPRESSO_VERSION"
 
 PDFLATEX="@PDFLATEX@ -halt-on-error -interaction=batchmode"

--- a/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
+++ b/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
@@ -267,7 +267,9 @@
     "    temp_measured = energy['kinetic'] / ((3.0 / 2.0) * n_part)\n",
     "    print(\"t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f},T={3:.4f}\"\n",
     "          .format(system.time, energy['total'], energy['coulomb'], temp_measured), end='\\r')\n",
-    "    system.integrator.run(200)"
+    "    system.integrator.run(200)\n",
+    "\n",
+    "print()"
    ]
   },
   {
@@ -303,12 +305,15 @@
     "for i in range(num_configs):\n",
     "    energy = system.analysis.energy()\n",
     "    temp_measured = energy['kinetic'] / ((3.0 / 2.0) * n_part)\n",
-    "    print(\"t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T={3:.4f}\"\n",
-    "          .format(system.time, energy['total'], energy['coulomb'], temp_measured), end='\\r')\n",
+    "    print(\"progress={:.0f}%, t={:.1f}, E_total={:.2f}, E_coulomb={:.2f}, T={:.4f}\"\n",
+    "          .format((i + 1) * 100. / num_configs, system.time, energy['total'],\n",
+    "                  energy['coulomb'], temp_measured), end='\\r')\n",
     "    system.integrator.run(integ_steps_per_config)\n",
     "\n",
     "    # Internally append particle configuration\n",
-    "    system.analysis.append()"
+    "    system.analysis.append()\n",
+    "\n",
+    "print()"
    ]
   },
   {

--- a/doc/tutorials/02-charged_system/02-charged_system-2.ipynb
+++ b/doc/tutorials/02-charged_system/02-charged_system-2.ipynb
@@ -340,9 +340,12 @@
     "for i in range(int(num_steps_equilibration / 100)):\n",
     "    energy = system.analysis.energy()\n",
     "    temp_measured = energy['kinetic'] / ((3.0 / 2.0) * n_part)\n",
-    "    print(\"t={0:.1f}, E_total={1:.2f}, E_coulomb={2:.2f}, T={3:.4f}\"\n",
-    "          .format(system.time, energy['total'], energy['coulomb'], temp_measured), end='\\r')\n",
-    "    system.integrator.run(100)"
+    "    print(\"progress={:.0f}%, t={:.1f}, E_total={:.2f}, E_coulomb={:.2f}, T={:.4f}\"\n",
+    "          .format(i * 100. / int(num_steps_equilibration / 100 - 1), system.time,\n",
+    "                  energy['total'], energy['coulomb'], temp_measured), end='\\r')\n",
+    "    system.integrator.run(100)\n",
+    "\n",
+    "print()"
    ]
   },
   {

--- a/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part1.ipynb
+++ b/doc/tutorials/04-lattice_boltzmann/04-lattice_boltzmann_part1.ipynb
@@ -395,8 +395,7 @@
     "system.set_random_state_PRNG()\n",
     "np.random.seed(seed=system.seed)\n",
     "system.time_step = 0.2\n",
-    "system.cell_system.skin = 0.4\n",
-    "\n"
+    "system.cell_system.skin = 0.4"
    ]
   },
   {

--- a/doc/tutorials/05-raspberry_electrophoresis/05-raspberry_electrophoresis.ipynb
+++ b/doc/tutorials/05-raspberry_electrophoresis/05-raspberry_electrophoresis.ipynb
@@ -181,14 +181,15 @@
     "system.non_bonded_inter[1, 0].lennard_jones.set_params(\n",
     "    epsilon=eps_cs, sigma=sig_cs,\n",
     "    cutoff=sig_cs * np.power(2., 1. / 6.), shift=\"auto\")\n",
-    "# the LJ potential (WCA potential) between surface beads causes them to be roughly equidistant on the colloid surface\n",
+    "# the LJ potential (WCA potential) between surface beads causes them to be roughly equidistant on the\n",
+    "# colloid surface\n",
     "system.non_bonded_inter[1, 1].lennard_jones.set_params(\n",
     "    epsilon=eps_ss, sigma=sig_ss,\n",
     "    cutoff=sig_ss * np.power(2., 1. / 6.), shift=\"auto\")\n",
     "\n",
     "# the harmonic potential pulls surface beads towards the central colloid bead\n",
     "col_center_surface_bond = interactions.HarmonicBond(k=3000., r_0=harmonic_radius)\n",
-    "system.bonded_inter.add(col_center_surface_bond)\n"
+    "system.bonded_inter.add(col_center_surface_bond)"
    ]
   },
   {
@@ -284,7 +285,7 @@
     "colPos = system.part[0].pos\n",
     "for p in system.part[1:]:\n",
     "    p.pos = (p.pos - colPos) / np.linalg.norm(system.distance(p, system.part[0])) * radius_col + colPos\n",
-    "    p.pos = (p.pos - colPos) / np.linalg.norm(p.pos - colPos) * radius_col + colPos\n"
+    "    p.pos = (p.pos - colPos) / np.linalg.norm(p.pos - colPos) * radius_col + colPos"
    ]
   },
   {
@@ -307,8 +308,9 @@
    "source": [
     "# Select the desired implementation for virtual sites\n",
     "system.virtual_sites = VirtualSitesRelative(have_velocity=True)\n",
-    "# Setting min_global_cut is necessary when there is no interaction defined with a range larger than the colloid\n",
-    "# such that the virtual particles are able to communicate their forces to the real particle at the center of the colloid\n",
+    "# Setting min_global_cut is necessary when there is no interaction defined with a range larger than\n",
+    "# the colloid such that the virtual particles are able to communicate their forces to the real particle\n",
+    "# at the center of the colloid\n",
     "system.min_global_cut = radius_col\n",
     "\n",
     "# Calculate the center of mass position (com) and the moment of inertia (momI) of the colloid\n",
@@ -372,7 +374,7 @@
     "        system.part.add(pos=pos, type=3, q=-1)\n",
     "        i += 1\n",
     "\n",
-    "print(\"# Added {} negative ions\".format(N_co_ions))\n"
+    "print(\"# Added {} negative ions\".format(N_co_ions))"
    ]
   },
   {

--- a/doc/tutorials/06-active_matter/06-active_matter.tex
+++ b/doc/tutorials/06-active_matter/06-active_matter.tex
@@ -619,12 +619,13 @@ and load it into ParaView. Now add a \code{Glyph} from the ribbon just above
 the Pipeline Browser to the highlighted \code{points_5.0.vtk} entry. Select
 \code{Sphere} from the \code{Glyph Type} drop down. Scroll down and select
 \code{off} in the \code{Scale Mode} drop down. Tick the \code{Edit} box and set
-the scale factor to 1.0, then select \code{All Points} from the \code{Glyph
-Mode} drop down. As you can see, there are clearly far more particles in the
-`front' chamber, than there are in the other, see Fig.~\ref{fig:rectify}(b).
-This can be explained by the fact that the activity makes it easier to take the
-barrier in one direction than in the other. Or in technical terms: the
-equivalence between thermodynamic pressure and mechanical pressure is lost.
+the scale factor to 1.0, then select \code{All Points} from the
+\code{Glyph Mode} drop down. As you can see, there are clearly far more
+particles in the `front' chamber, than there are in the other, see
+Fig.~\ref{fig:rectify}(b). This can be explained by the fact that the activity
+makes it easier to take the barrier in one direction than in the other. Or in
+technical terms: the equivalence between thermodynamic pressure and mechanical
+pressure is lost.
 
 \section{\label{sec:flow}Flow Field around a Swimmer}
 

--- a/doc/tutorials/06-active_matter/SOLUTIONS/enhanced_diffusion.py
+++ b/doc/tutorials/06-active_matter/SOLUTIONS/enhanced_diffusion.py
@@ -39,7 +39,6 @@ required_features = ["ENGINE", "ROTATION"]
 assert_features(required_features)
 
 # create an output folder
-
 outdir = "./RESULTS_ENHANCED_DIFFUSION/"
 try:
     os.makedirs(outdir)
@@ -49,7 +48,6 @@ except:
 ##########################################################################
 
 # Read in the active velocity from the command prompt
-
 if len(sys.argv) != 2:
     print("Usage:", sys.argv[0], "<vel> (0 <= vel < 10.0)")
     exit()
@@ -57,7 +55,6 @@ if len(sys.argv) != 2:
 vel = float(sys.argv[1])
 
 # Set the basic simulation parameters
-
 sampsteps = 5000
 samplength = 1000
 tstep = 0.01
@@ -76,20 +73,16 @@ system.time_step = tstep
 
 for run in range(5):
     # Set up a random seed (a new one for each run)
-
     system.seed = np.random.randint(0, 2**31 - 1)
 
     # Use the Langevin thermostat (no hydrodynamics)
-
     system.thermostat.set_langevin(kT=1.0, gamma=1.0, seed=42)
 
     # Place a single active particle (that can rotate freely! rotation=[1,1,1])
-
     system.part.add(pos=[5.0, 5.0, 5.0], swimming={
                     'v_swim': vel}, rotation=[1, 1, 1])
 
     # Initialize the mean squared displacement (MSD) correlator
-
     tmax = tstep * sampsteps
 
     pos_id = ParticlePositions(ids=[0])
@@ -101,7 +94,6 @@ for run in range(5):
     system.auto_update_accumulators.add(msd)
 
     # Initialize the velocity auto-correlation function (VACF) correlator
-
     vel_id = ParticleVelocities(ids=[0])
     vacf = Correlator(obs1=vel_id,
                       corr_operation="scalar_product",
@@ -112,7 +104,6 @@ for run in range(5):
 
     # Initialize the angular velocity auto-correlation function (AVACF)
     # correlator
-
     ang_id = ParticleAngularVelocities(ids=[0])
     avacf = Correlator(obs1=ang_id,
                        corr_operation="scalar_product",
@@ -122,12 +113,15 @@ for run in range(5):
     system.auto_update_accumulators.add(avacf)
 
     # Integrate 5,000,000 steps. This can be done in one go as well.
-
     for i in range(sampsteps):
+        if (i + 1) % 100 == 0:
+            print('\rrun %i: %.0f%%' % (run + 1, (i + 1) * 100. / sampsteps),
+                  end='')
+            sys.stdout.flush()
         system.integrator.run(samplength)
+    print()
 
     # Finalize the accumulators and write to disk
-
     system.auto_update_accumulators.remove(msd)
     msd.finalize()
     np.savetxt("{}/msd_{}_{}.dat".format(outdir, vel, run), msd.result())

--- a/doc/tutorials/06-active_matter/SOLUTIONS/flow_field.py
+++ b/doc/tutorials/06-active_matter/SOLUTIONS/flow_field.py
@@ -36,7 +36,6 @@ from espressomd import assert_features, lb
 assert_features(["ENGINE", "LB_GPU", "MASS", "ROTATION", "ROTATIONAL_INERTIA"])
 
 # Read in the hydrodynamic type (pusher/puller) and position
-
 if len(sys.argv) != 3:
     print("Usage:", sys.argv[0], "<type> <pos>")
     exit()
@@ -53,7 +52,6 @@ except:
     print("INFO: Directory \"{}\" exists".format(outdir))
 
 # System parameters
-
 length = 25.0
 prod_steps = 1000
 prod_length = 50
@@ -67,20 +65,17 @@ system.min_global_cut = 1.0
 ##########################################################################
 
 # Set the position of the particle
-
 x0 = 0.5 * length
 y0 = 0.5 * length
 z0 = 0.5 * length + pos
 
 # Sphere size, mass, and moment of inertia, dipole force
-
 sph_size = 0.5
 sph_mass = 4.8
 Ixyz = 4.8
 force = 0.1
 
 # Setup the particle
-
 system.part.add(
     pos=[x0, y0, z0], type=0, mass=sph_mass, rinertia=[Ixyz, Ixyz, Ixyz],
     swimming={'f_swim': force, 'mode': mode, 'dipole_length': sph_size + 0.5})
@@ -88,7 +83,6 @@ system.part.add(
 ##########################################################################
 
 # Setup the fluid (quiescent)
-
 agrid = 1
 vskin = 0.1
 frict = 20.0
@@ -103,15 +97,17 @@ system.thermostat.set_lb(LB_fluid=lbf, gamma=frict, seed=42)
 ##########################################################################
 
 # Output the coordinates
-
 with open("{}/trajectory.dat".format(outdir), 'w') as outfile:
     print("####################################################", file=outfile)
     print("#        time        position       velocity       #", file=outfile)
     print("####################################################", file=outfile)
 
     # Production run
-
     for k in range(prod_steps):
+        if (k + 1) % 10 == 0:
+            print('\rprogress: %.0f%%' % ((k + 1) * 100. / prod_steps), end='')
+            sys.stdout.flush()
+
         # Output quantities
         print("{time} {pos[0]} {pos[1]} {pos[2]} {vel[0]} {vel[1]} {vel[2]}"
               .format(time=system.time, pos=system.part[0].pos, vel=system.part[0].v),
@@ -125,3 +121,4 @@ with open("{}/trajectory.dat".format(outdir), 'w') as outfile:
                 "{}/position_{}.vtk".format(outdir, num), types=[0])
 
         system.integrator.run(prod_length)
+print()

--- a/doc/tutorials/06-active_matter/SOLUTIONS/rectification_simulation.py
+++ b/doc/tutorials/06-active_matter/SOLUTIONS/rectification_simulation.py
@@ -1,6 +1,6 @@
 ################################################################################
 #                                                                              #
-# Copyright (C) 2010-2018 The ESPResSo project            #
+# Copyright (C) 2010-2018 The ESPResSo project                                 #
 #                                                                              #
 # This file is part of ESPResSo.                                               #
 #                                                                              #
@@ -63,7 +63,6 @@ def a2quat(phi, theta):
 ##########################################################################
 
 # Read in the active velocity from the command prompt
-
 if len(sys.argv) != 2:
     print("Usage:", sys.argv[0], "<vel> (0 <= vel < 10.0)")
     exit()
@@ -73,7 +72,6 @@ vel = float(sys.argv[1])
 ##########################################################################
 
 # create an output folder
-
 outdir = "./RESULTS_RECTIFICATION"
 try:
     os.makedirs(outdir)
@@ -82,7 +80,6 @@ except:
 
 # Setup the box (we pad the diameter to ensure that the LB boundaries
 # and therefore the constraints, are away from the edge of the box)
-
 length = 100
 diameter = 20
 prod_steps = 500
@@ -90,7 +87,6 @@ prod_length = 500
 dt = 0.01
 
 # Setup the MD parameters
-
 system = espressomd.System(box_l=[length, diameter + 4, diameter + 4])
 system.set_random_state_PRNG()
 system.box_l = [length, diameter + 4, diameter + 4]
@@ -114,7 +110,6 @@ cylinder = Cylinder(
 system.constraints.add(shape=cylinder, particle_type=1)
 
 # Setup walls
-
 wall = Wall(dist=2, normal=[1, 0, 0])
 system.constraints.add(shape=wall, particle_type=2)
 
@@ -122,7 +117,6 @@ wall = Wall(dist=-(length - 2), normal=[-1, 0, 0])
 system.constraints.add(shape=wall, particle_type=3)
 
 # Setup cone
-
 irad = 4.0
 angle = pi / 4.0
 orad = (diameter - irad) / sin(angle)
@@ -190,22 +184,23 @@ for cntr in range(npart):
 ##########################################################################
 
 # Equilibrate
-
 system.integrator.run(25 * prod_length)
 
 # Output the CMS coordinates
-
 with open("{}/CMS_{}.dat".format(outdir, vel), "w") as outfile:
     print("####################################################", file=outfile)
     print("#        time    CMS x coord    average CMS        #", file=outfile)
     print("####################################################", file=outfile)
 
     # Production run
-
     dev_sum = 0.0
     dev_av = 0.0
     time_0 = system.time
     for i in range(prod_steps):
+        if (i + 1) % 5 == 0:
+            print('\rprogress: %.0f%%' % ((i + 1) * 100. / prod_steps), end='')
+            sys.stdout.flush()
+
         # We output the coordinate of the center of mass in
         # the direction of the long axis, here we consider
         # the deviation from the center
@@ -223,5 +218,5 @@ with open("{}/CMS_{}.dat".format(outdir, vel), "w") as outfile:
         system.integrator.run(prod_length)
 
 # Output the final configuration
-
 system.part.writevtk("{}/points_{}.vtk".format(outdir, vel), types=[0])
+print()

--- a/doc/tutorials/07-electrokinetics/scripts/eof_electrokinetics.py
+++ b/doc/tutorials/07-electrokinetics/scripts/eof_electrokinetics.py
@@ -85,10 +85,8 @@ system.actors.add(ek)
 # Integrate the system
 for i in range(100):
     system.integrator.run(integration_length)
-    sys.stdout.write("\rintegration step: %03i" % i)
+    sys.stdout.write("\rintegration: %i%%" % (i + 1))
     sys.stdout.flush()
-
-print("Integration finished.")
 
 # Output
 position_list = []


### PR DESCRIPTION
Fixes #2173

Added basic progress bars to slow (> 10 seconds) cells and stand-alone python scripts.

`'\r'` is used to avoid spamming stdout; progress ends with an empty `print()` to add a newline.