### PR TITLE
Debian9/Intel18/Clang6/ROCm: switch Python2 to Python3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ status_pending:
 style:
   <<: *global_job_definition
   stage: prepare
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang:6.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang-python3:6.0
   dependencies: []
   before_script:
     - git submodule deinit .
@@ -140,9 +140,9 @@ nocheckmaxset:
 debian:9:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/debian-python3:9
   script:
-    - export with_cuda=false
+    - export with_cuda=false python_version=3
     - export myconfig=maxset make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -290,9 +290,9 @@ empty:
 ubuntu:wo-dependencies:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:wo-dependencies
   script:
-    - export myconfig=maxset make_check=false
+    - export myconfig=maxset make_check=false python_version=3
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -303,9 +303,9 @@ ubuntu:wo-dependencies:
 rocm-maxset:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/rocm:latest
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/rocm-python3:latest
   script:
-    - export myconfig=maxset
+    - export myconfig=maxset python_version=3
     - bash maintainer/CI/build_cmake.sh
   tags:
     - amdgpu
@@ -371,9 +371,9 @@ osx-cuda:
 clang:6.0:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang-python3:6
   script:
-    - export myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900
+    - export myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900 python_version=3
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -384,9 +384,9 @@ clang:6.0:
 intel:18:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/intel-python3:18
   script:
-    - export myconfig=maxset with_coverage=false I_MPI_SHM_LMT=shm
+    - export myconfig=maxset with_coverage=false I_MPI_SHM_LMT=shm python_version=3
     - export cxx_flags=-O2
     - bash maintainer/CI/build_cmake.sh
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ default:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_cuda=false myconfig=default with_coverage=true python_version=3
+    - export with_cuda=false myconfig=default with_coverage=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -97,7 +97,7 @@ min_boost:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:min_boost
   script:
-    - export with_cuda=false myconfig=maxset python_version=3
+    - export with_cuda=false myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -107,7 +107,7 @@ maxset:
   <<: *global_job_definition
   stage: build
   script:
-    - export myconfig=maxset with_coverage=true python_version=3
+    - export myconfig=maxset with_coverage=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -117,7 +117,7 @@ no_rotation:
   <<: *global_job_definition
   stage: build
   script:
-    - export myconfig=no_rotation with_coverage=true python_version=3
+    - export myconfig=no_rotation with_coverage=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -127,7 +127,7 @@ nocheckmaxset:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_cuda=false myconfig=nocheck-maxset python_version=3 make_check=false
+    - export with_cuda=false myconfig=nocheck-maxset make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -142,7 +142,7 @@ debian:9:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/debian-python3:9
   script:
-    - export with_cuda=false python_version=3
+    - export with_cuda=false
     - export myconfig=maxset make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -154,7 +154,7 @@ opensuse:15.1:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
-    - export with_cuda=false myconfig=maxset make_check=false python_version=3
+    - export with_cuda=false myconfig=maxset make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -165,7 +165,7 @@ centos:7:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/centos-python3:7
   script:
-    - export with_cuda=false myconfig=maxset make_check=true python_version=3
+    - export with_cuda=false myconfig=maxset make_check=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -176,7 +176,7 @@ fedora:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/centos-python3:next
   script:
-    - export with_cuda=false myconfig=maxset make_check=false python_version=3
+    - export with_cuda=false myconfig=maxset make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -193,7 +193,7 @@ cuda-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   script:
-    - export myconfig=maxset with_coverage=true python_version=3 test_timeout=900 srcdir=${CI_PROJECT_DIR}
+    - export myconfig=maxset with_coverage=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
     - bash maintainer/CI/build_cmake.sh
   artifacts:
     paths:
@@ -209,7 +209,7 @@ tutorials-samples-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=maxset with_coverage=false python_version=3 make_check=false
+    - export myconfig=maxset with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -222,7 +222,7 @@ tutorials-samples-default:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=default with_coverage=false python_version=3 make_check=false
+    - export myconfig=default with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -237,7 +237,7 @@ tutorials-samples-empty:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=empty with_coverage=false python_version=3 make_check=false
+    - export myconfig=empty with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -252,7 +252,7 @@ tutorials-samples-no-gpu:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
   script:
-    - export myconfig=maxset with_coverage=false python_version=3 make_check=false
+    - export myconfig=maxset with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200 hide_gpu=true
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -269,7 +269,7 @@ cuda-no-gpu:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   script:
-    - export myconfig=maxset hide_gpu=true python_version=3 test_timeout=900
+    - export myconfig=maxset hide_gpu=true test_timeout=900
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -280,7 +280,7 @@ empty:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   script:
-    - export myconfig=empty python_version=3
+    - export myconfig=empty
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -292,7 +292,7 @@ ubuntu:wo-dependencies:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:wo-dependencies
   script:
