### PR TITLE
Fix bytestring issues in Python3

### DIFF
--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -23,7 +23,7 @@ include "myconfig.pxi"
 from espressomd.system cimport *
 cimport numpy as np
 from espressomd.utils cimport *
-from espressomd.utils import is_valid_type
+from espressomd.utils import is_valid_type, to_str
 
 cdef extern from "SystemInterface.hpp":
     cdef cppclass SystemInterface:
@@ -135,7 +135,7 @@ IF ELECTROSTATICS:
             response = p3m_adaptive_tune(& log)
             handle_errors("Error in p3m_adaptive_tune")
             if log.strip():
-                print(log)
+                print(to_str(log))
             return response
 
         cdef inline python_p3m_set_params(p_r_cut, p_mesh, p_cao, p_alpha, p_accuracy):
@@ -224,9 +224,9 @@ IF ELECTROSTATICS:
         if MMM1D_sanity_checks() == 1:
             handle_errors(
                 "MMM1D Sanity check failed: wrong periodicity or wrong cellsystem, PRTFM")
-        resp = mmm1d_tune( & log)
+        resp = mmm1d_tune(& log)
         if resp:
-            print(log)
+            print(to_str(log))
         return resp
 
 IF ELECTROSTATICS:

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -28,7 +28,7 @@ IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
     from . cimport scafacos
 from espressomd.utils cimport handle_errors
-from espressomd.utils import is_valid_type
+from espressomd.utils import is_valid_type, to_str
 from . cimport checks
 from .c_analyze cimport partCfg, PartCfg
 from .particle_data cimport particle
@@ -66,7 +66,7 @@ IF ELECTROSTATICS == 1:
 
         def _deactivate_method(self):
             deactivate_method()
-            handle_errors("Coulom method deactivation")
+            handle_errors("Coulomb method deactivation")
 
         def tune(self, **tune_params_subset):
             if tune_params_subset is not None:

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -26,7 +26,7 @@ IF SCAFACOS == 1:
     from . cimport scafacos
 
 from espressomd.utils cimport handle_errors
-from espressomd.utils import is_valid_type
+from espressomd.utils import is_valid_type, to_str
 
 IF DIPOLES == 1:
     cdef class MagnetostaticInteraction(Actor):
@@ -173,7 +173,7 @@ IF DP3M == 1:
             if resp:
                 raise Exception(
                     "failed to tune dipolar P3M parameters to required accuracy")
-            print(log)
+            print(to_str(log))
             self._params.update(self._get_params_from_es_core())
 
         def _activate_method(self):

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -61,7 +61,7 @@ cpdef check_type_or_throw_except(x, n, t, msg):
     checking is done on the elements, and all elements are checked. Integers
     are accepted when a float was asked for.
 
-     """
+    """
     # Check whether x is an array/list/tuple or a single value
     if n > 1:
         if hasattr(x, "__getitem__"):
@@ -254,13 +254,15 @@ cpdef handle_errors(msg):
 
     """
     errors = mpi_gather_runtime_errors()
+    # print all errors and warnings
     for err in errors:
         err.print()
 
+    # raise an exception with the first error
     for err in errors:
-    # Cast because cython does not support typed enums completely
-        if < int > err.level() == <int > ERROR:
-            raise Exception("{}: {}".format(msg, err.format()))
+        # Cast because cython does not support typed enums completely
+        if < int > err.level() == < int > ERROR:
+            raise Exception("{}: {}".format(msg, to_str(err.format())))
 
 
 def nesting_level(obj):


### PR DESCRIPTION
Fixes #2709

Description of changes:
 - use `to_str()` whenever the core returns a string in P3M, DipolarP3M, MMM1D
- use `to_str()` when formatting Python exception messages based on error messages from the core
