### PR TITLE
Fix tutorials CI/CD

### DIFF
--- a/maintainer/CI/deploy_tutorials.py
+++ b/maintainer/CI/deploy_tutorials.py
@@ -29,7 +29,7 @@ for filepath in glob.glob('*/*.html'):
     deploy_list.append(filepath)
     # extract all figures
     dirname = os.path.dirname(filepath)
-    with open(filepath) as f:
+    with open(filepath, encoding='utf-8') as f:
         html = lxml.html.parse(f)
     figures = filter(lambda src: not src.startswith('data:image'),
                      html.xpath('//img/@src'))


### PR DESCRIPTION
Fixes `UnicodeDecodeError` in some versions of `lxml` ([logfile](https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/-/jobs/143937))