### PR TITLE
Move intel and qemu builds to tags and release branches only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -325,7 +325,8 @@ rocm-maxset:
     - docker
     - linux
   only:
-    - schedules
+    - /.*\..*/
+    - tags
 
 ubuntu:arm64:
   <<: *arch_definition
@@ -395,6 +396,9 @@ intel:18:
     - linux
     - cuda
     - icp
+  only:
+    - /.*\..*/
+    - tags
 
 check_sphinx:
   <<: *global_job_definition


### PR DESCRIPTION
As discussed earlier. The regex matches any branch that contains a dot, e.g. _4.0_. Fixed #2942.