### PR TITLE
Remove redundant CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu:18.04
+image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:18.04
 
 stages:
   - permission
@@ -71,7 +71,7 @@ default:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_cuda=false myconfig=default with_coverage=true
+    - export with_cuda=false myconfig=default with_coverage=true python_version=3
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -81,27 +81,15 @@ maxset:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_cuda=false myconfig=maxset with_coverage=true
-    - bash maintainer/CI/build_cmake.sh
-  tags:
-    - docker
-    - linux
-
-maxset-python3:
-  <<: *global_job_definition
-  stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:18.04
-  script:
     - export myconfig=maxset with_coverage=true python_version=3
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
 
-no_rotation-python3:
+no_rotation:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:18.04
   script:
     - export myconfig=no_rotation with_coverage=true python_version=3
     - bash maintainer/CI/build_cmake.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,7 @@ nocheckmaxset:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_cuda=false myconfig=nocheck-maxset make_check=false
+    - export with_cuda=false myconfig=nocheck-maxset python_version=3 make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -335,15 +335,6 @@ osx:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_ccache=false myconfig=maxset with_cuda=false
-    - bash maintainer/CI/build_cmake.sh
-  tags:
-    - mac
-
-osx-python3:
-  <<: *global_job_definition
-  stage: build
-  script:
     - export with_ccache=false myconfig=maxset with_cuda=false python_version=3
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -353,7 +344,7 @@ osx-cuda:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_ccache=false myconfig=maxset with_cuda=true make_check=false
+    - export with_ccache=false myconfig=maxset with_cuda=true python_version=3 make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ matrix:
     - os: linux
       sudo: required
       services: docker
-      env: myconfig=maxset python_version=2
-    - os: linux
-      sudo: required
-      services: docker
       env: myconfig=maxset image=ubuntu-python3 python_version=3
 
 script:


### PR DESCRIPTION
First PR for #2694

Description of changes:
- updated MacOS X jobs and some Ubuntu 18 jobs to Python3
- removed redundant Python2 jobs: 2 in GitLab CI and 1 in Travis CI
- there should be no difference in coverage (espressomd/docker#78)