### PR TITLE
clang-tidy: readability-function-size check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,7 +36,8 @@ Checks: |
    readability-static-accessed-through-instance,
    readability-static-definition-in-anonymous-namespace,
    readability-string-compare,
-   readability-uniqueptr-delete-release'
+   readability-uniqueptr-delete-release,
+   readability-function-size'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
@@ -117,3 +118,6 @@ CheckOptions:
     value:           '0'
   - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
     value:           '3'
+  - key:             readability-function-size.BranchThreshold
+    value:           '3'
+    

--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -467,7 +467,7 @@ public:
  */
 #define REGISTER_CALLBACK(cb)                                                  \
   namespace Communication {                                                    \
-  static ::Communication::RegisterCallback register_##cb(&cb);                 \
+  static ::Communication::RegisterCallback register_##cb(&(cb));                 \
   }
 
 #endif

--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -467,7 +467,7 @@ public:
  */
 #define REGISTER_CALLBACK(cb)                                                  \
   namespace Communication {                                                    \
-  static ::Communication::RegisterCallback register_##cb(&(cb));                 \
+  static ::Communication::RegisterCallback register_##cb(&(cb));               \
   }
 
 #endif

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -241,7 +241,7 @@ void mpi_init() {
   Communication::m_callbacks =
       std::make_unique<Communication::MpiCallbacks>(comm_cart);
 
-#define CB(name) Communication::m_callbacks->add(&name);
+#define CB(name) Communication::m_callbacks->add(&(name));
   CALLBACK_LIST
 #undef CB
 

--- a/src/core/electrostatics_magnetostatics/mmm-common.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm-common.hpp
@@ -32,9 +32,9 @@
 /** \name Math Constants */
 /*@{*/
 #define C_2PI (2 * M_PI)
-#define C_GAMMA 0.57721566490153286060651209008
-#define C_2LOG4PI -5.0620484939385815859557831885
-#define C_2PISQR C_2PI *C_2PI
+#define C_GAMMA (0.57721566490153286060651209008)
+#define C_2LOG4PI (-5.0620484939385815859557831885)
+#define C_2PISQR (C_2PI *C_2PI)
 /*@}*/
 
 /** table of the Taylor expansions of the modified polygamma functions */

--- a/src/core/electrostatics_magnetostatics/mmm-common.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm-common.hpp
@@ -34,7 +34,7 @@
 #define C_2PI (2 * M_PI)
 #define C_GAMMA (0.57721566490153286060651209008)
 #define C_2LOG4PI (-5.0620484939385815859557831885)
-#define C_2PISQR (C_2PI *C_2PI)
+#define C_2PISQR (C_2PI * C_2PI)
 /*@}*/
 
 /** table of the Taylor expansions of the modified polygamma functions */

--- a/src/core/reaction_ensemble.hpp
+++ b/src/core/reaction_ensemble.hpp
@@ -112,7 +112,7 @@ public:
   ReactionAlgorithm(int seed)
       : m_seeder({seed, seed, seed}), m_generator(m_seeder),
         m_normal_distribution(0.0, 1.0), m_uniform_real_distribution(0.0, 1.0) {
-    m_generator.discard(1e6);
+    m_generator.discard(1'000'000);
   }
 
   virtual ~ReactionAlgorithm() = default;


### PR DESCRIPTION
Added [function complexity check](https://clang.llvm.org/extra/clang-tidy/checks/readability-function-size.html), and fixed some warnings. This limits the number of branch statements in a function to 3, and the total number of statements to 800, which probably we should strive to make tighter in the future.
