### PR TITLE
Clarify which dipolar methods are MPI-enabled

### DIFF
--- a/doc/sphinx/magnetostatics.rst
+++ b/doc/sphinx/magnetostatics.rst
@@ -132,9 +132,9 @@ To use the methods, create an instance of either :class:`~espressomd.magnetostat
 
 For testing purposes, a variant of the dipolar direct sum is available which adds periodic copies to the system in periodic directions (:class:`~espressomd.magnetostatics.DipolarDirectSumWithReplicaCpu`).
 
-The dipolar direct sum methods do not support MPI parallelization. They
-are not intended to do simulations, but rather to check the results
-you get from more efficient methods like P3M.
+The dipolar direct sum methods are very slow, and the CPU-based implementations
+do not support MPI parallelization. They are not intended to do simulations, but
+rather to check the results you get from more efficient methods like P3M.
 
 
 

--- a/doc/sphinx/magnetostatics.rst
+++ b/doc/sphinx/magnetostatics.rst
@@ -132,9 +132,9 @@ To use the methods, create an instance of either :class:`espressomd.magnetostati
 
 For testing purposes, a variant of the dipolar direct sum is available which adds periodic copies to the system in periodic directions (:class:`espressomd.magnetostatics.DipolarDirectSumWithReplicaCpu`).
 
-As it is very slow, this method is not intended to do simulations, but
-rather to check the results you get from more efficient methods like
-P3M.
+The dipolar direct sum methods do not support MPI parallelization. They
+are not intended to do simulations, but rather to check the results
+you get from more efficient methods like P3M.
 
 
 

