### PR TITLE
Installation instructions for Python 3

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -188,7 +188,9 @@ If you have installed the requirements (see section :ref:`Requirements
 create a build directory and call ``cmake`` and ``make`` (optional steps
 which modify the build process are commented out).
 To chose the correct Python version, run
+
 .. code-block:: bash
+
     python -V
     python3 -V
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -44,6 +44,7 @@ C++ Compiler
 
 Boost
     A number of advanced C++ features used by ESPResSo is provided by Boost.
+    We strongly recommend to use at least boost 1.67.
 
 FFTW
     For some algorithms (P\ :math:`^3`\ M), ESPResSo needs the FFTW library
@@ -55,24 +56,31 @@ MPI
     environment that implements the MPI standard version 1.2.
 
 Python
-    ESPResSo's main user interface is via the Python scripting interface. Both, Python 2 and 3 are supported.
+    ESPResSo's main user interface is via the Python scripting interface.
+    We strongly recommend Python 3. Python 2 support is about to be removed.
 
 Cython
-    Cython is used for connecting the C++ core to Python
+    Cython is used for connecting the C++ core to Python.
+    At least version 0.23 is required.
+
 
 .. _Installing Requirements on Ubuntu Linux:
 
 Installing Requirements on Ubuntu Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These instructions pertain to Python 3. If you need to use the deprecated
+Python 2 support, leave out the `3` in the Python package names.
+I.e., use `python-numpy` rather than `python3-numpy`.
 
-To make ESPResSo run on Ubuntu 16.04 LTS or 18.04 LTS, its dependencies can be
+
+To make ESPResSo run on 18.04 LTS, its dependencies can be
 installed with:
 
 .. code-block:: bash
 
-    sudo apt install build-essential cmake cython python-numpy \
+    sudo apt install build-essential cmake cython python3-numpy \
     libboost-all-dev openmpi-common fftw3-dev libhdf5-dev libhdf5-openmpi-dev \
-    doxygen python-opengl python-sphinx python-pip libgsl-dev
+    doxygen python3-opengl python3-sphinx python3-pip libgsl-dev
 
 
 Optionally the ccmake utility can be installed for easier configuration:
@@ -166,9 +174,9 @@ command in |es| 's source directory:
 
 .. code-block:: bash
 
-    pip install -r requirements.txt --user --upgrade
+    pip3 install -r requirements.txt --user --upgrade
 
-Please note that on some systems, ``pip`` has to be replaced by ``pip2`` to install Python 2 versions of the packages.
+Please note that on some systems, ``pip3`` has to be replaced by ``pip`` or ``pip2`` to install Python 2 versions of the packages.
 
 .. _Quick installation:
 
@@ -178,7 +186,14 @@ Quick installation
 If you have installed the requirements (see section :ref:`Requirements
 <requirements>` ) in standard locations, to compile, it is usually enough to
 create a build directory and call ``cmake`` and ``make`` (optional steps
-which modify the build process are commented out):
+which modify the build process are commented out).
+To chose the correct Python version, run
+.. code-block:: bash
+    python -V
+    python3 -V
+
+This shows which Python version the binaries are for. Then pass the one you'd like to use in the cmake command line, below.
+
 
 .. code-block:: bash
 
@@ -186,7 +201,7 @@ which modify the build process are commented out):
     cd build
     #cp myconfig-default.hpp myconfig.hpp # use the default configuration as template
     #nano myconfig.hpp                    # edit to add/remove features as desired
-    cmake ..
+    cmake -DPYTHON_EXECUTABLE=`which python3` ..
     #ccmake . // in order to add/remove features like SCAFACOS or CUDA
     make
 
@@ -219,7 +234,7 @@ command:
 
     ./pypresso <SCRIPT>
 
-where is ``<SCRIPT>`` is a ``python`` script which has to
+where ``<SCRIPT>`` is a ``python`` script which has to
 be written by the user. You can find some examples in the :file:`samples`
 folder of the source code directory. If you want to run in parallel, you should
 have compiled with *Open MPI*, and need to tell MPI to run in parallel. The actual


### PR DESCRIPTION
This adds preliminary instructions to build with Python3. 
Once Python 2 support is removed, the docs have to be touched again, because they can then be simplified.

@jngrad 


 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
