### PR TITLE
Make particle sorting unique for nsquare

### DIFF
--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -544,9 +544,9 @@ public:
    *
    * This method can only be called on the head node.
    */
-  template <class R, class... Args>
+  template <class R, class... Args, class... ArgRef>
   auto call(Result::OneRank, boost::optional<R> (*fp)(Args...),
-            Args... args) const -> std::remove_reference_t<R> {
+            ArgRef... args) const -> std::remove_reference_t<R> {
 
     const int id = m_func_ptr_to_id.at(reinterpret_cast<void (*)()>(fp));
     call(id, args...);

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -58,8 +58,7 @@ CellPList local_cells = {nullptr, 0, 0};
 CellPList ghost_cells = {nullptr, 0, 0};
 
 /** Type of cell structure in use */
-CellStructure cell_structure = {
-    CELL_STRUCTURE_NONEYET, true, {}, {}, {}, {}, nullptr, nullptr};
+CellStructure cell_structure;
 
 double max_range = 0.0;
 
@@ -366,7 +365,7 @@ void cells_resort_particles(int global_flag) {
     layered_exchange_and_sort_particles(global_flag, &displaced_parts);
   } break;
   case CELL_STRUCTURE_NSQUARE:
-    nsq_balance_particles(global_flag);
+    nsq_balance_particles(global_flag, &displaced_parts);
     break;
   case CELL_STRUCTURE_DOMDEC:
     dd_exchange_and_sort_particles(global_flag, &displaced_parts, node_grid);

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -327,7 +327,7 @@ ParticleList sort_and_fold_parts(const CellStructure &cs, CellPList cells) {
 
       fold_and_reset(p);
 
-      auto target_cell = cs.position_to_cell(p.r.p);
+      auto target_cell = cs.position_to_cell(p);
 
       if (target_cell == nullptr) {
         append_unindexed_particle(&displaced_parts,
@@ -465,5 +465,5 @@ Cell *find_current_cell(const Particle &p) {
     return nullptr;
   }
 
-  return cell_structure.position_to_cell(p.l.p_old);
+  return cell_structure.position_to_cell(p);
 }

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -326,7 +326,7 @@ ParticleList sort_and_fold_parts(const CellStructure &cs, CellPList cells) {
 
       fold_and_reset(p);
 
-      auto target_cell = cs.position_to_cell(p);
+      auto target_cell = cs.particle_to_cell(p);
 
       if (target_cell == nullptr) {
         append_unindexed_particle(&displaced_parts,
@@ -365,7 +365,7 @@ void cells_resort_particles(int global_flag) {
     layered_exchange_and_sort_particles(global_flag, &displaced_parts);
   } break;
   case CELL_STRUCTURE_NSQUARE:
-    nsq_balance_particles(global_flag, &displaced_parts);
+    nsq_exchange_particles(global_flag, &displaced_parts);
     break;
   case CELL_STRUCTURE_DOMDEC:
     dd_exchange_and_sort_particles(global_flag, &displaced_parts, node_grid);
@@ -464,5 +464,5 @@ Cell *find_current_cell(const Particle &p) {
     return nullptr;
   }
 
-  return cell_structure.position_to_cell(p);
+  return cell_structure.particle_to_cell(p);
 }

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -157,11 +157,12 @@ struct CellStructure {
   GhostCommunicator collect_ghost_force_comm;
 
   /** Cell system dependent function to find the right cell for a
-   *  particle at position @p pos.
-   *  \param  p Position of a particle.
-   *  \return pointer to cell  where to put the particle.
+   *  particle.
+   *  \param  p Particle.
+   *  \return pointer to cell  where to put the particle, nullptr
+   *          if the particle does not belong on this node.
    */
-  Cell *(*position_to_cell)(const Particle &p) = nullptr;
+  Cell *(*particle_to_cell)(const Particle &p) = nullptr;
 };
 
 /*@}*/

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -143,9 +143,9 @@ struct CellPList {
  */
 struct CellStructure {
   /** type descriptor */
-  int type;
+  int type = CELL_STRUCTURE_NONEYET;
 
-  bool use_verlet_list;
+  bool use_verlet_list = true;
 
   /** Communicator to exchange ghost cell information. */
   GhostCommunicator ghost_cells_comm;
@@ -156,18 +156,12 @@ struct CellStructure {
   /** Communicator to collect ghost forces. */
   GhostCommunicator collect_ghost_force_comm;
 
-  /** Cell system dependent function to find the right node for a
-   *  particle at position @p pos.
-   *  \param  pos Position of a particle.
-   *  \return number of the node where to put the particle.
-   */
-  int (*position_to_node)(const Utils::Vector3d &pos);
   /** Cell system dependent function to find the right cell for a
    *  particle at position @p pos.
    *  \param  p Position of a particle.
    *  \return pointer to cell  where to put the particle.
    */
-  Cell *(*position_to_cell)(const Particle &p);
+  Cell *(*position_to_cell)(const Particle &p) = nullptr;
 };
 
 /*@}*/

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -164,10 +164,10 @@ struct CellStructure {
   int (*position_to_node)(const Utils::Vector3d &pos);
   /** Cell system dependent function to find the right cell for a
    *  particle at position @p pos.
-   *  \param  pos Position of a particle.
+   *  \param  p Position of a particle.
    *  \return pointer to cell  where to put the particle.
    */
-  Cell *(*position_to_cell)(const Utils::Vector3d &pos);
+  Cell *(*position_to_cell)(const Particle &p);
 };
 
 /*@}*/

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -371,7 +371,7 @@ void place_vs_and_relate_to_particle(const int current_vs_pid,
   added_particle(current_vs_pid);
   Particle new_part;
   new_part.p.identity = current_vs_pid;
-  new_part.r.p = new_part.r.p_old = pos;
+  new_part.r.p = pos;
   auto p_vs = append_indexed_particle(local_cells.cell[0], std::move(new_part));
 
   local_vs_relate_to(p_vs, &get_part(relate_to));

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -366,16 +366,13 @@ void coldet_do_three_particle_bond(Particle &p, Particle &p1, Particle &p2) {
 
 #ifdef VIRTUAL_SITES_RELATIVE
 void place_vs_and_relate_to_particle(const int current_vs_pid,
-                                     const Utils::Vector3d &pos, int relate_to,
-                                     const Utils::Vector3d &initial_pos) {
-
-  // The virtual site is placed at initial_pos which will be in the local
-  // node's domain. It will then be moved to its final position.
-  // A resort occurs after vs-based collisions anyway, which will move the vs
-  // into the right cell.
+                                     const Utils::Vector3d &pos,
+                                     int relate_to) {
   added_particle(current_vs_pid);
-  auto p_vs = local_place_particle(current_vs_pid, initial_pos.data(), 1);
-  p_vs->r.p = pos;
+  Particle new_part;
+  new_part.p.identity = current_vs_pid;
+  new_part.r.p = new_part.r.p_old = pos;
+  auto p_vs = append_indexed_particle(local_cells.cell[0], std::move(new_part));
 
   local_vs_relate_to(p_vs, &get_part(relate_to));
 
@@ -577,12 +574,6 @@ void handle_collisions() {
 
       } else { // We consider the pair because one particle
                // is local to the node and the other is local or ghost
-
-        // Use initial position for new vs, which is in the local node's
-        // domain
-        // Vs is moved afterwards and resorted after all collision s are handled
-        const Utils::Vector3d initial_pos{my_left[0], my_left[1], my_left[2]};
-
         // If we are in the two vs mode
         // Virtual site related to first particle in the collision
         if (collision_params.mode & COLLISION_MODE_VS) {
@@ -598,7 +589,7 @@ void handle_collisions() {
           auto handle_particle = [&](Particle *p, Utils::Vector3d const &pos) {
             if (not p->l.ghost) {
               place_vs_and_relate_to_particle(current_vs_pid, pos,
-                                              p->identity(), initial_pos);
+                                              p->identity());
               // Particle storage locations may have changed due to
               // added particle
               p1 = local_particles[c.pp1];
@@ -661,8 +652,8 @@ void handle_collisions() {
 
           // Vs placement happens on the node that has p1
           if (!attach_vs_to.l.ghost) {
-            place_vs_and_relate_to_particle(
-                current_vs_pid, pos, attach_vs_to.identity(), initial_pos);
+            place_vs_and_relate_to_particle(current_vs_pid, pos,
+                                            attach_vs_to.identity());
             // Particle storage locations may have changed due to
             // added particle
             p1 = local_particles[c.pp1];
@@ -685,11 +676,9 @@ void handle_collisions() {
     }
 #endif
 
-    // If any node had a collision, all nodes need to do on_particle_change
-    // and resort
-
+    // If any node had a collision, all nodes need to resort
     if (!gathered_queue.empty()) {
-      on_particle_change();
+      set_resort_particles(Cells::RESORT_GLOBAL);
       cells_update_ghosts();
     }
   }    // are we in one of the vs_based methods

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -290,9 +290,9 @@ boost::optional<int> mpi_place_new_particle_slave(int part,
 
 REGISTER_CALLBACK_ONE_RANK(mpi_place_new_particle_slave)
 
-int mpi_place_new_particle(int id, double *pos) {
+int mpi_place_new_particle(int id, const Utils::Vector3d &pos) {
   return mpi_call(Communication::Result::one_rank, mpi_place_new_particle_slave,
-                  id, Utils::Vector3d{pos[0], pos[1], pos[2]});
+                  id, pos);
 }
 
 /****************** REQ_REM_PART ************/

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -142,7 +142,7 @@ void mpi_reshape_communicator(std::array<int, 3> const &node_grid,
  *  \param node  the node to attach it to.
  *  \param pos   the particles position.
  */
-void mpi_place_particle(int node, int id, double pos[3]);
+void mpi_place_particle(int node, int id, const Utils::Vector3d &pos);
 
 /** Issue REQ_PLACE: create particle at a position on a node.
  *  Also calls \ref on_particle_change.

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -149,7 +149,7 @@ void mpi_place_particle(int node, int id, double pos[3]);
  *  \param id    the particle to create.
  *  \param pos   the particles position.
  */
-int mpi_place_new_particle(int id, double *pos);
+int mpi_place_new_particle(int id, const Utils::Vector3d &pos);
 
 /** Issue REQ_SET_EXCLUSION: send exclusions.
  *  Also calls \ref on_particle_change.

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -147,10 +147,9 @@ void mpi_place_particle(int node, int id, double pos[3]);
 /** Issue REQ_PLACE: create particle at a position on a node.
  *  Also calls \ref on_particle_change.
  *  \param id    the particle to create.
- *  \param node  the node to attach it to.
  *  \param pos   the particles position.
  */
-void mpi_place_new_particle(int node, int id, double pos[3]);
+int mpi_place_new_particle(int id, double *pos);
 
 /** Issue REQ_SET_EXCLUSION: send exclusions.
  *  Also calls \ref on_particle_change.

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -244,10 +244,10 @@ void check_particle_sorting() {
     auto cell = local_cells.cell[c];
     for (int n = 0; n < cell->n; n++) {
       auto p = cell->part[n];
-      if (cell_structure.position_to_cell(p.r.p) != cell) {
+      if (cell_structure.position_to_cell(p) != cell) {
         fprintf(stderr, "%d: misplaced part id %d. %p != %p\n", this_node,
                 p.p.identity, (void *)cell,
-                (void *)cell_structure.position_to_cell(p.r.p));
+                (void *)cell_structure.position_to_cell(p));
         errexit();
       }
     }

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -248,16 +248,6 @@ void check_particle_sorting() {
         fprintf(stderr, "%d: misplaced part id %d. %p != %p\n", this_node,
                 p.p.identity, (void *)cell,
                 (void *)cell_structure.position_to_cell(p.r.p));
-        auto folded_pos = folded_position(p);
-        fprintf(stderr, "%d: misplaced folded cell %p\n", this_node,
-                (void *)cell_structure.position_to_cell(folded_pos));
-        fprintf(stderr, "%d: misplaced pos %e %e %e\n", this_node, p.r.p[0],
-                p.r.p[1], p.r.p[2]);
-        fprintf(stderr, "%d: misplaced folded_pos %e %e %e\n", this_node,
-                folded_pos[0], folded_pos[1], folded_pos[2]);
-        fprintf(stderr, "%d: misplaced part node %d\n", this_node,
-                cell_structure.position_to_node(p.r.p));
-
         errexit();
       }
     }

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -244,10 +244,10 @@ void check_particle_sorting() {
     auto cell = local_cells.cell[c];
     for (int n = 0; n < cell->n; n++) {
       auto p = cell->part[n];
-      if (cell_structure.position_to_cell(p) != cell) {
+      if (cell_structure.particle_to_cell(p) != cell) {
         fprintf(stderr, "%d: misplaced part id %d. %p != %p\n", this_node,
                 p.p.identity, (void *)cell,
-                (void *)cell_structure.position_to_cell(p));
+                (void *)cell_structure.particle_to_cell(p));
         errexit();
       }
     }

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -648,7 +648,6 @@ void dd_topology_init(CellPList *old, const Utils::Vector3i &grid) {
   min_num_cells = std::max(min_num_cells, calc_processor_min_num_cells(grid));
 
   cell_structure.type = CELL_STRUCTURE_DOMDEC;
-  cell_structure.position_to_node = map_position_node_array;
   cell_structure.position_to_cell = [](const Particle &p) {
     return dd_save_position_to_cell(p.r.p);
   };

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -643,17 +643,15 @@ void dd_topology_init(CellPList *old, const Utils::Vector3i &grid) {
   int c, p;
   int exchange_data, update_data;
 
-  CELL_TRACE(fprintf(stderr,
-                     "%d: dd_topology_init: Number of recieved cells=%d\n",
-                     this_node, old->n));
-
   /* Min num cells can not be smaller than calc_processor_min_num_cells,
-     but may be set to a larger value by the user for performance reasons. */
+    but may be set to a larger value by the user for performance reasons. */
   min_num_cells = std::max(min_num_cells, calc_processor_min_num_cells(grid));
 
   cell_structure.type = CELL_STRUCTURE_DOMDEC;
   cell_structure.position_to_node = map_position_node_array;
-  cell_structure.position_to_cell = dd_save_position_to_cell;
+  cell_structure.position_to_cell = [](const Particle &p) {
+    return dd_save_position_to_cell(p.r.p);
+  };
 
   /* set up new domain decomposition cell structure */
   dd_create_cell_grid();

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -648,7 +648,7 @@ void dd_topology_init(CellPList *old, const Utils::Vector3i &grid) {
   min_num_cells = std::max(min_num_cells, calc_processor_min_num_cells(grid));
 
   cell_structure.type = CELL_STRUCTURE_DOMDEC;
-  cell_structure.position_to_cell = [](const Particle &p) {
+  cell_structure.particle_to_cell = [](const Particle &p) {
     return dd_save_position_to_cell(p.r.p);
   };
 

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -396,7 +396,9 @@ void mpi_mpiio_common_read(const char *filename, unsigned fields) {
                              3 * pref, MPI_DOUBLE);
 
     for (int i = 0; i < nlocalpart; ++i) {
-      local_place_particle(id[i], &pos[3 * i], 1);
+      local_place_particle(
+          id[i],
+          Utils::Vector3d{pos[3 * i + 0], pos[3 * i + 1], pos[3 * i + 2]}, 1);
     }
   }
 

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -309,7 +309,9 @@ void layered_topology_init(CellPList *old, Utils::Vector3i &grid) {
 
   cell_structure.type = CELL_STRUCTURE_LAYERED;
   cell_structure.position_to_node = map_position_node_array;
-  cell_structure.position_to_cell = layered_position_to_cell;
+  cell_structure.position_to_cell = [](const Particle &p) {
+    return layered_position_to_cell(p.r.p);
+  };
 
   /* check node grid. All we can do is 1x1xn. */
   if (grid[0] != 1 || grid[1] != 1) {

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -308,7 +308,7 @@ void layered_topology_init(CellPList *old, Utils::Vector3i &grid) {
       this_node, old->n, max_range));
 
   cell_structure.type = CELL_STRUCTURE_LAYERED;
-  cell_structure.position_to_cell = [](const Particle &p) {
+  cell_structure.particle_to_cell = [](const Particle &p) {
     return layered_position_to_cell(p.r.p);
   };
 

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -308,7 +308,6 @@ void layered_topology_init(CellPList *old, Utils::Vector3i &grid) {
       this_node, old->n, max_range));
 
   cell_structure.type = CELL_STRUCTURE_LAYERED;
-  cell_structure.position_to_node = map_position_node_array;
   cell_structure.position_to_cell = [](const Particle &p) {
     return layered_position_to_cell(p.r.p);
   };

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -34,7 +34,9 @@
 
 Cell *local;
 
-Cell *nsq_position_to_cell(const Utils::Vector3d &pos) { return local; }
+Cell *nsq_position_to_cell(int id) {
+  return ((id % n_nodes) == this_node) ? local : nullptr;
+}
 int nsq_position_to_node(const Utils::Vector3d &) { return this_node; }
 
 void nsq_topology_release() {
@@ -69,9 +71,8 @@ void nsq_topology_init(CellPList *old) {
   CELL_TRACE(fprintf(stderr, "%d: nsq_topology_init, %d\n", this_node, old->n));
 
   cell_structure.type = CELL_STRUCTURE_NSQUARE;
-  cell_structure.position_to_node = nsq_position_to_node;
   cell_structure.position_to_cell = [](const Particle &p) {
-    return nsq_position_to_cell(p.r.p);
+    return nsq_position_to_cell(p.identity());
   };
 
   realloc_cells(n_nodes);
@@ -155,98 +156,28 @@ void nsq_topology_init(CellPList *old) {
   update_local_particles(local);
 }
 
-void nsq_balance_particles(int global_flag) {
-  int i, n, surplus, s_node, tmp, lack, l_node, transfer;
-
-  /* we don't have the concept of neighbors, and therefore don't need that.
-     However, if global particle changes happen, we might want to rebalance. */
-  if (global_flag != CELL_GLOBAL_EXCHANGE)
+void nsq_balance_particles(int global_flag, ParticleList *displaced_parts) {
+  if (not global_flag) {
+    assert(displaced_parts->n == 0);
     return;
-
-  int pp = cells_get_n_particles();
-  auto *ppnode = (int *)Utils::malloc(n_nodes * sizeof(int));
-  /* minimal difference between node shares */
-  int minshare = n_part / n_nodes;
-  int maxshare = minshare + 1;
-
-  CELL_TRACE(fprintf(stderr, "%d: nsq_balance_particles: load %d-%d\n",
-                     this_node, minshare, maxshare));
-
-  MPI_Allgather(&pp, 1, MPI_INT, ppnode, 1, MPI_INT, comm_cart);
-  for (;;) {
-    /* find node with most excessive particles */
-    surplus = -1;
-    s_node = -1;
-    for (n = 0; n < n_nodes; n++) {
-      tmp = ppnode[n] - minshare;
-      CELL_TRACE(fprintf(stderr, "%d: nsq_balance_particles: node %d has %d\n",
-                         this_node, n, ppnode[n]));
-      if (tmp > surplus) {
-        surplus = tmp;
-        s_node = n;
-      }
-    }
-    CELL_TRACE(fprintf(stderr,
-                       "%d: nsq_balance_particles: excess %d on node %d\n",
-                       this_node, surplus, s_node));
-
-    /* find node with most lacking particles */
-    lack = -1;
-    l_node = -1;
-    for (n = 0; n < n_nodes; n++) {
-      tmp = maxshare - ppnode[n];
-      if (tmp > lack) {
-        lack = tmp;
-        l_node = n;
-      }
-    }
-    CELL_TRACE(fprintf(stderr,
-                       "%d: nsq_balance_particles: lack %d on node %d\n",
-                       this_node, lack, l_node));
-
-    /* should not happen: minshare or maxshare wrong or more likely,
-       the algorithm */
-    if (s_node == -1 || l_node == -1) {
-      fprintf(stderr, "%d: Particle load balancing failed\n", this_node);
-      break;
-    }
-
-    /* exit if all nodes load is withing min and max share */
-    if (lack <= 1 && surplus <= 1)
-      break;
-
-    transfer = lack < surplus ? lack : surplus;
-
-    if (s_node == this_node) {
-      ParticleList send_buf;
-      init_particlelist(&send_buf);
-      realloc_particlelist(&send_buf, send_buf.n = transfer);
-      for (i = 0; i < transfer; i++) {
-        send_buf.part[i] = std::move(local->part[--local->n]);
-      }
-      realloc_particlelist(local, local->n);
-      update_local_particles(local);
-
-      send_particles(&send_buf, l_node);
-
-#ifdef ADDITIONAL_CHECKS
-      check_particle_consistency();
-#endif
-
-    } else if (l_node == this_node) {
-      ParticleList recv_buf{};
-
-      recv_particles(&recv_buf, s_node);
-      for (int i = 0; i < recv_buf.n; i++) {
-        append_indexed_particle(local, std::move(recv_buf.part[i]));
-      }
-
-      realloc_particlelist(&recv_buf, 0);
-    }
-    ppnode[s_node] -= transfer;
-    ppnode[l_node] += transfer;
   }
-  CELL_TRACE(fprintf(stderr, "%d: nsq_balance_particles: done\n", this_node));
 
-  free(ppnode);
+  /* Sort displaced particles by the node they belong to. */
+  std::vector<std::vector<Particle>> send_buf(n_nodes);
+  for (auto &p : Utils::make_span(displaced_parts->part, displaced_parts->n)) {
+    auto const target_node = (p.identity() % n_nodes);
+    send_buf.at(target_node).emplace_back(std::move(p));
+  }
+  displaced_parts->n = 0;
+
+  /* Exchange particles */
+  std::vector<std::vector<Particle>> recv_buf(n_nodes);
+  boost::mpi::all_to_all(comm_cart, send_buf, recv_buf);
+
+  /* Add new particles belonging to this node */
+  for (auto &parts : recv_buf) {
+    for (auto &p : parts) {
+      append_indexed_particle(local, std::move(p));
+    }
+  }
 }

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -70,7 +70,9 @@ void nsq_topology_init(CellPList *old) {
 
   cell_structure.type = CELL_STRUCTURE_NSQUARE;
   cell_structure.position_to_node = nsq_position_to_node;
-  cell_structure.position_to_cell = nsq_position_to_cell;
+  cell_structure.position_to_cell = [](const Particle &p) {
+    return nsq_position_to_cell(p.r.p);
+  };
 
   realloc_cells(n_nodes);
 

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -34,7 +34,7 @@
 
 Cell *local;
 
-Cell *nsq_position_to_cell(int id) {
+static Cell *nsq_id_to_cell(int id) {
   return ((id % n_nodes) == this_node) ? local : nullptr;
 }
 
@@ -71,7 +71,7 @@ void nsq_topology_init(CellPList *old) {
 
   cell_structure.type = CELL_STRUCTURE_NSQUARE;
   cell_structure.particle_to_cell = [](const Particle &p) {
-    return nsq_position_to_cell(p.identity());
+    return nsq_id_to_cell(p.identity());
   };
 
   realloc_cells(n_nodes);

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -37,7 +37,6 @@ Cell *local;
 Cell *nsq_position_to_cell(int id) {
   return ((id % n_nodes) == this_node) ? local : nullptr;
 }
-int nsq_position_to_node(const Utils::Vector3d &) { return this_node; }
 
 void nsq_topology_release() {
   CELL_TRACE(fprintf(stderr, "%d: nsq_topology_release:\n", this_node));
@@ -71,7 +70,7 @@ void nsq_topology_init(CellPList *old) {
   CELL_TRACE(fprintf(stderr, "%d: nsq_topology_init, %d\n", this_node, old->n));
 
   cell_structure.type = CELL_STRUCTURE_NSQUARE;
-  cell_structure.position_to_cell = [](const Particle &p) {
+  cell_structure.particle_to_cell = [](const Particle &p) {
     return nsq_position_to_cell(p.identity());
   };
 
@@ -156,7 +155,7 @@ void nsq_topology_init(CellPList *old) {
   update_local_particles(local);
 }
 
-void nsq_balance_particles(int global_flag, ParticleList *displaced_parts) {
+void nsq_exchange_particles(int global_flag, ParticleList *displaced_parts) {
   if (not global_flag) {
     assert(displaced_parts->n == 0);
     return;
@@ -168,7 +167,7 @@ void nsq_balance_particles(int global_flag, ParticleList *displaced_parts) {
     auto const target_node = (p.identity() % n_nodes);
     send_buf.at(target_node).emplace_back(std::move(p));
   }
-  displaced_parts->n = 0;
+  realloc_particlelist(displaced_parts, displaced_parts->n = 0);
 
   /* Exchange particles */
   std::vector<std::vector<Particle>> recv_buf(n_nodes);

--- a/src/core/nsquare.hpp
+++ b/src/core/nsquare.hpp
@@ -43,17 +43,6 @@
  *  This means, that each communication cycle, 1 processor is idle, which is
  *  pretty ineffective.
  *
- *  The second main part of this cell system is a load balancer which
- *  at the beginning of the integration is called and balances the
- *  numbers of particles between the nodes. This means that the number
- *  of particles per node should be around \f$N/P\f$, so the goal is to
- *  let every processor have a number of particles which is one of the
- *  two integers closest to \f$N/P\f$. The algorithm is greedy, i. e. it
- *  searches for the node with most and least particles and transfers
- *  as much as possible particles between them so that at least one of
- *  them satisfies the constraints. Of course the algorithm terminates
- *  if both satisfy the condition without transfer.
- *
  *  The calculations themselves are just simple loops over all
  *  appropriate particle pairs.
  *
@@ -69,5 +58,5 @@ void nsq_topology_release();
 void nsq_topology_init(CellPList *local);
 
 /** implements the load balancing as described above. */
-void nsq_balance_particles(int global_flag, ParticleList *displaced_parts);
+void nsq_exchange_particles(int global_flag, ParticleList *displaced_parts);
 #endif

--- a/src/core/nsquare.hpp
+++ b/src/core/nsquare.hpp
@@ -69,5 +69,5 @@ void nsq_topology_release();
 void nsq_topology_init(CellPList *local);
 
 /** implements the load balancing as described above. */
-void nsq_balance_particles(int global_flag);
+void nsq_balance_particles(int global_flag, ParticleList *displaced_parts);
 #endif

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -833,16 +833,17 @@ void prefetch_particle_data(std::vector<int> ids) {
                            std::make_move_iterator(parts.begin()));
 }
 
-int place_particle(int part, double p[3]) {
+int place_particle(int part, const double *p_) {
+  Utils::Vector3d p{p_[0], p_[1], p_[2]};
+
   if (particle_exists(part)) {
-    mpi_place_particle(get_particle_node(part), part, p);
+    mpi_place_particle(get_particle_node(part), part, p.data());
 
     return ES_PART_OK;
-  } else {
-    particle_node[part] = mpi_place_new_particle(part, p);
-
-    return ES_PART_CREATED;
   }
+  particle_node[part] = mpi_place_new_particle(part, p);
+
+  return ES_PART_CREATED;
 }
 
 void set_particle_v(int part, double *v) {

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1187,7 +1187,6 @@ Particle *local_place_particle(int part, const double p[3], int _new) {
     Particle new_part;
     new_part.p.identity = part;
     new_part.r.p = pp;
-    new_part.r.p_old = new_part.r.p;
     new_part.l.i = i;
 
     /* allocate particle anew */
@@ -1202,7 +1201,6 @@ Particle *local_place_particle(int part, const double p[3], int _new) {
   auto pt = local_particles[part];
   pt->r.p = pp;
   pt->l.i = i;
-  pt->r.p_old = pp;
 
   return pt;
 }

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -834,25 +834,15 @@ void prefetch_particle_data(std::vector<int> ids) {
 }
 
 int place_particle(int part, double p[3]) {
-  int retcode = ES_PART_OK;
-
-  int pnode;
   if (particle_exists(part)) {
-    pnode = get_particle_node(part);
-    mpi_place_particle(pnode, part, p);
+    mpi_place_particle(get_particle_node(part), part, p);
+
+    return ES_PART_OK;
   } else {
-    /* new particle, node by spatial position */
-    pnode = cell_structure.position_to_node(Utils::Vector3d{p, p + 3});
+    particle_node[part] = mpi_place_new_particle(part, p);
 
-    /* master node specific stuff */
-    particle_node[part] = pnode;
-
-    retcode = ES_PART_CREATED;
-
-    mpi_place_new_particle(pnode, part, p);
+    return ES_PART_CREATED;
   }
-
-  return retcode;
 }
 
 void set_particle_v(int part, double *v) {

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1190,7 +1190,7 @@ Particle *local_place_particle(int part, const double p[3], int _new) {
     new_part.l.i = i;
 
     /* allocate particle anew */
-    auto cell = cell_structure.position_to_cell(new_part);
+    auto cell = cell_structure.particle_to_cell(new_part);
     if (!cell) {
       return nullptr;
     }

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -833,11 +833,11 @@ void prefetch_particle_data(std::vector<int> ids) {
                            std::make_move_iterator(parts.begin()));
 }
 
-int place_particle(int part, const double *p_) {
-  Utils::Vector3d p{p_[0], p_[1], p_[2]};
+int place_particle(int part, const double *pos) {
+  Utils::Vector3d p{pos[0], pos[1], pos[2]};
 
   if (particle_exists(part)) {
-    mpi_place_particle(get_particle_node(part), part, p.data());
+    mpi_place_particle(get_particle_node(part), part, p);
 
     return ES_PART_OK;
   }
@@ -1178,14 +1178,14 @@ void local_remove_particle(int part) {
   Particle p_destroy = extract_indexed_particle(cell, n);
 }
 
-Particle *local_place_particle(int part, const double p[3], int _new) {
-  auto pp = Utils::Vector3d{p[0], p[1], p[2]};
+Particle *local_place_particle(int id, const Utils::Vector3d &pos, int _new) {
+  auto pp = Utils::Vector3d{pos[0], pos[1], pos[2]};
   auto i = Utils::Vector3i{};
   fold_position(pp, i);
 
   if (_new) {
     Particle new_part;
-    new_part.p.identity = part;
+    new_part.p.identity = id;
     new_part.r.p = pp;
     new_part.l.i = i;
 
@@ -1198,7 +1198,7 @@ Particle *local_place_particle(int part, const double p[3], int _new) {
     return append_indexed_particle(cell, std::move(new_part));
   }
 
-  auto pt = local_particles[part];
+  auto pt = local_particles[id];
   pt->r.p = pp;
   pt->l.i = i;
 

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -838,13 +838,13 @@ void remove_all_bonds_to(int part);
  *  Move a particle to a new position. If it does not exist, it is created.
  *  The position must be on the local node!
  *
- *  @param part the identity of the particle to move
- *  @param p    its new position
+ *  @param id the identity of the particle to move
+ *  @param pos    its new position
  *  @param _new  if true, the particle is allocated, else has to exists already
  *
  *  @return Pointer to the particle.
  */
-Particle *local_place_particle(int part, const double p[3], int _new);
+Particle *local_place_particle(int id, const Utils::Vector3d &pos, int _new);
 
 /** Used by \ref mpi_place_particle, should not be used elsewhere.
  *  Called if on a different node a new particle was added.

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -582,12 +582,12 @@ void invalidate_fetch_cache();
  *  Move a particle to a new position.
  *  If it does not exist, it is created.
  *  @param part the identity of the particle to move
- *  @param p    its new position
+ *  @param p_    its new position
  *  @retval ES_PART_OK if particle existed
  *  @retval ES_PART_CREATED if created
  *  @retval ES_PART_ERROR if id is illegal
  */
-int place_particle(int part, double p[3]);
+int place_particle(int part, const double *p_);
 
 /** Call only on the master node: set particle velocity.
  *  @param part the particle.


### PR DESCRIPTION
The nsq cell system did not have a unique mapping of
particles to nodes/cells (same thing), which was causing me trouble. Now they are mapped
to the node by their id, which also allowed to simplify the particle exchange considerably and
a global mapping of positions to nodes is no longer needed.


Description of changes:
 - Allow particle sorting by other properties than position
 - Sort by particle id for nsquare cell system
 - Removed CellStructure::position_to_node
