### PR TITLE
Improve maintainability of build_cmake.sh

### DIFF
--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -58,14 +58,14 @@ function set_default_value {
     if [ "${default}" = true -o "${default}" = false ]; then
         # cast boolean values to true/false
         local -r val=$(echo "${value}" | tr '[:upper:]' '[:lower:]')
-        if [ "${val}" = false -o "${val}" = "off" -o "${val}" = 0 ]; then
+        if [ "${val}" = false -o "${val}" = "off" -o "${val}" = 0 -o "${val}" = "no" ]; then
             eval "${varname}=false"
-        elif [ "${val}" = true -o "${val}" = "on" -o "${val}" = 1 ]; then
+        elif [ "${val}" = true -o "${val}" = "on" -o "${val}" = 1 -o "${val}" = "yes" ]; then
             eval "${varname}=true"
         elif [ -z "${val}" ]; then
             eval "${varname}='${default}'"
         else
-            echo "Cannot cast '${value}' to boolean"
+            echo "Cannot interpret '${value}' as a true/false value in variable '${varname}'"
             exit 1
         fi
     elif [ -z "${value}" ]; then

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -10,7 +10,7 @@
 abort()
 {
     echo "An error occurred. Exiting..." >&2
-    echo "Command that failed: $BASH_COMMAND" >&2
+    echo "Command that failed: ${BASH_COMMAND}" >&2
     exit 1
 }
 
@@ -22,7 +22,7 @@ set -e
 # output value of env variables
 function outp {
     for p in $*; do
-        echo "  $p=${!p}"
+        echo "  ${p}=${!p}"
     done
 }
 
@@ -42,45 +42,45 @@ function end {
 
 # execute and output a command
 # handle environment variables
-[ -z "$insource" ] && insource="false"
-[ -z "$srcdir" ] && srcdir=`pwd`
-[ -z "$cmake_params" ] && cmake_params=""
-[ -z "$with_fftw" ] && with_fftw="true"
-[ -z "$with_python_interface" ] && with_python_interface="true"
-[ -z "$with_coverage" ] && with_coverage="false"
-[ -z "$with_ubsan" ] && with_ubsan="false"
-[ -z "$with_asan" ] && with_asan="false"
-[ -z "$with_static_analysis" ] && with_static_analysis="false"
-[ -z "$myconfig" ] && myconfig="default"
-[ -z "$build_procs" ] && build_procs=2
-[ -z "$check_procs" ] && check_procs=$build_procs
-[ -z "$make_check" ] && make_check="true"
-[ -z "$check_odd_only" ] && check_odd_only="false"
-[ -z "$check_gpu_only" ] && check_gpu_only="false"
-[ -z "$check_skip_long" ] && check_skip_long="false"
-[ -z "$make_check_tutorials" ] && make_check_tutorials="false"
-[ -z "$make_check_samples" ] && make_check_samples="false"
-[ -z "$make_check_benchmarks" ] && make_check_benchmarks="false"
-[ -z "$python_version" ] && python_version="2"
-[ -z "$with_cuda" ] && with_cuda="true"
-[ -z "$build_type" ] && build_type="Debug"
-[ -z "$with_ccache" ] && with_ccache="false"
-[ -z "$test_timeout" ] && test_timeout="300"
-[ -z "$hide_gpu" ] && hide_gpu="false" 
+[ -z "${insource}" ] && insource="false"
+[ -z "${srcdir}" ] && srcdir=`pwd`
+[ -z "${cmake_params}" ] && cmake_params=""
+[ -z "${with_fftw}" ] && with_fftw="true"
+[ -z "${with_python_interface}" ] && with_python_interface="true"
+[ -z "${with_coverage}" ] && with_coverage="false"
+[ -z "${with_ubsan}" ] && with_ubsan="false"
+[ -z "${with_asan}" ] && with_asan="false"
+[ -z "${with_static_analysis}" ] && with_static_analysis="false"
+[ -z "${myconfig}" ] && myconfig="default"
+[ -z "${build_procs}" ] && build_procs=2
+[ -z "${check_procs}" ] && check_procs=${build_procs}
+[ -z "${make_check}" ] && make_check="true"
+[ -z "${check_odd_only}" ] && check_odd_only="false"
+[ -z "${check_gpu_only}" ] && check_gpu_only="false"
+[ -z "${check_skip_long}" ] && check_skip_long="false"
+[ -z "${make_check_tutorials}" ] && make_check_tutorials="false"
+[ -z "${make_check_samples}" ] && make_check_samples="false"
+[ -z "${make_check_benchmarks}" ] && make_check_benchmarks="false"
+[ -z "${python_version}" ] && python_version="2"
+[ -z "${with_cuda}" ] && with_cuda="true"
+[ -z "${build_type}" ] && build_type="Debug"
+[ -z "${with_ccache}" ] && with_ccache="false"
+[ -z "${test_timeout}" ] && test_timeout="300"
+[ -z "${hide_gpu}" ] && hide_gpu="false" 
 
-if [ $make_check ] || [ $make_check_tutorials ] || [ $make_check_samples ] || [ $make_check_benchmarks ]; then
+if [ ${make_check} ] || [ ${make_check_tutorials} ] || [ ${make_check_samples} ] || [ ${make_check_benchmarks} ]; then
   run_checks="true"
 fi
 
 # If there are no user-provided flags they
-# are added according to with_coverage.
+# are added according to ${with_coverage}.
 nvcc_flags=${cxx_flags}
-if [ -z "$cxx_flags" ]; then
-    if $with_coverage; then
+if [ -z "${cxx_flags}" ]; then
+    if ${with_coverage}; then
         cxx_flags="-Og"
         nvcc_flags="-O3"
     else
-        if $run_checks; then
+        if ${run_checks}; then
             cxx_flags="-O3"
             nvcc_flags="-O3"
         else
@@ -94,24 +94,24 @@ if [ ! -z ${with_coverage+x} ]; then
   bash <(curl -s https://codecov.io/env) &> /dev/null;
 fi
 
-cmake_params="-DCMAKE_BUILD_TYPE=$build_type -DPYTHON_EXECUTABLE=$(which python$python_version) -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=$check_procs $cmake_params -DWITH_SCAFACOS=ON"
-cmake_params="$cmake_params -DCMAKE_CXX_FLAGS=$cxx_flags -DCUDA_NVCC_FLAGS=$nvcc_flags"
-cmake_params="$cmake_params -DCMAKE_INSTALL_PREFIX=/tmp/espresso-unit-tests"
-cmake_params="$cmake_params -DTEST_TIMEOUT=$test_timeout"
-if $with_ccache; then
-  cmake_params="$cmake_params -DWITH_CCACHE=ON"
+cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DPYTHON_EXECUTABLE=$(which python${python_version}) -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=${check_procs} ${cmake_params} -DWITH_SCAFACOS=ON"
+cmake_params="${cmake_params} -DCMAKE_CXX_FLAGS=${cxx_flags} -DCUDA_NVCC_FLAGS=${nvcc_flags}"
+cmake_params="${cmake_params} -DCMAKE_INSTALL_PREFIX=/tmp/espresso-unit-tests"
+cmake_params="${cmake_params} -DTEST_TIMEOUT=${test_timeout}"
+if ${with_ccache}; then
+  cmake_params="${cmake_params} -DWITH_CCACHE=ON"
 fi
 
 command -v nvidia-smi && nvidia-smi
-if [ $hide_gpu = "true" ]; then
+if [ ${hide_gpu} = "true" ]; then
   echo "Hiding gpu from Cuda via CUDA_VISIBLE_DEVICES"
   export CUDA_VISIBLE_DEVICES=
 fi
 
-if $insource; then
-    builddir=$srcdir
-elif [ -z "$builddir" ]; then
-    builddir=$srcdir/build
+if ${insource}; then
+    builddir=${srcdir}
+elif [ -z "${builddir}" ]; then
+    builddir=${srcdir}/build
 fi
 
 outp insource srcdir builddir \
@@ -140,9 +140,9 @@ pep8_command () {
     fi
 }
 
-pep8_command --filename=*.pyx,*.pxd,*.py --select=E111 $srcdir/src/python/espressomd/
+pep8_command --filename=*.pyx,*.pxd,*.py --select=E111 ${srcdir}/src/python/espressomd/
 ec=$?
-if [ $ec -eq 0 ]; then
+if [ ${ec} -eq 0 ]; then
     echo ""
     echo "Indentation in Python files correct..."
     echo ""
@@ -150,7 +150,7 @@ else
     echo ""
     echo "Error: Python files are not indented the right way. Please use 4 spaces per indentation level!"
     echo ""
-    exit $ec
+    exit ${ec}
 fi
 # enforce style rules
 pylint_command () {
@@ -172,76 +172,76 @@ if [ $(pylint_command --version | grep -o 'pylint.*[0-9]\.[0-9]\.[0-9]' | awk '{
 else
     score_option=''
 fi
-pylint_command $score_option --reports=no --disable=all --enable=C1001 $(find . -name '*.py*') || { echo -e "\nOld-style classes found.\nPlease convert to new-style:\nclass C: => class C(object):\n" && exit 1; }
+pylint_command ${score_option} --reports=no --disable=all --enable=C1001 $(find . -name '*.py*') || { echo -e "\nOld-style classes found.\nPlease convert to new-style:\nclass C: => class C(object):\n" && exit 1; }
 
-if ! $insource; then
-    if [ ! -d $builddir ]; then
-        echo "Creating $builddir..."
-        mkdir -p $builddir
+if ! ${insource}; then
+    if [ ! -d ${builddir} ]; then
+        echo "Creating ${builddir}..."
+        mkdir -p ${builddir}
     fi
 fi
 
-if ! $insource; then
-    cd $builddir
+if ! ${insource}; then
+    cd ${builddir}
 fi
 
 # load MPI module if necessary
 if [ -f "/etc/os-release" ]; then
     grep -q suse /etc/os-release && source /etc/profile.d/modules.sh && module load gnu-openmpi
-    grep -q 'rhel\|fedora' /etc/os-release && for f in /etc/profile.d/*module*.sh; do source $f; done && module load mpi
+    grep -q 'rhel\|fedora' /etc/os-release && for f in /etc/profile.d/*module*.sh; do source ${f}; done && module load mpi
 fi
 
 # CONFIGURE
 start "CONFIGURE"
 
-if [ $with_fftw = "true" ]; then
+if [ ${with_fftw} = "true" ]; then
     :
 else
-    cmake_params="-DCMAKE_DISABLE_FIND_PACKAGE_FFTW3=ON $cmake_params"
+    cmake_params="-DCMAKE_DISABLE_FIND_PACKAGE_FFTW3=ON ${cmake_params}"
 fi
 
-if [ $with_python_interface = "true" ]; then
-    cmake_params="-DWITH_PYTHON=ON $cmake_params"
+if [ ${with_python_interface} = "true" ]; then
+    cmake_params="-DWITH_PYTHON=ON ${cmake_params}"
 else
-    cmake_params="-DWITH_PYTHON=OFF $cmake_params"
+    cmake_params="-DWITH_PYTHON=OFF ${cmake_params}"
 fi
 
-if [ $with_coverage = "true" ]; then
-    cmake_params="-DWITH_COVERAGE=ON $cmake_params"
+if [ ${with_coverage} = "true" ]; then
+    cmake_params="-DWITH_COVERAGE=ON ${cmake_params}"
 fi
 
-if [ $with_asan = "true" ]; then
-    cmake_params="-DWITH_ASAN=ON $cmake_params"
+if [ ${with_asan} = "true" ]; then
+    cmake_params="-DWITH_ASAN=ON ${cmake_params}"
 fi
 
-if [ $with_ubsan = "true" ]; then
-    cmake_params="-DWITH_UBSAN=ON $cmake_params"
+if [ ${with_ubsan} = "true" ]; then
+    cmake_params="-DWITH_UBSAN=ON ${cmake_params}"
 fi
 
-if [ $with_static_analysis = "true" ]; then
-    cmake_params="-DWITH_CLANG_TIDY=ON $cmake_params"
+if [ ${with_static_analysis} = "true" ]; then
+    cmake_params="-DWITH_CLANG_TIDY=ON ${cmake_params}"
 fi
 
-if [ $with_cuda = "true" ]; then
+if [ ${with_cuda} = "true" ]; then
     :
 else
-    cmake_params="-DWITH_CUDA=OFF $cmake_params"
+    cmake_params="-DWITH_CUDA=OFF ${cmake_params}"
 fi
 
-MYCONFIG_DIR=$srcdir/maintainer/configs
-if [ "$myconfig" = "default" ]; then
+MYCONFIG_DIR=${srcdir}/maintainer/configs
+if [ "${myconfig}" = "default" ]; then
     echo "Using default myconfig."
 else
-    myconfig_file=$MYCONFIG_DIR/$myconfig.hpp
-    if [ ! -e "$myconfig_file" ]; then
-        echo "$myconfig_file does not exist!"
+    myconfig_file=${MYCONFIG_DIR}/${myconfig}.hpp
+    if [ ! -e "${myconfig_file}" ]; then
+        echo "${myconfig_file} does not exist!"
         exit 1
     fi
-    echo "Copying $myconfig.hpp to $builddir/myconfig.hpp..."
-    cp $myconfig_file $builddir/myconfig.hpp
+    echo "Copying ${myconfig}.hpp to ${builddir}/myconfig.hpp..."
+    cp ${myconfig_file} ${builddir}/myconfig.hpp
 fi
 
-cmake $cmake_params $srcdir || exit 1
+cmake ${cmake_params} ${srcdir} || exit 1
 end "CONFIGURE"
 
 # BUILD
@@ -253,76 +253,76 @@ end "BUILD"
 
 # check for exit function, which should never be called from shared library
 # can't do this on CUDA though because nvcc creates a host function that just calls exit for each device funtion
-if [ $with_cuda != "true" -o "$(echo $NVCC | grep -o clang)" = "clang" ]; then
+if [ ${with_cuda} != "true" -o "$(echo ${NVCC} | grep -o clang)" = "clang" ]; then
     if nm -o -C $(find . -name *.so) | grep '[^a-z]exit@@GLIBC'; then
         echo "Found calls to exit() function in shared libraries."
         exit 1
     fi
 fi
 
-if $run_checks; then
+if ${run_checks}; then
     start "TEST"
 
     # integration and unit tests
-    if $make_check; then
-        if [ -z "$run_tests" ]; then
-            if $check_odd_only; then
-                make -j${build_procs} check_python_parallel_odd $make_params || exit 1
-            elif $check_gpu_only; then
-                make -j${build_procs} check_python_gpu $make_params || exit 1
-            elif $check_skip_long; then
-                make -j${build_procs} check_python_skip_long $make_params || exit 1
+    if ${make_check}; then
+        if [ -z "${run_tests}" ]; then
+            if ${check_odd_only}; then
+                make -j${build_procs} check_python_parallel_odd ${make_params} || exit 1
+            elif ${check_gpu_only}; then
+                make -j${build_procs} check_python_gpu ${make_params} || exit 1
+            elif ${check_skip_long}; then
+                make -j${build_procs} check_python_skip_long ${make_params} || exit 1
             else
-                make -j${build_procs} check_python $make_params || exit 1
+                make -j${build_procs} check_python ${make_params} || exit 1
             fi
         else
-            make python_tests $make_params
-            for t in $run_tests; do
-                ctest --timeout 60 --output-on-failure -R $t || exit 1
+            make python_tests ${make_params}
+            for t in ${run_tests}; do
+                ctest --timeout 60 --output-on-failure -R ${t} || exit 1
             done
         fi
-        make -j${build_procs} check_unit_tests $make_params || exit 1
+        make -j${build_procs} check_unit_tests ${make_params} || exit 1
     fi
 
     # tutorial tests
-    if $make_check_tutorials; then
-        make -j${build_procs} check_tutorials $make_params || exit 1
+    if ${make_check_tutorials}; then
+        make -j${build_procs} check_tutorials ${make_params} || exit 1
     fi
 
     # sample tests
-    if $make_check_samples; then
-        make -j${build_procs} check_samples $make_params || exit 1
+    if ${make_check_samples}; then
+        make -j${build_procs} check_samples ${make_params} || exit 1
     fi
 
     # benchmark tests
-    if $make_check_benchmarks; then
-        make -j${build_procs} check_benchmarks $make_params || exit 1
+    if ${make_check_benchmarks}; then
+        make -j${build_procs} check_benchmarks ${make_params} || exit 1
     fi
 
     # installation tests
-    make check_cmake_install $make_params || exit 1
+    make check_cmake_install ${make_params} || exit 1
 
     end "TEST"
 else
     start "TEST"
 
-    if [ "$HIP_PLATFORM" != "hcc" ]; then
-      mpiexec -n $check_procs ./pypresso $srcdir/testsuite/python/particle.py || exit 1
+    if [ "${HIP_PLATFORM}" != "hcc" ]; then
+      mpiexec -n ${check_procs} ./pypresso ${srcdir}/testsuite/python/particle.py || exit 1
     fi
 
     end "TEST"
 fi
 
-if $with_coverage; then
-    cd $builddir
+if ${with_coverage}; then
+    cd ${builddir}
     lcov -q --directory . --ignore-errors graph --capture --output-file coverage.info # capture coverage info
     lcov -q --remove coverage.info '/usr/*' --output-file coverage.info # filter out system
     lcov -q --remove coverage.info '*/doc/*' --output-file coverage.info # filter out docs
     # Uploading report to CodeCov
-    if [ -z "$CODECOV_TOKEN" ]; then
+    if [ -z "${CODECOV_TOKEN}" ]; then
         bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"
     else
-        bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -X gcov || echo "Codecov did not collect coverage reports"
+        bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -X gcov || echo "Codecov did not collect coverage reports"
     fi
 fi
 

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -105,13 +105,13 @@ fi
 command -v nvidia-smi && nvidia-smi
 if [ ${hide_gpu} = "true" ]; then
   echo "Hiding gpu from Cuda via CUDA_VISIBLE_DEVICES"
-  export CUDA_VISIBLE_DEVICES=
+  export CUDA_VISIBLE_DEVICES=""
 fi
 
 if ${insource}; then
-    builddir=${srcdir}
+    builddir="${srcdir}"
 elif [ -z "${builddir}" ]; then
-    builddir=${srcdir}/build
+    builddir="${srcdir}/build"
 fi
 
 outp insource srcdir builddir \
@@ -140,7 +140,7 @@ pep8_command () {
     fi
 }
 
-pep8_command --filename=*.pyx,*.pxd,*.py --select=E111 ${srcdir}/src/python/espressomd/
+pep8_command --filename=*.pyx,*.pxd,*.py --select=E111 "${srcdir}/src/python/espressomd/"
 ec=$?
 if [ ${ec} -eq 0 ]; then
     echo ""
@@ -175,14 +175,14 @@ fi
 pylint_command ${score_option} --reports=no --disable=all --enable=C1001 $(find . -name '*.py*') || { echo -e "\nOld-style classes found.\nPlease convert to new-style:\nclass C: => class C(object):\n" && exit 1; }
 
 if ! ${insource}; then
-    if [ ! -d ${builddir} ]; then
+    if [ ! -d "${builddir}" ]; then
         echo "Creating ${builddir}..."
-        mkdir -p ${builddir}
+        mkdir -p "${builddir}"
     fi
 fi
 
 if ! ${insource}; then
-    cd ${builddir}
+    cd "${builddir}"
 fi
 
 # load MPI module if necessary
@@ -228,20 +228,20 @@ else
     cmake_params="-DWITH_CUDA=OFF ${cmake_params}"
 fi
 
-MYCONFIG_DIR=${srcdir}/maintainer/configs
+MYCONFIG_DIR="${srcdir}/maintainer/configs"
 if [ "${myconfig}" = "default" ]; then
     echo "Using default myconfig."
 else
-    myconfig_file=${MYCONFIG_DIR}/${myconfig}.hpp
+    myconfig_file="${MYCONFIG_DIR}/${myconfig}.hpp"
     if [ ! -e "${myconfig_file}" ]; then
         echo "${myconfig_file} does not exist!"
         exit 1
     fi
     echo "Copying ${myconfig}.hpp to ${builddir}/myconfig.hpp..."
-    cp ${myconfig_file} ${builddir}/myconfig.hpp
+    cp "${myconfig_file}" "${builddir}/myconfig.hpp"
 fi
 
-cmake ${cmake_params} ${srcdir} || exit 1
+cmake ${cmake_params} "${srcdir}" || exit 1
 end "CONFIGURE"
 
 # BUILD
@@ -307,14 +307,14 @@ else
     start "TEST"
 
     if [ "${HIP_PLATFORM}" != "hcc" ]; then
-      mpiexec -n ${check_procs} ./pypresso ${srcdir}/testsuite/python/particle.py || exit 1
+      mpiexec -n ${check_procs} ./pypresso "${srcdir}/testsuite/python/particle.py" || exit 1
     fi
 
     end "TEST"
 fi
 
 if ${with_coverage}; then
-    cd ${builddir}
+    cd "${builddir}"
     lcov -q --directory . --ignore-errors graph --capture --output-file coverage.info # capture coverage info
     lcov -q --remove coverage.info '/usr/*' --output-file coverage.info # filter out system
     lcov -q --remove coverage.info '*/doc/*' --output-file coverage.info # filter out docs

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -6,7 +6,7 @@ cat > $ENV_FILE <<EOF
 insource=$insource
 cmake_params=$cmake_params
 with_fftw=$with_fftw
-with_python_interface=yes
+with_python_interface=true
 with_coverage=$with_coverage
 myconfig=$myconfig
 check_procs=$check_procs
@@ -15,7 +15,7 @@ python_version=$python_version
 EOF
 
 if [ -z "$image" ]; then
-	image=ubuntu
+    image=ubuntu
 fi
 
 image=espressomd/espresso-$image:latest


### PR DESCRIPTION
The number of pitfalls in a shell script can be reduced if Google's [Shell Style Guide](https://google.github.io/styleguide/shell.xml#Variable_expansion) is followed:
- no more cryptic `if [ ! -z "${var+x}" ]` to test if a variable is undeclared (also, the conditional was used incorrectly and caused the error message `line 94: curl: command not found` in Travis-CI without triggering the trap)
- use CMake-like boolean values and test explicitly if a variable is equal to  `true` or `false` (we had a mix of `true`, `yes` and empty strings)
- every variable is brace-quoted
- every string variable is quoted (no more `build_dir="build maxset"; cd ${build_dir}` causing `bash: cd: too many arguments`)