### PR TITLE
Generate Sphinx documentation for visualizers in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,6 +211,7 @@ cuda-maxset:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   script:
     - export myconfig=maxset with_coverage=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
+    - sed -i 's/ or "DISPLAY" in os.environ/ or True/' src/python/espressomd/visualization.pyx
     - bash maintainer/CI/build_cmake.sh
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -422,6 +422,7 @@ check_sphinx:
     - cuda-maxset
   when: on_success
   script:
+    - sed -i 's/ or "DISPLAY" in os.environ/ or True/' ${CI_PROJECT_DIR}/src/python/espressomd/visualization.pyx
     - cd ${CI_PROJECT_DIR}/build
     - make -t && make sphinx
     - bash ../maintainer/CI/doc_warnings.sh

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -250,7 +250,7 @@ napoleon_use_param = False
 
 # Suppress warnings for features not compiled in
 # http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
-autodoc_mock_imports = ['featuredefs', 'mayavi', 'pyface', 'tvtk', 'vtk', 'MDAnalysis', 'electrostatics']
+autodoc_mock_imports = ['featuredefs', 'matplotlib', 'OpenGL', 'mayavi', 'pyface', 'tvtk', 'vtk', 'MDAnalysis', 'electrostatics']
 
 def setup(app):
     app.add_stylesheet('bibtex.css')

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -31,8 +31,8 @@
 # negative lookahead filters out common Python types (for performance reasons).
 regex_sphinx_broken_link='<code class=\"xref py py-[a-z]+ docutils literal notranslate\"><span class=\"pre\">(?!(int|float|bool|str|object|list|tuple|dict)<)[^<>]+?</span></code>(?!</a>)'
 
-# list of espresso modules not compiled in CI (visualization, scafacos)
-regex_ignored_es_features_ci='(espressomd\.)?(visualization|([a-z]+\.)?[sS]cafacos)'
+# list of espresso modules not compiled in CI (scafacos)
+regex_ignored_es_features_ci='(espressomd\.)?(([a-z]+\.)?[sS]cafacos)'
 
 if [ ! -f doc/sphinx/html/index.html ]; then
     echo "Please run Sphinx first."
@@ -54,7 +54,7 @@ if [ $? = "0" ]; then
         is_standard_type_or_module="false"
         grep -Pq '^([a-zA-Z0-9_]+Error|[a-zA-Z0-9_]*Exception|(?!espressomd\.)[a-zA-Z0-9_]+\.[a-zA-Z0-9_\.]+)$' <<< "${reference}"
         [ "$?" = "0" ] && is_standard_type_or_module="true"
-        # skip espresso modules not compiled in CI (visualization, scafacos)
+        # skip espresso modules not compiled in CI
         is_es_feature_skipped="false"
         if [ "${CI}" != "" ]; then
             grep -Pq "^${regex_ignored_es_features_ci}" <<< "${reference}"
@@ -105,7 +105,7 @@ if [ $? = "0" ]; then
     # warn user about ignored features in CI
     grep -Pq "${regex_ignored_es_features_ci}" doc_warnings.log
     if [ "$?" = "0" ] && [ "${CI}" = "" ]; then
-        echo "(Note that features visualization and Scafacos are ignored in CI)"
+        echo "(Note that feature Scafacos is ignored in CI)"
     fi
 fi
 

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -171,7 +171,9 @@ cdef class HydrodynamicInteraction(Actor):
         if python_lbfluid_get_agrid(self._params["agrid"]):
             raise Exception("lb_lbfluid_set_agrid error")
 
-        if not self._params["ext_force_density"] == default_params["ext_force_density"]:
+        if not np.allclose(self._params["ext_force_density"],
+                           default_params["ext_force_density"],
+                           atol=1e-4):
             self._params["ext_force_density"] = self.ext_force_density
 
         return self._params

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -336,12 +336,6 @@ class openGLLive:
         IF not ROTATION:
             self.specs['director_arrows'] = False
 
-        IF not CUDA:
-            self.specs['LB_draw_velocity_plane'] = False
-            self.specs['LB_draw_boundaries'] = False
-            self.specs['LB_draw_nodes'] = False
-            self.specs['LB_draw_node_boundaries'] = False
-
         IF not LB_BOUNDARIES and not LB_BOUNDARIES_GPU:
             self.specs['LB_draw_boundaries'] = False
             self.specs['LB_draw_node_boundaries'] = False

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -1579,13 +1579,7 @@ class openGLLive:
         # LOOK FOR LB ACTOR
         if self.specs['LB_draw_velocity_plane'] or self.specs['LB_draw_nodes'] or self.specs['LB_draw_node_boundaries']:
             for a in self.system.actors:
