### PR TITLE
Set cmake policy CMP0074

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ cmake_minimum_required(VERSION 3.4)
 include(FeatureSummary)
 project(ESPResSo)
 include(cmake/FindPythonModule.cmake)
+cmake_policy(SET CMP0074 NEW)
 
 enable_language(CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ cmake_minimum_required(VERSION 3.4)
 include(FeatureSummary)
 project(ESPResSo)
 include(cmake/FindPythonModule.cmake)
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.12")
   cmake_policy(SET CMP0074 NEW)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ cmake_minimum_required(VERSION 3.4)
 include(FeatureSummary)
 project(ESPResSo)
 include(cmake/FindPythonModule.cmake)
-cmake_policy(SET CMP0074 NEW)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+  cmake_policy(SET CMP0074 NEW)
+endif()
 
 enable_language(CXX)
 


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/policy/CMP0074.html
Without the policy, cmake >= 3.12 will not use the PACKAGE_NAME_ROOT
environment variables as hints for finding said packages.

Fixes an issue for FFTW3_ROOT for me. Should be useful for others as well.

Description of changes:
 - One line added to CMakeLists.txt


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
