### PR TITLE
Remove legacy bond angle struct

### DIFF
--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -168,7 +168,6 @@ struct Bonded_coulomb_sr_bond_parameters {
   double q1q2;
 };
 
-
 /** Parameters for three-body angular potential (harmonic). */
 struct Angle_harmonic_bond_parameters {
   /** bending constant */

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -36,11 +36,11 @@ enum BondedInteraction {
   /** Type of tabulated bonded interaction potential,
       may be of bond length, of bond angle or of dihedral type. */
   BONDED_IA_TABULATED,
-  /** Type of bonded interaction is a (-LJ) potential. */
+  /** Type of bonded interaction is a subtracted-LJ potential. */
   BONDED_IA_SUBT_LJ,
-  /** Type of a Rigid/Constrained bond*/
+  /** Type of bonded interaction is a rigid/constrained bond. */
   BONDED_IA_RIGID_BOND,
-  /** Type of a virtual bond*/
+  /** Type of bonded interaction is a virtual bond. */
   BONDED_IA_VIRTUAL_BOND,
   /** Type of bonded interaction is a bond angle cosine potential. */
   BONDED_IA_ANGLE_HARMONIC,
@@ -221,7 +221,7 @@ struct Umbrella_bond_parameters {
 };
 #endif
 
-/** Dummy parameters for -LJ Potential */
+/** Dummy parameters for subtracted-LJ Potential */
 struct Subt_lj_bond_parameters {};
 
 /** Parameters for the rigid_bond/SHAKE/RATTLE ALGORITHM */

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -168,22 +168,6 @@ struct Bonded_coulomb_sr_bond_parameters {
   double q1q2;
 };
 
-/** Parameters for three-body angular potential.
- *  @note
- *      ATTENTION: there are different implementations of the bond angle
- *      potential which you may choose with a compiler flag in the file
- *      \ref config.hpp !
- */
-struct Angle_bond_parameters {
-  /** bending constant */
-  double bend;
-  /** equilibrium angle (default is 180 degrees) */
-  double phi0;
-  /** cosine of @p phi0 (internal parameter) */
-  double cos_phi0;
-  /** sine of @p phi0 (internal parameter) */
-  double sin_phi0;
-};
 
 /** Parameters for three-body angular potential (harmonic). */
 struct Angle_harmonic_bond_parameters {
@@ -314,7 +298,6 @@ union Bond_parameters {
   Quartic_bond_parameters quartic;
   Bonded_coulomb_bond_parameters bonded_coulomb;
   Bonded_coulomb_sr_bond_parameters bonded_coulomb_sr;
-  Angle_bond_parameters angle;
   Angle_harmonic_bond_parameters angle_harmonic;
   Angle_cosine_bond_parameters angle_cosine;
   Angle_cossquare_bond_parameters angle_cossquare;

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -409,13 +409,6 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
     cdef struct Bonded_coulomb_bond_parameters:
         double prefactor
 
-    #* Parameters for three body angular potential (bond-angle potentials).
-    cdef struct Angle_bond_parameters:
-        double bend
-        double phi0
-        double cos_phi0
-        double sin_phi0
-
     #* Parameters for three body angular potential (bond_angle_harmonic).
     cdef struct Angle_harmonic_bond_parameters:
         double bend
@@ -519,7 +512,6 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
         Bonded_coulomb_sr_bond_parameters bonded_coulomb_sr
         Harmonic_bond_parameters harmonic
         Harmonic_dumbbell_bond_parameters harmonic_dumbbell
-        Angle_bond_parameters angle
         Angle_harmonic_bond_parameters angle_harmonic
         Angle_cosine_bond_parameters angle_cosine
         Angle_cossquare_bond_parameters angle_cossquare


### PR DESCRIPTION
`Angle_bond_parameters` isn't used anywhere.
