### PR TITLE
Update bibliography and Sphinx

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/espressomd/espresso/branch/python/graph/badge.svg)](https://codecov.io/gh/espressomd/espresso)
 
 This is the Molecular Dynamics software ESPResSo ("Extensible
-Simulation Package for the Research on Soft Matter Systems").
+Simulation Package for Research on Soft Matter Systems").
 
 ESPResSo is a highly versatile software package for performing and
 analyzing scientific Molecular Dynamics many-particle simulations of

--- a/doc/sphinx/CMakeLists.txt
+++ b/doc/sphinx/CMakeLists.txt
@@ -47,6 +47,7 @@ if(SPHINX_FOUND)
         "${CMAKE_CURRENT_SOURCE_DIR}/under_the_hood.rst"
         "${CMAKE_CURRENT_SOURCE_DIR}/visualization.rst"
         "${CMAKE_CURRENT_SOURCE_DIR}/zrefs.bib"
+        "${CMAKE_CURRENT_SOURCE_DIR}/zreferences.rst"
         )
 
     foreach(file ${FILE_LIST})

--- a/doc/sphinx/CMakeLists.txt
+++ b/doc/sphinx/CMakeLists.txt
@@ -22,6 +22,9 @@ if(SPHINX_FOUND)
     # Copy the figure directory to the build dir
     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/figures DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+    # Copy the _static directory to the build dir
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/_static DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
     # Files to be copied to the build directory
     set(FILE_LIST
         "${CMAKE_SOURCE_DIR}/doc/logo/logo_48x48.png"

--- a/doc/sphinx/_static/bibtex.css
+++ b/doc/sphinx/_static/bibtex.css
@@ -1,0 +1,10 @@
+/*
+ * Bibliography HTML formatting:
+ * - sphinxcontrib.bibtex 0.4.0 in Sphinx 1.7.8: based on <table>
+ * - sphinxcontrib.bibtex 0.4.2 in Sphinx 2.0.1: based on <dl>
+ * The <dl> version has a float:left property in basic.css that merges the
+ * citation key into the citation body, making the bibliography unreadable.
+ */
+dl.citation > dt {
+    margin-right: 1em; /* add space between citation key and body */
+}

--- a/doc/sphinx/advanced_methods.rst
+++ b/doc/sphinx/advanced_methods.rst
@@ -10,7 +10,7 @@ Advanced Methods
 Creating bonds when particles collide
 -------------------------------------
 
-Please cite :cite:`espresso2` when using dynamic bonding.
+Please cite :cite:`arnold13a` when using dynamic bonding.
 
 With the help of this feature, bonds between particles can be created
 automatically during the simulation, every time two particles collide.
@@ -314,7 +314,7 @@ University of Zilina:
 
 | ivan.cimrak@fri.uniza.sk or iveta.jancigova@fri.uniza.sk.
 
-  If using this module, please cite :cite:`Cimrak2014` (Bibtex key Cimrak2014 in doc/sphinx/zref.bib) and :cite:`Cimrak2012` (Bibtex key Cimrak2012 in doc/sphinx/zref.bib)
+  If using this module, please cite :cite:`Cimrak2014` (Bibtex key Cimrak2014 in doc/sphinx/zrefs.bib) and :cite:`Cimrak2012` (Bibtex key Cimrak2012 in doc/sphinx/zrefs.bib)
 
 | This documentation introduces the features of module Object-in-fluid
   (OIF). Even though ESPResSo was not primarily intended to work with closed
@@ -1948,7 +1948,7 @@ Combination of the Reaction Ensemble with the Wang-Landau algorithm
 allows for enhanced sampling of the reacting system, and
 and for the determination of the density of states with respect
 to the reaction coordinate or with respect to some other collective
-variable :cite:`landsgesell16a`. Here the 1/t Wang-Landau
+variable :cite:`landsgesell17a`. Here the 1/t Wang-Landau
 algorithm :cite:`belardinelli07a` is implemented since it
 does not suffer from systematic errors. Additionally to the above
 commands for the reaction ensemble use the following commands for the
@@ -1970,7 +1970,7 @@ In the constant pH method due to Reed and Reed
 of :math:`H^{+}` ions, assuming that the simulated system is coupled to an
 infinite reservoir. This value is the used to simulate dissociation
 equilibrium of acids and bases. Under certain conditions, the constant
-pH method can yield equivalent results as the reaction ensemble :cite:`landsgesell16b`. However, it
+pH method can yield equivalent results as the reaction ensemble :cite:`landsgesell17b`. However, it
 treats the chemical potential of :math:`H^{+}` ions and their actual
 number in the simulation box as independent variables, which can lead to
 serious artifacts.

--- a/doc/sphinx/appendix.rst
+++ b/doc/sphinx/appendix.rst
@@ -294,7 +294,7 @@ In pseudo code, the far formula algorithm looks like:
          :math:`\xi^{(+,s/c,s/c)}_j\Xi^{(l,s/c,s/c)}_s` and
          :math:`\xi^{(-,s/c,s/c)}_j\Xi^{(h,s/c,s/c)}_s`
 
-For further details, see :cite:`arnold02a,arnold02b,arnold02c`.
+For further details, see :cite:`arnold02a,arnold02b,arnold02c,arnold02d`.
 
 .. _Dielectric contrast:
 
@@ -320,7 +320,7 @@ the lowest/topmost layer. This are all modifications necessary for the
 far formula part. In addition to the far formula part, there is an
 additional loop over the particles at the boundary to directly calculate
 their interactions with their images. For details, refer to
-:cite:`icmmm2d`.
+:cite:`tyagi07a`.
 
 .. _MMM1D theory:
 
@@ -471,7 +471,7 @@ Ewald methods, for which decreasing the error bound can lead to
 excessive computation time. For example, P3M cannot reach precisions
 above :math:`10^{-5}` in general. The precise form of the error
 estimates is of little importance here, for details see
-:cite:`arnold02c`.
+:cite:`arnold02c,arnold02d`.
 
 One important aspect is that the error estimates are also exponential in
 the non-periodic coordinate. Since the number of close by and far away

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -17,6 +17,7 @@
 import sys
 import os
 import shlex
+import sphinx
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -310,7 +311,14 @@ texinfo_documents = [
 # Supress warning if html is build
 # http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
 autodoc_mock_imports = ['featuredefs', 'mayavi', 'pyface', 'tvtk', 'vtk', 'MDAnalysis', 'electrostatics']
-autodoc_default_flags = ['members', 'show-inheritance', 'undoc-members']
+if sphinx.version_info[:2] < (1, 8):
+    autodoc_default_flags = ['members', 'show-inheritance', 'undoc-members']
+else:
+    autodoc_default_options = {
+        'members': None,
+        'show-inheritance': None,
+        'undoc-members': None,
+    }
 # For sidebar toc depth
 rst_prolog = """
 :tocdepth: 3

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -16,7 +16,6 @@
 
 import sys
 import os
-import shlex
 import sphinx
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -126,7 +125,6 @@ html_theme = 'classic'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
 html_theme_options = {
     "stickysidebar": "true",
     "sidebarwidth": 320,
@@ -224,93 +222,13 @@ html_show_copyright = True
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ESPResSo'
 
-# -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+# -- reStructuredText options ---------------------------------------------
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'ExtensibleSimulationPackageforResearchonSoftMatterSystems.tex',
-     'Extensible Simulation Package for Research on Soft Matter Systems Documentation',
-     'Florian Weik', 'manual'),
-]
-
-# The name of an image file (relative to this directory) to place at the top of
-# the title page.
-#latex_logo = None
-
-# For "manual" documents, if this is true, then toplevel headings are parts,
-# not chapters.
-#latex_use_parts = False
-
-# If true, show page references after internal links.
-#latex_show_pagerefs = False
-
-# If true, show URL addresses after external links.
-#latex_show_urls = False
-
-# Documents to append as an appendix to all manuals.
-#latex_appendices = []
-
-# If false, no module index is generated.
-#latex_domain_indices = True
-
-
-# -- Options for manual page output ---------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'extensiblesimulationpackageforresearchonsoftmattersystems',
-     'Extensible Simulation Package for Research on Soft Matter Systems Documentation',
-     [author], 1)
-]
-
-# If true, show URL addresses after external links.
-#man_show_urls = False
-
-
-# -- Options for Texinfo output -------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-texinfo_documents = [
-    (master_doc, 'ExtensibleSimulationPackageforResearchonSoftMatterSystems',
-     'Extensible Simulation Package for Research on Soft Matter Systems Documentation',
-     author, 'ExtensibleSimulationPackageforSoftMatterResearch',
-     'One line description of project.', 'Miscellaneous'),
-]
-
-# Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
-
-# If false, no module index is generated.
-#texinfo_domain_indices = True
-
-# How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
-
-# If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
-
-# Supress warning if html is build
+# Suppress warnings for features not compiled in
 # http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
 autodoc_mock_imports = ['featuredefs', 'mayavi', 'pyface', 'tvtk', 'vtk', 'MDAnalysis', 'electrostatics']
+
 if sphinx.version_info[:2] < (1, 8):
     autodoc_default_flags = ['members', 'show-inheritance', 'undoc-members']
 else:

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -153,7 +153,7 @@ html_short_title = "ESPResSo doc"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -225,10 +225,6 @@ htmlhelp_basename = 'ESPResSo'
 
 # -- reStructuredText options ---------------------------------------------
 
-# Suppress warnings for features not compiled in
-# http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
-autodoc_mock_imports = ['featuredefs', 'mayavi', 'pyface', 'tvtk', 'vtk', 'MDAnalysis', 'electrostatics']
-
 if sphinx.version_info[:2] < (1, 8):
     autodoc_default_flags = ['members', 'show-inheritance', 'undoc-members']
 else:
@@ -245,6 +241,16 @@ rst_prolog = """
 rst_epilog = """
 .. |es| replace:: `ESPResSo`
 """
+
+
+# -- Other options --------------------------------------------------------
+
+# Suppress warnings for features not compiled in
+# http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
+autodoc_mock_imports = ['featuredefs', 'mayavi', 'pyface', 'tvtk', 'vtk', 'MDAnalysis', 'electrostatics']
+
+def setup(app):
+    app.add_stylesheet('bibtex.css')
 
 
 # -- Options for Cython ---------------------------------------------------

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -67,7 +67,7 @@ checking for the feature ``FFTW`` with ``espressomd.features``.
 P3M requires full periodicity (1 1 1). Make sure that you know the relevance of the
 P3M parameters before using P3M! If you are not sure, read the following
 references
-:cite:`ewald21,hockney88,kolafa92,deserno98,deserno98a,deserno00,deserno00a,cerda08a`.
+:cite:`ewald21,hockney88,kolafa92,deserno98a,deserno98b,deserno00,deserno00a,cerda08d`.
 
 .. _Tuning Coulomb P3M:
 
@@ -252,7 +252,7 @@ With each iteration, ICC has to solve electrostatics which can severely slow
 down the integration. The performance can be improved by using multiple cores,
 a minimal set of ICC particles and convergence and relaxation parameters that
 result in a minimal number of iterations. Also please make sure to read the
-corresponding articles, mainly :cite:`espresso2,tyagi10a,kesselheim11a` before
+corresponding articles, mainly :cite:`arnold13a,tyagi10a,kesselheim11a` before
 using it.
 
 .. _MMM2D:
@@ -334,8 +334,8 @@ algorithm is definitely faster than MMM2D for larger numbers of particles
 (:math:`>400` at reasonable accuracy requirements). The periodicity has to be
 set to ``1 1 1`` still, *ELC* cancels the electrostatic contribution of the
 periodic replica in **z-direction**. Make sure that you read the papers on ELC
-(:cite:`arnold02c,icelc`) before using it. ELC is an |es| actor and is used
-with::
+(:cite:`arnold02c,arnold02d,tyagi08a`) before using it. ELC is an |es| actor
+and is used with::
 
     elc = electrostatic_extensions.ELC(gap_size=box_l * 0.2, maxPWerror=1e-3)
     system.actors.add(elc)
@@ -358,7 +358,7 @@ Parameters are:
     * ``delta_mid_top``/``delta_mid_bot``:
         *ELC* can also be used to simulate 2D periodic systems with image charges,
         specified by dielectric contrasts on the non-periodic boundaries
-        (:cite:`icelc`).  Similar to *MMM2D*, these can be set with the
+        (:cite:`tyagi08a`).  Similar to *MMM2D*, these can be set with the
         keywords ``delta_mid_bot`` and ``delta_mid_top``, setting the dielectric
         jump from the simulation region (*middle*) to *bottom* (at ``z<0``) and
         from *middle* to *top* (``z > box_l[2] - gap_size``). The fully metallic case

--- a/doc/sphinx/lb.rst
+++ b/doc/sphinx/lb.rst
@@ -16,7 +16,7 @@ geometries and boundary conditions are somewhat limited in comparison to
 Here we restrict the documentation to the interface. For a more detailed
 description of the method, please refer to the literature.
 
-.. note:: Please cite :cite:`espresso2` (Bibtex key espresso2 in :file:`doc/sphinx/zref.bib`) if you use the LB fluid and :cite:`lbgpu` (Bibtex key lbgpu in :file:`doc/sphinx/zref.bib`) if you use the GPU implementation.
+.. note:: Please cite :cite:`arnold13a` (Bibtex key ``arnold13a`` in :file:`doc/sphinx/zrefs.bib`) if you use the LB fluid and :cite:`rohm12a` (Bibtex key ``rohm12a`` in :file:`doc/sphinx/zrefs.bib`) if you use the GPU implementation.
 
 .. _Setting up a LB fluid:
 

--- a/doc/sphinx/magnetostatics.rst
+++ b/doc/sphinx/magnetostatics.rst
@@ -60,7 +60,7 @@ It is also possible to pass a subset of the method parameters such as ``mesh``. 
     p3m = magnetostatics.DipolarP3M(prefactor=1, mesh=32, accuracy=1E-4)
     system.actors.add(p3m)
 
-It is important to note that the error estimates given in :cite:`cerda08a` used in the tuning contain assumptions about the system. In particular, a homogeneous system is assumed. If this is no longer the case during the simulation, actual force and torque errors can be significantly larger.
+It is important to note that the error estimates given in :cite:`cerda08d` used in the tuning contain assumptions about the system. In particular, a homogeneous system is assumed. If this is no longer the case during the simulation, actual force and torque errors can be significantly larger.
 
 .. _Dipolar Layer Correction (DLC):
 

--- a/doc/sphinx/ug.rst
+++ b/doc/sphinx/ug.rst
@@ -21,5 +21,5 @@
     under_the_hood.rst
     contributing.rst
     appendix.rst
+    zreferences.rst
 
-.. bibliography:: zrefs.bib

--- a/doc/sphinx/zreferences.rst
+++ b/doc/sphinx/zreferences.rst
@@ -1,0 +1,6 @@
+.. _Bibliography:
+
+Bibliography
+============
+
+.. bibliography:: zrefs.bib

--- a/doc/sphinx/zrefs.bib
+++ b/doc/sphinx/zrefs.bib
@@ -13,9 +13,9 @@
 }
 
 @ARTICLE{andersen80a,
-  author = {Andersen},
-  title = {{Molecular-Dynamics Simulations At Constant Pressure And/Or Temperature}},
-  journal = {J. Chem. Phys},
+  author = {Andersen, Hans C.},
+  title = {Molecular dynamics simulations at constant pressure and/or temperature},
+  journal = {J. Chem. Phys.},
   year = {1980},
   volume = {72},
   pages = {{2384-2393}},
@@ -24,16 +24,18 @@
   language = {{English}},
   owner = {floh},
   timestamp = {2011.03.29},
+  doi = {10.1063/1.439486},
   unique-id = {{ISI:A1980JK06800026}}
 }
 
 @ARTICLE{andersen83a,
-  author = {Hans C. Andersen},
+  author = {Andersen, Hans C.},
   title = {Rattle: A "Velocity" Version of the Shake Algorithm for Molecular
 	Dynamics Calculations},
-  journal = {J. Comp. Phys.},
+  journal = {J. Comput. Phys.},
   year = {1983},
   volume = {51},
+  doi = {10.1016/0021-9991(83)90014-1},
   pages = {24--34}
 }
 
@@ -45,18 +47,33 @@
   year = {2002},
   volume = {354},
   pages = {324--330},
+  doi = {10.1016/S0009-2614(02)00131-8},
   owner = {olenz},
   timestamp = {2007.06.13}
 }
 
 @ARTICLE{arnold02c,
-  author = {Axel Arnold and Jason {de Joannis} and Christian Holm},
-  title = {{Electrostatics in Periodic Slab Geometries I+II}},
+  author = {A. Arnold and J. de Joannis and C. Holm},
+  title = {Electrostatics in Periodic Slab Geometries {I}},
   journal = {J. Chem. Phys.},
   year = {2002},
   volume = {117},
-  pages = {2496--2512},
-  eprint = {cond-mat/0202399 and cond-mat/0202400}
+  pages = {2496--2502},
+  doi = {10.1063/1.1491955},
+  owner = {dommert},
+  timestamp = {2009.03.16}
+}
+
+@ARTICLE{arnold02d,
+  title = {Electrostatics in Periodic Slab Geometries {II}},
+  author = {A. Arnold and J. de Joannis and C. Holm},
+  journal = {J. Chem. Phys.},
+  year = {2002},
+  volume = {117},
+  pages = {2503--2512},
+  doi = {10.1063/1.1491954},
+  owner = {holm},
+  timestamp = {2007.02.23}
 }
 
 @ARTICLE{ballenegger09a,
@@ -79,23 +96,23 @@
 @article{beenakker86a,
    author = {Beenakker, C. W. J.},
    title = {Ewald sum of the Rotne--Prager tensor},
-   journal = {The Journal of Chemical Physics},
+   journal = {J. Chem. Phys.},
    year = {1986},
    volume = {85},
    number = {3}, 
    pages = {1581-1582},
-   url = {http://scitation.aip.org/content/aip/journal/jcp/85/3/10.1063/1.451199},
    doi = {10.1063/1.451199}
 }
 
 @article{belardinelli07a,
   title={Fast algorithm to calculate density of states},
-  author={Belardinelli, RE and Pereyra, VD},
-  journal={Physical Review E},
+  author={Belardinelli, R. E. and Pereyra, V. D.},
+  journal={Phys. Rev. E},
   volume={75},
   number={4},
   pages={046701},
   year={2007},
+  doi={10.1103/PhysRevE.75.046701},
   publisher={APS}
 }
 
@@ -111,43 +128,33 @@
 }
 
 @ARTICLE{berendsen84a,
-  author = {H. J. C. Berendsen and J. P. M. Postma and W. F. van Gunsteren and
-	A. DiNola and J. R. Haak},
-  title = {Molecular dynamics with coupling to a heat bath},
+  author = {Berendsen, H. J. C. and Postma, J. P. M. and {van Gunsteren}, W. F. and {DiNola}, A. and Haak, J. R.},
+  title = {Molecular dynamics with coupling to an external bath},
   journal = {J. Chem. Phys.},
   year = {1984},
   volume = {81},
+  number = {8},
   pages = {3684--3690},
+  doi = {10.1063/1.448118},
   owner = {dommert},
   timestamp = {2009.03.16}
 }
 
 @ARTICLE{brodka04a,
-  author = {A. Brodka},
+  author = {Br{\'o}dka, A.},
   title = {Ewald summation method with electrostatic layer correction for interactions
 	of point dipoles in slab geometry},
   journal = {Chem. Phys. Lett.},
   year = {2004},
   volume = {400},
+  doi = {10.1016/j.cplett.2004.10.086},
   pages = {62--67}
-}
-
-@ARTICLE{cerda08a,
-  author = {Juan J. Cerda and V. Ballenegger and O. Lenz and C.Holm},
-  title = {{P3M algorithm for dipolar interactions}},
-  journal = {J. Chem. Phys.},
-  year = {2008},
-  volume = {129},
-  pages = {234104},
-  eprint = {cond-mat/????},
-  owner = {jcerda},
-  timestamp = {2009.01.09}
 }
 
 @ARTICLE{chatterjee2007,
 author = {Chatterjee, A.},
 title = {Modification to {Lees--Edwards} periodic boundary condition for dissipative particle dynamics simulation with high dissipation rates},
-journal = {Molecular Simulation},
+journal = {Mol. Simulat.},
 volume = {33},
 number = {15},
 pages = {1233-1236},
@@ -161,16 +168,18 @@ year = {2007},
 	year = {2012},
 	number = {3},
 	volume = {64},
+	doi = {10.1016/j.camwa.2012.01.062},
 	pages = {278--288}
 }
 
 @ARTICLE{Cimrak2014,
   author = {I. Cimr\'ak and M. Gusenbauer and I. Jan\v{c}igov\'a},
   title = {{An {ESPResSo} implementation of elastic objects immersed in a fluid}},
-  journal = {Computer Physics Communications },
+  journal = {Comput. Phys. Commun.},
   year = {2014},
   volume = {185},
   pages = {900 - 907},
+  doi = {10.1016/j.cpc.2013.12.013},
   number = {3}
 }
 
@@ -178,11 +187,12 @@ year = {2007},
 @article{Crowl2010,
 author = {Crowl, Lindsay M and Fogelson, Aaron L},
 title = {{Computational model of whole blood exhibiting lateral platelet motion induced by red blood cells}},
-journal = {Int. J. Numer. Meth. Biomed. Engng.},
+journal = {Int. J. Numer. Meth. Biomed. Eng.},
 year = {2010},
 volume = {26},
 number = {3-4},
 pages = {471--487},
+doi = {10.1002/cnm.1274},
 }
 
 @ARTICLE{dao03,
@@ -207,11 +217,12 @@ pages = {471--487},
 }
 
 @INBOOK{deserno00,
-  chapter = {How to mesh up {E}wald sums.},
-  title = {Molecular Dynamics on Parallel Computers},
+  title = {How to mesh up {E}wald sums.},
+  booktitle = {Molecular Dynamics on Parallel Computers},
   publisher = {World Scientific, Singapore},
   year = {2000},
   author = {M. Deserno and C. Holm and H. J. Limbach},
+  doi = {10.1142/9789812793768_0023},
   owner = {RDLimbacHJ},
   timestamp = {2007.08.29}
 }
@@ -225,26 +236,28 @@ pages = {471--487},
   timestamp = {2007.08.29}
 }
 
-@ARTICLE{deserno98,
-  author = {M. Deserno and C. Holm},
-  title = {How to mesh up {E}wald sums. I.},
-  journal = {J. Chem. Phys.},
-  year = {1998},
-  volume = {109},
-  pages = {7678},
-  owner = {RDLimbacHJ},
-  timestamp = {2007.08.29}
-}
-
 @ARTICLE{deserno98a,
   author = {M. Deserno and C. Holm},
-  title = {How to mesh up {E}wald sums. II.},
+  title = {How to mesh up {E}wald sums. {I.} {A} theoretical and numerical comparison of various particle mesh routines},
   journal = {J. Chem. Phys.},
   year = {1998},
+  pages = {7678},
   volume = {109},
+  doi = {10.1063/1.477414},
+  owner = {dommert},
+  timestamp = {2009.03.16}
+}
+
+@ARTICLE{deserno98b,
+  author = {M. Deserno and C. Holm},
+  title = {How to mesh up {E}wald sums. {II.} {A}n accurate error estimate for the {P}article-{P}article-{P}article-{M}esh algorithm},
+  journal = {J. Chem. Phys.},
+  year = {1998},
   pages = {7694},
-  owner = {RDLimbacHJ},
-  timestamp = {2007.08.29}
+  volume = {109},
+  doi = {10.1063/1.477415},
+  owner = {dommert},
+  timestamp = {2009.03.16}
 }
 
 @BOOK{doi86a,
@@ -260,31 +273,29 @@ pages = {471--487},
   year={2008},
   booktitle={Lattice Boltzmann Simulations of Soft Matter Systems},
   author = {D{\"u}nweg, Burkhard and Ladd, Anthony J.C.},
-  doi = {10.1007/12_2008_4},
+  doi = {10.1007/978-3-540-87706-6_2},
   language = {English},
   pages = {1--78},
   publisher = {Springer Berlin Heidelberg},
   series = {{Advances in Polymer Science}},
   title = {{Lattice Boltzmann Simulations of Soft Matter Systems}},
-  url = {http://dx.doi.org/10.1007/12_2008_4}
 }
 
 @ARTICLE{dupin07,
   author = {Dupin, M.M. and Halliday, I. and Care, C.M. and Alboul, L.},
   title = {Modeling the flow of dense suspensions of deformable particles in
 	three dimensions},
-  journal = {Phys Rev E Stat Nonlin Soft Matter Phys.},
+  journal = {Phys. Rev. E},
   year = {2007},
   volume = {75},
   pages = {066707},
+  doi = {10.1103/PhysRevE.75.066707},
   owner = {cimo},
   timestamp = {2011.01.04}
 }
 
-
-@ARTICLE{espresso,
-  author = {Hans-J{\"o}rg Limbach and Axel Arnold and Bernward A. Mann
-            and Christian Holm},
+@ARTICLE{limbach06a,
+  author = {H. J. Limbach and A. Arnold and B. A. Mann and C. Holm},
   title = {{ESPResSo} -- An Extensible Simulation Package for Research
 	   on Soft Matter Systems},
   journal = {Comput. Phys. Commun.},
@@ -293,29 +304,31 @@ pages = {471--487},
   pages = {704--727},
   number = {9},
   doi = {10.1016/j.cpc.2005.10.005},
+  owner = {olenz},
+  timestamp = {2006.08.18}
 }
 
-@INCOLLECTION{espresso2,
-  author = {Axel Arnold and Olaf Lenz and Stefan Kesselheim and Rudolf Weeber
-	and Florian Fahrenberger and Dominic Roehm and Peter Kosovan and
-	Christian Holm},
-  title = {{ESPResSo 3.1} -- Molecular Dynamics Software for Coarse-Grained
-	Models},
-  booktitle = {Proceedings of the Sixth International Workshop on Meshfree Methods
-	for Partial Differential Equations},
-  publisher = {Springer},
-  year = {submitted},
-  editor = {Michael Griebel and Christian Rieger and Marc Alexander Schweitzer},
+@INCOLLECTION{arnold13a,
+  author = {A. Arnold and O. Lenz and S. Kesselheim and R. Weeber and F. Fahrenberger and D. R{\"o}hm and P. Ko\v{s}ovan and C. Holm},
+  title = {{ESPResSo}~3.1 --- Molecular Dynamics Software for Coarse-Grained Models},
+  booktitle = {Meshfree Methods for Partial Differential Equations {VI}},
+  publisher = {Springer Berlin Heidelberg},
+  year = {2013},
+  editor = {M. Griebel and M. A. Schweitzer},
   series = {Lecture Notes in Computational Science and Engineering},
+  pages = {1--23},
+  volume = {89},
+  doi = {10.1007/978-3-642-32979-1_1},
 }
 
 @ARTICLE{ewald21,
   author = {P.P. Ewald},
-  title = {Die Berechnung optischer und elektrostatischer Gitterpotentiale},
+  title = {Die {B}erechnung optischer und elektrostatischer {G}itterpotentiale},
   journal = {Ann. Phys.},
   year = {1921},
   volume = {64},
   pages = {253-287},
+  doi = {10.1002/andp.19213690304},
   owner = {RDLimbacHJ},
   timestamp = {2007.08.29}
 }
@@ -323,7 +336,11 @@ pages = {471--487},
 @ARTICLE{fahrenberger15b,
   author = {Fahrenberger, F. and Hickey, O. A. and Smiatek, J. and Holm, C.},
   title = {Importance of varying permittivity on the conductivity of polyelectrolyte solutions},
-  journal = {Physical Review Letters},
+  journal = {Phys. Rev. Lett.},
+  pages = {118301},
+  volume = {115},
+  doi = {10.1103/PhysRevLett.115.118301},
+  issue = {11},
   year = {2015}
 }
 
@@ -356,6 +373,7 @@ pages = {1305--1320}
   volume = {33},
   pages = {3628--31},
   number = {5},
+  doi = {10.1103/PhysRevA.33.3628},
   owner = {olenz},
   timestamp = {2007.06.13}
 }
@@ -369,7 +387,7 @@ pages = {1305--1320}
   volume = {{105}},
   number = {{14}},
   month = {{SEP 29}},
-  doi = {{10.1103/PhysRevLett.105.148301}}
+  doi = {10.1103/PhysRevLett.105.148301}
 }
 
 @BOOK{hockney88,
@@ -393,45 +411,53 @@ pages = {1305--1320}
 }
 
 @article{hsu12a,
-  title={Ab initio determination of coarse-grained interactions in double-stranded DNA},
+  title={Ab initio determination of coarse-grained interactions in double-stranded {DNA}},
   author={Hsu, Chia Wei and Fyta, Maria and Lakatos, Greg and Melchionna, Simone and Kaxiras, Efthimios},
-  journal={The Journal of chemical physics},
+  journal={J. Chem. Phys.},
   volume={137},
   number={10},
   pages={105102},
   year={2012},
+  doi = {10.1063/1.4748105},
   publisher={AIP Publishing}
 }
 
 @ARTICLE{humphrey96a,
   author = {W. Humphrey and A. Dalke and K. Schulten},
   title = {{VMD}: Visual Molecular Dynamics},
-  journal = {J. Mol. Graphics},
+  journal = {J. Mol. Graph.},
   year = {1996},
   volume = {14},
   pages = {33--38},
+  doi = {10.1016/0263-7855(96)00018-5},
   owner = {dommert},
   timestamp = {2009.03.16}
 }
 
-@ARTICLE{icelc,
+@ARTICLE{tyagi08a,
   author = {Sandeep Tyagi and Axel Arnold and Christian Holm},
   title = {Electrostatic layer correction with image charges: A linear scaling
-	method to treat slab 2D + h systems with dielectric interfaces},
+	method to treat slab 2{D} + h systems with dielectric interfaces},
   journal = {J. Chem. Phys.},
   year = {2008},
   volume = {129},
   pages = {204102},
+  doi = {10.1063/1.3021064},
+  owner = {dommert},
+  timestamp = {2009.03.16},
   number = {20}
 }
 
-@ARTICLE{icmmm2d,
+@ARTICLE{tyagi07a,
   author = {S. Tyagi and A. Arnold and C. Holm},
   title = {{ICMMM2D}: An accurate method to include planar dielectric interfaces
 	via image charge summation},
   journal = {J. Chem. Phys.},
   year = {2007},
   volume = {127},
+  doi = {10.1063/1.2790428},
+  owner = {dommert},
+  timestamp = {2009.03.16},
   pages = {154723}
 }
 
@@ -449,24 +475,27 @@ pages = {1305--1320}
 
 @ARTICLE{kesselheim11a,
   author = {Stefan Kesselheim and Marcello Sega and Christian Holm},
-  title = {Applying to DNA translocation: Effect of dielectric boundaries},
-  journal = {Computer Physics Communications},
+  title = {Applying {ICC}* to {DNA} translocation. {E}ffect of dielectric boundaries},
+  journal = {Comput. Phys. Commun.},
   year = {2011},
   volume = {182},
   pages = {33 - 35},
   number = {1},
   doi = {10.1016/j.cpc.2010.08.014},
   issn = {0010-4655},
+  owner = {wmueller},
+  timestamp = {2011.08.02},
 }
 
 @ARTICLE{kolafa92,
   author = {Jiri Kolafa and John W. Perram},
-  title = {Cutoff Errors in the Ewald Summation Formulae for Point Charge Systems},
+  title = {Cutoff Errors in the {E}wald Summation Formulae for Point Charge Systems},
   journal = {Molecular Simulation},
   year = {1992},
   volume = {9},
   pages = {351-368},
   number = {5},
+  doi = {10.1080/08927029208049126},
   owner = {RDLimbacHJ},
   timestamp = {2007.08.29}
 }
@@ -491,6 +520,7 @@ pages = {1305--1320}
   year = {1990},
   volume = {92},
   pages = {5057},
+  doi = {10.1063/1.458541},
   owner = {olenz},
   timestamp = {2007.06.15}
 }
@@ -502,10 +532,10 @@ school = {Universit{\"a}t Bochum},
 year = {2011}
 }
 
-@Article{landsgesell16a,
-title                      = {Wang-Landau Reaction Ensemble Method: Simulation of Weak Polyelectrolytes and General Acid-Base Reactions},
+@Article{landsgesell17a,
+title                      = {{W}ang-{L}andau Reaction Ensemble Method: {S}imulation of Weak Polyelectrolytes and General Acid-Base Reactions},
 author                     = {Landsgesell, Jonas and Holm, Christian and Smiatek, Jens},
-journal                    = {Journal of Chemical Theory and Computation},
+journal                    = {J. Chem. Theory Comput.},
 volume                     = {13},
 number                     = {2},
 pages                      = {852--862},
@@ -513,10 +543,10 @@ year                       = {2017},
 doi                        = {10.1021/acs.jctc.6b00791}
 }
 
-@Article{landsgesell16b,
-title                      = {Simulation of weak polyelectrolytes: A comparison between the constant pH and the reaction ensemble method},
+@Article{landsgesell17b,
+title                      = {Simulation of weak polyelectrolytes: {A} comparison between the constant p{H} and the reaction ensemble method},
 author                     = {Landsgesell, Jonas and Holm, Christian and Smiatek, Jens},
-journal                    = {The European Physical Journal Special Topics},
+journal                    = {Eur. Phys. J. Special Topics},
 year                       = {2017},
 doi                        = {10.1140/epjst/e2016-60324-3}
 }
@@ -531,13 +561,16 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   doi = {10.1088/0022-3719/5/15/006}
 }
 
-@Article{lbgpu,
-  author = 	 {D. Roehm and A. Arnold},
-  title = 	 {Lattice Boltzmann simulations on {GPU}s with {ESPResSo}},
-  journal = 	 {Eur. Phys. J. ST},
-  year = 	 {2012},
-  volume = 	 {210},
-  pages = 	 {73--88}
+@Article{rohm12a,
+  author = {Roehm, D. and Arnold, A.},
+  title = {Lattice {B}oltzmann simulations on {GPU}s with {ESPResSo}},
+  journal = {Eur. Phys. J. Special Topics},
+  year = {2012},
+  volume = {210},
+  doi = {10.1140/epjst/e2012-01639-6},
+  pages = {89-100},
+  owner = {dominic},
+  timestamp = {2012.09.11}
 }
 
 @PHDTHESIS{limbach01,
@@ -558,6 +591,7 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   pages = {8041--8055},
   number = {32},
   owner = {olenz},
+  doi = {10.1021/jp027606p},
   timestamp = {2007.06.13}
 }
 
@@ -570,7 +604,7 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   pages = {4011-4021},
   number = {{24}},
   month = {{AUG 20}},
-  doi = {{10.1364/AO.40.004011}},
+  doi = {10.1364/AO.40.004011},
   issn = {{0003-6935}},
   owner = {kosovan},
   timestamp = {2012.02.14},
@@ -615,24 +649,25 @@ doi                        = {10.1140/epjst/e2016-60324-3}
 @ARTICLE{arnold05a,
   author = {A. Arnold and C. Holm},
   title = {{MMM1D}: {A} method for calculating electrostatic interactions in
-	1{D} periodic geometries},
+	one-dimensional periodic geometries},
   journal = {J. Chem. Phys.},
   year = {2005},
   volume = {123},
   pages = {144103},
+  doi = {10.1063/1.2052647},
   number = {12}
 }
 
 @ARTICLE{arnold02a,
   author = {Axel Arnold and Christian Holm},
-  title = {{MMM2D}: A fast and accurate summation methodlimnb for electrostatic
-	interactions in 2D slab geometries},
+  title = {{MMM2D}: A fast and accurate summation method for electrostatic
+	interactions in {2D} slab geometries},
   journal = {Comput. Phys. Commun.},
   year = {2002},
   volume = {148},
   pages = {327--348},
   number = {3},
-  eprint = {cond-mat/0202265}
+  doi = {10.1016/S0010-4655(02)00586-6},
 }
 
 @ARTICLE{Nikunen03,
@@ -654,6 +689,7 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   pages = {3999--4020},
   number = {38},
   month = sep,
+  doi = {10.1088/0953-8984/16/38/017},
   owner = {dommert},
   timestamp = {2009.03.16}
 }
@@ -661,9 +697,10 @@ doi                        = {10.1140/epjst/e2016-60324-3}
 @article{Peskin2002,
 author = {Peskin, Charles S},
 title = {{The immersed boundary method}},
-journal = {Acta Numerica},
+journal = {Acta Numer.},
 year = {2003},
 volume = {11},
+doi = {10.1017/S0962492902000077},
 pages = {479--517}
 }
 
@@ -678,11 +715,12 @@ pages = {479--517}
 }
 
 @ARTICLE{Polyakov2013,
-author = {Polyakov, A.Yu. and Lyutyy, T.V. and Denisov, S. and Reva, V.V. and H{\"{a}}nggi, P.},
+author = {Polyakov, A. Yu. and Lyutyy, T. V. and Denisov, S. and Reva, V. V. and H{\"{a}}nggi, P.},
 title = {{Large-scale ferrofluid simulations on graphics processing units}},
-journal = {Computer Physics Communications},
+journal = {Comput. Phys. Commun.},
 year = {2013},
 volume = {184},
+doi = {10.1016/j.cpc.2013.01.016},
 pages = {1483--1489}
 }
 
@@ -690,7 +728,7 @@ pages = {1483--1489}
   author = {Matej Praprotnik and Luigi {Delle Site} and Kurt Kremer},
   title = {Adaptive resolution molecular-dynamics simulation: Changing the degrees
 	of freedom on the fly},
-  journal = {The Journal of Chemical Physics},
+  journal = {J. Chem. Phys.},
   year = {2005},
   volume = {123},
   pages = {224106--14},
@@ -718,23 +756,24 @@ pages = {1483--1489}
   volume = {133},
   pages = {154103},
   number = {{15}},
-  month = {{OCT 21}},
+  month = oct,
   article-number = {{154103}},
-  doi = {{10.1063/1.3491098}},
+  doi = {10.1063/1.3491098},
   issn = {{0021-9606}},
   owner = {kosovan},
-  timestamp = {2012.02.14},
+  timestamp = {2011.12.14},
   unique-id = {{ISI:000283359300008}}
 }
 
 @article{reed92a,
-  title={Monte Carlo study of titration of linear polyelectrolytes},
+  title={{M}onte {C}arlo study of titration of linear polyelectrolytes},
   author={Reed, Christopher E and Reed, Wayne F},
   journal={J. Chem. Phys.},
   volume={96},
   number={2},
   pages={1609--1620},
   year={1992},
+  doi={10.1063/1.462145},
   publisher={AIP Publishing}
 }
 
@@ -757,8 +796,8 @@ pages = {1483--1489}
   volume = {35},
   pages = {711-718},
   number = {{4}},
-  month = {{APR}},
-  doi = {{10.1080/09500348814550731}},
+  month = apr,
+  doi = {10.1080/09500348814550731},
   issn = {{0950-0340}},
   owner = {kosovan},
   timestamp = {2012.02.14},
@@ -766,19 +805,23 @@ pages = {1483--1489}
 }
 
 @ARTICLE{sega13c,
- title = {Mesoscale structures at complex fluid–fluid interfaces: a novel lattice Boltzmann/molecular dynamics coupling},
+ title = {Mesoscale structures at complex fluid--fluid interfaces: a novel lattice Boltzmann/molecular dynamics coupling},
  author = {M. Sega and   M. Sbragaglia  and   S. S. Kantorovich and    A. O. Ivanov},
  journal = {Soft Matter},
- year = {2013, in press},
+ year = {2013},
+ volume = {9},
+ number = {42},
+ pages = {10092-10107},
  doi = {10.1039/C3SM51556G}
 }
 
 @ARTICLE{smiatek08a,
   author = {J. Smiatek and M. P. Allen and F. Schmidt},
-  title = {Tunable slip boundaries for coarse-grained simulations of fluid flow},
+  title = {Tunable-slip boundaries for coarse-grained simulations of fluid flow},
   journal = {Eur. Phys. J. E},
   year = {2008},
   volume = {26},
+  doi = {10.1140/epje/i2007-10311-4},
   pages = {115}
 }
 
@@ -789,18 +832,20 @@ pages = {1483--1489}
   year = {1981},
   volume = {375},
   pages = {475--505},
+  doi = {10.1098/rspa.1981.0064},
   owner = {olenz},
   timestamp = {2007.06.13}
 }
 
 @article{smith94a,
-  title={The reaction ensemble method for the computer simulation of chemical and phase equilibria. I. Theory and basic examples},
+  title={The reaction ensemble method for the computer simulation of chemical and phase equilibria. {I.} {T}heory and basic examples},
   author={Smith, WR and Triska, B},
-  journal={The Journal of chemical physics},
+  journal={J. Chem. Phys.},
   volume={100},
   number={4},
   pages={3019--3027},
   year={1994},
+  doi={10.1063/1.466443},
   publisher={AIP Publishing}
 }
 
@@ -810,7 +855,8 @@ pages = {1483--1489}
   journal = {Eur. Phys. J. E},
   year = {2001},
   volume = {6},
-  pages = {409}
+  doi = {10.1007/s10189-001-8054-4},
+  pages = {409-419}
 }
 
 @ARTICLE{soddeman03a,
@@ -825,7 +871,7 @@ pages = {1483--1489}
 
 @PHDTHESIS{strebel99a,
   author = {R. Strebel},
-  title = {{Pieces of software for the Coulombic $m$ body problem}},
+  title = {{Pieces of software for the Coulombic m body problem}},
   school = {ETH Z\"urich},
   year = {1999},
   type = {Dissertation},
@@ -833,7 +879,7 @@ pages = {1483--1489}
   number = {13504},
   owner = {olenz},
   timestamp = {2007.06.13},
-  url = {http://e-collection.ethbib.ethz.ch/show?type=diss\&nr=13504}
+  doi = {10.3929/ethz-a-003856704}
 }
 
 @BOOK{succi01a,
@@ -846,12 +892,14 @@ pages = {1483--1489}
 }
 
 @ARTICLE{thompson09a,
-  author = {Thompson, A.~ P. and Plimpton, S.~ J. and Mattson, W.},
+  author = {Thompson, A. P. and Plimpton, S. J. and Mattson, W.},
   title = {General formulation of pressure and stress tensor for arbitrary many-body
 	interaction potentials under periodic boundary conditions},
-  journal = {Journal of Chemical Physics},
+  journal = {J. Chem. Phys.},
   year = {2009},
   volume = {131},
+  number = {15},
+  doi = {10.1063/1.3245303},
   pages = {154107},
   owner = {kosovan},
   timestamp = {2011.05.25}
@@ -865,6 +913,7 @@ pages = {1483--1489}
   number={2},
   pages={119--146},
   year={2008},
+  doi={10.1080/08927020801986564},
   publisher={Taylor \& Francis Group}
 }
 
@@ -884,8 +933,8 @@ pages = {1483--1489}
 
 @article{wagner02,
   author = {Alexander J. Wagner and Ignacio Pagonabarraga},
-  title = {Lees–Edwards boundary conditions for lattice Boltzmann},
-  journal = {Journal of statistical physics},
+  title = {{Lees--Edwards boundary conditions for lattice Boltzmann}},
+  journal = {J. Stat. Phys.},
   year = {2002},
   volume = {107},
   pages = {521-537},
@@ -895,7 +944,7 @@ pages = {1483--1489}
 @article{wang01a,
   title={Efficient, multiple-range random walk algorithm to calculate the density of states},
   author={Wang, Fugao and Landau, David P},
-  journal={Physical review letters},
+  journal={Phys. Rev. Lett.},
   volume={86},
   number={10},
   pages={2050},
@@ -910,6 +959,7 @@ pages = {1483--1489}
   year = {2004},
   volume = {156},
   pages = {143--153},
+  doi = {10.1016/S0010-4655(03)00467-3},
   owner = {olenz},
   timestamp = {2007.06.14}
 }
@@ -917,7 +967,7 @@ pages = {1483--1489}
 @Article{cerda08d,
   title                    = {{P3M} algorithm for dipolar interactions.},
   author                   = {Juan J. Cerd\`{a} and V. Ballenegger and O. Lenz and Ch. Holm},
-  journal                  = {Journal of Chemical Physics},
+  journal                  = {J. Chem. Phys.},
   year                     = {2008},
   pages                    = {234104},
   volume                   = {129},
@@ -930,21 +980,34 @@ pages = {1483--1489}
 @article{essmann1995smooth,
   title={A smooth particle mesh Ewald method},
   author={Essmann, Ulrich and Perera, Lalith and Berkowitz, Max L and Darden, Tom and Lee, Hsing and Pedersen, Lee G},
-  journal={The Journal of chemical physics},
+  journal={J. Chem. Phys.},
   volume={103},
   number={19},
   pages={8577--8593},
   year={1995},
+  doi={10.1063/1.470117},
   publisher={AIP}
 }
 
-@article{brown1995general,
+@article{brown95a,
   title={A general pressure tensor calculation for molecular dynamics simulations},
   author={Brown, David and Neyertz, Sylvie},
-  journal={Molecular Physics},
+  journal={Mol. Phys.},
   volume={84},
   number={3},
   pages={577--595},
   year={1995},
+  doi={10.1080/00268979500100371},
   publisher={Taylor \& Francis}
+}
+
+@Article{hofling11a,
+  title = {Anomalous transport resolved in space and time by fluorescence correlation spectroscopy},
+  author = {Felix H\"{o}fling and Karl-Ulrich Bamberg and Thomas Franosch},
+  journal = {Soft Matter},
+  year = {2011},
+  pages = {1358},
+  volume = {7},
+  doi = {10.1039/C0SM00718H},
+  owner = {rajarshi}
 }

--- a/doc/sphinx/zrefs.bib
+++ b/doc/sphinx/zrefs.bib
@@ -20,41 +20,10 @@
   volume = {72},
   pages = {{2384-2393}},
   number = {4},
-  abstract = {In the molecular dynamics simulation method for fluids, the equations
-	of motion for a collection of particles in a fixed volume are solved
-	numerically. The energy, volume, and number of particles are constant
-	for a particular simulation, and it is assumed that time averages
-	of properties of the simulated fluid are equal to microcanonical
-	ensemble averages of the same properties. In some situations, it
-	is desirable to perform simulations of a fluid for particular values
-	of temperature and/or pressure or under conditions in which the energy
-	and volume of the fluid can fluctuate. This paper proposes and discusses
-	three methods for performing molecular dynamics simulations under
-	conditions of constant temperature and/or pressure, rather than constant
-	energy and volume. For these three methods, it is shown that time
-	averages of properties of the simulated fluid are equal to averages
-	over the isoenthalpic-isobaric, canonical, and isothermal-isobaric
-	ensembles. Each method is a way of describing the dynamics of a certain
-	number of particles in a volume element of a fluid while taking into
-	account the influence of surrounding particles in changing the energy
-	and/or density of the simulated volume element. The influence of
-	the surroundings is taken into account without introducing unwanted
-	surface effects. Examples of situations where these methods may be
-	useful are discussed.},
-  address = {{CIRCULATION FULFILLMENT DIV, 500 SUNNYSIDE BLVD, WOODBURY, NY 11797-2999}},
-  affiliation = {{ANDERSEN, HC (Reprint Author), STANFORD UNIV,DEPT CHEM,STANFORD,CA
-	94305.}},
-  doc-delivery-number = {{JK068}},
   issn = {{0021-9606}},
-  journal-iso = {{J. Chem. Phys.}},
   language = {{English}},
-  number-of-cited-references = {{29}},
   owner = {floh},
-  publisher = {{AMER INST PHYSICS}},
-  subject-category = {{Physics, Atomic, Molecular \& Chemical}},
-  times-cited = {{2085}},
   timestamp = {2011.03.29},
-  type = {{Article}},
   unique-id = {{ISI:A1980JK06800026}}
 }
 
@@ -76,7 +45,6 @@
   year = {2002},
   volume = {354},
   pages = {324--330},
-  file = {arnold02b.pdf:arnold02b.pdf:PDF},
   owner = {olenz},
   timestamp = {2007.06.13}
 }
@@ -101,35 +69,11 @@
   pages = {094107},
   number = {9},
   eid = {094107},
-  abstract = {We introduce a regularization procedure to define electrostatic energies
-	and forces in a slab system of thickness h that is periodic in two
-	dimensions and carries a net charge. The regularization corresponds
-	to a neutralization of the system by two charged walls and can be
-	viewed as the extension to the two-dimensional (2D)+h geometry of
-	the neutralization by a homogeneous background in the standard three-dimensional
-	Ewald method. The energies and forces can be computed efficiently
-	by using advanced methods for systems with 2D periodicity, such as
-	MMM2D or P3M-ELC, or by introducing a simple background-charge correction
-	to the Yeh???Berkowitz approach of slab systems. The results are
-	checked against direct lattice sum calculations on simple systems.
-	We show, in particular, that the Madelung energy of a 2D square charge
-	lattice in a uniform compensating background is correctly reproduced
-	to high accuracy. A molecular dynamics simulation of a sodium ion
-	close to an air-water interface is performed to demonstrate that
-	the method does indeed provide consistent long-range electrostatics.
-	The mean force on the ion reduces at large distances to the image-charge
-	interaction predicted by macroscopic electrostatics. This result
-	is used to determine precisely the position of the macroscopic dielectric
-	interface with respect to the true molecular surface},
   doi = {10.1063/1.3216473},
-  file = {:/home/icpwiki/bib/ballenegger09a.pdf:PDF;ballenegger09a.pdf:ballenegger09a.pdf:PDF},
-  keywords = {boundary-value problems; electrostatics; lattice energy; molecular
-	dynamics method},
   numpages = {10},
   owner = {jcerda},
   publisher = {AIP},
   timestamp = {2009.11.17},
-  url = {http://link.aip.org/link/?JCP/131/094107/1}
 }
 
 @article{beenakker86a,
@@ -140,7 +84,6 @@
    volume = {85},
    number = {3}, 
    pages = {1581-1582},
-   file = {beenakker86a.pdf:beenakker86a.pdf:PDF},
    url = {http://scitation.aip.org/content/aip/journal/jcp/85/3/10.1063/1.451199},
    doi = {10.1063/1.451199}
 }
@@ -197,7 +140,6 @@
   volume = {129},
   pages = {234104},
   eprint = {cond-mat/????},
-  file = {cerda08a.pdf:cerda08a.pdf:PDF},
   owner = {jcerda},
   timestamp = {2009.01.09}
 }
@@ -319,7 +261,6 @@ pages = {471--487},
   booktitle={Lattice Boltzmann Simulations of Soft Matter Systems},
   author = {D{\"u}nweg, Burkhard and Ladd, Anthony J.C.},
   doi = {10.1007/12_2008_4},
-  keywords = {Boundary conditions; Brownian motion; Chapman--Enskog; Colloidal dispersions; Fluctuation--dissipation theorem; Force coupling; Hydrodynamic interactions; Hydrodynamic screening; Lattice Boltzmann; Polymer solutions; Soft matter},
   language = {English},
   pages = {1--78},
   publisher = {Springer Berlin Heidelberg},
@@ -366,7 +307,6 @@ pages = {471--487},
   year = {submitted},
   editor = {Michael Griebel and Christian Rieger and Marc Alexander Schweitzer},
   series = {Lecture Notes in Computational Science and Engineering},
-  address = {Berlin, Germany}
 }
 
 @ARTICLE{ewald21,
@@ -416,14 +356,6 @@ pages = {1305--1320}
   volume = {33},
   pages = {3628--31},
   number = {5},
-  abstract = {We describe an efficient and general algorithm for simulating polymers,
-	which can be used for single, large chains as well as many-chain
-	systems. The method is tested for linear and cyclic chains of 50
-	to 200 monomers. We have confirmed two theoretical results which
-	have not been observed numerically or experimentally, namely, the
-	anomalous behaviour of $S(q)$ for rings and the $t^{0.54}$ power
-	law for the motion of a monomer in a self avoiding chain undergoing
-	Rouse relaxation.},
   owner = {olenz},
   timestamp = {2007.06.13}
 }
@@ -456,16 +388,6 @@ pages = {1305--1320}
   year = {1991},
   volume = {268},
   pages = {247 - 252},
-  abstract = {A hamiltonian-guided Monte Carlo algorithm for simulations of lattice
-	field theories is presented. It is a generalization of the Hybrid
-	Monte Carlo algorithm allowing the trajectory length to be shrunk
-	to the step-size without losing on the speed of configuration decorrelation.
-	Without the Monte Carlo step, this limit of the generalized algorithm
-	reduces to the second-order Langevin equation. The latter is shown
-	in a gaussian model and in compact QED to be faster than the Hybrid
-	algorithm. The performance of the two algorithms with the Monte Carlo
-	step, HMC and L2MC, turned out to be comparable in compact QED. It
-	is pointed out that L2MC is safer from rounding errors.},
   owner = {sela},
   timestamp = {2012.03.18}
 }
@@ -533,12 +455,8 @@ pages = {1305--1320}
   volume = {182},
   pages = {33 - 35},
   number = {1},
-  note = {<ce:title>Computer Physics Communications Special Edition for Conference
-	on Computational Physics Kaohsiung, Taiwan, Dec 15-19, 2009</ce:title>},
   doi = {10.1016/j.cpc.2010.08.014},
   issn = {0010-4655},
-  keywords = {Dielectric boundary force},
-  url = {http://www.sciencedirect.com/science/article/pii/S001046551000305X}
 }
 
 @ARTICLE{kolafa92,
@@ -549,34 +467,21 @@ pages = {1305--1320}
   volume = {9},
   pages = {351-368},
   number = {5},
-  abstract = {Closed formulae for both real and reciprocal space parts of cutoff
-	errors in the Ewald summation method in cubic periodic boundary conditions
-	are derived. Such estimates are useful in tuning parameters in molecular
-	simulations. Errors in both the electrostatic energy and forces are
-	considered. The estimates apply to a disordered configuration of
-	point charges and, with some limitations, also to point-charge molecular
-	models. The accuracy of our estimates is tested and confirmed using
-	simulated configurations of two systems (molten salt and diethylether)
-	under a variety of conditions.},
   owner = {RDLimbacHJ},
   timestamp = {2007.08.29}
 }
 
-..
-    @ARTICLE{kolb99a,
-      author = {A. Kolb and B. D{\"u}nweg},
-      title = {Optimized constant pressure stochastic dynamics},
-      journal = {J. Chem. Phys.},
-      year = {1999},
-      volume = {111},
-      pages = {4453--59},
-      number = {10},
-      abstract = {The reason for treating the Gaussian thermal fluctuation by a mean-value
-        distribution},
-      file = {kolb99a.pdf:kolb99a.pdf:PDF},
-      owner = {dommert},
-      timestamp = {2009.03.16}
-    }
+@ARTICLE{kolb99a,
+  author = {A. Kolb and B. D{\"u}nweg},
+  title = {Optimized constant pressure stochastic dynamics},
+  journal = {J. Chem. Phys.},
+  year = {1999},
+  volume = {111},
+  pages = {4453--59},
+  number = {10},
+  owner = {dommert},
+  timestamp = {2009.03.16}
+}
 
 @ARTICLE{kremer90a,
   author = {K. Kremer and G. S. Grest},
@@ -652,25 +557,6 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   volume = {107},
   pages = {8041--8055},
   number = {32},
-  abstract = {Using molecular dynamics simulations in which we take counterions
-	explicitly into account, we study the behavior of a dilute solution
-	of strongly charged polyelectrolytes in poor solvents. We focus on
-	the chain conformational properties under conditions in which chain-chain
-	interactions can be neglected but the counterion concentration remains
-	finite. We investigate the conformations with regard to the parameters
-	chain length, Coulomb interaction strength, and solvent quality and
-	explore in which regime the competition between short-range hydrophobic
-	interactions and long-range Coulomb interactions leads to pearl-necklace-like
-	structures. We observe that large number and size fluctuations in
-	the pearls and strings lead to only small direct signatures in experimental
-	observables like the single-chain form factor. Furthermore, we do
-	not observe the predicted first-order collapse of the necklace into
-	a globular structure when counterion condensation sets in. We will
-	also show that the pearl-necklace regime is rather small for strongly
-	charged polyelectrolytes at finite densities. Even small changes
-	in the charge fraction of the chain can have a large impact on the
-	conformation due to the delicate interplay between counterion distribution
-	and chain conformation.},
   owner = {olenz},
   timestamp = {2007.06.13}
 }
@@ -684,23 +570,6 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   pages = {4011-4021},
   number = {{24}},
   month = {{AUG 20}},
-  abstract = {{We present a PC-based multi-tau software correlator suitable for
-	processing dynamic light-scattering data. The correlator is based
-	on a simple algorithm that was developed with the graphical programming
-	language LabVIEW, according to which the incoming data are processed
-	on line without any storage on the hard disk. By use of a standard
-	photon-counting unit, a National Instruments Model 6602-PCI timer-counter,
-	and a 550-MHz Pentium III personal computer, correlation functions
-	can be worked out in full real-time overtime scales of similar to5
-	mus and in batch processing down to time scales of similar to 300
-	ns. The latter limit is imposed by the speed of data transfer between
-	the counter and the PC's memory and thus is prone to be progressively
-	reduced with future technological development. Testing of the correlator
-	and evaluation of its performances were carried out by use of dilute
-	solutions of calibrated polystyrene spheres. Our results indicate
-	that the correlation functions are determined with such precision
-	that the corresponding particle diameters can be recovered to within
-	an accuracy of a few percent rms. (C) 2001 Optical Society of America.}},
   doi = {{10.1364/AO.40.004011}},
   issn = {{0003-6935}},
   owner = {kosovan},
@@ -715,7 +584,6 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   year = {2005},
   address = {Mainz, Germany},
   month = dec,
-  file = {mann05d.pdf:mann05d.pdf:PDF},
   owner = {dommert},
   timestamp = {2009.03.16}
 }
@@ -786,17 +654,6 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   pages = {3999--4020},
   number = {38},
   month = sep,
-  abstract = {We derive and describe in detail a recently proposed method for obtaining
-	Coulomb interactions as the potential of mean force between charges
-	which are dynamically coupled to a local electromagnetic field. We
-	focus on the molecular dynamics version of the method and show that
-	it is intimately related to the Car-Parrinello approach, while being
-	equivalent to solving Maxwell's equations with a freely adjustable
-	speed of light. Unphysical self-energies arise as a result of the
-	lattice interpolation of charges, and are corrected by a subtraction
-	scheme based on the exact lattice Green function. The method can
-	be straightforwardly parallelized using standard domain decomposition.
-	Some preliminary benchmark results are presented.},
   owner = {dommert},
   timestamp = {2009.03.16}
 }
@@ -862,21 +719,6 @@ pages = {1483--1489}
   pages = {154103},
   number = {{15}},
   month = {{OCT 21}},
-  abstract = {{Time correlation functions yield profound information about the dynamics
-	of a physical system and hence are frequently calculated in computer
-	simulations. For systems whose dynamics span a wide range of time,
-	currently used methods require significant computer time and memory.
-	In this paper, we discuss the multiple-tau correlator method for
-	the efficient calculation of accurate time correlation functions
-	on the fly during computer simulations. The multiple-tau correlator
-	is efficacious in terms of computational requirements and can be
-	tuned to the desired level of accuracy. Further, we derive estimates
-	for the error arising from the use of the multiple-tau correlator
-	and extend it for use in the calculation of mean-square particle
-	displacements and dynamic structure factors. The method described
-	here, in hardware implementation, is routinely used in light scattering
-	experiments but has not yet found widespread use in computer simulations.
-	(C) 2010 American Institute of Physics. {[}doi:10.1063/1.3491098]}},
   article-number = {{154103}},
   doi = {{10.1063/1.3491098}},
   issn = {{0021-9606}},
@@ -923,26 +765,6 @@ pages = {1483--1489}
   unique-id = {{ISI:A1988N368800009}}
 }
 
-..
-    @ARTICLE{schmitz00a,
-      author = {Heiko Schmitz and Florian Muller-Plathe},
-      title = {Calculation of the lifetime of positronium in polymers via molecular
-        dynamics simulations},
-      journal = {J. Chem. Phys.},
-      year = {2000},
-      volume = {112},
-      pages = {1040-1045},
-      number = {2},
-      doi = {10.1063/1.480627},
-      file = {schmitz00a.pdf:schmitz00a.pdf:PDF},
-      keywords = {polymers; positronium; molecular dynamics method; digital simulation;
-        Monte Carlo methods; positron annihilation},
-      owner = {olenz},
-      publisher = {AIP},
-      timestamp = {2007.06.13},
-      url = {http://link.aip.org/link/?JCP/112/1040/1}
-    }
-
 @ARTICLE{sega13c,
  title = {Mesoscale structures at complex fluid–fluid interfaces: a novel lattice Boltzmann/molecular dynamics coupling},
  author = {M. Sega and   M. Sbragaglia  and   S. S. Kantorovich and    A. O. Ivanov},
@@ -950,16 +772,6 @@ pages = {1483--1489}
  year = {2013, in press},
  doi = {10.1039/C3SM51556G}
 }
-
-..
-    @article{shan93a,
-       author={  X. Shan  and  H. Chen },
-       title = {Lattice Boltzmann model for simulating flows with multiple phases and components},
-       journal={  Phys. Rev. E},
-       volume={47},
-       pages={1815},
-       year={1993}
-    }
 
 @ARTICLE{smiatek08a,
   author = {J. Smiatek and M. P. Allen and F. Schmidt},
@@ -1098,7 +910,6 @@ pages = {1483--1489}
   year = {2004},
   volume = {156},
   pages = {143--153},
-  file = {wolff04a.pdf:wolff04a.pdf:PDF},
   owner = {olenz},
   timestamp = {2007.06.14}
 }
@@ -1112,8 +923,6 @@ pages = {1483--1489}
   volume                   = {129},
   date-modified            = {2009-01-28 08:15:14 +0100},
   doi                      = {10.1063/1.3000389},
-  e-print                  = {0805.4783},
-  file = {cerda08d.pdf:cerda08d.pdf:PDF},
   owner                    = {jcerda},
   timestamp                = {2008.01.14}
 }

--- a/src/python/espressomd/accumulators.py
+++ b/src/python/espressomd/accumulators.py
@@ -90,144 +90,144 @@ class Correlator(ScriptInterfaceHelper):
 
     Parameters
     ----------
-    obs1, obs2 : Instances of :class:`espressomd.observables.Observable`.
-                 The observables A and B that are to be correlated. If `obs2`
-                 is omitted, autocorrelation of `obs1` is calculated by
-                 default.
+    obs1 : :class:`espressomd.observables.Observable`
+        The observable :math:`A` to be correlated with :math:`B` (``obs2``).
+        If ``obs2`` is omitted, autocorrelation of ``obs1`` is calculated by
+        default.
+
+    obs2 : :class:`espressomd.observables.Observable`, optional
+        The observable :math:`B` to be correlated with :math:`A` (``obs1``).
+
     corr_operation : :obj:`str`
-                     The operation that is performed on :math:`A(t)` and
-                     :math:`B(t+\\tau)` to obtain :math:`C(\\tau)`. The
-                     following operations are currently available:
+        The operation that is performed on :math:`A(t)` and
+        :math:`B(t+\\tau)` to obtain :math:`C(\\tau)`. The
+        following operations are currently available:
 
-                         * `scalar_product`: Scalar product of :math:`A` and
-                           :math:`B`, i.e., :math:`C=\sum\limits_{i} A_i B_i`
+        * `scalar_product`: Scalar product of :math:`A` and
+          :math:`B`, i.e., :math:`C=\\sum\\limits_{i} A_i B_i`
 
-                         * `componentwise_product`: Componentwise product of
-                           :math:`A` and :math:`B`, i.e., :math:`C_i = A_i B_i`
+        * `componentwise_product`: Componentwise product of
+          :math:`A` and :math:`B`, i.e., :math:`C_i = A_i B_i`
 
-                         * `square_distance_componentwise`: Each component of
-                           the correlation vector is the square of the difference
-                           between the corresponding components of the
-                           observables, i.E., :math:`C_i = (A_i-B_i)^2`. Example:
-                           when :math:`A` is `ParticlePositions`, it produces the
-                           mean square displacement (for each component
-                           separately).
+        * `square_distance_componentwise`: Each component of
+          the correlation vector is the square of the difference
+          between the corresponding components of the
+          observables, i.E., :math:`C_i = (A_i-B_i)^2`. Example:
+          when :math:`A` is `ParticlePositions`, it produces the
+          mean square displacement (for each component separately).
 
-                         * `tensor_product`: Tensor product of :math:`A` and
-                           :math:`B`, i.e., :math:`C_{i \\cdot l_B + j} = A_i B_j`
-                           with :math:`l_B` the length of :math:`B`.
+        * `tensor_product`: Tensor product of :math:`A` and
+          :math:`B`, i.e., :math:`C_{i \\cdot l_B + j} = A_i B_j`
+          with :math:`l_B` the length of :math:`B`.
 
-                         * `complex_conjugate_product`: assuming that the observables
-                           consist of a complex and real part
-                           :math:`A=(A_x+iA_y)`, and :math:`B=(B_x+iB_y)`, this
-                           operation computes the result :math:`C=(C_x+iC_y)`,
-                           as:
+        * `complex_conjugate_product`: assuming that the observables
+          consist of a complex and real part
+          :math:`A=(A_x+iA_y)`, and :math:`B=(B_x+iB_y)`, this
+          operation computes the result :math:`C=(C_x+iC_y)`, as:
 
-                           .. math::
+          .. math::
 
-                                C_x = A_xB_x + A_yB_y\\\\
-                                C_y = A_yB_x - A_xB_y
+                C_x = A_xB_x + A_yB_y\\\\
+                C_y = A_yB_x - A_xB_y
 
+        * `fcs_acf`: Fluorescence Correlation Spectroscopy (FCS)
+          autocorrelation function, i.e.,
 
-                         * `fcs_acf`:
+          .. math::
 
-                           Fluorescence Correlation Spectroscopy (FCS)
-                           autocorrelation function, i.e.,
+               G_i(\\tau) =
+               \\frac{1}{N} \\left< \\exp \\left(
+               - \\frac{\\Delta x_i^2(\\tau)}{w_x^2}
+               - \\frac{\\Delta y_i^2(\\tau)}{w_y^2}
+               - \\frac{\\Delta z_i^2(\\tau)}{w_z^2}
+               \\right) \\right>
 
-                           .. math::
+          where
 
-                               G_i(\\tau) =
-                               \\frac{1}{N} \\left< \\exp \\left(
-                               - \\frac{\\Delta x_i^2(\\tau)}{w_x^2}
-                               - \\frac{\\Delta y_i^2(\\tau)}{w_y^2}
-                               - \\frac{\\Delta z_i^2(\\tau)}{w_z^2}
-                               \\right) \\right>
+          .. math::
 
-                           where
+              \\Delta x_i^2(\\tau) = \\left( x_i(0) - x_i(\\tau) \\right)^2
 
-                           .. math::
+          is the square displacement of particle
+          :math:`i` in the :math:`x` direction, and :math:`w_x`
+          is the beam waist of the intensity profile of the
+          exciting laser beam,
 
-                               \\Delta x_i^2(\\tau) = \\left( x_i(0) - x_i(\\tau) \\right)^2
+          .. math::
 
-                           is the square displacement of particle
-                           :math:`i` in the :math:`x` direction, and :math:`w_x`
-                           is the beam waist of the intensity profile of the
-                           exciting laser beam,
+              W(x,y,z) = I_0 \\exp
+              \\left( - \\frac{2x^2}{w_x^2} - \\frac{2y^2}{w_y^2} -
+              \\frac{2z^2}{w_z^2} \\right).
 
-                           .. math::
+          The values of :math:`w_x`, :math:`w_y`, and :math:`w_z`
+          are passed to the correlator as `args`
 
-                               W(x,y,z) = I_0 \\exp
-                               \\left( - \\frac{2x^2}{w_x^2} - \\frac{2y^2}{w_y^2} -
-                               \\frac{2z^2}{w_z^2} \\right).
-
-                           The values of :math:`w_x`, :math:`w_y`, and :math:`w_z`
-                           are passed to the correlator as `args`
-
-                           The above equations are a
-                           generalization of the formula presented by Hoefling
-                           et. al. :cite:`hofling11a`. For more information, see
-                           references therein. Per each 3 dimensions of the
-                           observable, one dimension of the correlation output
-                           is produced. If `fcs_acf` is used with other
-                           observables than `ParticlePositions`, the physical
-                           meaning of the result is unclear.
+          The above equations are a
+          generalization of the formula presented by Hoefling
+          et. al. :cite:`hofling11a`. For more information, see
+          references therein. Per each 3 dimensions of the
+          observable, one dimension of the correlation output
+          is produced. If `fcs_acf` is used with other
+          observables than `ParticlePositions`, the physical
+          meaning of the result is unclear.
 
     delta_N : :obj:`int`
         Number of timesteps between subsequent samples for the auto update mechanism.
 
     tau_max : :obj:`float`
-              This is the maximum value of :math:`\\tau` for which the
-              correlation should be computed.  Warning: Unless you are using
-              the multiple tau correlator, choosing `tau_max` of more than
-              100 `dt` will result in a huge computational overhead.  In a
-              multiple tau correlator with reasonable parameters, `tau_max`
-              can span the entire simulation without too much additional cpu
-              time.
+        This is the maximum value of :math:`\\tau` for which the
+        correlation should be computed.  Warning: Unless you are using
+        the multiple tau correlator, choosing `tau_max` of more than
+        100 `dt` will result in a huge computational overhead.  In a
+        multiple tau correlator with reasonable parameters, `tau_max`
+        can span the entire simulation without too much additional cpu time.
 
     tau_lin : :obj:`int`
-              The number of data-points for which the results are linearly spaced
-              in `tau`. This is a parameter of the multiple tau correlator. If you
-              want to use it, make sure that you know how it works. By default, it
-              is set equal to `tau_max` which results in the trivial linear
-              correlator. By setting `tau_lin` < `tau_max` the multiple
-              tau correlator is switched on. In many cases, `tau_lin=16` is a
-              good choice but this may strongly depend on the observables you are
-              correlating. For more information, we recommend to read
-              Ref. :cite:`ramirez10a` or to perform your own tests.
+        The number of data-points for which the results are linearly spaced
+        in `tau`. This is a parameter of the multiple tau correlator. If you
+        want to use it, make sure that you know how it works. By default, it
+        is set equal to `tau_max` which results in the trivial linear
+        correlator. By setting `tau_lin` < `tau_max` the multiple
+        tau correlator is switched on. In many cases, `tau_lin=16` is a
+        good choice but this may strongly depend on the observables you are
+        correlating. For more information, we recommend to read
+        ref. :cite:`ramirez10a` or to perform your own tests.
 
-    compress1 and compress2 : :obj:`str`
-                              These functions are used to compress the data when
-                              going to the next level of the multiple tau
-                              correlator. This is done by producing one value out of two.
-                              The following compression functions are available:
+    compress1 : :obj:`str`
+        These functions are used to compress the data when
+        going to the next level of the multiple tau
+        correlator. This is done by producing one value out of two.
+        The following compression functions are available:
 
-                                * `discard2`: (default value) discard the second value from the time series, use the first value as the result
+        * `discard2`: (default value) discard the second value from the time series, use the first value as the result
 
-                                * `discard1`: discard the first value from the time series, use the second value as the result
+        * `discard1`: discard the first value from the time series, use the second value as the result
 
-                                * `linear`: make a linear combination (average) of the two values
+        * `linear`: make a linear combination (average) of the two values
 
-                              If only `compress1` is specified, then
-                              the same compression function is used for both
-                              observables. If both `compress1` and `compress2` are specified,
-                              then `compress1` is used for `obs1` and `compress2` for `obs2`.
+        If only `compress1` is specified, then
+        the same compression function is used for both
+        observables. If both `compress1` and `compress2` are specified,
+        then `compress1` is used for `obs1` and `compress2` for `obs2`.
 
-                              Both `discard1` and `discard2` are safe for all
-                              observables but produce poor statistics in the
-                              tail. For some observables, `linear` compression
-                              can be used which makes an average of two
-                              neighboring values but produces systematic
-                              errors.  Depending on the observable, the
-                              systematic error using the `linear` compression
-                              can be anything between harmless and disastrous.
-                              For more information, we recommend to read Ref.
-                              :cite:`ramirez10a` or to perform your own tests.
+        Both `discard1` and `discard2` are safe for all
+        observables but produce poor statistics in the
+        tail. For some observables, `linear` compression
+        can be used which makes an average of two
+        neighboring values but produces systematic
+        errors.  Depending on the observable, the
+        systematic error using the `linear` compression
+        can be anything between harmless and disastrous.
+        For more information, we recommend to read ref.
+        :cite:`ramirez10a` or to perform your own tests.
+
+    compress2 : :obj:`str`, optional
+        See ``compress1``.
 
     args: :obj:`float` of length 3
-                     Three floats which are passed as arguments to the
-                     correlation function.  Currently it is only used by
-                     fcs_acf. Other correlation operations will ignore these
-                     values.
+        Three floats which are passed as arguments to the correlation
+        function.  Currently it is only used by `fcs_acf`.
+        Other correlation operations will ignore these values.
     """
 
     _so_name = "Accumulators::Correlator"

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -371,7 +371,10 @@ class Analysis(object):
         return buffer
 
     def pressure(self, v_comp=False):
-        """Calculates the instantaneous pressure (in parallel). This is only sensible in an isotropic system which is homogeneous (on average)! Do not use this in an anisotropic or inhomogeneous system. In order to obtain the pressure the ensemble average needs to be calculated.
+        """Calculates the instantaneous pressure (in parallel). This is only
+        sensible in an isotropic system which is homogeneous (on average)! Do
+        not use this in an anisotropic or inhomogeneous system. In order to
+        obtain the pressure the ensemble average needs to be calculated.
 
         Returns
         -------
@@ -385,7 +388,9 @@ class Analysis(object):
         * "nonbonded", type_i, type_j, nonbonded pressure which arises from the interactions between type_i and type_j
         * "nonbonded_intra", type_i, type_j, nonbonded pressure between short ranged forces between type i and j and with the same mol_id
         * "nonbonded_inter" type_i, type_j", nonbonded pressure between short ranged forces between type i and j and different mol_ids
-        * "coulomb", Coulomb pressure, how it is calculated depends on the method. It is equivalent to 1/3 of the trace of the coulomb stress tensor. For how the stress tensor is calculated see below. The averaged value in an isotropic NVT simulation is equivalent to the average of :math:`E^{coulomb}/(3V)`, see :cite:`brown1995general`.
+        * "coulomb", Coulomb pressure, how it is calculated depends on the method. It is equivalent to 1/3 of the trace of the coulomb stress tensor.
+          For how the stress tensor is calculated see below. The averaged value in an isotropic NVT simulation is equivalent to the average of
+          :math:`E^{coulomb}/(3V)`, see :cite:`brown95a`.
         * "dipolar", TODO
         * "virtual_sites", Stress contribution due to virtual sites
 


### PR DESCRIPTION
Description of changes:
- added support to newer versions of Sphinx (closes #2270)
   - upgradeed `conf.py` to v1.8+
   - fixed CSS rendering issue on v2.0.1
   - tested on v1.7.8/python2 and v2.0.1/python3
- removed unused features of the `conf.py` script
- fixed a Python class whose docstring was truncated by Sphinx
- merged our `icp.bib` into `zrefs.bib` to fix the outdated/broken/missing references
