### PR TITLE
utils: memory order as parameter for get_linear_index

### DIFF
--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -85,6 +85,8 @@ get_linear_index(int a, int b, int c, const Vector3i &adim,
     return a + adim[0] * (b + adim[1] * c);
   case MemoryOrder::ROW_MAJOR:
     return adim[1] * adim[2] * a + adim[2] * b + c;
+  default:
+    throw std::runtime_error("Unknown memory order");
   }
 }
 

--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -84,7 +84,6 @@ inline int get_linear_index(int a, int b, int c, const Vector3i &adim,
   return a + adim[0] * (b + adim[1] * c);
 }
 
-
 /** get the linear index from the position (@p a,@p b,@p c) in a 3D grid
  *  of dimensions @p adim, , usiung row major memory order.
  *

--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -58,28 +58,52 @@ inline void unravel_index(InputIterator dimensions_begin,
   }
 }
 
+namespace MemoryOrder {
+constexpr struct RowMajor {
+} row_major;
+constexpr struct ColumnMajor { } coulumn_major; } // namespace MemoryOrder
+
 /*************************************************************/
 /** \name Three dimensional grid operations                  */
 /*************************************************************/
 /*@{*/
 
 /** get the linear index from the position (@p a,@p b,@p c) in a 3D grid
- *  of dimensions @p adim.
+ *  of dimensions @p adim, usiung column major memory order.
  *
  * @return           The linear index
  * @param a , b , c  Position in 3D space
  * @param adim       Dimensions of the underlying grid
  */
