### PR TITLE
Feature assertions: ELECTROSTATICS != P3M

### DIFF
--- a/samples/billiard.py
+++ b/samples/billiard.py
@@ -25,10 +25,6 @@ from threading import Thread
 
 import espressomd
 from espressomd import thermostat
-from espressomd import analyze
-from espressomd import integrate
-from espressomd import electrostatics
-from espressomd import minimize_energy
 import espressomd.interactions
 import espressomd.visualization_opengl
 import espressomd.shapes

--- a/samples/electrophoresis.py
+++ b/samples/electrophoresis.py
@@ -22,7 +22,7 @@ This sample simulates electrophoresis using P3M solver.
 from __future__ import print_function
 import espressomd
 
-required_features = ["ELECTROSTATICS", "EXTERNAL_FORCES", "LENNARD_JONES"]
+required_features = ["P3M", "EXTERNAL_FORCES", "LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 from espressomd import thermostat

--- a/samples/grand_canonical.py
+++ b/samples/grand_canonical.py
@@ -27,7 +27,7 @@ import espressomd
 from espressomd import reaction_ensemble
 from espressomd import electrostatics
 
-required_features = ["ELECTROSTATICS", "EXTERNAL_FORCES", "LENNARD_JONES"]
+required_features = ["P3M", "EXTERNAL_FORCES", "LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 # print help message if proper command-line arguments are not provided

--- a/samples/lj_liquid_structurefactor.py
+++ b/samples/lj_liquid_structurefactor.py
@@ -24,7 +24,6 @@ required_features = ["LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 from espressomd import thermostat
-from espressomd import analyze
 
 print("""
 =======================================================

--- a/samples/load_checkpoint.py
+++ b/samples/load_checkpoint.py
@@ -20,7 +20,7 @@ This sample illustrates how various observables of interest can be checkpointed.
 from __future__ import print_function
 import espressomd
 
-required_features = ["ELECTROSTATICS", "LENNARD_JONES"]
+required_features = ["P3M", "LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 from espressomd import checkpointing

--- a/samples/minimal-charged-particles.py
+++ b/samples/minimal-charged-particles.py
@@ -24,7 +24,7 @@ temperature using a Langevin thermostat.
 from __future__ import print_function
 import espressomd
 
-required_features = ["ELECTROSTATICS", "LENNARD_JONES"]
+required_features = ["P3M", "LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 from espressomd import electrostatics

--- a/samples/minimal-polymer.py
+++ b/samples/minimal-polymer.py
@@ -25,7 +25,7 @@ espressomd.assert_features(["LENNARD_JONES"])
 from espressomd import thermostat
 from espressomd import interactions
 from espressomd import polymer
-from espressomd.io.writer import vtf
+from espressomd.io.writer import vtf  # pylint: disable=import-error
 import numpy as np
 
 # System parameters

--- a/samples/p3m.py
+++ b/samples/p3m.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import numpy as np
 import espressomd
 
-required_features = ["ELECTROSTATICS", "LENNARD_JONES"]
+required_features = ["P3M", "LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 from espressomd import thermostat

--- a/samples/p3m.py
+++ b/samples/p3m.py
@@ -106,14 +106,15 @@ print("Interactions:\n")
 act_min_dist = system.analysis.min_dist()
 print("Start with minimal distance {}".format(act_min_dist))
 
-system.cell_system.max_num_cells = 2744
+system.cell_system.max_num_cells = 14**3
 
 
-# Assign charge to particles
+# Assign charges to particles
 for i in range(n_part // 2 - 1):
     system.part[2 * i].q = -1.0
     system.part[2 * i + 1].q = 1.0
-# P3M setup after charge assigned
+
+# P3M setup after charge assignment
 #############################################################
 
 print("\nSCRIPT--->Create p3m\n")

--- a/samples/save_checkpoint.py
+++ b/samples/save_checkpoint.py
@@ -20,7 +20,7 @@ This sample demonstrates how to checkpoint a simulation.
 
 import espressomd
 
-required_features = ["ELECTROSTATICS", "LENNARD_JONES"]
+required_features = ["P3M", "LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 from espressomd import electrostatics

--- a/samples/store_properties.py
+++ b/samples/store_properties.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 import numpy as np
 import espressomd
 
-required_features = ["ELECTROSTATICS", "LENNARD_JONES"]
+required_features = ["P3M", "LENNARD_JONES"]
 espressomd.assert_features(required_features)
 
 from espressomd import electrostatics

--- a/samples/visualization_charged.py
+++ b/samples/visualization_charged.py
@@ -24,7 +24,7 @@ from espressomd.visualization_opengl import openGLLive
 from espressomd import electrostatics
 import numpy as np
 
-required_features = ["ELECTROSTATICS", "LENNARD_JONES", "MASS"]
+required_features = ["P3M", "LENNARD_JONES", "MASS"]
 espressomd.assert_features(required_features)
 
 box = [40, 40, 40]

--- a/samples/wang_landau_reaction_ensemble.py
+++ b/samples/wang_landau_reaction_ensemble.py
@@ -23,9 +23,6 @@ from __future__ import print_function
 import numpy as np
 
 import espressomd
-from espressomd import code_info
-from espressomd import analyze
-from espressomd import integrate
 from espressomd import reaction_ensemble
 from espressomd.interactions import HarmonicBond
 

--- a/samples/widom_insertion.py
+++ b/samples/widom_insertion.py
@@ -31,7 +31,7 @@ from espressomd import integrate
 from espressomd import reaction_ensemble
 from espressomd import electrostatics
 
-required_features = ["LENNARD_JONES", "ELECTROSTATICS"]
+required_features = ["LENNARD_JONES", "P3M"]
 espressomd.assert_features(required_features)
 
 # System parameters

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -227,6 +227,9 @@ IF P3M == 1:
         tune : :obj:`bool`, optional
             Used to activate/deactivate the tuning method on activation.
             Defaults to True.
+        check_neutrality : :obj:`bool`, optional
+            Raise a warning if the system is not electrically neutral when
+            set to ``True`` (default).
 
         """
 
@@ -367,6 +370,9 @@ IF P3M == 1:
             tune : :obj:`bool`, optional
                 Used to activate/deactivate the tuning method on activation.
                 Defaults to True.
+            check_neutrality : :obj:`bool`, optional
+                Raise a warning if the system is not electrically neutral when
+                set to ``True`` (default).
 
             """
 

--- a/testsuite/python/actor.py
+++ b/testsuite/python/actor.py
@@ -102,10 +102,10 @@ class ActorTest(ut.TestCase):
         a._deactivate()
         self.assertFalse(a.is_active())
 
-        parms = a.get_params()
-        self.assertTrue(parms["a"])
-        self.assertFalse(parms["b"])
-        self.assertTrue(parms["c"])
+        params = a.get_params()
+        self.assertTrue(params["a"])
+        self.assertFalse(params["b"])
+        self.assertTrue(params["c"])
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/coulomb_mixed_periodicity.py
+++ b/testsuite/python/coulomb_mixed_periodicity.py
@@ -29,7 +29,7 @@ import tests_common
 @utx.skipIfMissingFeatures(["ELECTROSTATICS", "PARTIAL_PERIODIC"])
 class CoulombMixedPeriodicity(ut.TestCase):
 
-    """"Test mixed periodicity electrostatics"""
+    """Test mixed periodicity electrostatics"""
 
     S = espressomd.System(box_l=[1.0, 1.0, 1.0])
     buf_node_grid = S.cell_system.node_grid

--- a/testsuite/python/elc_vs_mmm2d_neutral.py
+++ b/testsuite/python/elc_vs_mmm2d_neutral.py
@@ -23,7 +23,7 @@ import espressomd.electrostatics
 from espressomd import electrostatic_extensions
 
 
-@utx.skipIfMissingFeatures(["ELECTROSTATICS", "PARTIAL_PERIODIC"])
+@utx.skipIfMissingFeatures(["P3M", "PARTIAL_PERIODIC"])
 class ELC_vs_MMM2D_neutral(ut.TestCase):
     # Handle to espresso system
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])

--- a/testsuite/python/elc_vs_mmm2d_nonneutral.py
+++ b/testsuite/python/elc_vs_mmm2d_nonneutral.py
@@ -24,7 +24,7 @@ import espressomd.electrostatics
 from espressomd import electrostatic_extensions
 
 
-@utx.skipIfMissingFeatures(["ELECTROSTATICS", "PARTIAL_PERIODIC"])
+@utx.skipIfMissingFeatures(["P3M", "PARTIAL_PERIODIC"])
 class ELC_vs_MMM2D_neutral(ut.TestCase):
     # Handle to espresso system
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])