-    - export myconfig=maxset make_check=false python_version=3
+    - export myconfig=maxset make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -305,7 +305,7 @@ rocm-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/rocm-python3:latest
   script:
-    - export myconfig=maxset python_version=3
+    - export myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
   tags:
     - amdgpu
@@ -319,7 +319,7 @@ rocm-maxset:
   script:
     - export with_cuda=false test_timeout=900 check_skip_long=true
     - export OMPI_MCA_btl_vader_single_copy_mechanism=none
-    - export myconfig=maxset python_version=3
+    - export myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -352,7 +352,7 @@ osx:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_ccache=false myconfig=maxset with_cuda=false python_version=3
+    - export with_ccache=false myconfig=maxset with_cuda=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - mac
@@ -361,7 +361,7 @@ osx-cuda:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_ccache=false myconfig=maxset with_cuda=true python_version=3 make_check=false
+    - export with_ccache=false myconfig=maxset with_cuda=true make_check=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - mac
@@ -373,7 +373,7 @@ clang:6.0:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang-python3:6
   script:
-    - export myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900 python_version=3
+    - export myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -386,7 +386,7 @@ intel:18:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/intel-python3:18
   script:
-    - export myconfig=maxset with_coverage=false I_MPI_SHM_LMT=shm python_version=3
+    - export myconfig=maxset with_coverage=false I_MPI_SHM_LMT=shm
     - export cxx_flags=-O2
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -441,7 +441,7 @@ check_with_odd_no_of_processors:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   when: on_success
   script:
-    - export myconfig=maxset with_coverage=true python_version=3 build_procs=3 check_procs=3 check_odd_only=true
+    - export myconfig=maxset with_coverage=true build_procs=3 check_procs=3 check_odd_only=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ status_pending:
 style:
   <<: *global_job_definition
   stage: prepare
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang-python3:6.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang:6.0
   dependencies: []
   before_script:
     - git submodule deinit .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -371,7 +371,7 @@ osx-cuda:
 clang:6.0:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang-python3:6
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/clang-python3:6.0
   script:
     - export myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900
     - bash maintainer/CI/build_cmake.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - os: linux
       sudo: required
       services: docker
-      env: myconfig=maxset image=ubuntu-python3 python_version=3
+      env: myconfig=maxset image=ubuntu-python3
 
 script:
   - maintainer/CI/build_docker.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ if(WITH_CUDA)
   endif()
 endif(WITH_CUDA)
 
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
 
 if(WITH_PYTHON)
   find_package(Cython 0.23 REQUIRED)

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -94,7 +94,7 @@ set_default_value check_skip_long false
 set_default_value make_check_tutorials false
 set_default_value make_check_samples false
 set_default_value make_check_benchmarks false
-set_default_value python_version 2
+set_default_value python_version 3
 set_default_value with_cuda true
 set_default_value build_type "Debug"
 set_default_value with_ccache false

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -94,7 +94,6 @@ set_default_value check_skip_long false
 set_default_value make_check_tutorials false
 set_default_value make_check_samples false
 set_default_value make_check_benchmarks false
-set_default_value python_version 3
 set_default_value with_cuda true
 set_default_value build_type "Debug"
 set_default_value with_ccache false
@@ -129,7 +128,7 @@ if [ ${with_coverage} = true ]; then
     bash <(curl -s https://codecov.io/env) &> /dev/null;
 fi
 
-cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DPYTHON_EXECUTABLE=$(which python${python_version}) -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=${check_procs} ${cmake_params} -DWITH_SCAFACOS=ON"
+cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=${check_procs} ${cmake_params} -DWITH_SCAFACOS=ON"
 cmake_params="${cmake_params} -DCMAKE_CXX_FLAGS=${cxx_flags} -DCUDA_NVCC_FLAGS=${nvcc_flags}"
 cmake_params="${cmake_params} -DCMAKE_INSTALL_PREFIX=/tmp/espresso-unit-tests"
 cmake_params="${cmake_params} -DTEST_TIMEOUT=${test_timeout}"
@@ -157,7 +156,7 @@ outp insource srcdir builddir \
     check_odd_only \
     with_static_analysis myconfig \
     build_procs check_procs \
-    python_version with_cuda with_ccache
+    with_cuda with_ccache
 
 # check indentation of python files
 pep8_command () {

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -11,7 +11,6 @@ with_coverage=$with_coverage
 myconfig=$myconfig
 check_procs=$check_procs
 make_check=$make_check
-python_version=$python_version
 EOF
 
 if [ -z "$image" ]; then


### PR DESCRIPTION
Final PR for #2694

Images Debian9/Intel18/Clang6/ROCm now have a Python3 version (espressomd/docker#104)

Closes #2694
Closes #2951