### PR TITLE
leftovers of the PARTIAL_PERIODIC feature

### DIFF
--- a/testsuite/python/elc_vs_mmm2d_neutral.py
+++ b/testsuite/python/elc_vs_mmm2d_neutral.py
@@ -22,7 +22,7 @@ import espressomd.electrostatics
 from espressomd import electrostatic_extensions
 
 
-@utx.skipIfMissingFeatures(["P3M", "PARTIAL_PERIODIC"])
+@utx.skipIfMissingFeatures(["P3M"])
 class ELC_vs_MMM2D_neutral(ut.TestCase):
     # Handle to espresso system
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])

--- a/testsuite/python/elc_vs_mmm2d_nonneutral.py
+++ b/testsuite/python/elc_vs_mmm2d_nonneutral.py
@@ -23,7 +23,7 @@ import espressomd.electrostatics
 from espressomd import electrostatic_extensions
 
 
-@utx.skipIfMissingFeatures(["P3M", "PARTIAL_PERIODIC"])
+@utx.skipIfMissingFeatures(["P3M"])
 class ELC_vs_MMM2D_neutral(ut.TestCase):
     # Handle to espresso system
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])


### PR DESCRIPTION
ELC vs MMM2D testcases were never executed because of the removed feature `PARTIAL_PERIODIC` in #2902