### PR TITLE
Use steepest descent without thermostat in tutorial 02

### DIFF
--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -96,7 +96,7 @@ For example, ::
     7.0
     >>> system.analysis.dist_to(pos=[0, 0, 0])
     1.4142135623730951
-    >>> system.analysis.mindist()
+    >>> system.analysis.min_dist()
     1.0
 
 

--- a/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
+++ b/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
@@ -200,7 +200,7 @@
     "# Lennard-Jones Equilibration\n",
     "max_sigma = max(lj_sigmas.values())\n",
     "min_dist = 0.0\n",
-    "system.minimize_energy.init(f_max=1, gamma=10.0, max_steps=10,\n",
+    "system.minimize_energy.init(f_max=0, gamma=10.0, max_steps=10,\n",
     "                            max_displacement=max_sigma * 0.01)\n",
     "\n",
     "while min_dist < max_sigma:\n",

--- a/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
+++ b/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "## 1 Introduction\n",
     "\n",
-    "This tutorial introduces some of the basic features of **ESPResSo** for charged systems by constructing a simulation script for a simple salt crystal. In the subsequent task, we use a more realistic force-field for a NaCl crystal. Finally, we introduce constraints and 2D-Electrostatics to simulate a molten salt in a parallel plate capacitor. We assume that the reader is familiar with the basic concepts of Python and MD simulations.  Compile espresso with the following features in your <tt>myconfig.hpp</tt> to be set throughout the whole tutorial:\n",
+    "This tutorial introduces some of the basic features of **ESPResSo** for charged systems by constructing a simulation script for a simple salt crystal. In the subsequent task, we use a more realistic force-field for a NaCl crystal. Finally, we introduce constraints and 2D-Electrostatics to simulate a molten salt in a parallel plate capacitor. We assume that the reader is familiar with the basic concepts of Python and MD simulations.  Compile **ESPResSo** with the following features in your <tt>myconfig.hpp</tt> to be set throughout the whole tutorial:\n",
     "\n",
     "```c++\n",
     "#define EXTERNAL_FORCES\n",
@@ -93,8 +93,7 @@
     "<tt>espressomd.System()</tt> properties. We create an instance <tt>system</tt> and\n",
     "set the box length, periodicity and time step. The skin depth <tt>skin</tt> \n",
     "is a parameter for the link--cell system which tunes its\n",
