### PR TITLE
Avoid unneeded reallocations of ghost data

### DIFF
--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -226,6 +226,21 @@ bool topology_check_resort(int cs, bool local_resort) {
   }
 }
 
+
+/** Go through \ref ghost_cells and remove the ghost entries from \ref
+    local_particles. */
+static void invalidate_ghosts() {
+  for(auto const&p: ghost_cells.particles()) {
+    if(local_particles[p.identity()] == &p) {
+      local_particles[p.identity()] = {};
+    }
+  }
+
+  for(auto &c: ghost_cells) {
+    c->n = 0;
+  }
+}
+
 /*@}*/
 
 /************************************************************

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -226,17 +226,16 @@ bool topology_check_resort(int cs, bool local_resort) {
   }
 }
 
-
 /** Go through \ref ghost_cells and remove the ghost entries from \ref
     local_particles. */
 static void invalidate_ghosts() {
-  for(auto const&p: ghost_cells.particles()) {
-    if(local_particles[p.identity()] == &p) {
+  for (auto const &p : ghost_cells.particles()) {
+    if (local_particles[p.identity()] == &p) {
       local_particles[p.identity()] = {};
     }
   }
 
-  for(auto &c: ghost_cells) {
+  for (auto &c : ghost_cells) {
     c->n = 0;
   }
 }

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -416,6 +416,8 @@ void cells_resort_particles(int global_flag) {
   resort_particles = Cells::RESORT_NONE;
   rebuild_verletlist = 1;
 
+  realloc_particlelist(&displaced_parts, 0);
+
   on_resort_particles();
 
   CELL_TRACE(

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -165,11 +165,9 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
         }
         if (data_parts & GHOSTTRANS_POSSHFTD) {
           /* ok, this is not nice, but perhaps fast */
-          auto *pp = reinterpret_cast<ParticlePosition *>(insert);
-          int i;
-          *pp = pt->r;
-          for (i = 0; i < 3; i++)
-            pp->p[i] += gc->shift[i];
+          auto pp = pt->r;
+          pp.p += gc->shift;
+          memcpy(insert, &pp, sizeof(pp));
           insert += sizeof(ParticlePosition);
         } else if (data_parts & GHOSTTRANS_POSITION) {
           memcpy(insert, &pt->r, sizeof(ParticlePosition));
@@ -336,7 +334,9 @@ void add_forces_from_recv_buffer(GhostCommunication *gc) {
     part = gc->part_lists[pl]->part;
     for (p = 0; p < np; p++) {
       pt = &part[p];
-      pt->f += *(reinterpret_cast<ParticleForce *>(retrieve));
+      ParticleForce pf;
+      memcpy(&pf, retrieve, sizeof(pf));
+      pt->f += pf;
       retrieve += sizeof(ParticleForce);
     }
   }

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -222,13 +222,13 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
   }
 }
 
-static void prepare_ghost_cell(Cell *cell, int size)  {
+static void prepare_ghost_cell(Cell *cell, int size) {
   using Utils::make_span;
   auto const old_cap = cell->max;
 
   /* reset excess particles */
-  if(size < cell->max) {
-    for(auto &p : make_span<Particle>(cell->part + size, cell->max - size)) {
+  if (size < cell->max) {
+    for (auto &p : make_span<Particle>(cell->part + size, cell->max - size)) {
       p = Particle{};
     }
   }
@@ -237,12 +237,12 @@ static void prepare_ghost_cell(Cell *cell, int size)  {
   cell->resize(size);
 
   /* initialize new particles */
-  if(old_cap < cell->max) {
+  if (old_cap < cell->max) {
     auto new_parts = make_span(cell->part + old_cap, cell->max - old_cap);
     std::uninitialized_fill(new_parts.begin(), new_parts.end(), Particle{});
   }
 
-  for(auto &p : Utils::make_span(cell->part, cell->n)) {
+  for (auto &p : Utils::make_span(cell->part, cell->n)) {
     /* Keep heap if any, but set the logical size to 0 */
     p.bl.n = 0;
 #ifdef EXCLUSIONS

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -239,9 +239,7 @@ static void prepare_ghost_cell(Cell *cell, int size) {
     Particle *part = cell->part;
     for (int p = 0; p < np; p++) {
       auto *pt = new (&part[p]) Particle();
-
-      // init ghost variable
-      pt->l.ghost = 1;
+      pt->l = ParticleLocal{/* .ghost */ true};
     }
   }
 }

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -103,9 +103,6 @@ int calc_transmit_size(GhostCommunication *gc, int data_parts) {
       // sending size of bond/exclusion lists
       if (ghosts_have_bonds) {
         n_buffer_new += sizeof(int);
-#ifdef EXCLUSIONS
-        n_buffer_new += sizeof(int);
-#endif
       }
     }
     if (data_parts & GHOSTTRANS_POSITION)
@@ -164,14 +161,6 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
               s_bondbuffer.insert(s_bondbuffer.end(), pt->bl.e,
                                   pt->bl.e + pt->bl.n);
             }
-#ifdef EXCLUSIONS
-            *(int *)insert = pt->el.n;
-            insert += sizeof(int);
-            if (pt->el.n) {
-              s_bondbuffer.insert(s_bondbuffer.end(), pt->el.e,
-                                  pt->el.e + pt->el.n);
-            }
-#endif
           }
         }
         if (data_parts & GHOSTTRANS_POSSHFTD) {
@@ -243,9 +232,6 @@ static void prepare_ghost_cell(Cell *cell, int size) {
   for (auto &p : Utils::make_span(cell->part, cell->n)) {
     /* Keep heap if any, but set the logical size to 0 */
     p.bl.n = 0;
-#ifdef EXCLUSIONS
-    p.el.n = 0;
-#endif
     /* Reset all the trivial data members */
     p.p = ParticleProperties{};
     p.r = ParticlePosition{};
@@ -301,16 +287,6 @@ void put_recv_buffer(GhostCommunication *gc, int data_parts) {
               std::copy_n(bond_retrieve, n_bonds, pt->bl.begin());
               bond_retrieve += n_bonds;
             }
-#ifdef EXCLUSIONS
-            int n_exclusions;
-            memcpy(&n_exclusions, retrieve, sizeof(int));
-            retrieve += sizeof(int);
-            if (n_exclusions) {
-              pt->el.resize(n_exclusions);
-              std::copy_n(bond_retrieve, n_exclusions, pt->el.begin());
-              bond_retrieve += n_exclusions;
-            }
-#endif
           }
           if (local_particles[pt->p.identity] == nullptr) {
             local_particles[pt->p.identity] = pt;
@@ -411,9 +387,6 @@ void cell_cell_transfer(GhostCommunication *gc, int data_parts) {
           pt2->p = pt1->p;
           if (ghosts_have_bonds) {
             pt2->bl = pt1->bl;
-#ifdef EXCLUSIONS
-            pt2->el = pt1->el;
-#endif
           }
         }
         if (data_parts & GHOSTTRANS_POSSHFTD) {

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -25,14 +25,12 @@
  *  see \ref ghosts.hpp "ghosts.hpp"
  */
 #include "ghosts.hpp"
-#include "cells.hpp"
 #include "communication.hpp"
 #include "debug.hpp"
 #include "errorhandling.hpp"
 #include "particle_data.hpp"
 
 #include <algorithm>
-#include <boost/range/algorithm/fill.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -209,10 +209,6 @@ void ghost_communicator(GhostCommunicator *gc);
  */
 void ghost_communicator(GhostCommunicator *gc, int data_parts);
 
-/** Go through \ref ghost_cells and remove the ghost entries from \ref
-    local_particles. Part of \ref dd_exchange_and_sort_particles.*/
-void invalidate_ghosts();
-
 /*@}*/
 
 #endif

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -169,7 +169,7 @@ typedef struct {
   /** if \ref GhostCommunicator::data_parts has \ref GHOSTTRANS_POSSHFTD, then
      this is the shift vector. Normally this a integer multiple of the box
      length. The shift is done on the sender side */
-  double shift[3];
+  Utils::Vector3d shift;
 } GhostCommunication;
 
 /** Properties for a ghost communication. A ghost communication is defined */

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -282,13 +282,12 @@ struct ParticleMomentum {
  *  node the particle belongs to
  */
 struct ParticleLocal {
+  /** check whether a particle is a ghost or not */
+  bool ghost = false;
   /** position in the last time step before last Verlet list update. */
   Utils::Vector3d p_old = {0, 0, 0};
   /** index of the simulation box image where the particle really sits. */
   Utils::Vector3i i = {0, 0, 0};
-
-  /** check whether a particle is a ghost or not */
-  int ghost = 0;
 };
 
 struct ParticleParametersSwimming {

--- a/src/utils/include/utils/List.hpp
+++ b/src/utils/include/utils/List.hpp
@@ -66,7 +66,7 @@ private:
     std::copy(rhs.begin(), rhs.end(), begin());
   }
 
-  void move(List &&rhs) {
+  void move(List &&rhs) noexcept {
     using std::swap;
     swap(n, rhs.n);
     swap(max, rhs.max);
@@ -140,8 +140,9 @@ public:
     assert(size <= max_size());
     if (size != capacity()) {
       realloc(size);
-      this->n = size;
     }
+
+    this->n = size;
   }
 
   void push_back(T const &v) {


### PR DESCRIPTION
So I looked at profiles of the particle exchange code, and noticed
some things... In some situations the can improve the performance
considerably, so I think this should go into the release.
This has some overlap with #2296, but the approach is similar, 
and this is slightly cleaner and can be merged.
It's slightly hackish, but I think this is the best we can do with
the current `Cell` data structure.

Description of changes:
 - Realloc ghost particles only if needed
 - Fixed memleak in resort code
 - Fixed corner-case of Utils::List::resize
 - Removed exclusions from ghosts
