### PR TITLE
Simplify energy/force/pressure code

### DIFF
--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -82,7 +82,7 @@ using are_allowed_arguments =
  * @param f Functor to be called
  * @param ia Buffer to extract the parameters from
  *
- * @return Return value of calling @param f.
+ * @return Return value of calling @p f.
  */
 template <class F, class... Args>
 auto invoke(F f, boost::mpi::packed_iarchive &ia) {
@@ -114,9 +114,6 @@ struct callback_concept_t {
    * @brief Execute the callback.
    *
    * Unpack parameters for this callback, and then call it.
-   *
-   * @param comm communicator used for return value collection.
-   * @param ia MPI buffer containing the arguments.
    */
   virtual void operator()(boost::mpi::communicator const &,
                           boost::mpi::packed_iarchive &) const = 0;

--- a/src/core/PartCfg.hpp
+++ b/src/core/PartCfg.hpp
@@ -62,13 +62,7 @@ public:
   }
 };
 
-/** unfold coordinates to physical position.
-    \param pos the position...
-    \param image_box and the box
-
-    Both pos and image_box are I/O, i.e. image_box will be (0,0,0)
-    afterwards.
-*/
+/** Unfold coordinates to physical position. */
 class PositionUnfolder {
 public:
   template <typename Particle> void operator()(Particle &p) const {

--- a/src/core/bonded_interactions/angle_cosine.hpp
+++ b/src/core/bonded_interactions/angle_cosine.hpp
@@ -74,21 +74,12 @@ calc_angle_cosine_3body_forces(Particle const *p_mid, Particle const *p_left,
  *  @param[out] f_right   Force on @p p_right.
  *  @retval false
  */
-inline bool calc_angle_cosine_force(Particle const *p_mid,
-                                    Particle const *p_left,
-                                    Particle const *p_right,
-                                    Bonded_ia_parameters const *iaparams,
-                                    double f_mid[3], double f_left[3],
-                                    double f_right[3]) {
-
-  Utils::Vector3d f_mid_v, f_left_v, f_right_v;
-  std::tie(f_mid_v, f_left_v, f_right_v) =
+inline bool calc_angle_cosine_force(
+    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
+    Bonded_ia_parameters const *iaparams, Utils::Vector3d &f_mid,
+    Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
+  std::tie(f_mid, f_left, f_right) =
       calc_angle_cosine_3body_forces(p_mid, p_left, p_right, iaparams);
-  for (int i = 0; i < 3; ++i) {
-    f_mid[i] = f_mid_v[i];
-    f_left[i] = f_left_v[i];
-    f_right[i] = f_right_v[i];
-  }
   return false;
 }
 

--- a/src/core/bonded_interactions/angle_cosine.hpp
+++ b/src/core/bonded_interactions/angle_cosine.hpp
@@ -46,9 +46,10 @@ int angle_cosine_set_params(int bond_type, double bend, double phi0);
  *  @return Forces on the second, first and third particles, in that order.
  */
 inline std::tuple<Utils::Vector3d, Utils::Vector3d, Utils::Vector3d>
-calc_angle_cosine_3body_forces(Particle const *p_mid, Particle const *p_left,
-                               Particle const *p_right,
-                               Bonded_ia_parameters const *iaparams) {
+calc_angle_cosine_3body_forces(Particle const *const p_mid,
+                               Particle const *const p_left,
+                               Particle const *const p_right,
+                               Bonded_ia_parameters const *const iaparams) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
@@ -75,9 +76,9 @@ calc_angle_cosine_3body_forces(Particle const *p_mid, Particle const *p_left,
  *  @retval false
  */
 inline bool calc_angle_cosine_force(
-    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Utils::Vector3d &f_mid,
-    Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
+    Particle const *const p_mid, Particle const *const p_left,
+    Particle const *const p_right, Bonded_ia_parameters const *const iaparams,
+    Utils::Vector3d &f_mid, Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
   std::tie(f_mid, f_left, f_right) =
       calc_angle_cosine_3body_forces(p_mid, p_left, p_right, iaparams);
   return false;
@@ -91,9 +92,10 @@ inline bool calc_angle_cosine_force(
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool angle_cosine_energy(Particle const *p_mid, Particle const *p_left,
-                                Particle const *p_right,
-                                Bonded_ia_parameters const *iaparams,
+inline bool angle_cosine_energy(Particle const *const p_mid,
+                                Particle const *const p_left,
+                                Particle const *const p_right,
+                                Bonded_ia_parameters const *const iaparams,
                                 double *_energy) {
   auto const vectors =
       calc_vectors_and_cosine(p_mid->r.p, p_left->r.p, p_right->r.p, true);

--- a/src/core/bonded_interactions/angle_cossquare.hpp
+++ b/src/core/bonded_interactions/angle_cossquare.hpp
@@ -47,9 +47,10 @@ int angle_cossquare_set_params(int bond_type, double bend, double phi0);
  *  @return Forces on the second, first and third particles, in that order.
  */
 inline std::tuple<Utils::Vector3d, Utils::Vector3d, Utils::Vector3d>
-calc_angle_cossquare_3body_forces(Particle const *p_mid, Particle const *p_left,
-                                  Particle const *p_right,
-                                  Bonded_ia_parameters const *iaparams) {
+calc_angle_cossquare_3body_forces(Particle const *const p_mid,
+                                  Particle const *const p_left,
+                                  Particle const *const p_right,
+                                  Bonded_ia_parameters const *const iaparams) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const cos_phi0 = iaparams->p.angle_cossquare.cos_phi0;
@@ -72,9 +73,9 @@ calc_angle_cossquare_3body_forces(Particle const *p_mid, Particle const *p_left,
  *  @retval false
  */
 inline bool calc_angle_cossquare_force(
-    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Utils::Vector3d &f_mid,
-    Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
+    Particle const *const p_mid, Particle const *const p_left,
+    Particle const *const p_right, Bonded_ia_parameters const *const iaparams,
+    Utils::Vector3d &f_mid, Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
   std::tie(f_mid, f_left, f_right) =
       calc_angle_cossquare_3body_forces(p_mid, p_left, p_right, iaparams);
   return false;
@@ -88,10 +89,10 @@ inline bool calc_angle_cossquare_force(
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool angle_cossquare_energy(Particle const *p_mid,
-                                   Particle const *p_left,
-                                   Particle const *p_right,
-                                   Bonded_ia_parameters const *iaparams,
+inline bool angle_cossquare_energy(Particle const *const p_mid,
+                                   Particle const *const p_left,
+                                   Particle const *const p_right,
+                                   Bonded_ia_parameters const *const iaparams,
                                    double *_energy) {
   auto const vectors =
       calc_vectors_and_cosine(p_mid->r.p, p_left->r.p, p_right->r.p, true);

--- a/src/core/bonded_interactions/angle_cossquare.hpp
+++ b/src/core/bonded_interactions/angle_cossquare.hpp
@@ -71,21 +71,12 @@ calc_angle_cossquare_3body_forces(Particle const *p_mid, Particle const *p_left,
  *  @param[out] f_right   Force on @p p_right.
  *  @retval false
  */
-inline bool calc_angle_cossquare_force(Particle const *p_mid,
-                                       Particle const *p_left,
-                                       Particle const *p_right,
-                                       Bonded_ia_parameters const *iaparams,
-                                       double f_mid[3], double f_left[3],
-                                       double f_right[3]) {
-
-  Utils::Vector3d f_mid_v, f_left_v, f_right_v;
-  std::tie(f_mid_v, f_left_v, f_right_v) =
+inline bool calc_angle_cossquare_force(
+    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
+    Bonded_ia_parameters const *iaparams, Utils::Vector3d &f_mid,
+    Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
+  std::tie(f_mid, f_left, f_right) =
       calc_angle_cossquare_3body_forces(p_mid, p_left, p_right, iaparams);
-  for (int i = 0; i < 3; ++i) {
-    f_mid[i] = f_mid_v[i];
-    f_left[i] = f_left_v[i];
-    f_right[i] = f_right_v[i];
-  }
   return false;
 }
 

--- a/src/core/bonded_interactions/angle_harmonic.hpp
+++ b/src/core/bonded_interactions/angle_harmonic.hpp
@@ -47,9 +47,10 @@ int angle_harmonic_set_params(int bond_type, double bend, double phi0);
  *  @return Forces on the second, first and third particles, in that order.
  */
 inline std::tuple<Utils::Vector3d, Utils::Vector3d, Utils::Vector3d>
-calc_angle_harmonic_3body_forces(Particle const *p_mid, Particle const *p_left,
-                                 Particle const *p_right,
-                                 Bonded_ia_parameters const *iaparams) {
+calc_angle_harmonic_3body_forces(Particle const *const p_mid,
+                                 Particle const *const p_left,
+                                 Particle const *const p_right,
+                                 Bonded_ia_parameters const *const iaparams) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
@@ -74,9 +75,9 @@ calc_angle_harmonic_3body_forces(Particle const *p_mid, Particle const *p_left,
  *  @retval false
  */
 inline bool calc_angle_harmonic_force(
-    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Utils::Vector3d &f_mid,
-    Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
+    Particle const *const p_mid, Particle const *const p_left,
+    Particle const *const p_right, Bonded_ia_parameters const *const iaparams,
+    Utils::Vector3d &f_mid, Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
   std::tie(f_mid, f_left, f_right) =
       calc_angle_harmonic_3body_forces(p_mid, p_left, p_right, iaparams);
   return false;
@@ -90,9 +91,10 @@ inline bool calc_angle_harmonic_force(
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool angle_harmonic_energy(Particle const *p_mid, Particle const *p_left,
-                                  Particle const *p_right,
-                                  Bonded_ia_parameters const *iaparams,
+inline bool angle_harmonic_energy(Particle const *const p_mid,
+                                  Particle const *const p_left,
+                                  Particle const *const p_right,
+                                  Bonded_ia_parameters const *const iaparams,
                                   double *_energy) {
   auto const vectors =
       calc_vectors_and_cosine(p_mid->r.p, p_left->r.p, p_right->r.p, true);

--- a/src/core/bonded_interactions/angle_harmonic.hpp
+++ b/src/core/bonded_interactions/angle_harmonic.hpp
@@ -73,21 +73,12 @@ calc_angle_harmonic_3body_forces(Particle const *p_mid, Particle const *p_left,
  *  @param[out] f_right   Force on @p p_right.
  *  @retval false
  */
-inline bool calc_angle_harmonic_force(Particle const *p_mid,
-                                      Particle const *p_left,
-                                      Particle const *p_right,
-                                      Bonded_ia_parameters const *iaparams,
-                                      double f_mid[3], double f_left[3],
-                                      double f_right[3]) {
-
-  Utils::Vector3d f_mid_v, f_left_v, f_right_v;
-  std::tie(f_mid_v, f_left_v, f_right_v) =
+inline bool calc_angle_harmonic_force(
+    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
+    Bonded_ia_parameters const *iaparams, Utils::Vector3d &f_mid,
+    Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
+  std::tie(f_mid, f_left, f_right) =
       calc_angle_harmonic_3body_forces(p_mid, p_left, p_right, iaparams);
-  for (int i = 0; i < 3; ++i) {
-    f_mid[i] = f_mid_v[i];
-    f_left[i] = f_left_v[i];
-    f_right[i] = f_right_v[i];
-  }
   return false;
 }
 

--- a/src/core/bonded_interactions/bonded_coulomb.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb.hpp
@@ -52,11 +52,10 @@ int bonded_coulomb_set_params(int bond_type, double prefactor);
  *  @param[out] force     Force.
  *  @retval false
  */
-inline bool calc_bonded_coulomb_pair_force(Particle const *p1,
-                                           Particle const *p2,
-                                           Bonded_ia_parameters const *iaparams,
-                                           Utils::Vector3d const &dx,
-                                           Utils::Vector3d &force) {
+inline bool calc_bonded_coulomb_pair_force(
+    Particle const *const p1, Particle const *const p2,
+    Bonded_ia_parameters const *const iaparams, Utils::Vector3d const &dx,
+    Utils::Vector3d &force) {
   auto const dist2 = dx.norm2();
   auto const dist = std::sqrt(dist2);
 
@@ -75,10 +74,10 @@ inline bool calc_bonded_coulomb_pair_force(Particle const *p1,
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool bonded_coulomb_pair_energy(Particle const *p1, Particle const *p2,
-                                       Bonded_ia_parameters const *iaparams,
-                                       Utils::Vector3d const &dx,
-                                       double *_energy) {
+inline bool
+bonded_coulomb_pair_energy(Particle const *const p1, Particle const *const p2,
+                           Bonded_ia_parameters const *const iaparams,
+                           Utils::Vector3d const &dx, double *_energy) {
   auto const dist = dx.norm();
 
   *_energy = iaparams->p.bonded_coulomb.prefactor * p1->p.q * p2->p.q / dist;

--- a/src/core/bonded_interactions/bonded_coulomb.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb.hpp
@@ -56,15 +56,13 @@ inline bool calc_bonded_coulomb_pair_force(Particle const *p1,
                                            Particle const *p2,
                                            Bonded_ia_parameters const *iaparams,
                                            Utils::Vector3d const &dx,
-                                           double *force) {
+                                           Utils::Vector3d &force) {
   auto const dist2 = dx.norm2();
   auto const dist = std::sqrt(dist2);
 
   auto const fac =
       iaparams->p.bonded_coulomb.prefactor * p1->p.q * p2->p.q / (dist * dist2);
-
-  for (int i = 0; i < 3; i++)
-    force[i] = fac * dx[i];
+  force = fac * dx;
 
   return false;
 }

--- a/src/core/bonded_interactions/bonded_coulomb_sr.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb_sr.hpp
@@ -53,7 +53,7 @@ int bonded_coulomb_sr_set_params(int bond_type, double q1q2);
  *  @retval false
  */
 inline bool
-calc_bonded_coulomb_sr_pair_force(Bonded_ia_parameters const *iaparams,
+calc_bonded_coulomb_sr_pair_force(Bonded_ia_parameters const *const iaparams,
                                   Utils::Vector3d const &dx,
                                   Utils::Vector3d &force) {
   auto const dist = dx.norm();
@@ -71,11 +71,11 @@ calc_bonded_coulomb_sr_pair_force(Bonded_ia_parameters const *iaparams,
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool bonded_coulomb_sr_pair_energy(const Particle *p1,
-                                          const Particle *p2,
-                                          Bonded_ia_parameters const *iaparams,
-                                          Utils::Vector3d const &dx,
-                                          double *_energy) {
+inline bool
+bonded_coulomb_sr_pair_energy(Particle const *const p1,
+                              Particle const *const p2,
+                              Bonded_ia_parameters const *const iaparams,
+                              Utils::Vector3d const &dx, double *_energy) {
   auto const dist2 = dx.norm2();
   auto const dist = sqrt(dist2);
 

--- a/src/core/bonded_interactions/bonded_coulomb_sr.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb_sr.hpp
@@ -54,15 +54,11 @@ int bonded_coulomb_sr_set_params(int bond_type, double q1q2);
  */
 inline bool
 calc_bonded_coulomb_sr_pair_force(Bonded_ia_parameters const *iaparams,
-                                  Utils::Vector3d const &dx, double *force) {
+                                  Utils::Vector3d const &dx,
+                                  Utils::Vector3d &force) {
   auto const dist = dx.norm();
 
-  auto const forcevec = Coulomb::central_force(
-      iaparams->p.bonded_coulomb_sr.q1q2, dx.data(), dist);
-
-  force[0] = forcevec[0];
-  force[1] = forcevec[1];
-  force[2] = forcevec[2];
+  force = Coulomb::central_force(iaparams->p.bonded_coulomb_sr.q1q2, dx, dist);
 
   return false;
 }
@@ -84,7 +80,7 @@ inline bool bonded_coulomb_sr_pair_energy(const Particle *p1,
   auto const dist = sqrt(dist2);
 
   *_energy = Coulomb::pair_energy(p1, p2, iaparams->p.bonded_coulomb_sr.q1q2,
-                                  dx.data(), dist, dist2);
+                                  dx, dist, dist2);
   return false;
 }
 

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -364,8 +364,8 @@ void make_bond_type_exist(int type);
  * @param p          particle on which the bond may be stored
  * @param partner    bond partner
  * @param bond_type  numerical bond type */
-inline bool pair_bond_exists_on(const Particle *const p,
-                                const Particle *const partner, int bond_type) {
+inline bool pair_bond_exists_on(Particle const *const p,
+                                Particle const *const partner, int bond_type) {
   // First check the bonds of p1
   if (p->bl.e) {
     int i = 0;
@@ -389,8 +389,8 @@ inline bool pair_bond_exists_on(const Particle *const p,
  *  @param p_partner   bond partner
  *  @param bond        enum bond type
  */
-inline bool pair_bond_enum_exists_on(const Particle *const p_bond,
-                                     const Particle *const p_partner,
+inline bool pair_bond_enum_exists_on(Particle const *const p_bond,
+                                     Particle const *const p_partner,
                                      BondedInteraction bond) {
 #ifdef ADDITIONAL_CHECKS
   extern int ghosts_have_bonds;
@@ -400,7 +400,7 @@ inline bool pair_bond_enum_exists_on(const Particle *const p_bond,
   int i = 0;
   while (i < p_bond->bl.n) {
     int type_num = p_bond->bl.e[i];
-    Bonded_ia_parameters *iaparams = &bonded_ia_params[type_num];
+    Bonded_ia_parameters const *const iaparams = &bonded_ia_params[type_num];
     if (iaparams->type == (int)bond &&
         p_bond->bl.e[i + 1] == p_partner->p.identity) {
       return true;
@@ -417,8 +417,8 @@ inline bool pair_bond_enum_exists_on(const Particle *const p_bond,
  *  @param p2     particle on which the bond may be stored
  *  @param bond   numerical bond type
  */
-inline bool pair_bond_enum_exists_between(const Particle *const p1,
-                                          const Particle *const p2,
+inline bool pair_bond_enum_exists_between(Particle const *const p1,
+                                          Particle const *const p2,
                                           BondedInteraction bond) {
   if (p1 == p2)
     return false;

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -61,11 +61,13 @@
  *
  *  * The recommended signatures of the force and energy functions are:
  *    @code{.cpp}
- *    inline bool calc_fene_pair_force(Particle *p1, Particle *p2,
- *                                     Bonded_ia_parameters *iaparams,
+ *    inline bool calc_fene_pair_force(Particle const *const p1,
+ *                                     Particle const *const p2,
+ *                                     Bonded_ia_parameters const *const iaparams,
  *                                     Vector3d const &dx, Vector3d &force);
- *    inline bool fene_pair_energy(Particle *p1, Particle *p2,
- *                                 Bonded_ia_parameters *iaparams,
+ *    inline bool fene_pair_energy(Particle const *const p1,
+ *                                 Particle const *const p2,
+ *                                 Bonded_ia_parameters const *const iaparams,
  *                                 Vector3d const &dx, double *energy);
  *    @endcode
  *  * The setter function gets a \p bond_type which is a numerical id

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -63,10 +63,10 @@
  *    @code{.cpp}
  *    inline bool calc_fene_pair_force(Particle *p1, Particle *p2,
  *                                     Bonded_ia_parameters *iaparams,
- *                                     double const dx[3], double force[3]);
+ *                                     Vector3d const &dx, Vector3d &force);
  *    inline bool fene_pair_energy(Particle *p1, Particle *p2,
  *                                 Bonded_ia_parameters *iaparams,
- *                                 double const dx[3], double energy[3]);
+ *                                 Vector3d const &dx, double *energy);
  *    @endcode
  *  * The setter function gets a \p bond_type which is a numerical id
  *    identifying the number of the bond type in the simulation.

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -71,8 +71,8 @@ int tabulated_bonded_set_params(int bond_type,
  *  @param[out] force     Force.
  *  @return whether the bond is broken
  */
-inline bool calc_tab_bond_force(Bonded_ia_parameters const *iaparams,
-                                const Utils::Vector3d &dx,
+inline bool calc_tab_bond_force(Bonded_ia_parameters const *const iaparams,
+                                Utils::Vector3d const &dx,
                                 Utils::Vector3d &force) {
   auto const *tab_pot = iaparams->p.tab.pot;
   auto const dist = dx.norm();
@@ -96,8 +96,8 @@ inline bool calc_tab_bond_force(Bonded_ia_parameters const *iaparams,
  *  @param[out] _energy   Energy.
  *  @return whether the bond is broken
  */
-inline bool tab_bond_energy(Bonded_ia_parameters const *iaparams,
-                            const Utils::Vector3d &dx, double *_energy) {
+inline bool tab_bond_energy(Bonded_ia_parameters const *const iaparams,
+                            Utils::Vector3d const &dx, double *_energy) {
   auto const *tab_pot = iaparams->p.tab.pot;
   auto const dist = dx.norm();
 
@@ -116,9 +116,10 @@ inline bool tab_bond_energy(Bonded_ia_parameters const *iaparams,
  *  @return Forces on the second, first and third particles, in that order.
  */
 inline std::tuple<Utils::Vector3d, Utils::Vector3d, Utils::Vector3d>
-calc_angle_3body_tabulated_forces(Particle const *p_mid, Particle const *p_left,
-                                  Particle const *p_right,
-                                  Bonded_ia_parameters const *iaparams) {
+calc_angle_3body_tabulated_forces(Particle const *const p_mid,
+                                  Particle const *const p_left,
+                                  Particle const *const p_right,
+                                  Bonded_ia_parameters const *const iaparams) {
 
   auto forceFactor = [&iaparams](double const cos_phi) {
     auto const sin_phi = sqrt(1 - Utils::sqr(cos_phi));
@@ -146,12 +147,10 @@ calc_angle_3body_tabulated_forces(Particle const *p_mid, Particle const *p_left,
  *  @param[out] f_right   Force on @p p_right.
  *  @retval false
  */
-inline bool calc_tab_angle_force(Particle const *p_mid, Particle const *p_left,
-                                 Particle const *p_right,
-                                 Bonded_ia_parameters const *iaparams,
-                                 Utils::Vector3d &f_mid,
-                                 Utils::Vector3d &f_left,
-                                 Utils::Vector3d &f_right) {
+inline bool calc_tab_angle_force(
+    Particle const *const p_mid, Particle const *const p_left,
+    Particle const *const p_right, Bonded_ia_parameters const *const iaparams,
+    Utils::Vector3d &f_mid, Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
 
   std::tie(f_mid, f_left, f_right) =
       calc_angle_3body_tabulated_forces(p_mid, p_left, p_right, iaparams);
@@ -169,9 +168,10 @@ inline bool calc_tab_angle_force(Particle const *p_mid, Particle const *p_left,
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool tab_angle_energy(Particle const *p_mid, Particle const *p_left,
-                             Particle const *p_right,
-                             Bonded_ia_parameters const *iaparams,
+inline bool tab_angle_energy(Particle const *const p_mid,
+                             Particle const *const p_left,
+                             Particle const *const p_right,
+                             Bonded_ia_parameters const *const iaparams,
                              double *_energy) {
   auto const vectors =
       calc_vectors_and_cosine(p_mid->r.p, p_left->r.p, p_right->r.p, true);
@@ -199,12 +199,12 @@ inline bool tab_angle_energy(Particle const *p_mid, Particle const *p_left,
  *  @param[out] force3    Force on particle 3.
  *  @return false
  */
-inline bool calc_tab_dihedral_force(Particle const *p2, Particle const *p1,
-                                    Particle const *p3, Particle const *p4,
-                                    Bonded_ia_parameters const *iaparams,
-                                    Utils::Vector3d &force2,
-                                    Utils::Vector3d &force1,
-                                    Utils::Vector3d &force3) {
+inline bool
+calc_tab_dihedral_force(Particle const *const p2, Particle const *const p1,
+                        Particle const *const p3, Particle const *const p4,
+                        Bonded_ia_parameters const *const iaparams,
+                        Utils::Vector3d &force2, Utils::Vector3d &force1,
+                        Utils::Vector3d &force3) {
   /* vectors for dihedral angle calculation */
   Utils::Vector3d v12, v23, v34, v12Xv23, v23Xv34;
   double l_v12Xv23, l_v23Xv34;
@@ -255,9 +255,11 @@ inline bool calc_tab_dihedral_force(Particle const *p2, Particle const *p1,
  *  @param[out] _energy   Energy.
  *  @return false
  */
-inline bool tab_dihedral_energy(Particle const *p2, Particle const *p1,
-                                Particle const *p3, Particle const *p4,
-                                Bonded_ia_parameters const *iaparams,
+inline bool tab_dihedral_energy(Particle const *const p2,
+                                Particle const *const p1,
+                                Particle const *const p3,
+                                Particle const *const p4,
+                                Bonded_ia_parameters const *const iaparams,
                                 double *_energy) {
   /* vectors for dihedral calculations. */
   Utils::Vector3d v12, v23, v34, v12Xv23, v23Xv34;

--- a/src/core/bonded_interactions/dihedral.hpp
+++ b/src/core/bonded_interactions/dihedral.hpp
@@ -117,8 +117,9 @@ inline void calc_dihedral_angle(Particle const *p1, Particle const *p2,
 inline bool calc_dihedral_force(Particle const *p2, Particle const *p1,
                                 Particle const *p3, Particle const *p4,
                                 Bonded_ia_parameters const *iaparams,
-                                double force2[3], double force1[3],
-                                double force3[3]) {
+                                Utils::Vector3d &force2,
+                                Utils::Vector3d &force1,
+                                Utils::Vector3d &force3) {
   /* vectors for dihedral angle calculation */
   Utils::Vector3d v12, v23, v34, v12Xv23, v23Xv34;
   double l_v12Xv23, l_v23Xv34;
@@ -132,11 +133,9 @@ inline bool calc_dihedral_force(Particle const *p2, Particle const *p1,
                       v23Xv34, &l_v23Xv34, &cosphi, &phi);
   /* dihedral angle not defined - force zero */
   if (phi == -1.0) {
-    for (int i = 0; i < 3; i++) {
-      force1[i] = 0.0;
-      force2[i] = 0.0;
-      force3[i] = 0.0;
-    }
+    force1 = {};
+    force2 = {};
+    force3 = {};
     return false;
   }
 
@@ -169,11 +168,10 @@ inline bool calc_dihedral_force(Particle const *p2, Particle const *p1,
   fac *= sinmphi_sinphi;
 
   /* store dihedral forces */
-  for (int i = 0; i < 3; i++) {
-    force1[i] = fac * v23Xf1[i];
-    force2[i] = fac * (v34Xf4[i] - v12Xf1[i] - v23Xf1[i]);
-    force3[i] = fac * (v12Xf1[i] - v23Xf4[i] - v34Xf4[i]);
-  }
+  force1 = fac * v23Xf1;
+  force2 = fac * (v34Xf4 - v12Xf1 - v23Xf1);
+  force3 = fac * (v12Xf1 - v23Xf4 - v34Xf4);
+
   return false;
 }
 

--- a/src/core/bonded_interactions/dihedral.hpp
+++ b/src/core/bonded_interactions/dihedral.hpp
@@ -63,12 +63,12 @@ int dihedral_set_params(int bond_type, int mult, double bend, double phase);
  * @param[out] cosphi Cosine of the dihedral angle
  * @param[out] phi Dihedral angle
  */
-inline void calc_dihedral_angle(Particle const *p1, Particle const *p2,
-                                Particle const *p3, Particle const *p4,
-                                Utils::Vector3d &a, Utils::Vector3d &b,
-                                Utils::Vector3d &c, Utils::Vector3d &aXb,
-                                double *l_aXb, Utils::Vector3d &bXc,
-                                double *l_bXc, double *cosphi, double *phi) {
+inline void
+calc_dihedral_angle(Particle const *const p1, Particle const *const p2,
+                    Particle const *const p3, Particle const *const p4,
+                    Utils::Vector3d &a, Utils::Vector3d &b, Utils::Vector3d &c,
+                    Utils::Vector3d &aXb, double *l_aXb, Utils::Vector3d &bXc,
+                    double *l_bXc, double *cosphi, double *phi) {
   a = get_mi_vector(p2->r.p, p1->r.p, box_geo);
   b = get_mi_vector(p3->r.p, p2->r.p, box_geo);
   c = get_mi_vector(p4->r.p, p3->r.p, box_geo);
@@ -114,12 +114,12 @@ inline void calc_dihedral_angle(Particle const *p1, Particle const *p2,
  *  @param[out] force3    Force on particle 3.
  *  @return false
  */
-inline bool calc_dihedral_force(Particle const *p2, Particle const *p1,
-                                Particle const *p3, Particle const *p4,
-                                Bonded_ia_parameters const *iaparams,
-                                Utils::Vector3d &force2,
-                                Utils::Vector3d &force1,
-                                Utils::Vector3d &force3) {
+inline bool
+calc_dihedral_force(Particle const *const p2, Particle const *const p1,
+                    Particle const *const p3, Particle const *const p4,
+                    Bonded_ia_parameters const *const iaparams,
+                    Utils::Vector3d &force2, Utils::Vector3d &force1,
+                    Utils::Vector3d &force3) {
   /* vectors for dihedral angle calculation */
   Utils::Vector3d v12, v23, v34, v12Xv23, v23Xv34;
   double l_v12Xv23, l_v23Xv34;
@@ -185,9 +185,9 @@ inline bool calc_dihedral_force(Particle const *p2, Particle const *p1,
  *  @param[out] _energy   Energy.
  *  @return false
  */
-inline bool dihedral_energy(Particle const *p1, Particle const *p2,
-                            Particle const *p3, Particle const *p4,
-                            Bonded_ia_parameters const *iaparams,
+inline bool dihedral_energy(Particle const *const p1, Particle const *const p2,
+                            Particle const *const p3, Particle const *const p4,
+                            Bonded_ia_parameters const *const iaparams,
                             double *_energy) {
   /* vectors for dihedral calculations. */
   Utils::Vector3d v12, v23, v34, v12Xv23, v23Xv34;

--- a/src/core/bonded_interactions/fene.hpp
+++ b/src/core/bonded_interactions/fene.hpp
@@ -44,7 +44,7 @@ int fene_set_params(int bond_type, double k, double drmax, double r0);
  *  @param[out] force     Force.
  *  @return whether the bond is broken
  */
-inline bool calc_fene_pair_force(Bonded_ia_parameters const *iaparams,
+inline bool calc_fene_pair_force(Bonded_ia_parameters const *const iaparams,
                                  Utils::Vector3d const &dx,
                                  Utils::Vector3d &force) {
   auto const len = dx.norm();
@@ -73,7 +73,7 @@ inline bool calc_fene_pair_force(Bonded_ia_parameters const *iaparams,
  *  @param[out] _energy   Energy.
  *  @return whether the bond is broken
  */
-inline bool fene_pair_energy(Bonded_ia_parameters const *iaparams,
+inline bool fene_pair_energy(Bonded_ia_parameters const *const iaparams,
                              Utils::Vector3d const &dx, double *_energy) {
   /* compute bond stretching (r-r0) */
   double const dr = dx.norm() - iaparams->p.fene.r0;

--- a/src/core/bonded_interactions/fene.hpp
+++ b/src/core/bonded_interactions/fene.hpp
@@ -45,7 +45,8 @@ int fene_set_params(int bond_type, double k, double drmax, double r0);
  *  @return whether the bond is broken
  */
 inline bool calc_fene_pair_force(Bonded_ia_parameters const *iaparams,
-                                 Utils::Vector3d const &dx, double *force) {
+                                 Utils::Vector3d const &dx,
+                                 Utils::Vector3d &force) {
   auto const len = dx.norm();
   auto const dr = len - iaparams->p.fene.r0;
 
@@ -61,8 +62,7 @@ inline bool calc_fene_pair_force(Bonded_ia_parameters const *iaparams,
     fac = 0.0;
   }
 
-  for (int i = 0; i < 3; i++)
-    force[i] = fac * dx[i];
+  force = fac * dx;
 
   return false;
 }

--- a/src/core/bonded_interactions/harmonic.hpp
+++ b/src/core/bonded_interactions/harmonic.hpp
@@ -46,7 +46,7 @@ int harmonic_set_params(int bond_type, double k, double r, double r_cut);
  *  @param[out] force     Force.
  *  @return whether the bond is broken
  */
-inline bool calc_harmonic_pair_force(Bonded_ia_parameters const *iaparams,
+inline bool calc_harmonic_pair_force(Bonded_ia_parameters const *const iaparams,
                                      Utils::Vector3d const &dx,
                                      Utils::Vector3d &force) {
   auto const dist = dx.norm();
@@ -74,7 +74,7 @@ inline bool calc_harmonic_pair_force(Bonded_ia_parameters const *iaparams,
  *  @param[out] _energy   Energy.
  *  @return whether the bond is broken
  */
-inline bool harmonic_pair_energy(Bonded_ia_parameters const *iaparams,
+inline bool harmonic_pair_energy(Bonded_ia_parameters const *const iaparams,
                                  Utils::Vector3d const &dx, double *_energy) {
   auto const dist = dx.norm();
 

--- a/src/core/bonded_interactions/harmonic.hpp
+++ b/src/core/bonded_interactions/harmonic.hpp
@@ -47,7 +47,8 @@ int harmonic_set_params(int bond_type, double k, double r, double r_cut);
  *  @return whether the bond is broken
  */
 inline bool calc_harmonic_pair_force(Bonded_ia_parameters const *iaparams,
-                                     Utils::Vector3d const &dx, double *force) {
+                                     Utils::Vector3d const &dx,
+                                     Utils::Vector3d &force) {
   auto const dist = dx.norm();
 
   if ((iaparams->p.harmonic.r_cut > 0.0) &&
@@ -62,9 +63,7 @@ inline bool calc_harmonic_pair_force(Bonded_ia_parameters const *iaparams,
   } else {
     fac = 0;
   }
-
-  for (int i = 0; i < 3; i++)
-    force[i] = fac * dx[i];
+  force = fac * dx;
 
   return false;
 }

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -53,7 +53,7 @@ int harmonic_dumbbell_set_params(int bond_type, double k1, double k2, double r,
  *  @return whether the bond is broken
  */
 inline bool calc_harmonic_dumbbell_pair_force(
-    Particle *p1, Bonded_ia_parameters const *iaparams,
+    Particle *const p1, Bonded_ia_parameters const *const iaparams,
     Utils::Vector3d const &dx, Utils::Vector3d &force) {
   auto const dist = dx.norm();
 
@@ -81,10 +81,10 @@ inline bool calc_harmonic_dumbbell_pair_force(
  *  @param[out] _energy   Energy.
  *  @return whether the bond is broken
  */
-inline bool harmonic_dumbbell_pair_energy(Particle const *p1,
-                                          Bonded_ia_parameters const *iaparams,
-                                          Utils::Vector3d const &dx,
-                                          double *_energy) {
+inline bool
+harmonic_dumbbell_pair_energy(Particle const *const p1,
+                              Bonded_ia_parameters const *const iaparams,
+                              Utils::Vector3d const &dx, double *_energy) {
   auto const dist = dx.norm();
 
   if ((iaparams->p.harmonic_dumbbell.r_cut > 0.0) &&

--- a/src/core/bonded_interactions/harmonic_dumbbell.hpp
+++ b/src/core/bonded_interactions/harmonic_dumbbell.hpp
@@ -52,10 +52,9 @@ int harmonic_dumbbell_set_params(int bond_type, double k1, double k2, double r,
  *  @param[out]     force     Force.
  *  @return whether the bond is broken
  */
-inline bool
-calc_harmonic_dumbbell_pair_force(Particle *p1,
-                                  Bonded_ia_parameters const *iaparams,
-                                  Utils::Vector3d const &dx, double *force) {
+inline bool calc_harmonic_dumbbell_pair_force(
+    Particle *p1, Bonded_ia_parameters const *iaparams,
+    Utils::Vector3d const &dx, Utils::Vector3d &force) {
   auto const dist = dx.norm();
 
   if ((iaparams->p.harmonic_dumbbell.r_cut > 0.0) &&
@@ -66,14 +65,12 @@ calc_harmonic_dumbbell_pair_force(Particle *p1,
   auto const dr = dist - iaparams->p.harmonic_dumbbell.r;
   auto const normalizer = (dist > ROUND_ERROR_PREC) ? 1. / dist : 0.0;
   auto const fac = -iaparams->p.harmonic_dumbbell.k1 * dr * normalizer;
+  force = fac * dx;
 
-  for (int i = 0; i < 3; i++)
-    force[i] = fac * dx[i];
-
-  auto const dhat = Utils::Vector3d{dx[0], dx[1], dx[2]} * normalizer;
+  auto const dhat = dx * normalizer;
   auto const da = vector_product(dhat, p1->r.calc_director());
-
   p1->f.torque += iaparams->p.harmonic_dumbbell.k2 * da;
+
   return false;
 }
 
@@ -95,32 +92,15 @@ inline bool harmonic_dumbbell_pair_energy(Particle const *p1,
     return true;
   }
 
-  double dhat[3];
-  dhat[0] = dx[0] / dist;
-  dhat[1] = dx[1] / dist;
-  dhat[2] = dx[2] / dist;
+  auto const dhat = dx / dist;
+  auto const director = p1->r.calc_director();
+  auto const da = vector_product(dhat, director);
+  auto const torque = iaparams->p.harmonic_dumbbell.k2 * da;
+  auto const diff = dhat - director;
 
-  double da[3];
-  const Utils::Vector3d director1 = p1->r.calc_director();
-  da[0] = dhat[1] * director1[2] - dhat[2] * director1[1];
-  da[1] = dhat[2] * director1[0] - dhat[0] * director1[2];
-  da[2] = dhat[0] * director1[1] - dhat[1] * director1[0];
-
-  double torque[3];
-  torque[0] = iaparams->p.harmonic_dumbbell.k2 * da[0];
-  torque[1] = iaparams->p.harmonic_dumbbell.k2 * da[1];
-  torque[2] = iaparams->p.harmonic_dumbbell.k2 * da[2];
-
-  double diff[3];
-  diff[0] = dhat[0] - director1[0];
-  diff[1] = dhat[1] - director1[1];
-  diff[2] = dhat[2] - director1[2];
-
-  *_energy =
-      0.5 * iaparams->p.harmonic_dumbbell.k1 *
-          Utils::sqr(dist - iaparams->p.harmonic.r) +
-      0.5 * iaparams->p.harmonic_dumbbell.k2 *
-          (torque[0] * diff[0] + torque[1] * diff[1] + torque[2] * diff[2]);
+  *_energy = 0.5 * iaparams->p.harmonic_dumbbell.k1 *
+                 Utils::sqr(dist - iaparams->p.harmonic.r) +
+             0.5 * iaparams->p.harmonic_dumbbell.k2 * (torque * diff);
   return false;
 }
 

--- a/src/core/bonded_interactions/quartic.hpp
+++ b/src/core/bonded_interactions/quartic.hpp
@@ -50,7 +50,8 @@ int quartic_set_params(int bond_type, double k0, double k1, double r,
  *  @return whether the bond is broken
  */
 inline bool calc_quartic_pair_force(Bonded_ia_parameters const *iaparams,
-                                    Utils::Vector3d const &dx, double *force) {
+                                    Utils::Vector3d const &dx,
+                                    Utils::Vector3d &force) {
   auto const dist = dx.norm();
 
   if ((iaparams->p.quartic.r_cut > 0.0) && (dist > iaparams->p.quartic.r_cut)) {
@@ -58,13 +59,10 @@ inline bool calc_quartic_pair_force(Bonded_ia_parameters const *iaparams,
   }
 
   auto const dr = dist - iaparams->p.quartic.r;
-
   auto const fac =
       (iaparams->p.quartic.k0 * dr + iaparams->p.quartic.k1 * dr * dr * dr) /
       dist;
-
-  for (int i = 0; i < 3; i++)
-    force[i] = -fac * dx[i];
+  force = -fac * dx;
 
   return false;
 }

--- a/src/core/bonded_interactions/quartic.hpp
+++ b/src/core/bonded_interactions/quartic.hpp
@@ -49,7 +49,7 @@ int quartic_set_params(int bond_type, double k0, double k1, double r,
  *  @param[out] force     Force.
  *  @return whether the bond is broken
  */
-inline bool calc_quartic_pair_force(Bonded_ia_parameters const *iaparams,
+inline bool calc_quartic_pair_force(Bonded_ia_parameters const *const iaparams,
                                     Utils::Vector3d const &dx,
                                     Utils::Vector3d &force) {
   auto const dist = dx.norm();
@@ -73,7 +73,7 @@ inline bool calc_quartic_pair_force(Bonded_ia_parameters const *iaparams,
  *  @param[out] _energy   Energy.
  *  @return whether the bond is broken
  */
-inline bool quartic_pair_energy(Bonded_ia_parameters const *iaparams,
+inline bool quartic_pair_energy(Bonded_ia_parameters const *const iaparams,
                                 Utils::Vector3d const &dx, double *_energy) {
   auto const dist = dx.norm();
 

--- a/src/core/bonded_interactions/subt_lj.hpp
+++ b/src/core/bonded_interactions/subt_lj.hpp
@@ -49,8 +49,9 @@ int subt_lj_set_params(int bond_type);
  *  @param[out] force     Force.
  *  @retval false
  */
-inline bool calc_subt_lj_pair_force(Particle *p1, Particle *p2,
-                                    Bonded_ia_parameters *,
+inline bool calc_subt_lj_pair_force(Particle const *const p1,
+                                    Particle const *const p2,
+                                    Bonded_ia_parameters const *,
                                     Utils::Vector3d const &dx,
                                     Utils::Vector3d &force) {
   auto ia_params = get_ia_param(p1->p.type, p2->p.type);
@@ -69,8 +70,9 @@ inline bool calc_subt_lj_pair_force(Particle *p1, Particle *p2,
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool subt_lj_pair_energy(const Particle *p1, const Particle *p2,
-                                Bonded_ia_parameters *,
+inline bool subt_lj_pair_energy(Particle const *const p1,
+                                Particle const *const p2,
+                                Bonded_ia_parameters const *,
                                 Utils::Vector3d const &dx, double *_energy) {
   auto ia_params = get_ia_param(p1->p.type, p2->p.type);
 

--- a/src/core/bonded_interactions/subt_lj.hpp
+++ b/src/core/bonded_interactions/subt_lj.hpp
@@ -51,12 +51,13 @@ int subt_lj_set_params(int bond_type);
  */
 inline bool calc_subt_lj_pair_force(Particle *p1, Particle *p2,
                                     Bonded_ia_parameters *,
-                                    Utils::Vector3d const &dx, double *force) {
+                                    Utils::Vector3d const &dx,
+                                    Utils::Vector3d &force) {
   auto ia_params = get_ia_param(p1->p.type, p2->p.type);
 
   auto const neg_dir = -dx;
 
-  add_lj_pair_force(ia_params, neg_dir.data(), neg_dir.norm(), force);
+  add_lj_pair_force(ia_params, neg_dir, neg_dir.norm(), force);
 
   return false;
 }

--- a/src/core/bonded_interactions/thermalized_bond.hpp
+++ b/src/core/bonded_interactions/thermalized_bond.hpp
@@ -60,11 +60,11 @@ void thermalized_bond_init();
  *  @retval 1 if the bond is broken
  *  @retval 0 otherwise
  */
-inline bool calc_thermalized_bond_forces(const Particle *p1, const Particle *p2,
-                                         const Bonded_ia_parameters *iaparams,
-                                         const Utils::Vector3d &dx,
-                                         Utils::Vector3d &force1,
-                                         Utils::Vector3d &force2) {
+inline bool
+calc_thermalized_bond_forces(Particle const *const p1, Particle const *const p2,
+                             Bonded_ia_parameters const *const iaparams,
+                             const Utils::Vector3d &dx, Utils::Vector3d &force1,
+                             Utils::Vector3d &force2) {
   // Bond broke?
   if (iaparams->p.thermalized_bond.r_cut > 0.0 &&
       dx.norm() > iaparams->p.thermalized_bond.r_cut) {

--- a/src/core/bonded_interactions/umbrella.hpp
+++ b/src/core/bonded_interactions/umbrella.hpp
@@ -54,10 +54,10 @@ inline double umbrella_force_r(double k, int dir, double r, double distn) {
  *  @param[out] force     Force.
  *  @retval false
  */
-inline bool calc_umbrella_pair_force(Particle const *p1, Particle const *p2,
-                                     Bonded_ia_parameters const *ia_params,
-                                     Utils::Vector3d const &d,
-                                     Utils::Vector3d &force) {
+inline bool
+calc_umbrella_pair_force(Particle const *const p1, Particle const *const p2,
+                         Bonded_ia_parameters const *const ia_params,
+                         Utils::Vector3d const &d, Utils::Vector3d &force) {
   auto const distn = d[ia_params->p.umbrella.dir];
   auto const fac = -ia_params->p.umbrella.k * (distn - ia_params->p.umbrella.r);
   force[ia_params->p.umbrella.dir] = fac;
@@ -85,8 +85,9 @@ inline bool calc_umbrella_pair_force(Particle const *p1, Particle const *p2,
  *  @param[out] _energy   Energy.
  *  @retval false
  */
-inline bool umbrella_pair_energy(Particle const *p1, Particle const *p2,
-                                 Bonded_ia_parameters const *ia_params,
+inline bool umbrella_pair_energy(Particle const *const p1,
+                                 Particle const *const p2,
+                                 Bonded_ia_parameters const *const ia_params,
                                  Utils::Vector3d const &d, double *_energy) {
   auto const distn = d[ia_params->p.umbrella.dir];
   *_energy = 0.5 * ia_params->p.umbrella.k *

--- a/src/core/bonded_interactions/umbrella.hpp
+++ b/src/core/bonded_interactions/umbrella.hpp
@@ -56,10 +56,11 @@ inline double umbrella_force_r(double k, int dir, double r, double distn) {
  */
 inline bool calc_umbrella_pair_force(Particle const *p1, Particle const *p2,
                                      Bonded_ia_parameters const *ia_params,
-                                     double const d[3], double force[3]) {
+                                     Utils::Vector3d const &d,
+                                     Utils::Vector3d &force) {
   auto const distn = d[ia_params->p.umbrella.dir];
   auto const fac = -ia_params->p.umbrella.k * (distn - ia_params->p.umbrella.r);
-  force[ia_params->p.umbrella.dir] += fac;
+  force[ia_params->p.umbrella.dir] = fac;
 
   ONEPART_TRACE(if (p1->p.identity == check_id)
                     fprintf(stderr,
@@ -86,7 +87,7 @@ inline bool calc_umbrella_pair_force(Particle const *p1, Particle const *p2,
  */
 inline bool umbrella_pair_energy(Particle const *p1, Particle const *p2,
                                  Bonded_ia_parameters const *ia_params,
-                                 double const d[3], double *_energy) {
+                                 Utils::Vector3d const &d, double *_energy) {
   auto const distn = d[ia_params->p.umbrella.dir];
   *_energy = 0.5 * ia_params->p.umbrella.k *
              Utils::sqr(distn - ia_params->p.umbrella.r);

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -166,9 +166,7 @@ void mpi_remove_particle(int node, int id);
  */
 int mpi_integrate(int n_steps, int reuse_forces);
 
-/** Issue REQ_MIN_ENERGY: start energy minimization.
- *  @return nonzero on error
- */
+/** Issue REQ_MIN_ENERGY: start energy minimization. */
 void mpi_minimize_energy();
 
 void mpi_bcast_all_ia_params();

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -56,14 +56,15 @@ double ShapeBasedConstraint::min_dist(const ParticleRange &particles) {
   return global_mindist;
 }
 
-ParticleForce ShapeBasedConstraint::force(const Particle &p,
-                                          const Utils::Vector3d &folded_pos,
+ParticleForce ShapeBasedConstraint::force(Particle const &p,
+                                          Utils::Vector3d const &folded_pos,
                                           double t) {
 
   double dist = 0.;
   Utils::Vector3d dist_vec, force1{}, torque1{}, torque2{}, outer_normal_vec;
 
-  IA_parameters *ia_params = get_ia_param(p.p.type, part_rep.p.type);
+  IA_parameters const *const ia_params =
+      get_ia_param(p.p.type, part_rep.p.type);
 
   if (checkIfInteraction(ia_params)) {
     m_shape->calculate_dist(folded_pos, dist, dist_vec);

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -44,8 +44,9 @@ double ShapeBasedConstraint::min_dist(const ParticleRange &particles) {
         IA_parameters *ia_params;
         ia_params = get_ia_param(p.p.type, part_rep.p.type);
         if (checkIfInteraction(ia_params)) {
-          double vec[3], dist;
-          m_shape->calculate_dist(folded_position(p.r.p, box_geo), &dist, vec);
+          double dist;
+          Utils::Vector3d vec;
+          m_shape->calculate_dist(folded_position(p.r.p, box_geo), dist, vec);
           return std::min(min, dist);
         }
         return min;
@@ -60,30 +61,22 @@ ParticleForce ShapeBasedConstraint::force(const Particle &p,
                                           double t) {
 
   double dist = 0.;
-  Utils::Vector3d dist_vec, force, torque1, torque2, outer_normal_vec;
+  Utils::Vector3d dist_vec, force1{}, torque1{}, torque2{}, outer_normal_vec;
 
   IA_parameters *ia_params = get_ia_param(p.p.type, part_rep.p.type);
 
-  for (int j = 0; j < 3; j++) {
-    force[j] = 0;
-#ifdef ROTATION
-    torque1[j] = torque2[j] = 0;
-#endif
-  }
-
   if (checkIfInteraction(ia_params)) {
-    m_shape->calculate_dist(folded_pos, &dist, dist_vec.data());
+    m_shape->calculate_dist(folded_pos, dist, dist_vec);
 
     if (dist > 0) {
       outer_normal_vec = -dist_vec / dist;
       auto const dist2 = dist * dist;
-      calc_non_bonded_pair_force(&p, &part_rep, ia_params, dist_vec.data(),
-                                 dist, dist2, force.data(), torque1.data(),
-                                 torque2.data());
+      calc_non_bonded_pair_force(&p, &part_rep, ia_params, dist_vec, dist,
+                                 dist2, force1, &torque1, &torque2);
 #ifdef DPD
       if (thermo_switch & THERMO_DPD) {
-        force += dpd_pair_force(&p, &part_rep, ia_params, dist_vec.data(), dist,
-                                dist2);
+        force1 +=
+            dpd_pair_force(&p, &part_rep, ia_params, dist_vec, dist, dist2);
         // Additional use of DPD here requires counter increase
         dpd_rng_counter_increment();
       }
@@ -91,13 +84,12 @@ ParticleForce ShapeBasedConstraint::force(const Particle &p,
     } else if (m_penetrable && (dist <= 0)) {
       if ((!m_only_positive) && (dist < 0)) {
         auto const dist2 = dist * dist;
-        calc_non_bonded_pair_force(&p, &part_rep, ia_params, dist_vec.data(),
-                                   -1.0 * dist, dist2, force.data(),
-                                   torque1.data(), torque2.data());
+        calc_non_bonded_pair_force(&p, &part_rep, ia_params, dist_vec, -dist,
+                                   dist2, force1, &torque1, &torque2);
 #ifdef DPD
         if (thermo_switch & THERMO_DPD) {
-          force += dpd_pair_force(&p, &part_rep, ia_params, dist_vec.data(),
-                                  dist, dist2);
+          force1 +=
+              dpd_pair_force(&p, &part_rep, ia_params, dist_vec, dist, dist2);
           // Additional use of DPD here requires counter increase
           dpd_rng_counter_increment();
         }
@@ -110,14 +102,14 @@ ParticleForce ShapeBasedConstraint::force(const Particle &p,
     }
   }
 
-  m_local_force -= force;
-  m_outer_normal_force -= outer_normal_vec * force;
+  m_local_force -= force1;
+  m_outer_normal_force -= outer_normal_vec * force1;
 
 #ifdef ROTATION
   part_rep.f.torque += torque2;
-  return {force, torque1};
+  return {force1, torque1};
 #else
-  return force;
+  return force1;
 #endif
 }
 
@@ -132,8 +124,8 @@ void ShapeBasedConstraint::add_energy(const Particle &p,
 
   dist = 0.;
   if (checkIfInteraction(ia_params)) {
-    double vec[3];
-    m_shape->calculate_dist(folded_pos, &dist, vec);
+    Utils::Vector3d vec;
+    m_shape->calculate_dist(folded_pos, dist, vec);
     if (dist > 0) {
       nonbonded_en = calc_non_bonded_pair_energy(&p, &part_rep, ia_params, vec,
                                                  dist, dist * dist);

--- a/src/core/constraints/ShapeBasedConstraint.hpp
+++ b/src/core/constraints/ShapeBasedConstraint.hpp
@@ -49,7 +49,8 @@ public:
   double min_dist(const ParticleRange &particles);
 
   /* Calculate distance from the constraint */
-  void calc_dist(const Utils::Vector3d &pos, double *dist, double *vec) const {
+  void calc_dist(const Utils::Vector3d &pos, double &dist,
+                 Utils::Vector3d &vec) const {
     m_shape->calculate_dist(pos, dist, vec);
   }
 

--- a/src/core/cuda_utils.hpp
+++ b/src/core/cuda_utils.hpp
@@ -23,15 +23,14 @@
 #error Do not include CUDA headers in normal C++-code!!!
 #endif
 
-/**cuda streams for parallel computing on cpu and gpu */
+/** cuda streams for parallel computing on cpu and gpu */
 extern cudaStream_t stream[1];
 
-/**erroroutput for memory allocation and memory copy
- * @param err cuda error code
- * @param *file .cu file were the error took place
- * @param line line of the file were the error took place
+/** Error output for memory allocation and memory copy
+ *  @param err   cuda error code
+ *  @param file  .cu file were the error took place
+ *  @param line  line of the file were the error took place
  */
-
 void _cuda_safe_mem(cudaError_t err, const char *file, unsigned int line);
 
 void _cuda_check_errors(const dim3 &block, const dim3 &grid,

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -159,8 +159,8 @@ static double weight(int type, double r_cut, double r) {
   return 1. - r / r_cut;
 }
 
-Vector3d dpd_pair_force(DPDParameters const &params, const Vector3d &v,
-                        double dist, const Vector3d &noise) {
+Vector3d dpd_pair_force(DPDParameters const &params, Vector3d const &v,
+                        double dist, Vector3d const &noise) {
   if (dist < params.cutoff) {
     auto const omega = weight(params.wf, params.cutoff, dist);
     auto const omega2 = Utils::sqr(omega);
@@ -174,9 +174,11 @@ Vector3d dpd_pair_force(DPDParameters const &params, const Vector3d &v,
   return {};
 }
 
-Vector3d dpd_pair_force(Particle const *p1, Particle const *p2,
-                        const IA_parameters *ia_params,
-                        Utils::Vector3d const &d, double dist, double dist2) {
+Utils::Vector3d dpd_pair_force(Particle const *const p1,
+                               Particle const *const p2,
+                               IA_parameters const *const ia_params,
+                               Utils::Vector3d const &d, double dist,
+                               double dist2) {
   if (ia_params->dpd_radial.cutoff <= 0.0 &&
       ia_params->dpd_trans.cutoff <= 0.0) {
     return {};

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -193,12 +193,12 @@ Utils::Vector3d dpd_pair_force(Particle const *const p1,
   auto const f_r = dpd_pair_force(ia_params->dpd_radial, v21, dist, noise_vec);
   auto const f_t = dpd_pair_force(ia_params->dpd_trans, v21, dist, noise_vec);
 
-  auto const d21 = Vector3d{d[0], d[1], d[2]};
   /* Projection operator to radial direction */
-  auto const P = tensor_product(d21 / dist2, d21);
+  auto const P = tensor_product(d / dist2, d);
   /* This is equivalent to P * f_r + (1 - P) * f_t, but with
    * doing only one matrix-vector multiplication */
-  return P * (f_r - f_t) + f_t;
+  auto const force = P * (f_r - f_t) + f_t;
+  return force;
 }
 
 static auto dpd_viscous_stress_local() {

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -175,8 +175,8 @@ Vector3d dpd_pair_force(DPDParameters const &params, const Vector3d &v,
 }
 
 Vector3d dpd_pair_force(Particle const *p1, Particle const *p2,
-                        const IA_parameters *ia_params, double const *d,
-                        double dist, double dist2) {
+                        const IA_parameters *ia_params,
+                        Utils::Vector3d const &d, double dist, double dist2) {
   if (ia_params->dpd_radial.cutoff <= 0.0 &&
       ia_params->dpd_trans.cutoff <= 0.0) {
     return {};

--- a/src/core/dpd.hpp
+++ b/src/core/dpd.hpp
@@ -52,8 +52,9 @@ void dpd_init();
 void dpd_update_params(double pref2_scale);
 
 Utils::Vector3d dpd_pair_force(Particle const *p1, Particle const *p2,
-                               const IA_parameters *ia_params, double const *d,
-                               double dist, double dist2);
+                               const IA_parameters *ia_params,
+                               Utils::Vector3d const &d, double dist,
+                               double dist2);
 Utils::Vector9d dpd_stress();
 
 /** philox interface */

--- a/src/core/dpd.hpp
+++ b/src/core/dpd.hpp
@@ -52,7 +52,7 @@ void dpd_init();
 void dpd_update_params(double pref2_scale);
 
 Utils::Vector3d dpd_pair_force(Particle const *p1, Particle const *p2,
-                               const IA_parameters *ia_params,
+                               IA_parameters const *ia_params,
                                Utils::Vector3d const &d, double dist,
                                double dist2);
 Utils::Vector9d dpd_stress();

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -16,17 +16,16 @@
 /*@{*/
 
 enum CoulombMethod {
-  COULOMB_NONE,      //< Coulomb interaction switched off (NONE)
-  COULOMB_DH,        //< Coulomb method is Debye-Hueckel
-  COULOMB_P3M,       //< Coulomb method is P3M
-  COULOMB_P3M_GPU,   //< Coulomb method is P3M with GPU based long range part
-  COULOMB_ELC_P3M,   //< Coulomb method is P3M plus ELC
-  COULOMB_MMM1D,     //< Coulomb method is one-dimensional MMM
-  COULOMB_MMM2D,     //< Coulomb method is two-dimensional MMM
-  COULOMB_RF,        //< Coulomb method is Reaction-Field
-                     // calculation
-  COULOMB_MMM1D_GPU, //< Coulomb method is one-dimensional MMM running on GPU
-  COULOMB_SCAFACOS,  //< Coulomb method is scafacos
+  COULOMB_NONE,      ///< %Coulomb interaction switched off (NONE)
+  COULOMB_DH,        ///< %Coulomb method is Debye-Hueckel
+  COULOMB_P3M,       ///< %Coulomb method is P3M
+  COULOMB_P3M_GPU,   ///< %Coulomb method is P3M with GPU-based long-range part
+  COULOMB_ELC_P3M,   ///< %Coulomb method is P3M plus ELC
+  COULOMB_MMM1D,     ///< %Coulomb method is one-dimensional MMM
+  COULOMB_MMM2D,     ///< %Coulomb method is two-dimensional MMM
+  COULOMB_RF,        ///< %Coulomb method is Reaction-Field
+  COULOMB_MMM1D_GPU, ///< %Coulomb method is one-dimensional MMM running on GPU
+  COULOMB_SCAFACOS,  ///< %Coulomb method is scafacos
 };
 /*@}*/
 

--- a/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
@@ -16,8 +16,8 @@
 #include "electrostatics_magnetostatics/scafacos.hpp"
 
 namespace Coulomb {
-inline Utils::Vector3d central_force(double const q1q2, const double *d,
-                                     double dist) {
+inline Utils::Vector3d central_force(double const q1q2,
+                                     Utils::Vector3d const &d, double dist) {
   Utils::Vector3d f{};
 
   switch (coulomb.method) {
@@ -25,24 +25,24 @@ inline Utils::Vector3d central_force(double const q1q2, const double *d,
   case COULOMB_P3M_GPU:
   case COULOMB_P3M:
   case COULOMB_ELC_P3M:
-    p3m_add_pair_force(q1q2, d, dist, f.data());
+    p3m_add_pair_force(q1q2, d, dist, f);
     break;
 #endif
   case COULOMB_MMM1D:
-    add_mmm1d_coulomb_pair_force(q1q2, d, dist, f.data());
+    add_mmm1d_coulomb_pair_force(q1q2, d, dist, f);
     break;
   case COULOMB_MMM2D:
-    add_mmm2d_coulomb_pair_force(q1q2, d, dist, f.data());
+    add_mmm2d_coulomb_pair_force(q1q2, d, dist, f);
     break;
   case COULOMB_DH:
-    add_dh_coulomb_pair_force(q1q2, d, dist, f.data());
+    add_dh_coulomb_pair_force(q1q2, d, dist, f);
     break;
   case COULOMB_RF:
-    add_rf_coulomb_pair_force(q1q2, d, dist, f.data());
+    add_rf_coulomb_pair_force(q1q2, d, dist, f);
     break;
 #ifdef SCAFACOS
   case COULOMB_SCAFACOS:
-    Scafacos::add_pair_force(q1q2, d, dist, f.data());
+    Scafacos::add_pair_force(q1q2, d.data(), dist, f.data());
     break;
 #endif
   default:
@@ -52,8 +52,9 @@ inline Utils::Vector3d central_force(double const q1q2, const double *d,
   return coulomb.prefactor * f;
 }
 
-inline void calc_pair_force(Particle *p1, Particle *p2, const double *d,
-                            double dist, Utils::Vector3d &force) {
+inline void calc_pair_force(Particle *p1, Particle *p2,
+                            Utils::Vector3d const &d, double dist,
+                            Utils::Vector3d &force) {
   auto const q1q2 = p1->p.q * p2->p.q;
 
   if (q1q2 == 0)
@@ -69,7 +70,7 @@ inline void calc_pair_force(Particle *p1, Particle *p2, const double *d,
     Utils::Vector3d f1{};
     Utils::Vector3d f2{};
 
-    ELC_P3M_dielectric_layers_force_contribution(p1, p2, f1.data(), f2.data());
+    ELC_P3M_dielectric_layers_force_contribution(p1, p2, f1, f2);
 
     p1->f.f += coulomb.prefactor * f1;
     p2->f.f += coulomb.prefactor * f2;
@@ -103,7 +104,7 @@ inline Utils::Vector<Utils::Vector3d, 3> pair_pressure(const Particle *p1,
   case COULOMB_MMM1D:
   case COULOMB_DH:
   case COULOMB_RF: {
-    auto const force = central_force(p1->p.q * p2->p.q, d.data(), dist);
+    auto const force = central_force(p1->p.q * p2->p.q, d, dist);
 
     return Utils::tensor_product(force, d);
   }
@@ -118,8 +119,8 @@ inline Utils::Vector<Utils::Vector3d, 3> pair_pressure(const Particle *p1,
 
 // energy_inline
 inline double pair_energy(const Particle *p1, const Particle *p2,
-                          double const q1q2, const double *d, double dist,
-                          double dist2) {
+                          double const q1q2, Utils::Vector3d const &d,
+                          double dist, double dist2) {
   /* real space Coulomb */
   auto E = [&]() {
     switch (coulomb.method) {

--- a/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
@@ -90,9 +90,9 @@ inline void calc_pair_force(Particle *p1, Particle *p2,
  * @param dist |d|
  * @return Contribution to the pressure tensor.
  */
-inline Utils::Vector<Utils::Vector3d, 3> pair_pressure(const Particle *p1,
-                                                       const Particle *p2,
-                                                       const Utils::Vector3d &d,
+inline Utils::Vector<Utils::Vector3d, 3> pair_pressure(Particle const *const p1,
+                                                       Particle const *const p2,
+                                                       Utils::Vector3d const &d,
                                                        double dist) {
   switch (coulomb.method) {
   case COULOMB_NONE:
@@ -118,7 +118,7 @@ inline Utils::Vector<Utils::Vector3d, 3> pair_pressure(const Particle *p1,
 }
 
 // energy_inline
-inline double pair_energy(const Particle *p1, const Particle *p2,
+inline double pair_energy(Particle const *const p1, Particle const *const p2,
                           double const q1q2, Utils::Vector3d const &d,
                           double dist, double dist2) {
   /* real space Coulomb */

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
@@ -54,8 +54,10 @@ int dh_set_params(double kappa, double r_cut);
     @param dist      Distance between p1 and p2.
     @param force     returns the force on particle 1.
 */
-inline void add_dh_coulomb_pair_force(double const q1q2, double const d[3],
-                                      double const dist, double force[3]) {
+inline void add_dh_coulomb_pair_force(double const q1q2,
+                                      Utils::Vector3d const &d,
+                                      double const dist,
+                                      Utils::Vector3d &force) {
   if (dist < dh_params.r_cut) {
     double fac;
     if (dh_params.kappa > 0.0) {
@@ -67,8 +69,7 @@ inline void add_dh_coulomb_pair_force(double const q1q2, double const d[3],
       /* pure Coulomb case: */
       fac = q1q2 / (dist * dist * dist);
     }
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 

--- a/src/core/electrostatics_magnetostatics/dipole_inline.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole_inline.hpp
@@ -32,7 +32,7 @@ inline void calc_pair_force(Particle *p1, Particle *p2,
 }
 
 // energy_inline
-inline void add_pair_energy(const Particle *p1, const Particle *p2,
+inline void add_pair_energy(Particle const *const p1, Particle const *const p2,
                             Utils::Vector3d const &d, double dist, double dist2,
                             Observable_stat &energy) {
   double ret = 0;

--- a/src/core/electrostatics_magnetostatics/dipole_inline.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole_inline.hpp
@@ -8,19 +8,20 @@
 
 namespace Dipole {
 // forces_inline
-inline void calc_pair_force(Particle *p1, Particle *p2, double *d, double dist,
-                            double dist2, Utils::Vector3d &force) {
+inline void calc_pair_force(Particle *p1, Particle *p2,
+                            Utils::Vector3d const &d, double dist, double dist2,
+                            Utils::Vector3d &force) {
   switch (dipole.method) {
 #ifdef DP3M
   case DIPOLAR_MDLC_P3M:
     // fall trough
   case DIPOLAR_P3M: {
 #ifdef NPT
-    double eng = dp3m_add_pair_force(p1, p2, d, dist2, dist, force.data());
+    double eng = dp3m_add_pair_force(p1, p2, d, dist2, dist, force);
     if (integ_switch == INTEG_METHOD_NPT_ISO)
       nptiso.p_vir[0] += eng;
 #else
-    dp3m_add_pair_force(p1, p2, d, dist2, dist, force.data());
+    dp3m_add_pair_force(p1, p2, d, dist2, dist, force);
 #endif
     break;
   }
@@ -32,7 +33,7 @@ inline void calc_pair_force(Particle *p1, Particle *p2, double *d, double dist,
 
 // energy_inline
 inline void add_pair_energy(const Particle *p1, const Particle *p2,
-                            const double *d, double dist, double dist2,
+                            Utils::Vector3d const &d, double dist, double dist2,
                             Observable_stat &energy) {
   double ret = 0;
   if (dipole.method != DIPOLAR_NONE) {

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -1329,7 +1329,7 @@ void ELC_P3M_self_forces() {
       pos[2] = -p.r.p[2];
       auto const d = get_mi_vector(p.r.p, pos, box_geo);
 
-      p3m_add_pair_force(q, d.data(), d.norm(), p.f.f.data());
+      p3m_add_pair_force(q, d, d.norm(), p.f.f);
     }
     if (p.r.p[2] > (elc_params.h - elc_params.space_layer)) {
       q = elc_params.delta_mid_top * p.p.q * p.p.q;
@@ -1338,7 +1338,7 @@ void ELC_P3M_self_forces() {
       pos[2] = 2 * elc_params.h - p.r.p[2];
       auto const d = get_mi_vector(p.r.p, pos, box_geo);
 
-      p3m_add_pair_force(q, d.data(), d.norm(), p.f.f.data());
+      p3m_add_pair_force(q, d, d.norm(), p.f.f);
     }
   }
 }
@@ -1413,8 +1413,8 @@ void ELC_p3m_charge_assign_image() {
 
 void ELC_P3M_dielectric_layers_force_contribution(const Particle *p1,
                                                   const Particle *p2,
-                                                  double *force1,
-                                                  double *force2) {
+                                                  Utils::Vector3d &force1,
+                                                  Utils::Vector3d &force2) {
   Utils::Vector3d pos;
   double q;
 
@@ -1425,7 +1425,7 @@ void ELC_P3M_dielectric_layers_force_contribution(const Particle *p1,
     pos[2] = -p1->r.p[2];
     auto const d = get_mi_vector(p2->r.p, pos, box_geo);
 
-    p3m_add_pair_force(q, d.data(), d.norm(), force2);
+    p3m_add_pair_force(q, d, d.norm(), force2);
   }
 
   if (p1->r.p[2] > (elc_params.h - elc_params.space_layer)) {
@@ -1435,7 +1435,7 @@ void ELC_P3M_dielectric_layers_force_contribution(const Particle *p1,
     pos[2] = 2 * elc_params.h - p1->r.p[2];
     auto const d = get_mi_vector(p2->r.p, pos, box_geo);
 
-    p3m_add_pair_force(q, d.data(), d.norm(), force2);
+    p3m_add_pair_force(q, d, d.norm(), force2);
   }
 
   if (p2->r.p[2] < elc_params.space_layer) {
@@ -1445,7 +1445,7 @@ void ELC_P3M_dielectric_layers_force_contribution(const Particle *p1,
     pos[2] = -p2->r.p[2];
     auto const d = get_mi_vector(p1->r.p, pos, box_geo);
 
-    p3m_add_pair_force(q, d.data(), d.norm(), force1);
+    p3m_add_pair_force(q, d, d.norm(), force1);
   }
 
   if (p2->r.p[2] > (elc_params.h - elc_params.space_layer)) {
@@ -1455,7 +1455,7 @@ void ELC_P3M_dielectric_layers_force_contribution(const Particle *p1,
     pos[2] = 2 * elc_params.h - p2->r.p[2];
     auto const d = get_mi_vector(p1->r.p, pos, box_geo);
 
-    p3m_add_pair_force(q, d.data(), d.norm(), force1);
+    p3m_add_pair_force(q, d, d.norm(), force1);
   }
 }
 

--- a/src/core/electrostatics_magnetostatics/elc.hpp
+++ b/src/core/electrostatics_magnetostatics/elc.hpp
@@ -129,8 +129,8 @@ double ELC_P3M_dielectric_layers_energy_contribution(const Particle *p1,
 /// pairwise contributions from the lowest and top layers to the force
 void ELC_P3M_dielectric_layers_force_contribution(const Particle *p1,
                                                   const Particle *p2,
-                                                  double *force1,
-                                                  double *force2);
+                                                  Utils::Vector3d &force1,
+                                                  Utils::Vector3d &force2);
 /// self energies of top and bottom layers with their virtual images
 double ELC_P3M_dielectric_layers_energy_self();
 /// forces of particles in border layers with themselves

--- a/src/core/electrostatics_magnetostatics/fft.cpp
+++ b/src/core/electrostatics_magnetostatics/fft.cpp
@@ -53,6 +53,7 @@ using Utils::get_linear_index;
 #define REQ_FFT_BACK 302
 /*@}*/
 
+namespace {
 /** This ugly function does the bookkeeping: which nodes have to
  *  communicate to each other, when you change the node grid.
  *  Changing the domain decomposition requires communication. This
@@ -68,17 +69,16 @@ using Utils::get_linear_index;
  *  other. see e.g. \ref calc_2d_grid in \ref grid.cpp for how to do
  *  this.).
  *
- * \param[in]  grid1       The node grid you start with.
- * \param[in]  grid2       The node grid you want to have.
- * \param[in]  node_list1  Linear node index list for grid1.
- * \param[out] node_list2  Linear node index list for grid2.
- * \param[out] group       Communication group (node identity list) for the
- *                         calling node.
- * \param[out] pos         Positions of the nodes in grid2
- * \param[out] my_pos      Position of comm.rank() in grid2.
- * \return Size of the communication group.
+ *  \param[in]  grid1       The node grid you start with.
+ *  \param[in]  grid2       The node grid you want to have.
+ *  \param[in]  node_list1  Linear node index list for grid1.
+ *  \param[out] node_list2  Linear node index list for grid2.
+ *  \param[out] group       Communication group (node identity list) for the
+ *                          calling node.
+ *  \param[out] pos         Positions of the nodes in grid2
+ *  \param[out] my_pos      Position of comm.rank() in grid2.
+ *  \return Size of the communication group.
  */
-namespace {
 boost::optional<std::vector<int>>
 find_comm_groups(Utils::Vector3i const &grid1, Utils::Vector3i const &grid2,
                  int const *node_list1, int *node_list2, int *pos, int *my_pos,

--- a/src/core/electrostatics_magnetostatics/fft.cpp
+++ b/src/core/electrostatics_magnetostatics/fft.cpp
@@ -73,8 +73,6 @@ namespace {
  *  \param[in]  grid2       The node grid you want to have.
  *  \param[in]  node_list1  Linear node index list for grid1.
  *  \param[out] node_list2  Linear node index list for grid2.
- *  \param[out] group       Communication group (node identity list) for the
- *                          calling node.
  *  \param[out] pos         Positions of the nodes in grid2
  *  \param[out] my_pos      Position of comm.rank() in grid2.
  *  \return Size of the communication group.
@@ -82,7 +80,7 @@ namespace {
 boost::optional<std::vector<int>>
 find_comm_groups(Utils::Vector3i const &grid1, Utils::Vector3i const &grid2,
                  int const *node_list1, int *node_list2, int *pos, int *my_pos,
-                 const boost::mpi::communicator &comm) {
+                 boost::mpi::communicator const &comm) {
   int i;
   /* communication group cell size on grid1 and grid2 */
   int s1[3], s2[3];

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -68,8 +68,8 @@ void force_calc_iccp3m();
 /** Variant of add_non_bonded_pair_force where only Coulomb
  *  contributions are calculated   */
 inline void add_non_bonded_pair_force_iccp3m(Particle *p1, Particle *p2,
-                                             double d[3], double dist,
-                                             double dist2) {
+                                             Utils::Vector3d const &d,
+                                             double dist, double dist2) {
   Utils::Vector3d force{};
   Coulomb::calc_pair_force(p1, p2, d, dist, force);
 
@@ -193,8 +193,8 @@ void force_calc_iccp3m() {
 
   short_range_loop(Utils::NoOp{}, [](Particle &p1, Particle &p2, Distance &d) {
     /* calc non bonded interactions */
-    add_non_bonded_pair_force_iccp3m(&(p1), &(p2), d.vec21.data(),
-                                     sqrt(d.dist2), d.dist2);
+    add_non_bonded_pair_force_iccp3m(&(p1), &(p2), d.vec21, sqrt(d.dist2),
+                                     d.dist2);
   });
 
   Coulomb::calc_long_range_force();

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -19,15 +19,14 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** \file
- * code for calculating the MDLC (magnetic dipolar layer
- *correction).
+ *  code for calculating the MDLC (magnetic dipolar layer correction).
  *  Purpose:   get the corrections for dipolar 3D algorithms
  *             when applied to a slab geometry and dipolar
- *	      particles. DLC & co
+ *             particles. DLC & co
  *  Article:   A. Brodka, Chemical Physics Letters 400, 62-67 (2004).
  *
- *	      We also include a tuning function that returns the
- *	      cut-off necessary to attend a certain accuracy.
+ *             We also include a tuning function that returns the
+ *             cut-off necessary to attend a certain accuracy.
  *
  *  Restrictions: the slab must be such that the z is the short
  *                direction. Otherwise we get trash.
@@ -60,8 +59,6 @@ void calc_mu_max() {
   MPI_Allreduce(MPI_IN_PLACE, &mu_max, 1, MPI_DOUBLE, MPI_MAX, comm_cart);
 }
 
-/* ******************************************************************* */
-
 inline double g1_DLC_dip(double g, double x) {
   double a, c, cc2, x3;
   c = g / x;
@@ -70,7 +67,6 @@ inline double g1_DLC_dip(double g, double x) {
   a = g * g * g / x + 1.5 * cc2 + 1.5 * g / x3 + 0.75 / (x3 * x);
   return a;
 }
-/* ******************************************************************* */
 
 inline double g2_DLC_dip(double g, double x) {
   double a, x2;
@@ -78,7 +74,6 @@ inline double g2_DLC_dip(double g, double x) {
   a = g * g / x + 2.0 * g / x2 + 2.0 / (x2 * x);
   return a;
 }
-/* ******************************************************************* */
 
 /* Compute Mx, My, Mz and Mtotal */
 double slab_dip_count_mu(double *mt, double *mx, double *my) {
@@ -105,14 +100,12 @@ double slab_dip_count_mu(double *mt, double *mx, double *my) {
 
   return Mz;
 }
-/* ******************************************************************* */
 
-/* ****************************************************************************************************
+/**
    Compute the dipolar DLC corrections for forces and torques.
    Algorithm implemented accordingly to the paper of A. Brodka, Chem. Phys.
    Lett. 400, 62-67, (2004).
-   ****************************************************************************************************
-   */
+ */
 double get_DLC_dipolar(int kcut, std::vector<Utils::Vector3d> &fs,
                        std::vector<Utils::Vector3d> &ts) {
 
@@ -267,15 +260,12 @@ double get_DLC_dipolar(int kcut, std::vector<Utils::Vector3d> &fs,
 
   return energy;
 }
-/* ******************************************************************* */
 
-/* ****************************************************************************************************
+/**
    Compute the dipolar DLC corrections
    Algorithm implemented accordingly to the paper of A. Brodka, Chem. Phys.
    Lett. 400, 62-67, (2004).
-   ****************************************************************************************************
-   */
-
+ */
 double get_DLC_energy_dipolar(int kcut) {
 
   int ix, iy, ip;
@@ -352,13 +342,10 @@ double get_DLC_energy_dipolar(int kcut) {
   energy *= (-piarea);
   return (this_node == 0) ? energy : 0.0;
 }
-/* ***************************************************************** */
 
-/* **************************************************************************
-********** Compute and add the terms needed to correct the 3D dipolar*****
-********** methods when we have an slab geometry *************************
-************************************************************************** */
-
+/** Compute and add the terms needed to correct the 3D dipolar
+ *  methods when we have an slab geometry
+ */
 void add_mdlc_force_corrections() {
   int dip_DLC_kcut = dlc_params.far_cut;
   double mz = 0.0, mx = 0.0, my = 0.0, volume, mtot = 0.0;
@@ -390,7 +377,7 @@ void add_mdlc_force_corrections() {
   mz = slab_dip_count_mu(&mtot, &mx, &my);
 
   // --- Transfer the computed corrections to the Forces, Energy and torques
-  //	of the particles
+  //     of the particles
 
   int ip = 0;
   for (auto &p : local_cells.particles()) {
@@ -418,13 +405,10 @@ void add_mdlc_force_corrections() {
     ip++;
   }
 }
-/* ***************************************************************** */
 
-/* **************************************************************************
-********** Compute and add the terms needed to correct the energy of *****
-********** 3D dipolar methods when we have an slab geometry          *****
-************************************************************************** */
-
+/** Compute and add the terms needed to correct the energy of
+ *  3D dipolar methods when we have an slab geometry
+ */
 double add_mdlc_energy_corrections() {
   double dip_DLC_energy = 0.0;
   double mz = 0.0, mx = 0.0, my = 0.0, volume, mtot = 0.0;
@@ -476,9 +460,8 @@ double add_mdlc_energy_corrections() {
   }
   return 0.0;
 }
-/* ***************************************************************** */
 
-/* -------------------------------------------------------------------------------
+/**
    Subroutine to compute the cut-off (NCUT) necessary in the DLC dipolar part
    to get a certain accuracy (acc). We assume particles to have all them a
    same
@@ -493,10 +476,7 @@ double add_mdlc_energy_corrections() {
    direction
    (2) You must also tune the other 3D method to the same accuracy, otherwise
    it has no sense to have a good accurate result for DLC-dipolar.
-
-   ----------------------------------------------------------------------------------
-   */
-
+ */
 int mdlc_tune(double error) {
   double de, n, gc, lz, lx, a, fa1, fa2, fa0, h;
   int kc, limitkc = 200, flag;
@@ -560,9 +540,6 @@ int mdlc_tune(double error) {
   return ES_OK;
 }
 
-//======================================================================================================================
-//======================================================================================================================
-
 int mdlc_sanity_checks() {
   if (!box_geo.periodic(0) || !box_geo.periodic(1) || !box_geo.periodic(2)) {
     runtimeErrorMsg() << "mdlc requires periodicity 1 1 1";
@@ -576,7 +553,6 @@ int mdlc_sanity_checks() {
 
   return 0;
 }
-/* ***************************************************************** */
 
 int mdlc_set_params(double maxPWerror, double gap_size, double far_cut) {
   MDLC_TRACE(fprintf(stderr, "%d: mdlc_set_params().\n", this_node));
@@ -603,6 +579,5 @@ int mdlc_set_params(double maxPWerror, double gap_size, double far_cut) {
 
   return ES_OK;
 }
-/* ***************************************************************** */
 
 #endif

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -80,37 +80,24 @@ inline double g2_DLC_dip(double g, double x) {
 }
 /* ******************************************************************* */
 
-/* Subroutine designed to  compute Mx, My, Mz and Mtotal  */
-
+/* Compute Mx, My, Mz and Mtotal */
 double slab_dip_count_mu(double *mt, double *mx, double *my) {
-  double node_sums[3], tot_sums[3], Mz, M, My, Mx;
-
-  node_sums[0] = 0.0;
-  tot_sums[0] = 0.0;
-  node_sums[1] = 0.0;
-  tot_sums[1] = 0.0;
-  node_sums[2] = 0.0;
-  tot_sums[2] = 0.0;
+  Utils::Vector3d node_sums{};
+  Utils::Vector3d tot_sums{};
 
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm != 0.0) {
-      auto const dip = p.calc_dip();
-      node_sums[0] += dip[0];
-      node_sums[1] += dip[1];
-      node_sums[2] += dip[2];
+      node_sums += p.calc_dip();
     }
   }
 
-  MPI_Allreduce(node_sums, tot_sums, 3, MPI_DOUBLE, MPI_SUM, comm_cart);
+  MPI_Allreduce(node_sums.data(), tot_sums.data(), 3, MPI_DOUBLE, MPI_SUM,
+                comm_cart);
 
-  M = sqrt(tot_sums[0] * tot_sums[0] + tot_sums[1] * tot_sums[1] +
-           tot_sums[2] * tot_sums[2]);
-  Mz = tot_sums[2];
-  Mx = tot_sums[0];
-  My = tot_sums[1];
-
-  // fprintf(stderr,"Mz=%20.15le \n",Mz);
-  // fprintf(stderr,"M=%20.15le \n",M);
+  auto const M = tot_sums.norm();
+  auto const Mz = tot_sums[2];
+  auto const Mx = tot_sums[0];
+  auto const My = tot_sums[1];
 
   *mt = M;
   *mx = Mx;
@@ -126,64 +113,53 @@ double slab_dip_count_mu(double *mt, double *mx, double *my) {
    Lett. 400, 62-67, (2004).
    ****************************************************************************************************
    */
+double get_DLC_dipolar(int kcut, std::vector<Utils::Vector3d> &fs,
+                       std::vector<Utils::Vector3d> &ts) {
 
-double get_DLC_dipolar(int kcut, std::vector<double> &fx,
-                       std::vector<double> &fy, std::vector<double> &fz,
-                       std::vector<double> &tx, std::vector<double> &ty,
-                       std::vector<double> &tz) {
+  int ip;
 
-  int ix, iy, ip;
-  double gx, gy, gr;
-
-  double S[4] = {0.0, 0.0, 0.0, 0.0}; // S of Brodka method, or is S[4] =
-                                      // {Re(S+), Im(S+), Re(S-), Im(S-)}
   std::vector<double> ReSjp(n_local_particles), ReSjm(n_local_particles);
   std::vector<double> ImSjp(n_local_particles), ImSjm(n_local_particles);
   std::vector<double> ReGrad_Mup(n_local_particles),
       ImGrad_Mup(n_local_particles);
   std::vector<double> ReGrad_Mum(n_local_particles),
       ImGrad_Mum(n_local_particles);
-  double a, b, c, d, er, ez, f, fa1;
   double s1, s2, s3, s4;
   double s1z, s2z, s3z, s4z;
   double ss;
-  double energy, piarea, facux, facuy;
-  int j;
 
-  facux = 2.0 * M_PI / box_geo.length()[0];
-  facuy = 2.0 * M_PI / box_geo.length()[1];
+  auto const facux = 2.0 * M_PI / box_geo.length()[0];
+  auto const facuy = 2.0 * M_PI / box_geo.length()[1];
+  double energy = 0.0;
 
-  energy = 0.0;
-
-  for (ix = -kcut; ix <= +kcut; ix++) {
-    for (iy = -kcut; iy <= +kcut; iy++) {
+  for (int ix = -kcut; ix <= +kcut; ix++) {
+    for (int iy = -kcut; iy <= +kcut; iy++) {
       if (!(ix == 0 && iy == 0)) {
-        gx = (double)ix * facux;
-        gy = (double)iy * facuy;
+        auto const gx = (double)ix * facux;
+        auto const gy = (double)iy * facuy;
 
-        gr = sqrt(gx * gx + gy * gy);
+        auto const gr = sqrt(gx * gx + gy * gy);
 
-        fa1 =
-            1. / (gr * (exp(gr * box_geo.length()[2]) -
-                        1.0)); // We assume short slab direction is z direction
+        // We assume short slab direction is z direction
+        auto const fa1 = 1. / (gr * (exp(gr * box_geo.length()[2]) - 1.0));
 
         // ... Compute S+,(S+)*,S-,(S-)*, and Spj,Smj for the current g
 
-        S[0] = S[1] = S[2] = S[3] = 0.0;
-
+        double S[4] = {0.0, 0.0, 0.0, 0.0}; // S of Brodka method, or is S[4] =
+                                            // {Re(S+), Im(S+), Re(S-), Im(S-)}
         ip = 0;
 
         for (auto const &p : local_cells.particles()) {
           if (p.p.dipm > 0) {
-            const Utils::Vector3d dip = p.calc_dip();
+            Utils::Vector3d const dip = p.calc_dip();
 
-            a = gx * dip[0] + gy * dip[1];
-            b = gr * dip[2];
-            er = gx * p.r.p[0] + gy * p.r.p[1];
-            ez = gr * p.r.p[2];
-            c = cos(er);
-            d = sin(er);
-            f = exp(ez);
+            auto const a = gx * dip[0] + gy * dip[1];
+            auto const b = gr * dip[2];
+            auto const er = gx * p.r.p[0] + gy * p.r.p[1];
+            auto const ez = gr * p.r.p[2];
+            auto const c = cos(er);
+            auto const d = sin(er);
+            auto const f = exp(ez);
 
             ReSjp[ip] = (b * c - a * d) * f;
             ImSjp[ip] = (c * a + b * d) * f;
@@ -228,10 +204,9 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
             s4z = +(ReSjp[ip] * S[2] + ImSjp[ip] * S[3]);
 
             ss = s1 + s2 + s3 + s4;
-            fx[ip] += fa1 * gx * ss;
-            fy[ip] += fa1 * gy * ss;
-
-            fz[ip] += fa1 * gr * (s1z + s2z + s3z + s4z);
+            fs[ip][0] += fa1 * gx * ss;
+            fs[ip][1] += fa1 * gy * ss;
+            fs[ip][2] += fa1 * gr * (s1z + s2z + s3z + s4z);
 
             // We compute the contributions to the electrical field
             // ............
@@ -247,10 +222,9 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
             s4z = +(ReGrad_Mup[ip] * S[2] + ImGrad_Mup[ip] * S[3]);
 
             ss = s1 + s2 + s3 + s4;
-            tx[ip] += fa1 * gx * ss;
-            ty[ip] += fa1 * gy * ss;
-
-            tz[ip] += fa1 * gr * (s1z + s2z + s3z + s4z);
+            ts[ip][0] += fa1 * gx * ss;
+            ts[ip][1] += fa1 * gy * ss;
+            ts[ip][2] += fa1 * gr * (s1z + s2z + s3z + s4z);
           } // if dipm>0 ....
           ip++;
         } // loop j
@@ -269,13 +243,7 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
   ip = 0;
   for (auto const &p : local_cells.particles()) {
     if (p.p.dipm > 0) {
-      const Utils::Vector3d dip = p.calc_dip();
-      a = dip[1] * tz[ip] - dip[2] * ty[ip];
-      b = dip[2] * tx[ip] - dip[0] * tz[ip];
-      c = dip[0] * ty[ip] - dip[1] * tx[ip];
-      tx[ip] = a;
-      ty[ip] = b;
-      tz[ip] = c;
+      ts[ip] = vector_product(p.calc_dip(), ts[ip]);
     }
     ip++;
   }
@@ -284,15 +252,11 @@ double get_DLC_dipolar(int kcut, std::vector<double> &fx,
 
   // printf("box_l: %le %le %le \n",box_l[0],box_l[1],box_l[2]);
 
-  piarea = M_PI / (box_geo.length()[0] * box_geo.length()[1]);
+  auto const piarea = M_PI / (box_geo.length()[0] * box_geo.length()[1]);
 
-  for (j = 0; j < n_local_particles; j++) {
-    fx[j] *= piarea;
-    fy[j] *= piarea;
-    fz[j] *= piarea;
-    tx[j] *= piarea;
-    ty[j] *= piarea;
-    tz[j] *= piarea;
+  for (int j = 0; j < n_local_particles; j++) {
+    fs[j] *= piarea;
+    ts[j] *= piarea;
   }
 
   energy *= (-piarea);
@@ -396,18 +360,8 @@ double get_DLC_energy_dipolar(int kcut) {
 ************************************************************************** */
 
 void add_mdlc_force_corrections() {
-  int i, ip;
-  int dip_DLC_kcut;
-  std::vector<double> dip_DLC_f_x(n_part), dip_DLC_f_y(n_part),
-      dip_DLC_f_z(n_part);
-  std::vector<double> dip_DLC_t_x(n_part), dip_DLC_t_y(n_part),
-      dip_DLC_t_z(n_part);
+  int dip_DLC_kcut = dlc_params.far_cut;
   double mz = 0.0, mx = 0.0, my = 0.0, volume, mtot = 0.0;
-#if defined(ROTATION) && defined(DP3M)
-  double dx, dy, dz, correps;
-#endif
-
-  dip_DLC_kcut = dlc_params.far_cut;
 
   n_local_particles = local_cells.particles().size();
 
@@ -416,21 +370,13 @@ void add_mdlc_force_corrections() {
   // --- Create arrays that should contain the corrections to
   //     the forces and torques, and set them to zero.
 
-  for (i = 0; i < n_local_particles; i++) {
-    dip_DLC_f_x[i] = 0.0;
-    dip_DLC_f_y[i] = 0.0;
-    dip_DLC_f_z[i] = 0.0;
-
-    dip_DLC_t_x[i] = 0.0;
-    dip_DLC_t_y[i] = 0.0;
-    dip_DLC_t_z[i] = 0.0;
-  }
+  std::vector<Utils::Vector3d> dip_DLC_f(n_part);
+  std::vector<Utils::Vector3d> dip_DLC_t(n_part);
 
   //---- Compute the corrections ----------------------------------
 
   // First the DLC correction
-  get_DLC_dipolar(dip_DLC_kcut, dip_DLC_f_x, dip_DLC_f_y, dip_DLC_f_z,
-                  dip_DLC_t_x, dip_DLC_t_y, dip_DLC_t_z);
+  get_DLC_dipolar(dip_DLC_kcut, dip_DLC_f, dip_DLC_t);
 
   // Now we compute the the correction like Yeh and Klapp to take into account
   // the fact that you are using a
@@ -446,48 +392,27 @@ void add_mdlc_force_corrections() {
   // --- Transfer the computed corrections to the Forces, Energy and torques
   //	of the particles
 
-  ip = 0;
+  int ip = 0;
   for (auto &p : local_cells.particles()) {
     if ((p.p.dipm) != 0.0) {
-      const Utils::Vector3d dip = p.calc_dip();
-
-      p.f.f[0] += dipole.prefactor * dip_DLC_f_x[ip];
-      p.f.f[1] += dipole.prefactor * dip_DLC_f_y[ip];
-      p.f.f[2] += dipole.prefactor *
-                  dip_DLC_f_z[ip]; // SDC correction term is zero for the forces
+      // SDC correction term is zero for the forces
+      p.f.f += dipole.prefactor * dip_DLC_f[ip];
 
 #if defined(ROTATION) && defined(DP3M)
-      double correc = 4. * M_PI / volume;
+      auto const dip = p.calc_dip();
+      auto const correc = 4. * M_PI / volume;
+      Utils::Vector3d d;
       // in the Next lines: the second term (correc*...)is the SDC
       // correction
       // for the torques
       if (dp3m.params.epsilon == P3M_EPSILON_METALLIC) {
-
-        dx = 0.0;
-        dy = 0.0;
-        dz = correc * (-1.0) * mz;
-
-        p.f.torque[0] +=
-            dipole.prefactor * (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
-        p.f.torque[1] +=
-            dipole.prefactor * (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
-        p.f.torque[2] +=
-            dipole.prefactor * (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
-
+        d = {0.0, 0.0, -correc * mz};
       } else {
-
-        correps = correc / (2.0 * dp3m.params.epsilon + 1.0);
-        dx = correps * mx;
-        dy = correps * my;
-        dz = correc * (-1.0 + 1. / (2.0 * dp3m.params.epsilon + 1.0)) * mz;
-
-        p.f.torque[0] +=
-            dipole.prefactor * (dip_DLC_t_x[ip] + dip[1] * dz - dip[2] * dy);
-        p.f.torque[1] +=
-            dipole.prefactor * (dip_DLC_t_y[ip] + dip[2] * dx - dip[0] * dz);
-        p.f.torque[2] +=
-            dipole.prefactor * (dip_DLC_t_z[ip] + dip[0] * dy - dip[1] * dx);
+        auto const correps = correc / (2.0 * dp3m.params.epsilon + 1.0);
+        d = {correps * mx, correps * my,
+             correc * mz * (-1.0 + 1. / (2.0 * dp3m.params.epsilon + 1.0))};
       }
+      p.f.torque += dipole.prefactor * (dip_DLC_t[ip] + vector_product(dip, d));
 #endif
     }
     ip++;

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -180,10 +180,10 @@ void MMM1D_init() {
                            mmm1d_params.far_switch_radius_2);
 }
 
-void add_mmm1d_coulomb_pair_force(double chpref, const double d[3], double r,
-                                  double force[3]) {
+void add_mmm1d_coulomb_pair_force(double chpref, Utils::Vector3d const &d,
+                                  double r, Utils::Vector3d &force) {
   int dim;
-  double F[3];
+  Utils::Vector3d F;
   double rxy2, rxy2_d, z_d;
   double pref;
   double Fx, Fy, Fz;
@@ -245,9 +245,7 @@ void add_mmm1d_coulomb_pair_force(double chpref, const double d[3], double r,
     Fy += pref * d[1];
     Fz += pref * shift_z;
 
-    F[0] = Fx;
-    F[1] = Fy;
-    F[2] = Fz;
+    F = {Fx, Fy, Fz};
   } else {
     /* far range formula */
     double rxy = sqrt(rxy2);
@@ -272,18 +270,15 @@ void add_mmm1d_coulomb_pair_force(double chpref, const double d[3], double r,
     sr *= uz2 * 4 * C_2PI;
     sz *= uz2 * 4 * C_2PI;
 
-    pref = 1. * (sr / rxy + 2 * uz / rxy2);
+    pref = sr / rxy + 2 * uz / rxy2;
 
-    F[0] = pref * d[0];
-    F[1] = pref * d[1];
-    F[2] = 1. * sz;
+    F = {pref * d[0], pref * d[1], sz};
   }
 
-  for (dim = 0; dim < 3; dim++)
-    force[dim] += chpref * F[dim];
+  force += chpref * F;
 }
 
-double mmm1d_coulomb_pair_energy(double const chpref, double const d[3],
+double mmm1d_coulomb_pair_energy(double const chpref, Utils::Vector3d const &d,
                                  double r2, double r) {
   double rxy2, rxy2_d, z_d;
   double E;

--- a/src/core/electrostatics_magnetostatics/mmm1d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.hpp
@@ -64,11 +64,11 @@ int MMM1D_sanity_checks();
 /// initialize the MMM1D constants
 void MMM1D_init();
 
-void add_mmm1d_coulomb_pair_force(double chpref, const double d[3], double r,
-                                  double force[3]);
+void add_mmm1d_coulomb_pair_force(double chpref, Utils::Vector3d const &d,
+                                  double r, Utils::Vector3d &force);
 
-double mmm1d_coulomb_pair_energy(double q1q2, double const d[3], double r2,
-                                 double r);
+double mmm1d_coulomb_pair_energy(double q1q2, Utils::Vector3d const &d,
+                                 double r2, double r);
 
 /** Tuning of the parameters which are not set by the user, e.g. the
  *  switching radius or the bessel_cutoff. Call this only on the master node.

--- a/src/core/electrostatics_magnetostatics/mmm2d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.hpp
@@ -33,6 +33,8 @@
 
 #include "config.hpp"
 
+#include <utils/Vector.hpp>
+
 #ifdef ELECTROSTATICS
 
 /** MMM2D error messages */
@@ -95,12 +97,12 @@ inline void MMM2D_add_far_force() { MMM2D_add_far(1, 0); }
 inline double MMM2D_far_energy() { return MMM2D_add_far(0, 1); }
 
 /** pairwise calculated parts of MMM2D force (near neighbors) */
-void add_mmm2d_coulomb_pair_force(double pref, const double d[3], double dl,
-                                  double force[3]);
+void add_mmm2d_coulomb_pair_force(double pref, Utils::Vector3d const &d,
+                                  double dl, Utils::Vector3d &force);
 
 /** pairwise calculated parts of MMM2D force (near neighbors) */
-double mmm2d_coulomb_pair_energy(double charge_factor, const double dv[3],
-                                 double d);
+double mmm2d_coulomb_pair_energy(double charge_factor,
+                                 Utils::Vector3d const &dv, double d);
 
 /// check that MMM2D can run with the current parameters
 int MMM2D_sanity_checks();

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -285,7 +285,8 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2,
 }
 
 /** Calculate real space contribution of dipolar pair energy. */
-inline double dp3m_pair_energy(const Particle *p1, const Particle *p2,
+inline double dp3m_pair_energy(Particle const *const p1,
+                               Particle const *const p2,
                                Utils::Vector3d const &d, double dist2,
                                double dist) {
   auto const dip1 = p1->calc_dip();

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -225,18 +225,15 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2,
   if ((p1->p.dipm == 0.) || (p2->p.dipm == 0.))
     return 0.;
 
-  double coeff, exp_adist2;
-  auto const dip1 = p1->calc_dip();
-  auto const dip2 = p2->calc_dip();
-  double B_r, C_r, D_r;
-  double alpsq = dp3m.params.alpha * dp3m.params.alpha;
-
   if (dist < dp3m.params.r_cut && dist > 0) {
-    double adist = dp3m.params.alpha * dist;
+    auto const dip1 = p1->calc_dip();
+    auto const dip2 = p2->calc_dip();
+    auto const alpsq = dp3m.params.alpha * dp3m.params.alpha;
+    auto const adist = dp3m.params.alpha * dist;
 #if USE_ERFC_APPROXIMATION
-    double erfc_part_ri = Utils::AS_erfc_part(adist) / dist;
+    auto const erfc_part_ri = Utils::AS_erfc_part(adist) / dist;
 #else
-    double erfc_part_ri = erfc(adist) / dist;
+    auto const erfc_part_ri = erfc(adist) / dist;
 #endif
 
     // Calculate scalar multiplications for vectors mi, mj, rij
@@ -245,10 +242,11 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2,
     auto const mir = dip1 * d;
     auto const mjr = dip2 * d;
 
-    coeff = 2.0 * dp3m.params.alpha * Utils::sqrt_pi_i();
-    double dist2i = 1 / dist2;
-    exp_adist2 = exp(-adist * adist);
+    auto const coeff = 2.0 * dp3m.params.alpha * Utils::sqrt_pi_i();
+    auto const dist2i = 1 / dist2;
+    auto const exp_adist2 = exp(-adist * adist);
 
+    double B_r, C_r, D_r;
     if (dp3m.params.accuracy > 5e-06)
       B_r = (erfc_part_ri + coeff) * exp_adist2 * dist2i;
     else
@@ -273,12 +271,11 @@ inline double dp3m_add_pair_force(Particle *p1, Particle *p2,
 #endif
 #ifdef NPT
 #if USE_ERFC_APPROXIMATION
-    double fac1 =
-        dipole.prefactor * p1->p.dipm * p2->p.dipm * exp(-adist * adist);
+    auto const fac = dipole.prefactor * p1->p.dipm * p2->p.dipm * exp_adist2;
 #else
-    double fac1 = dipole.prefactor * p1->p.dipm * p2->p.dipm;
+    auto const fac = dipole.prefactor * p1->p.dipm * p2->p.dipm;
 #endif
-    return fac1 * (mimj * B_r - mir * mjr * C_r);
+    return fac * (mimj * B_r - mir * mjr * C_r);
 #endif
   }
   return 0.0;
@@ -291,21 +288,18 @@ inline double dp3m_pair_energy(Particle const *const p1,
                                double dist) {
   auto const dip1 = p1->calc_dip();
   auto const dip2 = p2->calc_dip();
-  double /* fac1,*/ adist, erfc_part_ri, coeff, exp_adist2, dist2i;
-  double mimj, mir, mjr;
-  double B_r, C_r;
-  double alpsq = dp3m.params.alpha * dp3m.params.alpha;
 
   if (dist < dp3m.params.r_cut && dist > 0) {
-    adist = dp3m.params.alpha * dist;
+    auto const alpsq = dp3m.params.alpha * dp3m.params.alpha;
+    auto const adist = dp3m.params.alpha * dist;
     /*fac1 = dipole.prefactor;*/
 
 #if USE_ERFC_APPROXIMATION
-    erfc_part_ri = Utils::AS_erfc_part(adist) / dist;
+    auto const erfc_part_ri = Utils::AS_erfc_part(adist) / dist;
     /*  fac1 = dipole.prefactor * p1->p.dipm*p2->p.dipm; IT WAS WRONG */
     /* *exp(-adist*adist); */
 #else
-    erfc_part_ri = erfc(adist) / dist;
+    auto const erfc_part_ri = erfc(adist) / dist;
     /* fac1 = dipole.prefactor * p1->p.dipm*p2->p.dipm;  IT WAS WRONG*/
 #endif
 
@@ -314,16 +308,17 @@ inline double dp3m_pair_energy(Particle const *const p1,
     auto const mir = dip1 * d;
     auto const mjr = dip2 * d;
 
-    coeff = 2.0 * dp3m.params.alpha * Utils::sqrt_pi_i();
-    dist2i = 1 / dist2;
-    exp_adist2 = exp(-adist * adist);
+    auto const coeff = 2.0 * dp3m.params.alpha * Utils::sqrt_pi_i();
+    auto const dist2i = 1 / dist2;
+    auto const exp_adist2 = exp(-adist * adist);
 
+    double B_r;
     if (dp3m.params.accuracy > 5e-06)
       B_r = (erfc_part_ri + coeff) * exp_adist2 * dist2i;
     else
       B_r = (erfc(adist) / dist + coeff * exp_adist2) * dist2i;
 
-    C_r = (3 * B_r + 2 * alpsq * coeff * exp_adist2) * dist2i;
+    auto const C_r = (3 * B_r + 2 * alpsq * coeff * exp_adist2) * dist2i;
 
     /*
       printf("(%4i %4i) pair energy = %f (B_r=%15.12f C_r=%15.12f)\n",

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -216,12 +216,9 @@ void p3m_assign_charge(double q, Utils::Vector3d &real_pos, int cp_cnt);
 /** Shrink wrap the charge grid */
 void p3m_shrink_wrap_charge_grid(int n_charges);
 
-/** Calculate real space contribution of Coulomb pair forces.
- *
- *  If NPT is compiled in, it returns the energy, which is needed for NPT.
- */
-inline void p3m_add_pair_force(double q1q2, double const *d, double dist,
-                               double *force) {
+/** Calculate real space contribution of Coulomb pair forces. */
+inline void p3m_add_pair_force(double q1q2, Utils::Vector3d const &d,
+                               double dist, Utils::Vector3d &force) {
   if (dist < p3m.params.r_cut) {
     if (dist > 0.0) {
       double adist = p3m.params.alpha * dist;
@@ -240,8 +237,7 @@ inline void p3m_add_pair_force(double q1q2, double const *d, double dist,
            2.0 * p3m.params.alpha * Utils::sqrt_pi_i() * exp(-adist * adist)) /
           (dist * dist);
 #endif
-      for (int j = 0; j < 3; j++)
-        force[j] += fac2 * d[j];
+      force += fac2 * d;
     }
   }
 }

--- a/src/core/electrostatics_magnetostatics/reaction_field.hpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.hpp
@@ -57,17 +57,14 @@ extern Reaction_field_params rf_params;
 int rf_set_params(double kappa, double epsilon1, double epsilon2, double r_cut);
 
 inline void add_rf_coulomb_pair_force_no_cutoff(double const q1q2,
-                                                double const d[3],
+                                                Utils::Vector3d const &d,
                                                 double const dist,
-                                                double force[3]) {
-  int j;
+                                                Utils::Vector3d &force) {
   double fac;
   fac = 1.0 / (dist * dist * dist) +
         rf_params.B / (rf_params.r_cut * rf_params.r_cut * rf_params.r_cut);
   fac *= q1q2;
-
-  for (j = 0; j < 3; j++)
-    force[j] += fac * d[j];
+  force += fac * d;
 }
 
 /** Computes the Reaction Field pair force and adds this
@@ -77,8 +74,10 @@ inline void add_rf_coulomb_pair_force_no_cutoff(double const q1q2,
  *  @param dist      Distance between p1 and p2.
  *  @param force     returns the force on particle 1.
  */
-inline void add_rf_coulomb_pair_force(double const q1q2, double const d[3],
-                                      double const dist, double force[3]) {
+inline void add_rf_coulomb_pair_force(double const q1q2,
+                                      Utils::Vector3d const &d,
+                                      double const dist,
+                                      Utils::Vector3d &force) {
   if (dist < rf_params.r_cut) {
     add_rf_coulomb_pair_force_no_cutoff(q1q2, d, dist, force);
   }

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -99,8 +99,7 @@ void energy_calc(double *result) {
     short_range_loop(
         [](Particle const &p) { add_single_particle_energy(&p); },
         [](Particle const &p1, Particle const &p2, Distance const &d) {
-          add_non_bonded_pair_energy(&p1, &p2, d.vec21.data(), sqrt(d.dist2),
-                                     d.dist2);
+          add_non_bonded_pair_energy(&p1, &p2, d.vec21, sqrt(d.dist2), d.dist2);
         });
   } else {
     // Otherwise, only do the single-particle contribution

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -78,11 +78,12 @@
  *  @param dist2      distance squared between p1 and p2.
  *  @return the short ranged interaction energy between the two particles
  */
-inline double calc_non_bonded_pair_energy(const Particle *p1,
-                                          const Particle *p2,
-                                          const IA_parameters *ia_params,
-                                          Utils::Vector3d const &d, double dist,
-                                          double dist2) {
+inline double calc_non_bonded_pair_energy(Particle const *const p1,
+                                          Particle const *const p2,
+                                          IA_parameters const *const ia_params,
+                                          Utils::Vector3d const &d,
+                                          double const dist,
+                                          double const dist2) {
   double ret = 0;
 
 #ifdef NO_INTRA_NB
@@ -179,10 +180,11 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
  *  @param dist      distance between p1 and p2.
  *  @param dist2     distance squared between p1 and p2.
  */
-inline void add_non_bonded_pair_energy(const Particle *p1, const Particle *p2,
-                                       Utils::Vector3d const &d, double dist,
-                                       double dist2) {
-  IA_parameters const *ia_params = get_ia_param(p1->p.type, p2->p.type);
+inline void add_non_bonded_pair_energy(Particle const *const p1,
+                                       Particle const *const p2,
+                                       Utils::Vector3d const &d,
+                                       double const dist, double const dist2) {
+  IA_parameters const *const ia_params = get_ia_param(p1->p.type, p2->p.type);
 
 #if defined(ELECTROSTATICS) || defined(DIPOLES)
 #endif
@@ -206,22 +208,20 @@ inline void add_non_bonded_pair_energy(const Particle *p1, const Particle *p2,
 /** Calculate bonded energies for one particle.
  *  @param p1 particle for which to calculate energies
  */
-inline void add_bonded_energy(const Particle *p1) {
-  Particle *p3 = nullptr, *p4 = nullptr;
-  Bonded_ia_parameters *iaparams;
-  int i;
-  bool bond_broken = true;
-  double ret = 0;
-
-  i = 0;
+inline void add_bonded_energy(Particle const *const p1) {
+  int i = 0;
   while (i < p1->bl.n) {
+    Particle const *p3 = nullptr;
+    Particle const *p4 = nullptr;
     int type_num = p1->bl.e[i++];
-    iaparams = &bonded_ia_params[type_num];
+    Bonded_ia_parameters const *const iaparams = &bonded_ia_params[type_num];
     int type = iaparams->type;
     int n_partners = iaparams->num;
+    bool bond_broken = true;
+    double ret = 0;
 
     /* fetch particle 2, which is always needed */
-    Particle *p2 = local_particles[p1->bl.e[i++]];
+    Particle const *const p2 = local_particles[p1->bl.e[i++]];
     if (!p2) {
       runtimeErrorMsg() << "bond broken between particles " << p1->p.identity
                         << " and " << p1->bl.e[i - 1]
@@ -376,7 +376,7 @@ inline void add_bonded_energy(const Particle *p1) {
 /** Calculate kinetic energies for one particle.
  *  @param p1 particle for which to calculate energies
  */
-inline void add_kinetic_energy(const Particle *p1) {
+inline void add_kinetic_energy(Particle const *const p1) {
 #ifdef VIRTUAL_SITES
   if (p1->p.is_virtual)
     return;
@@ -397,7 +397,7 @@ inline void add_kinetic_energy(const Particle *p1) {
 #endif
 }
 
-inline void add_single_particle_energy(const Particle *p) {
+inline void add_single_particle_energy(Particle const *const p) {
   add_kinetic_energy(p);
   add_bonded_energy(p);
 }

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -69,14 +69,14 @@
 #include "electrostatics_magnetostatics/dipole_inline.hpp"
 #endif
 
-/** Calculate non bonded energies between a pair of particles.
- *  @param p1         pointer to particle 1.
- *  @param p2         pointer to particle 2.
+/** Calculate non-bonded energies between a pair of particles.
+ *  @param p1         particle 1.
+ *  @param p2         particle 2.
  *  @param ia_params  the interaction parameters between the two particles
  *  @param d          vector between p1 and p2.
  *  @param dist       distance between p1 and p2.
  *  @param dist2      distance squared between p1 and p2.
- *  @return the short ranged interaction energy between the two particles
+ *  @return the short-range interaction energy between the two particles
  */
 inline double calc_non_bonded_pair_energy(Particle const *const p1,
                                           Particle const *const p2,
@@ -173,9 +173,10 @@ inline double calc_non_bonded_pair_energy(Particle const *const p1,
   return ret;
 }
 
-/** Add non bonded energies and short range Coulomb between a pair of particles.
- *  @param p1        pointer to particle 1.
- *  @param p2        pointer to particle 2.
+/** Add non-bonded and short-range Coulomb energies between a pair of particles
+ *  to the @ref energy observable.
+ *  @param p1        particle 1.
+ *  @param p2        particle 2.
  *  @param d         vector between p1 and p2.
  *  @param dist      distance between p1 and p2.
  *  @param dist2     distance squared between p1 and p2.
@@ -202,8 +203,8 @@ inline void add_non_bonded_pair_energy(Particle const *const p1,
 #endif
 }
 
-/** Calculate bonded energies for one particle.
- *  @param p1 particle for which to calculate energies
+/** Add bonded energies for one particle to the @ref energy observable.
+ *  @param[in] p1   particle for which to calculate energies
  */
 inline void add_bonded_energy(Particle const *const p1) {
   int i = 0;
@@ -371,8 +372,8 @@ inline void add_bonded_energy(Particle const *const p1) {
   }
 }
 
-/** Calculate kinetic energies for one particle.
- *  @param p1 particle for which to calculate energies
+/** Add kinetic energies for one particle to the @ref energy observable.
+ *  @param[in] p1   particle for which to calculate energies
  */
 inline void add_kinetic_energy(Particle const *const p1) {
 #ifdef VIRTUAL_SITES
@@ -395,6 +396,10 @@ inline void add_kinetic_energy(Particle const *const p1) {
 #endif
 }
 
+/** Add kinetic and bonded energies for one particle to the @ref energy
+ *  observable.
+ *  @param[in] p   particle for which to calculate energies
+ */
 inline void add_single_particle_energy(Particle const *const p) {
   add_kinetic_energy(p);
   add_bonded_energy(p);

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -81,7 +81,7 @@
 inline double calc_non_bonded_pair_energy(const Particle *p1,
                                           const Particle *p2,
                                           const IA_parameters *ia_params,
-                                          const double d[3], double dist,
+                                          Utils::Vector3d const &d, double dist,
                                           double dist2) {
   double ret = 0;
 
@@ -180,7 +180,7 @@ inline double calc_non_bonded_pair_energy(const Particle *p1,
  *  @param dist2     distance squared between p1 and p2.
  */
 inline void add_non_bonded_pair_energy(const Particle *p1, const Particle *p2,
-                                       const double *d, double dist,
+                                       Utils::Vector3d const &d, double dist,
                                        double dist2) {
   IA_parameters const *ia_params = get_ia_param(p1->p.type, p2->p.type);
 

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -84,12 +84,12 @@ inline double calc_non_bonded_pair_energy(Particle const *const p1,
                                           Utils::Vector3d const &d,
                                           double const dist,
                                           double const dist2) {
-  double ret = 0;
-
 #ifdef NO_INTRA_NB
   if (p1->p.mol_id == p2->p.mol_id)
     return 0;
 #endif
+
+  double ret = 0;
 
 #ifdef LENNARD_JONES
   /* Lennard-Jones */
@@ -186,9 +186,6 @@ inline void add_non_bonded_pair_energy(Particle const *const p1,
                                        double const dist, double const dist2) {
   IA_parameters const *const ia_params = get_ia_param(p1->p.type, p2->p.type);
 
-#if defined(ELECTROSTATICS) || defined(DIPOLES)
-#endif
-
 #ifdef EXCLUSIONS
   if (do_nonbonded(p1, p2))
 #endif
@@ -217,8 +214,6 @@ inline void add_bonded_energy(Particle const *const p1) {
     Bonded_ia_parameters const *const iaparams = &bonded_ia_params[type_num];
     int type = iaparams->type;
     int n_partners = iaparams->num;
-    bool bond_broken = true;
-    double ret = 0;
 
     /* fetch particle 2, which is always needed */
     Particle const *const p2 = local_particles[p1->bl.e[i++]];
@@ -252,6 +247,9 @@ inline void add_bonded_energy(Particle const *const p1) {
         return;
       }
     }
+
+    bool bond_broken = true;
+    double ret = 0;
 
     if (n_partners == 1) {
       auto const dx = get_mi_vector(p1->r.p, p2->r.p, box_geo);

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -108,7 +108,7 @@ void force_calc(CellStructure &cell_structure) {
   if (max_cut > 0) {
     short_range_loop([](Particle &p) { add_single_particle_force(&p); },
                      [](Particle &p1, Particle &p2, Distance &d) {
-                       add_non_bonded_pair_force(&(p1), &(p2), d.vec21.data(),
+                       add_non_bonded_pair_force(&(p1), &(p2), d.vec21,
                                                  sqrt(d.dist2), d.dist2);
                      });
   } else {

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -118,10 +118,10 @@ inline ParticleForce init_local_particle_force(const Particle *part) {
 }
 
 inline void calc_non_bonded_pair_force_parts(
-    const Particle *const p1, const Particle *const p2,
-    IA_parameters *ia_params, Utils::Vector3d const &d, double dist,
-    double dist2, Utils::Vector3d &force, Utils::Vector3d *torque1 = nullptr,
-    Utils::Vector3d *torque2 = nullptr) {
+    Particle const *const p1, Particle const *const p2,
+    IA_parameters const *const ia_params, Utils::Vector3d const &d,
+    double const dist, double const dist2, Utils::Vector3d &force,
+    Utils::Vector3d *torque1 = nullptr, Utils::Vector3d *torque2 = nullptr) {
 #ifdef NO_INTRA_NB
   if (p1->p.mol_id == p2->p.mol_id)
     return;
@@ -199,8 +199,9 @@ inline void calc_non_bonded_pair_force_parts(
 #endif
 }
 
-inline void calc_non_bonded_pair_force(const Particle *p1, const Particle *p2,
-                                       IA_parameters *ia_params,
+inline void calc_non_bonded_pair_force(Particle const *const p1,
+                                       Particle const *const p2,
+                                       IA_parameters const *const ia_params,
                                        Utils::Vector3d const &d, double dist,
                                        double dist2, Utils::Vector3d &force,
                                        Utils::Vector3d *torque1 = nullptr,
@@ -209,10 +210,10 @@ inline void calc_non_bonded_pair_force(const Particle *p1, const Particle *p2,
                                    torque1, torque2);
 }
 
-inline void calc_non_bonded_pair_force(Particle *p1, Particle *p2,
+inline void calc_non_bonded_pair_force(Particle *const p1, Particle *const p2,
                                        Utils::Vector3d const &d, double dist,
                                        double dist2, Utils::Vector3d &force) {
-  IA_parameters *ia_params = get_ia_param(p1->p.type, p2->p.type);
+  IA_parameters const *const ia_params = get_ia_param(p1->p.type, p2->p.type);
   calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, dist2, force);
 }
 
@@ -223,10 +224,10 @@ inline void calc_non_bonded_pair_force(Particle *p1, Particle *p2,
  *  @param dist      distance between p1 and p2.
  *  @param dist2     distance squared between p1 and p2.
  */
-inline void add_non_bonded_pair_force(Particle *p1, Particle *p2,
+inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
                                       Utils::Vector3d const &d, double dist,
                                       double dist2) {
-  IA_parameters *ia_params = get_ia_param(p1->p.type, p2->p.type);
+  IA_parameters const *ia_params = get_ia_param(p1->p.type, p2->p.type);
   Utils::Vector3d force{};
   Utils::Vector3d *torque1 = nullptr;
   Utils::Vector3d *torque2 = nullptr;
@@ -333,8 +334,8 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2,
 #endif
 }
 
-inline bool calc_bond_pair_force(Particle *p1, Particle *p2,
-                                 Bonded_ia_parameters *iaparams,
+inline bool calc_bond_pair_force(Particle *const p1, Particle const *const p2,
+                                 Bonded_ia_parameters const *const iaparams,
                                  Utils::Vector3d const &dx,
                                  Utils::Vector3d &force) {
   bool bond_broken = false;
@@ -388,10 +389,7 @@ inline bool calc_bond_pair_force(Particle *p1, Particle *p2,
 /** Calculate bonded forces for one particle.
  *  @param p1   particle for which to calculate forces
  */
-inline void add_bonded_force(Particle *p1) {
-  Particle *p3 = nullptr, *p4 = nullptr;
-  bool bond_broken = true;
-
+inline void add_bonded_force(Particle *const p1) {
   int i = 0;
   while (i < p1->bl.n) {
     Utils::Vector3d force1{};
@@ -400,10 +398,13 @@ inline void add_bonded_force(Particle *p1) {
 #if defined(OIF_LOCAL_FORCES)
     Utils::Vector3d force4{};
 #endif
+    Particle *p3 = nullptr;
+    Particle *p4 = nullptr;
     int type_num = p1->bl.e[i++];
-    auto iaparams = &bonded_ia_params[type_num];
+    Bonded_ia_parameters const *const iaparams = &bonded_ia_params[type_num];
     int type = iaparams->type;
     int n_partners = iaparams->num;
+    bool bond_broken = true;
 
     Particle *p2 = nullptr;
     if (n_partners) {
@@ -594,7 +595,7 @@ inline void add_bonded_force(Particle *p1) {
   }   // loop over the particle's bond list
 }
 
-inline void check_particle_force(Particle *part) {
+inline void check_particle_force(Particle const *const part) {
   for (int i = 0; i < 3; i++) {
     if (std::isnan(part->f.f[i])) {
       runtimeErrorMsg() << "force on particle " << part->p.identity
@@ -612,7 +613,7 @@ inline void check_particle_force(Particle *part) {
 #endif
 }
 
-inline void add_single_particle_force(Particle *p) {
+inline void add_single_particle_force(Particle *const p) {
   if (p->bl.n) {
     add_bonded_force(p);
   }

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -217,12 +217,13 @@ inline void calc_non_bonded_pair_force(Particle *const p1, Particle *const p2,
   calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, dist2, force);
 }
 
-/** Calculate non bonded forces between a pair of particles.
- *  @param p1        pointer to particle 1.
- *  @param p2        pointer to particle 2.
- *  @param d         vector between p1 and p2.
- *  @param dist      distance between p1 and p2.
- *  @param dist2     distance squared between p1 and p2.
+/** Calculate non-bonded forces between a pair of particles and update their
+ *  forces and torques.
+ *  @param[in,out] p1   particle 1.
+ *  @param[in,out] p2   particle 2.
+ *  @param[in] d        vector between @p p1 and @p p2.
+ *  @param dist         distance between @p p1 and @p p2.
+ *  @param dist2        distance squared between @p p1 and @p p2.
  */
 inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
                                       Utils::Vector3d const &d, double dist,
@@ -238,7 +239,7 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
   torque2 = &_torque2;
 #endif
 
-  // Early exit if there is no interactoin to calculate
+  // Early exit if there is no interaction to calculate
   // The exception for MMM2d is there, because the method assumes that
   // pairs within a cell system layer but outside the cutoff are considered
 
@@ -259,8 +260,8 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
     detect_collision(p1, p2, dist);
 #endif
 
-/*affinity potential*/
 #ifdef AFFINITY
+  /* affinity potential */
   // Prevent jump to non-inlined function
   if (dist < ia_params->affinity_cut) {
     add_affinity_pair_force(p1, p2, ia_params, d, dist, force);
@@ -271,7 +272,7 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
                       p1->p.identity, p2->p.identity, dist));
 
   /***********************************************/
-  /* non bonded pair potentials                  */
+  /* non-bonded pair potentials                  */
   /***********************************************/
 
   if (dist < ia_params->max_cut) {
@@ -283,17 +284,17 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
   }
 
   /***********************************************/
-  /* short range electrostatics                  */
+  /* short-range electrostatics                  */
   /***********************************************/
 
 #ifdef ELECTROSTATICS
   Coulomb::calc_pair_force(p1, p2, d, dist, force);
 #endif
 
-/*********************************************************************/
-/* everything before this contributes to the virial pressure in NpT, */
-/* but nothing afterwards                                            */
-/*********************************************************************/
+  /*********************************************************************/
+  /* everything before this contributes to the virial pressure in NpT, */
+  /* but nothing afterwards                                            */
+  /*********************************************************************/
 #ifdef NPT
   if (integ_switch == INTEG_METHOD_NPT_ISO) {
     for (int j = 0; j < 3; j++) {
@@ -302,11 +303,11 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
   }
 #endif
 
-/***********************************************/
-/* thermostat                                  */
-/***********************************************/
+  /***********************************************/
+  /* thermostat                                  */
+  /***********************************************/
 
-/** The inter dpd force should not be part of the virial */
+  /** The inter dpd force should not be part of the virial */
 #ifdef DPD
   if (thermo_switch & THERMO_DPD) {
     force += dpd_pair_force(p1, p2, ia_params, d, dist, dist2);
@@ -314,7 +315,7 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
 #endif
 
   /***********************************************/
-  /* long range magnetostatics                   */
+  /* long-range magnetostatics                   */
   /***********************************************/
 
 #ifdef DIPOLES
@@ -323,7 +324,7 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
 #endif /* ifdef DIPOLES */
 
   /***********************************************/
-  /* add total nonbonded forces to particle      */
+  /* add total non-bonded forces to particle     */
   /***********************************************/
 
   p1->f.f += force;
@@ -334,6 +335,15 @@ inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
 #endif
 }
 
+/** Compute the bonded interaction force between particle pairs.
+ *
+ *  @param[in,out] p1      First particle.
+ *  @param[in] p2          Second particle.
+ *  @param[in] iaparams    Bonded parameters for the interaction.
+ *  @param[in] dx          Vector between @p p1 and @p p2.
+ *  @param[out] force      Force between @p p1 and @p p2.
+ *  @return whether the bond is broken
+ */
 inline bool calc_bond_pair_force(Particle *const p1, Particle const *const p2,
                                  Bonded_ia_parameters const *const iaparams,
                                  Utils::Vector3d const &dx,

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -119,8 +119,9 @@ inline ParticleForce init_local_particle_force(const Particle *part) {
 
 inline void calc_non_bonded_pair_force_parts(
     const Particle *const p1, const Particle *const p2,
-    IA_parameters *ia_params, double d[3], double dist, double dist2,
-    double force[3], double torque1[3] = nullptr, double torque2[3] = nullptr) {
+    IA_parameters *ia_params, Utils::Vector3d const &d, double dist,
+    double dist2, Utils::Vector3d &force, Utils::Vector3d *torque1 = nullptr,
+    Utils::Vector3d *torque2 = nullptr) {
 #ifdef NO_INTRA_NB
   if (p1->p.mol_id == p2->p.mol_id)
     return;
@@ -199,17 +200,18 @@ inline void calc_non_bonded_pair_force_parts(
 }
 
 inline void calc_non_bonded_pair_force(const Particle *p1, const Particle *p2,
-                                       IA_parameters *ia_params, double *d,
-                                       double dist, double dist2, double *force,
-                                       double *torque1 = nullptr,
-                                       double *torque2 = nullptr) {
+                                       IA_parameters *ia_params,
+                                       Utils::Vector3d const &d, double dist,
+                                       double dist2, Utils::Vector3d &force,
+                                       Utils::Vector3d *torque1 = nullptr,
+                                       Utils::Vector3d *torque2 = nullptr) {
   calc_non_bonded_pair_force_parts(p1, p2, ia_params, d, dist, dist2, force,
                                    torque1, torque2);
 }
 
-inline void calc_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
-                                       double dist, double dist2,
-                                       double force[3]) {
+inline void calc_non_bonded_pair_force(Particle *p1, Particle *p2,
+                                       Utils::Vector3d const &d, double dist,
+                                       double dist2, Utils::Vector3d &force) {
   IA_parameters *ia_params = get_ia_param(p1->p.type, p2->p.type);
   calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, dist2, force);
 }
@@ -221,20 +223,26 @@ inline void calc_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
  *  @param dist      distance between p1 and p2.
  *  @param dist2     distance squared between p1 and p2.
  */
-inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
-                                      double dist, double dist2) {
+inline void add_non_bonded_pair_force(Particle *p1, Particle *p2,
+                                      Utils::Vector3d const &d, double dist,
+                                      double dist2) {
   IA_parameters *ia_params = get_ia_param(p1->p.type, p2->p.type);
   Utils::Vector3d force{};
-  double torque1[3] = {0., 0., 0.};
-  double torque2[3] = {0., 0., 0.};
-  int j;
+  Utils::Vector3d *torque1 = nullptr;
+  Utils::Vector3d *torque2 = nullptr;
+#ifdef ROTATION
+  Utils::Vector3d _torque1{};
+  Utils::Vector3d _torque2{};
+  torque1 = &_torque1;
+  torque2 = &_torque2;
+#endif
 
   // Early exit if there is no interactoin to calculate
   // The exception for MMM2d is there, because the method assumes that
   // pairs within a cell system layer but outside the cutoff are considered
 
 #ifdef ELECTROSTATICS
-  if (!(coulomb.method == COULOMB_MMM2D))
+  if (coulomb.method != COULOMB_MMM2D)
 #endif
   {
     if (dist > max_cut)
@@ -254,7 +262,7 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
 #ifdef AFFINITY
   // Prevent jump to non-inlined function
   if (dist < ia_params->affinity_cut) {
-    add_affinity_pair_force(p1, p2, ia_params, d, dist, force.data());
+    add_affinity_pair_force(p1, p2, ia_params, d, dist, force);
   }
 #endif
 
@@ -269,8 +277,8 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
 #ifdef EXCLUSIONS
     if (do_nonbonded(p1, p2))
 #endif
-      calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, dist2,
-                                 force.data(), torque1, torque2);
+      calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, dist2, force,
+                                 torque1, torque2);
   }
 
   /***********************************************/
@@ -287,7 +295,7 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
 /*********************************************************************/
 #ifdef NPT
   if (integ_switch == INTEG_METHOD_NPT_ISO) {
-    for (j = 0; j < 3; j++) {
+    for (int j = 0; j < 3; j++) {
       nptiso.p_vir[j] += force[j] * d[j];
     }
   }
@@ -319,18 +327,16 @@ inline void add_non_bonded_pair_force(Particle *p1, Particle *p2, double d[3],
 
   p1->f.f += force;
   p2->f.f -= force;
-
-  for (j = 0; j < 3; j++) {
 #ifdef ROTATION
-    p1->f.torque[j] += torque1[j];
-    p2->f.torque[j] += torque2[j];
+  p1->f.torque += *torque1;
+  p2->f.torque += *torque2;
 #endif
-  }
 }
 
 inline bool calc_bond_pair_force(Particle *p1, Particle *p2,
                                  Bonded_ia_parameters *iaparams,
-                                 const Utils::Vector3d &dx, double *force) {
+                                 Utils::Vector3d const &dx,
+                                 Utils::Vector3d &force) {
   bool bond_broken = false;
 
   switch (iaparams->type) {
@@ -388,11 +394,11 @@ inline void add_bonded_force(Particle *p1) {
 
   int i = 0;
   while (i < p1->bl.n) {
-    double force[3] = {0., 0., 0.};
-    double force2[3] = {0., 0., 0.};
-    double force3[3] = {0., 0., 0.};
+    Utils::Vector3d force1{};
+    Utils::Vector3d force2{};
+    Utils::Vector3d force3{};
 #if defined(OIF_LOCAL_FORCES)
-    double force4[3] = {0., 0., 0.};
+    Utils::Vector3d force4{};
 #endif
     int type_num = p1->bl.e[i++];
     auto iaparams = &bonded_ia_params[type_num];
@@ -438,18 +444,19 @@ inline void add_bonded_force(Particle *p1) {
          not needed,
          and the pressure calculation not yet clear. */
       auto const dx = get_mi_vector(p1->r.p, p2->r.p, box_geo);
-      bond_broken = calc_bond_pair_force(p1, p2, iaparams, dx, force);
+      bond_broken = calc_bond_pair_force(p1, p2, iaparams, dx, force1);
 
 #ifdef NPT
-      if (integ_switch == INTEG_METHOD_NPT_ISO)
+      if (integ_switch == INTEG_METHOD_NPT_ISO) {
         for (int j = 0; j < 3; j++)
-          nptiso.p_vir[j] += force[j] * dx[j];
+          nptiso.p_vir[j] += force1[j] * dx[j];
+      }
 #endif
 
       switch (type) {
       case BONDED_IA_THERMALIZED_DIST:
         bond_broken =
-            calc_thermalized_bond_forces(p1, p2, iaparams, dx, force, force2);
+            calc_thermalized_bond_forces(p1, p2, iaparams, dx, force1, force2);
         break;
 
       default:
@@ -459,15 +466,15 @@ inline void add_bonded_force(Particle *p1) {
     else if (n_partners == 2) {
       switch (type) {
       case BONDED_IA_ANGLE_HARMONIC:
-        bond_broken = calc_angle_harmonic_force(p1, p2, p3, iaparams, force,
+        bond_broken = calc_angle_harmonic_force(p1, p2, p3, iaparams, force1,
                                                 force2, force3);
         break;
       case BONDED_IA_ANGLE_COSINE:
-        bond_broken = calc_angle_cosine_force(p1, p2, p3, iaparams, force,
+        bond_broken = calc_angle_cosine_force(p1, p2, p3, iaparams, force1,
                                               force2, force3);
         break;
       case BONDED_IA_ANGLE_COSSQUARE:
-        bond_broken = calc_angle_cossquare_force(p1, p2, p3, iaparams, force,
+        bond_broken = calc_angle_cossquare_force(p1, p2, p3, iaparams, force1,
                                                  force2, force3);
         break;
 #ifdef OIF_GLOBAL_FORCES
@@ -477,8 +484,8 @@ inline void add_bonded_force(Particle *p1) {
 #endif
       case BONDED_IA_TABULATED:
         if (iaparams->num == 2)
-          bond_broken =
-              calc_tab_angle_force(p1, p2, p3, iaparams, force, force2, force3);
+          bond_broken = calc_tab_angle_force(p1, p2, p3, iaparams, force1,
+                                             force2, force3);
         break;
       case BONDED_IA_IBM_TRIEL:
         bond_broken = IBM_Triel_CalcForce(p1, p2, p3, iaparams);
@@ -499,7 +506,7 @@ inline void add_bonded_force(Particle *p1) {
 #endif
 #ifdef OIF_LOCAL_FORCES
       case BONDED_IA_OIF_LOCAL_FORCES:
-        bond_broken = calc_oif_local(p1, p2, p3, p4, iaparams, force, force2,
+        bond_broken = calc_oif_local(p1, p2, p3, p4, iaparams, force1, force2,
                                      force3, force4);
         break;
 #endif
@@ -511,13 +518,13 @@ inline void add_bonded_force(Particle *p1) {
         break;
       }
       case BONDED_IA_DIHEDRAL:
-        bond_broken = calc_dihedral_force(p1, p2, p3, p4, iaparams, force,
+        bond_broken = calc_dihedral_force(p1, p2, p3, p4, iaparams, force1,
                                           force2, force3);
         break;
       case BONDED_IA_TABULATED:
         if (iaparams->num == 3)
-          bond_broken = calc_tab_dihedral_force(p1, p2, p3, p4, iaparams, force,
-                                                force2, force3);
+          bond_broken = calc_tab_dihedral_force(p1, p2, p3, p4, iaparams,
+                                                force1, force2, force3);
         break;
       default:
         runtimeErrorMsg() << "add_bonded_force: bond type of atom "
@@ -535,16 +542,14 @@ inline void add_bonded_force(Particle *p1) {
         continue;
       }
 
-      for (int j = 0; j < 3; j++) {
-        switch (type) {
-        case BONDED_IA_THERMALIZED_DIST:
-          p1->f.f[j] += force[j];
-          p2->f.f[j] += force2[j];
-          break;
-        default:
-          p1->f.f[j] += force[j];
-          p2->f.f[j] -= force[j];
-        }
+      switch (type) {
+      case BONDED_IA_THERMALIZED_DIST:
+        p1->f.f += force1;
+        p2->f.f += force2;
+        break;
+      default:
+        p1->f.f += force1;
+        p2->f.f -= force1;
       }
       break;
     case 2:
@@ -555,14 +560,9 @@ inline void add_bonded_force(Particle *p1) {
         continue;
       }
 
-      for (int j = 0; j < 3; j++) {
-        switch (type) {
-        default:
-          p1->f.f[j] += force[j];
-          p2->f.f[j] += force2[j];
-          p3->f.f[j] += force3[j];
-        }
-      }
+      p1->f.f += force1;
+      p2->f.f += force2;
+      p3->f.f += force3;
       break;
     case 3:
       if (bond_broken) {
@@ -574,22 +574,18 @@ inline void add_bonded_force(Particle *p1) {
 
       switch (type) {
       case BONDED_IA_DIHEDRAL:
-        for (int j = 0; j < 3; j++) {
-          p1->f.f[j] += force[j];
-          p2->f.f[j] += force2[j];
-          p3->f.f[j] += force3[j];
-          p4->f.f[j] -= force[j] + force2[j] + force3[j];
-        }
+        p1->f.f += force1;
+        p2->f.f += force2;
+        p3->f.f += force3;
+        p4->f.f -= force1 + force2 + force3;
         break;
 
 #ifdef OIF_LOCAL_FORCES
       case BONDED_IA_OIF_LOCAL_FORCES:
-        for (int j = 0; j < 3; j++) {
-          p1->f.f[j] += force2[j];
-          p2->f.f[j] += force[j];
-          p3->f.f[j] += force3[j];
-          p4->f.f[j] += force4[j];
-        }
+        p1->f.f += force2;
+        p2->f.f += force1;
+        p3->f.f += force3;
+        p4->f.f += force4;
         break;
 #endif
       } // Switch type of 4-particle bond

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -227,7 +227,7 @@ inline void calc_non_bonded_pair_force(Particle *const p1, Particle *const p2,
 inline void add_non_bonded_pair_force(Particle *const p1, Particle *const p2,
                                       Utils::Vector3d const &d, double dist,
                                       double dist2) {
-  IA_parameters const *ia_params = get_ia_param(p1->p.type, p2->p.type);
+  IA_parameters const *const ia_params = get_ia_param(p1->p.type, p2->p.type);
   Utils::Vector3d force{};
   Utils::Vector3d *torque1 = nullptr;
   Utils::Vector3d *torque2 = nullptr;
@@ -513,7 +513,7 @@ inline void add_bonded_force(Particle *const p1) {
 #endif
       // IMMERSED_BOUNDARY
       case BONDED_IA_IBM_TRIBEND: {
-        IBM_Tribend_CalcForce(p1, p2, p3, p4, *iaparams);
+        IBM_Tribend_CalcForce(p1, p2, p3, p4, iaparams);
         bond_broken = false;
 
         break;

--- a/src/core/grid.hpp
+++ b/src/core/grid.hpp
@@ -168,7 +168,7 @@ inline Utils::Vector3d folded_position(const Utils::Vector3d &p,
 
 inline Utils::Vector3d image_shift(const Utils::Vector3i &image_box,
                                    const Utils::Vector3d &box) {
-  return {image_box[0] * box[0], image_box[1] * box[1], image_box[2] * box[2]};
+  return hadamard_product(image_box, box);
 }
 
 inline Utils::Vector3d unfolded_position(const Utils::Vector3d &pos,

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -123,7 +123,7 @@ void lb_init_boundaries() {
 
           double dist = 1e99;
           double dist_tmp = 0.0;
-          double dist_vec[3];
+          Utils::Vector3d dist_vec{};
 
 #ifdef EK_BOUNDARIES
           if (ek_initialized) {
@@ -135,7 +135,7 @@ void lb_init_boundaries() {
           int n = 0;
           for (auto lbb = lbboundaries.begin(); lbb != lbboundaries.end();
                ++lbb, n++) {
-            (**lbb).calc_dist(pos, &dist_tmp, dist_vec);
+            (**lbb).calc_dist(pos, dist_tmp, dist_vec);
 
             if (dist > dist_tmp || n == 0) {
               dist = dist_tmp;
@@ -242,12 +242,12 @@ void lb_init_boundaries() {
 
           double dist = 1e99;
           double dist_tmp = 0.0;
-          double dist_vec[3];
+          Utils::Vector3d dist_vec{};
 
           int n = 0;
           for (auto it = lbboundaries.begin(); it != lbboundaries.end();
                ++it, ++n) {
-            (**it).calc_dist(pos, &dist_tmp, dist_vec);
+            (**it).calc_dist(pos, dist_tmp, dist_vec);
 
             if (dist_tmp < dist || n == 0) {
               dist = dist_tmp;

--- a/src/core/grid_based_algorithms/lbboundaries/LBBoundary.hpp
+++ b/src/core/grid_based_algorithms/lbboundaries/LBBoundary.hpp
@@ -45,7 +45,8 @@ public:
   }
 
   /* Calculate distance from the lbboundary */
-  void calc_dist(const Utils::Vector3d &pos, double *dist, double *vec) const {
+  void calc_dist(const Utils::Vector3d &pos, double &dist,
+                 Utils::Vector3d &vec) const {
     m_shape->calculate_dist(pos, dist, vec);
   }
 

--- a/src/core/immersed_boundary/ibm_tribend.cpp
+++ b/src/core/immersed_boundary/ibm_tribend.cpp
@@ -26,11 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <utils/constants.hpp>
 
-/*************
-   IBM_Tribend_CalcForce
-Calculate the bending force and add it to the particles
- **************/
-
 void IBM_Tribend_CalcForce(Particle *p1, Particle *p2, Particle *p3,
                            Particle *p4,
                            Bonded_ia_parameters const *const iaparams) {
@@ -90,19 +85,15 @@ void IBM_Tribend_CalcForce(Particle *p1, Particle *p2, Particle *p3,
   p2->f.f +=
       Pre * (vector_product(get_mi_vector(p3->r.p, p1->r.p, box_geo), v1) / Ai);
 
-  // Force for Particle 3:
+  // Force for particle 3:
   p3->f.f +=
       Pre * (vector_product(get_mi_vector(p1->r.p, p2->r.p, box_geo), v1) / Ai +
              vector_product(get_mi_vector(p4->r.p, p1->r.p, box_geo), v2) / Aj);
 
-  // Force for Particle 4:
+  // Force for particle 4:
   p4->f.f +=
       Pre * (vector_product(get_mi_vector(p1->r.p, p3->r.p, box_geo), v2) / Aj);
 }
-
-/***********
-   IBM_Tribend_SetParams
-************/
 
 int IBM_Tribend_SetParams(const int bond_type, const int ind1, const int ind2,
                           const int ind3, const int ind4, const double kb,

--- a/src/core/immersed_boundary/ibm_tribend.cpp
+++ b/src/core/immersed_boundary/ibm_tribend.cpp
@@ -32,7 +32,8 @@ Calculate the bending force and add it to the particles
  **************/
 
 void IBM_Tribend_CalcForce(Particle *p1, Particle *p2, Particle *p3,
-                           Particle *p4, const Bonded_ia_parameters &iaparams) {
+                           Particle *p4,
+                           Bonded_ia_parameters const *const iaparams) {
   assert(p1);
   assert(p2);
   assert(p3);
@@ -57,26 +58,25 @@ void IBM_Tribend_CalcForce(Particle *p1, Particle *p2, Particle *p3,
   n2 /= Aj;
 
   // Get the prefactor for the force term
-  double sc = n1 * n2;
+  auto sc = n1 * n2;
   if (sc > 1.0)
     sc = 1.0;
 
   // Get theta as angle between normals
-  double theta = acos(sc);
+  auto theta = acos(sc);
 
   auto const direc = vector_product(n1, n2);
-  const double desc = (dx1 * direc);
+  auto const desc = (dx1 * direc);
 
   if (desc < 0)
-    theta = -1.0 * theta;
-  const double DTh = theta - iaparams.p.ibm_tribend.theta0;
+    theta *= -1;
 
-  double Pre;
+  auto const DTh = theta - iaparams->p.ibm_tribend.theta0;
+
+  auto Pre = iaparams->p.ibm_tribend.kb * DTh;
   // Correct version with linearized sin
-  if (theta > 0)
-    Pre = 1.0 * iaparams.p.ibm_tribend.kb * DTh;
-  else
-    Pre = -1.0 * iaparams.p.ibm_tribend.kb * DTh;
+  if (theta < 0)
+    Pre *= -1;
 
   auto const v1 = (n2 - sc * n1).normalize();
   auto const v2 = (n1 - sc * n2).normalize();
@@ -142,7 +142,7 @@ int IBM_Tribend_SetParams(const int bond_type, const int ind1, const int ind2,
       auto const n2 = n2l / n2l.norm();
 
       // calculate theta by taking the acos of the scalar n1*n2
-      double sc = n1 * n2;
+      auto sc = n1 * n2;
       if (sc > 1.0)
         sc = 1.0;
 

--- a/src/core/immersed_boundary/ibm_tribend.hpp
+++ b/src/core/immersed_boundary/ibm_tribend.hpp
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 int IBM_Tribend_SetParams(int bond_type, int ind1, int ind2, int ind3, int ind4,
                           double kb, bool flat);
 
-// This function calculates and adds the actual force
+/** Calculate the forces */
 void IBM_Tribend_CalcForce(Particle *p1, Particle *p2, Particle *p3,
                            Particle *p4, Bonded_ia_parameters const *iaparams);
 

--- a/src/core/immersed_boundary/ibm_tribend.hpp
+++ b/src/core/immersed_boundary/ibm_tribend.hpp
@@ -31,6 +31,6 @@ int IBM_Tribend_SetParams(int bond_type, int ind1, int ind2, int ind3, int ind4,
 
 // This function calculates and adds the actual force
 void IBM_Tribend_CalcForce(Particle *p1, Particle *p2, Particle *p3,
-                           Particle *p4, const Bonded_ia_parameters &iaparams);
+                           Particle *p4, Bonded_ia_parameters const *iaparams);
 
 #endif

--- a/src/core/immersed_boundary/ibm_triel.cpp
+++ b/src/core/immersed_boundary/ibm_triel.cpp
@@ -84,16 +84,16 @@ int IBM_Triel_CalcForce(Particle *const p1, Particle *const p2,
   auto const vec1 = get_mi_vector(p2->r.p, p1->r.p, box_geo);
   auto const lp = vec1.norm();
 
-  // angles between these vectors; calculated directly via the products
-  const double cosPhi = (vec1 * vec2) / (lp * l);
-  auto const vecpro = vector_product(vec1, vec2);
-  const double sinPhi = vecpro.norm() / (l * lp);
-
   // Check for sanity
   if ((lp - iaparams->p.ibm_triel.lp0 > iaparams->p.ibm_triel.maxDist) ||
       (l - iaparams->p.ibm_triel.l0 > iaparams->p.ibm_triel.maxDist)) {
     return 1;
   }
+
+  // angles between these vectors; calculated directly via the products
+  auto const cosPhi = (vec1 * vec2) / (lp * l);
+  auto const vecpro = vector_product(vec1, vec2);
+  auto const sinPhi = vecpro.norm() / (l * lp);
 
   // Variables in the reference state
   const double l0 = iaparams->p.ibm_triel.l0;

--- a/src/core/immersed_boundary/ibm_triel.cpp
+++ b/src/core/immersed_boundary/ibm_triel.cpp
@@ -37,7 +37,7 @@ namespace {
  */
 void RotateForces(Utils::Vector2d const &f1_rot, Utils::Vector2d const &f2_rot,
                   Utils::Vector3d &f1, Utils::Vector3d &f2,
-                  const Utils::Vector3d &v12, const Utils::Vector3d &v13) {
+                  Utils::Vector3d const &v12, Utils::Vector3d const &v13) {
   // fRot is in the rotated system, i.e. in a system where the side lPrime of
   // the triangle (i.e. v12) is parallel to the x-axis, and the y-axis is
   // perpendicular to the x-axis (cf. Krueger, Fig. 7.1c).
@@ -70,8 +70,9 @@ void RotateForces(Utils::Vector2d const &f1_rot, Utils::Vector2d const &f2_rot,
 Calculate the repulsion and add it to the particle
  **************/
 
-int IBM_Triel_CalcForce(Particle *p1, Particle *p2, Particle *p3,
-                        Bonded_ia_parameters *iaparams) {
+int IBM_Triel_CalcForce(Particle *const p1, Particle *const p2,
+                        Particle *const p3,
+                        Bonded_ia_parameters const *const iaparams) {
 
   // Calculate the current shape of the triangle (l,lp,cos(phi),sin(phi));
   // l = length between 1 and 3

--- a/src/core/immersed_boundary/ibm_triel.cpp
+++ b/src/core/immersed_boundary/ibm_triel.cpp
@@ -28,12 +28,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <utils/math/sqr.hpp>
 
 namespace {
-/** Rotate calculated trielastic forces in the 2d plane back to the 3d plane
- *Use knowledge that the x-axis in rotated system is parallel to r(p1->p2) in
- *original system; To find the corresponding unit vector to y in the rotated
- *system, construct vector perpendicular to r(p1->p2); note that f3 is not
- *calculated here but is implicitly calculated by f3 = -(f1+f2) which is
- *consistent with the literature
+/** Rotate calculated trielastic forces in the 2d plane back to the 3d plane.
+ *  Use knowledge that the x-axis in rotated system is parallel to r(p1->p2) in
+ *  original system; To find the corresponding unit vector to y in the rotated
+ *  system, construct vector perpendicular to r(p1->p2); note that f3 is not
+ *  calculated here but is implicitly calculated by f3 = -(f1+f2) which is
+ *  consistent with the literature
  */
 void RotateForces(Utils::Vector2d const &f1_rot, Utils::Vector2d const &f2_rot,
                   Utils::Vector3d &f1, Utils::Vector3d &f2,
@@ -55,7 +55,7 @@ void RotateForces(Utils::Vector2d const &f1_rot, Utils::Vector2d const &f2_rot,
   // Krueger, Fig. 7.1b. Therefore: First get the projection of v13 onto v12:
   // The direction is definied by xu, the length by the scalar product (scalar
   // product can be interpreted as a projection, after all). --> sca * xu Then:
-  // v13 - sca * xu gives the component of v13 orthogonal to v12, i..e.
+  // v13 - sca * xu gives the component of v13 orthogonal to v12, i.e.
   // perpendicular to the x-axis --> yu Last: Normalize yu.
   auto const yu = (v13 - (v13 * xu) * xu).normalize();
 
@@ -64,11 +64,6 @@ void RotateForces(Utils::Vector2d const &f1_rot, Utils::Vector2d const &f2_rot,
   f2 = f2_rot[0] * xu + f2_rot[1] * yu;
 }
 } // namespace
-
-/*************
-   IBM_Triel_CalcForce
-Calculate the repulsion and add it to the particle
- **************/
 
 int IBM_Triel_CalcForce(Particle *const p1, Particle *const p2,
                         Particle *const p3,
@@ -243,10 +238,6 @@ int IBM_Triel_CalcForce(Particle *const p1, Particle *const p2,
   return 0;
 }
 
-/****************
-  IBM_Triel_ResetParams
- *****************/
-
 int IBM_Triel_ResetParams(const int bond_type, const double k1,
                           const double l0) {
 
@@ -294,10 +285,6 @@ int IBM_Triel_ResetParams(const int bond_type, const double k1,
 
   return ES_OK;
 }
-
-/***********
-   IBM_Triel_SetParams
-************/
 
 int IBM_Triel_SetParams(const int bond_type, const int ind1, const int ind2,
                         const int ind3, const double maxDist,

--- a/src/core/immersed_boundary/ibm_triel.hpp
+++ b/src/core/immersed_boundary/ibm_triel.hpp
@@ -36,6 +36,6 @@ int IBM_Triel_ResetParams(int bond_type, double k1, double l0);
 
 // This function calculates and adds the actual force
 int IBM_Triel_CalcForce(Particle *p1, Particle *p2, Particle *p3,
-                        Bonded_ia_parameters *iaparams);
+                        Bonded_ia_parameters const *iaparams);
 
 #endif

--- a/src/core/immersed_boundary/ibm_triel.hpp
+++ b/src/core/immersed_boundary/ibm_triel.hpp
@@ -34,7 +34,9 @@ int IBM_Triel_SetParams(int bond_type, int ind1, int ind2, int ind3,
 //       * only pass two values here to check consistency
 int IBM_Triel_ResetParams(int bond_type, double k1, double l0);
 
-// This function calculates and adds the actual force
+/** Calculate the forces
+ *  @retval 0
+ */
 int IBM_Triel_CalcForce(Particle *p1, Particle *p2, Particle *p3,
                         Bonded_ia_parameters const *iaparams);
 

--- a/src/core/nonbonded_interactions/bmhtf-nacl.hpp
+++ b/src/core/nonbonded_interactions/bmhtf-nacl.hpp
@@ -38,24 +38,24 @@ int BMHTF_set_params(int part_type_a, int part_type_b, double A, double B,
 /** Calculate smooth step force between particle p1 and p2 */
 inline void add_BMHTF_pair_force(const Particle *const p1,
                                  const Particle *const p2,
-                                 IA_parameters *ia_params, double const d[3],
-                                 double dist, double dist2, double force[3]) {
+                                 IA_parameters *ia_params,
+                                 Utils::Vector3d const &d, double dist,
+                                 double dist2, Utils::Vector3d &force) {
   if (dist < ia_params->BMHTF_cut) {
     auto const pw8 = dist2 * dist2 * dist2 * dist2;
     auto const fac =
         ia_params->BMHTF_A * ia_params->BMHTF_B *
             exp(ia_params->BMHTF_B * (ia_params->BMHTF_sig - dist)) / dist -
         6 * ia_params->BMHTF_C / pw8 - 8 * ia_params->BMHTF_D / pw8 / dist2;
-
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 
 /** Calculate smooth step potential energy between particle p1 and p2. */
 inline double BMHTF_pair_energy(const Particle *p1, const Particle *p2,
                                 const IA_parameters *ia_params,
-                                const double d[3], double dist, double dist2) {
+                                Utils::Vector3d const &d, double dist,
+                                double dist2) {
   if (dist < ia_params->BMHTF_cut) {
     auto const pw6 = dist2 * dist2 * dist2;
     return ia_params->BMHTF_A *

--- a/src/core/nonbonded_interactions/bmhtf-nacl.hpp
+++ b/src/core/nonbonded_interactions/bmhtf-nacl.hpp
@@ -36,9 +36,9 @@ int BMHTF_set_params(int part_type_a, int part_type_b, double A, double B,
                      double C, double D, double sig, double cut);
 
 /** Calculate smooth step force between particle p1 and p2 */
-inline void add_BMHTF_pair_force(const Particle *const p1,
-                                 const Particle *const p2,
-                                 IA_parameters *ia_params,
+inline void add_BMHTF_pair_force(Particle const *const p1,
+                                 Particle const *const p2,
+                                 IA_parameters const *const ia_params,
                                  Utils::Vector3d const &d, double dist,
                                  double dist2, Utils::Vector3d &force) {
   if (dist < ia_params->BMHTF_cut) {
@@ -52,8 +52,9 @@ inline void add_BMHTF_pair_force(const Particle *const p1,
 }
 
 /** Calculate smooth step potential energy between particle p1 and p2. */
-inline double BMHTF_pair_energy(const Particle *p1, const Particle *p2,
-                                const IA_parameters *ia_params,
+inline double BMHTF_pair_energy(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist,
                                 double dist2) {
   if (dist < ia_params->BMHTF_cut) {

--- a/src/core/nonbonded_interactions/bmhtf-nacl.hpp
+++ b/src/core/nonbonded_interactions/bmhtf-nacl.hpp
@@ -35,7 +35,7 @@
 int BMHTF_set_params(int part_type_a, int part_type_b, double A, double B,
                      double C, double D, double sig, double cut);
 
-/** Calculate smooth step force between particle p1 and p2 */
+/** Calculate BMHTF force between particle p1 and p2 */
 inline void add_BMHTF_pair_force(Particle const *const p1,
                                  Particle const *const p2,
                                  IA_parameters const *const ia_params,
@@ -51,7 +51,7 @@ inline void add_BMHTF_pair_force(Particle const *const p1,
   }
 }
 
-/** Calculate smooth step potential energy between particle p1 and p2. */
+/** Calculate BMHTF potential energy between particles p1 and p2. */
 inline double BMHTF_pair_energy(Particle const *const p1,
                                 Particle const *const p2,
                                 IA_parameters const *const ia_params,

--- a/src/core/nonbonded_interactions/buckingham.hpp
+++ b/src/core/nonbonded_interactions/buckingham.hpp
@@ -53,8 +53,9 @@ inline double buck_energy_r(double A, double B, double C, double D,
     it to their force. */
 inline void add_buck_pair_force(const Particle *const p1,
                                 const Particle *const p2,
-                                IA_parameters *ia_params, double const d[3],
-                                double dist, double force[3]) {
+                                IA_parameters *ia_params,
+                                Utils::Vector3d const &d, double dist,
+                                Utils::Vector3d &force) {
   if (dist < ia_params->BUCK_cut) {
     /* case: resulting force/energy greater than discontinuity and
              less than cutoff (true Buckingham region) */
@@ -63,9 +64,7 @@ inline void add_buck_pair_force(const Particle *const p1,
       fac = buck_force_r(ia_params->BUCK_A, ia_params->BUCK_B,
                          ia_params->BUCK_C, ia_params->BUCK_D, dist) /
             dist;
-      for (int j = 0; j < 3; j++) {
-        force[j] += fac * d[j];
-      }
+      force += fac * d;
 #ifdef LJ_WARN_WHEN_CLOSE
       if (fac * dist > 1000)
         fprintf(stderr, "%d: BUCK-Warning: Pair (%d-%d) force=%f dist=%f\n",
@@ -74,9 +73,7 @@ inline void add_buck_pair_force(const Particle *const p1,
     } else {
       /* resulting force/energy in the linear region*/
       fac = -ia_params->BUCK_F2 / dist;
-      for (int j = 0; j < 3; j++) {
-        force[j] += fac * d[j];
-      }
+      force += fac * d;
     }
 
     ONEPART_TRACE(if (p1->p.identity == check_id)
@@ -102,7 +99,7 @@ inline void add_buck_pair_force(const Particle *const p1,
 /** calculate Buckingham energy between particle p1 and p2. */
 inline double buck_pair_energy(const Particle *p1, const Particle *p2,
                                const IA_parameters *ia_params,
-                               const double d[3], double dist) {
+                               Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->BUCK_cut) {
     /* case: resulting force/energy greater than discont and
              less than cutoff (true Buckingham region) */

--- a/src/core/nonbonded_interactions/buckingham.hpp
+++ b/src/core/nonbonded_interactions/buckingham.hpp
@@ -51,9 +51,9 @@ inline double buck_energy_r(double A, double B, double C, double D,
 
 /** Calculate Buckingham force between particle p1 and p2 and add
     it to their force. */
-inline void add_buck_pair_force(const Particle *const p1,
-                                const Particle *const p2,
-                                IA_parameters *ia_params,
+inline void add_buck_pair_force(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist,
                                 Utils::Vector3d &force) {
   if (dist < ia_params->BUCK_cut) {
@@ -97,8 +97,9 @@ inline void add_buck_pair_force(const Particle *const p1,
 }
 
 /** calculate Buckingham energy between particle p1 and p2. */
-inline double buck_pair_energy(const Particle *p1, const Particle *p2,
-                               const IA_parameters *ia_params,
+inline double buck_pair_energy(Particle const *const p1,
+                               Particle const *const p2,
+                               IA_parameters const *const ia_params,
                                Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->BUCK_cut) {
     /* case: resulting force/energy greater than discont and

--- a/src/core/nonbonded_interactions/gaussian.hpp
+++ b/src/core/nonbonded_interactions/gaussian.hpp
@@ -36,9 +36,9 @@ int gaussian_set_params(int part_type_a, int part_type_b, double eps,
                         double sig, double cut);
 
 /** Calculate Gaussian force between particle p1 and p2. */
-inline void add_gaussian_pair_force(const Particle *const p1,
-                                    const Particle *const p2,
-                                    IA_parameters *ia_params,
+inline void add_gaussian_pair_force(Particle const *const p1,
+                                    Particle const *const p2,
+                                    IA_parameters const *const ia_params,
                                     Utils::Vector3d const &d, double dist,
                                     double dist2, Utils::Vector3d &force) {
   if (dist < ia_params->Gaussian_cut) {
@@ -49,8 +49,9 @@ inline void add_gaussian_pair_force(const Particle *const p1,
 }
 
 /** Calculate Gaussian energy between particle p1 and p2. */
-inline double gaussian_pair_energy(const Particle *p1, const Particle *p2,
-                                   const IA_parameters *ia_params,
+inline double gaussian_pair_energy(Particle const *const p1,
+                                   Particle const *const p2,
+                                   IA_parameters const *const ia_params,
                                    Utils::Vector3d const &d, double dist,
                                    double dist2) {
   if (dist < ia_params->Gaussian_cut) {

--- a/src/core/nonbonded_interactions/gaussian.hpp
+++ b/src/core/nonbonded_interactions/gaussian.hpp
@@ -38,22 +38,20 @@ int gaussian_set_params(int part_type_a, int part_type_b, double eps,
 /** Calculate Gaussian force between particle p1 and p2. */
 inline void add_gaussian_pair_force(const Particle *const p1,
                                     const Particle *const p2,
-                                    IA_parameters *ia_params, double const d[3],
-                                    double dist, double dist2,
-                                    double force[3]) {
+                                    IA_parameters *ia_params,
+                                    Utils::Vector3d const &d, double dist,
+                                    double dist2, Utils::Vector3d &force) {
   if (dist < ia_params->Gaussian_cut) {
     auto const fac = ia_params->Gaussian_eps / pow(ia_params->Gaussian_sig, 2) *
                      exp(-0.5 * Utils::sqr(dist / ia_params->Gaussian_sig));
-
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 
 /** Calculate Gaussian energy between particle p1 and p2. */
 inline double gaussian_pair_energy(const Particle *p1, const Particle *p2,
                                    const IA_parameters *ia_params,
-                                   const double d[3], double dist,
+                                   Utils::Vector3d const &d, double dist,
                                    double dist2) {
   if (dist < ia_params->Gaussian_cut) {
     return ia_params->Gaussian_eps *

--- a/src/core/nonbonded_interactions/gb.hpp
+++ b/src/core/nonbonded_interactions/gb.hpp
@@ -40,9 +40,11 @@ int gay_berne_set_params(int part_type_a, int part_type_b, double eps,
 
 inline void add_gb_pair_force(const Particle *const p1,
                               const Particle *const p2,
-                              IA_parameters *ia_params, double const d[3],
-                              double dist, double force[3], double torque1[3],
-                              double torque2[3]) {
+                              IA_parameters *ia_params,
+                              Utils::Vector3d const &d, double dist,
+                              Utils::Vector3d &force,
+                              Utils::Vector3d *const torque1,
+                              Utils::Vector3d *const torque2) {
   using Utils::int_pow;
   using Utils::sqr;
 
@@ -50,16 +52,11 @@ inline void add_gb_pair_force(const Particle *const p1,
     return;
   }
 
-  auto const u1x = p1->r.calc_director()[0];
-  auto const u1y = p1->r.calc_director()[1];
-  auto const u1z = p1->r.calc_director()[2];
-  auto const u2x = p2->r.calc_director()[0];
-  auto const u2y = p2->r.calc_director()[1];
-  auto const u2z = p2->r.calc_director()[2];
-
-  auto const a = d[0] * u1x + d[1] * u1y + d[2] * u1z;
-  auto const b = d[0] * u2x + d[1] * u2y + d[2] * u2z;
-  auto const c = u1x * u2x + u1y * u2y + u1z * u2z;
+  auto const u1 = p1->r.calc_director();
+  auto const u2 = p2->r.calc_director();
+  auto const a = d * u1;
+  auto const b = d * u2;
+  auto const c = u1 * u2;
   auto const E1 = 1 / sqrt(1 - ia_params->GB_chi1 * ia_params->GB_chi1 * c * c);
   auto const Plus1 = (a + b) / (1 + ia_params->GB_chi1 * c);
   auto const Plus2 = (a + b) / (1 + ia_params->GB_chi2 * c);
@@ -115,49 +112,28 @@ inline void add_gb_pair_force(const Particle *const p1,
 
     /*--------------------------------------------------------------------*/
 
-    auto const FikX = -dU_dr * d[0] - dU_da * u1x - dU_db * u2x;
-    auto const FikY = -dU_dr * d[1] - dU_da * u1y - dU_db * u2y;
-    auto const FikZ = -dU_dr * d[2] - dU_da * u1z - dU_db * u2z;
-
-    force[0] += FikX;
-    force[1] += FikY;
-    force[2] += FikZ;
+    force -= dU_dr * d + dU_da * u1 + dU_db * u2;
 
     if (torque1 != nullptr) {
       /* calculate torque:  torque = u_1 x G   */
-
-      auto Gx = -dU_da * d[0] - dU_dc * u2x;
-      auto Gy = -dU_da * d[1] - dU_dc * u2y;
-      auto Gz = -dU_da * d[2] - dU_dc * u2z;
-
-      torque1[0] += u1y * Gz - u1z * Gy;
-      torque1[1] += u1z * Gx - u1x * Gz;
-      torque1[2] += u1x * Gy - u1y * Gx;
+      auto const G2 = -dU_da * d - dU_dc * u2;
+      *torque1 += vector_product(u1, G2);
 
       if (torque2 != nullptr) {
         /* calculate torque:  torque = u_2 x G     */
-
-        Gx = -dU_db * d[0] - dU_dc * u1x;
-        Gy = -dU_db * d[1] - dU_dc * u1y;
-        Gz = -dU_db * d[2] - dU_dc * u1z;
-
-        torque2[0] += u2y * Gz - u2z * Gy;
-        torque2[1] += u2z * Gx - u2x * Gz;
-        torque2[2] += u2x * Gy - u2y * Gx;
+        auto const G1 = -dU_db * d - dU_dc * u1;
+        *torque2 += vector_product(u2, G1);
       }
     }
   } else { /* the particles are too close to each other */
     Koef1 = 100;
-
-    force[0] += Koef1 * d[0];
-    force[1] += Koef1 * d[1];
-    force[2] += Koef1 * d[2];
+    force += Koef1 * d;
   }
 }
 
 inline double gb_pair_energy(const Particle *p1, const Particle *p2,
-                             const IA_parameters *ia_params, const double d[3],
-                             double dist) {
+                             const IA_parameters *ia_params,
+                             Utils::Vector3d const &d, double dist) {
   using Utils::int_pow;
   using Utils::sqr;
 

--- a/src/core/nonbonded_interactions/gb.hpp
+++ b/src/core/nonbonded_interactions/gb.hpp
@@ -38,9 +38,9 @@ int gay_berne_set_params(int part_type_a, int part_type_b, double eps,
                          double sig, double cut, double k1, double k2,
                          double mu, double nu);
 
-inline void add_gb_pair_force(const Particle *const p1,
-                              const Particle *const p2,
-                              IA_parameters *ia_params,
+inline void add_gb_pair_force(Particle const *const p1,
+                              Particle const *const p2,
+                              IA_parameters const *const ia_params,
                               Utils::Vector3d const &d, double dist,
                               Utils::Vector3d &force,
                               Utils::Vector3d *const torque1,
@@ -131,8 +131,8 @@ inline void add_gb_pair_force(const Particle *const p1,
   }
 }
 
-inline double gb_pair_energy(const Particle *p1, const Particle *p2,
-                             const IA_parameters *ia_params,
+inline double gb_pair_energy(Particle const *const p1, Particle const *const p2,
+                             IA_parameters const *const ia_params,
                              Utils::Vector3d const &d, double dist) {
   using Utils::int_pow;
   using Utils::sqr;

--- a/src/core/nonbonded_interactions/hat.hpp
+++ b/src/core/nonbonded_interactions/hat.hpp
@@ -54,20 +54,20 @@ inline double hat_energy_r(double Fmax, double r, double dist) {
 /** Calculate hat potential force between particle p1 and p2. */
 inline void add_hat_pair_force(const Particle *const p1,
                                const Particle *const p2,
-                               IA_parameters *ia_params, double const d[3],
-                               double dist, double force[3]) {
+                               IA_parameters *ia_params,
+                               Utils::Vector3d const &d, double dist,
+                               Utils::Vector3d &force) {
   if (dist > 0. && dist < ia_params->HAT_r) {
     auto const fac =
         hat_force_r(ia_params->HAT_Fmax, ia_params->HAT_r, dist) / dist;
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 
 /** Calculate hat energy between particle p1 and p2. */
 inline double hat_pair_energy(const Particle *p1, const Particle *p2,
-                              const IA_parameters *ia_params, const double d[3],
-                              double dist) {
+                              const IA_parameters *ia_params,
+                              Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->HAT_r) {
     return hat_energy_r(ia_params->HAT_Fmax, ia_params->HAT_r, dist);
   }

--- a/src/core/nonbonded_interactions/hat.hpp
+++ b/src/core/nonbonded_interactions/hat.hpp
@@ -52,9 +52,9 @@ inline double hat_energy_r(double Fmax, double r, double dist) {
 }
 
 /** Calculate hat potential force between particle p1 and p2. */
-inline void add_hat_pair_force(const Particle *const p1,
-                               const Particle *const p2,
-                               IA_parameters *ia_params,
+inline void add_hat_pair_force(Particle const *const p1,
+                               Particle const *const p2,
+                               IA_parameters const *const ia_params,
                                Utils::Vector3d const &d, double dist,
                                Utils::Vector3d &force) {
   if (dist > 0. && dist < ia_params->HAT_r) {
@@ -65,8 +65,9 @@ inline void add_hat_pair_force(const Particle *const p1,
 }
 
 /** Calculate hat energy between particle p1 and p2. */
-inline double hat_pair_energy(const Particle *p1, const Particle *p2,
-                              const IA_parameters *ia_params,
+inline double hat_pair_energy(Particle const *const p1,
+                              Particle const *const p2,
+                              IA_parameters const *const ia_params,
                               Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->HAT_r) {
     return hat_energy_r(ia_params->HAT_Fmax, ia_params->HAT_r, dist);

--- a/src/core/nonbonded_interactions/hertzian.hpp
+++ b/src/core/nonbonded_interactions/hertzian.hpp
@@ -38,23 +38,21 @@ int hertzian_set_params(int part_type_a, int part_type_b, double eps,
 /** Calculate Hertzian force between particle p1 and p2 */
 inline void add_hertzian_pair_force(const Particle *const p1,
                                     Particle const *const p2,
-                                    IA_parameters *ia_params, double const d[3],
-                                    double dist, double dist2,
-                                    double force[3]) {
+                                    IA_parameters *ia_params,
+                                    Utils::Vector3d const &d, double dist,
+                                    double dist2, Utils::Vector3d &force) {
   if (dist < ia_params->Hertzian_sig) {
     auto const fac = 5. / 2. * ia_params->Hertzian_eps /
                      ia_params->Hertzian_sig *
                      pow(1 - dist / ia_params->Hertzian_sig, 3. / 2.) / dist;
-
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 
 /** Calculate Hertzian energy between particle p1 and p2. */
 inline double hertzian_pair_energy(const Particle *p1, const Particle *p2,
                                    const IA_parameters *ia_params,
-                                   const double d[3], double dist,
+                                   Utils::Vector3d const &d, double dist,
                                    double dist2) {
   if (dist < ia_params->Hertzian_sig) {
     return ia_params->Hertzian_eps *

--- a/src/core/nonbonded_interactions/hertzian.hpp
+++ b/src/core/nonbonded_interactions/hertzian.hpp
@@ -36,9 +36,9 @@ int hertzian_set_params(int part_type_a, int part_type_b, double eps,
                         double sig);
 
 /** Calculate Hertzian force between particle p1 and p2 */
-inline void add_hertzian_pair_force(const Particle *const p1,
+inline void add_hertzian_pair_force(Particle const *const p1,
                                     Particle const *const p2,
-                                    IA_parameters *ia_params,
+                                    IA_parameters const *const ia_params,
                                     Utils::Vector3d const &d, double dist,
                                     double dist2, Utils::Vector3d &force) {
   if (dist < ia_params->Hertzian_sig) {
@@ -50,8 +50,9 @@ inline void add_hertzian_pair_force(const Particle *const p1,
 }
 
 /** Calculate Hertzian energy between particle p1 and p2. */
-inline double hertzian_pair_energy(const Particle *p1, const Particle *p2,
-                                   const IA_parameters *ia_params,
+inline double hertzian_pair_energy(Particle const *const p1,
+                                   Particle const *const p2,
+                                   IA_parameters const *const ia_params,
                                    Utils::Vector3d const &d, double dist,
                                    double dist2) {
   if (dist < ia_params->Hertzian_sig) {

--- a/src/core/nonbonded_interactions/lj.hpp
+++ b/src/core/nonbonded_interactions/lj.hpp
@@ -42,7 +42,7 @@ int lennard_jones_set_params(int part_type_a, int part_type_b, double eps,
                              double offset, double min);
 
 /** Calculate Lennard-Jones force between particle p1 and p2 */
-inline void add_lj_pair_force(IA_parameters *ia_params,
+inline void add_lj_pair_force(IA_parameters const *ia_params,
                               Utils::Vector3d const &d, double dist,
                               Utils::Vector3d &force) {
   if ((dist < ia_params->LJ_cut + ia_params->LJ_offset) &&
@@ -56,7 +56,7 @@ inline void add_lj_pair_force(IA_parameters *ia_params,
 }
 
 /** Calculate Lennard-Jones energy between particle p1 and p2. */
-inline double lj_pair_energy(const IA_parameters *ia_params, double dist) {
+inline double lj_pair_energy(IA_parameters const *ia_params, double dist) {
   if ((dist < ia_params->LJ_cut + ia_params->LJ_offset) &&
       (dist > ia_params->LJ_min + ia_params->LJ_offset)) {
     auto const r_off = dist - ia_params->LJ_offset;

--- a/src/core/nonbonded_interactions/lj.hpp
+++ b/src/core/nonbonded_interactions/lj.hpp
@@ -42,16 +42,16 @@ int lennard_jones_set_params(int part_type_a, int part_type_b, double eps,
                              double offset, double min);
 
 /** Calculate Lennard-Jones force between particle p1 and p2 */
-inline void add_lj_pair_force(IA_parameters *ia_params, const double d[3],
-                              double dist, double force[3]) {
+inline void add_lj_pair_force(IA_parameters *ia_params,
+                              Utils::Vector3d const &d, double dist,
+                              Utils::Vector3d &force) {
   if ((dist < ia_params->LJ_cut + ia_params->LJ_offset) &&
       (dist > ia_params->LJ_min + ia_params->LJ_offset)) {
     auto const r_off = dist - ia_params->LJ_offset;
     auto const frac6 = Utils::int_pow<6>(ia_params->LJ_sig / r_off);
     auto const fac =
         48.0 * ia_params->LJ_eps * frac6 * (frac6 - 0.5) / (r_off * dist);
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 

--- a/src/core/nonbonded_interactions/ljcos.hpp
+++ b/src/core/nonbonded_interactions/ljcos.hpp
@@ -40,9 +40,9 @@
 int ljcos_set_params(int part_type_a, int part_type_b, double eps, double sig,
                      double cut, double offset);
 
-inline void add_ljcos_pair_force(const Particle *const p1,
-                                 const Particle *const p2,
-                                 IA_parameters *ia_params,
+inline void add_ljcos_pair_force(Particle const *const p1,
+                                 Particle const *const p2,
+                                 IA_parameters const *const ia_params,
                                  Utils::Vector3d const &d, double dist,
                                  Utils::Vector3d &force) {
   if ((dist < ia_params->LJCOS_cut + ia_params->LJCOS_offset)) {
@@ -71,8 +71,9 @@ inline void add_ljcos_pair_force(const Particle *const p1,
   }
 }
 
-inline double ljcos_pair_energy(const Particle *p1, const Particle *p2,
-                                const IA_parameters *ia_params,
+inline double ljcos_pair_energy(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->LJCOS_cut + ia_params->LJCOS_offset)) {
     auto const r_off = dist - ia_params->LJCOS_offset;

--- a/src/core/nonbonded_interactions/ljcos.hpp
+++ b/src/core/nonbonded_interactions/ljcos.hpp
@@ -42,8 +42,9 @@ int ljcos_set_params(int part_type_a, int part_type_b, double eps, double sig,
 
 inline void add_ljcos_pair_force(const Particle *const p1,
                                  const Particle *const p2,
-                                 IA_parameters *ia_params, double const d[3],
-                                 double dist, double force[3]) {
+                                 IA_parameters *ia_params,
+                                 Utils::Vector3d const &d, double dist,
+                                 Utils::Vector3d &force) {
   if ((dist < ia_params->LJCOS_cut + ia_params->LJCOS_offset)) {
     auto const r_off = dist - ia_params->LJCOS_offset;
     /* cos part of ljcos potential. */
@@ -52,17 +53,14 @@ inline void add_ljcos_pair_force(const Particle *const p1,
                        ia_params->LJCOS_eps *
                        (sin(ia_params->LJCOS_alfa * Utils::sqr(r_off) +
                             ia_params->LJCOS_beta));
-      for (int j = 0; j < 3; j++)
-        force[j] += fac * d[j];
+      force += fac * d;
     }
     /* Lennard-Jones part of the potential. */
     else if (dist > 0) {
       auto const frac6 = Utils::int_pow<6>(ia_params->LJCOS_sig / r_off);
       auto const fac =
           48.0 * ia_params->LJCOS_eps * frac6 * (frac6 - 0.5) / (r_off * dist);
-
-      for (int j = 0; j < 3; j++)
-        force[j] += fac * d[j];
+      force += fac * d;
 
 #ifdef LJ_WARN_WHEN_CLOSE
       if (fac * dist > 1000)
@@ -75,7 +73,7 @@ inline void add_ljcos_pair_force(const Particle *const p1,
 
 inline double ljcos_pair_energy(const Particle *p1, const Particle *p2,
                                 const IA_parameters *ia_params,
-                                const double d[3], double dist) {
+                                Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->LJCOS_cut + ia_params->LJCOS_offset)) {
     auto const r_off = dist - ia_params->LJCOS_offset;
     /* Lennard-Jones part of the potential. */

--- a/src/core/nonbonded_interactions/ljcos2.hpp
+++ b/src/core/nonbonded_interactions/ljcos2.hpp
@@ -45,9 +45,9 @@ int ljcos2_set_params(int part_type_a, int part_type_b, double eps, double sig,
                       double offset, double w);
 
 /** Calculate lj-cos2 force between particle p1 and p2. */
-inline void add_ljcos2_pair_force(const Particle *const p1,
-                                  const Particle *const p2,
-                                  IA_parameters *ia_params,
+inline void add_ljcos2_pair_force(Particle const *const p1,
+                                  Particle const *const p2,
+                                  IA_parameters const *const ia_params,
                                   Utils::Vector3d const &d, double dist,
                                   Utils::Vector3d &force) {
   if (dist < (ia_params->LJCOS2_cut + ia_params->LJCOS2_offset)) {
@@ -91,8 +91,9 @@ inline void add_ljcos2_pair_force(const Particle *const p1,
 }
 
 /** Calculate lj-cos2 energy between particle p1 and p2. */
-inline double ljcos2_pair_energy(const Particle *p1, const Particle *p2,
-                                 const IA_parameters *ia_params,
+inline double ljcos2_pair_energy(Particle const *const p1,
+                                 Particle const *const p2,
+                                 IA_parameters const *const ia_params,
                                  Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->LJCOS2_cut + ia_params->LJCOS2_offset)) {
     auto const r_off = dist - ia_params->LJCOS2_offset;

--- a/src/core/nonbonded_interactions/ljcos2.hpp
+++ b/src/core/nonbonded_interactions/ljcos2.hpp
@@ -85,8 +85,8 @@ inline void add_ljcos2_pair_force(Particle const *const p1,
 
     LJ_TRACE(fprintf(
         stderr, "%d: LJ: Pair (%d-%d) dist=%.3f: force+-: (%.3e,%.3e,%.3e)\n",
-        this_node, p1->p.identity, p2->p.identity, dist, fac * d[0], fac * d[1],
-        fac * d[2]));
+        this_node, p1->p.identity, p2->p.identity, dist, force[0], force[1],
+        force[2]));
   }
 }
 

--- a/src/core/nonbonded_interactions/ljcos2.hpp
+++ b/src/core/nonbonded_interactions/ljcos2.hpp
@@ -47,8 +47,9 @@ int ljcos2_set_params(int part_type_a, int part_type_b, double eps, double sig,
 /** Calculate lj-cos2 force between particle p1 and p2. */
 inline void add_ljcos2_pair_force(const Particle *const p1,
                                   const Particle *const p2,
-                                  IA_parameters *ia_params, double const d[3],
-                                  double dist, double force[3]) {
+                                  IA_parameters *ia_params,
+                                  Utils::Vector3d const &d, double dist,
+                                  Utils::Vector3d &force) {
   if (dist < (ia_params->LJCOS2_cut + ia_params->LJCOS2_offset)) {
     auto const r_off = dist - ia_params->LJCOS2_offset;
     auto fac = 0.0;
@@ -61,9 +62,7 @@ inline void add_ljcos2_pair_force(const Particle *const p1,
           -ia_params->LJCOS2_eps * M_PI / 2 / ia_params->LJCOS2_w / dist *
           sin(M_PI * (r_off - ia_params->LJCOS2_rchange) / ia_params->LJCOS2_w);
     }
-
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
 
 #ifdef LJ_WARN_WHEN_CLOSE
     if (fac * dist > 1000)
@@ -94,7 +93,7 @@ inline void add_ljcos2_pair_force(const Particle *const p1,
 /** Calculate lj-cos2 energy between particle p1 and p2. */
 inline double ljcos2_pair_energy(const Particle *p1, const Particle *p2,
                                  const IA_parameters *ia_params,
-                                 const double d[3], double dist) {
+                                 Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->LJCOS2_cut + ia_params->LJCOS2_offset)) {
     auto const r_off = dist - ia_params->LJCOS2_offset;
     if (r_off < ia_params->LJCOS2_rchange) {

--- a/src/core/nonbonded_interactions/ljgen.hpp
+++ b/src/core/nonbonded_interactions/ljgen.hpp
@@ -105,8 +105,8 @@ inline void add_ljgen_pair_force(Particle const *const p1,
     LJ_TRACE(fprintf(
         stderr,
         "%d: LJGEN: Pair (%d-%d) dist=%.3f: force+-: (%.3e,%.3e,%.3e)\n",
-        this_node, p1->p.identity, p2->p.identity, dist, fac * d[0], fac * d[1],
-        fac * d[2]));
+        this_node, p1->p.identity, p2->p.identity, dist, force[0], force[1],
+        force[2]));
   }
 }
 

--- a/src/core/nonbonded_interactions/ljgen.hpp
+++ b/src/core/nonbonded_interactions/ljgen.hpp
@@ -55,9 +55,9 @@ int ljgen_set_params(int part_type_a, int part_type_b, double eps, double sig,
 );
 
 /** Calculate Lennard-Jones force between particle p1 and p2 */
-inline void add_ljgen_pair_force(const Particle *const p1,
-                                 const Particle *const p2,
-                                 IA_parameters *ia_params,
+inline void add_ljgen_pair_force(Particle const *const p1,
+                                 Particle const *const p2,
+                                 IA_parameters const *const ia_params,
                                  Utils::Vector3d const &d, double dist,
                                  Utils::Vector3d &force) {
   if (dist < (ia_params->LJGEN_cut + ia_params->LJGEN_offset)) {
@@ -111,8 +111,9 @@ inline void add_ljgen_pair_force(const Particle *const p1,
 }
 
 /** Calculate Lennard-Jones energy between particle p1 and p2. */
-inline double ljgen_pair_energy(const Particle *p1, const Particle *p2,
-                                const IA_parameters *ia_params,
+inline double ljgen_pair_energy(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->LJGEN_cut + ia_params->LJGEN_offset)) {
     auto r_off = dist - ia_params->LJGEN_offset;

--- a/src/core/nonbonded_interactions/ljgen.hpp
+++ b/src/core/nonbonded_interactions/ljgen.hpp
@@ -57,8 +57,9 @@ int ljgen_set_params(int part_type_a, int part_type_b, double eps, double sig,
 /** Calculate Lennard-Jones force between particle p1 and p2 */
 inline void add_ljgen_pair_force(const Particle *const p1,
                                  const Particle *const p2,
-                                 IA_parameters *ia_params, double const d[3],
-                                 double dist, double force[3]) {
+                                 IA_parameters *ia_params,
+                                 Utils::Vector3d const &d, double dist,
+                                 Utils::Vector3d &force) {
   if (dist < (ia_params->LJGEN_cut + ia_params->LJGEN_offset)) {
     auto r_off = dist - ia_params->LJGEN_offset;
 
@@ -81,8 +82,7 @@ inline void add_ljgen_pair_force(const Particle *const p1,
                         ia_params->LJGEN_b2 * ia_params->LJGEN_a2 *
                             pow(frac, ia_params->LJGEN_a2)) /
                      (r_off * dist);
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
 
 #ifdef LJ_WARN_WHEN_CLOSE
     if (fac * dist > 1000)
@@ -113,7 +113,7 @@ inline void add_ljgen_pair_force(const Particle *const p1,
 /** Calculate Lennard-Jones energy between particle p1 and p2. */
 inline double ljgen_pair_energy(const Particle *p1, const Particle *p2,
                                 const IA_parameters *ia_params,
-                                const double d[3], double dist) {
+                                Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->LJGEN_cut + ia_params->LJGEN_offset)) {
     auto r_off = dist - ia_params->LJGEN_offset;
 #ifdef LJGEN_SOFTCORE

--- a/src/core/nonbonded_interactions/morse.hpp
+++ b/src/core/nonbonded_interactions/morse.hpp
@@ -41,16 +41,16 @@ int morse_set_params(int part_type_a, int part_type_b, double eps, double alpha,
 /** Calculate Morse force between particle p1 and p2 */
 inline void add_morse_pair_force(const Particle *const p1,
                                  const Particle *const p2,
-                                 IA_parameters *ia_params, double const d[3],
-                                 double dist, double force[3]) {
+                                 IA_parameters *ia_params,
+                                 Utils::Vector3d const &d, double dist,
+                                 Utils::Vector3d &force) {
   if (dist < ia_params->MORSE_cut) {
     auto const add =
         exp(-ia_params->MORSE_alpha * (dist - ia_params->MORSE_rmin));
     double fac = -ia_params->MORSE_eps * 2.0 * ia_params->MORSE_alpha *
                  (add - Utils::sqr(add)) / dist;
+    force += fac * d;
 
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
 #ifdef MORSE_WARN_WHEN_CLOSE
     if (fac * dist > 1000)
       fprintf(stderr, "%d: Morse-Warning: Pair (%d-%d) force=%f dist=%f\n",
@@ -79,7 +79,7 @@ inline void add_morse_pair_force(const Particle *const p1,
 /** Calculate Morse energy between particle p1 and p2. */
 inline double morse_pair_energy(const Particle *p1, const Particle *p2,
                                 const IA_parameters *ia_params,
-                                const double d[3], double dist) {
+                                Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->MORSE_cut) {
     auto const add =
         exp(-ia_params->MORSE_alpha * (dist - ia_params->MORSE_rmin));

--- a/src/core/nonbonded_interactions/morse.hpp
+++ b/src/core/nonbonded_interactions/morse.hpp
@@ -39,9 +39,9 @@ int morse_set_params(int part_type_a, int part_type_b, double eps, double alpha,
                      double rmin, double cut);
 
 /** Calculate Morse force between particle p1 and p2 */
-inline void add_morse_pair_force(const Particle *const p1,
-                                 const Particle *const p2,
-                                 IA_parameters *ia_params,
+inline void add_morse_pair_force(Particle const *const p1,
+                                 Particle const *const p2,
+                                 IA_parameters const *const ia_params,
                                  Utils::Vector3d const &d, double dist,
                                  Utils::Vector3d &force) {
   if (dist < ia_params->MORSE_cut) {
@@ -77,8 +77,9 @@ inline void add_morse_pair_force(const Particle *const p1,
 }
 
 /** Calculate Morse energy between particle p1 and p2. */
-inline double morse_pair_energy(const Particle *p1, const Particle *p2,
-                                const IA_parameters *ia_params,
+inline double morse_pair_energy(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->MORSE_cut) {
     auto const add =

--- a/src/core/nonbonded_interactions/morse.hpp
+++ b/src/core/nonbonded_interactions/morse.hpp
@@ -71,8 +71,8 @@ inline void add_morse_pair_force(Particle const *const p1,
 
     MORSE_TRACE(fprintf(
         stderr, "%d: LJ: Pair (%d-%d) dist=%.3f: force+-: (%.3e,%.3e,%.3e)\n",
-        this_node, p1->p.identity, p2->p.identity, dist, fac * d[0], fac * d[1],
-        fac * d[2]));
+        this_node, p1->p.identity, p2->p.identity, dist, force[0], force[1],
+        force[2]));
   }
 }
 

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.hpp
@@ -348,7 +348,7 @@ void reset_ia_params();
 int interactions_sanity_checks();
 
 /** Check if a non bonded interaction is defined */
-inline bool checkIfInteraction(IA_parameters *data) {
+inline bool checkIfInteraction(IA_parameters const *const data) {
   return data->particlesInteract;
 }
 

--- a/src/core/nonbonded_interactions/nonbonded_tab.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_tab.hpp
@@ -56,20 +56,18 @@ int tabulated_set_params(int part_type_a, int part_type_b, double min,
 inline void add_tabulated_pair_force(const Particle *const p1,
                                      const Particle *const p2,
                                      IA_parameters const *ia_params,
-                                     double const d[3], double dist,
-                                     double force[3]) {
+                                     Utils::Vector3d const &d, double dist,
+                                     Utils::Vector3d &force) {
   if (dist < ia_params->TAB.cutoff()) {
     auto const fac = ia_params->TAB.force(dist) / dist;
-
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 
 /** Add a non-bonded pair energy by linear interpolation from a table. */
 inline double tabulated_pair_energy(Particle const *, Particle const *,
                                     IA_parameters const *ia_params,
-                                    const double d[3], double dist) {
+                                    Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->TAB.cutoff()) {
     return ia_params->TAB.energy(dist);
   }

--- a/src/core/nonbonded_interactions/nonbonded_tab.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_tab.hpp
@@ -53,9 +53,9 @@ int tabulated_set_params(int part_type_a, int part_type_b, double min,
                          std::vector<double> const &force);
 
 /** Add a non-bonded pair force by linear interpolation from a table. */
-inline void add_tabulated_pair_force(const Particle *const p1,
-                                     const Particle *const p2,
-                                     IA_parameters const *ia_params,
+inline void add_tabulated_pair_force(Particle const *const p1,
+                                     Particle const *const p2,
+                                     IA_parameters const *const ia_params,
                                      Utils::Vector3d const &d, double dist,
                                      Utils::Vector3d &force) {
   if (dist < ia_params->TAB.cutoff()) {
@@ -66,7 +66,7 @@ inline void add_tabulated_pair_force(const Particle *const p1,
 
 /** Add a non-bonded pair energy by linear interpolation from a table. */
 inline double tabulated_pair_energy(Particle const *, Particle const *,
-                                    IA_parameters const *ia_params,
+                                    IA_parameters const *const ia_params,
                                     Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->TAB.cutoff()) {
     return ia_params->TAB.energy(dist);

--- a/src/core/nonbonded_interactions/soft_sphere.hpp
+++ b/src/core/nonbonded_interactions/soft_sphere.hpp
@@ -53,9 +53,9 @@ inline double soft_energy_r(double a, double n, double r) {
 }
 
 /** Calculate soft-sphere potential force between particle p1 and p2 */
-inline void add_soft_pair_force(const Particle *const p1,
-                                const Particle *const p2,
-                                IA_parameters *ia_params,
+inline void add_soft_pair_force(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist,
                                 Utils::Vector3d &force) {
   double fac = 0.0;
@@ -90,8 +90,9 @@ inline void add_soft_pair_force(const Particle *const p1,
 }
 
 /** Calculate soft-sphere energy between particle p1 and p2. */
-inline double soft_pair_energy(const Particle *p1, const Particle *p2,
-                               const IA_parameters *ia_params,
+inline double soft_pair_energy(Particle const *const p1,
+                               Particle const *const p2,
+                               IA_parameters const *const ia_params,
                                Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->soft_cut + ia_params->soft_offset)) {
     auto const r_off = dist - ia_params->soft_offset;

--- a/src/core/nonbonded_interactions/soft_sphere.hpp
+++ b/src/core/nonbonded_interactions/soft_sphere.hpp
@@ -55,16 +55,16 @@ inline double soft_energy_r(double a, double n, double r) {
 /** Calculate soft-sphere potential force between particle p1 and p2 */
 inline void add_soft_pair_force(const Particle *const p1,
                                 const Particle *const p2,
-                                IA_parameters *ia_params, double const d[3],
-                                double dist, double force[3]) {
+                                IA_parameters *ia_params,
+                                Utils::Vector3d const &d, double dist,
+                                Utils::Vector3d &force) {
   double fac = 0.0;
   if (dist < (ia_params->soft_cut + ia_params->soft_offset)) {
     /* normal case: resulting force/energy smaller than zero. */
     auto const r_off = dist - ia_params->soft_offset;
     if (r_off > 0.0) {
       fac = soft_force_r(ia_params->soft_a, ia_params->soft_n, r_off) / dist;
-      for (int j = 0; j < 3; j++)
-        force[j] += fac * d[j];
+      force += fac * d;
 
 #ifdef LJ_WARN_WHEN_CLOSE
       if (fac * dist > 1000)
@@ -92,11 +92,10 @@ inline void add_soft_pair_force(const Particle *const p1,
 /** Calculate soft-sphere energy between particle p1 and p2. */
 inline double soft_pair_energy(const Particle *p1, const Particle *p2,
                                const IA_parameters *ia_params,
-                               const double d[3], double dist) {
+                               Utils::Vector3d const &d, double dist) {
   if (dist < (ia_params->soft_cut + ia_params->soft_offset)) {
     auto const r_off = dist - ia_params->soft_offset;
     /* normal case: resulting force/energy smaller than zero. */
-
     return soft_energy_r(ia_params->soft_a, ia_params->soft_n, r_off);
   }
   return 0.0;

--- a/src/core/nonbonded_interactions/steppot.hpp
+++ b/src/core/nonbonded_interactions/steppot.hpp
@@ -38,8 +38,9 @@ int smooth_step_set_params(int part_type_a, int part_type_b, double d, int n,
 /** Calculate smooth step force between particle p1 and p2 */
 inline void add_SmSt_pair_force(const Particle *const p1,
                                 const Particle *const p2,
-                                IA_parameters *ia_params, double const d[3],
-                                double dist, double dist2, double force[3]) {
+                                IA_parameters *ia_params,
+                                Utils::Vector3d const &d, double dist,
+                                double dist2, Utils::Vector3d &force) {
   if (dist >= ia_params->SmSt_cut) {
     return;
   }
@@ -51,15 +52,14 @@ inline void add_SmSt_pair_force(const Particle *const p1,
                                                     ia_params->SmSt_k0 * dist *
                                                     er / Utils::sqr(1.0 + er)) /
                    dist2;
-
-  for (int j = 0; j < 3; j++)
-    force[j] += fac * d[j];
+  force += fac * d;
 }
 
 /** Calculate smooth step energy between particle p1 and p2. */
 inline double SmSt_pair_energy(const Particle *p1, const Particle *p2,
                                const IA_parameters *ia_params,
-                               const double d[3], double dist, double dist2) {
+                               Utils::Vector3d const &d, double dist,
+                               double dist2) {
   if (dist >= ia_params->SmSt_cut) {
     return 0.0;
   }

--- a/src/core/nonbonded_interactions/steppot.hpp
+++ b/src/core/nonbonded_interactions/steppot.hpp
@@ -36,9 +36,9 @@ int smooth_step_set_params(int part_type_a, int part_type_b, double d, int n,
                            double eps, double k0, double sig, double cut);
 
 /** Calculate smooth step force between particle p1 and p2 */
-inline void add_SmSt_pair_force(const Particle *const p1,
-                                const Particle *const p2,
-                                IA_parameters *ia_params,
+inline void add_SmSt_pair_force(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist,
                                 double dist2, Utils::Vector3d &force) {
   if (dist >= ia_params->SmSt_cut) {
@@ -56,8 +56,9 @@ inline void add_SmSt_pair_force(const Particle *const p1,
 }
 
 /** Calculate smooth step energy between particle p1 and p2. */
-inline double SmSt_pair_energy(const Particle *p1, const Particle *p2,
-                               const IA_parameters *ia_params,
+inline double SmSt_pair_energy(Particle const *const p1,
+                               Particle const *const p2,
+                               IA_parameters const *const ia_params,
                                Utils::Vector3d const &d, double dist,
                                double dist2) {
   if (dist >= ia_params->SmSt_cut) {

--- a/src/core/nonbonded_interactions/thole.hpp
+++ b/src/core/nonbonded_interactions/thole.hpp
@@ -41,7 +41,8 @@ int thole_set_params(int part_type_a, int part_type_b, double scaling_coeff,
 inline void add_thole_pair_force(const Particle *const p1,
                                  const Particle *const p2,
                                  const IA_parameters *ia_params,
-                                 const double *d, double dist, double *force) {
+                                 Utils::Vector3d const &d, double dist,
+                                 Utils::Vector3d &force) {
   auto const thole_q1q2 = ia_params->THOLE_q1q2;
   auto const thole_s = ia_params->THOLE_scaling_coeff;
 
@@ -55,16 +56,13 @@ inline void add_thole_pair_force(const Particle *const p1,
     double sr = thole_s * dist;
     double dS_r = 0.5 * (2.0 - (exp(-sr) * (sr * (sr + 2.0) + 2.0)));
     auto const f = Coulomb::central_force(thole_q1q2 * (-1. + dS_r), d, dist);
-
-    force[0] += f[0];
-    force[1] += f[1];
-    force[2] += f[2];
+    force += f;
   }
 }
 
 inline double thole_pair_energy(const Particle *p1, const Particle *p2,
                                 const IA_parameters *ia_params,
-                                const double d[3], double dist) {
+                                Utils::Vector3d const &d, double dist) {
 
   auto const thole_s = ia_params->THOLE_scaling_coeff;
   auto const thole_q1q2 = ia_params->THOLE_q1q2;

--- a/src/core/nonbonded_interactions/thole.hpp
+++ b/src/core/nonbonded_interactions/thole.hpp
@@ -38,9 +38,9 @@
 int thole_set_params(int part_type_a, int part_type_b, double scaling_coeff,
                      double q1q2);
 
-inline void add_thole_pair_force(const Particle *const p1,
-                                 const Particle *const p2,
-                                 const IA_parameters *ia_params,
+inline void add_thole_pair_force(Particle const *const p1,
+                                 Particle const *const p2,
+                                 IA_parameters const *const ia_params,
                                  Utils::Vector3d const &d, double dist,
                                  Utils::Vector3d &force) {
   auto const thole_q1q2 = ia_params->THOLE_q1q2;
@@ -60,8 +60,9 @@ inline void add_thole_pair_force(const Particle *const p1,
   }
 }
 
-inline double thole_pair_energy(const Particle *p1, const Particle *p2,
-                                const IA_parameters *ia_params,
+inline double thole_pair_energy(Particle const *const p1,
+                                Particle const *const p2,
+                                IA_parameters const *const ia_params,
                                 Utils::Vector3d const &d, double dist) {
 
   auto const thole_s = ia_params->THOLE_scaling_coeff;

--- a/src/core/nonbonded_interactions/wca.hpp
+++ b/src/core/nonbonded_interactions/wca.hpp
@@ -37,9 +37,9 @@
 int wca_set_params(int part_type_a, int part_type_b, double eps, double sig);
 
 /** Calculate WCA force between particle p1 and p2 */
-inline void add_wca_pair_force(const Particle *const p1,
-                               const Particle *const p2,
-                               IA_parameters *ia_params,
+inline void add_wca_pair_force(Particle const *const p1,
+                               Particle const *const p2,
+                               IA_parameters const *const ia_params,
                                Utils::Vector3d const &d, double dist,
                                Utils::Vector3d &force) {
   if (dist < ia_params->WCA_cut) {
@@ -51,8 +51,9 @@ inline void add_wca_pair_force(const Particle *const p1,
 }
 
 /** Calculate WCA energy between particle p1 and p2. */
-inline double wca_pair_energy(const Particle *p1, const Particle *p2,
-                              const IA_parameters *ia_params,
+inline double wca_pair_energy(Particle const *const p1,
+                              Particle const *const p2,
+                              IA_parameters const *const ia_params,
                               Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->WCA_cut) {
     auto const frac6 = Utils::int_pow<6>(ia_params->WCA_sig / dist);

--- a/src/core/nonbonded_interactions/wca.hpp
+++ b/src/core/nonbonded_interactions/wca.hpp
@@ -39,21 +39,21 @@ int wca_set_params(int part_type_a, int part_type_b, double eps, double sig);
 /** Calculate WCA force between particle p1 and p2 */
 inline void add_wca_pair_force(const Particle *const p1,
                                const Particle *const p2,
-                               IA_parameters *ia_params, double const d[3],
-                               double dist, double force[3]) {
+                               IA_parameters *ia_params,
+                               Utils::Vector3d const &d, double dist,
+                               Utils::Vector3d &force) {
   if (dist < ia_params->WCA_cut) {
     auto const frac6 = Utils::int_pow<6>(ia_params->WCA_sig / dist);
     auto const fac =
         48.0 * ia_params->WCA_eps * frac6 * (frac6 - 0.5) / (dist * dist);
-    for (int j = 0; j < 3; j++)
-      force[j] += fac * d[j];
+    force += fac * d;
   }
 }
 
 /** Calculate WCA energy between particle p1 and p2. */
 inline double wca_pair_energy(const Particle *p1, const Particle *p2,
-                              const IA_parameters *ia_params, const double d[3],
-                              double dist) {
+                              const IA_parameters *ia_params,
+                              Utils::Vector3d const &d, double dist) {
   if (dist < ia_params->WCA_cut) {
     auto const frac6 = Utils::int_pow<6>(ia_params->WCA_sig / dist);
     return 4.0 * ia_params->WCA_eps * (Utils::sqr(frac6) - frac6 + .25);

--- a/src/core/object-in-fluid/affinity.hpp
+++ b/src/core/object-in-fluid/affinity.hpp
@@ -52,8 +52,9 @@ inline void add_affinity_pair_force(Particle *const p1, Particle *const p2,
   if (ia_params->affinity_type > 10) {
     aff_type_extracted = ia_params->affinity_type % 10;
     period_for_output = ia_params->affinity_type - aff_type_extracted;
-  } else
+  } else {
     aff_type_extracted = ia_params->affinity_type;
+  }
 
   auto const unfolded_pos =
       unfolded_position(p1->r.p, p1->l.i, box_geo.length());
@@ -90,8 +91,8 @@ inline void add_affinity_pair_force(Particle *const p1, Particle *const p2,
      *   no probability is involved
      *********************/
     double fac = 0.0;
-    if ((dist < ia_params->affinity_cut)) { // Checking whether I am inside the
-                                            // interaction cut-off radius.
+    if (dist < ia_params->affinity_cut) { // Checking whether I am inside the
+                                          // interaction cut-off radius.
       if (dist > 0.0) {
         // printf("bond_site: %f %f
         // %f\n",p1->p.bond_site[0],p1->p.bond_site[1],p1->p.bond_site[2]);
@@ -161,8 +162,8 @@ inline void add_affinity_pair_force(Particle *const p1, Particle *const p2,
      *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     double fac = 0.0;
-    if ((dist < ia_params->affinity_cut)) { // Checking whether I am inside the
-                                            // interaction cut-off radius.
+    if (dist < ia_params->affinity_cut) { // Checking whether I am inside the
+                                          // interaction cut-off radius.
       if (dist > 0.0) {
         // printf("bond_site: %f %f
         // %f\n",p1->p.bond_site[0],p1->p.bond_site[1],p1->p.bond_site[2]);
@@ -364,8 +365,8 @@ inline void add_affinity_pair_force(Particle *const p1, Particle *const p2,
      *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     double fac = 0.0;
-    if ((dist < ia_params->affinity_cut)) { // Checking whether I am inside the
-                                            // interaction cut-off radius.
+    if (dist < ia_params->affinity_cut) { // Checking whether I am inside the
+                                          // interaction cut-off radius.
       if (dist > 0.0) {
         // printf("bond_site: %f %f
         // %f\n",p1->p.bond_site[0],p1->p.bond_site[1],p1->p.bond_site[2]);
@@ -475,8 +476,8 @@ inline void add_affinity_pair_force(Particle *const p1, Particle *const p2,
      *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     double fac = 0.0;
-    if ((dist < ia_params->affinity_cut)) { // Checking whether I am inside the
-                                            // interaction cut-off radius.
+    if (dist < ia_params->affinity_cut) { // Checking whether I am inside the
+                                          // interaction cut-off radius.
       if (dist > 0.0) {
         // printf("bond_site: %f %f
         // %f\n",p1->p.bond_site[0],p1->p.bond_site[1],p1->p.bond_site[2]);
@@ -593,8 +594,8 @@ inline void add_affinity_pair_force(Particle *const p1, Particle *const p2,
      *   check, that bond length must not be greater that 0.8 cut_off
      *********************/
     double fac = 0.0;
-    if ((dist < ia_params->affinity_cut)) { // Checking whether I am inside the
-                                            // interaction cut-off radius.
+    if (dist < ia_params->affinity_cut) { // Checking whether I am inside the
+                                          // interaction cut-off radius.
       if (dist > 0.0) {
         // printf("bond_site: %f %f
         // %f\n",p1->p.bond_site[0],p1->p.bond_site[1],p1->p.bond_site[2]);

--- a/src/core/object-in-fluid/affinity.hpp
+++ b/src/core/object-in-fluid/affinity.hpp
@@ -39,8 +39,8 @@ int affinity_set_params(int part_type_a, int part_type_b, int afftype,
                         double maxBond, double cut);
 
 /** Calculate soft-sphere potential force between particle p1 and p2 */
-inline void add_affinity_pair_force(Particle *p1, Particle *p2,
-                                    IA_parameters *ia_params,
+inline void add_affinity_pair_force(Particle *const p1, Particle *const p2,
+                                    IA_parameters const *const ia_params,
                                     Utils::Vector3d const &d, double dist,
                                     Utils::Vector3d &force) {
 

--- a/src/core/object-in-fluid/membrane_collision.hpp
+++ b/src/core/object-in-fluid/membrane_collision.hpp
@@ -47,11 +47,9 @@ inline double sigmoid_force_r(double a, double n, double r) {
 }
 
 /** Calculate membrane-collision force between particle p1 and p2 */
-inline void add_membrane_collision_pair_force(const Particle *p1,
-                                              const Particle *p2,
-                                              IA_parameters *ia_params,
-                                              double d[3], double dist,
-                                              double force[3]) {
+inline void add_membrane_collision_pair_force(
+    const Particle *p1, const Particle *p2, IA_parameters *ia_params,
+    Utils::Vector3d const &d, double dist, Utils::Vector3d &force) {
   /************************
    *
    * Description of implementation:
@@ -69,43 +67,38 @@ inline void add_membrane_collision_pair_force(const Particle *p1,
    *
    *********************/
 
-  int j;
-  double r_off, fac = 0.0, product, angle, ndir;
-  Utils::Vector3d out1, out2, dir;
+  if (dist < (ia_params->membrane_cut + ia_params->membrane_offset)) {
 
-  if ((dist < ia_params->membrane_cut + ia_params->membrane_offset)) {
-
-    r_off = dist - ia_params->membrane_offset;
+    auto const r_off = dist - ia_params->membrane_offset;
     // offset needs to be checked for the unphysical case when r_off should be
     // negative
 
     if (r_off > 0.0) {
 
-      out1 = p1->p.out_direction;
-      out2 = p2->p.out_direction;
+      auto const out1 = p1->p.out_direction;
+      auto const out2 = p2->p.out_direction;
       // check whether out_direction was set
       if (fabs(out1[0]) + fabs(out1[1]) + fabs(out1[2]) + fabs(out2[0]) +
               fabs(out2[1]) + fabs(out2[2]) <
           SMALL_OIF_MEMBRANE_CUTOFF) {
-        throw std::runtime_error("out direction net set");
+        throw std::runtime_error("out direction not set");
       }
 
       // this is the direction in which the repulsive forces will be applied and
       // its norm
-      dir = out1 - out2;
-      ndir = dir.norm();
+      auto const dir = out1 - out2;
+      auto const ndir = dir.norm();
 
       // for very small angles the force should not be applied - these happen at
       // the crossing of the boundary and would result in oscillation
-      product = out1 * out2;
-      angle = acos(product);
+      auto const product = out1 * out2;
+      auto const angle = acos(product);
 
       if (fabs(angle) > SMALL_OIF_MEMBRANE_CUTOFF) {
-        fac = sigmoid_force_r(ia_params->membrane_a, ia_params->membrane_n,
-                              r_off) /
-              dist;
-        for (j = 0; j < 3; j++)
-          force[j] -= fac * dir[j] / ndir;
+        auto const fac = sigmoid_force_r(ia_params->membrane_a,
+                                         ia_params->membrane_n, r_off) /
+                         dist;
+        force -= (fac / ndir) * dir;
       }
     }
   }

--- a/src/core/object-in-fluid/membrane_collision.hpp
+++ b/src/core/object-in-fluid/membrane_collision.hpp
@@ -48,8 +48,9 @@ inline double sigmoid_force_r(double a, double n, double r) {
 
 /** Calculate membrane-collision force between particle p1 and p2 */
 inline void add_membrane_collision_pair_force(
-    const Particle *p1, const Particle *p2, IA_parameters *ia_params,
-    Utils::Vector3d const &d, double dist, Utils::Vector3d &force) {
+    Particle const *const p1, Particle const *const p2,
+    IA_parameters const *const ia_params, Utils::Vector3d const &d, double dist,
+    Utils::Vector3d &force) {
   /************************
    *
    * Description of implementation:

--- a/src/core/object-in-fluid/oif_local_forces.hpp
+++ b/src/core/object-in-fluid/oif_local_forces.hpp
@@ -31,7 +31,7 @@
 #include <utils/Vector.hpp>
 #include <utils/math/triangle_functions.hpp>
 
-// set parameters for local forces
+/** Set parameters for local forces */
 int oif_local_forces_set_params(int bond_type, double r0, double ks,
                                 double kslin, double phi0, double kb,
                                 double A01, double A02, double kal,
@@ -43,13 +43,13 @@ inline double KS(double lambda) { // Defined by (19) from Dupin2007
   return res;
 }
 
-/** Computes the local forces (Dupin2007) and adds them
+/** Compute the local forces (Dupin2007) and adds them
  *  to the particle forces.
  *  @param p1           %Particle of triangle 1.
  *  @param p2 , p3      Particles common to triangle 1 and triangle 2.
  *  @param p4           %Particle of triangle 2.
  *  @param iaparams     Bonded parameters for the OIF interaction.
- *  @param force        Force on @p p1.
+ *  @param force1       Force on @p p1.
  *  @param force2       Force on @p p2.
  *  @param force3       Force on @p p3.
  *  @param force4       Force on @p p4.
@@ -57,21 +57,19 @@ inline double KS(double lambda) { // Defined by (19) from Dupin2007
  */
 inline bool
 calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
-               Bonded_ia_parameters *iaparams, double force[3],
-               double force2[3], double force3[3],
-               double force4[3]) { // first-fold-then-the-same approach
+               Bonded_ia_parameters *iaparams, Utils::Vector3d &force1,
+               Utils::Vector3d &force2, Utils::Vector3d &force3,
+               Utils::Vector3d &force4) { // first-fold-then-the-same approach
 
   auto const fp2 = unfolded_position(p2->r.p, p2->l.i, box_geo.length());
   auto const fp1 = fp2 + get_mi_vector(p1->r.p, fp2, box_geo);
   auto const fp3 = fp2 + get_mi_vector(p3->r.p, fp2, box_geo);
   auto const fp4 = fp2 + get_mi_vector(p4->r.p, fp2, box_geo);
 
-  for (int i = 0; i < 3; i++) {
-    force[i] = 0;
-    force2[i] = 0;
-    force3[i] = 0;
-    force4[i] = 0;
-  }
+  force1 = {};
+  force2 = {};
+  force3 = {};
+  force4 = {};
 
   // non-linear stretching
   if (iaparams->p.oif_local_forces.ks > TINY_OIF_ELASTICITY_COEFFICIENT) {
@@ -81,10 +79,9 @@ calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
     auto const lambda = 1.0 * len / iaparams->p.oif_local_forces.r0;
     auto const fac =
         -iaparams->p.oif_local_forces.ks * KS(lambda) * dr; // no normalization
-    for (int i = 0; i < 3; i++) {
-      force2[i] += fac * dx[i] / len;
-      force3[i] += -fac * dx[i] / len;
-    }
+    auto const f = (fac / len) * dx;
+    force2 += f;
+    force3 -= f;
   }
 
   // linear stretching
@@ -94,11 +91,9 @@ calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
     auto const dr = len - iaparams->p.oif_local_forces.r0;
     auto const fac =
         -iaparams->p.oif_local_forces.kslin * dr; // no normalization
-
-    for (int i = 0; i < 3; i++) {
-      force2[i] += fac * dx[i] / len;
-      force3[i] += -fac * dx[i] / len;
-    }
+    auto const f = (fac / len) * dx;
+    force2 += f;
+    force3 -= f;
   }
 
   // viscous force
@@ -112,10 +107,8 @@ calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
     // Here the force is in the direction of relative velocity btw points
 
     // Code:
-    // for(int i=0;i<3;i++) {
-    // force2[i] += iaparams->p.oif_local_forces.kvisc*v[i];
-    // force3[i] -= iaparams->p.oif_local_forces.kvisc*v[i];
-    //}
+    // force2 += iaparams->p.oif_local_forces.kvisc * v;
+    // force3 -= iaparams->p.oif_local_forces.kvisc * v;
 
     // Variant B
     // Here the force is the projection of relative velocity btw points onto
@@ -135,11 +128,9 @@ calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
 
     // Code:
     auto const fac = iaparams->p.oif_local_forces.kvisc * (dx * v_ij) / len2;
-
-    for (int i = 0; i < 3; i++) {
-      force2[i] += fac * dx[i];
-      force3[i] -= fac * dx[i];
-    }
+    auto const f = fac * dx;
+    force2 += f;
+    force3 -= f;
   }
 
   /* bending
@@ -155,13 +146,12 @@ calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
                                .phi0); // no renormalization by phi0, to be
                                        // consistent with Krueger and Fedosov
     auto const fac = iaparams->p.oif_local_forces.kb * aa;
+    auto const f = 0.5 * fac * n1 + 0.5 * fac * n2;
 
-    for (int i = 0; i < 3; i++) {
-      force[i] += fac * n1[i];
-      force2[i] -= (0.5 * fac * n1[i] + 0.5 * fac * n2[i]);
-      force3[i] -= (0.5 * fac * n1[i] + 0.5 * fac * n2[i]);
-      force4[i] += fac * n2[i];
-    }
+    force1 += fac * n1;
+    force2 -= f;
+    force3 -= f;
+    force4 += fac * n2;
   }
 
   /* local area
@@ -179,8 +169,9 @@ calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
 
     auto handle_triangle = [](double kal, double A0, Utils::Vector3d const &fp1,
                               Utils::Vector3d const &fp2,
-                              Utils::Vector3d const &fp3, double force1[3],
-                              double force2[3], double force3[3]) {
+                              Utils::Vector3d const &fp3,
+                              Utils::Vector3d &force1, Utils::Vector3d &force2,
+                              Utils::Vector3d &force3) {
       auto const h = (1. / 3.) * (fp1 + fp2 + fp3);
       auto const A = Utils::area_triangle(fp1, fp2, fp3);
       auto const t = sqrt(A / A0) - 1.0;
@@ -197,15 +188,14 @@ calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
                        (m1_length * m1_length + m2_length * m2_length +
                         m3_length * m3_length);
 
-      for (int i = 0; i < 3; i++) { // local area force for p1
-        force1[i] += fac * m1[i] / 3.0;
-        force2[i] += fac * m2[i] / 3.0;
-        force3[i] += fac * m3[i] / 3.0;
-      }
+      // local area force for p1
+      force1 += (fac / 3.0) * m1;
+      force2 += (fac / 3.0) * m2;
+      force3 += (fac / 3.0) * m3;
     };
 
     handle_triangle(iaparams->p.oif_local_forces.kal,
-                    iaparams->p.oif_local_forces.A01, fp1, fp2, fp3, force,
+                    iaparams->p.oif_local_forces.A01, fp1, fp2, fp3, force1,
                     force2, force3);
     handle_triangle(iaparams->p.oif_local_forces.kal,
                     iaparams->p.oif_local_forces.A02, fp2, fp3, fp4, force2,

--- a/src/core/object-in-fluid/oif_local_forces.hpp
+++ b/src/core/object-in-fluid/oif_local_forces.hpp
@@ -56,9 +56,11 @@ inline double KS(double lambda) { // Defined by (19) from Dupin2007
  *  @return false
  */
 inline bool
-calc_oif_local(Particle *p2, Particle *p1, Particle *p3, Particle *p4,
-               Bonded_ia_parameters *iaparams, Utils::Vector3d &force1,
-               Utils::Vector3d &force2, Utils::Vector3d &force3,
+calc_oif_local(Particle const *const p2, Particle const *const p1,
+               Particle const *const p3, Particle const *const p4,
+               Bonded_ia_parameters const *const iaparams,
+               Utils::Vector3d &force1, Utils::Vector3d &force2,
+               Utils::Vector3d &force3,
                Utils::Vector3d &force4) { // first-fold-then-the-same approach
 
   auto const fp2 = unfolded_position(p2->r.p, p2->l.i, box_geo.length());

--- a/src/core/object-in-fluid/oif_local_forces.hpp
+++ b/src/core/object-in-fluid/oif_local_forces.hpp
@@ -182,13 +182,12 @@ calc_oif_local(Particle const *const p2, Particle const *const p1,
       auto const m2 = h - fp2;
       auto const m3 = h - fp3;
 
-      auto const m1_length = m1.norm();
-      auto const m2_length = m2.norm();
-      auto const m3_length = m3.norm();
+      auto const m1_length2 = m1.norm2();
+      auto const m2_length2 = m2.norm2();
+      auto const m3_length2 = m3.norm2();
 
-      auto const fac = kal * A0 * (2 * t + t * t) /
-                       (m1_length * m1_length + m2_length * m2_length +
-                        m3_length * m3_length);
+      auto const fac =
+          kal * A0 * (2 * t + t * t) / (m1_length2 + m2_length2 + m3_length2);
 
       // local area force for p1
       force1 += (fac / 3.0) * m1;

--- a/src/core/object-in-fluid/out_direction.hpp
+++ b/src/core/object-in-fluid/out_direction.hpp
@@ -54,6 +54,7 @@ inline int calc_out_direction(Particle *const p1, Particle const *const p2,
                               Particle const *const p3,
                               Particle const *const p4,
                               Bonded_ia_parameters const * /* iaparams */) {
+
   // first-fold-then-the-same approach
   auto const fp2 = unfolded_position(p2->r.p, p2->l.i, box_geo.length());
   auto const fp3 = fp2 + get_mi_vector(p3->r.p, fp2, box_geo);

--- a/src/core/object-in-fluid/out_direction.hpp
+++ b/src/core/object-in-fluid/out_direction.hpp
@@ -41,14 +41,14 @@ int oif_out_direction_set_params(int bond_type);
 /** Computes the outward direction of the membrane from one particle and its
  *  three neighbors
  *
- *  @param[out] p1            The central particle.
+ *  @param[in,out] p1         The central particle.
  *  @param[in]  p2 , p3 , p4  The neighboring particles.
  *
  *  Computes the normal of triangle p2p3p4. This triangle was initially
  *  oriented in such a way that its normal already points out of the object.
  *  Normalizes and stores the result as @ref ParticleProperties::out_direction
  *  "out_direction" in @p p1.
- *  @return 0
+ *  @retval 0
  */
 inline int calc_out_direction(Particle *const p1, Particle const *const p2,
                               Particle const *const p3,

--- a/src/core/object-in-fluid/out_direction.hpp
+++ b/src/core/object-in-fluid/out_direction.hpp
@@ -50,11 +50,11 @@ int oif_out_direction_set_params(int bond_type);
  *  "out_direction" in @p p1.
  *  @return 0
  */
-inline int calc_out_direction(
-    Particle *const p1, Particle const *const p2, Particle const *const p3,
-    Particle const *const p4,
-    Bonded_ia_parameters * /* iaparams */) // first-fold-then-the-same approach
-{
+inline int calc_out_direction(Particle *const p1, Particle const *const p2,
+                              Particle const *const p3,
+                              Particle const *const p4,
+                              Bonded_ia_parameters const * /* iaparams */) {
+  // first-fold-then-the-same approach
   auto const fp2 = unfolded_position(p2->r.p, p2->l.i, box_geo.length());
   auto const fp3 = fp2 + get_mi_vector(p3->r.p, fp2, box_geo);
   auto const fp4 = fp2 + get_mi_vector(p4->r.p, fp2, box_geo);

--- a/src/core/pair_criteria/pair_criteria.hpp
+++ b/src/core/pair_criteria/pair_criteria.hpp
@@ -68,7 +68,7 @@ public:
     IA_parameters *ia_params = get_ia_param(p1.p.type, p2.p.type);
 
     return (calc_non_bonded_pair_energy(
-               &p1, &p2, ia_params, vec21.data(), dist_betw_part,
+               &p1, &p2, ia_params, vec21, dist_betw_part,
                dist_betw_part * dist_betw_part)) >= m_cut_off;
   };
   double get_cut_off() { return m_cut_off; }

--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -97,9 +97,9 @@ bool is_valid_position(
           std::dynamic_pointer_cast<const Constraints::ShapeBasedConstraint>(c);
       if (cs) {
         double d;
-        double v[3];
+        Utils::Vector3d v;
 
-        cs->calc_dist(folded_pos, &d, v);
+        cs->calc_dist(folded_pos, d, v);
 
         if (d <= 0) {
           return false;

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -126,8 +126,8 @@ void pressure_calc(double *result, double *result_t, double *result_nb,
     short_range_loop(
         [&v_comp](Particle &p) { add_single_particle_virials(v_comp, p); },
         [](Particle &p1, Particle &p2, Distance &d) {
-          add_non_bonded_pair_virials(&(p1), &(p2), d.vec21.data(),
-                                      sqrt(d.dist2), d.dist2);
+          add_non_bonded_pair_virials(&(p1), &(p2), d.vec21, sqrt(d.dist2),
+                                      d.dist2);
         });
   } else {
     // Only add single particle virials

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -38,7 +38,7 @@
  *  @param dist      distance between p1 and p2.
  *  @param dist2     distance squared between p1 and p2.
  */
-inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2,
+inline void add_non_bonded_pair_virials(Particle *const p1, Particle *const p2,
                                         Utils::Vector3d const &d, double dist,
                                         double dist2) {
   int p1molid, p2molid, k, l;
@@ -114,9 +114,9 @@ inline void add_non_bonded_pair_virials(Particle *p1, Particle *p2,
  *  @param[out] f_right   Force on @p p_right.
  */
 inline void calc_three_body_bonded_forces(
-    Particle const *p_mid, Particle const *p_left, Particle const *p_right,
-    Bonded_ia_parameters const *iaparams, Utils::Vector3d &f_mid,
-    Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
+    Particle const *const p_mid, Particle const *const p_left,
+    Particle const *const p_right, Bonded_ia_parameters const *const iaparams,
+    Utils::Vector3d &f_mid, Utils::Vector3d &f_left, Utils::Vector3d &f_right) {
   switch (iaparams->type) {
   case BONDED_IA_ANGLE_HARMONIC:
     std::tie(f_mid, f_left, f_right) =
@@ -158,11 +158,9 @@ inline void calc_three_body_bonded_forces(
  *  the forces.
  *  @param p1 particle for which to calculate virials
  */
-inline void add_bonded_virials(Particle *p1) {
+inline void add_bonded_virials(Particle *const p1) {
   Utils::Vector3d force{};
   // char *errtxt;
-  Particle *p2;
-  Bonded_ia_parameters *iaparams;
 
   int i, k, l;
   int type_num;
@@ -170,14 +168,14 @@ inline void add_bonded_virials(Particle *p1) {
   i = 0;
   while (i < p1->bl.n) {
     type_num = p1->bl.e[i++];
-    iaparams = &bonded_ia_params[type_num];
+    Bonded_ia_parameters const *const iaparams = &bonded_ia_params[type_num];
     if (iaparams->num != 1) {
       i += iaparams->num;
       continue;
     }
 
     /* fetch particle 2 */
-    p2 = local_particles[p1->bl.e[i++]];
+    Particle const *const p2 = local_particles[p1->bl.e[i++]];
     if (!p2) {
       // for harmonic spring:
       // if cutoff was defined and p2 is not there it is anyway outside the
@@ -206,7 +204,7 @@ inline void add_bonded_virials(Particle *p1) {
  *  for the contribution of the entire interaction - this is the coding
  *  not the physics.
  */
-inline void add_three_body_bonded_stress(Particle *p1) {
+inline void add_three_body_bonded_stress(Particle const *const p1) {
   int i = 0;
   while (i < p1->bl.n) {
     /* scan bond list for angular interactions */
@@ -219,8 +217,8 @@ inline void add_three_body_bonded_stress(Particle *p1) {
       i += 1 + iaparams->num;
       continue;
     }
-    auto p2 = local_particles[p1->bl.e[i + 1]];
-    auto p3 = local_particles[p1->bl.e[i + 2]];
+    Particle const *const p2 = local_particles[p1->bl.e[i + 1]];
+    Particle const *const p3 = local_particles[p1->bl.e[i + 2]];
 
     auto const dx21 = -get_mi_vector(p1->r.p, p2->r.p, box_geo);
     auto const dx31 = get_mi_vector(p3->r.p, p1->r.p, box_geo);
@@ -246,7 +244,7 @@ inline void add_three_body_bonded_stress(Particle *p1) {
  *                (hence it only works with domain decomposition); naturally it
  *                therefore doesn't make sense to use it without NpT.
  */
-inline void add_kinetic_virials(Particle *p1, int v_comp) {
+inline void add_kinetic_virials(Particle const *const p1, int v_comp) {
   int k, l;
   /* kinetic energy */
   {

--- a/src/core/shapes/Cylinder.cpp
+++ b/src/core/shapes/Cylinder.cpp
@@ -51,8 +51,8 @@ std::pair<double, double> Cylinder::dist_half_pore(double r, double z) const {
   return {m_rad - r, 0};
 }
 
-void Cylinder::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                              double *vec) const {
+void Cylinder::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                              Utils::Vector3d &vec) const {
   /* Coordinate transform to cylinder coords
      with origin at m_center. */
   Utils::Vector3d const c_dist = pos - m_center;
@@ -78,9 +78,7 @@ void Cylinder::calculate_dist(const Utils::Vector3d &pos, double *dist,
     dz *= -1;
   }
 
-  *dist = std::sqrt(dr * dr + dz * dz) * m_direction * side;
-  for (int i = 0; i < 3; i++) {
-    vec[i] = (-dr * e_r[i] + -dz * e_z[i]);
-  }
+  dist = std::sqrt(dr * dr + dz * dz) * m_direction * side;
+  vec = -dr * e_r - dz * e_z;
 }
 } // namespace Shapes

--- a/src/core/shapes/Cylinder.hpp
+++ b/src/core/shapes/Cylinder.hpp
@@ -99,8 +99,8 @@ public:
   bool &open() { return m_open; }
   double &direction() { return m_direction; }
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 };
 } // namespace Shapes
 #endif

--- a/src/core/shapes/Ellipsoid.cpp
+++ b/src/core/shapes/Ellipsoid.cpp
@@ -26,8 +26,8 @@
 #include <cmath>
 
 namespace Shapes {
-void Ellipsoid::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                               double *vec) const {
+void Ellipsoid::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                               Utils::Vector3d &vec) const {
 
   /* get particle position in reference frame of ellipsoid */
   Utils::Vector3d const ppos_e = pos - m_center;
@@ -55,10 +55,9 @@ void Ellipsoid::calculate_dist(const Utils::Vector3d &pos, double *dist,
   for (int i = 0; i < 3; i++) {
     vec[i] = (ppos_e[i] - Utils::sqr(m_semiaxes[i]) * ppos_e[i] /
                               (l + Utils::sqr(m_semiaxes[i])));
-    distance += Utils::sqr(vec[i]);
   }
 
-  *dist = distance_prefactor * m_direction * std::sqrt(distance);
+  dist = distance_prefactor * m_direction * vec.norm();
 }
 
 bool Ellipsoid::inside_ellipsoid(const Utils::Vector3d &ppos) const {

--- a/src/core/shapes/Ellipsoid.hpp
+++ b/src/core/shapes/Ellipsoid.hpp
@@ -32,8 +32,8 @@ public:
       : m_center({0.0, 0.0, 0.0}), m_semiaxes({1.0, 1.0, 1.0}),
         m_direction(1.0) {}
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 
   void set_semiaxis_a(const double &value) { m_semiaxes[0] = value; }
   void set_semiaxis_b(const double &value) {

--- a/src/core/shapes/HollowCone.cpp
+++ b/src/core/shapes/HollowCone.cpp
@@ -27,8 +27,8 @@
 using namespace std;
 
 namespace Shapes {
-void HollowCone::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                                double *vec) const {
+void HollowCone::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                                Utils::Vector3d &vec) const {
   int number = -1;
   double r0, r1, w, alpha, xd, yd, zd, mu, x_2D, y_2D, t0, t1, t2, time1, time2,
       time3, time4, mdst0, mdst1, mdst2, mdst3, mindist, normalize, x, y, z, xp,
@@ -363,11 +363,9 @@ void HollowCone::calculate_dist(const Utils::Vector3d &pos, double *dist,
 
   // Pass the values we obtained to ESPResSo
 
-  for (int i = 0; i < 3; i++) {
-    vec[i] = normal_3D[i] * distance;
-  }
+  vec = normal_3D * distance;
 
-  *dist = distance * std::copysign(1.0, m_direction);
+  dist = distance * std::copysign(1.0, m_direction);
 
   // And we are done with the hollow cone
 }

--- a/src/core/shapes/HollowCone.hpp
+++ b/src/core/shapes/HollowCone.hpp
@@ -34,8 +34,8 @@ public:
         m_outer_radius(0.0), m_inner_radius(0.0), m_width(0.0),
         m_opening_angle(0.0), m_direction(0.0) {}
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 
   Utils::Vector3d const &position() const { return m_position; }
   void set_position(Utils::Vector3d const &position) { m_position = position; }

--- a/src/core/shapes/NoWhere.hpp
+++ b/src/core/shapes/NoWhere.hpp
@@ -34,13 +34,10 @@ namespace Shapes {
  */
 class NoWhere : public Shape {
 public:
-  void calculate_dist(const Utils::Vector3d &, double *dist,
-                      double *vec) const override {
-    *dist = std::numeric_limits<double>::infinity();
-
-    for (int i = 0; i < 3; i++) {
-      vec[i] = *dist;
-    }
+  void calculate_dist(const Utils::Vector3d &, double &dist,
+                      Utils::Vector3d &vec) const override {
+    dist = std::numeric_limits<double>::infinity();
+    vec = {dist, dist, dist};
   }
 };
 

--- a/src/core/shapes/Rhomboid.cpp
+++ b/src/core/shapes/Rhomboid.cpp
@@ -28,11 +28,13 @@ using namespace std;
 namespace Shapes {
 void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double &dist,
                               Utils::Vector3d &vec) const {
-  double tmp;
-  double d;
 
-  // calculate a couple of vectors and scalars that are going to be used
-  // frequently
+  using le = std::less_equal<double>;
+  using ge = std::greater_equal<double>;
+  using lt = std::less<double>;
+  using gt = std::greater<double>;
+
+  // calculate vectors and scalars that are going to be used frequently
 
   auto const axb = vector_product(m_a, m_b);
   auto const bxc = vector_product(m_b, m_c);
@@ -42,623 +44,160 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double &dist,
   auto const b_dot_axc = m_b * axc;
   auto const c_dot_axb = m_c * axb;
 
-  // represent the distance from pos to ppos as a linear combination of the edge
-  // vectors.
-
   auto const dpos = pos - m_pos;
-  auto A = dpos * bxc / a_dot_bxc;
-  auto B = dpos * axc / b_dot_axc;
-  auto C = dpos * axb / c_dot_axb;
 
-  // the coefficients tell whether ppos lies within the cone defined by pos and
-  // the adjacent edges
+  // compute distance from the rhomboid corners, edges and faces using linear
+  // combinations of the rhomboid edge vectors
 
-  if (A <= 0 && B <= 0 && C <= 0) {
-    vec = dpos;
-    dist = m_direction * vec.norm();
-    return;
+#ifndef DOXYGEN
+#define DISTANCE_FROM_CORNER(op1, op2, op3, distance)                          \
+  {                                                                            \
+    auto const d = distance;                                                   \
+    /* coefficients A, B, C tell whether ppos lies within a cone defined */    \
+    /* by pos and the adjacent edges */                                        \
+    auto const A = (d * bxc) / a_dot_bxc;                                      \
+    auto const B = (d * axc) / b_dot_axc;                                      \
+    auto const C = (d * axb) / c_dot_axb;                                      \
+    if (op1{}(A, 0) & op2{}(B, 0) & op3{}(C, 0)) {                             \
+      vec = d;                                                                 \
+      dist = m_direction * vec.norm();                                         \
+      return;                                                                  \
+    }                                                                          \
   }
 
   // check for cone at pos+a
-
-  auto const dpos_a = dpos - m_a;
-  A = dpos_a * bxc / a_dot_bxc;
-  B = dpos_a * axc / b_dot_axc;
-  C = dpos_a * axb / c_dot_axb;
-
-  if (A >= 0 && B <= 0 && C <= 0) {
-    vec = dpos_a;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_CORNER(le, le, le, dpos);
+  // check for cone at pos+a
+  DISTANCE_FROM_CORNER(ge, le, le, dpos - m_a);
   // check for cone at pos+b
-
-  auto const dpos_b = dpos - m_b;
-  A = dpos_b * bxc / a_dot_bxc;
-  B = dpos_b * axc / b_dot_axc;
-  C = dpos_b * axb / c_dot_axb;
-
-  if (A <= 0 && B >= 0 && C <= 0) {
-    vec = dpos_b;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_CORNER(le, ge, le, dpos - m_b);
   // check for cone at pos+c
-
-  auto const dpos_c = dpos - m_c;
-  A = dpos_c * bxc / a_dot_bxc;
-  B = dpos_c * axc / b_dot_axc;
-  C = dpos_c * axb / c_dot_axb;
-
-  if (A <= 0 && B <= 0 && C >= 0) {
-    vec = dpos_c;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_CORNER(le, le, ge, dpos - m_c);
   // check for cone at m_pos+a+b
-
-  auto const dpos_ab = dpos - m_a - m_b;
-  A = dpos_ab * bxc / a_dot_bxc;
-  B = dpos_ab * axc / b_dot_axc;
-  C = dpos_ab * axb / c_dot_axb;
-
-  if (A >= 0 && B >= 0 && C <= 0) {
-    vec = dpos_ab;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_CORNER(ge, ge, le, dpos - m_a - m_b);
   // check for cone at m_pos+a+c
-
-  auto const dpos_ac = dpos - m_a - m_c;
-  A = dpos_ac * bxc / a_dot_bxc;
-  B = dpos_ac * axc / b_dot_axc;
-  C = dpos_ac * axb / c_dot_axb;
-
-  if (A >= 0 && B <= 0 && C >= 0) {
-    vec = dpos_ac;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_CORNER(ge, le, ge, dpos - m_a - m_c);
   // check for cone at m_pos+b+c
-
-  auto const dpos_bc = dpos - m_b - m_c;
-  A = dpos_bc * bxc / a_dot_bxc;
-  B = dpos_bc * axc / b_dot_axc;
-  C = dpos_bc * axb / c_dot_axb;
-
-  if (A <= 0 && B >= 0 && C >= 0) {
-    vec = dpos_bc;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_CORNER(le, ge, ge, dpos - m_b - m_c);
   // check for cone at m_pos+a+b+c
+  DISTANCE_FROM_CORNER(ge, ge, ge, dpos - m_a - m_b - m_c);
 
-  auto const dpos_abc = dpos - m_a - m_b - m_c;
-  A = dpos_abc * bxc / a_dot_bxc;
-  B = dpos_abc * axc / b_dot_axc;
-  C = dpos_abc * axb / c_dot_axb;
-
-  if (A >= 0 && B >= 0 && C >= 0) {
-    vec = dpos_abc;
-    dist = m_direction * vec.norm();
-    return;
+#define DISTANCE_FROM_EDGE(op1, op2, distance, axis1, dir1, axis2, dir2, edge) \
+  {                                                                            \
+    auto const d = distance;                                                   \
+    auto const A = (d * axis1) / dir1##_dot_##axis1;                           \
+    auto const B = (d * axis2) / dir2##_dot_##axis2;                           \
+    if (op1{}(A, 0) & op2{}(B, 0)) {                                           \
+      auto const tmp = (d * edge) / edge.norm2();                              \
+      vec = d - edge * tmp;                                                    \
+      dist = m_direction * vec.norm();                                         \
+      return;                                                                  \
+    }                                                                          \
   }
 
   // check for prism at edge m_pos, a
-
-  B = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
-      (pos[2] - m_pos[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
-      (pos[2] - m_pos[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (B <= 0 && C <= 0) {
-    tmp = (pos[0] - m_pos[0]) * m_a[0] + (pos[1] - m_pos[1]) * m_a[1] +
-          (pos[2] - m_pos[2]) * m_a[2];
-    tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
-
-    vec = pos - m_pos - m_a * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(le, le, dpos, axc, b, axb, c, m_a);
   // check for prism at edge m_pos, b
-
-  A = (pos[0] - m_pos[0]) * bxc[0] + (pos[1] - m_pos[1]) * bxc[1] +
-      (pos[2] - m_pos[2]) * bxc[2];
-  A /= a_dot_bxc;
-  C = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
-      (pos[2] - m_pos[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (A <= 0 && C <= 0) {
-    tmp = (pos[0] - m_pos[0]) * m_b[0] + (pos[1] - m_pos[1]) * m_b[1] +
-          (pos[2] - m_pos[2]) * m_b[2];
-    tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
-
-    vec = pos - m_pos - m_b * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(le, le, dpos, bxc, a, axb, c, m_b);
   // check for prism at edge m_pos, c
-
-  A = (pos[0] - m_pos[0]) * bxc[0] + (pos[1] - m_pos[1]) * bxc[1] +
-      (pos[2] - m_pos[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
-      (pos[2] - m_pos[2]) * axc[2];
-  B /= b_dot_axc;
-
-  if (A <= 0 && B <= 0) {
-    tmp = (pos[0] - m_pos[0]) * m_c[0] + (pos[1] - m_pos[1]) * m_c[1] +
-          (pos[2] - m_pos[2]) * m_c[2];
-    tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
-
-    vec = pos - m_pos - m_c * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(le, le, dpos, bxc, a, axc, b, m_c);
   // check for prism at edge m_pos+a, b
-
-  A = (pos[0] - m_pos[0] - m_a[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2]) * bxc[2];
-  A /= a_dot_bxc;
-  C = (pos[0] - m_pos[0] - m_a[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (A >= 0 && C <= 0) {
-    tmp = (pos[0] - m_pos[0] - m_a[0]) * m_b[0] +
-          (pos[1] - m_pos[1] - m_a[1]) * m_b[1] +
-          (pos[2] - m_pos[2] - m_a[2]) * m_b[2];
-    tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
-
-    vec = pos - m_pos - m_a - m_b * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(ge, le, dpos - m_a, bxc, a, axb, c, m_b);
   // check for prism at edge m_pos+a, c
-
-  A = (pos[0] - m_pos[0] - m_a[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_a[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2]) * axc[2];
-  B /= b_dot_axc;
-
-  if (A >= 0 && B <= 0) {
-    tmp = (pos[0] - m_pos[0] - m_a[0]) * m_c[0] +
-          (pos[1] - m_pos[1] - m_a[1]) * m_c[1] +
-          (pos[2] - m_pos[2] - m_a[2]) * m_c[2];
-    tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
-
-    vec = pos - m_pos - m_a - m_c * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(ge, le, dpos - m_a, bxc, a, axc, b, m_c);
   // check for prism at edge m_pos+b+c, c
-
-  A = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * axc[2];
-  B /= b_dot_axc;
-
-  if (A <= 0 && B >= 0) {
-    tmp = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * m_c[0] +
-          (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * m_c[1] +
-          (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * m_c[2];
-    tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
-
-    vec = pos - m_pos - m_b - m_c - m_c * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(le, ge, dpos - m_b - m_c, bxc, a, axc, b, m_c);
   // check for prism at edge m_pos+b+c, b
-
-  A = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * bxc[2];
-  A /= a_dot_bxc;
-  C = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (A <= 0 && C >= 0) {
-    tmp = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * m_b[0] +
-          (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * m_b[1] +
-          (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * m_b[2];
-    tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
-
-    vec = pos - m_pos - m_b - m_c - m_b * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(le, ge, dpos - m_b - m_c, bxc, a, axb, c, m_b);
   // check for prism at edge m_pos+b+c, a
-
-  B = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (B >= 0 && C >= 0) {
-    tmp = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * m_a[0] +
-          (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * m_a[1] +
-          (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * m_a[2];
-    tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
-
-    vec = pos - m_pos - m_b - m_c - m_a * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(ge, ge, dpos - m_b - m_c, axc, b, axb, c, m_a);
   // check for prism at edge m_pos+a+b, a
-
-  B = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (B >= 0 && C <= 0) {
-    tmp = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * m_a[0] +
-          (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * m_a[1] +
-          (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * m_a[2];
-    tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
-
-    vec = pos - m_pos - m_a - m_b - m_a * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(ge, le, dpos - m_a - m_b, axc, b, axb, c, m_a);
   // check for prism at edge m_pos+a+b, c
-
-  A = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * axc[2];
-  B /= b_dot_axc;
-
-  if (A >= 0 && B >= 0) {
-    tmp = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * m_c[0] +
-          (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * m_c[1] +
-          (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * m_c[2];
-    tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
-
-    vec = pos - m_pos - m_a - m_b - m_c * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(ge, ge, dpos - m_a - m_b, bxc, a, axc, b, m_c);
   // check for prism at edge m_pos+a+c, a
-
-  B = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (B <= 0 && C >= 0) {
-    tmp = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * m_a[0] +
-          (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * m_a[1] +
-          (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * m_a[2];
-    tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
-
-    vec = pos - m_pos - m_a - m_c - m_a * tmp;
-    dist = m_direction * vec.norm();
-    return;
-  }
-
+  DISTANCE_FROM_EDGE(le, ge, dpos - m_a - m_c, axc, b, axb, c, m_a);
   // check for prism at edge m_pos+a+c, b
+  DISTANCE_FROM_EDGE(ge, ge, dpos - m_a - m_c, bxc, a, axb, c, m_b);
 
-  A = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * bxc[2];
-  A /= a_dot_bxc;
-  C = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
-
-  if (A >= 0 && C >= 0) {
-    tmp = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * m_b[0] +
-          (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * m_b[1] +
-          (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * m_b[2];
-    tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
-
-    vec = pos - m_pos - m_a - m_c - m_b * tmp;
-    dist = m_direction * vec.norm();
-    return;
+#define DISTANCE_FROM_FACE(op1, op2, distance, axis, dir, sign)                \
+  {                                                                            \
+    auto d = (distance)*axis;                                                  \
+    if (op1{}(dir##_dot_##axis, 0)) {                                          \
+      d *= -1;                                                                 \
+    }                                                                          \
+    if (d >= 0) {                                                              \
+      auto const tmp = axis.norm();                                            \
+      d /= tmp;                                                                \
+      dist = d * m_direction;                                                  \
+      if (op2{}(dir##_dot_##axis, 0)) {                                        \
+        d *= -1;                                                               \
+      }                                                                        \
+      vec = (sign * d / tmp) * axis;                                           \
+      return;                                                                  \
+    }                                                                          \
   }
 
   // check for face with normal -axb
-
-  dist = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
-         (pos[2] - m_pos[2]) * axb[2];
-  if (c_dot_axb > 0.0) {
-    dist *= -1.;
-  }
-
-  if (dist >= 0) {
-    tmp = axb.norm();
-    dist /= tmp;
-
-    vec = (-dist / tmp) * axb;
-    if (c_dot_axb < 0.0) {
-      vec *= -1.;
-    }
-
-    dist *= m_direction;
-
-    return;
-  }
-
+  DISTANCE_FROM_FACE(gt, lt, dpos, axb, c, -1);
   // calculate distance to face with normal axc
-
-  dist = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
-         (pos[2] - m_pos[2]) * axc[2];
-  if (b_dot_axc > 0.0) {
-    dist *= -1.;
-  }
-
-  if (dist >= 0) {
-    tmp = axc.norm();
-    dist /= tmp;
-
-    vec = (dist / tmp) * axc;
-    if (b_dot_axc > 0.0) {
-      vec *= -1.;
-    }
-
-    dist *= m_direction;
-
-    return;
-  }
-
+  DISTANCE_FROM_FACE(gt, gt, dpos, axc, b, +1);
   // calculate distance to face with normal -bxc
-
-  dist = (pos[0] - m_pos[0]) * bxc[0] + (pos[1] - m_pos[1]) * bxc[1] +
-         (pos[2] - m_pos[2]) * bxc[2];
-  if (a_dot_bxc > 0.0) {
-    dist *= -1.;
-  }
-
-  if (dist >= 0) {
-    tmp = bxc.norm();
-    dist /= tmp;
-
-    vec = -(dist / tmp) * bxc;
-    if (a_dot_bxc < 0.0) {
-      vec *= -1.;
-    }
-
-    dist *= m_direction;
-
-    return;
-  }
-
+  DISTANCE_FROM_FACE(gt, lt, dpos, bxc, a, -1);
   // calculate distance to face with normal axb
-
-  dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axb[0] +
-         (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axb[1] +
-         (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axb[2];
-  if (c_dot_axb < 0.0) {
-    dist *= -1.;
-  }
-
-  if (dist >= 0) {
-    tmp = axb.norm();
-    dist /= tmp;
-
-    vec = (dist / tmp) * axb;
-    if (c_dot_axb < 0.0) {
-      vec *= -1.;
-    }
-
-    dist *= m_direction;
-
-    return;
-  }
-
+  DISTANCE_FROM_FACE(lt, lt, dpos - m_a - m_b - m_c, axb, c, +1);
   // calculate distance to face with normal -axc
-
-  dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axc[0] +
-         (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axc[1] +
-         (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axc[2];
-  if (b_dot_axc < 0.0) {
-    dist *= -1.;
-  }
-
-  if (dist >= 0) {
-    tmp = axc.norm();
-    dist /= tmp;
-
-    vec = -(dist / tmp) * axc;
-    if (b_dot_axc > 0.0) {
-      vec *= -1.;
-    }
-
-    dist *= m_direction;
-
-    return;
-  }
-
+  DISTANCE_FROM_FACE(lt, gt, dpos - m_a - m_b - m_c, axc, b, -1);
   // calculate distance to face with normal bxc
+  DISTANCE_FROM_FACE(lt, lt, dpos - m_a - m_b - m_c, bxc, a, +1);
 
-  dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * bxc[0] +
-         (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * bxc[1] +
-         (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * bxc[2];
-  if (a_dot_bxc < 0.0) {
-    dist *= -1.;
-  }
-
-  if (dist >= 0) {
-    tmp = bxc.norm();
-    dist /= tmp;
-
-    vec = (dist / tmp) * bxc;
-    if (a_dot_bxc < 0.0) {
-      vec *= -1.;
-    }
-
-    dist *= m_direction;
-
-    return;
-  }
-
-  // ppos lies within rhomboid. Find nearest wall for interaction.
+  // ppos lies within rhomboid.
+  // Find nearest wall for interaction (test all 6 possibilities).
 
   // check for face with normal -axb
 
-  dist = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
-         (pos[2] - m_pos[2]) * axb[2];
-  if (c_dot_axb > 0.0) {
-    dist *= -1.;
+  {
+    auto d = dpos * axb;
+    if (c_dot_axb > 0.0) {
+      d *= -1;
+    }
+    auto tmp = axb.norm();
+    d /= tmp;
+    dist = d * m_direction;
+    if (c_dot_axb < 0.0) {
+      d *= -1;
+    }
+    vec = (-d / tmp) * axb;
   }
-  tmp = axb.norm();
-  dist /= tmp;
 
-  vec = -(dist / tmp) * axb;
-
-  if (c_dot_axb < 0.0) {
-    vec *= -1.;
+#define DISTANCE_FROM_FACE_INSIDE(op1, op2, distance, axis, dir, sign)         \
+  {                                                                            \
+    auto d = (distance)*axis;                                                  \
+    if (op1{}(dir##_dot_##axis, 0)) {                                          \
+      d *= -1;                                                                 \
+    }                                                                          \
+    auto const tmp = axis.norm();                                              \
+    d /= tmp;                                                                  \
+    if (abs(d) < abs(dist)) {                                                  \
+      dist = d * m_direction;                                                  \
+      if (op2{}(dir##_dot_##axis, 0)) {                                        \
+        d *= -1;                                                               \
+      }                                                                        \
+      vec = (sign * d / tmp) * axis;                                           \
+    }                                                                          \
   }
-
-  dist *= m_direction;
 
   // calculate distance to face with normal axc
-
-  d = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
-      (pos[2] - m_pos[2]) * axc[2];
-  if (b_dot_axc > 0.0) {
-    d *= -1.;
-  }
-  tmp = axc.norm();
-  d /= tmp;
-
-  if (abs(d) < abs(dist)) {
-    vec = (d / tmp) * axc;
-
-    if (b_dot_axc > 0.0) {
-      vec *= -1.;
-    }
-
-    dist = m_direction * d;
-  }
-
+  DISTANCE_FROM_FACE_INSIDE(gt, gt, dpos, axc, b, +1);
   // calculate distance to face with normal -bxc
-
-  d = (pos[0] - m_pos[0]) * bxc[0] + (pos[1] - m_pos[1]) * bxc[1] +
-      (pos[2] - m_pos[2]) * bxc[2];
-  if (a_dot_bxc > 0.0)
-    d *= -1.;
-  tmp = bxc.norm();
-  d /= tmp;
-
-  if (abs(d) < abs(dist)) {
-    vec = -(d / tmp) * bxc;
-
-    if (a_dot_bxc < 0.0) {
-      vec *= -1.;
-    }
-
-    dist = m_direction * d;
-  }
-
+  DISTANCE_FROM_FACE_INSIDE(gt, lt, dpos, bxc, a, -1);
   // calculate distance to face with normal axb
-
-  d = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axb[2];
-  if (c_dot_axb < 0.0) {
-    d *= -1.;
-  }
-  tmp = axb.norm();
-  d /= tmp;
-
-  if (abs(d) < abs(dist)) {
-    vec = (d / tmp) * axb;
-
-    if (c_dot_axb < 0.0) {
-      vec *= -1.;
-    }
-
-    dist = m_direction * d;
-  }
-
+  DISTANCE_FROM_FACE_INSIDE(lt, lt, dpos - m_a - m_b - m_c, axb, c, +1);
   // calculate distance to face with normal -axc
-
-  d = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axc[2];
-  if (b_dot_axc < 0.0)
-    d *= -1.;
-  tmp = axc.norm();
-  d /= tmp;
-
-  if (abs(d) < abs(dist)) {
-    vec = -(d / tmp) * axc;
-
-    if (b_dot_axc > 0.0) {
-      vec *= -1.;
-    }
-
-    dist = m_direction * d;
-  }
-
+  DISTANCE_FROM_FACE_INSIDE(lt, gt, dpos - m_a - m_b - m_c, axc, b, -1);
   // calculate distance to face with normal bxc
-
-  d = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * bxc[2];
-  if (a_dot_bxc < 0.0)
-    d *= -1.;
-  tmp = bxc.norm();
-  d /= tmp;
-
-  if (abs(d) < abs(dist)) {
-    vec = (d / tmp) * bxc;
-
-    if (a_dot_bxc < 0.0) {
-      vec *= -1.;
-    }
-
-    dist = m_direction * d;
-  }
+  DISTANCE_FROM_FACE_INSIDE(lt, lt, dpos - m_a - m_b - m_c, bxc, a, +1);
+#endif // ifndef DOXYGEN
 }
 
 } // namespace Shapes

--- a/src/core/shapes/Rhomboid.cpp
+++ b/src/core/shapes/Rhomboid.cpp
@@ -26,239 +26,127 @@
 using namespace std;
 
 namespace Shapes {
-void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                              double *vec) const {
-  double axb[3], bxc[3], axc[3];
-  double A, B, C;
-  double a_dot_bxc, b_dot_axc, c_dot_axb;
+void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                              Utils::Vector3d &vec) const {
   double tmp;
   double d;
 
   // calculate a couple of vectors and scalars that are going to be used
   // frequently
 
-  axb[0] = m_a[1] * m_b[2] - m_a[2] * m_b[1];
-  axb[1] = m_a[2] * m_b[0] - m_a[0] * m_b[2];
-  axb[2] = m_a[0] * m_b[1] - m_a[1] * m_b[0];
+  auto const axb = vector_product(m_a, m_b);
+  auto const bxc = vector_product(m_b, m_c);
+  auto const axc = vector_product(m_a, m_c);
 
-  bxc[0] = m_b[1] * m_c[2] - m_b[2] * m_c[1];
-  bxc[1] = m_b[2] * m_c[0] - m_b[0] * m_c[2];
-  bxc[2] = m_b[0] * m_c[1] - m_b[1] * m_c[0];
-
-  axc[0] = m_a[1] * m_c[2] - m_a[2] * m_c[1];
-  axc[1] = m_a[2] * m_c[0] - m_a[0] * m_c[2];
-  axc[2] = m_a[0] * m_c[1] - m_a[1] * m_c[0];
-
-  a_dot_bxc = m_a[0] * bxc[0] + m_a[1] * bxc[1] + m_a[2] * bxc[2];
-  b_dot_axc = m_b[0] * axc[0] + m_b[1] * axc[1] + m_b[2] * axc[2];
-  c_dot_axb = m_c[0] * axb[0] + m_c[1] * axb[1] + m_c[2] * axb[2];
+  auto const a_dot_bxc = m_a * bxc;
+  auto const b_dot_axc = m_b * axc;
+  auto const c_dot_axb = m_c * axb;
 
   // represent the distance from pos to ppos as a linear combination of the edge
   // vectors.
 
-  A = (pos[0] - m_pos[0]) * bxc[0] + (pos[1] - m_pos[1]) * bxc[1] +
-      (pos[2] - m_pos[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
-      (pos[2] - m_pos[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
-      (pos[2] - m_pos[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos = pos - m_pos;
+  auto A = dpos * bxc / a_dot_bxc;
+  auto B = dpos * axc / b_dot_axc;
+  auto C = dpos * axb / c_dot_axb;
 
   // the coefficients tell whether ppos lies within the cone defined by pos and
   // the adjacent edges
 
   if (A <= 0 && B <= 0 && C <= 0) {
-    vec[0] = pos[0] - m_pos[0];
-    vec[1] = pos[1] - m_pos[1];
-    vec[2] = pos[2] - m_pos[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos;
+    dist = m_direction * vec.norm();
     return;
   }
 
   // check for cone at pos+a
 
-  A = (pos[0] - m_pos[0] - m_a[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_a[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_a[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos_a = dpos - m_a;
+  A = dpos_a * bxc / a_dot_bxc;
+  B = dpos_a * axc / b_dot_axc;
+  C = dpos_a * axb / c_dot_axb;
 
   if (A >= 0 && B <= 0 && C <= 0) {
-    vec[0] = pos[0] - m_pos[0] - m_a[0];
-    vec[1] = pos[1] - m_pos[1] - m_a[1];
-    vec[2] = pos[2] - m_pos[2] - m_a[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos_a;
+    dist = m_direction * vec.norm();
     return;
   }
 
   // check for cone at pos+b
 
-  A = (pos[0] - m_pos[0] - m_b[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_b[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_b[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_b[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_b[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_b[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_b[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_b[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_b[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos_b = dpos - m_b;
+  A = dpos_b * bxc / a_dot_bxc;
+  B = dpos_b * axc / b_dot_axc;
+  C = dpos_b * axb / c_dot_axb;
 
   if (A <= 0 && B >= 0 && C <= 0) {
-    vec[0] = pos[0] - m_pos[0] - m_b[0];
-    vec[1] = pos[1] - m_pos[1] - m_b[1];
-    vec[2] = pos[2] - m_pos[2] - m_b[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos_b;
+    dist = m_direction * vec.norm();
     return;
   }
 
   // check for cone at pos+c
 
-  A = (pos[0] - m_pos[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_c[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_c[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos_c = dpos - m_c;
+  A = dpos_c * bxc / a_dot_bxc;
+  B = dpos_c * axc / b_dot_axc;
+  C = dpos_c * axb / c_dot_axb;
 
   if (A <= 0 && B <= 0 && C >= 0) {
-    vec[0] = pos[0] - m_pos[0] - m_c[0];
-    vec[1] = pos[1] - m_pos[1] - m_c[1];
-    vec[2] = pos[2] - m_pos[2] - m_c[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos_c;
+    dist = m_direction * vec.norm();
     return;
   }
 
   // check for cone at m_pos+a+b
 
-  A = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_a[0] - m_b[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos_ab = dpos - m_a - m_b;
+  A = dpos_ab * bxc / a_dot_bxc;
+  B = dpos_ab * axc / b_dot_axc;
+  C = dpos_ab * axb / c_dot_axb;
 
   if (A >= 0 && B >= 0 && C <= 0) {
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_b[0];
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_b[1];
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_b[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos_ab;
+    dist = m_direction * vec.norm();
     return;
   }
 
   // check for cone at m_pos+a+c
 
-  A = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_a[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos_ac = dpos - m_a - m_c;
+  A = dpos_ac * bxc / a_dot_bxc;
+  B = dpos_ac * axc / b_dot_axc;
+  C = dpos_ac * axb / c_dot_axb;
 
   if (A >= 0 && B <= 0 && C >= 0) {
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_c[0];
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_c[1];
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_c[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos_ac;
+    dist = m_direction * vec.norm();
     return;
   }
 
-  // check for cone at m_pos+a+c
+  // check for cone at m_pos+b+c
 
-  A = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_b[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_b[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos_bc = dpos - m_b - m_c;
+  A = dpos_bc * bxc / a_dot_bxc;
+  B = dpos_bc * axc / b_dot_axc;
+  C = dpos_bc * axb / c_dot_axb;
 
   if (A <= 0 && B >= 0 && C >= 0) {
-    vec[0] = pos[0] - m_pos[0] - m_b[0] - m_c[0];
-    vec[1] = pos[1] - m_pos[1] - m_b[1] - m_c[1];
-    vec[2] = pos[2] - m_pos[2] - m_b[2] - m_c[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos_bc;
+    dist = m_direction * vec.norm();
     return;
   }
 
   // check for cone at m_pos+a+b+c
 
-  A = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * bxc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * bxc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * bxc[2];
-  A /= a_dot_bxc;
-  B = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axc[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axc[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axc[2];
-  B /= b_dot_axc;
-  C = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axb[0] +
-      (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axb[1] +
-      (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axb[2];
-  C /= c_dot_axb;
+  auto const dpos_abc = dpos - m_a - m_b - m_c;
+  A = dpos_abc * bxc / a_dot_bxc;
+  B = dpos_abc * axc / b_dot_axc;
+  C = dpos_abc * axb / c_dot_axb;
 
   if (A >= 0 && B >= 0 && C >= 0) {
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0];
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1];
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2];
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = dpos_abc;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -276,13 +164,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2]) * m_a[2];
     tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_a[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_a[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_a[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_a * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -300,13 +183,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2]) * m_b[2];
     tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_b[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_b[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_b[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_b * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -324,13 +202,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2]) * m_c[2];
     tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_c[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_c[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_c[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_c * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -351,13 +224,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_a[2]) * m_b[2];
     tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_b[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_b[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_b[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_a - m_b * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -378,13 +246,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_a[2]) * m_c[2];
     tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_c[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_c[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_c[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_a - m_c * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -405,13 +268,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * m_c[2];
     tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_b[0] - m_c[0] - m_c[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_b[1] - m_c[1] - m_c[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_b[2] - m_c[2] - m_c[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_b - m_c - m_c * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -432,13 +290,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * m_b[2];
     tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_b[0] - m_c[0] - m_b[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_b[1] - m_c[1] - m_b[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_b[2] - m_c[2] - m_b[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_b - m_c - m_b * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -459,13 +312,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_b[2] - m_c[2]) * m_a[2];
     tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_b[0] - m_c[0] - m_a[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_b[1] - m_c[1] - m_a[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_b[2] - m_c[2] - m_a[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_b - m_c - m_a * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -486,13 +334,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * m_a[2];
     tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_a[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_a[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_a[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_a - m_b - m_a * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -513,13 +356,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_a[2] - m_b[2]) * m_c[2];
     tmp /= m_c[0] * m_c[0] + m_c[1] * m_c[1] + m_c[2] * m_c[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_a - m_b - m_c * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -540,13 +378,8 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * m_a[2];
     tmp /= m_a[0] * m_a[0] + m_a[1] * m_a[1] + m_a[2] * m_a[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_c[0] - m_a[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_c[1] - m_a[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_c[2] - m_a[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_a - m_c - m_a * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
@@ -567,165 +400,142 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
           (pos[2] - m_pos[2] - m_a[2] - m_c[2]) * m_b[2];
     tmp /= m_b[0] * m_b[0] + m_b[1] * m_b[1] + m_b[2] * m_b[2];
 
-    vec[0] = pos[0] - m_pos[0] - m_a[0] - m_c[0] - m_b[0] * tmp;
-    vec[1] = pos[1] - m_pos[1] - m_a[1] - m_c[1] - m_b[1] * tmp;
-    vec[2] = pos[2] - m_pos[2] - m_a[2] - m_c[2] - m_b[2] * tmp;
-
-    *dist =
-        m_direction * sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
-
+    vec = pos - m_pos - m_a - m_c - m_b * tmp;
+    dist = m_direction * vec.norm();
     return;
   }
 
   // check for face with normal -axb
 
-  *dist = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
-          (pos[2] - m_pos[2]) * axb[2];
-  if (c_dot_axb > 0.0)
-    *dist *= -1.;
+  dist = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
+         (pos[2] - m_pos[2]) * axb[2];
+  if (c_dot_axb > 0.0) {
+    dist *= -1.;
+  }
 
-  if (*dist >= 0) {
-    tmp = sqrt(axb[0] * axb[0] + axb[1] * axb[1] + axb[2] * axb[2]);
-    *dist /= tmp;
+  if (dist >= 0) {
+    tmp = axb.norm();
+    dist /= tmp;
 
-    vec[0] = -*dist * axb[0] / tmp;
-    vec[1] = -*dist * axb[1] / tmp;
-    vec[2] = -*dist * axb[2] / tmp;
+    vec = (-dist / tmp) * axb;
     if (c_dot_axb < 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist *= m_direction;
+    dist *= m_direction;
 
     return;
   }
 
   // calculate distance to face with normal axc
 
-  *dist = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
-          (pos[2] - m_pos[2]) * axc[2];
-  if (b_dot_axc > 0.0)
-    *dist *= -1.;
+  dist = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
+         (pos[2] - m_pos[2]) * axc[2];
+  if (b_dot_axc > 0.0) {
+    dist *= -1.;
+  }
 
-  if (*dist >= 0) {
-    tmp = sqrt(axc[0] * axc[0] + axc[1] * axc[1] + axc[2] * axc[2]);
-    *dist /= tmp;
+  if (dist >= 0) {
+    tmp = axc.norm();
+    dist /= tmp;
 
-    vec[0] = *dist * axc[0] / tmp;
-    vec[1] = *dist * axc[1] / tmp;
-    vec[2] = *dist * axc[2] / tmp;
+    vec = (dist / tmp) * axc;
     if (b_dot_axc > 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist *= m_direction;
+    dist *= m_direction;
 
     return;
   }
 
   // calculate distance to face with normal -bxc
 
-  *dist = (pos[0] - m_pos[0]) * bxc[0] + (pos[1] - m_pos[1]) * bxc[1] +
-          (pos[2] - m_pos[2]) * bxc[2];
-  if (a_dot_bxc > 0.0)
-    *dist *= -1.;
+  dist = (pos[0] - m_pos[0]) * bxc[0] + (pos[1] - m_pos[1]) * bxc[1] +
+         (pos[2] - m_pos[2]) * bxc[2];
+  if (a_dot_bxc > 0.0) {
+    dist *= -1.;
+  }
 
-  if (*dist >= 0) {
-    tmp = sqrt(bxc[0] * bxc[0] + bxc[1] * bxc[1] + bxc[2] * bxc[2]);
-    *dist /= tmp;
+  if (dist >= 0) {
+    tmp = bxc.norm();
+    dist /= tmp;
 
-    vec[0] = -*dist * bxc[0] / tmp;
-    vec[1] = -*dist * bxc[1] / tmp;
-    vec[2] = -*dist * bxc[2] / tmp;
+    vec = -(dist / tmp) * bxc;
     if (a_dot_bxc < 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist *= m_direction;
+    dist *= m_direction;
 
     return;
   }
 
   // calculate distance to face with normal axb
 
-  *dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axb[0] +
-          (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axb[1] +
-          (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axb[2];
-  if (c_dot_axb < 0.0)
-    *dist *= -1.;
+  dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axb[0] +
+         (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axb[1] +
+         (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axb[2];
+  if (c_dot_axb < 0.0) {
+    dist *= -1.;
+  }
 
-  if (*dist >= 0) {
-    tmp = sqrt(axb[0] * axb[0] + axb[1] * axb[1] + axb[2] * axb[2]);
-    *dist /= tmp;
+  if (dist >= 0) {
+    tmp = axb.norm();
+    dist /= tmp;
 
-    vec[0] = *dist * axb[0] / tmp;
-    vec[1] = *dist * axb[1] / tmp;
-    vec[2] = *dist * axb[2] / tmp;
+    vec = (dist / tmp) * axb;
     if (c_dot_axb < 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist *= m_direction;
+    dist *= m_direction;
 
     return;
   }
 
   // calculate distance to face with normal -axc
 
-  *dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axc[0] +
-          (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axc[1] +
-          (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axc[2];
-  if (b_dot_axc < 0.0)
-    *dist *= -1.;
+  dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axc[0] +
+         (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axc[1] +
+         (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axc[2];
+  if (b_dot_axc < 0.0) {
+    dist *= -1.;
+  }
 
-  if (*dist >= 0) {
-    tmp = sqrt(axc[0] * axc[0] + axc[1] * axc[1] + axc[2] * axc[2]);
-    *dist /= tmp;
+  if (dist >= 0) {
+    tmp = axc.norm();
+    dist /= tmp;
 
-    vec[0] = -*dist * axc[0] / tmp;
-    vec[1] = -*dist * axc[1] / tmp;
-    vec[2] = -*dist * axc[2] / tmp;
+    vec = -(dist / tmp) * axc;
     if (b_dot_axc > 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist *= m_direction;
+    dist *= m_direction;
 
     return;
   }
 
   // calculate distance to face with normal bxc
 
-  *dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * bxc[0] +
-          (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * bxc[1] +
-          (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * bxc[2];
-  if (a_dot_bxc < 0.0)
-    *dist *= -1.;
+  dist = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * bxc[0] +
+         (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * bxc[1] +
+         (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * bxc[2];
+  if (a_dot_bxc < 0.0) {
+    dist *= -1.;
+  }
 
-  if (*dist >= 0) {
-    tmp = sqrt(bxc[0] * bxc[0] + bxc[1] * bxc[1] + bxc[2] * bxc[2]);
-    *dist /= tmp;
+  if (dist >= 0) {
+    tmp = bxc.norm();
+    dist /= tmp;
 
-    vec[0] = *dist * bxc[0] / tmp;
-    vec[1] = *dist * bxc[1] / tmp;
-    vec[2] = *dist * bxc[2] / tmp;
+    vec = (dist / tmp) * bxc;
     if (a_dot_bxc < 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist *= m_direction;
+    dist *= m_direction;
 
     return;
   }
@@ -734,46 +544,40 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
 
   // check for face with normal -axb
 
-  *dist = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
-          (pos[2] - m_pos[2]) * axb[2];
-  if (c_dot_axb > 0.0)
-    *dist *= -1.;
-  tmp = sqrt(axb[0] * axb[0] + axb[1] * axb[1] + axb[2] * axb[2]);
-  *dist /= tmp;
+  dist = (pos[0] - m_pos[0]) * axb[0] + (pos[1] - m_pos[1]) * axb[1] +
+         (pos[2] - m_pos[2]) * axb[2];
+  if (c_dot_axb > 0.0) {
+    dist *= -1.;
+  }
+  tmp = axb.norm();
+  dist /= tmp;
 
-  vec[0] = -*dist * axb[0] / tmp;
-  vec[1] = -*dist * axb[1] / tmp;
-  vec[2] = -*dist * axb[2] / tmp;
+  vec = -(dist / tmp) * axb;
 
   if (c_dot_axb < 0.0) {
-    vec[0] *= -1.;
-    vec[1] *= -1.;
-    vec[2] *= -1.;
+    vec *= -1.;
   }
 
-  *dist *= m_direction;
+  dist *= m_direction;
 
   // calculate distance to face with normal axc
 
   d = (pos[0] - m_pos[0]) * axc[0] + (pos[1] - m_pos[1]) * axc[1] +
       (pos[2] - m_pos[2]) * axc[2];
-  if (b_dot_axc > 0.0)
+  if (b_dot_axc > 0.0) {
     d *= -1.;
-  tmp = sqrt(axc[0] * axc[0] + axc[1] * axc[1] + axc[2] * axc[2]);
+  }
+  tmp = axc.norm();
   d /= tmp;
 
-  if (abs(d) < abs(*dist)) {
-    vec[0] = d * axc[0] / tmp;
-    vec[1] = d * axc[1] / tmp;
-    vec[2] = d * axc[2] / tmp;
+  if (abs(d) < abs(dist)) {
+    vec = (d / tmp) * axc;
 
     if (b_dot_axc > 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist = m_direction * d;
+    dist = m_direction * d;
   }
 
   // calculate distance to face with normal -bxc
@@ -782,21 +586,17 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
       (pos[2] - m_pos[2]) * bxc[2];
   if (a_dot_bxc > 0.0)
     d *= -1.;
-  tmp = sqrt(bxc[0] * bxc[0] + bxc[1] * bxc[1] + bxc[2] * bxc[2]);
+  tmp = bxc.norm();
   d /= tmp;
 
-  if (abs(d) < abs(*dist)) {
-    vec[0] = -d * bxc[0] / tmp;
-    vec[1] = -d * bxc[1] / tmp;
-    vec[2] = -d * bxc[2] / tmp;
+  if (abs(d) < abs(dist)) {
+    vec = -(d / tmp) * bxc;
 
     if (a_dot_bxc < 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist = m_direction * d;
+    dist = m_direction * d;
   }
 
   // calculate distance to face with normal axb
@@ -804,23 +604,20 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
   d = (pos[0] - m_pos[0] - m_a[0] - m_b[0] - m_c[0]) * axb[0] +
       (pos[1] - m_pos[1] - m_a[1] - m_b[1] - m_c[1]) * axb[1] +
       (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axb[2];
-  if (c_dot_axb < 0.0)
+  if (c_dot_axb < 0.0) {
     d *= -1.;
-  tmp = sqrt(axb[0] * axb[0] + axb[1] * axb[1] + axb[2] * axb[2]);
+  }
+  tmp = axb.norm();
   d /= tmp;
 
-  if (abs(d) < abs(*dist)) {
-    vec[0] = d * axb[0] / tmp;
-    vec[1] = d * axb[1] / tmp;
-    vec[2] = d * axb[2] / tmp;
+  if (abs(d) < abs(dist)) {
+    vec = (d / tmp) * axb;
 
     if (c_dot_axb < 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist = m_direction * d;
+    dist = m_direction * d;
   }
 
   // calculate distance to face with normal -axc
@@ -830,21 +627,17 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
       (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * axc[2];
   if (b_dot_axc < 0.0)
     d *= -1.;
-  tmp = sqrt(axc[0] * axc[0] + axc[1] * axc[1] + axc[2] * axc[2]);
+  tmp = axc.norm();
   d /= tmp;
 
-  if (abs(d) < abs(*dist)) {
-    vec[0] = -d * axc[0] / tmp;
-    vec[1] = -d * axc[1] / tmp;
-    vec[2] = -d * axc[2] / tmp;
+  if (abs(d) < abs(dist)) {
+    vec = -(d / tmp) * axc;
 
     if (b_dot_axc > 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist = m_direction * d;
+    dist = m_direction * d;
   }
 
   // calculate distance to face with normal bxc
@@ -854,21 +647,17 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double *dist,
       (pos[2] - m_pos[2] - m_a[2] - m_b[2] - m_c[2]) * bxc[2];
   if (a_dot_bxc < 0.0)
     d *= -1.;
-  tmp = sqrt(bxc[0] * bxc[0] + bxc[1] * bxc[1] + bxc[2] * bxc[2]);
+  tmp = bxc.norm();
   d /= tmp;
 
-  if (abs(d) < abs(*dist)) {
-    vec[0] = d * bxc[0] / tmp;
-    vec[1] = d * bxc[1] / tmp;
-    vec[2] = d * bxc[2] / tmp;
+  if (abs(d) < abs(dist)) {
+    vec = (d / tmp) * bxc;
 
     if (a_dot_bxc < 0.0) {
-      vec[0] *= -1.;
-      vec[1] *= -1.;
-      vec[2] *= -1.;
+      vec *= -1.;
     }
 
-    *dist = m_direction * d;
+    dist = m_direction * d;
   }
 }
 

--- a/src/core/shapes/Rhomboid.hpp
+++ b/src/core/shapes/Rhomboid.hpp
@@ -32,8 +32,8 @@ public:
       : m_pos({0.0, 0.0, 0.0}), m_a({0.0, 0.0, 0.0}), m_b({0.0, 0.0, 0.0}),
         m_c({0.0, 0.0, 0.0}), m_direction(0.0) {}
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 
   Utils::Vector3d &pos() { return m_pos; }
   Utils::Vector3d &a() { return m_a; }

--- a/src/core/shapes/Shape.hpp
+++ b/src/core/shapes/Shape.hpp
@@ -28,8 +28,8 @@ namespace Shapes {
 
 class Shape {
 public:
-  virtual void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                              double *vec) const = 0;
+  virtual void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                              Utils::Vector3d &vec) const = 0;
   virtual ~Shape() = default;
 };
 

--- a/src/core/shapes/SimplePore.cpp
+++ b/src/core/shapes/SimplePore.cpp
@@ -68,8 +68,8 @@ std::pair<double, double> SimplePore::dist_half_pore(double r, double z) const {
   return {fac * dr, fac * dz};
 }
 
-void SimplePore::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                                double *vec) const {
+void SimplePore::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                                Utils::Vector3d &vec) const {
   /* Coordinate transform to cylinder coords
      with origin at m_center. */
   Utils::Vector3d const c_dist = pos - m_center;
@@ -107,9 +107,7 @@ void SimplePore::calculate_dist(const Utils::Vector3d &pos, double *dist,
     dz *= -1;
   }
 
-  *dist = std::sqrt(dr * dr + dz * dz) * side;
-  for (int i = 0; i < 3; i++) {
-    vec[i] = -dr * e_r[i] + -dz * e_z[i];
-  }
+  dist = std::sqrt(dr * dr + dz * dz) * side;
+  vec = -dr * e_r - dz * e_z;
 }
 } // namespace Shapes

--- a/src/core/shapes/SimplePore.hpp
+++ b/src/core/shapes/SimplePore.hpp
@@ -94,8 +94,8 @@ public:
 
   Utils::Vector3d &center() { return m_center; }
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 };
 } // namespace Shapes
 

--- a/src/core/shapes/Slitpore.cpp
+++ b/src/core/shapes/Slitpore.cpp
@@ -28,8 +28,8 @@
 using namespace std;
 
 namespace Shapes {
-void Slitpore::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                              double *vec) const {
+void Slitpore::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                              Utils::Vector3d &vec) const {
   // the left circles
   double c11[2] = {dividing_plane() - m_pore_width / 2 -
                        m_upper_smoothing_radius,
@@ -48,50 +48,48 @@ void Slitpore::calculate_dist(const Utils::Vector3d &pos, double *dist,
   if (pos[2] > m_pore_mouth + m_channel_width / 2) {
     //    printf("upper wall\n");
     // Feel the upper wall
-    *dist = m_pore_mouth + m_channel_width - pos[2];
+    dist = m_pore_mouth + m_channel_width - pos[2];
     vec[0] = vec[1] = 0;
-    vec[2] = -*dist;
+    vec[2] = -dist;
     return;
   }
 
   if (pos[0] < c11[0] || pos[0] > c21[0]) {
     // Feel the lower wall of the channel
-    *dist = pos[2] - m_pore_mouth;
+    dist = pos[2] - m_pore_mouth;
     vec[0] = vec[1] = 0;
-    vec[2] = *dist;
+    vec[2] = dist;
     return;
   }
 
   if (pos[2] > c11[1]) {
     // Feel the upper smoothing
     if (pos[0] < dividing_plane()) {
-      *dist = sqrt(Utils::sqr(c11[0] - pos[0]) + Utils::sqr(c11[1] - pos[2])) -
-              m_upper_smoothing_radius;
-      vec[0] =
-          -(c11[0] - pos[0]) * (*dist) / (*dist + m_upper_smoothing_radius);
+      dist = sqrt(Utils::sqr(c11[0] - pos[0]) + Utils::sqr(c11[1] - pos[2])) -
+             m_upper_smoothing_radius;
+      vec[0] = -(c11[0] - pos[0]) * (dist) / (dist + m_upper_smoothing_radius);
       vec[1] = 0;
-      vec[2] =
-          -(c11[1] - pos[2]) * (*dist) / (*dist + m_upper_smoothing_radius);
+      vec[2] = -(c11[1] - pos[2]) * (dist) / (dist + m_upper_smoothing_radius);
       return;
     }
-    *dist = sqrt(Utils::sqr(c21[0] - pos[0]) + Utils::sqr(c21[1] - pos[2])) -
-            m_upper_smoothing_radius;
-    vec[0] = -(c21[0] - pos[0]) * (*dist) / (*dist + m_upper_smoothing_radius);
+    dist = sqrt(Utils::sqr(c21[0] - pos[0]) + Utils::sqr(c21[1] - pos[2])) -
+           m_upper_smoothing_radius;
+    vec[0] = -(c21[0] - pos[0]) * (dist) / (dist + m_upper_smoothing_radius);
     vec[1] = 0;
-    vec[2] = -(c21[1] - pos[2]) * (*dist) / (*dist + m_upper_smoothing_radius);
+    vec[2] = -(c21[1] - pos[2]) * (dist) / (dist + m_upper_smoothing_radius);
     return;
   }
 
   if (pos[2] > c12[1]) {
     // Feel the pore wall
     if (pos[0] < dividing_plane()) {
-      *dist = pos[0] - (dividing_plane() - m_pore_width / 2);
-      vec[0] = *dist;
+      dist = pos[0] - (dividing_plane() - m_pore_width / 2);
+      vec[0] = dist;
       vec[1] = vec[2] = 0;
       return;
     }
-    *dist = (dividing_plane() + m_pore_width / 2) - pos[0];
-    vec[0] = -*dist;
+    dist = (dividing_plane() + m_pore_width / 2) - pos[0];
+    vec[0] = -dist;
     vec[1] = vec[2] = 0;
     return;
   }
@@ -99,25 +97,25 @@ void Slitpore::calculate_dist(const Utils::Vector3d &pos, double *dist,
   if (pos[0] > c12[0] && pos[0] < c22[0]) {
     //    printf("pore end\n");
     // Feel the pore end wall
-    *dist = pos[2] - (m_pore_mouth - m_pore_length);
+    dist = pos[2] - (m_pore_mouth - m_pore_length);
     vec[0] = vec[1] = 0;
-    vec[2] = *dist;
+    vec[2] = dist;
     return;
   }
   // Else
   // Feel the lower smoothing
   if (pos[0] < dividing_plane()) {
-    *dist = -sqrt(Utils::sqr(c12[0] - pos[0]) + Utils::sqr(c12[1] - pos[2])) +
-            m_lower_smoothing_radius;
-    vec[0] = (c12[0] - pos[0]) * (*dist) / (-*dist + m_lower_smoothing_radius);
+    dist = -sqrt(Utils::sqr(c12[0] - pos[0]) + Utils::sqr(c12[1] - pos[2])) +
+           m_lower_smoothing_radius;
+    vec[0] = (c12[0] - pos[0]) * (dist) / (-dist + m_lower_smoothing_radius);
     vec[1] = 0;
-    vec[2] = (c12[1] - pos[2]) * (*dist) / (-*dist + m_lower_smoothing_radius);
+    vec[2] = (c12[1] - pos[2]) * (dist) / (-dist + m_lower_smoothing_radius);
     return;
   }
-  *dist = -sqrt(Utils::sqr(c22[0] - pos[0]) + Utils::sqr(c22[1] - pos[2])) +
-          m_lower_smoothing_radius;
-  vec[0] = (c22[0] - pos[0]) * (*dist) / (-*dist + m_lower_smoothing_radius);
+  dist = -sqrt(Utils::sqr(c22[0] - pos[0]) + Utils::sqr(c22[1] - pos[2])) +
+         m_lower_smoothing_radius;
+  vec[0] = (c22[0] - pos[0]) * (dist) / (-dist + m_lower_smoothing_radius);
   vec[1] = 0;
-  vec[2] = (c22[1] - pos[2]) * (*dist) / (-*dist + m_lower_smoothing_radius);
+  vec[2] = (c22[1] - pos[2]) * (dist) / (-dist + m_lower_smoothing_radius);
 }
 } // namespace Shapes

--- a/src/core/shapes/Slitpore.hpp
+++ b/src/core/shapes/Slitpore.hpp
@@ -32,8 +32,8 @@ public:
         m_lower_smoothing_radius(0.0), m_channel_width(0.0), m_pore_width(0.0),
         m_pore_length(0.0), m_dividing_plane(0.0) {}
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 
   double &pore_mouth() { return m_pore_mouth; }
   double &upper_smoothing_radius() { return m_upper_smoothing_radius; }

--- a/src/core/shapes/Sphere.cpp
+++ b/src/core/shapes/Sphere.cpp
@@ -28,30 +28,21 @@
 using namespace std;
 
 namespace Shapes {
-void Sphere::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                            double *vec) const {
-  int i;
-  double fac, c_dist;
-
-  c_dist = 0.0;
-  for (i = 0; i < 3; i++) {
-    vec[i] = m_pos[i] - pos[i];
-    c_dist += Utils::sqr(vec[i]);
-  }
-  c_dist = sqrt(c_dist);
+void Sphere::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                            Utils::Vector3d &vec) const {
+  vec = m_pos - pos;
+  auto const c_dist = vec.norm();
 
   if (m_direction == -1) {
     /* apply force towards inside the sphere */
-    *dist = m_rad - c_dist;
-    fac = *dist / c_dist;
-    for (i = 0; i < 3; i++)
-      vec[i] *= fac;
+    dist = m_rad - c_dist;
+    auto const fac = dist / c_dist;
+    vec *= fac;
   } else {
     /* apply force towards outside the sphere */
-    *dist = c_dist - m_rad;
-    fac = *dist / c_dist;
-    for (i = 0; i < 3; i++)
-      vec[i] *= -fac;
+    dist = c_dist - m_rad;
+    auto const fac = dist / c_dist;
+    vec *= -fac;
   }
 }
 } // namespace Shapes

--- a/src/core/shapes/Sphere.hpp
+++ b/src/core/shapes/Sphere.hpp
@@ -30,8 +30,8 @@ class Sphere : public Shape {
 public:
   Sphere() : m_pos({0.0, 0.0, 0.0}), m_rad(0.0), m_direction(1.0) {}
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 
   Utils::Vector3d &pos() { return m_pos; }
   double &rad() { return m_rad; }

--- a/src/core/shapes/SpheroCylinder.cpp
+++ b/src/core/shapes/SpheroCylinder.cpp
@@ -24,8 +24,8 @@
 
 namespace Shapes {
 
-void SpheroCylinder::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                                    double *vec) const {
+void SpheroCylinder::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                                    Utils::Vector3d &vec) const {
   /* Coordinate transform to cylinder coords
      with origin at m_center. */
 
@@ -57,13 +57,10 @@ void SpheroCylinder::calculate_dist(const Utils::Vector3d &pos, double *dist,
       if (z < 0)
         dir = -1;
       Utils::Vector3d c_dist_cap = pos - (m_center + dir * e_z * m_half_length);
-      *dist = c_dist_cap.norm() - m_rad;
+      dist = c_dist_cap.norm() - m_rad;
       c_dist_cap.normalize();
-      Utils::Vector3d v = *dist * c_dist_cap;
-      for (int i = 0; i < 3; i++) {
-        vec[i] = v[i];
-      }
-      *dist *= m_direction;
+      vec = dist * c_dist_cap;
+      dist *= m_direction;
       return;
     }
     /* Closest feature: cylinder */
@@ -82,20 +79,15 @@ void SpheroCylinder::calculate_dist(const Utils::Vector3d &pos, double *dist,
         dir = -1;
       Utils::Vector3d c_dist_cap =
           -(pos - (m_center + dir * e_z * m_half_length));
-      *dist = m_rad - c_dist_cap.norm();
+      dist = m_rad - c_dist_cap.norm();
       c_dist_cap.normalize();
-      Utils::Vector3d v = *dist * c_dist_cap;
-      for (int i = 0; i < 3; i++) {
-        vec[i] = v[i];
-      }
-      *dist *= -m_direction;
+      vec = dist * c_dist_cap;
+      dist *= -m_direction;
       return;
     }
   }
 
-  *dist = std::sqrt(dr * dr) * m_direction * side;
-  for (int i = 0; i < 3; i++) {
-    vec[i] = -dr * e_r[i];
-  }
+  dist = std::abs(dr) * m_direction * side;
+  vec = -dr * e_r;
 }
 } // namespace Shapes

--- a/src/core/shapes/SpheroCylinder.hpp
+++ b/src/core/shapes/SpheroCylinder.hpp
@@ -94,8 +94,8 @@ public:
   Utils::Vector3d &center() { return m_center; }
   double &direction() { return m_direction; }
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 };
 } // namespace Shapes
 

--- a/src/core/shapes/Stomatocyte.cpp
+++ b/src/core/shapes/Stomatocyte.cpp
@@ -28,8 +28,8 @@
 using namespace std;
 
 namespace Shapes {
-void Stomatocyte::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                                 double *vec) const {
+void Stomatocyte::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                                 Utils::Vector3d &vec) const {
 
   using Utils::sqr;
 
@@ -67,7 +67,7 @@ void Stomatocyte::calculate_dist(const Utils::Vector3d &pos, double *dist,
   // So the shortest distance to the line is
 
   Utils::Vector2d dist_2D;
-  dist_2D[0] = Utils::Vector3d(closest_pos - pos).norm();
+  dist_2D[0] = (closest_pos - pos).norm();
   dist_2D[1] = mu * m_orientation.norm();
 
   /***** Use the obtained planar coordinates in distance function *****/
@@ -362,11 +362,8 @@ void Stomatocyte::calculate_dist(const Utils::Vector3d &pos, double *dist,
 
   // Pass the values we obtained to ESPResSo
 
-  for (int i = 0; i < 3; i++) {
-    vec[i] = normal_3D[i] * distance;
-  }
-
-  *dist = std::copysign(distance, m_direction);
+  vec = normal_3D * distance;
+  dist = std::copysign(distance, m_direction);
 
   // And we are done with the stomatocyte
 }

--- a/src/core/shapes/Stomatocyte.hpp
+++ b/src/core/shapes/Stomatocyte.hpp
@@ -33,8 +33,8 @@ public:
         m_outer_radius(0.0), m_inner_radius(0.0), m_layer_width(0.0),
         m_direction(0.0) {}
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 
   Utils::Vector3d const &position() const { return m_position; }
   void set_position(Utils::Vector3d const &position) { m_position = position; }

--- a/src/core/shapes/Torus.cpp
+++ b/src/core/shapes/Torus.cpp
@@ -4,8 +4,8 @@
 
 namespace Shapes {
 
-void Torus::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                           double *vec) const {
+void Torus::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                           Utils::Vector3d &vec) const {
   /* Coordinate transform to cylinder coords
      with origin at m_center. */
   Utils::Vector3d const c_dist = pos - m_center;
@@ -13,11 +13,9 @@ void Torus::calculate_dist(const Utils::Vector3d &pos, double *dist,
   auto const r_vec = c_dist - z * e_z;
   auto const r = r_vec.norm();
 
-  *dist = (sqrt(Utils::sqr(r - m_rad) + z * z) - m_tube_rad) * m_direction;
+  dist = (sqrt(Utils::sqr(r - m_rad) + z * z) - m_tube_rad) * m_direction;
   Utils::Vector3d const dir_vec = c_dist - r_vec * m_rad / r;
   auto const dir_vec_norm = dir_vec / dir_vec.norm();
-  vec[0] = -dir_vec_norm[0] * *dist;
-  vec[1] = -dir_vec_norm[1] * *dist;
-  vec[2] = -dir_vec_norm[2] * *dist;
+  vec = -dir_vec_norm * dist;
 }
 } // namespace Shapes

--- a/src/core/shapes/Torus.hpp
+++ b/src/core/shapes/Torus.hpp
@@ -52,8 +52,8 @@ public:
   Utils::Vector3d &center() { return m_center; }
   double &direction() { return m_direction; }
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 };
 } // namespace Shapes
 #endif

--- a/src/core/shapes/Wall.cpp
+++ b/src/core/shapes/Wall.cpp
@@ -23,16 +23,10 @@
 
 namespace Shapes {
 
-void Wall::calculate_dist(const Utils::Vector3d &pos, double *dist,
-                          double *vec) const {
-  int i;
-
-  *dist = -m_d;
-  for (i = 0; i < 3; i++)
-    *dist += pos[i] * m_n[i];
-
-  for (i = 0; i < 3; i++)
-    vec[i] = m_n[i] * *dist;
+void Wall::calculate_dist(const Utils::Vector3d &pos, double &dist,
+                          Utils::Vector3d &vec) const {
+  dist = -m_d + pos * m_n;
+  vec = m_n * dist;
 }
 
 } /* namespace Shapes */

--- a/src/core/shapes/Wall.hpp
+++ b/src/core/shapes/Wall.hpp
@@ -30,8 +30,8 @@ class Wall : public Shape {
 public:
   Wall() : m_n({1., 0., 0.}), m_d(0.0) {}
 
-  void calculate_dist(const Utils::Vector3d &pos, double *dist,
-                      double *vec) const override;
+  void calculate_dist(const Utils::Vector3d &pos, double &dist,
+                      Utils::Vector3d &vec) const override;
 
   void set_normal(const Utils::Vector3d &normal) {
     m_n = normal;

--- a/src/core/unit_tests/Ellipsoid_test.cpp
+++ b/src/core/unit_tests/Ellipsoid_test.cpp
@@ -37,7 +37,7 @@ bool check_distance_function(const Shapes::Shape &s) {
       double theta = 2. * i / N * M_PI;
       double v = j / (N - 1.);
 
-      double dist[3];
+      Utils::Vector3d dist;
       double d;
 
       /* pos part of surface */
@@ -46,18 +46,17 @@ bool check_distance_function(const Shapes::Shape &s) {
                              semiaxes[2] * v};
 
       /* check that points on ellipsoid yield zero distance */
-      s.calculate_dist(pos, &d, dist);
+      s.calculate_dist(pos, d, dist);
       if (std::abs(d) > 1e-12)
         return false;
 
       /* pos outside of surface */
       for (int dim = 0; dim < 3; dim++)
         pos[dim] += 2.3 - dim;
-      s.calculate_dist(pos, &d, dist);
+      s.calculate_dist(pos, d, dist);
 
       /* trivial test */
-      if ((dist[0] * dist[0] + dist[1] * dist[1] + dist[2] * dist[2] - d * d) >
-          1e-12)
+      if ((dist.norm2() - d * d) > 1e-12)
         return false;
     }
   }

--- a/src/core/unit_tests/Wall_test.cpp
+++ b/src/core/unit_tests/Wall_test.cpp
@@ -33,22 +33,19 @@ bool check_distance_function(const Shapes::Shape &s) {
     for (int j = 0; j < 100; j++)
       for (int k = 0; k < 100; k++) {
         Utils::Vector3d pos = {i * 0.1, j * 0.1, k * 0.1};
-        double dist[3];
+        Utils::Vector3d dist{};
         double d;
 
-        s.calculate_dist(pos, &d, dist);
-
+        s.calculate_dist(pos, d, dist);
         /* trivial test */
-        if ((dist[0] * dist[0] + dist[1] * dist[1] + dist[2] * dist[2] -
-             d * d) > 1e-12) {
+        if ((dist.norm2() - d * d) > 1e-12) {
           return false;
         }
 
         /* check if the returned closest point really is on the surface */
-        for (int dim = 0; dim < 3; dim++)
-          pos[dim] -= dist[dim];
+        pos -= dist;
 
-        s.calculate_dist(pos, &d, dist);
+        s.calculate_dist(pos, d, dist);
         if (std::abs(d) > 1e-12) {
           return false;
         }

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -179,7 +179,7 @@ void VirtualSitesRelative::pressure_and_stress_tensor_contribution(
 
     // Pressure = 1/3 trace of stress tensor
     // but the 1/3 is applied somewhere else.
-    *pressure += (p.f.f[0] * d[0] + p.f.f[1] * d[1] + p.f.f[2] * d[2]);
+    *pressure += p.f.f * d;
   }
 }
 

--- a/src/script_interface/shapes/Shape.hpp
+++ b/src/script_interface/shapes/Shape.hpp
@@ -39,9 +39,10 @@ public:
                       VariantMap const &params) override {
     if (name == "calc_distance") {
       auto const pos = get_value<Utils::Vector3d>(params.at("position"));
-      double dist, vec[3];
-      shape()->calculate_dist(pos, &dist, vec);
-      return std::vector<Variant>{dist, Utils::Vector3d{vec}};
+      double dist;
+      Utils::Vector3d vec;
+      shape()->calculate_dist(pos, dist, vec);
+      return std::vector<Variant>{dist, vec};
     }
 
     return {};


### PR DESCRIPTION
Changes:
- use Vector3d in energy/force/pressure calculation
    - affects bonded IAs, non-bonded IAs, electrostatics, magnetostatics, constraints, shapes
    - refactor code based on Vector3d-specific functions (scalar product, dot product, cross product, Hadamard product, norm)
- reduce code complexity substantially in functions involving dipoles

Required for #2502. No significant change in performance for LJ and P3M benchmarks with 1k particles (around 2% speed-up in some cases).