### PR TITLE
OpenGL.GL missing before GL_DEPTH_ATTACHEMENT

### DIFF
--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -520,7 +520,7 @@ class openGLLive(object):
                 OpenGL.GL.GL_RENDERBUFFER, OpenGL.GL.GL_DEPTH_COMPONENT,
                 self.specs['window_size'][0], self.specs['window_size'][1])
             OpenGL.GL.glFramebufferRenderbuffer(
-                OpenGL.GL.GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, OpenGL.GL.GL_RENDERBUFFER, dbo)
+                OpenGL.GL.GL_FRAMEBUFFER, OpenGL.GL.GL_DEPTH_ATTACHMENT, OpenGL.GL.GL_RENDERBUFFER, dbo)
 
             self._reshape_window(
                 self.specs['window_size'][0], self.specs['window_size'][1])


### PR DESCRIPTION
Fixes #2295
Crash when making screenshots with module `espressomd.visualization_opengl`:
```
Traceback (most recent call last):
  File "EOF.py", line 68, in <module>
    visualizer.screenshot()
  File "visualization_opengl.pyx", line 522, in espressomd.visualization_opengl.openGLLive.screenshot
NameError: name 'GL_DEPTH_ATTACHMENT' is not defined
```
Description of changes:
 - Added `OpenGL.GL.` in front of `GL_DEPTH_ATTACHEMENT`

PR Checklist
------------
 - [x] Tests: made Screenshots
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
