### PR TITLE
Exotic architecture containers have switched to Python 3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ ubuntu:wo-dependencies:
   script:
     - export with_cuda=false
     - export OMPI_MCA_btl_vader_single_copy_mechanism=none
-    - export myconfig=maxset
+    - export myconfig=maxset python_version=3
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker


### PR DESCRIPTION
Fixes the failed builds observed in https://github.com/espressomd/espresso/pull/2946