### PR TITLE
Require Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ if(WITH_CUDA)
   endif()
 endif(WITH_CUDA)
 
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
 
 if(WITH_PYTHON)
   find_package(Cython 0.23 REQUIRED)


### PR DESCRIPTION
This is needed for #2950 (otherwise the Apple-provided Python 2.7 is picked up), but must not be merged until all CI builds have been moved to Python 3.