### PR TITLE
CI: run deploy tasks on Linux

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -451,7 +451,7 @@ check_with_odd_no_of_processors:
   tags:
     - docker
     - linux
-    - cuda
+    - icp
 
 deploy_sphinx_documentation:
   extends: .deploy_base
@@ -460,8 +460,6 @@ deploy_sphinx_documentation:
   script:
     - cd ${CI_PROJECT_DIR}/build/doc/sphinx/html && 
       rsync -avz --delete -e "ssh -i ${HOME}/.ssh/espresso_rsa" ./ espresso@elk.icp.uni-stuttgart.de:/home/espresso/public_html/html/doc
-  tags:
-    - icp
 
 deploy_doxygen_documentation:
   extends: .deploy_base
@@ -470,8 +468,6 @@ deploy_doxygen_documentation:
   script:
     - cd ${CI_PROJECT_DIR}/build/doc/doxygen/html &&
       rsync -avz --delete -e "ssh -i ${HOME}/.ssh/espresso_rsa" ./ espresso@elk.icp.uni-stuttgart.de:/home/espresso/public_html/html/dox
-  tags:
-    - icp
 
 status_success:
   <<: *notification_job_definition


### PR DESCRIPTION
Fixes #2846, @KaiSzuttor. Sorry, I didn't see that `deploy_base` existed.