### PR TITLE
Detailed balance exclusion radius

### DIFF
--- a/samples/grand_canonical.py
+++ b/samples/grand_canonical.py
@@ -68,7 +68,7 @@ system.cell_system.max_num_cells = 2744
 # type 1 = A-
 # type 2 = H+
 
-for i in range(int(cs_bulk*box_l**3)):
+for i in range(int(cs_bulk * box_l**3)):
     system.part.add(pos=np.random.random(3) * system.box_l, type=1, q=-1)
     system.part.add(pos=np.random.random(3) * system.box_l, type=2, q=1)
 

--- a/samples/grand_canonical.py
+++ b/samples/grand_canonical.py
@@ -54,7 +54,7 @@ np.random.seed(seed=system.seed)
 system.time_step = 0.01
 system.cell_system.skin = 0.4
 temperature = 1.0
-system.thermostat.set_langevin(kT=temperature, gamma=1.0, seed=42)
+system.thermostat.set_langevin(kT=temperature, gamma=.5, seed=42)
 system.cell_system.max_num_cells = 2744
 
 
@@ -68,12 +68,9 @@ system.cell_system.max_num_cells = 2744
 # type 1 = A-
 # type 2 = H+
 
-N0 = 50  # number of titratable units
-
-for i in range(N0):
-    system.part.add(id=i, pos=np.random.random(3) * system.box_l, type=1, q=-1)
-for i in range(N0, 2 * N0):
-    system.part.add(id=i, pos=np.random.random(3) * system.box_l, type=2, q=1)
+for i in range(int(cs_bulk*box_l**3)):
+    system.part.add(pos=np.random.random(3) * system.box_l, type=1, q=-1)
+    system.part.add(pos=np.random.random(3) * system.box_l, type=2, q=1)
 
 lj_eps = 1.0
 lj_sig = 1.0
@@ -86,7 +83,7 @@ for type_1 in types:
             cutoff=lj_cut, shift="auto")
 
 RE = reaction_ensemble.ReactionEnsemble(
-    temperature=temperature, exclusion_radius=8.0, seed=3)
+    temperature=temperature, exclusion_radius=5.0, seed=3)
 RE.add_reaction(
     gamma=cs_bulk**2 * np.exp(excess_chemical_potential_pair / temperature),
     reactant_types=[], reactant_coefficients=[], product_types=[1, 2],

--- a/samples/grand_canonical.py
+++ b/samples/grand_canonical.py
@@ -86,7 +86,7 @@ for type_1 in types:
             cutoff=lj_cut, shift="auto")
 
 RE = reaction_ensemble.ReactionEnsemble(
-    temperature=temperature, exclusion_radius=1.0, seed=3)
+    temperature=temperature, exclusion_radius=8.0, seed=3)
 RE.add_reaction(
     gamma=cs_bulk**2 * np.exp(excess_chemical_potential_pair / temperature),
     reactant_types=[], reactant_coefficients=[], product_types=[1, 2],
@@ -97,7 +97,7 @@ system.setup_type_map([0, 1, 2])
 
 RE.reaction(10000)
 
-p3m = electrostatics.P3M(prefactor=0.9, accuracy=1e-3)
+p3m = electrostatics.P3M(prefactor=2.0, accuracy=1e-3)
 system.actors.add(p3m)
 p3m_params = p3m.get_params()
 for key in list(p3m_params.keys()):
@@ -133,7 +133,7 @@ system.force_cap = 0
 RE.reaction(1000)
 
 n_int_cycles = 10000
-n_int_steps = 300
+n_int_steps = 600
 num_As = []
 deviation = None
 for i in range(n_int_cycles):
@@ -146,8 +146,8 @@ for i in range(n_int_cycles):
               system.number_of_particles(type=2))
         concentration_in_box = np.mean(num_As) / box_l**3
         deviation = (concentration_in_box - cs_bulk) / cs_bulk * 100