--- a/doc/sphinx/magnetostatics.rst
+++ b/doc/sphinx/magnetostatics.rst
@@ -130,12 +130,15 @@ To use the methods, create an instance of either :class:`~espressomd.magnetostat
   system.actors.add(dds)
 
 
-For testing purposes, a variant of the dipolar direct sum is available which adds periodic copies to the system in periodic directions (:class:`~espressomd.magnetostatics.DipolarDirectSumWithReplicaCpu`).
-
-The dipolar direct sum methods are very slow, and the CPU-based implementations
-do not support MPI parallelization. They are not intended to do simulations, but
+For testing purposes, a variant of the dipolar direct sum is available which
+adds periodic copies to the system in periodic directions:
+:class:`~espressomd.magnetostatics.DipolarDirectSumWithReplicaCpu`.
+As it is very slow, this method is not intended to do simulations, but
 rather to check the results you get from more efficient methods like P3M.
 
+:class:`~espressomd.magnetostatics.DipolarDirectSumCpu` and
+:class:`~espressomd.magnetostatics.DipolarDirectSumWithReplicaCpu`
+do not support MPI parallelization.
 
 
 

--- a/doc/sphinx/magnetostatics.rst
+++ b/doc/sphinx/magnetostatics.rst
@@ -44,7 +44,7 @@ completely unphysical simulations.
 Dipolar P3M
 ~~~~~~~~~~~
 This is the dipolar version of the P3M algorithm, described in :cite:`cerda08d`.
-It is interfaced via :class:`espressomd.magnetostatics.DipolarP3M`.
+It is interfaced via :class:`~espressomd.magnetostatics.DipolarP3M`.
 
 Make sure that you know the relevance of the P3M parameters before using
 P3M! If you are not sure, read the following references
@@ -94,7 +94,7 @@ The method is used as follows::
 
 
 
-.. _Dipolar direct sum on gpu:
+.. _Dipolar direct sum:
 
 Dipolar direct sum
 ------------------
@@ -111,11 +111,11 @@ Due to the long-range nature of dipolar interactions, Direct summation with mini
 
 Two methods are available:
 
-* :class:`espressomd.magnetostatics.DipolarDirectSumCpu`
+* :class:`~espressomd.magnetostatics.DipolarDirectSumCpu`
   performs the calculation in double precision on the Cpu.
 
 
-* :class:`espressomd.magnetostatics.DipolarDirectSumGpu`
+* :class:`~espressomd.magnetostatics.DipolarDirectSumGpu`
   performs the calculations in single precision on a Cuda-capable graphics card.
   The implementation is optimized for large systems of several thousand
   particles. It makes use of one thread per particle. When there are fewer
@@ -123,14 +123,14 @@ Two methods are available:
   the rest of the gpu remains idle. Hence, the method will perform poorly
   for small systems.
 
-To use the methods, create an instance of either :class:`espressomd.magnetostatics.DipolarDirectSumCpu` or :class:`espressomd.magnetostatics.DipolarDirectSumGpu` and add it to the system's list of active actors. The only required parameter is the Prefactor :eq:`dipolar_prefactor`::
+To use the methods, create an instance of either :class:`~espressomd.magnetostatics.DipolarDirectSumCpu` or :class:`~espressomd.magnetostatics.DipolarDirectSumGpu` and add it to the system's list of active actors. The only required parameter is the Prefactor :eq:`dipolar_prefactor`::
 
   from espressomd.magnetostatics import DipolarDirectSumGpu
   dds = DipolarDirectSumGpu(bjerrum_length=1)
   system.actors.add(dds)
 
 
-For testing purposes, a variant of the dipolar direct sum is available which adds periodic copies to the system in periodic directions (:class:`espressomd.magnetostatics.DipolarDirectSumWithReplicaCpu`).
+For testing purposes, a variant of the dipolar direct sum is available which adds periodic copies to the system in periodic directions (:class:`~espressomd.magnetostatics.DipolarDirectSumWithReplicaCpu`).
 
 The dipolar direct sum methods do not support MPI parallelization. They
 are not intended to do simulations, but rather to check the results
@@ -154,7 +154,7 @@ an additive distance respectively. For the detailed description of the
 Barnes-Hut method application to the dipole-dipole interactions, please
 refer to :cite:`Polyakov2013`.
 
-To use the method, create an instance of :class:`espressomd.magnetostatics.DipolarBarnesHutGpu` and add it to the system's list of active actors::
+To use the method, create an instance of :class:`~espressomd.magnetostatics.DipolarBarnesHutGpu` and add it to the system's list of active actors::
 
   from espressomd.magnetostatics import DipolarBarnesHutGpu
   bh = DipolarBarnesHutGpu(prefactor=pf_dds_gpu, epssq=200.0, itolsq=8.0)
@@ -171,7 +171,7 @@ library for dipoles, if the methods support dipolar calculations. The feature
 feature. Dipolar calculations are only included in the ``dipolar`` branch of
 the Scafacos code.
 
-To use SCAFACOS, create an instance of :class:`espressomd.magnetostatics.Scafacos`
+To use SCAFACOS, create an instance of :class:`~espressomd.magnetostatics.Scafacos`
 and add it to the list of active actors. Three parameters have to be specified:
 
 * ``method_name``: name of the SCAFACOS method being used.

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -32,7 +32,7 @@
 regex_sphinx_broken_link='<code class=\"xref py py-[a-z]+ docutils literal notranslate\"><span class=\"pre\">(?!(int|float|bool|str|object|list|tuple|dict)<)[^<>]+?</span></code>(?!</a>)'
 
 # list of espresso modules not compiled in CI (visualization, scafacos)
-regex_ignored_es_features_ci='(visualization|[a-z]+\.[sS]cafacos)'
+regex_ignored_es_features_ci='^(espressomd\.)?(visualization|([a-z]+\.)?[sS]cafacos)'
 
 if [ ! -f doc/sphinx/html/index.html ]; then
     echo "Please run Sphinx first."
@@ -57,7 +57,7 @@ if [ $? = "0" ]; then
         # skip espresso modules not compiled in CI (visualization, scafacos)
         is_es_feature_skipped="false"
         if [ "${CI}" != "" ]; then
-            grep -Pq "^espressomd\.${regex_ignored_es_features_ci}" <<< "${reference}"
+            grep -Pq "${regex_ignored_es_features_ci}" <<< "${reference}"
             [ "$?" = "0" ] && is_es_feature_skipped="true"
         fi
         # private objects are not documented and cannot be linked
@@ -77,10 +77,21 @@ if [ $? = "0" ]; then
         filepath_rst=$(echo "${filepath_html}" | sed 's|/html/|/|')
         filepath_rst="${filepath_rst%.html}.rst"
         if [ -f "${filepath_rst}" ]; then
+            # look for the reference
             grep -q -F "\`${reference}\`" "${filepath_rst}"
             if [ $? = "0" ]; then
                 grep --color -FnHo -m 1 "\`${reference}\`" "${filepath_rst}" | tee -a doc_warnings.log~
                 continue
+            fi
+            # if not found, check if reference was shortened, for example
+            # :class:`~espressomd.system.System` outputs a link named `System`
+            grep -q -P "^[a-zA-Z0-9_]+$" <<< "${reference}"
+            if [ $? = "0" ]; then
+                grep -q -P "\`~.+${reference}\`" "${filepath_rst}"
+                if [ $? = "0" ]; then
+                    grep --color -PnHo -m 1 "\`~.+${reference}\`" "${filepath_rst}" | tee -a doc_warnings.log~
+                    continue
+                fi
             fi
         fi
         # if not in a .rst file, show the .html file without line number
@@ -92,7 +103,7 @@ if [ $? = "0" ]; then
     cat doc_warnings.log~ >> doc_warnings.log
     rm doc_warnings.log~
     # warn user about ignored features in CI
-    grep -Pq "espressomd\.${regex_ignored_es_features_ci}" doc_warnings.log
+    grep -Pq "${regex_ignored_es_features_ci}" doc_warnings.log
     if [ "$?" = "0" ] && [ "${CI}" = "" ]; then
         echo "(Note that features visualization and Scafacos are ignored in CI)"
     fi

--- a/src/core/electrostatics_magnetostatics/dipole.cpp
+++ b/src/core/electrostatics_magnetostatics/dipole.cpp
@@ -88,10 +88,9 @@ void integrate_sanity_check() {
   case DIPOLAR_P3M:
     break;
 #endif /* DP3M */
-  default: {
+  default:
     runtimeErrorMsg()
         << "NpT does not work with your dipolar method, please use P3M.";
-  }
   }
 }
 
@@ -340,7 +339,7 @@ void bcast_params(const boost::mpi::communicator &comm) {
 
 int set_Dprefactor(double prefactor) {
   if (prefactor < 0.0) {
-    runtimeErrorMsg() << "Dipolar prefactor has to be >=0";
+    runtimeErrorMsg() << "Dipolar prefactor has to be >= 0";
     return ES_ERROR;
   }
 

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -389,7 +389,8 @@ double magnetic_dipolar_direct_sum_calculations(int force_flag,
 
 int dawaanr_set_params() {
   if (n_nodes > 1) {
-    runtimeErrorMsg() << "MPI parallelization not supported by DAWAANR.";
+    runtimeErrorMsg() << "MPI parallelization not supported by "
+                      << "DipolarDirectSumCpu.";
     return ES_ERROR;
   }
   if (dipole.method != DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA) {
@@ -403,7 +404,8 @@ int dawaanr_set_params() {
 
 int mdds_set_params(int n_cut) {
   if (n_nodes > 1) {
-    runtimeErrorMsg() << "MPI parallelization not supported by MDDS.";
+    runtimeErrorMsg() << "MPI parallelization not supported by "
+                      << "DipolarDirectSumWithReplicaCpu.";
     return ES_ERROR;
   }
 

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -135,12 +135,12 @@ double dawaanr_calculations(int force_flag, int energy_flag) {
   double u;
 
   if (n_nodes != 1) {
-    fprintf(stderr, "error:  DAWAANR is just for one cpu .... \n");
+    fprintf(stderr, "error: DAWAANR is just for one cpu...\n");
     errexit();
   }
   if (!(force_flag) && !(energy_flag)) {
-    fprintf(stderr, " I don't know why you call dawaanr_caclulations with all "
-                    "flags zero \n");
+    fprintf(stderr, "I don't know why you call dawaanr_calculations() "
+                    "with all flags zero.\n");
     return 0;
   }
 
@@ -210,12 +210,12 @@ double magnetic_dipolar_direct_sum_calculations(int force_flag,
   double u;
 
   if (n_nodes != 1) {
-    fprintf(stderr, "error: magnetic Direct Sum is just for one cpu .... \n");
+    fprintf(stderr, "error: magnetic Direct Sum is just for one cpu...\n");
     errexit();
   }
   if (!(force_flag) && !(energy_flag)) {
-    fprintf(stderr, " I don't know why you call dawaanr_caclulations with all "
-                    "flags zero \n");
+    fprintf(stderr, "I don't know why you call magnetic_dipolar_direct_sum_"
+                    "calculations() with all flags zero\n");
     return 0;
   }
 
@@ -389,6 +389,7 @@ double magnetic_dipolar_direct_sum_calculations(int force_flag,
 
 int dawaanr_set_params() {
   if (n_nodes > 1) {
+    runtimeErrorMsg() << "MPI parallelization not supported by DAWAANR.";
     return ES_ERROR;
   }
   if (dipole.method != DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA) {
@@ -402,14 +403,15 @@ int dawaanr_set_params() {
 
 int mdds_set_params(int n_cut) {
   if (n_nodes > 1) {
+    runtimeErrorMsg() << "MPI parallelization not supported by MDDS.";
     return ES_ERROR;
   }
 
   Ncut_off_magnetic_dipolar_direct_sum = n_cut;
 
   if (Ncut_off_magnetic_dipolar_direct_sum == 0) {
-    fprintf(stderr, "Careful:  the number of extra replicas to take into "
-                    "account during the direct sum calculation is zero \n");
+    fprintf(stderr, "Careful: the number of extra replicas to take into "
+                    "account during the direct sum calculation is zero\n");
   }
 
   if (dipole.method != DIPOLAR_DS && dipole.method != DIPOLAR_MDLC_DS) {

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -35,7 +35,7 @@ IF DIPOLES == 1:
         Attributes
         ----------
         prefactor : :obj:`float`
-                Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
+            Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
 
         """
 
@@ -51,8 +51,7 @@ IF DIPOLES == 1:
 
             """
             if set_Dprefactor(self._params["prefactor"]):
-                    raise Exception(
-                        "Could not set magnetostatic prefactor")
+                raise Exception("Could not set magnetostatic prefactor")
             # also necessary on 1 CPU or GPU, does more than just broadcasting
             mpi_bcast_coulomb_params()
 
@@ -71,22 +70,22 @@ IF DP3M == 1:
         Attributes
         ----------
         prefactor : :obj:`float`
-                Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
+            Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
         accuracy : :obj:`float`
-                   P3M tunes its parameters to provide this target accuracy.
+            P3M tunes its parameters to provide this target accuracy.
         alpha : :obj:`float`
-                Ewald parameter.
+            Ewald parameter.
         cao : :obj:`int`
-              Charge-assignment order, an integer between -1 and 7.
+            Charge-assignment order, an integer between -1 and 7.
         mesh : :obj:`int` or array_like
-               Number of mesh points.
+            Number of mesh points.
         mesh_off : array_like :obj:`float`
-                   Mesh offset.
+            Mesh offset.
         r_cut : :obj:`float`
-                Real space cutoff.
+            Real space cutoff.
         tune : :obj:`bool`, optional
-               Activate/deactivate the tuning method on activation
-               (default is True, i.e., activated).
+            Activate/deactivate the tuning method on activation
+            (default is True, i.e., activated).
 
         """
 
@@ -105,7 +104,9 @@ IF DP3M == 1:
                     "P3M mesh has to be an integer or integer list of length 3")
 
             if (isinstance(self._params["mesh"], basestring) and len(self._params["mesh"]) == 3):
-                if (self._params["mesh"][0] % 2 != 0 and self._params["mesh"][0] != -1) or (self._params["mesh"][1] % 2 != 0 and self._params["mesh"][1] != -1) or (self._params["mesh"][2] % 2 != 0 and self._params["mesh"][2] != -1):
+                if (self._params["mesh"][0] % 2 != 0 and self._params["mesh"][0] != -1) or \
+                   (self._params["mesh"][1] % 2 != 0 and self._params["mesh"][1] != -1) or \
+                   (self._params["mesh"][2] % 2 != 0 and self._params["mesh"][2] != -1):
                     raise ValueError(
                         "P3M requires an even number of mesh points in all directions")
 
@@ -130,7 +131,9 @@ IF DP3M == 1:
                     "mesh_off should be a list of length 3 and values between 0.0 and 1.0")
 
         def valid_keys(self):
-            return "prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off", "cao", "inter", "accuracy", "epsilon", "cao_cut", "a", "ai", "alpha", "r_cut", "inter2", "cao3", "additional_mesh", "tune"
+            return ["prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off",
+                    "cao", "inter", "accuracy", "epsilon", "cao_cut", "a", "ai",
+                    "alpha", "r_cut", "inter2", "cao3", "additional_mesh", "tune"]
 
         def required_keys(self):
             return ["accuracy", ]
@@ -157,14 +160,16 @@ IF DP3M == 1:
             dp3m_set_eps(self._params["epsilon"])
             dp3m_set_ninterpol(self._params["inter"])
             self.python_dp3m_set_mesh_offset(self._params["mesh_off"])
-            self.python_dp3m_set_params(self._params["r_cut"], self._params["mesh"], self._params[
-                "cao"], self._params["alpha"], self._params["accuracy"])
+            self.python_dp3m_set_params(
+                self._params["r_cut"], self._params["mesh"],
+                self._params["cao"], self._params["alpha"], self._params["accuracy"])
 
         def _tune(self):
             self.set_magnetostatics_prefactor()
             dp3m_set_eps(self._params["epsilon"])
-            self.python_dp3m_set_tune_params(self._params["r_cut"], self._params["mesh"], self._params[
-                "cao"], -1.0, self._params["accuracy"], self._params["inter"])
+            self.python_dp3m_set_tune_params(
+                self._params["r_cut"], self._params["mesh"],
+                self._params["cao"], -1., self._params["accuracy"], self._params["inter"])
             resp, log = self.python_dp3m_adaptive_tune()
             if resp:
                 raise Exception(
@@ -193,7 +198,7 @@ IF DP3M == 1:
         def python_dp3m_adaptive_tune(self):
             cdef char * log = NULL
             cdef int response
-            response = dp3m_adaptive_tune(& log)
+            response = dp3m_adaptive_tune( & log)
             handle_errors(
                 "dipolar P3M_init: k-space cutoff is larger than half of box dimension")
             return response, log
@@ -236,14 +241,14 @@ IF DIPOLES == 1:
     cdef class DipolarDirectSumCpu(MagnetostaticInteraction):
         """Calculate magnetostatic interactions by direct summation over all pairs.
 
-        If the system has periodic boundaries, the minimum image convention is applied
-        in the respective directions.
+        If the system has periodic boundaries, the minimum image convention is
+        applied in the respective directions.
 
         Attributes
         ----------
 
         prefactor : :obj:`float`
-                Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
+            Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
 
         """
 
@@ -278,9 +283,9 @@ IF DIPOLES == 1:
         Attributes
         ----------
         prefactor : :obj:`float`
-                Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
+            Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
         n_replica : :obj:`int`
-                    Number of replicas to be taken into account at periodic boundaries.
+            Number of replicas to be taken into account at periodic boundaries.
 
         """
 
@@ -305,19 +310,23 @@ IF DIPOLES == 1:
             if mdds_set_params(self._params["n_replica"]):
                 raise Exception(
                     "Could not activate magnetostatics method " + self.__class__.__name__)
+
     IF SCAFACOS_DIPOLES == 1:
         class Scafacos(ScafacosConnector, MagnetostaticInteraction):
 
             """
             Calculates dipolar interactions using dipoles-capable method from the SCAFACOs library.
+
+            Attributes
+            ----------
             prefactor : :obj:`float`
                 Magnetostatics prefactor (:math:`\mu_0/(4\pi)`)
             method_name : :obj:`str`
                 Name of the method as defined in Scafacos
             method_params : :obj:`dict`
-                Dictionary with the key-value pairs of the method parameters as defined in Scafacos. Note that the values are cast to strings to match Scafacos' interface
-
-
+                Dictionary with the key-value pairs of the method parameters as
+                defined in Scafacos. Note that the values are cast to strings
+                to match Scafacos' interface
 
             """
 
@@ -343,10 +352,11 @@ IF DIPOLES == 1:
         cdef class DipolarDirectSumGpu(MagnetostaticInteraction):
             """Calculate magnetostatic interactions by direct summation over all pairs.
 
-            If the system has periodic boundaries, the minimum image convention is applied
-            in the respective directions.
+            If the system has periodic boundaries, the minimum image convention
+            is applied in the respective directions.
 
-            This is the GPU version of :class:`espressomd.magnetostatics.DipolarDirectSumCpu` but uses floating point precision.
+            This is the GPU version of :class:`espressomd.magnetostatics.DipolarDirectSumCpu`
+            but uses floating point precision.
 
             Attributes
             ----------

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -56,10 +56,6 @@ IF DIPOLES == 1:
             # also necessary on 1 CPU or GPU, does more than just broadcasting
             mpi_bcast_coulomb_params()
 
-        def get_params(self):
-            self._params = self._get_params_from_es_core()
-            return self._params
-
         def _get_active_method_from_es_core(self):
             return dipole.method
 

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -50,8 +50,8 @@ IF DIPOLES == 1:
             Set the magnetostatics prefactor
 
             """
-            if set_Dprefactor(self._params["prefactor"]):
-                raise Exception("Could not set magnetostatic prefactor")
+            set_Dprefactor(self._params["prefactor"])
+            handle_errors("Could not set magnetostatic prefactor")
             # also necessary on 1 CPU or GPU, does more than just broadcasting
             mpi_bcast_coulomb_params()
 
@@ -198,7 +198,7 @@ IF DP3M == 1:
         def python_dp3m_adaptive_tune(self):
             cdef char * log = NULL
             cdef int response
-            response = dp3m_adaptive_tune( & log)
+            response = dp3m_adaptive_tune(& log)
             handle_errors(
                 "dipolar P3M_init: k-space cutoff is larger than half of box dimension")
             return response, log
@@ -270,9 +270,9 @@ IF DIPOLES == 1:
 
         def _set_params_in_es_core(self):
             self.set_magnetostatics_prefactor()
-            if dawaanr_set_params():
-                raise Exception(
-                    "Could not activate magnetostatics method " + self.__class__.__name__)
+            dawaanr_set_params()
+            handle_errors("Could not activate magnetostatics method "
+                          + self.__class__.__name__)
 
     cdef class DipolarDirectSumWithReplicaCpu(MagnetostaticInteraction):
         """Calculate magnetostatic interactions by direct summation over all pairs.
@@ -307,9 +307,9 @@ IF DIPOLES == 1:
 
         def _set_params_in_es_core(self):
             self.set_magnetostatics_prefactor()
-            if mdds_set_params(self._params["n_replica"]):
-                raise Exception(
-                    "Could not activate magnetostatics method " + self.__class__.__name__)
+            mdds_set_params(self._params["n_replica"])
+            handle_errors("Could not activate magnetostatics method "
+                          + self.__class__.__name__)
 
     IF SCAFACOS_DIPOLES == 1:
         class Scafacos(ScafacosConnector, MagnetostaticInteraction):


### PR DESCRIPTION
Fixes #2828

The error messages are more verbose and the documentation now mentions which classes are not MPI-enabled. The bibliographic issue was already fixed in #2857. This PR branches from #2910.