### PR TITLE
Fix segfault on empty nodes for mindist calculation

### DIFF
--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -66,6 +66,9 @@ double mindist(PartCfg &partCfg, IntList const &set1, IntList const &set2) {
 
   auto mindist2 = std::numeric_limits<double>::infinity();
 
+  if (partCfg.empty())
+    return mindist2;
+
   for (auto jt = partCfg.begin(); jt != (--partCfg.end()); ++jt) {
     /* check which sets particle j belongs to
        bit 0: set1, bit1: set2

--- a/testsuite/python/analyze_distance_empty.py
+++ b/testsuite/python/analyze_distance_empty.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2010-2019 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest as ut
+import espressomd
+
+
+class AnalyzeDistanceEmpty(ut.TestCase):
+    system = espressomd.System(box_l=[1.0, 1.0, 1.0])
+
+    def test_min_dist(self):
+        self.assertEqual(self.system.analysis.min_dist(), float("inf"))
+
+if __name__ == "__main__":
+    ut.main()
+

--- a/testsuite/python/analyze_distance_empty.py
+++ b/testsuite/python/analyze_distance_empty.py
@@ -26,4 +26,3 @@ class AnalyzeDistanceEmpty(ut.TestCase):
 
 if __name__ == "__main__":
     ut.main()
-


### PR DESCRIPTION
Fixes a segfault for the mindist calculation if there is a node without particles.

Description of changes:
 - Check for empty partCfg and return inf in this case.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
