### PR TITLE
Sphinx Doc: Replace `array_like` and 'list of' with `(N,) array_like of` where appropriate.

### DIFF
--- a/doc/sphinx/constraints.rst
+++ b/doc/sphinx/constraints.rst
@@ -318,8 +318,8 @@ Pictured is an example constraint with a ``SimplePore`` shape created with ::
 
 The resulting surface is a stomatocyte shaped boundary.
 This command should be used with care.
-The position can be any point in the simulation box and is set via the 3-tuple parameter ``center``.
-The orientation of the (cylindrically symmetric) stomatocyte is given by an ``axis`` (a 3-tuple of :obj:`float`),
+The position can be any point in the simulation box and is set via the (3,) array_like parameter ``center``.
+The orientation of the (cylindrically symmetric) stomatocyte is given by an ``axis`` (a (3,) array_like of :obj:`float`),
 which points in the direction of the symmetry axis and does not need to be normalized.
 The parameters: ``outer_radius``, ``inner_radius``, and ``layer_width``, specify the shape of the stomatocyte.
 Here inappropriate choices of these parameters can yield undesired results.
@@ -431,10 +431,10 @@ The resulting surface is a section of a hollow cone.
 The parameters ``inner_radius`` and ``outer_radius`` specifies the two radii .
 The parameter ``opening_angle`` specifies the opening angle of the cone (in radians, between 0 and :math:`\pi/2` ), and thus also determines the length.
 
-The orientation of the (cylindrically symmetric) cone is specified with the parameter ``axis`` (a 3-tuple of :obj:`float`),
+The orientation of the (cylindrically symmetric) cone is specified with the parameter ``axis`` (a (3,) array_like of :obj:`float`),
 which points in the direction of the symmetry axis, and does not need to be normalized.
 
-The position is specified via the 3-tuple ``center`` and can be any point in the simulation box.
+The position is specified via the (3,) array_like ``center`` and can be any point in the simulation box.
 
 The ``width`` specifies the width.
 This shape supports the ``direction`` parameter, ``+1`` for outward and ``-1`` for inward.

--- a/doc/sphinx/constraints.rst
+++ b/doc/sphinx/constraints.rst
@@ -318,8 +318,8 @@ Pictured is an example constraint with a ``SimplePore`` shape created with ::
 
 The resulting surface is a stomatocyte shaped boundary.
 This command should be used with care.
-The position can be any point in the simulation box and is set via the array_like parameter ``center``.
-The orientation of the (cylindrically symmetric) stomatocyte is given by an array_like ``axis``,
+The position can be any point in the simulation box and is set via the 3-tuple parameter ``center``.
+The orientation of the (cylindrically symmetric) stomatocyte is given by an ``axis`` (a 3-tuple of :obj:`float`),
 which points in the direction of the symmetry axis and does not need to be normalized.
 The parameters: ``outer_radius``, ``inner_radius``, and ``layer_width``, specify the shape of the stomatocyte.
 Here inappropriate choices of these parameters can yield undesired results.
@@ -431,10 +431,10 @@ The resulting surface is a section of a hollow cone.
 The parameters ``inner_radius`` and ``outer_radius`` specifies the two radii .
 The parameter ``opening_angle`` specifies the opening angle of the cone (in radians, between 0 and :math:`\pi/2` ), and thus also determines the length.
 
-The orientation of the (cylindrically symmetric) cone is specified with the array_like parameter ``axis``,
+The orientation of the (cylindrically symmetric) cone is specified with the parameter ``axis`` (a 3-tuple of :obj:`float`),
 which points in the direction of the symmetry axis, and does not need to be normalized.
 
-The position is specified via the array_like parameter ``center`` and can be any point in the simulation box.
+The position is specified via the 3-tuple ``center`` and can be any point in the simulation box.
 
 The ``width`` specifies the width.
 This shape supports the ``direction`` parameter, ``+1`` for outward and ``-1`` for inward.

--- a/doc/sphinx/lb.rst
+++ b/doc/sphinx/lb.rst
@@ -75,8 +75,8 @@ the fluid thermalization::
 
     lbfluid = espressomd.lb.LBFluid(kT=1.0, seed=134, ...)
 
-The parameter ``ext_force_density`` takes a three dimensional vector as a
-3-tuple of :obj:`float`, representing a homogeneous external body force density in MD
+The parameter ``ext_force_density`` takes a three dimensional vector as an
+array_like of :obj:`float`, representing a homogeneous external body force density in MD
 units to be applied to the fluid. The parameter ``bulk_visc`` allows one to
 tune the bulk viscosity of the fluid and is given in MD units. In the limit of
 low Mach number, the flow does not compress the fluid and the resulting flow

--- a/doc/sphinx/lb.rst
+++ b/doc/sphinx/lb.rst
@@ -75,8 +75,8 @@ the fluid thermalization::
 
     lbfluid = espressomd.lb.LBFluid(kT=1.0, seed=134, ...)
 
-The parameter ``ext_force_density`` takes a three dimensional vector as an
-`array_like`, representing a homogeneous external body force density in MD
+The parameter ``ext_force_density`` takes a three dimensional vector as a
+3-tuple of :obj:`float`, representing a homogeneous external body force density in MD
 units to be applied to the fluid. The parameter ``bulk_visc`` allows one to
 tune the bulk viscosity of the fluid and is given in MD units. In the limit of
 low Mach number, the flow does not compress the fluid and the resulting flow

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -29,7 +29,7 @@
 # not enclosed within <a href="..."></a> tags. Sphinx doesn't use line
 # wrapping, so these broken links can be found via text search. The first
 # negative lookahead filters out common Python types (for performance reasons).
-regex_sphinx_broken_link='<code class=\"xref py py-[a-z]+ docutils literal notranslate\"><span class=\"pre\">(?!(int|float|bool|str|object|list|tuple|dict)<)[^<>]+?</span></code>(?!</a>)'
+regex_sphinx_broken_link='<code class=\"xref py py-[a-z]+ docutils literal notranslate\"><span class=\"pre\">(?!(int|float|bool|str|object|list|tuple|dict|(?:numpy\.|np\.)?(?:nd)?array)<)[^<>]+?</span></code>(?!</a>)'
 
 # list of espresso modules not compiled in CI (visualization, scafacos)
 regex_ignored_es_features_ci='(espressomd\.)?(visualization|([a-z]+\.)?[sS]cafacos)'

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -285,9 +285,9 @@ class Analysis:
 
         Parameters
         ----------
-        center : 3-tuple of :obj:`float`
+        center : (3,) array_like of :obj:`float`
             Coordinates of the centre of the cylinder.
-        axis : 3-tuple of :obj:`float`
+        axis : (3,) array_like of :obj:`float`
             Axis vectory of the cylinder, does not need to be normalized.
         length : :obj:`float`
             Length of the cylinder.
@@ -743,7 +743,7 @@ class Analysis:
 
         Returns
         -------
-        4-tuple of :obj:`float`
+        (4,) array_like of :obj:`float`
             Where [0] is the mean end-to-end distance of chains and [1] its
             standard deviation, [2] the mean square end-to-end distance and
             [3] its standard deviation.
@@ -775,7 +775,7 @@ class Analysis:
 
         Returns
         -------
-        4-tuple of :obj:`float`
+        (4,) array_like of :obj:`float`
             Where [0] is the mean radius of gyration of the chains and [1] its
             standard deviation, [2] the mean square radius of gyration and [3]
             its standard deviation.
@@ -806,7 +806,7 @@ class Analysis:
 
         Returns
         -------
-        2-tuple of :obj:`float`:
+        (2,) array_like of :obj:`float`:
             Where [0] is the mean hydrodynamic radius of the chains
             and [1] its standard deviation.
 

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -285,9 +285,9 @@ class Analysis:
 
         Parameters
         ----------
-        center : array_like :obj:`float`
+        center : 3-tuple of :obj:`float`
             Coordinates of the centre of the cylinder.