-        print("average num A {:.1f} +/- {:.1f}, average concentration {:.3f}, "
-              "deviation to target concentration {:.1f}%".format(
+        print("average num A {:.1f} +/- {:.1f}, average concentration {:.8f}, "
+              "deviation to target concentration {:.2f}%".format(
                   np.mean(num_As),
                   np.sqrt(np.var(num_As, ddof=1) / len(num_As)),
                   concentration_in_box, deviation))

--- a/samples/grand_canonical.py
+++ b/samples/grand_canonical.py
@@ -83,7 +83,7 @@ for type_1 in types:
             cutoff=lj_cut, shift="auto")
 
 RE = reaction_ensemble.ReactionEnsemble(
-    temperature=temperature, exclusion_radius=5.0, seed=3)
+    temperature=temperature, exclusion_radius=2.0, seed=3)
 RE.add_reaction(
     gamma=cs_bulk**2 * np.exp(excess_chemical_potential_pair / temperature),
     reactant_types=[], reactant_coefficients=[], product_types=[1, 2],

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -436,7 +436,7 @@ bool ReactionAlgorithm::generic_oneway_reaction(int reaction_id) {
   SingleReaction &current_reaction = reactions[reaction_id];
   current_reaction.tried_moves += 1;
   bool reaction_is_accepted = false;
-  particle_inserted_too_close_to_another_one = false;
+  particle_inside_exclusion_radius_was_touched = false;
   int old_state_index = -1; // for Wang-Landau algorithm
   on_reaction_entry(old_state_index);
   if (!all_reactant_particles_exist(reaction_id)) {
@@ -475,7 +475,7 @@ bool ReactionAlgorithm::generic_oneway_reaction(int reaction_id) {
                         p_ids_created_particles, hidden_particles_properties);
 
   double E_pot_new;
-  if (particle_inserted_too_close_to_another_one)
+  if (particle_inside_exclusion_radius_was_touched)
     E_pot_new = std::numeric_limits<double>::max();
   else
     E_pot_new = calculate_current_potential_energy_of_system();
@@ -583,6 +583,16 @@ void ReactionAlgorithm::hide_particle(int p_id, int previous_type) {
  *there would be a need for a rule for such "collision" reactions (a reaction
  *like the one above).
  */
+ 
+  auto part = get_particle_data(p_id);
+  std::vector<double> pos_of_to_be_hidden_particle(3);
+  pos_of_to_be_hidden_particle[0]=part.r.p[0];
+  pos_of_to_be_hidden_particle[1]=part.r.p[1];
+  pos_of_to_be_hidden_particle[2]=part.r.p[2];
+  double d_min = distto(partCfg(), part.r.p, p_id);
+  if (d_min < exclusion_radius)
+      particle_inside_exclusion_radius_was_touched = true;
+
 #ifdef ELECTROSTATICS
   // set charge
   set_particle_q(p_id, 0.0);
@@ -737,7 +747,7 @@ int ReactionAlgorithm::create_particle(int desired_type) {
   set_particle_v(p_id, vel);
   double d_min = distto(partCfg(), pos_vec, p_id);
   if (d_min < exclusion_radius)
-    particle_inserted_too_close_to_another_one =
+    particle_inside_exclusion_radius_was_touched =
         true; // setting of a minimal
               // distance is allowed to
               // avoid overlapping
@@ -781,7 +791,7 @@ bool ReactionAlgorithm::do_global_mc_move_for_particles_of_type(
     int type, int particle_number_of_type_to_be_changed, bool use_wang_landau) {
   m_tried_configurational_MC_moves += 1;
   bool got_accepted = false;
-  particle_inserted_too_close_to_another_one = false;
+  particle_inside_exclusion_radius_was_touched = false;
 
   int old_state_index = -1;
   if (use_wang_landau) {
@@ -840,11 +850,11 @@ bool ReactionAlgorithm::do_global_mc_move_for_particles_of_type(
     place_particle(p_id, new_pos.data());
     double d_min = distto(partCfg(), new_pos, p_id);
     if (d_min < exclusion_radius)
-      particle_inserted_too_close_to_another_one = true;
+      particle_inside_exclusion_radius_was_touched = true;
   }
 
   double E_pot_new;
-  if (particle_inserted_too_close_to_another_one)
+  if (particle_inside_exclusion_radius_was_touched)
     E_pot_new = std::numeric_limits<double>::max();
   else
     E_pot_new = calculate_current_potential_energy_of_system();

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -585,10 +585,6 @@ void ReactionAlgorithm::hide_particle(int p_id, int previous_type) {
  */
  
   auto part = get_particle_data(p_id);
-  std::vector<double> pos_of_to_be_hidden_particle(3);
-  pos_of_to_be_hidden_particle[0]=part.r.p[0];
-  pos_of_to_be_hidden_particle[1]=part.r.p[1];
-  pos_of_to_be_hidden_particle[2]=part.r.p[2];
   double d_min = distto(partCfg(), part.r.p, p_id);
   if (d_min < exclusion_radius)
       particle_inside_exclusion_radius_was_touched = true;

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -436,7 +436,7 @@ bool ReactionAlgorithm::generic_oneway_reaction(int reaction_id) {
   SingleReaction &current_reaction = reactions[reaction_id];
   current_reaction.tried_moves += 1;
   bool reaction_is_accepted = false;
-  particle_inside_exclusion_radius_was_touched = false;
+  particle_inside_exclusion_radius_touched = false;
   int old_state_index = -1; // for Wang-Landau algorithm
   on_reaction_entry(old_state_index);
   if (!all_reactant_particles_exist(reaction_id)) {
@@ -475,7 +475,7 @@ bool ReactionAlgorithm::generic_oneway_reaction(int reaction_id) {
                         p_ids_created_particles, hidden_particles_properties);
 
   double E_pot_new;
-  if (particle_inside_exclusion_radius_was_touched)
+  if (particle_inside_exclusion_radius_touched)
     E_pot_new = std::numeric_limits<double>::max();
   else
     E_pot_new = calculate_current_potential_energy_of_system();
@@ -587,7 +587,7 @@ void ReactionAlgorithm::hide_particle(int p_id, int previous_type) {
   auto part = get_particle_data(p_id);
   double d_min = distto(partCfg(), part.r.p, p_id);
   if (d_min < exclusion_radius)
-    particle_inside_exclusion_radius_was_touched = true;
+    particle_inside_exclusion_radius_touched = true;
 
 #ifdef ELECTROSTATICS
   // set charge
@@ -743,7 +743,7 @@ int ReactionAlgorithm::create_particle(int desired_type) {
   set_particle_v(p_id, vel);
   double d_min = distto(partCfg(), pos_vec, p_id);
   if (d_min < exclusion_radius)
-    particle_inside_exclusion_radius_was_touched =
+    particle_inside_exclusion_radius_touched =
         true; // setting of a minimal
               // distance is allowed to
               // avoid overlapping
@@ -787,7 +787,7 @@ bool ReactionAlgorithm::do_global_mc_move_for_particles_of_type(
     int type, int particle_number_of_type_to_be_changed, bool use_wang_landau) {
   m_tried_configurational_MC_moves += 1;
   bool got_accepted = false;
-  particle_inside_exclusion_radius_was_touched = false;
+  particle_inside_exclusion_radius_touched = false;
 
   int old_state_index = -1;
   if (use_wang_landau) {
@@ -846,11 +846,11 @@ bool ReactionAlgorithm::do_global_mc_move_for_particles_of_type(
     place_particle(p_id, new_pos.data());
     double d_min = distto(partCfg(), new_pos, p_id);
     if (d_min < exclusion_radius)
-      particle_inside_exclusion_radius_was_touched = true;
+      particle_inside_exclusion_radius_touched = true;
   }
 
   double E_pot_new;
-  if (particle_inside_exclusion_radius_was_touched)
+  if (particle_inside_exclusion_radius_touched)
     E_pot_new = std::numeric_limits<double>::max();
   else
     E_pot_new = calculate_current_potential_energy_of_system();

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -572,22 +572,22 @@ void ReactionAlgorithm::replace_particle(int p_id, int desired_type) {
  * here.
  */
 void ReactionAlgorithm::hide_particle(int p_id, int previous_type) {
-/**
- *remove_charge and put type to a non existing one --> no interactions anymore
- *it is as if the particle was non existing (currently only type-based
- *interactions are switched off, as well as the electrostatic interaction)
- *hide_particle() does not break bonds for simple reactions. as long as there
- *are no reactions like 2A -->B where one of the reacting A particles occurs in
- *the polymer (think of bond breakages if the monomer in the polymer gets
- *deleted in the reaction). This constraint is not of fundamental reason, but
- *there would be a need for a rule for such "collision" reactions (a reaction
- *like the one above).
- */
- 
+  /**
+   *remove_charge and put type to a non existing one --> no interactions anymore
+   *it is as if the particle was non existing (currently only type-based
+   *interactions are switched off, as well as the electrostatic interaction)
+   *hide_particle() does not break bonds for simple reactions. as long as there
+   *are no reactions like 2A -->B where one of the reacting A particles occurs
+   *in the polymer (think of bond breakages if the monomer in the polymer gets
+   *deleted in the reaction). This constraint is not of fundamental reason, but
+   *there would be a need for a rule for such "collision" reactions (a reaction
+   *like the one above).
+   */
+
   auto part = get_particle_data(p_id);
   double d_min = distto(partCfg(), part.r.p, p_id);
   if (d_min < exclusion_radius)
-      particle_inside_exclusion_radius_was_touched = true;
+    particle_inside_exclusion_radius_was_touched = true;
 
 #ifdef ELECTROSTATICS
   // set charge

--- a/src/core/reaction_ensemble.hpp
+++ b/src/core/reaction_ensemble.hpp
@@ -157,7 +157,7 @@ public:
                                                int particle_number_of_type,
                                                bool use_wang_landau);
 
-  bool particle_inside_exclusion_radius_was_touched;
+  bool particle_inside_exclusion_radius_touched;
 
 protected:
   std::vector<int> m_empty_p_ids_smaller_than_max_seen_particle;

--- a/src/core/reaction_ensemble.hpp
+++ b/src/core/reaction_ensemble.hpp
@@ -157,7 +157,7 @@ public:
                                                int particle_number_of_type,
                                                bool use_wang_landau);
 
-  bool particle_inserted_too_close_to_another_one;
+  bool particle_inside_exclusion_radius_was_touched;
 
 protected:
   std::vector<int> m_empty_p_ids_smaller_than_max_seen_particle;


### PR DESCRIPTION
This PR relaxes the conditions the exclusion radius has to meet. It now does not need to be small (i.e. comparable to the short ranged repulsive potential) anymore since now detailed balance is strictly obeyed during sampling.