-                types = [espressomd.lb.LBFluid]
-                IF CUDA:
-                    types.append(espressomd.lb.LBFluidGPU)
-
-                # if type(a) == espressomd.lb.LBFluidGPU or type(a) ==
-                # espressomd.lb.LBFluid
-                if type(a) in types:
+                if isinstance(a, espressomd.lb.HydrodynamicInteraction):
                     # if 'agrid' in pa:
                     self.lb_params = a.get_params()
                     self.lb = a

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -1579,7 +1579,7 @@ class openGLLive:
         # LOOK FOR LB ACTOR
         if self.specs['LB_draw_velocity_plane'] or self.specs['LB_draw_nodes'] or self.specs['LB_draw_node_boundaries']:
             for a in self.system.actors:
-                types = [types.append(espressomd.lb.LBFluid)]
+                types = [espressomd.lb.LBFluid]
                 IF CUDA:
                     types.append(espressomd.lb.LBFluidGPU)
 

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -191,21 +191,21 @@ class openGLLive:
 
     """
 
-    def __init__(self, system, **kwargs):
-        # MATERIALS
-        self.materials = {
-            'bright': [0.9, 1.0, 0.8, 0.4, 1.0],
-            'medium': [0.6, 0.8, 0.2, 0.4, 1.0],
-            'dark': [0.4, 0.5, 0.1, 0.4, 1.0],
-            'transparent1': [0.6, 0.8, 0.2, 0.5, 0.8],
-            'transparent2': [0.6, 0.8, 0.2, 0.5, 0.4],
-            'transparent3': [0.6, 0.8, 0.2, 0.5, 0.2],
-            'rubber': [0, 0.4, 0.7, 0.078125, 1.0],
-            'chrome': [0.25, 0.4, 0.774597, 0.6, 1.0],
-            'plastic': [0, 0.55, 0.7, 0.25, 1.0],
-            'steel': [0.25, 0.38, 0, 0.32, 1.0]
-        }
+    # MATERIALS
+    materials = {
+        'bright': [0.9, 1.0, 0.8, 0.4, 1.0],
+        'medium': [0.6, 0.8, 0.2, 0.4, 1.0],
+        'dark': [0.4, 0.5, 0.1, 0.4, 1.0],
+        'transparent1': [0.6, 0.8, 0.2, 0.5, 0.8],
+        'transparent2': [0.6, 0.8, 0.2, 0.5, 0.4],
+        'transparent3': [0.6, 0.8, 0.2, 0.5, 0.2],
+        'rubber': [0, 0.4, 0.7, 0.078125, 1.0],
+        'chrome': [0.25, 0.4, 0.774597, 0.6, 1.0],
+        'plastic': [0, 0.55, 0.7, 0.25, 1.0],
+        'steel': [0.25, 0.38, 0, 0.32, 1.0]
+    }
 
+    def __init__(self, system, **kwargs):
         # DEFAULT PROPERTIES
         self.specs = {
             'window_size': [800, 800],

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -1578,12 +1578,15 @@ class openGLLive:
 
         # LOOK FOR LB ACTOR
         if self.specs['LB_draw_velocity_plane'] or self.specs['LB_draw_nodes'] or self.specs['LB_draw_node_boundaries']:
+            lb_types = [espressomd.lb.LBFluid]
+            IF CUDA:
+                lb_types.append(espressomd.lb.LBFluidGPU)
             for a in self.system.actors:
-                if isinstance(a, espressomd.lb.HydrodynamicInteraction):
+                if isinstance(a, tuple(lb_types)):
                     # if 'agrid' in pa:
                     self.lb_params = a.get_params()
                     self.lb = a
-                    self.lb_is_cpu = type(a) == espressomd.lb.LBFluid
+                    self.lb_is_cpu = isinstance(a, espressomd.lb.LBFluid)
                     break
 
         if self.specs['LB_draw_velocity_plane']:


### PR DESCRIPTION
Description of changes:
- CI now generates Sphinx documentation for the OpenGL and Mayavi visualizers
   - [4.0.2 docs](http://espressomd.org/html/doc4.0.2/espressomd.html#module-espressomd.visualization): module is fully documented
   - [devel docs](http://espressomd.org/html/doc/espressomd.html#module-espressomd.visualization): module is currently just 2 import errors, fixed by 63adc57 + 6aa2782 
   - @christophlohrmann 
- fixes the broken OpenGL visualizer (69314fa)
   - error: `UnboundLocalError: local variable 'types' referenced before assignment`
