### PR TITLE
Benchmarks reliability

### DIFF
--- a/maintainer/benchmarks/CMakeLists.txt
+++ b/maintainer/benchmarks/CMakeLists.txt
@@ -59,15 +59,17 @@ function(PYTHON_BENCHMARK)
     endif()
     list(REMOVE_AT BENCHMARK_CONFIGURATIONS 0)
     foreach(nproc IN LISTS BENCHMARK_CONFIGURATIONS)
-      add_test(NAME benchmark__${BENCHMARK_NAME}__parallel_${nproc}
+      set(BENCHMARK_TEST_NAME benchmark__${BENCHMARK_NAME}__parallel_${nproc})
+      add_test(NAME ${BENCHMARK_TEST_NAME}
                COMMAND ${MPIEXEC} ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_NUMPROC_FLAG} ${nproc}
-                       ${CMAKE_BINARY_DIR}/pypresso ${BENCHMARK_FILE} ${BENCHMARK_ARGUMENTS}
-               CONFIGURATIONS "parallel")
+                       ${CMAKE_BINARY_DIR}/pypresso ${BENCHMARK_FILE} ${BENCHMARK_ARGUMENTS})
+      set_tests_properties(${BENCHMARK_TEST_NAME} PROPERTIES RUN_SERIAL TRUE)
     endforeach(nproc)
   else()
-      add_test(NAME benchmark__${BENCHMARK_NAME}__serial
-               COMMAND ${CMAKE_BINARY_DIR}/pypresso ${BENCHMARK_FILE} ${BENCHMARK_ARGUMENTS}
-               CONFIGURATIONS "serial")
+      set(BENCHMARK_TEST_NAME benchmark__${BENCHMARK_NAME}__serial)
+      add_test(NAME ${BENCHMARK_TEST_NAME}
+               COMMAND ${CMAKE_BINARY_DIR}/pypresso ${BENCHMARK_FILE} ${BENCHMARK_ARGUMENTS})
+      set_tests_properties(${BENCHMARK_TEST_NAME} PROPERTIES RUN_SERIAL TRUE)
   endif()
 endfunction(PYTHON_BENCHMARK)
 
@@ -80,14 +82,6 @@ python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=10000;--volume_fract
 python_benchmark(FILE p3m.py ARGUMENTS "--particles_per_core=1000;--volume_fraction=0.25;--prefactor=4")
 python_benchmark(FILE p3m.py ARGUMENTS "--particles_per_core=10000;--volume_fraction=0.25;--prefactor=4")
 
-add_custom_target(benchmark_python_serial COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} $(ARGS) -C serial --output-on-failure)
-add_dependencies(benchmark_python_serial pypresso)
-
-add_custom_target(benchmark_python_parallel COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} $(ARGS) -C parallel --output-on-failure)
-add_dependencies(benchmark_python_parallel pypresso)
-
-add_custom_target(benchmark_python)
-add_dependencies(benchmark_python pypresso benchmark_python_parallel)
-add_dependencies(benchmark_python pypresso benchmark_python_serial)
+add_custom_target(benchmark_python COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} $(ARGS) --output-on-failure)
 
 add_dependencies(benchmark benchmark_python)

--- a/maintainer/benchmarks/CMakeLists.txt
+++ b/maintainer/benchmarks/CMakeLists.txt
@@ -75,6 +75,8 @@ python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=1000;--volume_fracti
 python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=1000;--volume_fraction=0.02")
 python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=10000;--volume_fraction=0.50")
 python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=10000;--volume_fraction=0.02")
+python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=1000;--volume_fraction=0.10;--bonds" RUN_WITH_MPI FALSE)
+python_benchmark(FILE lj.py ARGUMENTS "--particles_per_core=10000;--volume_fraction=0.10;--bonds" RUN_WITH_MPI FALSE)
 python_benchmark(FILE p3m.py ARGUMENTS "--particles_per_core=1000;--volume_fraction=0.25;--prefactor=4")
 python_benchmark(FILE p3m.py ARGUMENTS "--particles_per_core=10000;--volume_fraction=0.25;--prefactor=4")
 