-    "performance, but shall not be discussed here. Further, we activate the Langevin thermostat\n",
-    "for our NVT ensemble with temperature <tt>temp</tt> and friction coefficient <tt>gamma</tt>. "
+    "performance, but shall not be discussed here."
    ]
   },
   {
@@ -109,8 +108,7 @@
     "system.seed = 42\n",
     "system.periodicity = [True, True, True]\n",
     "system.time_step = time_step\n",
-    "system.cell_system.skin = 0.3\n",
-    "system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)"
+    "system.cell_system.skin = 0.3"
    ]
   },
   {
@@ -186,11 +184,11 @@
     "With randomly positioned particles, we most likely have huge overlap and the strong repulsion will\n",
     "cause the simulation to crash. The next step in our script therefore is a suitable LJ equilibration.\n",
     "This is known to be a tricky part of a simulation and several approaches exist to reduce the particle overlap.\n",
-    "Here, we use a highly damped system (large gamma in the thermostat) and cap the forces of the LJ interaction.\n",
+    "Here, we use the steepest descent algorithm and cap the maximal particle displacement per integration step\n",
+    "to 1% of sigma.\n",
     "We use <tt>system.analysis.min_dist()</tt> to get the minimal distance between all particles pairs. This value\n",
-    "is used to progressively increase the force capping. This results in a slow increase of the force capping at\n",
-    "strong overlap. At the end, we reset our thermostat to the target values and deactivate the force cap by setting \n",
-    "it to zero."
+    "is used to stop the minimization when particles are far away enough from each other. At the end, we activate the\n",
+    "Langevin thermostat for our NVT ensemble with temperature <tt>temp</tt> and friction coefficient <tt>gamma</tt>."
    ]
   },
   {
@@ -202,21 +200,16 @@
     "# Lennard-Jones Equilibration\n",
     "max_sigma = max(lj_sigmas.values())\n",
     "min_dist = 0.0\n",
-    "cap = 10.0\n",
-    "# Warmup Helper: Cold, highly damped system\n",
-    "system.thermostat.set_langevin(kT=temp * 0.1, gamma=gamma * 50.0, seed=42)\n",
+    "system.minimize_energy.init(f_max=1, gamma=10.0, max_steps=10,\n",
+    "                            max_displacement=max_sigma * 0.01)\n",
     "\n",
     "while min_dist < max_sigma:\n",
-    "    # Warmup Helper: Cap max. force, increase slowly for overlapping particles\n",
     "    min_dist = system.analysis.min_dist([types[\"Anion\"], types[\"Cation\"]],\n",
     "                                        [types[\"Anion\"], types[\"Cation\"]])\n",
-    "    cap += min_dist\n",
-    "    system.force_cap = cap\n",
-    "    system.integrator.run(10)\n",
+    "    system.minimize_energy.minimize()\n",
     "\n",
-    "# Don't forget to reset thermostat and force cap\n",
-    "system.thermostat.set_langevin(kT=temp, gamma=gamma)\n",
-    "system.force_cap = 0"
+    "# Set thermostat\n",
+    "system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)"
    ]
   },
   {

--- a/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
+++ b/doc/tutorials/02-charged_system/02-charged_system-1.ipynb
@@ -90,7 +90,7 @@
     "equally sized, monovalent salt.\n",
     "\n",
     "The simulation engine itself is modified by changing the\n",
-    "espressomd.System() properties. We create an instance <tt>system</tt> and\n",
+    "<tt>espressomd.System()</tt> properties. We create an instance <tt>system</tt> and\n",
     "set the box length, periodicity and time step. The skin depth <tt>skin</tt> \n",
     "is a parameter for the link--cell system which tunes its\n",
     "performance, but shall not be discussed here. Further, we activate the Langevin thermostat\n",
@@ -107,7 +107,7 @@
     "box_l = (n_part / density)**(1. / 3.)\n",
     "system = System(box_l=[box_l, box_l, box_l])\n",
     "system.seed = 42\n",
-    "system.periodicity = [1, 1, 1]\n",
+    "system.periodicity = [True, True, True]\n",
     "system.time_step = time_step\n",
     "system.cell_system.skin = 0.3\n",
     "system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)"
@@ -187,7 +187,7 @@
     "cause the simulation to crash. The next step in our script therefore is a suitable LJ equilibration.\n",
     "This is known to be a tricky part of a simulation and several approaches exist to reduce the particle overlap.\n",
     "Here, we use a highly damped system (large gamma in the thermostat) and cap the forces of the LJ interaction.\n",
-    "We use <tt>system.analysis.mindist</tt> to get the minimal distance between all particles pairs. This value\n",
+    "We use <tt>system.analysis.min_dist()</tt> to get the minimal distance between all particles pairs. This value\n",
     "is used to progressively increase the force capping. This results in a slow increase of the force capping at\n",
     "strong overlap. At the end, we reset our thermostat to the target values and deactivate the force cap by setting \n",
     "it to zero."
@@ -214,7 +214,7 @@
     "    system.force_cap = cap\n",
     "    system.integrator.run(10)\n",
     "\n",
-    "# Don't forget to reset thermostat, timestep and force cap\n",
+    "# Don't forget to reset thermostat and force cap\n",
     "system.thermostat.set_langevin(kT=temp, gamma=gamma)\n",
     "system.force_cap = 0"
    ]

--- a/doc/tutorials/02-charged_system/02-charged_system-2.ipynb
+++ b/doc/tutorials/02-charged_system/02-charged_system-2.ipynb
@@ -161,8 +161,7 @@
     "\n",
     "system.periodicity = [True, True, True]\n",
     "system.time_step = time_step\n",