-inline int get_linear_index(int a, int b, int c, const Vector3i &adim) {
+inline int get_linear_index(int a, int b, int c, const Vector3i &adim,
+                            MemoryOrder::ColumnMajor = {}) {
   assert((a >= 0) && (a < adim[0]));
   assert((b >= 0) && (b < adim[1]));
   assert((c >= 0) && (c < adim[2]));
 
-  return (a + adim[0] * (b + adim[1] * c));
+  return a + adim[0] * (b + adim[1] * c);
 }
 
-inline int get_linear_index(const Vector3i &ind, const Vector3i &adim) {
-  return get_linear_index(ind[0], ind[1], ind[2], adim);
+
+/** get the linear index from the position (@p a,@p b,@p c) in a 3D grid
+ *  of dimensions @p adim, , usiung row major memory order.
+ *
+ * @return           The linear index
+ * @param a , b , c  Position in 3D space
+ * @param adim       Dimensions of the underlying grid
+ */
+inline int get_linear_index(int a, int b, int c, const Vector3i &adim,
+                            MemoryOrder::RowMajor) {
+  assert((a >= 0) && (a < adim[0]));
+  assert((b >= 0) && (b < adim[1]));
+  assert((c >= 0) && (c < adim[2]));
+
+  return adim[1] * adim[2] * a + adim[2] * b + c;
+}
+
+template <class MemoryOrder = MemoryOrder::ColumnMajor>
+int get_linear_index(const Vector3i &ind, const Vector3i &adim) {
+  return get_linear_index(ind[0], ind[1], ind[2], adim, MemoryOrder{});
 }
 
 /*@}*/

--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -66,7 +66,7 @@ enum class MemoryOrder { COLUMN_MAJOR, ROW_MAJOR };
 /*@{*/
 
 /** get the linear index from the position (@p a,@p b,@p c) in a 3D grid
- *  of dimensions @p adim, usiung column major memory order.
+ *  of dimensions @p adim.
  *
  * @return           The linear index
  * @param a , b , c  Position in 3D space

--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -58,10 +58,7 @@ inline void unravel_index(InputIterator dimensions_begin,
   }
 }
 
-namespace MemoryOrder {
-constexpr struct RowMajor {
-} row_major;
-constexpr struct ColumnMajor { } coulumn_major; } // namespace MemoryOrder
+enum class MemoryOrder { COLUMN_MAJOR, ROW_MAJOR };
 
 /*************************************************************/
 /** \name Three dimensional grid operations                  */
@@ -74,35 +71,27 @@ constexpr struct ColumnMajor { } coulumn_major; } // namespace MemoryOrder
  * @return           The linear index
  * @param a , b , c  Position in 3D space
  * @param adim       Dimensions of the underlying grid
+ * @param memory_order Row- or column-major
  */
-inline int get_linear_index(int a, int b, int c, const Vector3i &adim,
-                            MemoryOrder::ColumnMajor = {}) {
+inline int
+get_linear_index(int a, int b, int c, const Vector3i &adim,
+                 MemoryOrder memory_order = MemoryOrder::COLUMN_MAJOR) {
   assert((a >= 0) && (a < adim[0]));
   assert((b >= 0) && (b < adim[1]));
   assert((c >= 0) && (c < adim[2]));
 
-  return a + adim[0] * (b + adim[1] * c);
+  switch (memory_order) {
+  case MemoryOrder::COLUMN_MAJOR:
+    return a + adim[0] * (b + adim[1] * c);
+  case MemoryOrder::ROW_MAJOR:
+    return adim[1] * adim[2] * a + adim[2] * b + c;
+  }
 }
 
-/** get the linear index from the position (@p a,@p b,@p c) in a 3D grid
- *  of dimensions @p adim, , usiung row major memory order.
- *
- * @return           The linear index
- * @param a , b , c  Position in 3D space
- * @param adim       Dimensions of the underlying grid
- */
-inline int get_linear_index(int a, int b, int c, const Vector3i &adim,
-                            MemoryOrder::RowMajor) {
-  assert((a >= 0) && (a < adim[0]));
-  assert((b >= 0) && (b < adim[1]));
-  assert((c >= 0) && (c < adim[2]));
-
-  return adim[1] * adim[2] * a + adim[2] * b + c;
-}
-
-template <class MemoryOrder = MemoryOrder::ColumnMajor>
-int get_linear_index(const Vector3i &ind, const Vector3i &adim) {
-  return get_linear_index(ind[0], ind[1], ind[2], adim, MemoryOrder{});
+inline int
+get_linear_index(const Vector3i &ind, const Vector3i &adim,
+                 MemoryOrder memory_order = MemoryOrder::COLUMN_MAJOR) {
+  return get_linear_index(ind[0], ind[1], ind[2], adim, memory_order);
 }
 
 /*@}*/

--- a/src/utils/tests/index_test.cpp
+++ b/src/utils/tests/index_test.cpp
@@ -48,11 +48,19 @@ BOOST_AUTO_TEST_CASE(get_linear_index) {
   auto const grid_size = Utils::Vector3i{7, 5, 3};
   auto const index = Utils::Vector3i{5, 4, 2};
 
-  /* 3 ints version */
+  /* 3 ints version, column major (default) */
   {
     auto const linear_index =
         get_linear_index(index[0], index[1], index[2], grid_size);
     BOOST_CHECK_EQUAL(linear_index, (5 + 4 * 7 + 2 * (7 * 5)));
+  }
+
+  /* 3 ints version, row major */
+  {
+    auto const linear_index = get_linear_index(
+        index[0], index[1], index[2], grid_size, Utils::MemoryOrder::row_major);
+    BOOST_CHECK_EQUAL(linear_index,
+                      ((5 * 3) * index[0] + 3 * index[1] + index[2]));
   }
 
   /* Vector version */

--- a/src/utils/tests/index_test.cpp
+++ b/src/utils/tests/index_test.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(get_linear_index) {
   /* 3 ints version, row major */
   {
     auto const linear_index = get_linear_index(
-        index[0], index[1], index[2], grid_size, Utils::MemoryOrder::row_major);
+        index[0], index[1], index[2], grid_size, Utils::MemoryOrder::ROW_MAJOR);
     BOOST_CHECK_EQUAL(linear_index,
                       ((5 * 3) * index[0] + 3 * index[1] + index[2]));
   }


### PR DESCRIPTION
This is mostly to document what the memory order is, and I need
row major for the p3m. @jngrad do you have an idea how to document
the tag parameter in doxygen? I'd rather not name it because it's
not used...