@@ -85,10 +87,7 @@ add_custom_target(benchmark_python_parallel COMMAND ${CMAKE_CTEST_COMMAND} --tim
 add_dependencies(benchmark_python_parallel pypresso)
 
 add_custom_target(benchmark_python)
-if(EXISTS ${MPIEXEC})
-  add_dependencies(benchmark_python pypresso benchmark_python_parallel)
-else()
-  add_dependencies(benchmark_python pypresso benchmark_python_serial)
-endif()
+add_dependencies(benchmark_python pypresso benchmark_python_parallel)
+add_dependencies(benchmark_python pypresso benchmark_python_serial)
 
 add_dependencies(benchmark benchmark_python)

--- a/maintainer/benchmarks/lj.py
+++ b/maintainer/benchmarks/lj.py
@@ -186,16 +186,13 @@ if not args.visualizer:
     # write report
     cmd = " ".join(x for x in sys.argv[1:] if not x.startswith("--output"))
     report = ('"{script}","{arguments}",{cores},"{mpi}",{mean:.3e},'
-              '{ci:.3e},{n},{dur:.1f},{E1:.5e},{E2:.5e},{E3:.5e}\n'.format(
+              '{ci:.3e},{n},{dur:.1f}\n'.format(
                   script=os.path.basename(sys.argv[0]), arguments=cmd,
                   cores=n_proc, dur=main_tock - main_tick, n=measurement_steps,
-                  mpi="OMPI_COMM_WORLD_SIZE" in os.environ, mean=avg, ci=ci,
-                  E1=system.analysis.energy()["total"],
-                  E2=system.analysis.energy()["kinetic"],
-                  E3=system.analysis.energy()["non_bonded"]))
+                  mpi="OMPI_COMM_WORLD_SIZE" in os.environ, mean=avg, ci=ci))
     if not os.path.isfile(args.output):
         report = ('"script","arguments","cores","MPI","mean","ci",'
-                  '"steps_per_tick","duration","E1","E2","E3"\n' + report)
+                  '"steps_per_tick","duration"\n' + report)
     with open(args.output, "a") as f:
         f.write(report)
 else:

--- a/maintainer/benchmarks/lj.py
+++ b/maintainer/benchmarks/lj.py
@@ -124,7 +124,8 @@ system.integrator.set_steepest_descent(
 # warmup
 while system.analysis.energy()["total"] > 3 * n_part:
     print("minimization: {:.1f}".format(system.analysis.energy()["total"]))
-    system.integrator.run(10)
+    system.integrator.run(20)
+print("minimization: {:.1f}".format(system.analysis.energy()["total"]))
 print()
 system.integrator.set_vv()
 
@@ -154,8 +155,9 @@ if not args.visualizer:
         system.integrator.run(measurement_steps)
         tock = time()
         t = (tock - tick) / measurement_steps
-        print("step {}, time = {:.2e}, verlet: {:.2f}"
-              .format(i, t, system.cell_system.get_state()["verlet_reuse"]))
+        print("step {}, time = {:.2e}, verlet: {:.2f}, energy: {:.2e}"
+              .format(i, t, system.cell_system.get_state()["verlet_reuse"],
+                      system.analysis.energy()["total"]))
         all_t.append(t)
     main_tock = time()
     # average time

--- a/maintainer/benchmarks/lj.py
+++ b/maintainer/benchmarks/lj.py
@@ -192,7 +192,7 @@ if not args.visualizer:
                   mpi="OMPI_COMM_WORLD_SIZE" in os.environ, mean=avg, ci=ci))
     if not os.path.isfile(args.output):
         report = ('"script","arguments","cores","MPI","mean","ci",'
-                  '"steps_per_tick","duration"\n' + report)
+                  '"nsteps","duration"\n' + report)
     with open(args.output, "a") as f:
         f.write(report)
 else:

--- a/maintainer/benchmarks/p3m.py
+++ b/maintainer/benchmarks/p3m.py
@@ -199,7 +199,7 @@ if not args.visualizer:
                   mpi="OMPI_COMM_WORLD_SIZE" in os.environ, mean=avg, ci=ci))
     if not os.path.isfile(args.output):
         report = ('"script","arguments","cores","MPI","mean","ci",'
-                  '"steps_per_tick","duration"\n' + report)
+                  '"nsteps","duration"\n' + report)
     with open(args.output, "a") as f:
         f.write(report)
 else:

--- a/maintainer/benchmarks/p3m.py
+++ b/maintainer/benchmarks/p3m.py
@@ -65,7 +65,7 @@ if args.visualizer:
     from espressomd import visualization
     from threading import Thread
 
-required_features = ["ELECTROSTATICS", "LENNARD_JONES", "MASS"]
+required_features = ["P3M", "LENNARD_JONES", "MASS"]
 espressomd.assert_features(required_features)
 
 print(espressomd.features())

