### PR TITLE
maintainer: enable checks for centos.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,7 +154,7 @@ centos:7:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
-    - export with_cuda=false myconfig=maxset make_check=false
+    - export with_cuda=false myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker


### PR DESCRIPTION
since this is the linux with the oldest boost version, we should run the checks in this container.
