### PR TITLE
cmake: add soversion to libH5mdCore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,6 +229,7 @@ ubuntu:wo-dependencies:
   tags:
     - docker
     - linux
+  when: manual
 
 ubuntu:arm64:
   <<: *arch_definition
@@ -296,6 +297,7 @@ intel:15:
     - linux
     - cuda
     - icp
+  when: manual
 
 intel:17:
   stage: build
@@ -309,6 +311,7 @@ intel:17:
     - linux
     - cuda
     - icp
+  when: manual
 
 check_sphinx:
   stage: additional_checks

--- a/src/core/io/writer/CMakeLists.txt
+++ b/src/core/io/writer/CMakeLists.txt
@@ -7,5 +7,6 @@ target_include_directories(H5mdCore SYSTEM PUBLIC
 
 add_dependencies(H5mdCore EspressoConfig)
 target_include_directories(H5mdCore PRIVATE ${CMAKE_SOURCE_DIR}/src/core ${CMAKE_BINARY_DIR}/src/core)
+set_target_properties(H5mdCore PROPERTIES SOVERSION ${SOVERSION})
 install(TARGETS H5mdCore LIBRARY DESTINATION ${LIBDIR})
 endif()


### PR DESCRIPTION
Found on Fedora package.

This fix might not be needed on master as libs get installed in python directory if I recall correctly.