-    "system.cell_system.skin = 0.3\n",
-    "system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)"
+    "system.cell_system.skin = 0.3"
    ]
   },
   {
@@ -258,9 +257,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next is the Lennard-Jones Equilibration: Here we use an alternative way to get rid of the overlap: **ESPResSo** features a routine for energy\n",
-    "minimization with similar features as in the manual implementation used before. Basically it \n",
-    "caps the forces and limits the displacement during integration."
+    "Next is the Lennard-Jones equilibration, followed by the thermostat:"
    ]
   },
   {
@@ -270,12 +267,15 @@
    "outputs": [],
    "source": [
     "energy = system.analysis.energy()\n",
-    "print(\"Before Minimization: E_total=\", energy['total'])\n",
+    "print(\"Before Minimization: E_total = {:.3e}\".format(energy['total']))\n",
     "system.minimize_energy.init(f_max=10, gamma=10, max_steps=2000,\n",
-    "                            max_displacement=0.1)\n",
+    "                            max_displacement=0.01)\n",
     "system.minimize_energy.minimize()\n",
     "energy = system.analysis.energy()\n",
-    "print(\"After Minimization: E_total=\", energy['total'])"
+    "print(\"After Minimization: E_total = {:.3e}\".format(energy['total']))\n",
+    "\n",
+    "# Set thermostat\n",
+    "system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)"
    ]
   },
   {
@@ -424,7 +424,7 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "plt.ion()\n"
+    "plt.ion()"
    ]
   },
   {

--- a/doc/tutorials/02-charged_system/02-charged_system-2.ipynb
+++ b/doc/tutorials/02-charged_system/02-charged_system-2.ipynb
@@ -159,7 +159,7 @@
     "system.seed = 42\n",
     "box_volume = numpy.prod([box_l, box_l, box_z])\n",
     "\n",
-    "system.periodicity = [1, 1, 1]\n",
+    "system.periodicity = [True, True, True]\n",
     "system.time_step = time_step\n",
     "system.cell_system.skin = 0.3\n",
     "system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)"

--- a/doc/tutorials/02-charged_system/scripts/nacl.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl.py
@@ -57,7 +57,6 @@ system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
 system.periodicity = [True, True, True]
 system.time_step = time_step
 system.cell_system.skin = 0.3
-system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)
 
 # Place particles
 for i in range(int(n_ionpairs)):
@@ -97,21 +96,15 @@ for s in [["Anion", "Cation"], ["Anion", "Anion"], ["Cation", "Cation"]]:
 print("\n--->Lennard-Jones Equilibration")
 max_sigma = max(lj_sigmas.values())
 min_dist = 0.0
-cap = 10.0
-# Warmup Helper: Cold, highly damped system
-system.thermostat.set_langevin(kT=temp * 0.1, gamma=gamma * 50.0)
+system.minimize_energy.init(f_max=1, gamma=10, max_steps=10,
+                            max_displacement=max_sigma * 0.01)
 
 while min_dist < max_sigma:
-    # Warmup Helper: Cap max. force, increase slowly for overlapping particles
-    min_dist = system.analysis.min_dist([types["Anion"], types["Cation"]], [
-        types["Anion"], types["Cation"]])
-    cap += min_dist
-    system.force_cap = cap
-    system.integrator.run(10)
+    system.minimize_energy.minimize()
+    min_dist = system.analysis.min_dist()
 
-# Don't forget to reset thermostat, timestep and force cap
-system.thermostat.set_langevin(kT=temp, gamma=gamma)
-system.force_cap = 0
+# Set thermostat
+system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)
 
 print("\n--->Tuning Electrostatics")
 p3m = electrostatics.P3M(prefactor=l_bjerrum, accuracy=1e-3)

--- a/doc/tutorials/02-charged_system/scripts/nacl.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl.py
@@ -96,7 +96,7 @@ for s in [["Anion", "Cation"], ["Anion", "Anion"], ["Cation", "Cation"]]:
 print("\n--->Lennard-Jones Equilibration")
 max_sigma = max(lj_sigmas.values())
 min_dist = 0.0
