### PR TITLE
Document bonded potentials

### DIFF
--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -115,27 +115,21 @@ friction needs to be present for it to relax.
 The roles of the parameters :math:`k_1, r_0, r_\mathrm{cut}` are exactly the same as for the
 harmonic bond.
 
-..
-    .. _Quartic bond:
+.. _Quartic bond:
 
-    Quartic bond
-    ~~~~~~~~~~~~
+Quartic bond
+~~~~~~~~~~~~
 
-    .. todo::
-        Not implemented.
+A quartic bond can be instantiated via
+:class:`espressomd.interactions.QuarticBond`.
 
+The potential is minimal at particle distance :math:`r=R`. It is given by
 
-    inter quartic
+.. math:: V(r) = \frac{1}{2} K_0 \left( r - R \right)^2 + \frac{1}{4} K_1 \left( r - R \right)^4
 
-    This creates a bond type with identificator with a quartic potential.
-    The potential is minimal at particle distance :math:`r=R`. It is given
-    by
-
-    .. math:: V(r) = \frac{1}{2} K_0 \left( r - R \right)^2 + \frac{1}{4} K_1 \left( r - R \right)^4
-
-    The fourth, optional, parameter defines a cutoff radius. Whenever a
-    quartic bond gets longer than , the bond will be reported as broken, and
-    a background error will be raised.
+The fourth, optional, parameter defines a cutoff radius. Whenever a
+quartic bond gets longer than ``r_cut``, the bond will be reported as broken, and
+a background error will be raised.
 
 .. _Bonded Coulomb:
 
@@ -219,8 +213,8 @@ A rigid bond can be instantiated via
 To simulate rigid bonds, |es| uses the Rattle Shake algorithm which satisfies
 internal constraints for molecular models with internal constraints,
 using Lagrange multipliers.\ :cite:`andersen83a` The constrained bond distance
-is named :math:`r`, the positional tolerance is named :math:`ptol` and the velocity tolerance
-is named :math:`vtol`.
+is named ``r``, the positional tolerance is named ``ptol`` and the velocity tolerance
+is named ``vtol``.
 
 .. _Tabulated distance:
 

--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -216,6 +216,34 @@ using Lagrange multipliers.\ :cite:`andersen83a` The constrained bond distance
 is named ``r``, the positional tolerance is named ``ptol`` and the velocity tolerance
 is named ``vtol``.
 
+.. _Thermalized distance bond:
+
+Thermalized distance bond
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This bond can be used to apply Langevin thermalization on the centre of mass
+and the distance of a particle pair.  Each thermostat can have its own
+temperature and friction coefficient.
+
+The bond is configured with::
+
+    from espressomd.interactions import ThermalizedBond
+    thermalized_bond = ThermalizedBond(temp_com=<float>, gamma_com=<float>,
+                                       temp_distance=<float>, gamma_distance=<float>,
+                                       r_cut=<float>)
+    system.bonded_inter.add(thermalized_bond)
+
+The parameters are:
+
+    * ``temp_com``: Temperature of the Langevin thermostat for the COM of the particle pair.
+    * ``gamma_com``: Friction coefficient of the Langevin thermostat for the COM of the particle pair.
+    * ``temp_distance``: Temperature of the Langevin thermostat for the distance vector of the particle pair.
+    * ``gamma_distance``: Friction coefficient of the Langevin thermostat for the distance vector of the particle pair.
+    * ``r_cut``:  Specifies maximum distance beyond which the bond is considered broken.
+
+The bond is closely related to simulating :ref:`Particle polarizability with
+thermalized cold Drude oscillators`.
+
 .. _Tabulated distance:
 
 Tabulated distance
@@ -253,6 +281,177 @@ This creates a virtual bond type identifier for a pair bond
 without associated potential or force. It can be used to specify topologies
 and for some analysis that rely on bonds, or for bonds that should be
 displayed in the visualization.
+
+
+
+.. _Bond-angle interactions:
+
+Bond-angle interactions
+-----------------------
+
+Bond-angle interactions involve three particles forming the angle :math:`\phi`, as shown in the schematic below.
+
+.. _inter_angle:
+.. figure:: figures/inter_angle.png
+   :alt: Bond-angle interactions
+   :align: center
+   :height: 12.00cm
+
+This allows for a bond type having an angle-dependent potential. This potential
+is defined between three particles and depends on the angle :math:`\phi`
+between the vectors from the central particle to the two other particles.
+
+Similar to other bonded interactions, these are defined for every particle triplet and must be added to a particle (see :attr:`espressomd.particle_data.ParticleHandle.bonds`), in this case the central one.
+For example, for the schematic with particles ``id=0``, ``1`` (central particle) and ``2`` the bond was defined using ::
+
+    >>> system.part[1].add_bond((bond_angle, 0, 2))
+
+The parameter ``bond_angle`` is an instance of one of four possible bond-angle
+classes, described below.
+
+
+Harmonic angle potential
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`espressomd.interactions.AngleHarmonic`
+
+Equation:
+
+.. math:: V(\phi) = \frac{K}{2} \left(\phi - \phi_0\right)^2.
+
+:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
+angle in radians ranging from 0 to :math:`\pi`.
+
+Example::
+
+    >>> angle_harmonic = AngleHarmonic(bend=1.0, phi0=2 * np.pi / 3)
+    >>> system.bonded_inter.add(angle_harmonic)
+    >>> system.part[1].add_bond((angle_harmonic, 0, 2))
+
+
+Cosine angle potential
+~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`espressomd.interactions.AngleCosine`
+
+Equation:
+
+.. math:: V(\phi) = K \left[1 - \cos(\phi - \phi_0)\right]
+
+:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
+angle in radians ranging from 0 to :math:`\pi`.
+
+Around :math:`\phi_0`, this potential is close to a harmonic one
+(both are :math:`1/2(\phi-\phi_0)^2` in leading order), but it is
+periodic and smooth for all angles :math:`\phi`.
+
+Example::
+
+    >>> angle_cosine = AngleCosine(bend=1.0, phi0=2 * np.pi / 3)
+    >>> system.bonded_inter.add(angle_cosine)
+    >>> system.part[1].add_bond((angle_cosine, 0, 2))
+
+
+Harmonic cosine potential
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`espressomd.interactions.AngleCossquare`
+
+Equation:
+
+.. math:: V(\phi) = \frac{K}{2} \left[\cos(\phi) - \cos(\phi_0)\right]^2
+
+:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
+angle in radians ranging from 0 to :math:`\pi`.
+
+This form is used for example in the GROMOS96 force field. The
+potential is :math:`1/8(\phi-\phi_0)^4` around :math:`\phi_0`, and
+therefore much flatter than the two aforementioned potentials.
+
+Example::
+
+    >>> angle_cossquare = AngleCossquare(bend=1.0, phi0=2 * np.pi / 3)
+    >>> system.bonded_inter.add(angle_cossquare)
+    >>> system.part[1].add_bond((angle_cossquare, 0, 2))
+
+
+Tabulated angle potential
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A tabulated bond angle can be instantiated via
+:class:`espressomd.interactions.TabulatedAngle`::
+
+    from espressomd.interactions import TabulatedAngle
+    theta = np.linspace(0, np.pi, num=91, endpoint=True)
+    angle_tab = TabulatedAngle(energy=10 * (theta - 2 * np.pi / 3)**2,
+                               force=10 * (theta - 2 * np.pi / 3) / 2)
+    system.bonded_inter.add(angle_tab)
+    system.part[1].add_bond((angle_tab, 0, 2))
+
+The energy and force tables must be sampled from :math:`0` to :math:`\pi`,
+where :math:`\pi` corresponds to a flat angle. The forces are scaled with the
+inverse length of the connecting vectors. The force on the extremities acts
+perpendicular to the connecting vector between the corresponding particle and
+the center particle, in the plane defined by the three particles. The force on
+the center particle balances the other two forces.
+For details of the interpolation, see :ref:`Tabulated interaction`.
+
+
+.. _Dihedral interactions:
+
+Dihedral interactions
+---------------------
+
+Dihedral potential with phase shift
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dihedral interactions are available through the :class:`espressomd.interactions.Dihedral` class::
+
+    from espressomd.interactions import Dihedral
+    dihedral = Dihedral(bend=<K>, mult=<n>, phase=<phi_0>)
+    system.bonded_inter.add(dihedral)
+    system.part[1].add_bond((dihedral, 0, 2, 3))
+
+This creates a bond type with identifier with a dihedral potential, a
+four-body-potential. In the following, let the particle for which the
+bond is created be particle :math:`p_2`, and the other bond partners
+:math:`p_1`, :math:`p_3`, :math:`p_4`, in this order. Then, the
+dihedral potential is given by
+
+.. math:: V(\phi) = K\left[1 - \cos(n\phi - \phi_0)\right],
+
+where :math:`n` is the multiplicity of the potential (number of minima) and can
+take any integer value (typically from 1 to 6), :math:`\phi_0` is a phase
+parameter and :math:`K` is the bending constant of the potential. :math:`\phi` is
+the dihedral angle between the particles defined by the particle
+quadruple :math:`p_1`, :math:`p_2`, :math:`p_3` and :math:`p_4`, the
+angle between the planes defined by the particle triples :math:`p_1`,
+:math:`p_2` and :math:`p_3` and :math:`p_2`, :math:`p_3` and
+:math:`p_4`:
+
+.. _inter_dihedral:
+.. figure:: figures/dihedral-angle.pdf
+   :alt: Dihedral interaction
+   :align: center
+   :height: 12.00cm
+
+Together with appropriate Lennard-Jones interactions, this potential can
+mimic a large number of atomic torsion potentials.
+
+
+Tabulated dihedral potential
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A tabulated dihedral interaction can be instantiated via
+:class:`espressomd.interactions.TabulatedDihedral`::
+
+    from espressomd.interactions import TabulatedDihedral
+    dihedral_tab = TabulatedDihedral(energy=<energy>, force=<force>)
+    system.bonded_inter.add(dihedral_tab)
+    system.part[1].add_bond((dihedral_tab, 0, 2, 3))
+
+The energy and force tables must be sampled from :math:`0` to :math:`2\pi`.
+For details of the interpolation, see :ref:`Tabulated interaction`.
 
 
 
