### PR TITLE
polymer.pyx: Get rid of python DeprecationWarning 

### DIFF
--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -142,7 +142,7 @@ def positions(**kwargs):
     validate_params(params, default_params)
 
     cdef vector[Vector3d] start_positions
-    if (params["start_positions"] != []):
+    if (params["start_positions"].size > 0):
         for i in range(len(params["start_positions"])):
             start_positions.push_back(
                 make_Vector3d(params["start_positions"][i]))


### PR DESCRIPTION
Gets rid of the following deprecation warning when calling `polymer.position()`:
```
DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
```
