### PR TITLE
armhf: prevent OpenMPI issue on bwCloud

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,6 +332,10 @@ ubuntu:arm64:
 
 ubuntu:armhf:
   <<: *arch_definition
+  tags:
+    - docker
+    - linux
+    - icp
 
 ubuntu:i386:
   <<: *arch_definition


### PR DESCRIPTION
Fixes #2934

The `ubuntu:armhf` container cannot run on bwCloud.