@@ -501,204 +700,4 @@ calculates the outward normal vector of triangle defined by particles 1,
 approximately at its centroid). In order for the direction to be outward
 with respect to the underlying object, the triangle 123 needs to be
 properly oriented (as explained in paragraph `Volume conservation`_).
-
-
-
-.. _Bond-angle interactions:
-
-Bond-angle interactions
------------------------
-
-Bond-angle interactions involve three particles forming the angle :math:`\phi`, as shown in the schematic below.
-
-.. _inter_angle:
-.. figure:: figures/inter_angle.png
-   :alt: Bond-angle interactions
-   :align: center
-   :height: 12.00cm
-
-This allows for a bond type having an angle-dependent potential. This potential
-is defined between three particles and depends on the angle :math:`\phi`
-between the vectors from the central particle to the two other particles.
-
-Similar to other bonded interactions, these are defined for every particle triplet and must be added to a particle (see :attr:`espressomd.particle_data.ParticleHandle.bonds`), in this case the central one.
-For example, for the schematic with particles ``id=0``, ``1`` (central particle) and ``2`` the bond was defined using ::
-
-    >>> system.part[1].add_bond((bond_angle, 0, 2))
-
-The parameter ``bond_angle`` is an instance of one of four possible bond-angle
-classes, described below.
-
-
-Harmonic angle potential
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:class:`espressomd.interactions.AngleHarmonic`
-
-Equation:
-
-.. math:: V(\phi) = \frac{K}{2} \left(\phi - \phi_0\right)^2.
-
-:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
-angle in radians ranging from 0 to :math:`\pi`.
-
-Example::
-
-    >>> angle_harmonic = AngleHarmonic(bend=1.0, phi0=2 * np.pi / 3)
-    >>> system.bonded_inter.add(angle_harmonic)
-    >>> system.part[1].add_bond((angle_harmonic, 0, 2))
-
-
-Cosine angle potential
-~~~~~~~~~~~~~~~~~~~~~~
-
-:class:`espressomd.interactions.AngleCosine`
-
-Equation:
-
-.. math:: V(\phi) = K \left[1 - \cos(\phi - \phi_0)\right]
-
-:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
-angle in radians ranging from 0 to :math:`\pi`.
-
-Around :math:`\phi_0`, this potential is close to a harmonic one
-(both are :math:`1/2(\phi-\phi_0)^2` in leading order), but it is
-periodic and smooth for all angles :math:`\phi`.
-
-Example::
-
-    >>> angle_cosine = AngleCosine(bend=1.0, phi0=2 * np.pi / 3)
-    >>> system.bonded_inter.add(angle_cosine)
-    >>> system.part[1].add_bond((angle_cosine, 0, 2))
-
-
-Harmonic cosine potential
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:class:`espressomd.interactions.AngleCossquare`
-
-Equation:
-
-.. math:: V(\phi) = \frac{K}{2} \left[\cos(\phi) - \cos(\phi_0)\right]^2
-
-:math:`K` is the bending constant and :math:`\phi_0` is the equilibrium bond
-angle in radians ranging from 0 to :math:`\pi`.
-
-This form is used for example in the GROMOS96 force field. The
-potential is :math:`1/8(\phi-\phi_0)^4` around :math:`\phi_0`, and
-therefore much flatter than the two aforementioned potentials.
-
-Example::
-
-    >>> angle_cossquare = AngleCossquare(bend=1.0, phi0=2 * np.pi / 3)
-    >>> system.bonded_inter.add(angle_cossquare)
-    >>> system.part[1].add_bond((angle_cossquare, 0, 2))
-
-
-Tabulated angle potential
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A tabulated bond angle can be instantiated via
-:class:`espressomd.interactions.TabulatedAngle`::
-
-    from espressomd.interactions import TabulatedAngle
-    theta = np.linspace(0, np.pi, num=91, endpoint=True)
-    angle_tab = TabulatedAngle(energy=10 * (theta - 2 * np.pi / 3)**2,
-                               force=10 * (theta - 2 * np.pi / 3) / 2)
-    system.bonded_inter.add(angle_tab)
-    system.part[1].add_bond((angle_tab, 0, 2))
-
-The energy and force tables must be sampled from :math:`0` to :math:`\pi`,
-where :math:`\pi` corresponds to a flat angle. The forces are scaled with the
-inverse length of the connecting vectors. The force on the extremities acts
-perpendicular to the connecting vector between the corresponding particle and
-the center particle, in the plane defined by the three particles. The force on
-the center particle balances the other two forces.
-For details of the interpolation, see :ref:`Tabulated interaction`.
-
-
-.. _Dihedral interactions:
-
-Dihedral interactions
----------------------
-
-Dihedral potential with phase shift
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Dihedral interactions are available through the :class:`espressomd.interactions.Dihedral` class::
-
-    from espressomd.interactions import Dihedral
-    dihedral = Dihedral(bend=<K>, mult=<n>, phase=<phi_0>)
-    system.bonded_inter.add(dihedral)
-    system.part[1].add_bond((dihedral, 0, 2, 3))
-
-This creates a bond type with identifier with a dihedral potential, a
-four-body-potential. In the following, let the particle for which the
-bond is created be particle :math:`p_2`, and the other bond partners
-:math:`p_1`, :math:`p_3`, :math:`p_4`, in this order. Then, the
-dihedral potential is given by
-
-.. math:: V(\phi) = K\left[1 - \cos(n\phi - \phi_0)\right],
-
-where :math:`n` is the multiplicity of the potential (number of minima) and can
-take any integer value (typically from 1 to 6), :math:`\phi_0` is a phase
-parameter and :math:`K` is the bending constant of the potential. :math:`\phi` is
-the dihedral angle between the particles defined by the particle
-quadruple :math:`p_1`, :math:`p_2`, :math:`p_3` and :math:`p_4`, the
-angle between the planes defined by the particle triples :math:`p_1`,
-:math:`p_2` and :math:`p_3` and :math:`p_2`, :math:`p_3` and
-:math:`p_4`:
-
-.. _inter_dihedral:
-.. figure:: figures/dihedral-angle.pdf
-   :alt: Dihedral interaction
-   :align: center
-   :height: 12.00cm
-
-Together with appropriate Lennard-Jones interactions, this potential can
-mimic a large number of atomic torsion potentials.
-
-
-Tabulated dihedral potential
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A tabulated dihedral interaction can be instantiated via
-:class:`espressomd.interactions.TabulatedDihedral`::
-
-    from espressomd.interactions import TabulatedDihedral
-    dihedral_tab = TabulatedDihedral(energy=<energy>, force=<force>)
-    system.bonded_inter.add(dihedral_tab)
-    system.part[1].add_bond((dihedral_tab, 0, 2, 3))
-
-The energy and force tables must be sampled from :math:`0` to :math:`2\pi`.
-For details of the interpolation, see :ref:`Tabulated interaction`.
-
-
-.. _Thermalized distance bond:
-
-Thermalized distance bond
--------------------------
-
-This bond can be used to apply Langevin thermalization on the centre of mass
-and the distance of a particle pair.  Each thermostat can have its own
-temperature and friction coefficient.
-
-The bond is configured with::
-
-    from espressomd.interactions import ThermalizedBond
-    thermalized_bond = ThermalizedBond(temp_com=<float>, gamma_com=<float>,
-                                       temp_distance=<float>, gamma_distance=<float>,
-                                       r_cut=<float>)
-    system.bonded_inter.add(thermalized_bond)
-
-The parameters are:
-
-    * ``temp_com``: Temperature of the Langevin thermostat for the COM of the particle pair.
-    * ``gamma_com``: Friction coefficient of the Langevin thermostat for the COM of the particle pair.
-    * ``temp_distance``: Temperature of the Langevin thermostat for the distance vector of the particle pair.
-    * ``gamma_distance``: Friction coefficient of the Langevin thermostat for the distance vector of the particle pair.
-    * ``r_cut``:  Specifies maximum distance beyond which the bond is considered broken.
-
-The bond is closely related to simulating :ref:`Particle polarizability with
-thermalized cold Drude oscillators`.
 