--- a/maintainer/benchmarks/p3m.py
+++ b/maintainer/benchmarks/p3m.py
@@ -193,16 +193,13 @@ if not args.visualizer:
     # write report
     cmd = " ".join(x for x in sys.argv[1:] if not x.startswith("--output"))
     report = ('"{script}","{arguments}",{cores},"{mpi}",{mean:.3e},'
-              '{ci:.3e},{n},{dur:.1f},{E1:.5e},{E2:.5e},{E3:.5e}\n'.format(
+              '{ci:.3e},{n},{dur:.1f}\n'.format(
                   script=os.path.basename(sys.argv[0]), arguments=cmd,
                   cores=n_proc, dur=main_tock - main_tick, n=measurement_steps,
-                  mpi="OMPI_COMM_WORLD_SIZE" in os.environ, mean=avg, ci=ci,
-                  E1=system.analysis.energy()["total"],
-                  E2=system.analysis.energy()["coulomb"],
-                  E3=system.analysis.energy()["non_bonded"]))
+                  mpi="OMPI_COMM_WORLD_SIZE" in os.environ, mean=avg, ci=ci))
     if not os.path.isfile(args.output):
         report = ('"script","arguments","cores","MPI","mean","ci",'
-                  '"steps_per_tick","duration","E1","E2","E3"\n' + report)
+                  '"steps_per_tick","duration"\n' + report)
     with open(args.output, "a") as f:
         f.write(report)
 else:

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -18,7 +18,7 @@ cp ../maintainer/configs/maxset.hpp .
 # process configuration files
 for config in ${configs}; do
   # add minimal features for the benchmarks to run
-  echo -e "#define ELECTROSTATICS\n#define LENNARD_JONES\n#define MASS\n$(cat ${config})" > "${config}"
+  sed -i '1 i\#define ELECTROSTATICS\n#define LENNARD_JONES\n#define MASS\n' "${config}"
   # remove checks
   sed -ri "s/#define ADDITIONAL_CHECKS//" "${config}"
 done

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -37,7 +37,7 @@ for config in ${configs}; do
   make -j$(nproc)
   rm -f benchmarks.csv.part
   touch benchmarks.csv.part
-  make -j$(nproc) benchmark 2>&1 | tee -a benchmarks.log
+  make benchmark 2>&1 | tee -a benchmarks.log
   sed -ri "s/^/\"$(basename ${config})\",/" benchmarks.csv.part
   cat benchmarks.csv.part >> benchmarks.csv
 done

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 abort() {
-    echo "An error occurred in runner.sh, exiting now" >&2
-    echo "Command that failed: ${BASH_COMMAND}" >&2
-    exit 1
+  echo "An error occurred in runner.sh, exiting now" >&2
+  echo "Command that failed: ${BASH_COMMAND}" >&2
+  exit 1
 }
 
 trap abort EXIT

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+abort() {
+    echo "An error occurred in runner.sh, exiting now" >&2
+    echo "Command that failed: ${BASH_COMMAND}" >&2
+    exit 1
+}
+
+trap abort EXIT
+set -e
+
 # move to build directory
 build_dir="$1"
 cd "${build_dir}"
@@ -39,3 +48,4 @@ done
 
 rm benchmarks.csv.part
 
+trap : EXIT

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -23,17 +23,16 @@ for config in ${configs}; do
   sed -ri "s/#define ADDITIONAL_CHECKS//" "${config}"
 done
 
-# prepare build area
-rm -rf src/ maintainer/
-cmake -DWITH_BENCHMARKS=ON -DTEST_TIMEOUT=600 -DWITH_CUDA=OFF -DWITH_CCACHE=OFF ..
 cat > benchmarks.csv << EOF
 "config","script","arguments","cores","MPI","mean","ci","nsteps","duration"
 EOF
 
 # run benchmarks
 for config in ${configs}; do
-  echo "### ${config}" >> benchmarks.log
+  echo "### ${config}" | tee -a benchmarks.log
   cp ${config} myconfig.hpp
+  rm -rf src/ maintainer/
+  cmake -DWITH_BENCHMARKS=ON -DTEST_TIMEOUT=600 -DWITH_CUDA=OFF -DWITH_CCACHE=OFF ..
   make -j$(nproc)
   rm -f benchmarks.csv.part
   touch benchmarks.csv.part

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -27,7 +27,7 @@ done
 rm -rf src/ maintainer/
 cmake -DWITH_BENCHMARKS=ON -DTEST_TIMEOUT=600 -DWITH_CUDA=OFF -DWITH_CCACHE=OFF ..
 cat > benchmarks.csv << EOF
