### PR TITLE
python: make checkpointing of LB thermostat possible again.

### DIFF
--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -57,6 +57,7 @@ cdef class Thermostat(object):
 
     # We have to cdef the state variable because it is a cdef class
     cdef _state
+    cdef _LB_fluid
 
     def __init__(self):
         self._state = None
@@ -100,6 +101,7 @@ cdef class Thermostat(object):
                                   "gamma"], gamma_rotation=thmst["gamma_rotation"], act_on_virtual=thmst["act_on_virtual"], seed=thmst["seed"])
             if thmst["type"] == "LB":
                 self.set_lb(
+                    LB_fluid=thmst["LB_fluid"],
                     act_on_virtual=thmst["act_on_virtual"],
                     seed=thmst["rng_counter_fluid"])
             if thmst["type"] == "NPT_ISO":
@@ -144,6 +146,7 @@ cdef class Thermostat(object):
 
         if thermo_switch & THERMO_LB:
             lb_dict = {}
+            lb_dict["LB_fluid"] = self._LB_fluid
             lb_dict["gamma"] = lb_lbcoupling_get_gamma()
             lb_dict["type"] = "LB"
             lb_dict["act_on_virtual"] = thermo_virtual
@@ -379,6 +382,7 @@ cdef class Thermostat(object):
             raise ValueError(
                 "The LB thermostat requires a LB / LBGPU instance as a keyword arg.")
 
+        self._LB_fluid = LB_fluid
         if lb_lbfluid_get_kT() > 0.:
             if not seed and lb_lbcoupling_is_seed_required():
                 raise ValueError(

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -389,6 +389,8 @@ cdef class Thermostat(object):
                     "seed has to be given as keyword arg")
             elif seed:
                 lb_lbcoupling_set_rng_state(seed)
+        else:
+            lb_lbcoupling_set_rng_state(0)
 
         global thermo_switch
         thermo_switch = (thermo_switch or THERMO_LB)

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -64,7 +64,7 @@ endfunction(PYTHON_TEST)
 
 # Checkpointing tests: semicolon-separated list of mutually-compatible features.
 # Separate features with hyphens, use a period to add an optional flag.
-foreach(TEST_COMBINATION lb.cpu-p3m.cpu-lj;lb.gpu-p3m.cpu-lj;ek.gpu)
+foreach(TEST_COMBINATION lb.cpu-p3m.cpu-lj-lbtherm;lb.gpu-p3m.cpu-lj-lvtherm;ek.gpu)
   if(${TEST_COMBINATION} MATCHES "\\.gpu")
     set(TEST_LABELS "gpu")
   else()

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -54,6 +54,8 @@ elif 'LB.GPU' in modes and espressomd.gpu_available():
 if LB_implementation:
     lbf = LB_implementation(agrid=0.5, visc=1.3, dens=1.5, tau=0.01)
     system.actors.add(lbf)
+    if 'LBTHERM' in modes:
+        system.thermostat.set_lb(LB_fluid=lbf, seed=23, gamma=2.0)
     if espressomd.has_features("LB_BOUNDARIES") or espressomd.has_features("LB_BOUNDARIES_GPU"):
         if not 'EK.GPU' in modes:
             system.lbboundaries.add(
@@ -110,7 +112,8 @@ system.constraints.add(shape=Sphere(center=system.box_l / 2, radius=0.1),
                        particle_type=17)
 system.constraints.add(shape=Wall(normal=[1. / np.sqrt(3)] * 3, dist=0.5))
 
-system.thermostat.set_langevin(kT=1.0, gamma=2.0, seed=42)
+if not 'LBTHERM' in modes:
+    system.thermostat.set_langevin(kT=1.0, gamma=2.0, seed=42)
 
 if espressomd.has_features(['VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE']):
     system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative(

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -142,6 +142,13 @@ class CheckpointTest(ut.TestCase):
         np.testing.assert_allclose(np.copy(system.part[0].f), particle_force0)
         np.testing.assert_allclose(np.copy(system.part[1].f), particle_force1)
 
+    @ut.skipIf('LBTHERM' not in modes, 'LB thermostat not in modes')
+    def test_thermostat(self):
+        self.assertEqual(system.thermostat.get_state()[0]['type'], 'LB')
+        self.assertEqual(system.thermostat.get_state()[0]['seed'], 23)
+        self.assertEqual(system.thermostat.get_state()[0]['gamma'], 2.0)
+
+    @ut.skipIf('LBTHERM' in modes, 'Langevin incompatible with LB thermostat')
     def test_thermostat(self):
         self.assertEqual(system.thermostat.get_state()[0]['type'], 'LANGEVIN')
         self.assertEqual(system.thermostat.get_state()[0]['kT'], 1.0)


### PR DESCRIPTION
Fixes #2652

Description of changes:
 - store the LB fluid instance in the state of the LB thermostat
 - test LB thermostat checkpointing