-system.minimize_energy.init(f_max=1, gamma=10, max_steps=10,
+system.minimize_energy.init(f_max=0, gamma=10, max_steps=10,
                             max_displacement=max_sigma * 0.01)
 
 while min_dist < max_sigma:

--- a/doc/tutorials/02-charged_system/scripts/nacl.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl.py
@@ -54,7 +54,7 @@ lj_cuts = {"Anion": WCA_cut * lj_sigmas["Anion"],
 box_l = (n_part / density)**(1. / 3.)
 system = espressomd.System(box_l=[box_l] * 3)
 system.seed = system.cell_system.get_state()['n_nodes'] * [1234]
-system.periodicity = [1, 1, 1]
+system.periodicity = [True, True, True]
 system.time_step = time_step
 system.cell_system.skin = 0.3
 system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)

--- a/doc/tutorials/02-charged_system/scripts/nacl_units.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units.py
@@ -60,7 +60,7 @@ masses = {"Cl": 35.453, "Na": 22.99}
 # Setup System
 box_l = (n_ionpairs * sum(masses.values()) / density)**(1. / 3.)
 system.box_l = [box_l, box_l, box_l]
-system.periodicity = [1, 1, 1]
+system.periodicity = [True, True, True]
 system.time_step = time_step
 system.cell_system.skin = 0.3
 system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined.py
@@ -64,7 +64,7 @@ box_z = box_l + 2.0 * (lj_sigmas["Electrode"])
 box_volume = box_l * box_l * box_z
 elc_gap = box_z * 0.15
 system.box_l = [box_l, box_l, box_z + elc_gap]
-system.periodicity = [1, 1, 1]
+system.periodicity = [True, True, True]
 system.time_step = time_step
 system.cell_system.skin = 0.3
 system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_confined_vis.py
@@ -65,7 +65,7 @@ box_z = box_l + 2.0 * (lj_sigmas["Electrode"])
 box_volume = box_l * box_l * box_z
 elc_gap = box_z * 0.15
 system.box_l = [box_l, box_l, box_z + elc_gap]
-system.periodicity = [1, 1, 1]
+system.periodicity = [True, True, True]
 system.time_step = time_step
 system.cell_system.skin = 0.3
 system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)

--- a/doc/tutorials/02-charged_system/scripts/nacl_units_vis.py
+++ b/doc/tutorials/02-charged_system/scripts/nacl_units_vis.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import espressomd
-from espressomd import assert_features, electrostatics, electrostatic_extensions
+from espressomd import assert_features, electrostatics
 from espressomd import visualization_opengl
 import numpy
 from threading import Thread
@@ -97,7 +97,7 @@ masses = {"Cl": 35.453, "Na": 22.99}
 # Setup System
 box_l = (n_ionpairs * sum(masses.values()) / density)**(1. / 3.)
 system.box_l = [box_l, box_l, box_l]
-system.periodicity = [1, 1, 1]
+system.periodicity = [True, True, True]
 system.time_step = time_step
 system.cell_system.skin = 0.3
 system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)

