### PR TITLE
Doc: Clarified that time scale is independent of particle number

### DIFF
--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -459,7 +459,7 @@ everything in multiples of the van-der-Waals binding energy of the
 respective particles.
 
 The final choice is the time (or mass) scale. By default, |es| uses a reduced
-mass of 1, so that the mass unit is simply the mass of all particles.
+mass of 1 for all particles, so that the mass unit is simply the mass of one particle.
 Combined with the energy and length scale, this is sufficient to derive
 the resulting time scale:
 


### PR DESCRIPTION
A user on the mailing list was confused by the wording in the intro's section about units. This PR fixes the wording.

PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
