### PR TITLE
Detect unknown features in the testsuite

### DIFF
--- a/src/config/check_myconfig.py
+++ b/src/config/check_myconfig.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from sys import argv
 import sys
 from subprocess import CalledProcessError
 
@@ -49,7 +48,7 @@ def damerau_levenshtein_distance(s1, s2):
     return d[lenstr1 - 1, lenstr2 - 1]
 
 
-def handle_unkown(f, all_features):
+def handle_unknown(f, all_features):
     match = None
     max_dist = max(2, len(f) // 2)
     for d in all_features:
@@ -74,8 +73,8 @@ def print_exception(ex):
 
 
 def check_myconfig(compiler, feature_file, myconfig, pre_header=None):
-# This does not work on all compilers, so if the parsing fails
-# we just bail out.
+    # This does not work on all compilers, so if the parsing fails
+    # we just bail out.
     external_defs = []
 
     if pre_header:
@@ -93,7 +92,7 @@ def check_myconfig(compiler, feature_file, myconfig, pre_header=None):
         print_exception(ex)
         return
 
-# Parse feature file
+    # Parse feature file
     defs = featuredefs.defs(feature_file)
 
     error_state = False
@@ -107,21 +106,21 @@ def check_myconfig(compiler, feature_file, myconfig, pre_header=None):
         if u.startswith('__'):
             continue
         error_state = True
-        handle_unkown(u, defs.features)
+        handle_unknown(u, defs.features)
 
     if error_state:
-        raise FeatureError("There were errors in '{}'".format(argv[3]))
+        raise FeatureError("There were errors in '{}'".format(sys.argv[3]))
     else:
         return
 
 if __name__ == "__main__":
-    if(len(argv) > 4):
-        pre_header = argv[4]
+    if len(sys.argv) > 4:
+        pre_header = sys.argv[4]
     else:
         pre_header = None
 
     try:
-        check_myconfig(argv[1], argv[2], argv[3], pre_header)
+        check_myconfig(sys.argv[1], sys.argv[2], sys.argv[3], pre_header)
         sys.exit()
     except FeatureError:
-        sys.exit("There were errors in '{}'".format(argv[3]))
+        sys.exit("There were errors in '{}'".format(sys.argv[3]))

--- a/src/python/espressomd/__init__.py
+++ b/src/python/espressomd/__init__.py
@@ -58,15 +58,6 @@ def missing_features(*args):
     return set(args) - set(features())
 
 
-def unknown_features(*args):
-    """Returns a list of the unknown features in the argument"""
-
-    if len(args) == 1 and not isinstance(args[0], str) and hasattr(args[0], "__iter__"):
-        return set(args[0]) - set(all_features())
-
-    return set(args) - set(all_features())
-
-
 def assert_features(*args):
     """Raises an exception when a list of features is not a subset of the compiled-in features"""
 

--- a/src/python/espressomd/__init__.py
+++ b/src/python/espressomd/__init__.py
@@ -58,6 +58,15 @@ def missing_features(*args):
     return set(args) - set(features())
 
 
+def unknown_features(*args):
+    """Returns a list of the unknown features in the argument"""
+
+    if len(args) == 1 and not isinstance(args[0], str) and hasattr(args[0], "__iter__"):
+        return set(args[0]) - set(all_features())
+
+    return set(args) - set(all_features())
+
+
 def assert_features(*args):
     """Raises an exception when a list of features is not a subset of the compiled-in features"""
 

--- a/testsuite/python/unittest_decorators.py
+++ b/testsuite/python/unittest_decorators.py
@@ -26,12 +26,8 @@ def _id(x):
 def skipIfMissingFeatures(*args):
     """Unittest skipIf decorator for missing Espresso features."""
 
-    unknown_features = espressomd.unknown_features(*args)
-    if unknown_features:
-        raise ValueError("Unknown features " + ", ".join(unknown_features))
-
-    missing_features = espressomd.missing_features(*args)
-    if missing_features:
+    if not espressomd.has_features(*args):
+        missing_features = espressomd.missing_features(*args)
         return unittest.skip("Skipping test: missing feature{} {}".format(
             's' if len(missing_features) else '', ', '.join(missing_features)))
     return _id

--- a/testsuite/python/unittest_decorators.py
+++ b/testsuite/python/unittest_decorators.py
@@ -26,6 +26,10 @@ def _id(x):
 def skipIfMissingFeatures(*args):
     """Unittest skipIf decorator for missing Espresso features."""
 
+    unknown_features = espressomd.unknown_features(*args)
+    if unknown_features:
+        raise ValueError("Unknown features " + ", ".join(unknown_features))
+
     missing_features = espressomd.missing_features(*args)
     if missing_features:
         return unittest.skip("Skipping test: missing feature{} {}".format(


### PR DESCRIPTION
Long-term solution to #3076: `@utx.skipIfMissingFeatures()` will throw an exception on unknown features.