### PR TITLE
Increase make_lin_space test tolerance

### DIFF
--- a/src/utils/tests/make_lin_space_test.cpp
+++ b/src/utils/tests/make_lin_space_test.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
 
     auto const dx = (stop - start) / (num - 1);
     for (int i = 0; i < values.size(); i++) {
-      BOOST_CHECK_CLOSE(values.at(i), start + i * dx, 1e-14);
+      BOOST_CHECK_CLOSE(values.at(i), start + i * dx, 1e-13);
     }
   }
 
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
 
     auto const dx = (stop - start) / num;
     for (int i = 0; i < values.size(); i++) {
-      BOOST_CHECK_CLOSE(values.at(i), start + i * dx, 1e-14);
+      BOOST_CHECK_CLOSE(values.at(i), start + i * dx, 1e-13);
     }
   }
 }

--- a/src/utils/tests/make_lin_space_test.cpp
+++ b/src/utils/tests/make_lin_space_test.cpp
@@ -44,7 +44,8 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
 
     auto const dx = (stop - start) / (num - 1);
     for (int i = 0; i < values.size(); i++) {
-      BOOST_CHECK_CLOSE(values.at(i), start + i * dx, 1e-13);
+      BOOST_CHECK(std::fabs(start + i * dx - values.at(i)) <=
+                  std::numeric_limits<double>::epsilon());
     }
   }
 
@@ -64,7 +65,8 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
 
     auto const dx = (stop - start) / num;
     for (int i = 0; i < values.size(); i++) {
-      BOOST_CHECK_CLOSE(values.at(i), start + i * dx, 1e-13);
+      BOOST_CHECK(std::fabs(start + i * dx - values.at(i)) <=
+                  std::numeric_limits<double>::epsilon());
     }
   }
 }


### PR DESCRIPTION
Fixes #2825

Set tolerance to 1e-13% (aka 1e-15), like in `src/utils/tests/interpolation_test.cpp`.