-        axis : array_like :obj:`float`
+        axis : 3-tuple of :obj:`float`
             Axis vectory of the cylinder, does not need to be normalized.
         length : :obj:`float`
             Length of the cylinder.
@@ -723,8 +723,8 @@ class Analysis:
     def calc_re(self, chain_start=None, number_of_chains=None,
                 chain_length=None):
         """
-        Calculates the Mean end-to-end distance of chains and its
-        standard deviation, as well as Mean Square end-to-end distance of
+        Calculates the mean end-to-end distance of chains and its
+        standard deviation, as well as mean square end-to-end distance of
         chains and its standard deviation.
 
         This requires that a set of chains of equal length which start with the
@@ -743,9 +743,9 @@ class Analysis:
 
         Returns
         -------
-        array_like :obj:`float`
-            Where [0] is the Mean end-to-end distance of chains and [1] its
-            standard deviation, [2] the Mean Square end-to-end distance and
+        4-tuple of :obj:`float`
+            Where [0] is the mean end-to-end distance of chains and [1] its
+            standard deviation, [2] the mean square end-to-end distance and
             [3] its standard deviation.
 
         """
@@ -775,9 +775,9 @@ class Analysis:
 
         Returns
         -------
-        array_like :obj:`float`
-            Where [0] is the Mean radius of gyration of the chains and [1] its
-            standard deviation, [2] the Mean Square radius of gyration and [3]
+        4-tuple of :obj:`float`
+            Where [0] is the mean radius of gyration of the chains and [1] its
+            standard deviation, [2] the mean square radius of gyration and [3]
             its standard deviation.
 
         """
@@ -806,7 +806,7 @@ class Analysis:
 
         Returns
         -------
-        array_like :obj:`float`:
+        2-tuple of :obj:`float`:
             Where [0] is the mean hydrodynamic radius of the chains
             and [1] its standard deviation.
 
@@ -856,7 +856,7 @@ class Analysis:
 
         Returns
         -------
-        array_like
+        :obj:`ndarray`
             Where [0] contains q
             and [1] contains the structure factor s(q)
 
@@ -909,7 +909,7 @@ class Analysis:
 
         Returns
         -------
-        array_like
+        :obj:`ndarray`
             Where [0] contains the midpoints of the bins,
             and [1] contains the values of the rdf.
 
@@ -997,7 +997,7 @@ class Analysis:
 
         Returns
         -------
-        array_like
+        :obj:`ndarray`
             Where [0] contains the midpoints of the bins,
             and [1] contains the values of the rdf.
 
@@ -1144,7 +1144,7 @@ class Analysis:
 
         Returns
         -------
-        array_like
+        :obj:`ndarray`
             3x3 moment of inertia matrix.
 
         """

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -243,7 +243,7 @@ class _Interpolated(Constraint):
 
         Arguments
         ---------
-        box_size : 3-tuple of obj:`float`
+        box_size : (3,) array_like of obj:`float`
             The box the field should be used.
 
         grid_spacing : array_like obj:`float`
@@ -262,7 +262,7 @@ class _Interpolated(Constraint):
 
         Arguments
         ---------
-        box_size : 3-tuple of obj:`float`
+        box_size : (3,) array_like of obj:`float`
             The box the field should be used.
 
         grid_spacing : array_like obj:`float`
@@ -293,7 +293,7 @@ class _Interpolated(Constraint):
 
         Arguments
         ---------
-        box_size : 3-tuple of obj:`float`
+        box_size : (3,) array_like of obj:`float`
             The box the field should be used.
 
         grid_spacing : array_like obj:`float`
@@ -519,7 +519,7 @@ class HomogeneousFlowField(Constraint):
     ----------
     gamma : :obj:`float`
         The coupling constant
-    u : 3-tuple of :obj:`float`
+    u : (3,) array_like of :obj:`float`
         The velocity of the field.
 
     """

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -220,7 +220,7 @@ class _Interpolated(Constraint):
     ----------
 
     field_data: array_like :obj:`float`
-        The actual field please be aware that depending on the interpolation
+        The actual field. Please be aware that depending on the interpolation
         order additional points are used on the boundaries.
 
     grid_spacing: array_like :obj:`float`
@@ -243,7 +243,7 @@ class _Interpolated(Constraint):
 
         Arguments
         ---------
-        box_size : array_like obj:`float`
+        box_size : 3-tuple of obj:`float`
             The box the field should be used.
 
         grid_spacing : array_like obj:`float`
@@ -262,7 +262,7 @@ class _Interpolated(Constraint):
 
         Arguments
         ---------
-        box_size : array_like obj:`float`
+        box_size : 3-tuple of obj:`float`
             The box the field should be used.
 
         grid_spacing : array_like obj:`float`
@@ -293,7 +293,7 @@ class _Interpolated(Constraint):
 
         Arguments
         ---------
-        box_size : array_like obj:`float`
+        box_size : 3-tuple of obj:`float`
             The box the field should be used.
 
         grid_spacing : array_like obj:`float`
@@ -519,7 +519,7 @@ class HomogeneousFlowField(Constraint):
     ----------
     gamma : :obj:`float`
         The coupling constant
-    u : array_like :obj:`float`
+    u : 3-tuple of :obj:`float`
         The velocity of the field.
 
     """

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -214,7 +214,7 @@ IF P3M == 1:
             A positive number for the dielectric constant of the
             surrounding medium. Use ``'metallic'`` to set the dielectric
             constant of the surrounding medium to infinity (default).
-        mesh : :obj:`int` or array_like of :obj:`int`, optional
+        mesh : :obj:`int` or 3-tuple of :obj:`int`, optional
             The number of mesh points in x, y and z direction. Use a single
             value for cubic boxes.
         r_cut : :obj:`float`, optional
@@ -357,7 +357,7 @@ IF P3M == 1:
                 A positive number for the dielectric constant of the
                 surrounding medium. Use ``'metallic'`` to set the dielectric
                 constant of the surrounding medium to infinity (default).
-            mesh : :obj:`int` or array_like of :obj:`int`, optional
+            mesh : :obj:`int` or 3-tuple of :obj:`int`, optional
                 The number of mesh points in x, y and z direction. Use a single
                 value for cubic boxes.
             r_cut : :obj:`float`, optional

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -214,7 +214,7 @@ IF P3M == 1:
             A positive number for the dielectric constant of the
             surrounding medium. Use ``'metallic'`` to set the dielectric
             constant of the surrounding medium to infinity (default).
-        mesh : :obj:`int` or 3-tuple of :obj:`int`, optional
+        mesh : :obj:`int` or (3,) array_like of :obj:`int`, optional
             The number of mesh points in x, y and z direction. Use a single
             value for cubic boxes.
         r_cut : :obj:`float`, optional
@@ -357,7 +357,7 @@ IF P3M == 1:
                 A positive number for the dielectric constant of the
                 surrounding medium. Use ``'metallic'`` to set the dielectric
                 constant of the surrounding medium to infinity (default).
-            mesh : :obj:`int` or 3-tuple of :obj:`int`, optional
+            mesh : :obj:`int` or (3,) array_like of :obj:`int`, optional
                 The number of mesh points in x, y and z direction. Use a single
                 value for cubic boxes.
             r_cut : :obj:`float`, optional

--- a/src/python/espressomd/galilei.pyx
+++ b/src/python/espressomd/galilei.pyx
@@ -52,8 +52,8 @@ cdef class GalileiTransform:
 
         Returns
         -------
-        cms : :obj:`list`
-              The of the center of mass position vector as a list of floats.
+        cms : 3-tuple of :obj:`float`
+              The of the center of mass position vector.
 
         """
         return make_array_locked(mpi_system_CMS())
@@ -65,8 +65,8 @@ cdef class GalileiTransform:
 
         Returns
         -------
-        cms_vel : :obj:`list` of :obj:`float`
-                  The of the center of mass velocity vector as a list of floats
+        cms_vel : 3-tuple of :obj:`float`
+                  The of the center of mass velocity vector.
 
         """
 