--- a/doc/tutorials/05-raspberry_electrophoresis/05-raspberry_electrophoresis.ipynb
+++ b/doc/tutorials/05-raspberry_electrophoresis/05-raspberry_electrophoresis.ipynb
@@ -143,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system.periodicity = [1, 1, 1]"
+    "system.periodicity = [True, True, True]"
    ]
   },
   {

--- a/src/core/minimize_energy.cpp
+++ b/src/core/minimize_energy.cpp
@@ -40,13 +40,6 @@
 #define MINIMIZE_ENERGY_TRACE(A)
 #endif
 
-struct MinimizeEnergyParameters {
-  double f_max;
-  double gamma;
-  int max_steps;
-  double max_displacement;
-};
-
 static MinimizeEnergyParameters *params = nullptr;
 
 /* Signum of val */

--- a/src/core/minimize_energy.cpp
+++ b/src/core/minimize_energy.cpp
@@ -40,9 +40,10 @@
 #define MINIMIZE_ENERGY_TRACE(A)
 #endif
 
+/** Currently active steepest descent instance */
 static MinimizeEnergyParameters *params = nullptr;
 
-/* Signum of val */
+/** Sign of the argument */
 template <typename T> int sgn(T val) { return (T(0) < val) - (val < T(0)); }
 
 bool steepest_descent_step(const ParticleRange &particles) {
@@ -112,8 +113,6 @@ bool steepest_descent_step(const ParticleRange &particles) {
   auto const f_max_global =
       mpi::all_reduce(comm_cart, f_max, mpi::maximum<double>());
 
-  // Return true, if the maximum force/torque encountered is below the user
-  // limit.
   return (sqrt(f_max_global) < params->f_max);
 }
 

--- a/src/core/minimize_energy.cpp
+++ b/src/core/minimize_energy.cpp
@@ -54,18 +54,12 @@ template <typename T> int sgn(T val) { return (T(0) < val) - (val < T(0)); }
 
 bool steepest_descent_step(const ParticleRange &particles) {
   // Maximal force encountered on node
-  double f_max = -std::numeric_limits<double>::max();
-  // and globally
-
-  // Positional increments
-  double dp, dp2, dp2_max = -std::numeric_limits<double>::max();
+  auto f_max = -std::numeric_limits<double>::max();
 
   // Iteration over all local particles
-
   for (auto &p : particles) {
     auto f = 0.0;
 
-    dp2 = 0.0;
     // For all Cartesian coordinates
     for (int j = 0; j < 3; j++) {
 #ifdef EXTERNAL_FORCES
@@ -81,11 +75,11 @@ bool steepest_descent_step(const ParticleRange &particles) {
           f += Utils::sqr(p.f.f[j]);
 
           // Positional increment
-          dp = params->gamma * p.f.f[j];
-          if (fabs(dp) > params->max_displacement)
+          auto dp = params->gamma * p.f.f[j];
+          if (fabs(dp) > params->max_displacement) {
             // Crop to maximum allowed by user
             dp = sgn<double>(dp) * params->max_displacement;
-          dp2 += Utils::sqr(dp);
+          }
 
           // Move particle
           p.r.p[j] += dp;
@@ -116,7 +110,6 @@ bool steepest_descent_step(const ParticleRange &particles) {
 #endif
     // Note maximum force/torque encountered
     f_max = std::max(f_max, f);
-    dp2_max = std::max(dp2_max, dp2);
   }
 
   set_resort_particles(Cells::RESORT_LOCAL);

--- a/src/core/minimize_energy.hpp
+++ b/src/core/minimize_energy.hpp
@@ -24,16 +24,45 @@
 
 #include "ParticleRange.hpp"
 
+/** Parameters for the steepest descent algorithm */
 struct MinimizeEnergyParameters {
+  /** Maximal particle force
+   *
+   *  If the maximal force experienced by particles in the system (in any
+   *  direction) is inferior to this threshold, minimization stops.
+   */
   double f_max;
+  /** Dampening constant */
   double gamma;
+  /** Maximal number of integration steps */
   int max_steps;
+  /** Maximal particle displacement
+   *
+   *  Maximal distance that a particle can travel during one integration step,
+   *  in one direction.
+   */
   double max_displacement;
 };
 
+/** Steepest descent initializer
+ *
+ *  Sets the parameters in @ref MinimizeEnergyParameters
+ */
 void minimize_energy_init(double f_max, double gamma, int max_steps,
                           double max_displacement);
+
+/** Steepest descent main integration loop
+ *
+ *  Integration stops when the maximal force is lower than the user limit
+ *  @ref MinimizeEnergyParameters::f_max "f_max" or when the maximal number
+ *  of steps @ref MinimizeEnergyParameters::max_steps "max_steps" is reached.
+ */
 void minimize_energy();
+
+/** Steepest descent integrator
+ *  @return whether the maximum force/torque encountered is below the user
+ *          limit @ref MinimizeEnergyParameters::f_max "f_max".
+ */
 bool steepest_descent_step(const ParticleRange &particles);
 
 #endif /* __MINIMIZE_ENERGY */

--- a/src/core/minimize_energy.hpp
+++ b/src/core/minimize_energy.hpp
@@ -24,9 +24,16 @@
 
 #include "ParticleRange.hpp"
 
-void minimize_energy();
+struct MinimizeEnergyParameters {
+  double f_max;
+  double gamma;
+  int max_steps;
+  double max_displacement;
+};
+
 void minimize_energy_init(double f_max, double gamma, int max_steps,
                           double max_displacement);
+void minimize_energy();
 bool steepest_descent_step(const ParticleRange &particles);
 
 #endif /* __MINIMIZE_ENERGY */

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -87,7 +87,8 @@ class Analysis:
         ----------
         p1, p2 : lists of :obj:`int`
             Particle :attr:`~espressomd.particle_data.ParticleHandle.type` in
-            both sets.
+            both sets. If both are set to ``'default'``, the minimum distance
+            of all pairs is returned.
 
         """
 
@@ -968,11 +969,11 @@ class Analysis:
                      r_min=0.0, r_max=None, r_bins=100, log_flag=0, int_flag=0):
         """
         Calculates the distance distribution of particles (probability of
-        finding a particle of type at a certain distance around a particle of
-        type , disregarding the fact that a spherical shell of a larger radius
-        covers a larger volume) The distance is defined as the minimal distance
-        between a particle of group `type_list_a` to any of the group
-        `type_list_b`.  Returns two arrays, the bins and the (normalized)
+        finding a particle of type A at a certain distance around a particle of
+        type B, disregarding the fact that a spherical shell of a larger radius
+        covers a larger volume). The distance is defined as the minimal distance
+        between a particle of group ``type_list_a`` to any of the group
+        ``type_list_b``. Returns two arrays, the bins and the (normalized)
         distribution.
 
         Parameters

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -870,11 +870,8 @@ class Analysis:
 
         p_types = create_int_list_from_python_object(sf_types)
 
-        sf = analyze.calc_structurefactor(
-    analyze.partCfg(),
-     p_types.e,
-     p_types.n,
-     sf_order)
+        sf = analyze.calc_structurefactor(analyze.partCfg(), p_types.e,
+                                          p_types.n, sf_order)
 
         return np.transpose(analyze.modify_stucturefactor(sf_order, sf.data()))
 
@@ -1027,9 +1024,8 @@ class Analysis:
         p2_types = create_int_list_from_python_object(type_list_b)
 
         analyze.calc_part_distribution(
-            analyze.partCfg(
-                ), p1_types.e, p1_types.n, p2_types.e, p2_types.n,
-                                         r_min, r_max, r_bins, log_flag, & low, distribution.data())
+            analyze.partCfg(), p1_types.e, p1_types.n, p2_types.e, p2_types.n,
+            r_min, r_max, r_bins, log_flag, & low, distribution.data())
 
         np_distribution = create_nparray_from_double_array(
             distribution.data(), r_bins)

--- a/src/python/espressomd/minimize_energy.pxd
+++ b/src/python/espressomd/minimize_energy.pxd
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Minimize Energy
 
 include "myconfig.pxi"
 from espressomd.system cimport *

--- a/src/python/espressomd/minimize_energy.pyx
+++ b/src/python/espressomd/minimize_energy.pyx
@@ -16,25 +16,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Minimize Energy
 
 from . cimport minimize_energy
 from espressomd.utils import is_valid_type
 
 cdef class MinimizeEnergy:
     """
-    Initialize steepest descent energy minimization.
+    Steepest descent algorithm for energy minimization.
+
+    Particles located at :math:`\\vec{r}_i` at integration step :math:`i` and
+    experiencing a potential :math:`\mathcal{H}(\\vec{r}_i)` are displaced
+    according to the equation:
+
+    :math:`\\vec{r}_{i+1} = \\vec{r}_i - \\gamma\\nabla\mathcal{H}(\\vec{r}_i)`
 
     Parameters
     ----------
     f_max : :obj:`float`
-        Maximal allowed force.
+        Convergence criterion. Minimization stops when the maximal force on
+        particles in the system is lower than this threshold.
     gamma : :obj:`float`
         Dampening constant.
     max_steps : :obj:`int`
         Maximal number of iterations.
     max_displacement : :obj:`float`
-        Maximal allowed displacement per step.
+        Maximal allowed displacement per step. Typical values for a LJ liquid
+        are in the range of 0.1% to 10% of the particle sigma.
 
     """
     cdef object _params

--- a/src/python/espressomd/minimize_energy.pyx
+++ b/src/python/espressomd/minimize_energy.pyx
@@ -34,7 +34,9 @@ cdef class MinimizeEnergy:
     ----------
     f_max : :obj:`float`
         Convergence criterion. Minimization stops when the maximal force on
-        particles in the system is lower than this threshold.
+        particles in the system is lower than this threshold. Set this to 0
+        when running minimization in a loop that stops when a custom
+        convergence criterion is met.
     gamma : :obj:`float`
         Dampening constant.
     max_steps : :obj:`int`


### PR DESCRIPTION
Fixes #3030

Description of changes:
- cleanup and document the steepest descent algorithm
- reflect recent changes to the Python interface in the tutorials: `mindist()` renamed to `min_dist()`, periodicity takes a list of booleans
- in tutorial 02 charged system:
    - set Langevin thermostat after energy minimization
    - replace adaptive force-cap minimization strategy with steepest descent