### PR TITLE
Allow creation of monomer positions via `polymer.positions`

### DIFF
--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -29,9 +29,9 @@ def validate_params(_params, default):
     if _params["n_polymers"] <= 0:
         raise ValueError(
             "n_polymers has to be a positive integer")
-    if _params["beads_per_chain"] <= 1:
+    if _params["beads_per_chain"] <= 0:
         raise ValueError(
-            "beads_per_chain has to be a positive integer larger than 1")
+            "beads_per_chain has to be a positive integer")
     if _params["bond_length"] < 0:
         raise ValueError(
             "bond_length has to be a positive float")


### PR DESCRIPTION
At the moment, the positions one can request from `espressomd.polymer` require `beads_per_chain` > 1. This PR relaxes this condition to `beads_per_chain` > 0.

This has two advantages:
  1. creating monomers one can make use of `respect_constraints=True` and `min_distance=<exclusion_radius>`
  2. when simulating polymer solutions, one might want to compare to the case of same concentration of unconnected particles. Without the change introduced by this PR, this case requires special treatment in the simulation script.