--- a/src/python/espressomd/galilei.pyx
+++ b/src/python/espressomd/galilei.pyx
@@ -52,7 +52,7 @@ cdef class GalileiTransform:
 
         Returns
         -------
-        cms : 3-tuple of :obj:`float`
+        cms : (3,) array_like of :obj:`float`
               The of the center of mass position vector.
 
         """
@@ -65,7 +65,7 @@ cdef class GalileiTransform:
 
         Returns
         -------
-        cms_vel : 3-tuple of :obj:`float`
+        cms_vel : (3,) array_like of :obj:`float`
                   The of the center of mass velocity vector.
 
         """

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -139,8 +139,8 @@ cdef class Integrator:
             The external pressure.
         piston : :obj:`float`
             The mass of the applied piston.
-        direction : :obj:`list`, optional
-            Three integers to set the box geometry for non-cubic boxes
+        direction : 3-tuple of :obj:`int`, optional
+            Set the box geometry for non-cubic boxes.
         cubic_box : :obj:`bool`, optional
             If this optional parameter is true, a cubic box is assumed.
 

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -139,7 +139,7 @@ cdef class Integrator:
             The external pressure.
         piston : :obj:`float`
             The mass of the applied piston.
-        direction : 3-tuple of :obj:`int`, optional
+        direction : (3,) array_like of :obj:`int`, optional
             Set the box geometry for non-cubic boxes.
         cubic_box : :obj:`bool`, optional
             If this optional parameter is true, a cubic box is assumed.

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -193,12 +193,12 @@ cdef class HydrodynamicInteraction(Actor):
 
         Parameters
         ----------
-        pos : 3-tuple of :obj:`float`
+        pos : (3,) array_like of :obj:`float`
               The position at which velocity is requested.
 
         Returns
         -------
-        v : 3-tuple :obj:`float`
+        v : (3,) array_like :obj:`float`
             The LB fluid velocity at ``pos``.
 
         """

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -193,12 +193,12 @@ cdef class HydrodynamicInteraction(Actor):
 
         Parameters
         ----------
-        pos : array_like :obj:`float`
+        pos : 3-tuple of :obj:`float`
               The position at which velocity is requested.
 
         Returns
         -------
-        v : array_like :obj:`float`
+        v : 3-tuple :obj:`float`
             The LB fluid velocity at ``pos``.
 
         """

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -76,10 +76,10 @@ IF DP3M == 1:
             Ewald parameter.
         cao : :obj:`int`
             Charge-assignment order, an integer between -1 and 7.
-        mesh : :obj:`int` or 3-tuple of :obj:`int`
+        mesh : :obj:`int` or (3,) array_like of :obj:`int`
             The number of mesh points in x, y and z direction. Use a single
             value for cubic boxes.
-        mesh_off : 3-tuple of :obj:`float`
+        mesh_off : (3,) array_like of :obj:`float`
             Mesh offset.
         r_cut : :obj:`float`
             Real space cutoff.