-"config","script","arguments","cores","MPI","mean","ci","steps_per_tick","duration"
+"config","script","arguments","cores","MPI","mean","ci","nsteps","duration"
 EOF
 
 # run benchmarks

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-cd "$(git rev-parse --show-toplevel)"
-mkdir -p build
-cd build
+# move to build directory
+build_dir="$1"
+cd "${build_dir}"
 
 # manage configuration files with different features
 configs="empty.hpp default.hpp maxset.hpp"

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -4,15 +4,19 @@ cd "$(git rev-parse --show-toplevel)"
 mkdir -p build
 cd build
 
-# manage headers files with different features
-configs="myconfig-minimal.hpp myconfig-default.hpp myconfig-maxset.hpp"
-cat > myconfig-minimal.hpp << EOF
-#define ELECTROSTATICS
-#define LENNARD_JONES
-#define MASS
-EOF
-cp ../src/config/myconfig-default.hpp myconfig-default.hpp
-sed 's/#define ADDITIONAL_CHECKS//' ../maintainer/configs/maxset.hpp > myconfig-maxset.hpp
+# manage configuration files with different features
+configs="empty.hpp default.hpp maxset.hpp"
+cp ../maintainer/configs/empty.hpp .
+cp ../src/config/myconfig-default.hpp default.hpp
+cp ../maintainer/configs/maxset.hpp .
+
+# process configuration files
+for config in ${configs}; do
+  # add minimal features for the benchmarks to run
+  echo -e "#define ELECTROSTATICS\n#define LENNARD_JONES\n#define MASS\n$(cat ${config})" > "${config}"
+  # remove checks
+  sed -ri "s/#define ADDITIONAL_CHECKS//" "${config}"
+done
 
 # prepare build area
 rm -rf src/ maintainer/
@@ -22,8 +26,7 @@ cat > benchmarks.csv << EOF
 EOF
 
 # run benchmarks
-for config in ${configs}
-do
+for config in ${configs}; do
   echo "### ${config}" >> benchmarks.log
   cp ${config} myconfig.hpp
   make -j$(nproc)

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -18,7 +18,7 @@ sed 's/#define ADDITIONAL_CHECKS//' ../maintainer/configs/maxset.hpp > myconfig-
 rm -rf src/ maintainer/
 cmake -DWITH_BENCHMARKS=ON -DTEST_TIMEOUT=600 -DWITH_CUDA=OFF -DWITH_CCACHE=OFF ..
 cat > benchmarks.csv << EOF