--- a/testsuite/python/p3m_electrostatic_pressure.py
+++ b/testsuite/python/p3m_electrostatic_pressure.py
@@ -39,7 +39,7 @@ class pressureViaVolumeScaling(object):
         self.new_box_l = (self.new_volume)**(1. / 3.)
 
         self.list_of_previous_values = []
-    
+
     def measure_pressure_via_volume_scaling(self):
         # taken from "Efficient pressure estimation in molecular simulations
         # without evaluating the virial" only works so far for isotropic volume
@@ -58,7 +58,7 @@ class pressureViaVolumeScaling(object):
         current_value = (self.new_volume / self.old_volume)**particle_number * \
             np.exp(-DeltaEpot / self.kbT)
         self.list_of_previous_values.append(current_value)
-    
+
     def get_result(self):
         average_value = np.mean(self.list_of_previous_values)
 
@@ -90,7 +90,7 @@ class VirialPressureConsistency(ut.TestCase):
             epsilon=1.0, sigma=1.0, cutoff=2**(1.0 / 6.0), shift="auto")
         num_part = 40
         mass = 1
-        
+
         for i in range(num_part):
             self.system.part.add(
                 pos=np.random.random(3) * self.system.box_l, q=1,

--- a/testsuite/python/p3m_electrostatic_pressure.py
+++ b/testsuite/python/p3m_electrostatic_pressure.py
@@ -66,7 +66,7 @@ class pressureViaVolumeScaling(object):
         return pressure
 
 
-@utx.skipIfMissingFeatures(["ELECTROSTATICS", "LENNARD_JONES"])
+@utx.skipIfMissingFeatures(["P3M", "LENNARD_JONES"])
 class VirialPressureConsistency(ut.TestCase):
 
     """Test the consistency of the core implementation of the virial pressure

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -77,7 +77,7 @@ system.part.add(pos=[1.0, 1.0, 2.0])
 if espressomd.has_features('EXCLUSIONS'):
     system.part.add(pos=[2.0] * 3, exclusions=[0, 1])
 
-if espressomd.has_features('ELECTROSTATICS') and 'P3M.CPU' in modes:
+if espressomd.has_features('P3M') and 'P3M.CPU' in modes:
     system.part[0].q = 1
     system.part[1].q = -1
     p3m = espressomd.electrostatics.P3M(

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -175,7 +175,7 @@ class CheckpointTest(ut.TestCase):
         np.testing.assert_array_equal(
             acc.get_variance(), np.array([0., 0.5, 2., 0., 0., 0.]))
 
-    @utx.skipIfMissingFeatures('ELECTROSTATICS')
+    @utx.skipIfMissingFeatures('P3M')
     @ut.skipIf('P3M.CPU' not in modes,
                "Skipping test due to missing combination.")
     def test_p3m(self):

--- a/testsuite/scripts/samples/test_observables_correlators.py
+++ b/testsuite/scripts/samples/test_observables_correlators.py
@@ -28,7 +28,7 @@ class Sample(ut.TestCase):
     system = sample.system
 
     def test_fcs_acf(self):
-        fcs_acf_weights = sample.fcs.get_params()['args']
+        fcs_acf_weights = np.copy(sample.fcs.get_params()['args'])
         np.testing.assert_allclose(fcs_acf_weights, [100., 100., 100.])
 
 


### PR DESCRIPTION
Update features assertions: when ELECTROSTATICS is enabled but FFTW is not installed, P3M is not enabled and multiple tests fail. Now all tests pass in `debian:9` and `ubuntu:wo-dependencies` (excepted the MMM2D check in `coulomb_mixed_periodicity.py`). The files were cleaned up, too.