### PR TITLE
utils: boost::mpi::is_mpi_datatype specializations for Utils types

### DIFF
--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -24,6 +24,7 @@
 
 #include <utils/NumeratedContainer.hpp>
 #include <utils/as_const.hpp>
+#include <utils/mpi/datatypes.hpp>
 #include <utils/tuple.hpp>
 #include <utils/type_traits.hpp>
 

--- a/src/utils/include/utils/Array.hpp
+++ b/src/utils/include/utils/Array.hpp
@@ -141,4 +141,13 @@ private:
   }
 };
 } // namespace Utils
+
+namespace boost {
+namespace mpi {
+template <class T> struct is_mpi_datatype;
+template <class T, size_t N>
+struct is_mpi_datatype<Utils::Array<T, N>> : is_mpi_datatype<T> {};
+} // namespace mpi
+} // namespace boost
+
 #endif

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -357,4 +357,11 @@ template <typename T, size_t N> struct decay_to_scalar<Vector<T, N>> {
 template <typename T> struct decay_to_scalar<Vector<T, 1>> { using type = T; };
 
 } // namespace Utils
+
+namespace boost {
+namespace mpi {
+template <class T, size_t N>
+struct is_mpi_datatype<Utils::Vector<T, N>> : is_mpi_datatype<T> {};
+} // namespace mpi
+} // namespace boost
 #endif

--- a/src/utils/include/utils/mpi/datatypes.hpp
+++ b/src/utils/include/utils/mpi/datatypes.hpp
@@ -1,0 +1,14 @@
+#ifndef ESPRESSO_UTILS_MPI_DATATYPE_HPP
+#define ESPRESSO_UTILS_MPI_DATATYPE_HPP
+
+#include <boost/mpi/datatype_fwd.hpp>
+#include <boost/optional/optional_fwd.hpp>
+
+namespace boost {
+namespace mpi {
+template <class T>
+struct is_mpi_datatype<boost::optional<T>> : is_mpi_datatype<T> {};
+} // namespace mpi
+} // namespace boost
+
+#endif

--- a/src/utils/include/utils/serialization/List.hpp
+++ b/src/utils/include/utils/serialization/List.hpp
@@ -52,6 +52,12 @@ void serialize(Archive &ar, Utils::List<T> &v,
   split_free(ar, v, file_version);
 }
 } // namespace serialization
+
+namespace mpi {
+template <class T> struct is_mpi_datatype;
+template <class T>
+struct is_mpi_datatype<Utils::List<T>> : is_mpi_datatype<T> {};
+} // namespace mpi
 } // namespace boost
 
 #endif

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -43,3 +43,4 @@ unit_test(NAME all_compare_test SRC all_compare_test.cpp DEPENDS utils Boost::mp
 unit_test(NAME gatherv_test SRC gatherv_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX)
 unit_test(NAME all_gatherv_test SRC all_gatherv_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX)
 unit_test(NAME sendrecv_test SRC sendrecv_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX utils NUM_PROC 3)
+unit_test(NAME datatypes_test SRC datatypes_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX)

--- a/src/utils/tests/datatypes_test.cpp
+++ b/src/utils/tests/datatypes_test.cpp
@@ -1,0 +1,69 @@
+/*
+Copyright (C) 2019 The ESPResSo project
+
+This file is part of ESPResSo.
+
+ESPResSo is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ESPResSo is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#define BOOST_TEST_MODULE abs test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <utils/Array.hpp>
+#include <utils/Vector.hpp>
+#include <utils/mpi/datatypes.hpp>
+#include <utils/serialization/List.hpp>
+
+struct NotAnMpiDatatype {};
+struct AnMpiDatatype {};
+
+namespace boost {
+namespace mpi {
+template <>
+struct is_mpi_datatype<NotAnMpiDatatype> : public boost::mpl::false_ {};
+template <> struct is_mpi_datatype<AnMpiDatatype> : public boost::mpl::true_ {};
+} // namespace mpi
+} // namespace boost
+
+BOOST_AUTO_TEST_CASE(optional) {
+  static_assert(
+      not boost::mpi::is_mpi_datatype<boost::optional<NotAnMpiDatatype>>::value,
+      "");
+  static_assert(
+      boost::mpi::is_mpi_datatype<boost::optional<AnMpiDatatype>>::value, "");
+}
+
+BOOST_AUTO_TEST_CASE(array) {
+  static_assert(
+      not boost::mpi::is_mpi_datatype<Utils::Array<NotAnMpiDatatype, 2>>::value,
+      "");
+  static_assert(
+      boost::mpi::is_mpi_datatype<Utils::Array<AnMpiDatatype, 3>>::value, "");
+}
+
+BOOST_AUTO_TEST_CASE(vector) {
+  static_assert(not boost::mpi::is_mpi_datatype<
+                    Utils::Vector<NotAnMpiDatatype, 2>>::value,
+                "");
+  static_assert(
+      boost::mpi::is_mpi_datatype<Utils::Vector<AnMpiDatatype, 3>>::value, "");
+}
+
+BOOST_AUTO_TEST_CASE(list) {
+  static_assert(
+      not boost::mpi::is_mpi_datatype<Utils::List<NotAnMpiDatatype>>::value,
+      "");
+  static_assert(boost::mpi::is_mpi_datatype<Utils::List<AnMpiDatatype>>::value,
+                "");
+}


### PR DESCRIPTION
Description of changes:
 - Defining `boost::mpi::is_mpi_datatype` for serializable datatype from `namespace Utils`

This can avoid some copies when sending those datatype over mpi.