-"config","script","arguments","cores","MPI","mean","ci","steps_per_tick","duration","E1","E2","E3"
+"config","script","arguments","cores","MPI","mean","ci","steps_per_tick","duration"
 EOF
 
 # run benchmarks

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -9,10 +9,6 @@ abort() {
 trap abort EXIT
 set -e
 
-# move to build directory
-build_dir="$1"
-cd "${build_dir}"
-
 # manage configuration files with different features
 configs="empty.hpp default.hpp maxset.hpp"
 cp ../maintainer/configs/empty.hpp .

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -6,10 +6,20 @@ commits="HEAD"
 # list of directories to checkout
 directories="../src ../libs"
 
+abort() {
+    echo "An error occurred in suite.sh, exiting now" >&2
+    echo "Command that failed: ${BASH_COMMAND}" >&2
+    cleanup
+    exit 1
+}
+
 cleanup() {
     # restore files
     git checkout HEAD ${directories}
 }
+
+trap abort EXIT
+set -e
 
 # move to top-level directory
 cd "$(git rev-parse --show-toplevel)"
@@ -40,4 +50,5 @@ done
 
 rm benchmarks.csv
 
+trap : EXIT
 cleanup

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -32,6 +32,13 @@ fi
 mkdir "${build_dir}"
 cd "${build_dir}"
 
+# check for unstaged changes
+if [ "$(git diff-index HEAD -- ${directories})" ]; then
+  echo "fatal: you have unstaged changes, please commit or stash them:"
+  git diff-index --name-only HEAD -- ${directories}
+  exit 1
+fi
+
 cleanup() {
   # restore files in source directory
   git checkout HEAD ${directories}

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -3,9 +3,24 @@
 # list of commits to benchmark
 commits="HEAD"
 
+# list of directories to checkout
+directories="../src ../libs"
+
+cleanup() {
+    # restore files
+    git checkout HEAD ${directories}
+}
+
+# move to top-level directory
 cd "$(git rev-parse --show-toplevel)"
-mkdir -p build
-cd build
+build_dir="$(realpath build-benchmarks)"
+
+# move to build directory
+if [ -d "${build_dir}" ]; then
+  rm -rf "${build_dir}"
+fi
+mkdir "${build_dir}"
+cd "${build_dir}"
 
 # prepare output files
 rm -f benchmarks.log
@@ -17,14 +32,12 @@ EOF
 for commit in ${commits}
 do
   echo "### commit ${commit}" >> benchmarks.log
-  git checkout ${commit} ../src ../libs
-  bash ../maintainer/benchmarks/runner.sh
+  git checkout ${commit} ${directories}
+  bash ../maintainer/benchmarks/runner.sh "${build_dir}"
   sed -ri "s/^/\"${commit}\",/" benchmarks.csv
   tail -n +2 benchmarks.csv >> benchmarks_suite.csv
 done
 
 rm benchmarks.csv
 
-# restore files
-git checkout HEAD ../src ../libs
-
+cleanup

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -35,7 +35,7 @@ cd "${build_dir}"
 # prepare output files
 rm -f benchmarks.log
 cat > benchmarks_suite.csv << EOF
-"commit","config","script","arguments","cores","MPI","mean","ci","steps_per_tick","duration"
+"commit","config","script","arguments","cores","MPI","mean","ci","nsteps","duration"
 EOF
 
 # run benchmarks

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -6,16 +6,16 @@ commits="HEAD"
 # list of directories to checkout
 directories="../src ../libs"
 
-abort() {
-    echo "An error occurred in suite.sh, exiting now" >&2
-    echo "Command that failed: ${BASH_COMMAND}" >&2
-    cleanup
-    exit 1
+cleanup() {
+  # empty for now
+  :
 }
 
-cleanup() {
-    # restore files
-    git checkout HEAD ${directories}
+abort() {
+  echo "An error occurred in suite.sh, exiting now" >&2
+  echo "Command that failed: ${BASH_COMMAND}" >&2
+  cleanup
+  exit 1
 }
 
 trap abort EXIT
@@ -32,6 +32,11 @@ fi
 mkdir "${build_dir}"
 cd "${build_dir}"
 
+cleanup() {
+  # restore files in source directory
+  git checkout HEAD ${directories}
+}
+
 # prepare output files
 rm -f benchmarks.log
 cat > benchmarks_suite.csv << EOF
@@ -39,8 +44,7 @@ cat > benchmarks_suite.csv << EOF
 EOF
 
 # run benchmarks
-for commit in ${commits}
-do
+for commit in ${commits}; do
   echo "### commit ${commit}" >> benchmarks.log
   git checkout ${commit} ${directories}
   bash ../maintainer/benchmarks/runner.sh

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -35,7 +35,7 @@ cd "${build_dir}"
 # prepare output files
 rm -f benchmarks.log
 cat > benchmarks_suite.csv << EOF
-"commit","config","script","arguments","cores","MPI","mean","ci","steps_per_tick","duration","E1","E2","E3"
+"commit","config","script","arguments","cores","MPI","mean","ci","steps_per_tick","duration"
 EOF
 
 # run benchmarks
@@ -43,7 +43,7 @@ for commit in ${commits}
 do
   echo "### commit ${commit}" >> benchmarks.log
   git checkout ${commit} ${directories}
-  bash ../maintainer/benchmarks/runner.sh "${build_dir}"
+  bash ../maintainer/benchmarks/runner.sh
   sed -ri "s/^/\"${commit}\",/" benchmarks.csv
   tail -n +2 benchmarks.csv >> benchmarks_suite.csv
 done


### PR DESCRIPTION
Since 4.0 a few things changed in the CMake workflow (either in espresso CMake files, or in newer CMake releases) that broke the benchmark functionality:
- changing myconfig.hpp doesn't always cause a full project recompilation (rare)
- ctest sometimes runs benchmarks in parallel

The benchmark bash scripts were also brittle. They were both refactored based on `build_cmake.sh`:
- trap mechanism with clear error message
- another trap with cleanup action
- simplified CMake logic
- ctest runs benchmarks in serial
- erase /build/src before each compilation

Other changes:
- don't print debug energy values in the CSV output
- some column names were changed
- the [wiki documentation](https://github.com/espressomd/espresso/wiki/Development#benchmarking) was updated accordingly
    - and it now discusses condor on ICP machines
- reduce risk of LJ simulation crashing with a longer energy minimization
- add a benchmark for bonded interactions
- print more info in stdout (config file being processed, energy during LJ minimization and simulation)