@@ -128,7 +128,7 @@ IF DP3M == 1:
 
             if not (self._params["mesh_off"] == default_params["mesh_off"] or len(self._params["mesh_off"]) == 3):
                 raise ValueError(
-                    "mesh_off should be a 3-tuple of values between 0.0 and 1.0")
+                    "mesh_off should be a (3,) array_like of values between 0.0 and 1.0")
 
         def valid_keys(self):
             return ["prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off",

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -76,10 +76,10 @@ IF DP3M == 1:
             Ewald parameter.
         cao : :obj:`int`
             Charge-assignment order, an integer between -1 and 7.
-        mesh : :obj:`int` or array_like of :obj:`int`
+        mesh : :obj:`int` or 3-tuple of :obj:`int`
             The number of mesh points in x, y and z direction. Use a single
             value for cubic boxes.
-        mesh_off : array_like :obj:`float`
+        mesh_off : 3-tuple of :obj:`float`
             Mesh offset.
         r_cut : :obj:`float`
             Real space cutoff.
@@ -128,7 +128,7 @@ IF DP3M == 1:
 
             if not (self._params["mesh_off"] == default_params["mesh_off"] or len(self._params["mesh_off"]) == 3):
                 raise ValueError(
-                    "mesh_off should be a list of length 3 and values between 0.0 and 1.0")
+                    "mesh_off should be a 3-tuple of values between 0.0 and 1.0")
 
         def valid_keys(self):
             return ["prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off",

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -435,9 +435,9 @@ class CylindricalDensityProfile(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : array_like of :obj:`float`
+    center : 3-tuple of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : array_like
+    axis : 3-tuple of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -471,9 +471,9 @@ class CylindricalFluxDensityProfile(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : array_like of :obj:`float`
+    center : 3-tuple of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : array_like
+    axis : 3-tuple of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -507,9 +507,9 @@ class CylindricalLBFluxDensityProfileAtParticlePositions(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : array_like of :obj:`float`
+    center : 3-tuple of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : array_like
+    axis : 3-tuple of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -543,9 +543,9 @@ class CylindricalLBVelocityProfileAtParticlePositions(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : array_like of :obj:`float`
+    center : 3-tuple of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : array_like
+    axis : 3-tuple of :obj:`float` 
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -579,9 +579,9 @@ class CylindricalVelocityProfile(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : array_like of :obj:`float`
+    center : 3-tuple of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : array_like
+    axis : 3-tuple of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -617,9 +617,9 @@ class CylindricalLBVelocityProfile(Observable):
 
     Parameters
     ----------
-    center : array_like of :obj:`float`
+    center : 3-tuple of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : array_like
+    axis : 3-tuple of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -435,9 +435,9 @@ class CylindricalDensityProfile(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -471,9 +471,9 @@ class CylindricalFluxDensityProfile(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -507,9 +507,9 @@ class CylindricalLBFluxDensityProfileAtParticlePositions(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -543,9 +543,9 @@ class CylindricalLBVelocityProfileAtParticlePositions(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : 3-tuple of :obj:`float` 
+    axis : (3,) array_like of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -579,9 +579,9 @@ class CylindricalVelocityProfile(Observable):
     ----------
     ids : array_like of :obj:`int`
           The ids of (existing) particles to take into account.
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.
@@ -617,9 +617,9 @@ class CylindricalLBVelocityProfile(Observable):
 
     Parameters
     ----------
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
              Position of the center of the polar coordinate system for the histogram.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
            Orientation vector of the ``z``-axis of the polar coordinate system for the histogram.
     n_r_bins : :obj:`int`
                Number of bins in radial direction.

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -144,7 +144,7 @@ cdef class ParticleHandle:
         """
         The unwrapped (not folded into central box) particle position.
 
-        pos : 3-tuple of :obj:`float`
+        pos : (3,) array_like of :obj:`float`
             The particles's absolute position.
 
         """
@@ -166,7 +166,7 @@ cdef class ParticleHandle:
         """
         The wrapped (folded into central box) position vector of a particle.
 
-        pos : 3-tuple of :obj:`float`
+        pos : (3,) array_like of :obj:`float`
             The particles's position.
 
         .. note::
@@ -224,7 +224,7 @@ cdef class ParticleHandle:
         """
         The particle velocity in the lab frame.
 
-        v : 3-tuple of :obj:`float`
+        v : (3,) array_like of :obj:`float`
             The particles's velocity
 
         .. note::
@@ -249,7 +249,7 @@ cdef class ParticleHandle:
         """
         The instantaneous force acting on this particle.
 
-        f : 3-tuple of :obj:`float`
+        f : (3,) array_like of :obj:`float`
             The current forces on the particle
 
         .. note::
@@ -372,7 +372,7 @@ cdef class ParticleHandle:
             """
             The particle angular velocity the lab frame.
 
-            omega_lab : 3-tuple of :obj:`float`
+            omega_lab : (3,) array_like of :obj:`float`
                 The particle's angular velocity measured from the lab frame.
 
             .. note::
@@ -406,7 +406,7 @@ cdef class ParticleHandle:
             """
             Particle quaternion representation.
 
-            quat : 4-tuple of :obj:`float`
+            quat : (4,) array_like of :obj:`float`
                 Sets the quaternion representation of the
                 rotational position of this particle.
 
@@ -454,7 +454,7 @@ cdef class ParticleHandle:
             """
             The particle angular velocity in body frame.
 
-            omega_body : 3-tuple of :obj:`float`
+            omega_body : (3,) array_like of :obj:`float`
 
             This property sets the angular momentum of this particle in the
             particles co-rotating frame (or body frame).
@@ -482,7 +482,7 @@ cdef class ParticleHandle:
             """
             The particle torque in the lab frame.
 
-            torque_lab : 3-tuple of :obj:`float`
+            torque_lab : (3,) array_like of :obj:`float`
 
             This property defines the torque of this particle
             in the fixed frame (or laboratory frame).
@@ -518,7 +518,7 @@ cdef class ParticleHandle:
             """
             The particle rotational inertia.
 
-            rintertia : 3-tuple of :obj:`float`
+            rintertia : (3,) array_like of :obj:`float`
 
             Sets the diagonal elements of this particles rotational inertia
             tensor. These correspond with the inertial moments along the
@@ -674,7 +674,7 @@ cdef class ParticleHandle:
             This quaternion describes the virtual particles orientation in the
             body fixed frame of the related real particle.
 
-            vs_quat : 4-tuple of :obj:`float`
+            vs_quat : (4,) array_like of :obj:`float`
 
             .. note::
                This needs the feature ``VIRTUAL_SITES_RELATIVE``.
@@ -754,7 +754,7 @@ cdef class ParticleHandle:
             """
             The orientation of the dipole axis.
 
-            dip : 3-tuple of :obj:`float`
+            dip : (3,) array_like of :obj:`float`
 
             .. note::
                This needs the feature ``DIPOLES``.
@@ -802,7 +802,7 @@ cdef class ParticleHandle:
             """
             An additional external force applied to the particle.
 
-            ext_force : 3-tuple of :obj:`float`
+            ext_force : (3,) array_like of :obj:`float`
 
             .. note::
                This needs the feature ``EXTERNAL_FORCES``.
@@ -833,7 +833,7 @@ cdef class ParticleHandle:
             """
             Fixes the particle motion in the specified cartesian directions.
 
-            fix : 3-tuple of :obj:`int`
+            fix : (3,) array_like of :obj:`int`
 
             Fixes the particle in space. By supplying a set of 3 integers as
             arguments it is possible to fix motion in x, y, or z coordinates
@@ -872,7 +872,7 @@ cdef class ParticleHandle:
                 """
                 An additional external torque is applied to the particle.
 
-                ext_torque : 3-tuple of :obj:`float`
+                ext_torque : (3,) array_like of :obj:`float`
 
                 ..  note::
                     * This torque is specified in the laboratory frame!
@@ -906,7 +906,7 @@ cdef class ParticleHandle:
                 """
                 The body-fixed frictional coefficient used in the the Langevin thermostat.
 
-                gamma : `float` or 3-tuple of :obj:`float`
+                gamma : `float` or (3,) array_like of :obj:`float`
 
                 .. note::
                     This needs features ``LANGEVIN_PER_PARTICLE`` and
@@ -970,7 +970,7 @@ cdef class ParticleHandle:
                     """
                     The particle translational frictional coefficient used in the Langevin thermostat.
 
-                    gamma_rot : :obj:`float` of 3-tuple of :obj:`float`
+                    gamma_rot : :obj:`float` of (3,) array_like of :obj:`float`
 
                     .. note::
                         This needs features ``LANGEVIN_PER_PARTICLE``,
@@ -1048,7 +1048,7 @@ cdef class ParticleHandle:
 
             The default is not to integrate any rotational degrees of freedom.
 
-            rotation : 3-tuple of :obj:`int`
+            rotation : (3,) array_like of :obj:`int`
 
             .. note::
                 This needs the feature ``ROTATION``.

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -144,8 +144,8 @@ cdef class ParticleHandle:
         """
         The unwrapped (not folded into central box) particle position.
 
-        pos : list of :obj:`float`
-            A list of three floats representing the particles's absolute position.
+        pos : 3-tuple of :obj:`float`
+            The particles's absolute position.
 
         """
 
@@ -166,8 +166,8 @@ cdef class ParticleHandle:
         """
         The wrapped (folded into central box) position vector of a particle.
 
-        pos : list of :obj:`float`
-            A list of three floats representing the particles's position.
+        pos : 3-tuple of :obj:`float`
+            The particles's position.
 
         .. note::
            Setting the folded position is ambiguous and is thus not possible, please use `pos`.
@@ -224,8 +224,8 @@ cdef class ParticleHandle:
         """
         The particle velocity in the lab frame.
 
-        v : list of :obj:`float`
-            A list of three floats representing the Particles's velocity
+        v : 3-tuple of :obj:`float`
+            The particles's velocity
 
         .. note::
            The velocity remains variable and will be changed during integration.
@@ -249,8 +249,8 @@ cdef class ParticleHandle:
         """
         The instantaneous force acting on this particle.
 
-        f : list of :obj:`float`
-            A list of three floats representing the current forces on the Particle
+        f : 3-tuple of :obj:`float`
+            The current forces on the particle
 
         .. note::
            Whereas the velocity is modified with respect to the velocity you set
@@ -372,9 +372,8 @@ cdef class ParticleHandle:
             """
             The particle angular velocity the lab frame.
 
-            omega_lab : list of :obj:`float`
-                List of three floats giving the particle angular
-                velocity as measured from the lab frame.
+            omega_lab : 3-tuple of :obj:`float`
+                The particle's angular velocity measured from the lab frame.
 
             .. note::
                This needs the feature ``ROTATION``.
@@ -407,9 +406,9 @@ cdef class ParticleHandle:
             """
             Particle quaternion representation.
 
-            quat : list fo :obj:`float` (of length four)
-                This list of four floats sets the quaternion representation
-                of the rotational position of this particle.
+            quat : 4-tuple of :obj:`float`
+                Sets the quaternion representation of the
+                rotational position of this particle.
 
             .. note::
                This needs the feature ``ROTATION``.
@@ -455,7 +454,7 @@ cdef class ParticleHandle:
             """
             The particle angular velocity in body frame.
 
-            omega_body : list of :obj:`float`
+            omega_body : 3-tuple of :obj:`float`
 
             This property sets the angular momentum of this particle in the
             particles co-rotating frame (or body frame).
@@ -483,7 +482,7 @@ cdef class ParticleHandle:
             """
             The particle torque in the lab frame.
 
-            torque_lab : list of :obj:`float`
+            torque_lab : 3-tuple of :obj:`float`
 
             This property defines the torque of this particle
             in the fixed frame (or laboratory frame).
@@ -519,7 +518,7 @@ cdef class ParticleHandle:
             """
             The particle rotational inertia.
 
-            rintertia : list of :obj:`float`
+            rintertia : 3-tuple of :obj:`float`
 
             Sets the diagonal elements of this particles rotational inertia
             tensor. These correspond with the inertial moments along the
@@ -675,7 +674,7 @@ cdef class ParticleHandle:
             This quaternion describes the virtual particles orientation in the
             body fixed frame of the related real particle.
 
-            vs_quat : array_like of :obj:`float`
+            vs_quat : 4-tuple of :obj:`float`
 
             .. note::
                This needs the feature ``VIRTUAL_SITES_RELATIVE``.
@@ -755,7 +754,7 @@ cdef class ParticleHandle:
             """
             The orientation of the dipole axis.
 
-            dip : list of :obj:`float`
+            dip : 3-tuple of :obj:`float`
 
             .. note::
                This needs the feature ``DIPOLES``.
@@ -803,7 +802,7 @@ cdef class ParticleHandle:
             """
             An additional external force applied to the particle.
 
-            ext_force : list of :obj:`float`
+            ext_force : 3-tuple of :obj:`float`
 
             .. note::
                This needs the feature ``EXTERNAL_FORCES``.
@@ -834,7 +833,7 @@ cdef class ParticleHandle:
             """
             Fixes the particle motion in the specified cartesian directions.
 
-            fix : list of integers
+            fix : 3-tuple of :obj:`int`
 
             Fixes the particle in space. By supplying a set of 3 integers as
             arguments it is possible to fix motion in x, y, or z coordinates
@@ -873,7 +872,7 @@ cdef class ParticleHandle:
                 """
                 An additional external torque is applied to the particle.
 
-                ext_torque : list of :obj:`float`
+                ext_torque : 3-tuple of :obj:`float`
 
                 ..  note::
                     * This torque is specified in the laboratory frame!
@@ -907,7 +906,7 @@ cdef class ParticleHandle:
                 """
                 The body-fixed frictional coefficient used in the the Langevin thermostat.
 
-                gamma : list of :obj:`float`
+                gamma : `float` or 3-tuple of :obj:`float`
 
                 .. note::
                     This needs features ``LANGEVIN_PER_PARTICLE`` and
@@ -971,7 +970,7 @@ cdef class ParticleHandle:
                     """
                     The particle translational frictional coefficient used in the Langevin thermostat.
 
-                    gamma_rot : list of :obj:`float`
+                    gamma_rot : :obj:`floati` of 3-tuple of :obj:`float`
 
                     .. note::
                         This needs features ``LANGEVIN_PER_PARTICLE``,
@@ -1049,7 +1048,7 @@ cdef class ParticleHandle:
 
             The default is not to integrate any rotational degrees of freedom.
 
-            rotation : list of :obj:`int`
+            rotation : 3-tuple of :obj:`int`
 
             .. note::
                 This needs the feature ``ROTATION``.
@@ -1525,8 +1524,8 @@ cdef class ParticleHandle:
 
         See Also
         ----------
-        delete_bond : Delete an unverified bond held by the Particle.
-        bonds : Particle property containing a list of all current bonds help by Particle.
+        delete_bond : Delete an unverified bond held by the particle.
+        bonds : Particle property containing a list of all current bonds help by particle.
 
         """
 

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -970,7 +970,7 @@ cdef class ParticleHandle:
                     """
                     The particle translational frictional coefficient used in the Langevin thermostat.
 
-                    gamma_rot : :obj:`floati` of 3-tuple of :obj:`float`
+                    gamma_rot : :obj:`float` of 3-tuple of :obj:`float`
 
                     .. note::
                         This needs features ``LANGEVIN_PER_PARTICLE``,

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -92,7 +92,7 @@ def positions(**kwargs):
 
     Returns
     -------
-    array_like :obj:`float`
+    :obj:`ndarray`
         Three-dimensional numpy array, namely a list of polymers containing the
         coordinates of the respective monomers.
 

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -29,9 +29,9 @@ class Cylinder(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
         Coordinates of the center of the cylinder.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
         Axis of the cylinder.
     radius : :obj:`float`
         Radius of the cylinder.
@@ -58,7 +58,7 @@ class Ellipsoid(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
         Coordinates of the center of the ellipsoid.
     a : :obj:`float`
         Semiaxis along the axis of rotational symmetry.
@@ -85,9 +85,9 @@ class HollowCone(Shape, ScriptInterfaceHelper):
         Outer radius of the cone.
     opening_angle : :obj:`float`
         Opening angle of the cone (in rad).
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
         Axis of symmetry, prescribes orientation of the cone.
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
         Position of the cone.
     width : :obj:`float`
         Wall thickness of the cone.
@@ -107,13 +107,13 @@ class Rhomboid(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    a : 3-tuple of :obj:`float`
+    a : (3,) array_like of :obj:`float`
         First base vector.
-    b : 3-tuple of :obj:`float`
+    b : (3,) array_like of :obj:`float`
         Second base vector.
-    c : 3-tuple of :obj:`float`
+    c : (3,) array_like of :obj:`float`
         Third base vector.
-    corner : 3-tuple of :obj:`float`
+    corner : (3,) array_like of :obj:`float`
         Lower left corner of the rhomboid.
     direction : :obj:`int`
         Surface orientation, for +1 the normal points
@@ -153,7 +153,7 @@ class Sphere(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
         Center of the sphere
     radius : :obj:`float`
         Radius of the sphere.
@@ -173,9 +173,9 @@ class SpheroCylinder(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
         Coordinates of the center of the cylinder.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
         Axis of the cylinder.
     radius : :obj:`float`
         Radius of the cylinder.
@@ -199,9 +199,9 @@ class Stomatocyte(Shape, ScriptInterfaceHelper):
         Inner radius of the stomatocyte.
     outer_radius : :obj:`float`
         Outer radius of the stomatocyte.
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
         Symmetry axis, prescribing the orientation of the stomatocyte.
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
         Position of the stomatocyte.
     layer_width : :obj:`float`
         Scaling parameter.
@@ -221,9 +221,9 @@ class Torus(Shape, ScriptInterfaceHelper):
     A torus shape.
     Attributes
     ----------
-    center : 3-tuple of :obj:`float`
+    center : (3,) array_like of :obj:`float`
         Coordinates of the center of the torus.
-    normal : 3-tuple of :obj:`float`
+    normal : (3,) array_like of :obj:`float`
         Normal axis of the torus.
     radius : :obj:`float`
         Radius of the torus.
@@ -247,7 +247,7 @@ class Wall(Shape, ScriptInterfaceHelper):
     ----------
     dist : :obj:`float`
         Distance from the origin.
-    normal : 3-tuple of :obj:`int`
+    normal : (3,) array_like of :obj:`int`
         Normal vector of the plane (needs not to be length 1).
 
     """
@@ -270,9 +270,9 @@ class SimplePore(Shape, ScriptInterfaceHelper):
         The distance between the planes.
     smoothing_radius: float
         Radius of the torus segments
-    axis: 3-tuple of :obj:`float`
+    axis: (3,) array_like of :obj:`float`
         Axis of the cylinder and normal of the planes
-    center: 3-tuple of :obj:`float`
+    center: (3,) array_like of :obj:`float`
         Position of the center of the cylinder.
 
     """

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -29,9 +29,9 @@ class Cylinder(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : array_like :obj:`float`
+    center : 3-tuple of :obj:`float`
         Coordinates of the center of the cylinder.
-    axis : array_like :obj:`float`
+    axis : 3-tuple of :obj:`float`
         Axis of the cylinder.
     radius : :obj:`float`
         Radius of the cylinder.
@@ -58,7 +58,7 @@ class Ellipsoid(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : array_like :obj:`float`
+    center : 3-tuple of :obj:`float`
         Coordinates of the center of the ellipsoid.
     a : :obj:`float`
         Semiaxis along the axis of rotational symmetry.
@@ -85,9 +85,9 @@ class HollowCone(Shape, ScriptInterfaceHelper):
         Outer radius of the cone.
     opening_angle : :obj:`float`
         Opening angle of the cone (in rad).
-    axis : array_like :obj:`float`
+    axis : 3-tuple of :obj:`float`
         Axis of symmetry, prescribes orientation of the cone.
-    center : array_like :obj:`float`
+    center : 3-tuple of :obj:`float`
         Position of the cone.
     width : :obj:`float`
         Wall thickness of the cone.
@@ -107,13 +107,13 @@ class Rhomboid(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    a : array_like :obj:`float`
+    a : 3-tuple of :obj:`float`
         First base vector.
-    b : array_like :obj:`float`
+    b : 3-tuple of :obj:`float`
         Second base vector.
-    c : array_like :obj:`float`
+    c : 3-tuple of :obj:`float`
         Third base vector.
-    corner : array_like :obj:`float`
+    corner : 3-tuple of :obj:`float`
         Lower left corner of the rhomboid.
     direction : :obj:`int`
         Surface orientation, for +1 the normal points
@@ -153,7 +153,7 @@ class Sphere(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : array_like :obj:`float`
+    center : 3-tuple of :obj:`float`
         Center of the sphere
     radius : :obj:`float`
         Radius of the sphere.
@@ -173,9 +173,9 @@ class SpheroCylinder(Shape, ScriptInterfaceHelper):
 
     Attributes
     ----------
-    center : array_like :obj:`float`
+    center : 3-tuple of :obj:`float`
         Coordinates of the center of the cylinder.
-    axis : array_like :obj:`float`
+    axis : 3-tuple of :obj:`float`
         Axis of the cylinder.
     radius : :obj:`float`
         Radius of the cylinder.
@@ -199,9 +199,9 @@ class Stomatocyte(Shape, ScriptInterfaceHelper):
         Inner radius of the stomatocyte.
     outer_radius : :obj:`float`
         Outer radius of the stomatocyte.
-    axis : array_like :obj:`float`
+    axis : 3-tuple of :obj:`float`
         Symmetry axis, prescribing the orientation of the stomatocyte.
-    center : array_like :obj:`float`
+    center : 3-tuple of :obj:`float`
         Position of the stomatocyte.
     layer_width : :obj:`float`
         Scaling parameter.
@@ -221,9 +221,9 @@ class Torus(Shape, ScriptInterfaceHelper):
     A torus shape.
     Attributes
     ----------
-    center : array_like :obj:`float`
+    center : 3-tuple of :obj:`float`
         Coordinates of the center of the torus.
-    normal : array_like :obj:`float`
+    normal : 3-tuple of :obj:`float`
         Normal axis of the torus.
     radius : :obj:`float`
         Radius of the torus.
@@ -247,8 +247,8 @@ class Wall(Shape, ScriptInterfaceHelper):
     ----------
     dist : :obj:`float`
         Distance from the origin.
-    normal : array_like :obj:`int`
-        Normal vector of the plan (needs not to be length 1).
+    normal : 3-tuple of :obj:`int`
+        Normal vector of the plane (needs not to be length 1).
 
     """
     _so_name = "Shapes::Wall"
@@ -270,9 +270,9 @@ class SimplePore(Shape, ScriptInterfaceHelper):
         The distance between the planes.
     smoothing_radius: float
         Radius of the torus segments
-    axis: array_like
+    axis: 3-tuple of :obj:`float`
         Axis of the cylinder and normal of the planes
-    center: array_like
+    center: 3-tuple of :obj:`float`
         Position of the center of the cylinder.
 
     """

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -184,7 +184,7 @@ cdef class System:
 
     property box_l:
         """
-        3-tuple of :obj:`float`:
+        (3,) array_like of :obj:`float`:
             Dimensions of the simulation box
 
         """
@@ -215,7 +215,7 @@ cdef class System:
 
     property periodicity:
         """
-        3-tuple of :obj:`bool`:
+        (3,) array_like of :obj:`bool`:
             System periodicity in ``[x, y, z]``, ``False`` for no periodicity
             in this direction, ``True`` for periodicity
 

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -184,7 +184,7 @@ cdef class System:
 
     property box_l:
         """
-        array_like of :obj:`float`:
+        3-tuple of :obj:`float`:
             Dimensions of the simulation box
 
         """
@@ -215,7 +215,7 @@ cdef class System:
 
     property periodicity:
         """
-        array_like of :obj:`bool`:
+        3-tuple of :obj:`bool`:
             System periodicity in ``[x, y, z]``, ``False`` for no periodicity
             in this direction, ``True`` for periodicity
 

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -32,13 +32,13 @@ class openGLLive:
     ----------
 
     system : :class:`espressomd.system.System`
-    window_size : 2-tuple of :obj:`int`, optional
+    window_size : (2,) array_like of :obj:`int`, optional
         Size of the visualizer window in pixels.
     name : :obj:`str`, optional
         The name of the visualizer window.
-    background_color : 3-tuple of :obj:`int`, optional
+    background_color : (3,) array_like of :obj:`int`, optional
         RGB of the background.
-    periodic_images : 3-tuple of :obj:`int`, optional
+    periodic_images : (3,) array_like of :obj:`int`, optional
         Periodic repetitions on both sides of the box in xyz-direction.
     draw_box : :obj:`bool`, optional
         Draw wireframe boundaries.
@@ -60,11 +60,11 @@ class openGLLive:
         The distance from the viewer to the near clipping plane.
     far_cut_distance : :obj:`float`, optional
         The distance from the viewer to the far clipping plane.
-    camera_position : :obj:`str` or 3-tuple of :obj:`float`, optional
+    camera_position : :obj:`str` or (3,) array_like of :obj:`float`, optional
         Initial camera position. ``auto`` (default) for shiftet position in z-direction.
-    camera_target : :obj:`str` or 3-tuple of :obj:`float`, optional
+    camera_target : :obj:`str` or (3,) array_like of :obj:`float`, optional
         Initial camera target. ``auto`` (default) to look towards the system center.
-    camera_right : 3-tuple of :obj:`float`, optional
+    camera_right : (3,) array_like of :obj:`float`, optional
         Camera right vector in system coordinates. Default is [1, 0, 0]
     particle_sizes : :obj:`str` or array_like :obj:`float` or callable, optional
         auto (default): The Lennard-Jones sigma value of the
@@ -88,7 +88,7 @@ class openGLLive:
         Colors for particle types.
     particle_type_materials : :obj:`str`, optional
         Materials of the particle types.
-    particle_charge_colors : 2-tuple of :obj:`float`, optional
+    particle_charge_colors : (2,) array_like of :obj:`float`, optional
         Two colors for min/max charged particles.
     draw_constraints : :obj:`bool`, optional
         Enables constraint visualization. For simple constraints
@@ -165,7 +165,7 @@ class openGLLive:
         Draws the LB shapes.
     LB_draw_velocity_plane : :obj:`bool`, optional
         Draws LB node velocity arrows specified by LB_plane_axis, LB_plane_dist, LB_plane_ngrid.
-    light_pos : 3-tuple of :obj:`float`, optional
+    light_pos : (3,) array_like of :obj:`float`, optional
         If auto (default) is used, the light is placed dynamically in
         the particle barycenter of the system. Otherwise, a fixed
         coordinate can be set.

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -32,14 +32,14 @@ class openGLLive:
     ----------
 
     system : :class:`espressomd.system.System`
-    window_size : array_like :obj:`int`, optional
+    window_size : 2-tuple of :obj:`int`, optional
         Size of the visualizer window in pixels.
     name : :obj:`str`, optional
         The name of the visualizer window.
-    background_color : array_like :obj:`int`, optional
+    background_color : 3-tuple of :obj:`int`, optional
         RGB of the background.
-    periodic_images : array_like :obj:`int`, optional
-        Periodic repetitions on both sides of the box in xyzdirection.
+    periodic_images : 3-tuple of :obj:`int`, optional
+        Periodic repetitions on both sides of the box in xyz-direction.
     draw_box : :obj:`bool`, optional
         Draw wireframe boundaries.
     draw_axis : :obj:`bool`, optional
@@ -60,11 +60,11 @@ class openGLLive:
         The distance from the viewer to the near clipping plane.
     far_cut_distance : :obj:`float`, optional
         The distance from the viewer to the far clipping plane.
-    camera_position : :obj:`str` or array_like :obj:`float`, optional
+    camera_position : :obj:`str` or 3-tuple of :obj:`float`, optional
         Initial camera position. ``auto`` (default) for shiftet position in z-direction.
-    camera_target : :obj:`str` or array_like :obj:`float`, optional
+    camera_target : :obj:`str` or 3-tuple of :obj:`float`, optional
         Initial camera target. ``auto`` (default) to look towards the system center.
-    camera_right : array_like :obj:`float`, optional
+    camera_right : 3-tuple of :obj:`float`, optional
         Camera right vector in system coordinates. Default is [1, 0, 0]
     particle_sizes : :obj:`str` or array_like :obj:`float` or callable, optional
         auto (default): The Lennard-Jones sigma value of the
@@ -88,7 +88,7 @@ class openGLLive:
         Colors for particle types.
     particle_type_materials : :obj:`str`, optional
         Materials of the particle types.
-    particle_charge_colors : array_like :obj:`float`, optional
+    particle_charge_colors : 2-tuple of :obj:`float`, optional
         Two colors for min/max charged particles.
     draw_constraints : :obj:`bool`, optional
         Enables constraint visualization. For simple constraints
@@ -119,7 +119,7 @@ class openGLLive:
     ext_force_arrows_type_colors : array_like :obj:`float`, optional
         Colors of ext_force arrows for different particle types.
     ext_force_arrows_type_materials : array_like :obj:`float`, optional
-        Materils of ext_force arrows for different particle types.
+        Materials of ext_force arrows for different particle types.
     ext_force_arrows_type_radii : array_like :obj:`float`, optional
         List of arrow radii for different particle types.
     force_arrows : :obj:`bool`, optional
@@ -165,7 +165,7 @@ class openGLLive:
         Draws the LB shapes.
     LB_draw_velocity_plane : :obj:`bool`, optional
         Draws LB node velocity arrows specified by LB_plane_axis, LB_plane_dist, LB_plane_ngrid.
-    light_pos : array_like :obj:`float`, optional
+    light_pos : 3-tuple of :obj:`float`, optional
         If auto (default) is used, the light is placed dynamically in
         the particle barycenter of the system. Otherwise, a fixed
         coordinate can be set.

--- a/src/python/object_in_fluid/oif_utils.py
+++ b/src/python/object_in_fluid/oif_utils.py
@@ -34,11 +34,11 @@ def get_triangle_normal(a, b, c):
 
     Parameters
     ----------
-    a : 3-tuple of :obj:`float`
+    a : (3,) array_like of :obj:`float`
           Point a
-    b : 3-tuple of of :obj:`float`
+    b : (3,) array_like of of :obj:`float`
           Point b
-    c : 3-tuple of :obj:`float`
+    c : (3,) array_like of :obj:`float`
           Point c
     """
     n = [0.0, 0.0, 0.0]
@@ -54,7 +54,7 @@ def norm(vect):
 
     Parameters
     ----------
-    vect : 3-tuple of :obj:`float`
+    vect : (3,) array_like of :obj:`float`
           Input vector
 
     """
@@ -68,9 +68,9 @@ def vec_distance(a, b):
 
     Parameters
     ----------
-    a : 3-tuple of :obj:`float`
+    a : (3,) array_like of :obj:`float`
           Point a
-    b : 3-tuple of :obj:`float`
+    b : (3,) array_like of :obj:`float`
           Point b
 
     """
@@ -84,11 +84,11 @@ def area_triangle(a, b, c):
 
     Parameters
     ----------
-    a : 3-tuple of :obj:`float`
+    a : (3,) array_like of :obj:`float`
           Point a
-    b : 3-tuple of :obj:`float`
+    b : (3,) array_like of :obj:`float`
           Point b
-    c : 3-tuple of :obj:`float`
+    c : (3,) array_like of :obj:`float`
           Point c
 
     """
@@ -103,13 +103,13 @@ def angle_btw_triangles(P1, P2, P3, P4):
 
     Parameters
     ----------
-    P1 : 3-tuple of :obj:`float`
+    P1 : (3,) array_like of :obj:`float`
           Point P1
-    P2 : 3-tuple of :obj:`float`
+    P2 : (3,) array_like of :obj:`float`
           Point P2
-    P3 : 3-tuple of :obj:`float`
+    P3 : (3,) array_like of :obj:`float`
           Point P3
-    P4 : 3-tuple of :obj:`float`
+    P4 : (3,) array_like of :obj:`float`
           Point P4
 
     """
@@ -178,9 +178,9 @@ def oif_calc_stretching_force(ks, pA, pB, dist0, dist):
     ----------
     ks : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : 3-tuple of :obj:`float`
+    pA : (3,) array_like of :obj:`float`
           position of the first particle
-    pB : 3-tuple of :obj:`float`
+    pB : (3,) array_like of :obj:`float`
           position of the second particle
     dist0 : :obj:`float`
           relaxed distance btw particles
@@ -210,9 +210,9 @@ def oif_calc_linear_stretching_force(ks, pA, pB, dist0, dist):
     ----------
     ks : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : 3-tuple of :obj:`float`
+    pA : (3,) array_like of :obj:`float`
           position of the first particle
-    pB : 3-tuple of :obj:`float`
+    pB : (3,) array_like of :obj:`float`
           position of the second particle
     dist0 : :obj:`float`
           relaxed distance btw particles
@@ -236,13 +236,13 @@ def oif_calc_bending_force(kb, pA, pB, pC, pD, phi0, phi):
     ----------
     kb : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : 3-tuple of :obj:`float`
+    pA : (3,) array_like of :obj:`float`
           position of the first particle
-    pB : 3-tuple of :obj:`float`
+    pB : (3,) array_like of :obj:`float`
           position of the second particle
-    pC : 3-tuple of :obj:`float`
+    pC : (3,) array_like of :obj:`float`
           position of the third particle
-    pD : 3-tuple of :obj:`float`
+    pD : (3,) array_like of :obj:`float`
           position of the fourth particle
     phi0 : :obj:`float`
           relaxed angle btw two triangles
@@ -273,11 +273,11 @@ def oif_calc_local_area_force(kal, pA, pB, pC, A0, A):
     ----------
     kal : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : 3-tuple of :obj:`float`
+    pA : (3,) array_like of :obj:`float`
           position of the first particle
-    pB : 3-tuple of :obj:`float`
+    pB : (3,) array_like of :obj:`float`
           position of the second particle
-    pC : 3-tuple of :obj:`float`
+    pC : (3,) array_like of :obj:`float`
           position of the third particle
     A0 : :obj:`float`
           relaxed area of the triangle
@@ -323,11 +323,11 @@ def oif_calc_global_area_force(kag, pA, pB, pC, Ag0, Ag):
     ----------
     kag : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : 3-tuple of :obj:`float`
+    pA : (3,) array_like of :obj:`float`
           position of the first particle
-    pB : 3-tuple of :obj:`float`
+    pB : (3,) array_like of :obj:`float`
           position of the second particle
-    pC : 3-tuple of :obj:`float`
+    pC : (3,) array_like of :obj:`float`
           position of the third particle
     Ag0 : :obj:`float`
           relaxed surface area of the cell
@@ -371,11 +371,11 @@ def oif_calc_volume_force(kv, pA, pB, pC, V0, V):
     ----------
     kv : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : 3-tuple of :obj:`float`
+    pA : (3,) array_like of :obj:`float`
           position of the first particle
-    pB : 3-tuple of :obj:`float`
+    pB : (3,) array_like of :obj:`float`
           position of the second particle
-    pC : 3-tuple of :obj:`float`
+    pC : (3,) array_like of :obj:`float`
           position of the third particle
     V0 : :obj:`float`
           relaxed volume of the cell
@@ -576,7 +576,7 @@ def output_vtk_pore(
 
     Parameters
     ----------
-    axis : 3-tuple of :obj:`float`
+    axis : (3,) array_like of :obj:`float`
           The axis
     length : :obj:`float`
           length of pore
@@ -590,7 +590,7 @@ def output_vtk_pore(
           inner right radius of pore
     smoothing_radius : :obj:`float`
           smoothing radius for surface connecting outer and inner radii of the pore
-    pos : 3-tuple of :obj:`float`
+    pos : (3,) array_like of :obj:`float`
           Position of the center of the pore
     m : :obj:`int`
           number of discretization sections

--- a/src/python/object_in_fluid/oif_utils.py
+++ b/src/python/object_in_fluid/oif_utils.py
@@ -34,12 +34,12 @@ def get_triangle_normal(a, b, c):
 
     Parameters
     ----------
-    a : list of :obj:`float`
-          vector with 3 components, point a
-    b : list of :obj:`float`
-          vector with 3 components, point b
-    c : list of :obj:`float`
-          vector with 3 components, point c
+    a : 3-tuple of :obj:`float`
+          Point a
+    b : 3-tuple of of :obj:`float`
+          Point b
+    c : 3-tuple of :obj:`float`
+          Point c
     """
     n = [0.0, 0.0, 0.0]
     n[0] = (b[1] - a[1]) * (c[2] - a[2]) - (b[2] - a[2]) * (c[1] - a[1])
@@ -54,8 +54,8 @@ def norm(vect):
 
     Parameters
     ----------
-    vect : list of :obj:`float`
-          vector with 3 components
+    vect : 3-tuple of :obj:`float`
+          Input vector
 
     """
     v = np.array(vect)
@@ -68,10 +68,10 @@ def vec_distance(a, b):
 
     Parameters
     ----------
-    a : list of :obj:`float`
-          vector with 3 components, point a
-    b : list of :obj:`float`
-          vector with 3 components, point b
+    a : 3-tuple of :obj:`float`
+          Point a
+    b : 3-tuple of :obj:`float`
+          Point b
 
     """
     return norm(np.array(a) - np.array(b))
@@ -79,17 +79,17 @@ def vec_distance(a, b):
 
 def area_triangle(a, b, c):
     """
-    Returns the area of a triangle given by points a,b,c.
+    Returns the area of a triangle given by points a, b, c.
 
 
     Parameters
     ----------
-    a : list of :obj:`float`
-          vector with 3 components, point a
-    b : list of :obj:`float`
-          vector with 3 components, point b
-    c : list of :obj:`float`
-          vector with 3 components, point c
+    a : 3-tuple of :obj:`float`
+          Point a
+    b : 3-tuple of :obj:`float`
+          Point b
+    c : 3-tuple of :obj:`float`
+          Point c
 
     """
     n = get_triangle_normal(a, b, c)
@@ -103,14 +103,14 @@ def angle_btw_triangles(P1, P2, P3, P4):
 
     Parameters
     ----------
-    P1 : list of :obj:`float`
-          vector with 3 components, point P1
-    P2 : list of :obj:`float`
-          vector with 3 components, point P2
-    P3 : list of :obj:`float`
-          vector with 3 components, point P3
-    P4 : list of :obj:`float`
-          vector with 3 components, point P4
+    P1 : 3-tuple of :obj:`float`
+          Point P1
+    P2 : 3-tuple of :obj:`float`
+          Point P2
+    P3 : 3-tuple of :obj:`float`
+          Point P3
+    P4 : 3-tuple of :obj:`float`
+          Point P4
 
     """
     n1 = get_triangle_normal(P2, P1, P3)
@@ -178,9 +178,9 @@ def oif_calc_stretching_force(ks, pA, pB, dist0, dist):
     ----------
     ks : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : list of :obj:`float`
+    pA : 3-tuple of :obj:`float`
           position of the first particle
-    pB : list of :obj:`float`
+    pB : 3-tuple of :obj:`float`
           position of the second particle
     dist0 : :obj:`float`
           relaxed distance btw particles
@@ -210,9 +210,9 @@ def oif_calc_linear_stretching_force(ks, pA, pB, dist0, dist):
     ----------
     ks : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : list of :obj:`float`
+    pA : 3-tuple of :obj:`float`
           position of the first particle
-    pB : list of :obj:`float`
+    pB : 3-tuple of :obj:`float`
           position of the second particle
     dist0 : :obj:`float`
           relaxed distance btw particles
@@ -236,13 +236,13 @@ def oif_calc_bending_force(kb, pA, pB, pC, pD, phi0, phi):
     ----------
     kb : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : list of :obj:`float`
+    pA : 3-tuple of :obj:`float`
           position of the first particle
-    pB : list of :obj:`float`
+    pB : 3-tuple of :obj:`float`
           position of the second particle
-    pC : list of :obj:`float`
+    pC : 3-tuple of :obj:`float`
           position of the third particle
-    pD : list of :obj:`float`
+    pD : 3-tuple of :obj:`float`
           position of the fourth particle
     phi0 : :obj:`float`
           relaxed angle btw two triangles
@@ -273,11 +273,11 @@ def oif_calc_local_area_force(kal, pA, pB, pC, A0, A):
     ----------
     kal : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : list of :obj:`float`
+    pA : 3-tuple of :obj:`float`
           position of the first particle
-    pB : list of :obj:`float`
+    pB : 3-tuple of :obj:`float`
           position of the second particle
-    pC : list of :obj:`float`
+    pC : 3-tuple of :obj:`float`
           position of the third particle
     A0 : :obj:`float`
           relaxed area of the triangle
@@ -323,11 +323,11 @@ def oif_calc_global_area_force(kag, pA, pB, pC, Ag0, Ag):
     ----------
     kag : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : list of :obj:`float`
+    pA : 3-tuple of :obj:`float`
           position of the first particle
-    pB : list of :obj:`float`
+    pB : 3-tuple of :obj:`float`
           position of the second particle
-    pC : list of :obj:`float`
+    pC : 3-tuple of :obj:`float`
           position of the third particle
     Ag0 : :obj:`float`
           relaxed surface area of the cell
@@ -371,11 +371,11 @@ def oif_calc_volume_force(kv, pA, pB, pC, V0, V):
     ----------
     kv : :obj:`float`
           coefficient of the stretching, spring stiffness
-    pA : list of :obj:`float`
+    pA : 3-tuple of :obj:`float`
           position of the first particle
-    pB : list of :obj:`float`
+    pB : 3-tuple of :obj:`float`
           position of the second particle
-    pC : list of :obj:`float`
+    pC : 3-tuple of :obj:`float`
           position of the third particle
     V0 : :obj:`float`
           relaxed volume of the cell
@@ -536,7 +536,7 @@ def output_vtk_lines(lines, out_file):
 
     Parameters
     ----------
-    lines : list of :obj:`float`
+    lines : array_like :obj:`float`
           lines is a list of pairs of points p1, p2
           each pair represents a line segment to output to vtk
           each line in lines contains 6 floats: p1x, p1y, p1z, p2x, p2y, p2z
@@ -576,8 +576,8 @@ def output_vtk_pore(
 
     Parameters
     ----------
-    axis : list of :obj:`float`
-          3 floats specifying the axis
+    axis : 3-tuple of :obj:`float`
+          The axis
     length : :obj:`float`
           length of pore
     outer_rad_left : :obj:`float`
@@ -590,8 +590,8 @@ def output_vtk_pore(
           inner right radius of pore
     smoothing_radius : :obj:`float`
           smoothing radius for surface connecting outer and inner radii of the pore
-    pos : list of :obj:`float`
-          3 floats specifying position of the center of the pore
+    pos : 3-tuple of :obj:`float`
+          Position of the center of the pore
     m : :obj:`int`
           number of discretization sections
     out_file : :obj:`str`


### PR DESCRIPTION
Follow up on PR #3029.
As discussed offline this PR changes the code documentation such that the non-specific `array_like` inputs are replaced by n-tuples where appropriate.

Description of changes:
 - Array-like input parameters of a fixed expected length are documented as `<n>-tuple of :obj:<type>`. This style is used by numpy-doc for fixed-length inputs, see e.g. the `axis` parameter in [numpy.linalg.norm](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.norm.html).
 - Array-like input parameters with variable length are kept as `array_like`.
 - Return arrays are usually of type `ndarray`. This is updated where appropriate.