### PR TITLE
Activate tabulated bonded IAs

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -521,24 +521,20 @@ section :ref:`Isotropic non-bonded interactions`):
 -  ``BMHTF_NACL`` Enable the Born-Meyer-Huggins-Tosi-Fumi potential, which can be used
    to model salt melts.
 
-Some of the short range interactions have additional features:
-
--  ``LJ_WARN_WHEN_CLOSE`` This adds an additional check to the Lennard-Jones potentials that
-   prints a warning if particles come too close so that the simulation
-   becomes unphysical.
-
-If you want to use bond-angle potentials (see section :ref:`Bond-angle interactions`), you need the
-following features.
-
--  ``BOND_ANGLE``
-
--  ``LJGEN_SOFTCORE``
-
 -  ``GAUSSIAN``
 
 -  ``HAT``
 
 -  ``UMBRELLA`` (experimental)
+
+Some of the short-range interactions have additional features:
+
+-  ``LJ_WARN_WHEN_CLOSE`` This adds an additional check to the Lennard-Jones
+   potentials that prints a warning if particles come so close to each other
+   that the simulation becomes unphysical.
+
+-  ``LJGEN_SOFTCORE`` This modifies the generic Lennard-Jones potential
+   (``LENNARD_JONES_GENERIC``) with tunable parameters.
 
 
 .. _Debug messages:

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -491,7 +491,7 @@ Interaction features
 The following switches turn on various short ranged interactions (see
 section :ref:`Isotropic non-bonded interactions`):
 
--  ``TABULATED`` Enable support for user-defined interactions.
+-  ``TABULATED`` Enable support for user-defined non-bonded interaction potentials.
 
 -  ``LENNARD_JONES`` Enable the Lennard-Jones potential.
 

--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -227,11 +227,6 @@ is named :math:`vtol`.
 Tabulated bond interactions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-
-    Requires ``TABULATED`` feature.
-
-
 A tabulated bond can be instantiated via
 :class:`espressomd.interactions.Tabulated`::
 