--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -412,7 +412,7 @@ Dihedral interactions are available through the :class:`espressomd.interactions.
     system.bonded_inter.add(dihedral)
     system.part[1].add_bond((dihedral, 0, 2, 3))
 
-This creates a bond type with identifier with a dihedral potential, a
+This creates a bond type identifier with a dihedral potential, a
 four-body-potential. In the following, let the particle for which the
 bond is created be particle :math:`p_2`, and the other bond partners
 :math:`p_1`, :math:`p_3`, :math:`p_4`, in this order. Then, the

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -118,11 +118,11 @@ The minimum of the potential is at
 -\epsilon + 4 \epsilon c_\mathrm{shift}`. Beyond this value the interaction is attractive.
 Beyond the distance :math:`r_\mathrm{cut}` the potential is cut off and the interaction force is zero.
 
-If :math:`c_\mathrm{shift}` is not set or it is set to the string *auto*, the shift will be
+If :math:`c_\mathrm{shift}` is set to the string ``'auto'``, the shift will be
 automatically computed such that the potential is continuous at the
-cutoff radius. If is not set, it is set to :math:`0`.
+cutoff radius.
 
-The net force on a particle can be capped by using force capping , see
+The net force on a particle can be capped by using force capping, see
 section :ref:`Capping the force during warmup`
 
 An optional additional parameter can be used to restrict the interaction

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -48,11 +48,12 @@ enum BondedInteraction {
   BONDED_IA_ANGLE_COSINE,
   /** Type of bonded interaction is a bond angle cosine potential. */
   BONDED_IA_ANGLE_COSSQUARE,
-  /** Type of bonded interaction: oif local forces. */
+  /** Type of bonded interaction: OIF local forces. */
   BONDED_IA_OIF_LOCAL_FORCES,
-  /** Type of bonded interaction: oif global forces. */
+  /** Type of bonded interaction: OIF global forces. */
   BONDED_IA_OIF_GLOBAL_FORCES,
-  /** Type of bonded interaction: determining outward direction of oif membrane.
+  /** Type of bonded interaction: determining outward direction of OIF membrane
+   *  (not associated to a parameter struct).
    */
   BONDED_IA_OIF_OUT_DIRECTION,
   /** Type of bonded interaction is a wall repulsion (immersed boundary). */
@@ -71,9 +72,9 @@ enum BondedInteraction {
 /** Specify tabulated bonded interactions  */
 enum TabulatedBondedInteraction {
   TAB_UNKNOWN = 0,
-  TAB_BOND_LENGTH = 1,
-  TAB_BOND_ANGLE = 2,
-  TAB_BOND_DIHEDRAL = 3
+  TAB_BOND_LENGTH = 1,  /**< Flag for @ref BONDED_IA_TABULATED_DISTANCE */
+  TAB_BOND_ANGLE = 2,   /**< Flag for @ref BONDED_IA_TABULATED_ANGLE */
+  TAB_BOND_DIHEDRAL = 3 /**< Flag for @ref BONDED_IA_TABULATED_DIHEDRAL */
 };
 
 /** Parameters for FENE bond Potential. */
@@ -90,24 +91,44 @@ struct Fene_bond_parameters {
   double drmax2i;
 };
 
-/** Parameters for oif_global_forces */
+/** Parameters for OIF global forces
+ *
+ *  Characterize the distribution of the force of the global mesh deformation
+ *  onto individual vertices of the mesh.
+ */
 struct Oif_global_forces_bond_parameters {
+  /** Relaxed area of the mesh */
   double A0_g;
+  /** Area coefficient */
   double ka_g;
+  /** Relaxed volume of the mesh */
   double V0;
+  /** Volume coefficient */
   double kv;
 };
 
-/** Parameters for oif_local_forces */
+/** Parameters for OIF local forces
+ *
+ *  Characterize the deformation of two triangles sharing an edge.
+ */
 struct Oif_local_forces_bond_parameters {
+  /** Equilibrium bond length of triangle edges */
   double r0;
+  /** Non-linear stretching coefficient of triangle edges */
   double ks;
+  /** Linear stretching coefficient of triangle edges */
   double kslin;
+  /** Equilibrium angle between the two triangles */
   double phi0;
+  /** Bending coefficient for the angle between the two triangles */
   double kb;
+  /** Equilibrium surface of the first triangle */
   double A01;
+  /** Equilibrium surface of the second triangle */
   double A02;
+  /** Stretching coefficient of a triangle surface */
   double kal;
+  /** Viscous coefficient of the triangle vertices */
   double kvisc;
 };
 

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -18,19 +18,19 @@ enum BondedInteraction {
   /** Type of bonded interaction is a FENE potential
       (to be combined with Lennard-Jones). */
   BONDED_IA_FENE,
-  /** Type of bonded interaction is a HARMONIC potential. */
+  /** Type of bonded interaction is a harmonic potential. */
   BONDED_IA_HARMONIC,
-  /** Type of bonded interaction is a HARMONIC_DUMBBELL potential. */
+  /** Type of bonded interaction is a harmonic dumbbell potential. */
   BONDED_IA_HARMONIC_DUMBBELL,
-  /** Type of bonded interaction is a QUARTIC potential. */
+  /** Type of bonded interaction is a quartic potential. */
   BONDED_IA_QUARTIC,
-  /** Type of bonded interaction is a BONDED_COULOMB */
+  /** Type of bonded interaction is a bonded %Coulomb. */
   BONDED_IA_BONDED_COULOMB,
-  /** Type of bonded interaction is a BONDED_COULOMB_SR */
+  /** Type of bonded interaction is a bonded %Coulomb SR. */
   BONDED_IA_BONDED_COULOMB_SR,
   /** Type of bonded interaction is a dihedral potential. */
   BONDED_IA_DIHEDRAL,
-  /** Type of bonded interaction is a tabulated bond potential. */
+  /** Type of bonded interaction is a tabulated distance potential. */
   BONDED_IA_TABULATED_DISTANCE,
   /** Type of bonded interaction is a tabulated angle potential. */
   BONDED_IA_TABULATED_ANGLE,
@@ -176,13 +176,13 @@ struct Quartic_bond_parameters {
   double r_cut;
 };
 
-/** Parameters for Coulomb bond Potential */
+/** Parameters for %Coulomb bond Potential */
 struct Bonded_coulomb_bond_parameters {
-  /** Coulomb prefactor */
+  /** %Coulomb prefactor */
   double prefactor;
 };
 
-/** Parameters for Coulomb bond short-range Potential */
+/** Parameters for %Coulomb bond short-range Potential */
 struct Bonded_coulomb_sr_bond_parameters {
   /** charge factor */
   double q1q2;

--- a/src/core/object-in-fluid/oif_global_forces.cpp
+++ b/src/core/object-in-fluid/oif_global_forces.cpp
@@ -193,7 +193,7 @@ void add_oif_global_forces(
         auto const p33 = p11 + get_mi_vector(p3->r.p, p11, box_geo);
 
         // unfolded positions correct
-        /// starting code from volume force
+        // starting code from volume force
         auto const VOL_norm = get_n_triangle(p11, p22, p33).normalize();
         auto const VOL_A = area_triangle(p11, p22, p33);
         auto const VOL_vv = (VOL_volume - iaparams->p.oif_global_forces.V0) /
@@ -204,7 +204,7 @@ void add_oif_global_forces(
         p1->f.f += VOL_force;
         p2->f.f += VOL_force;
         p3->f.f += VOL_force;
-        ///  ending code from volume force
+        // ending code from volume force
 
         auto const h = (1. / 3.) * (p11 + p22 + p33);
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -2072,9 +2072,6 @@ class FeneBond(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        """Sets parameters that are not required to their default value.
-
-        """
         self._params = {"r_0": 0.}
         # Everything else has to be supplied by the user, anyway
 
@@ -2765,22 +2762,6 @@ class TabulatedDihedral(_TabulatedBase):
 
 IF TABULATED == 1:
     cdef class TabulatedNonBonded(NonBondedInteraction):
-        """
-        Tabulated non-bonded interaction.
-
-        Parameters
-        ----------
-
-        min : :obj:`float`
-            The minimal interaction distance.
-        max : :obj:`float`
-            The maximal interaction distance.
-        energy: array_like :obj:`float`
-            The energy table.
-        force: array_like :obj:`float`
-            The force table.
-
-        """
 
         cdef int state
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -82,8 +82,8 @@ cdef class NonBondedInteraction:
         """Get interaction parameters.
 
         """
-        # If this instance refers to an actual interaction defined in the es core, load
-        # current parameters from there
+        # If this instance refers to an actual interaction defined in
+        # the es core, load current parameters from there
         if self._part_types[0] >= 0 and self._part_types[1] >= 0:
             self._params = self._get_params_from_es_core()
         return self._params
@@ -183,8 +183,8 @@ cdef class NonBondedInteraction:
         """Virtual method.
 
         """
-        # If this instance refers to an actual interaction defined in the es core, load
-        # current parameters from there
+        # If this instance refers to an actual interaction defined in
+        # the es core, load current parameters from there
         if self._part_types[0] >= 0 and self._part_types[1] >= 0:
             self._params = self._get_params_from_es_core()
         raise Exception(
@@ -212,6 +212,7 @@ cdef class NonBondedInteraction:
             "Subclasses of NonBondedInteraction must define the required_keys() method.")
 
 IF LENNARD_JONES == 1:
+
     cdef class LennardJonesInteraction(NonBondedInteraction):
 
         def validate_params(self):
@@ -250,7 +251,7 @@ IF LENNARD_JONES == 1:
             return (self._params["epsilon"] > 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the Lennard-Jones interaction.
+            """Set parameters for the Lennard-Jones interaction.
 
             Parameters
             ----------
@@ -276,7 +277,8 @@ IF LENNARD_JONES == 1:
         def _set_params_in_es_core(self):
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
-                self._params["shift"] = -((self._params["sigma"] / self._params["cutoff"])**12 - (
+                self._params["shift"] = -((
+                    self._params["sigma"] / self._params["cutoff"])**12 - (
                     self._params["sigma"] / self._params["cutoff"])**6)
 
             if lennard_jones_set_params(
@@ -320,6 +322,7 @@ IF LENNARD_JONES == 1:
             return "epsilon", "sigma", "cutoff", "shift"
 
 IF WCA == 1:
+
     cdef class WCAInteraction(NonBondedInteraction):
 
         def validate_params(self):
@@ -353,7 +356,7 @@ IF WCA == 1:
             return (self._params["epsilon"] > 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the WCA interaction.
+            """Set parameters for the WCA interaction.
 
             Parameters
             ----------
@@ -447,8 +450,9 @@ IF LENNARD_JONES_GENERIC == 1:
         def _set_params_in_es_core(self):
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
-                self._params["shift"] = -(self._params["b1"] * (self._params["sigma"] / self._params["cutoff"])**self._params[
-                                          "e1"] - self._params["b2"] * (self._params["sigma"] / self._params["cutoff"])**self._params["e2"])
+                self._params["shift"] = -(
+                    self._params["b1"] * (self._params["sigma"] / self._params["cutoff"])**self._params["e1"] -
+                    self._params["b2"] * (self._params["sigma"] / self._params["cutoff"])**self._params["e2"])
             IF LJGEN_SOFTCORE:
                 if ljgen_set_params(self._part_types[0], self._part_types[1],
                                     self._params["epsilon"],
@@ -551,6 +555,7 @@ IF LENNARD_JONES_GENERIC == 1:
             return "epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2"
 
 IF LJCOS:
+
     cdef class LennardJonesCosInteraction(NonBondedInteraction):
 
         def validate_params(self):
@@ -593,7 +598,8 @@ IF LJCOS:
             super().set_params(**kwargs)
 
         def _set_params_in_es_core(self):
-            if ljcos_set_params(self._part_types[0], self._part_types[1],
+            if ljcos_set_params(self._part_types[0],
+                                self._part_types[1],
                                 self._params["epsilon"],
                                 self._params["sigma"],
                                 self._params["cutoff"],
@@ -628,6 +634,7 @@ IF LJCOS:
             return "epsilon", "sigma", "cutoff"
 
 IF LJCOS2:
+
     cdef class LennardJonesCos2Interaction(NonBondedInteraction):
 
         def validate_params(self):
@@ -654,7 +661,7 @@ IF LJCOS2:
             return(self._params["epsilon"] > 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the Lennard-Jones cosine squared interaction.
+            """Set parameters for the Lennard-Jones cosine squared interaction.
 
             Parameters
             ----------
@@ -706,7 +713,9 @@ IF LJCOS2:
             return "epsilon", "sigma", "width"
 
 IF HAT == 1:
+
     cdef class HatInteraction(NonBondedInteraction):
+
         def validate_params(self):
             if self._params["F_max"] < 0:
                 raise ValueError("Hat max force has to be >=0")
@@ -727,7 +736,7 @@ IF HAT == 1:
             return (self._params["F_max"] > 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the Hat interaction.
+            """Set parameters for the Hat interaction.
 
             Parameters
             ----------
@@ -761,6 +770,7 @@ IF HAT == 1:
             return "F_max", "cutoff"
 
 IF GAY_BERNE:
+
     cdef class GayBerneInteraction(NonBondedInteraction):
 
         def validate_params(self):
@@ -814,7 +824,8 @@ IF GAY_BERNE:
             super().set_params(**kwargs)
 
         def _set_params_in_es_core(self):
-            if gay_berne_set_params(self._part_types[0], self._part_types[1],
+            if gay_berne_set_params(self._part_types[0],
+                                    self._part_types[1],
                                     self._params["eps"],
                                     self._params["sig"],
                                     self._params["cut"],
@@ -856,7 +867,9 @@ IF GAY_BERNE:
             return "eps", "sig", "cut", "k1", "k2", "mu", "nu"
 
 IF DPD:
+
     cdef class DPDInteraction(NonBondedInteraction):
+
         def validate_params(self):
             return True
 
@@ -877,7 +890,7 @@ IF DPD:
             return (self._params["r_cut"] > 0) or (self._params["trans_r_cut"] > 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the DPD interaction.
+            """Set parameters for the DPD interaction.
 
             Parameters
             ----------
@@ -900,7 +913,8 @@ IF DPD:
             super().set_params(**kwargs)
 
         def _set_params_in_es_core(self):
-            if dpd_set_params(self._part_types[0], self._part_types[1],
+            if dpd_set_params(self._part_types[0],
+                              self._part_types[1],
                               self._params["gamma"],
                               self._params["r_cut"],
                               self._params["weight_function"],
@@ -966,7 +980,8 @@ IF SMOOTH_STEP == 1:
             return ((self._params["eps"] > 0) and (self._params["sig"] > 0))
 
         def _set_params_in_es_core(self):
-            if smooth_step_set_params(self._part_types[0], self._part_types[1],
+            if smooth_step_set_params(self._part_types[0],
+                                      self._part_types[1],
                                       self._params["d"],
                                       self._params["n"],
                                       self._params["eps"],
@@ -1047,9 +1062,8 @@ IF BMHTF_NACL == 1:
 
         def _get_params_from_es_core(self):
             cdef IA_parameters * ia_params
-            ia_params = get_ia_param_safe(
-                self._part_types[0],
-                self._part_types[1])
+            ia_params = get_ia_param_safe(self._part_types[0],
+                                          self._part_types[1])
             return {
                 "a": ia_params.bmhtf.A,
                 "b": ia_params.bmhtf.B,
@@ -1063,10 +1077,11 @@ IF BMHTF_NACL == 1:
             """Check if interaction is active.
 
             """
-            return ((self._params["a"] > 0) and (self._params["c"] > 0) and (self._params["d"] > 0))
+            return (self._params["a"] > 0) and (self._params["c"] > 0) and (self._params["d"] > 0)
 
         def _set_params_in_es_core(self):
-            if BMHTF_set_params(self._part_types[0], self._part_types[1],
+            if BMHTF_set_params(self._part_types[0],
+                                self._part_types[1],
                                 self._params["a"],
                                 self._params["b"],
                                 self._params["c"],
@@ -1162,7 +1177,8 @@ IF MORSE == 1:
             return (self._params["eps"] > 0)
 
         def _set_params_in_es_core(self):
-            if morse_set_params(self._part_types[0], self._part_types[1],
+            if morse_set_params(self._part_types[0],
+                                self._part_types[1],
                                 self._params["eps"],
                                 self._params["alpha"],
                                 self._params["rmin"],
@@ -1252,7 +1268,7 @@ IF BUCKINGHAM == 1:
             """Check if interaction is active.
 
             """
-            return ((self._params["a"] > 0) or (self._params["b"] > 0) or (self._params["d"] > 0) or (self._params["shift"] > 0))
+            return (self._params["a"] > 0) or (self._params["b"] > 0) or (self._params["d"] > 0) or (self._params["shift"] > 0)
 
         def _set_params_in_es_core(self):
             if buckingham_set_params(self._part_types[0], self._part_types[1],
@@ -1338,9 +1354,8 @@ IF SOFT_SPHERE == 1:
 
         def _get_params_from_es_core(self):
             cdef IA_parameters * ia_params
-            ia_params = get_ia_param_safe(
-                self._part_types[0],
-                self._part_types[1])
+            ia_params = get_ia_param_safe(self._part_types[0],
+                                          self._part_types[1])
             return {
                 "a": ia_params.soft_sphere.a,
                 "n": ia_params.soft_sphere.n,
@@ -1355,7 +1370,8 @@ IF SOFT_SPHERE == 1:
             return (self._params["a"] > 0)
 
         def _set_params_in_es_core(self):
-            if soft_sphere_set_params(self._part_types[0], self._part_types[1],
+            if soft_sphere_set_params(self._part_types[0],
+                                      self._part_types[1],
                                       self._params["a"],
                                       self._params["n"],
                                       self._params["cutoff"],
@@ -1409,6 +1425,7 @@ IF SOFT_SPHERE == 1:
             return "a", "n", "cutoff"
 
 IF AFFINITY == 1:
+
     cdef class AffinityInteraction(NonBondedInteraction):
 
         def validate_params(self):
@@ -1430,8 +1447,8 @@ IF AFFINITY == 1:
 
         def _get_params_from_es_core(self):
             cdef IA_parameters * ia_params
-            ia_params = get_ia_param_safe(
-                self._part_types[0], self._part_types[1])
+            ia_params = get_ia_param_safe(self._part_types[0],
+                                          self._part_types[1])
             return {
                 "affinity_type": ia_params.affinity.type,
                 "affinity_kappa": ia_params.affinity.kappa,
@@ -1445,7 +1462,8 @@ IF AFFINITY == 1:
             return (self._params["affinity_kappa"] > 0)
 
         def _set_params_in_es_core(self):
-            if affinity_set_params(self._part_types[0], self._part_types[1],
+            if affinity_set_params(self._part_types[0],
+                                   self._part_types[1],
                                    self._params["affinity_type"],
                                    self._params["affinity_kappa"],
                                    self._params["affinity_r0"],
@@ -1476,6 +1494,7 @@ IF AFFINITY == 1:
 
 
 IF MEMBRANE_COLLISION == 1:
+
     cdef class MembraneCollisionInteraction(NonBondedInteraction):
 
         def validate_params(self):
@@ -1497,12 +1516,12 @@ IF MEMBRANE_COLLISION == 1:
             return (self._params["a"] > 0)
 
         def _set_params_in_es_core(self):
-            if membrane_collision_set_params(
-                self._part_types[0], self._part_types[1],
-                                        self._params["a"],
-                                        self._params["n"],
-                                        self._params["cutoff"],
-                                        self._params["offset"]):
+            if membrane_collision_set_params(self._part_types[0],
+                                             self._part_types[1],
+                                             self._params["a"],
+                                             self._params["n"],
+                                             self._params["cutoff"],
+                                             self._params["offset"]):
                 raise Exception("Could not set Membrane Collision parameters")
 
         def default_params(self):
@@ -1552,7 +1571,8 @@ IF HERTZIAN == 1:
             return (self._params["eps"] > 0)
 
         def _set_params_in_es_core(self):
-            if hertzian_set_params(self._part_types[0], self._part_types[1],
+            if hertzian_set_params(self._part_types[0],
+                                   self._part_types[1],
                                    self._params["eps"],
                                    self._params["sig"]):
                 raise Exception("Could not set Hertzian parameters")
@@ -1632,7 +1652,8 @@ IF GAUSSIAN == 1:
             return (self._params["eps"] > 0)
 
         def _set_params_in_es_core(self):
-            if gaussian_set_params(self._part_types[0], self._part_types[1],
+            if gaussian_set_params(self._part_types[0],
+                                   self._part_types[1],
                                    self._params["eps"],
                                    self._params["sig"],
                                    self._params["cutoff"]):
@@ -2115,6 +2136,7 @@ class HarmonicBond(BondedInteraction):
             self._bond_id, self._params["k"], self._params["r_0"], self._params["r_cut"])
 
 if ELECTROSTATICS:
+
     class BondedCoulomb(BondedInteraction):
 
         """
@@ -2155,6 +2177,7 @@ if ELECTROSTATICS:
                 self._bond_id, self._params["prefactor"])
 
 if ELECTROSTATICS:
+
     class BondedCoulombSRBond(BondedInteraction):
 
         """
@@ -2256,9 +2279,11 @@ class ThermalizedBond(BondedInteraction):
 
     def _set_params_in_es_core(self):
         thermalized_bond_set_params(
-            self._bond_id, self._params["temp_com"], self._params["gamma_com"], self._params["temp_distance"], self._params["gamma_distance"], self._params["r_cut"])
+            self._bond_id, self._params["temp_com"], self._params["gamma_com"],
+            self._params["temp_distance"], self._params["gamma_distance"], self._params["r_cut"])
 
 IF THOLE:
+
     cdef class TholeInteraction(NonBondedInteraction):
 
         def validate_params(self):
@@ -2266,8 +2291,8 @@ IF THOLE:
 
         def _get_params_from_es_core(self):
             cdef IA_parameters * ia_params
-            ia_params = get_ia_param_safe(
-                self._part_types[0], self._part_types[1])
+            ia_params = get_ia_param_safe(self._part_types[0],
+                                          self._part_types[1])
             return {
                 "scaling_coeff": ia_params.thole.scaling_coeff,
                 "q1q2": ia_params.thole.q1q2
@@ -2277,7 +2302,7 @@ IF THOLE:
             return (self._params["scaling_coeff"] != 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the Thole interaction.
+            """Set parameters for the Thole interaction.
 
             Parameters
             ----------
@@ -2316,6 +2341,7 @@ IF THOLE:
             return "scaling_coeff", "q1q2"
 
 IF ROTATION:
+
     class HarmonicDumbbellBond(BondedInteraction):
 
         """
@@ -2377,6 +2403,7 @@ IF ROTATION:
                 self._params["r_0"], self._params["r_cut"])
 
 IF ROTATION != 1:
+
     class HarmonicDumbbellBond(BondedInteraction):
 
         """
@@ -2432,6 +2459,7 @@ IF ROTATION != 1:
 
 
 IF BOND_CONSTRAINT == 1:
+
     class RigidBond(BondedInteraction):
 
         """
@@ -2482,7 +2510,9 @@ IF BOND_CONSTRAINT == 1:
                             "vtol": 0.001}
 
         def _get_params_from_es_core(self):
-            return {"r": bonded_ia_params[self._bond_id].p.rigid_bond.d2**0.5, "ptol": bonded_ia_params[self._bond_id].p.rigid_bond.p_tol, "vtol": bonded_ia_params[self._bond_id].p.rigid_bond.v_tol}
+            return {"r": bonded_ia_params[self._bond_id].p.rigid_bond.d2**0.5,
+                    "ptol": bonded_ia_params[self._bond_id].p.rigid_bond.p_tol,
+                    "vtol": bonded_ia_params[self._bond_id].p.rigid_bond.v_tol}
 
         def _set_params_in_es_core(self):
             rigid_bond_set_params(
@@ -2747,6 +2777,7 @@ class TabulatedDihedral(_TabulatedBase):
 
 
 IF TABULATED == 1:
+
     cdef class TabulatedNonBonded(NonBondedInteraction):
 
         cdef int state
@@ -2827,6 +2858,7 @@ IF TABULATED == 1:
 
 
 IF LENNARD_JONES == 1:
+
     class SubtLJ(BondedInteraction):
 
         """
@@ -3119,8 +3151,10 @@ class IBM_Triel(BondedInteraction):
             el = NeoHookean
         if self._params["elasticLaw"] == "Skalak":
             el = Skalak
-        IBM_Triel_SetParams(self._bond_id, self._params["ind1"], self._params["ind2"], self._params[
-                            "ind3"], self._params["maxDist"], el, self._params["k1"], self._params["k2"])
+        IBM_Triel_SetParams(
+            self._bond_id, self._params["ind1"], self._params["ind2"],
+            self._params["ind3"], self._params["maxDist"], el,
+            self._params["k1"], self._params["k2"])
 
 
 class IBM_Tribend(BondedInteraction):
@@ -3354,6 +3388,7 @@ class OifLocalForces(BondedInteraction):
             self._params["kvisc"])
 
 IF MEMBRANE_COLLISION == 1:
+
     class OifOutDirection(BondedInteraction):
 
         """

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -227,7 +227,7 @@ IF LENNARD_JONES == 1:
                 If not true.
             """
             if self._params["epsilon"] < 0:
-                raise ValueError("Lennard-Jones eps has to be >=0")
+                raise ValueError("Lennard-Jones epsilon has to be >=0")
             if self._params["sigma"] < 0:
                 raise ValueError("Lennard-Jones sigma has to be >=0")
             if self._params["cutoff"] < 0:
@@ -265,8 +265,10 @@ IF LENNARD_JONES == 1:
                 Interaction length scale.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
-            shift : :obj:`float` or :obj:`str`
-                Constant shift of the potential. (4*epsilon*shift).
+            shift : :obj:`float` or :obj:`str` \{'auto'\}
+                Constant shift of the potential. If ``'auto'``, a default value
+                is computed from ``sigma`` and ``cutoff``. The LJ potential
+                will be shifted by :math:`4\\epsilon\\text{shift}`.
             offset : :obj:`float`, optional
                 Offset distance of the interaction.
             min : :obj:`float`, optional
@@ -278,7 +280,6 @@ IF LENNARD_JONES == 1:
         def _set_params_in_es_core(self):
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
-                # Calc shift
                 self._params["shift"] = -((self._params["sigma"] / self._params["cutoff"])**12 - (
                     self._params["sigma"] / self._params["cutoff"])**6)
 
@@ -416,7 +417,7 @@ IF LENNARD_JONES_GENERIC == 1:
                 If not true.
             """
             if self._params["epsilon"] < 0:
-                raise ValueError("Generic Lennard-Jones eps has to be >=0")
+                raise ValueError("Generic Lennard-Jones epsilon has to be >=0")
             if self._params["sigma"] < 0:
                 raise ValueError("Generic Lennard-Jones sigma has to be >=0")
             if self._params["cutoff"] < 0:
@@ -451,7 +452,6 @@ IF LENNARD_JONES_GENERIC == 1:
         def _set_params_in_es_core(self):
             # Handle the case of shift="auto"
             if self._params["shift"] == "auto":
-                # Calc shift
                 self._params["shift"] = -(self._params["b1"] * (self._params["sigma"] / self._params["cutoff"])**self._params[
                                           "e1"] - self._params["b2"] * (self._params["sigma"] / self._params["cutoff"])**self._params["e2"])
             IF LJGEN_SOFTCORE:
@@ -519,8 +519,10 @@ IF LENNARD_JONES_GENERIC == 1:
                 Interaction length scale.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
-            shift : :obj:`float`
-                Constant shift of the potential.
+            shift : :obj:`float` or :obj:`str` \{'auto'\}
+                Constant shift of the potential. If ``'auto'``, a default value
+                is computed from the other parameters. The LJ potential
+                will be shifted by :math:`\\epsilon\\text{shift}`.
             offset : :obj:`float`
                 Offset distance of the interaction.
             e1 : :obj:`int`
@@ -560,7 +562,7 @@ IF LJCOS:
 
         def validate_params(self):
             if self._params["epsilon"] < 0:
-                raise ValueError("Lennard-Jones eps has to be >=0")
+                raise ValueError("Lennard-Jones epsilon has to be >=0")
             if self._params["sigma"] < 0:
                 raise ValueError("Lennard-Jones sigma has to be >=0")
             return True
@@ -581,7 +583,7 @@ IF LJCOS:
             return(self._params["epsilon"] > 0)
 
         def set_params(self, **kwargs):
-            """Set parameters for the Lennard-Jones Cosine2 interaction.
+            """Set parameters for the Lennard-Jones cosine interaction.
 
             Parameters
             ----------
@@ -639,7 +641,7 @@ IF LJCOS2:
 
         def validate_params(self):
             if self._params["epsilon"] < 0:
-                raise ValueError("Lennard-Jones eps has to be >=0")
+                raise ValueError("Lennard-Jones epsilon has to be >=0")
             if self._params["sigma"] < 0:
                 raise ValueError("Lennard-Jones sigma has to be >=0")
             if self._params["width"] < 0:
@@ -661,7 +663,7 @@ IF LJCOS2:
             return(self._params["epsilon"] > 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the Lennard-Jones Cosine2 interaction.
+            """ Set parameters for the Lennard-Jones cosine2 interaction.
 
             Parameters
             ----------
@@ -890,22 +892,20 @@ IF DPD:
 
             Parameters
             ----------
-            weight_function : :obj:`float`
+            weight_function : :obj:`int`, \{0, 1\}
                 The distance dependence of the parallel part,
                 either 0 (constant) or 1 (linear)
             gamma : :obj:`float`
                 Friction coefficient of the parallel part
             r_cut : :obj:`float`
                 Cutoff of the parallel part
-            trans_weight_function : :obj:`float`
+            trans_weight_function : :obj:`int`, \{0, 1\}
                 The distance dependence of the orthogonal part,
                 either 0 (constant) or 1 (linear)
             trans_gamma : :obj:`float`
                 Friction coefficient of the orthogonal part
             trans_r_cut : :obj:`float`
                 Cutoff of the orthogonal part
-            seed : :obj:`int`, required
-                Initial counter value (or seed) of the philox RNG.
 
             """
             super().set_params(**kwargs)
@@ -3069,7 +3069,7 @@ class IBM_Triel(BondedInteraction):
 
     Parameters
     ----------
-    indX : :obj:`int`
+    ind1, ind2, ind3 : :obj:`int`
         First, second and third bonding partner. Used for
         initializing reference state
     k1 : :obj:`float`
@@ -3126,13 +3126,13 @@ class IBM_Tribend(BondedInteraction):
 
     Parameters
     ----------
-    indX : :obj:`int`
+    ind1, ind2, ind3, ind4 : :obj:`int`
         First, second, third and fourth bonding partner. Used for
         initializing reference state
     kb : :obj:`float`
         Bending modulus
     refShape : :obj:`str`, \{'Flat', 'Initial'\}
-        Reference shape
+        Reference shape, default is ``'Flat'``
 
     """
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -2522,6 +2522,20 @@ ELSE:
 
 class Dihedral(BondedInteraction):
 
+    """
+    Dihedral potential with phase shift.
+
+    Parameters
+    ----------
+    mult : :obj:`int`
+        Multiplicity of the potential (number of minima).
+    bend : :obj:`float`
+        Bending constant.
+    phase : :obj:`float`
+        Angle of the first local minimum in radians.
+
+    """
+
     def type_number(self):
         return BONDED_IA_DIHEDRAL
 
@@ -2547,7 +2561,7 @@ class Dihedral(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"mult'": 1., "bend": 0., "phase": 0.}
+        self._params = {"mult'": 1, "bend": 0., "phase": 0.}
 
     def _get_params_from_es_core(self):
         return \
@@ -2843,6 +2857,11 @@ IF TABULATED == 1:
 IF LENNARD_JONES == 1:
     class SubtLJ(BondedInteraction):
 
+        """
+        Subtracted LJ potential. Takes no parameter.
+
+        """
+
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
@@ -2928,7 +2947,12 @@ class AngleHarmonic(BondedInteraction):
     """
     Bond angle dependent harmonic potential.
 
-    See :ref:`Bond-angle interactions`
+    Parameters
+    ----------
+    phi0 : :obj:`float`
+        Equilibrium bond angle in radians.
+    bend : :obj:`float`
+        Magnitude of the bond interaction.
 
     """
 
@@ -2974,7 +2998,12 @@ class AngleCosine(BondedInteraction):
     """
     Bond angle dependent cosine potential.
 
-    See :ref:`Bond-angle interactions`
+    Parameters
+    ----------
+    phi0 : :obj:`float`
+        Equilibrium bond angle in radians.
+    bend : :obj:`float`
+        Magnitude of the bond interaction.
 
     """
 
@@ -3020,7 +3049,12 @@ class AngleCossquare(BondedInteraction):
     """
     Bond angle dependent cosine squared potential.
 
-    See :ref:`Bond-angle interactions`
+    Parameters
+    ----------
+    phi0 : :obj:`float`
+        Equilibrium bond angle in radians.
+    bend : :obj:`float`
+        Magnitude of the bond interaction.
 
     """
 
@@ -3216,7 +3250,21 @@ class IBM_VolCons(BondedInteraction):
 class OifGlobalForces(BondedInteraction):
 
     """
+    Characterize the distribution of the force of the global mesh deformation
+    onto individual vertices of the mesh.
+
     Part of the :ref:`Object-in-fluid` method.
+
+    Parameters
+    ----------
+    A0_g : :obj:`float`
+        Relaxed area of the mesh
+    ka_g : :obj:`float`
+        Area coefficient
+    V0 : :obj:`float`
+        Relaxed volume of the mesh
+    kv : :obj:`float`
+        Volume coefficient
 
     """
 
@@ -3262,7 +3310,30 @@ class OifGlobalForces(BondedInteraction):
 class OifLocalForces(BondedInteraction):
 
     """
+    Characterize the deformation of two triangles sharing an edge.
+
     Part of the :ref:`Object-in-fluid` method.
+
+    Parameters
+    ----------
+    r0 : :obj:`float`
+        Equilibrium bond length of triangle edges
+    ks : :obj:`float`
+        Non-linear stretching coefficient of triangle edges
+    kslin : :obj:`float`
+        Linear stretching coefficient of triangle edges
+    phi0 : :obj:`float`
+        Equilibrium angle between the two triangles
+    kb : :obj:`float`
+        Bending coefficient for the angle between the two triangles
+    A01 : :obj:`float`
+        Equilibrium surface of the first triangle
+    A02 : :obj:`float`
+        Equilibrium surface of the second triangle
+    kal : :obj:`float`
+        Stretching coefficient of a triangle surface
+    kvisc : :obj:`float`
+        Viscous coefficient of the triangle vertices
 
     """
 
@@ -3315,6 +3386,12 @@ class OifLocalForces(BondedInteraction):
 
 IF MEMBRANE_COLLISION == 1:
     class OifOutDirection(BondedInteraction):
+
+        """
+        Determine the surface normals of triangles on a mesh.
+        Takes no parameter.
+
+        """
 
         def type_number(self):
             return BONDED_IA_OIF_OUT_DIRECTION

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -25,8 +25,6 @@ from espressomd.utils import is_valid_type
 from globals cimport immersed_boundaries
 
 
-# Non-bonded interactions
-
 cdef class NonBondedInteraction:
     """
     Represents an instance of a non-bonded interaction, such as Lennard-Jones.
@@ -213,8 +211,6 @@ cdef class NonBondedInteraction:
         raise Exception(
             "Subclasses of NonBondedInteraction must define the required_keys() method.")
 
-# Lennard-Jones
-
 IF LENNARD_JONES == 1:
     cdef class LennardJonesInteraction(NonBondedInteraction):
 
@@ -268,7 +264,7 @@ IF LENNARD_JONES == 1:
             shift : :obj:`float` or :obj:`str` \{'auto'\}
                 Constant shift of the potential. If ``'auto'``, a default value
                 is computed from ``sigma`` and ``cutoff``. The LJ potential
-                will be shifted by :math:`4\\epsilon\\text{shift}`.
+                will be shifted by :math:`4\\epsilon\\cdot\\text{shift}`.
             offset : :obj:`float`, optional
                 Offset distance of the interaction.
             min : :obj:`float`, optional
@@ -403,7 +399,6 @@ IF WCA == 1:
             """
             return "epsilon", "sigma"
 
-# Generic Lennard-Jones
 IF LENNARD_JONES_GENERIC == 1:
 
     cdef class GenericLennardJonesInteraction(NonBondedInteraction):
@@ -522,7 +517,7 @@ IF LENNARD_JONES_GENERIC == 1:
             shift : :obj:`float` or :obj:`str` \{'auto'\}
                 Constant shift of the potential. If ``'auto'``, a default value
                 is computed from the other parameters. The LJ potential
-                will be shifted by :math:`\\epsilon\\text{shift}`.
+                will be shifted by :math:`\\epsilon\\cdot\\text{shift}`.
             offset : :obj:`float`
                 Offset distance of the interaction.
             e1 : :obj:`int`
@@ -554,8 +549,6 @@ IF LENNARD_JONES_GENERIC == 1:
 
             """
             return "epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2"
-
-# Lennard-Jones cosine
 
 IF LJCOS:
     cdef class LennardJonesCosInteraction(NonBondedInteraction):
@@ -634,8 +627,6 @@ IF LJCOS:
             """
             return "epsilon", "sigma", "cutoff"
 
-# Lennard-Jones cosine^2
-
 IF LJCOS2:
     cdef class LennardJonesCos2Interaction(NonBondedInteraction):
 
@@ -663,7 +654,7 @@ IF LJCOS2:
             return(self._params["epsilon"] > 0)
 
         def set_params(self, **kwargs):
-            """ Set parameters for the Lennard-Jones cosine2 interaction.
+            """ Set parameters for the Lennard-Jones cosine squared interaction.
 
             Parameters
             ----------
@@ -768,8 +759,6 @@ IF HAT == 1:
 
         def required_keys(self):
             return "F_max", "cutoff"
-
-# Gay-Berne
 
 IF GAY_BERNE:
     cdef class GayBerneInteraction(NonBondedInteraction):
@@ -938,8 +927,6 @@ IF DPD:
         def required_keys(self):
             return []
 
-# Smooth-step
-
 IF SMOOTH_STEP == 1:
 
     cdef class SmoothStepInteraction(NonBondedInteraction):
@@ -1039,8 +1026,6 @@ IF SMOOTH_STEP == 1:
 
             """
             return "d", "eps", "cutoff"
-
-# BMHTF
 
 IF BMHTF_NACL == 1:
 
@@ -1142,8 +1127,6 @@ IF BMHTF_NACL == 1:
             """
             return "a", "b", "c", "d", "sig", "cutoff"
 
-# Morse
-
 IF MORSE == 1:
 
     cdef class MorseInteraction(NonBondedInteraction):
@@ -1231,8 +1214,6 @@ IF MORSE == 1:
 
             """
             return "eps", "alpha", "rmin"
-
-# Buckingham
 
 IF BUCKINGHAM == 1:
 
@@ -1338,8 +1319,6 @@ IF BUCKINGHAM == 1:
 
             """
             return "a", "c", "d", "discont", "cutoff"
-
-# Soft-sphere
 
 IF SOFT_SPHERE == 1:
 
@@ -1542,11 +1521,6 @@ IF MEMBRANE_COLLISION == 1:
         def required_keys(self):
             return "a", "n", "cutoff"
 
-# Gay-Berne
-
-
-# Hertzian
-
 IF HERTZIAN == 1:
 
     cdef class HertzianInteraction(NonBondedInteraction):
@@ -1623,8 +1597,6 @@ IF HERTZIAN == 1:
 
             """
             return "eps", "sig"
-
-# Gaussian
 
 IF GAUSSIAN == 1:
 
@@ -1792,8 +1764,8 @@ class NonBondedInteractionHandle:
 
 cdef class NonBondedInteractions:
     """
-    Access to non-bonded interaction parameters via [i,j], where i,j are particle
-    types. Returns a :class:`NonBondedInteractionHandle` object.
+    Access to non-bonded interaction parameters via ``[i,j]``, where ``i, j``
+    are particle types. Returns a :class:`NonBondedInteractionHandle` object.
     Also: access to force capping.
 
     """
@@ -2235,11 +2207,11 @@ class ThermalizedBond(BondedInteraction):
     ----------
 
     temp_com : :obj:`float`
-        Temperature of the Langevin thermostat for the com of the
+        Temperature of the Langevin thermostat for the center of mass of the
         particle pair.
     gamma_com: :obj:`float`
-        Friction coefficient of the Langevin thermostat for the com of
-        the particle pair.
+        Friction coefficient of the Langevin thermostat for the center of mass
+        of the particle pair.
     temp_distance: :obj:`float`
         Tmperature of the Langevin thermostat for the distance vector
         of the particle pair.
@@ -2945,7 +2917,7 @@ class Virtual(BondedInteraction):
 class AngleHarmonic(BondedInteraction):
 
     """
-    Bond angle dependent harmonic potential.
+    Bond-angle-dependent harmonic potential.
 
     Parameters
     ----------
@@ -2996,7 +2968,7 @@ class AngleHarmonic(BondedInteraction):
 class AngleCosine(BondedInteraction):
 
     """
-    Bond angle dependent cosine potential.
+    Bond-angle-dependent cosine potential.
 
     Parameters
     ----------
@@ -3047,7 +3019,7 @@ class AngleCosine(BondedInteraction):
 class AngleCossquare(BondedInteraction):
 
     """
-    Bond angle dependent cosine squared potential.
+    Bond-angle-dependent cosine squared potential.
 
     Parameters
     ----------
@@ -3095,7 +3067,6 @@ class AngleCossquare(BondedInteraction):
             self._bond_id, self._params["bend"], self._params["phi0"])
 
 
-# IBM triel
 class IBM_Triel(BondedInteraction):
 
     """
@@ -3152,7 +3123,6 @@ class IBM_Triel(BondedInteraction):
                             "ind3"], self._params["maxDist"], el, self._params["k1"], self._params["k2"])
 
 
-# IBM tribend
 class IBM_Tribend(BondedInteraction):
 
     """
@@ -3203,11 +3173,10 @@ class IBM_Tribend(BondedInteraction):
                               self._params["ind4"], self._params["kb"], flat)
 
 
-# IBM VolCons
 class IBM_VolCons(BondedInteraction):
 
     """
-    IBM VolCons bond.
+    IBM volume conservation bond.
 
     Parameters
     ----------

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -260,9 +260,9 @@ IF LENNARD_JONES == 1:
             ----------
 
             epsilon : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             sigma : :obj:`float`
-                Determines the interaction length scale.
+                Interaction length scale.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
             shift : :obj:`float` or :obj:`str`
@@ -362,9 +362,9 @@ IF WCA == 1:
             ----------
 
             epsilon : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             sigma : :obj:`float`
-                Determines the interaction length scale.
+                Interaction length scale.
 
             """
             super().set_params(**kwargs)
@@ -514,9 +514,9 @@ IF LENNARD_JONES_GENERIC == 1:
             Parameters
             ----------
             epsilon : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             sigma : :obj:`float`
-                Determines the interaction length scale.
+                Interaction length scale.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
             shift : :obj:`float`
@@ -587,9 +587,9 @@ IF LJCOS:
             ----------
 
             epsilon : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             sigma : :obj:`float`
-                Determines the interaction length scale.
+                Interaction length scale.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
             offset : :obj:`float`
@@ -667,9 +667,9 @@ IF LJCOS2:
             ----------
 
             epsilon : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             sigma : :obj:`float`
-                Determines the interaction length scale.
+                Interaction length scale.
             offset : :obj:`float`
                 Offset distance of the interaction.
             width : :obj:`float`
@@ -739,7 +739,7 @@ IF HAT == 1:
             Parameters
             ----------
             F_max : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
 
@@ -1017,7 +1017,7 @@ IF SMOOTH_STEP == 1:
             n : :obj:`int`
                 Exponent of short range repulsion.
             eps : :obj:`float`
-                The magnitude of the second (soft) repulsion.
+                Magnitude of the second (soft) repulsion.
             k0 : :obj:`float`
                 Exponential factor in second (soft) repulsion.
             sig : :obj:`float`
@@ -1115,13 +1115,13 @@ IF BMHTF_NACL == 1:
             Parameters
             ----------
             a : :obj:`float`
-                The magnitude of exponential part of the interaction.
+                Magnitude of exponential part of the interaction.
             b : :obj:`float`
                 Exponential factor of the interaction.
             c : :obj:`float`
-                The magnitude of the term decaying with the sixth power of r.
+                Magnitude of the term decaying with the sixth power of r.
             d : :obj:`float`
-                The magnitude of the term decaying with the eighth power of r.
+                Magnitude of the term decaying with the eighth power of r.
             sig : :obj:`float`
                 Shift in the exponent.
             cutoff : :obj:`float`
@@ -1406,7 +1406,7 @@ IF SOFT_SPHERE == 1:
             Parameters
             ----------
             a : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             n : :obj:`float`
                 Exponent of the power law.
             cutoff : :obj:`float`
@@ -1604,9 +1604,10 @@ IF HERTZIAN == 1:
             Parameters
             ----------
             eps : :obj:`float`
-                The magnitude of the interaction.
+                Magnitude of the interaction.
             sig : :obj:`float`
-                Parameter sigma which determines the length over which the potential decays.
+                Parameter sigma. Determines the length over which the potential
+                decays.
 
             """
             super().set_params(**kwargs)
@@ -2035,11 +2036,11 @@ class FeneBond(BondedInteraction):
     Parameters
     ----------
     k : :obj:`float`
-        Specifies the magnitude of the bond interaction.
+        Magnitude of the bond interaction.
     d_r_max : :obj:`float`
-        Specifies the maximum stretch and compression length of the bond.
+        Maximum stretch and compression length of the bond.
     r_0 : :obj:`float`, optional
-        Specifies the equilibrium length of the bond.
+        Equilibrium bond length.
 
     """
 
@@ -2096,11 +2097,11 @@ class HarmonicBond(BondedInteraction):
     Parameters
     ----------
     k : :obj:`float`
-        Specifies the magnitude of the bond interaction.
+        Magnitude of the bond interaction.
     r_0 : :obj:`float`
-        Specifies the equilibrium length of the bond.
+        Equilibrium bond length.
     r_cut : :obj:`float`, optional
-        Specifies maximum distance beyond which the bond is considered broken.
+        Maximum distance beyond which the bond is considered broken.
 
     """
 
@@ -2154,7 +2155,7 @@ if ELECTROSTATICS:
         ----------
 
         prefactor : :obj:`float`
-            Sets the Coulomb prefactor of the bonded Coulomb interaction.
+            Coulomb prefactor of the bonded Coulomb interaction.
         """
 
         def __init__(self, *args, **kwargs):
@@ -2195,7 +2196,7 @@ if ELECTROSTATICS:
         ----------
 
         q1q2 : :obj:`float`
-            Sets the charge factor of the involved particle pair. Note the
+            Charge factor of the involved particle pair. Note the
             particle charges are used to allow e.g. only partial subtraction
             of the involved charges.
         """
@@ -2237,19 +2238,19 @@ class ThermalizedBond(BondedInteraction):
     ----------
 
     temp_com : :obj:`float`
-        Sets the temperature of the Langevin thermostat for the com of the
+        Temperature of the Langevin thermostat for the com of the
         particle pair.
     gamma_com: :obj:`float`
-        Sets the friction coefficient of the Langevin thermostat for the com of
+        Friction coefficient of the Langevin thermostat for the com of
         the particle pair.
     temp_distance: :obj:`float`
-        Sets the temperature of the Langevin thermostat for the distance vector
+        Tmperature of the Langevin thermostat for the distance vector
         of the particle pair.
     gamma_distance: :obj:`float`
-        Sets the friction coefficient of the Langevin thermostat for the
+        Friction coefficient of the Langevin thermostat for the
         distance vector of the particle pair.
     r_cut: :obj:`float`, optional
-        Specifies maximum distance beyond which the bond is considered broken.
+        Maximum distance beyond which the bond is considered broken.
     """
 
     def __init__(self, *args, **kwargs):
@@ -2318,7 +2319,7 @@ IF THOLE:
                 parameters  a_i, a_j via
                 scaling_coeff = (a_i+a_j)/2 / ((alpha_i*alpha_j)^(1/2))^(1/3)
             q1q2: :obj:`float`
-                charge factor of the involved charges. Has to be set because
+                Charge factor of the involved charges. Has to be set because
                 it acts only on the portion of the Drude core charge that is
                 associated to the dipole of the atom. For charged, polarizable
                 atoms that charge is not equal to the particle charge property.
@@ -2354,14 +2355,13 @@ IF ROTATION:
         Parameters
         ----------
         k1 : :obj:`float`
-            Specifies the magnitude of the bond interaction.
+            Magnitude of the bond interaction.
         k2 : :obj:`float`
-            Specifies the magnitude of the angular interaction.
+            Magnitude of the angular interaction.
         r_0 : :obj:`float`
-            Specifies the equilibrium length of the bond.
+            Equilibrium bond length.
         r_cut : :obj:`float`, optional
-            Specifies maximum distance beyond which the bond is considered
-            broken.
+            Maximum distance beyond which the bond is considered broken.
 
         """
 
@@ -2471,11 +2471,11 @@ IF BOND_CONSTRAINT == 1:
         Parameters
         ----------
         r : :obj:`float`
-            Specifies the length of the rigid bond.
+            Bond length.
         ptol : :obj:`float`, optional
-            Specifies the tolerance for positional deviations.
+            Tolerance for positional deviations.
         vtop : :obj:`float`, optional
-            Specifies the tolerance for velocity deviations.
+            Tolerance for velocity deviations.
 
         """
 
@@ -3089,12 +3089,12 @@ class IBM_Triel(BondedInteraction):
     Parameters
     ----------
     indX : :obj:`int`
-        Specify first, second and third bonding partner. Used for
+        First, second and third bonding partner. Used for
         initializing reference state
     k1 : :obj:`float`
-        Specifies shear elasticity for Skalak and Neo-Hookean
+        Shear elasticity for Skalak and Neo-Hookean
     k2 : :obj:`float`
-        Specifies area resistance for Skalak
+        Area resistance for Skalak
     maxDist : :obj:`float`
         Gives an error if an edge becomes longer than maxDist
     elasticLaw : :obj:`str`
@@ -3146,10 +3146,10 @@ class IBM_Tribend(BondedInteraction):
     Parameters
     ----------
     indX : :obj:`int`
-        Specify first, second, third and fourth bonding partner. Used for
+        First, second, third and fourth bonding partner. Used for
         initializing reference state
     kb : :obj:`float`
-        Specifies bending modulus
+        Bending modulus
     refShape : :obj:`str`, \{'Flat', 'Initial'\}
         Reference shape
 
@@ -3371,13 +3371,13 @@ class QuarticBond(BondedInteraction):
     Parameters
     ----------
     k0 : :obj:`float`
-        Specifies the magnitude of the square term.
+        Magnitude of the square term.
     k1 : :obj:`float`
-        Specifies the magnitude of the fourth order term.
+        Magnitude of the fourth order term.
     r : :obj:`float`
-        Specifies the equilibrium length of the bond.
+        Equilibrium bond length.
     r_cut : :obj:`float`
-        Specifies the maximum interaction length.
+        Maximum interaction length.
     """
 
     def __init__(self, *args, **kwargs):
@@ -3516,7 +3516,7 @@ class BondedInteractions:
                 yield self[i]
 
     def add(self, bonded_ia):
-        """Add a bonded ia to the simulation"""
+        """Add a bonded IA to the simulation"""
         self[bonded_ia_params.size()] = bonded_ia
 
     def __getstate__(self):


### PR DESCRIPTION
Fixes #3049

Description of changes:
- bonded IAs listed in #3049 are now documented in both Sphinx and Doxygen
- cleaned up outdated docstrings
- re-shuffled paragraphs in [7. Bonded interactions](http://espressomd.org/html/doc/inter_bonded.html)