--- a/src/core/bonded_interactions/bonded_interaction_data.cpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.cpp
@@ -34,13 +34,11 @@ void recalc_maximal_cutoff_bonded() {
       if (max_cut_bonded < sqrt(bonded_ia_params[i].p.rigid_bond.d2))
         max_cut_bonded = sqrt(bonded_ia_params[i].p.rigid_bond.d2);
       break;
-#ifdef TABULATED
     case BONDED_IA_TABULATED:
       if (bonded_ia_params[i].p.tab.type == TAB_BOND_LENGTH &&
           max_cut_bonded < bonded_ia_params[i].p.tab.pot->cutoff())
         max_cut_bonded = bonded_ia_params[i].p.tab.pot->cutoff();
       break;
-#endif
     case BONDED_IA_IBM_TRIEL:
       if (max_cut_bonded < bonded_ia_params[i].p.ibm_triel.maxDist)
         max_cut_bonded = bonded_ia_params[i].p.ibm_triel.maxDist;
@@ -58,12 +56,10 @@ void recalc_maximal_cutoff_bonded() {
     case BONDED_IA_DIHEDRAL:
       max_cut_bonded = max_cut_tmp;
       break;
-#ifdef TABULATED
     case BONDED_IA_TABULATED:
       if (bonded_ia_params[i].p.tab.type == TAB_BOND_DIHEDRAL)
         max_cut_bonded = max_cut_tmp;
       break;
-#endif
     default:
       break;
     }

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -319,9 +319,7 @@ union Bond_parameters {
   Angle_cosine_bond_parameters angle_cosine;
   Angle_cossquare_bond_parameters angle_cossquare;
   Dihedral_bond_parameters dihedral;
-#ifdef TABULATED
   Tabulated_bond_parameters tab;
-#endif
 #ifdef UMBRELLA
   Umbrella_bond_parameters umbrella;
 #endif

--- a/src/core/bonded_interactions/bonded_tab.cpp
+++ b/src/core/bonded_interactions/bonded_tab.cpp
@@ -20,7 +20,6 @@
 */
 #include "bonded_interactions/bonded_tab.hpp"
 
-#ifdef TABULATED
 #include "communication.hpp"
 #include "errorhandling.hpp"
 
@@ -70,5 +69,3 @@ int tabulated_bonded_set_params(int bond_type,
 
   return ES_OK;
 }
-
-#endif

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -28,7 +28,6 @@
 
 #include "config.hpp"
 
-#ifdef TABULATED
 #include "angle_common.hpp"
 #include "bonded_interactions/bonded_interaction_data.hpp"
 #include "bonded_interactions/dihedral.hpp"
@@ -283,5 +282,4 @@ inline int tab_dihedral_energy(Particle const *p2, Particle const *p1,
   return 0;
 }
 
-#endif
 #endif

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -345,12 +345,10 @@ void mpi_bcast_ia_params(int i, int j) {
     /* bonded interaction parameters */
     MPI_Bcast(&(bonded_ia_params[i]), sizeof(Bonded_ia_parameters), MPI_BYTE, 0,
               comm_cart);
-#ifdef TABULATED
     /* For tabulated potentials we have to send the tables extra */
     if (bonded_ia_params[i].type == BONDED_IA_TABULATED) {
       boost::mpi::broadcast(comm_cart, *bonded_ia_params[i].p.tab.pot, 0);
     }
-#endif
   }
 
   on_short_range_ia_change();
@@ -367,7 +365,6 @@ void mpi_bcast_ia_params_slave(int i, int j) {
     make_bond_type_exist(i); /* realloc bonded_ia_params on slave nodes! */
     MPI_Bcast(&(bonded_ia_params[i]), sizeof(Bonded_ia_parameters), MPI_BYTE, 0,
               comm_cart);
-#ifdef TABULATED
     /* For tabulated potentials we have to send the tables extra */
     if (bonded_ia_params[i].type == BONDED_IA_TABULATED) {
       auto *tab_pot = new TabulatedPotential();
@@ -375,7 +372,6 @@ void mpi_bcast_ia_params_slave(int i, int j) {
 
       bonded_ia_params[i].p.tab.pot = tab_pot;
     }
-#endif
   }
 
   on_short_range_ia_change();

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -288,12 +288,10 @@ inline void add_bonded_energy(const Particle *p1) {
         ret = 0;
         break;
 #endif
-#ifdef TABULATED
       case BONDED_IA_TABULATED:
         if (iaparams->num == 1)
           bond_broken = tab_bond_energy(iaparams, dx, &ret);
         break;
-#endif
 #ifdef UMBRELLA
       case BONDED_IA_UMBRELLA:
         bond_broken = umbrella_pair_energy(p1, p2, iaparams, dx, &ret);
@@ -320,12 +318,10 @@ inline void add_bonded_energy(const Particle *p1) {
       case BONDED_IA_ANGLE_COSSQUARE:
         bond_broken = angle_cossquare_energy(p1, p2, p3, iaparams, &ret);
         break;
-#ifdef TABULATED
       case BONDED_IA_TABULATED:
         if (iaparams->num == 2)
           bond_broken = tab_angle_energy(p1, p2, p3, iaparams, &ret);
         break;
-#endif
       default:
         runtimeErrorMsg() << "add_bonded_energy: bond type (" << type
                           << ") of atom " << p1->p.identity << " unknown\n";
@@ -337,12 +333,10 @@ inline void add_bonded_energy(const Particle *p1) {
       case BONDED_IA_DIHEDRAL:
         bond_broken = dihedral_energy(p2, p1, p3, p4, iaparams, &ret);
         break;
-#ifdef TABULATED
       case BONDED_IA_TABULATED:
         if (iaparams->num == 3)
           bond_broken = tab_dihedral_energy(p1, p2, p3, p4, iaparams, &ret);
         break;
-#endif
       default:
         runtimeErrorMsg() << "add_bonded_energy: bond type (" << type
                           << ") of atom " << p1->p.identity << " unknown\n";

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -389,12 +389,10 @@ inline int calc_bond_pair_force(Particle *p1, Particle *p2,
     bond_broken = calc_subt_lj_pair_force(p1, p2, iaparams, dx, force);
     break;
 #endif
-#ifdef TABULATED
   case BONDED_IA_TABULATED:
     if (iaparams->num == 1)
       bond_broken = calc_tab_bond_force(iaparams, dx, force);
     break;
-#endif
 #ifdef UMBRELLA
   case BONDED_IA_UMBRELLA:
     bond_broken = calc_umbrella_pair_force(p1, p2, iaparams, dx, force);
@@ -505,13 +503,11 @@ inline void add_bonded_force(Particle *p1) {
         bond_broken = 0;
         break;
 #endif
-#ifdef TABULATED
       case BONDED_IA_TABULATED:
         if (iaparams->num == 2)
           bond_broken =
               calc_tab_angle_force(p1, p2, p3, iaparams, force, force2, force3);
         break;
-#endif
       case BONDED_IA_IBM_TRIEL:
         bond_broken = IBM_Triel_CalcForce(p1, p2, p3, iaparams);
         break;
@@ -546,13 +542,11 @@ inline void add_bonded_force(Particle *p1) {
         bond_broken = calc_dihedral_force(p1, p2, p3, p4, iaparams, force,
                                           force2, force3);
         break;
-#ifdef TABULATED
       case BONDED_IA_TABULATED:
         if (iaparams->num == 3)
           bond_broken = calc_tab_dihedral_force(p1, p2, p3, p4, iaparams, force,
                                                 force2, force3);
         break;
-#endif
       default:
         runtimeErrorMsg() << "add_bonded_force: bond type of atom "
                           << p1->p.identity << " unknown " << type << ","

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -131,7 +131,6 @@ inline void calc_three_body_bonded_forces(
     std::tie(f_mid, f_left, f_right) =
         calc_angle_cossquare_3body_forces(p_mid, p_left, p_right, iaparams);
     break;
-#ifdef TABULATED
   case BONDED_IA_TABULATED:
     switch (iaparams->p.tab.type) {
     case TAB_BOND_ANGLE:
@@ -145,7 +144,6 @@ inline void calc_three_body_bonded_forces(
       return;
     }
     break;
-#endif
   default:
     fprintf(stderr, "calc_three_body_bonded_forces: \
             WARNING: Bond type %d, atom %d unhandled, Atom 2: %d\n",

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -293,13 +293,8 @@ ELSE:
         double r
         double r_cut
 
-IF TABULATED:
-    cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
+cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
     #* Parameters for n-body tabulated potential (n=2,3,4). */
-        cdef struct Tabulated_bond_parameters:
-            int type
-            TabulatedPotential * pot
-ELSE:
     cdef struct Tabulated_bond_parameters:
         int type
         TabulatedPotential * pot
@@ -542,12 +537,12 @@ IF ROTATION:
     cdef extern from "bonded_interactions/harmonic_dumbbell.hpp":
         int harmonic_dumbbell_set_params(int bond_type, double k1, double k2, double r, double r_cut)
 
-IF TABULATED:
-    cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
-        cdef enum TabulatedBondedInteraction:
-            TAB_UNKNOWN = 0, TAB_BOND_LENGTH, TAB_BOND_ANGLE, TAB_BOND_DIHEDRAL
-    cdef extern from "bonded_interactions/bonded_tab.hpp":
-        int tabulated_bonded_set_params(int bond_type, TabulatedBondedInteraction tab_type, double min, double max, vector[double] energy, vector[double] force)
+cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
+    cdef enum TabulatedBondedInteraction:
+        TAB_UNKNOWN = 0, TAB_BOND_LENGTH, TAB_BOND_ANGLE, TAB_BOND_DIHEDRAL
+
+cdef extern from "bonded_interactions/bonded_tab.hpp":
+    int tabulated_bonded_set_params(int bond_type, TabulatedBondedInteraction tab_type, double min, double max, vector[double] energy, vector[double] force)
 
 IF ELECTROSTATICS:
     cdef extern from "bonded_interactions/bonded_coulomb.hpp":

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -2568,118 +2568,119 @@ class Dihedral(BondedInteraction):
             self._bond_id, self._params["mult"], self._params["bend"], self._params["phase"])
 
 
+class Tabulated(BondedInteraction):
+
+    """
+    Tabulated bond.
+
+    Parameters
+    ----------
+
+    type : :obj:`str`
+        The type of bond, one of 'distance', 'angle' or
+        'dihedral'.
+    min : :obj:`float`
+        The minimal interaction distance. Has to be 0 if
+        type is 'angle' or 'dihedral'
+    max : :obj:`float`
+        The maximal interaction distance. Has to be pi if
+        type is 'angle' or 2pi if 'dihedral'
+    energy: array_like :obj:`float`
+        The energy table.
+    force: array_like :obj:`float`
+        The force table.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Tabulated, self).__init__(*args, **kwargs)
+
+    def type_number(self):
+        return BONDED_IA_TABULATED
+
+    def type_name(self):
+        """Name of interaction type.
+
+        """
+        return "TABULATED"
+
+    def valid_keys(self):
+        """All parameters that can be set.
+
+        """
+        return "type", "min", "max", "energy", "force"
+
+    def required_keys(self):
+        """Parameters that have to be set.
+
+        """
+        return "type", "min", "max", "energy", "force"
+
+    def set_default_params(self):
+        """Sets parameters that are not required to their default value.
+
+        """
+        self._params = {'min': -1., 'max': -1., 'energy': [], 'force': []}
+
+    def validate_params(self):
+        """Check that parameters are valid.
+
+        """
+        pi = 3.14159265358979
+        phi = [self._params["min"], self._params["max"]]
+        if self._params["type"] == "angle" and max(phi) > 0 and (
+                abs(phi[0] - 0.) > 1e-5 or abs(phi[1] - pi) > 1e-5):
+            raise ValueError("Tabulated angle expects forces/energies "
+                             "within the range [0, pi], got " + str(phi))
+        if self._params["type"] == "dihedral" and max(phi) > 0 and (
+                abs(phi[0] - 0.) > 1e-5 or abs(phi[1] - 2 * pi) > 1e-5):
+            raise ValueError("Tabulated dihedral expects forces/energies "
+                             "within the range [0, 2*pi], got " + str(phi))
+
+    def _get_params_from_es_core(self):
+        make_bond_type_exist(self._bond_id)
+        res = \
+            {"type": bonded_ia_params[self._bond_id].p.tab.type,
+             "min": bonded_ia_params[self._bond_id].p.tab.pot.minval,
+             "max": bonded_ia_params[self._bond_id].p.tab.pot.maxval,
+             "energy":
+                 bonded_ia_params[self._bond_id].p.tab.pot.energy_tab,
+             "force": bonded_ia_params[self._bond_id].p.tab.pot.force_tab
+             }
+        if res["type"] == 1:
+            res["type"] = "distance"
+        if res["type"] == 2:
+            res["type"] = "angle"
+        if res["type"] == 3:
+            res["type"] = "dihedral"
+        return res
+
+    def _set_params_in_es_core(self):
+        if self._params["type"] == "distance":
+            type_num = 1
+        elif self._params["type"] == "angle":
+            type_num = 2
+        elif self._params["type"] == "dihedral":
+            type_num = 3
+        else:
+            raise ValueError(
+                "Tabulated type needs to be distance, angle, or dihedral")
+
+        res = tabulated_bonded_set_params(
+            self._bond_id, < TabulatedBondedInteraction > type_num,
+            self._params["min"],
+            self._params["max"],
+            self._params["energy"],
+            self._params["force"])
+
+        if res == 1:
+            raise Exception(
+                "Could not setup tabulated bond. Invalid bond type.")
+        # Retrieve some params, Es calculates.
+        self._params = self._get_params_from_es_core()
+
+
 IF TABULATED == 1:
-    class Tabulated(BondedInteraction):
-
-        """
-        Tabulated bond.
-
-        Parameters
-        ----------
-
-        type : :obj:`str`,
-            The type of bond, one of 'distance', 'angle' or
-            'dihedral'.
-        min : :obj:`float`,
-            The minimal interaction distance. Has to be 0 if
-            type is 'angle' or 'dihedral'
-        max : :obj:`float`,
-            The maximal interaction distance. Has to be pi if
-            type is 'angle' or 2pi if 'dihedral'
-        energy: array_like :obj:`float`
-            The energy table.
-        force: array_like :obj:`float`
-            The force table.
-
-        """
-
-        def __init__(self, *args, **kwargs):
-            super(Tabulated, self).__init__(*args, **kwargs)
-
-        def type_number(self):
-            return BONDED_IA_TABULATED
-
-        def type_name(self):
-            """Name of interaction type.
-
-            """
-            return "TABULATED"
-
-        def valid_keys(self):
-            """All parameters that can be set.
-
-            """
-            return "type", "min", "max", "energy", "force"
-
-        def required_keys(self):
-            """Parameters that have to be set.
-
-            """
-            return "type", "min", "max", "energy", "force"
-
-        def set_default_params(self):
-            """Sets parameters that are not required to their default value.
-
-            """
-            self._params = {'min': -1., 'max': -1., 'energy': [], 'force': []}
-
-        def validate_params(self):
-            """Check that parameters are valid.
-
-            """
-            pi = 3.14159265358979
-            phi = [self._params["min"], self._params["max"]]
-            if self._params["type"] == "angle" and max(phi) > 0 and (
-                    abs(phi[0] - 0.) > 1e-5 or abs(phi[1] - pi) > 1e-5):
-                raise ValueError("Tabulated angle expects forces/energies "
-                                 "within the range [0, pi], got " + str(phi))
-            if self._params["type"] == "dihedral" and max(phi) > 0 and (
-                    abs(phi[0] - 0.) > 1e-5 or abs(phi[1] - 2 * pi) > 1e-5):
-                raise ValueError("Tabulated dihedral expects forces/energies "
-                                 "within the range [0, 2*pi], got " + str(phi))
-
-        def _get_params_from_es_core(self):
-            make_bond_type_exist(self._bond_id)
-            res = \
-                {"type": bonded_ia_params[self._bond_id].p.tab.type,
-                 "min": bonded_ia_params[self._bond_id].p.tab.pot.minval,
-                 "max": bonded_ia_params[self._bond_id].p.tab.pot.maxval,
-                 "energy":
-                     bonded_ia_params[self._bond_id].p.tab.pot.energy_tab,
-                 "force": bonded_ia_params[self._bond_id].p.tab.pot.force_tab
-                 }
-            if res["type"] == 1:
-                res["type"] = "distance"
-            if res["type"] == 2:
-                res["type"] = "angle"
-            if res["type"] == 3:
-                res["type"] = "dihedral"
-            return res
-
-        def _set_params_in_es_core(self):
-            if self._params["type"] == "distance":
-                type_num = 1
-            elif self._params["type"] == "angle":
-                type_num = 2
-            elif self._params["type"] == "dihedral":
-                type_num = 3
-            else:
-                raise ValueError(
-                    "Tabulated type needs to be distance, angle, or dihedral")
-
-            res = tabulated_bonded_set_params(
-                self._bond_id, < TabulatedBondedInteraction > type_num,
-                self._params["min"],
-                self._params["max"],
-                self._params["energy"],
-                self._params["force"])
-
-            if res == 1:
-                raise Exception(
-                    "Could not setup tabulated bond. Invalid bond type.")
-            # Retrieve some params, Es calculates.
-            self._params = self._get_params_from_es_core()
-
     cdef class TabulatedNonBonded(NonBondedInteraction):
         """
         Tabulated non-bonded interaction.
@@ -2687,9 +2688,9 @@ IF TABULATED == 1:
         Parameters
         ----------
 
-        min : :obj:`float`,
+        min : :obj:`float`
             The minimal interaction distance.
-        max : :obj:`float`,
+        max : :obj:`float`
             The maximal interaction distance.
         energy: array_like :obj:`float`
             The energy table.
@@ -2773,49 +2774,6 @@ IF TABULATED == 1:
             """
             if self.state == 0:
                 return True
-
-IF TABULATED != 1:
-    class Tabulated(BondedInteraction):
-
-        """
-        Tabulated non-bonded interaction.
-
-        Requires feature ``TABULATED``.
-
-        """
-
-        def type_number(self):
-            raise Exception("TABULATED has to be defined in myconfig.hpp.")
-
-        def type_name(self):
-            """Name of interaction type.
-
-            """
-            raise Exception("TABULATED has to be defined in myconfig.hpp.")
-
-        def valid_keys(self):
-            """All parameters that can be set.
-
-            """
-            raise Exception("TABULATED has to be defined in myconfig.hpp.")
-
-        def required_keys(self):
-            """Parameters that have to be set.
-
-            """
-            raise Exception("TABULATED has to be defined in myconfig.hpp.")
-
-        def set_default_params(self):
-            """Sets parameters that are not required to their default value.
-
-            """
-            raise Exception("TABULATED has to be defined in myconfig.hpp.")
-
-        def _get_params_from_es_core(self):
-            raise Exception("TABULATED has to be defined in myconfig.hpp.")
-
-        def _set_params_in_es_core(self):
-            raise Exception("TABULATED has to be defined in myconfig.hpp.")
 
 
 IF LENNARD_JONES == 1:

--- a/testsuite/python/interactions_bond_angle.py
+++ b/testsuite/python/interactions_bond_angle.py
@@ -192,7 +192,6 @@ class InteractionsAngleBondTest(ut.TestCase):
                       phi=phi, bend=acs_bend, phi0=acs_phi0),
                       acs_phi0)
 
-    @utx.skipIfMissingFeatures("TABULATED")
     def test_angle_tabulated(self):
         """Check that we can reproduce the three other potentials."""
         at_bend = 1

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -114,13 +114,12 @@ class ParticleProperties(ut.TestCase):
         test_subt_lj = generateTestForBondParams(
             0, espressomd.interactions.SubtLJ, {})
 
-    if espressomd.has_features(["TABULATED"]):
-        test_tabulated = generateTestForBondParams(
-            0, espressomd.interactions.Tabulated, {"type": "distance",
-                                                   "min": 1.,
-                                                   "max": 2.,
-                                                   "energy": [1., 2., 3.],
-                                                   "force": [3., 4., 5.]})
+    test_tabulated = generateTestForBondParams(
+        0, espressomd.interactions.Tabulated, {"type": "distance",
+                                               "min": 1.,
+                                               "max": 2.,
+                                               "energy": [1., 2., 3.],
+                                               "force": [3., 4., 5.]})
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/interactions_dihedral.py
+++ b/testsuite/python/interactions_dihedral.py
@@ -167,7 +167,6 @@ class InteractionsBondedTest(ut.TestCase):
             np.testing.assert_almost_equal(f2_sim_copy, f2_ref)
 
     # Test Tabulated Dihedral Angle
-    @utx.skipIfMissingFeatures(["TABULATED"])
     def test_tabulated_dihedral(self):
         N = 111
         d_phi = 2 * np.pi / N

--- a/testsuite/python/tabulated.py
+++ b/testsuite/python/tabulated.py
@@ -23,7 +23,6 @@ import espressomd
 import numpy as np
 
 
-@utx.skipIfMissingFeatures("TABULATED")
 class TabulatedTest(ut.TestCase):
     s = espressomd.System(box_l=[1.0, 1.0, 1.0])
     s.seed = s.cell_system.get_state()['n_nodes'] * [1234]
@@ -60,6 +59,7 @@ class TabulatedTest(ut.TestCase):
             self.assertAlmostEqual(
                 self.s.analysis.energy()['total'], 5. - z * 2.3)
 
+    @utx.skipIfMissingFeatures("TABULATED")
     def test_non_bonded(self):
         self.s.non_bonded_inter[0, 0].tabulated.set_params(
             min=self.min_, max=self.max_, energy=self.energy, force=self.force)
@@ -81,9 +81,8 @@ class TabulatedTest(ut.TestCase):
     def test_bonded(self):
         from espressomd.interactions import Tabulated
 
-        tb = Tabulated(
-            type='distance', min=self.min_, max=self.max_, energy=self.energy,
-                       force=self.force)
+        tb = Tabulated(type='distance', min=self.min_, max=self.max_,
+                       energy=self.energy, force=self.force)
         self.s.bonded_inter.add(tb)
 
         np.testing.assert_allclose(self.force, tb.params['force'])


### PR DESCRIPTION
Fixes #2304, closes #1025

Tabulated bonded IAs are now always active. The tabulated non-bonded IA is activated with `TABULATED`.