### PR TITLE
New logic for default parameters in IA classes

### DIFF
--- a/src/core/nonbonded_interactions/ljgen.cpp
+++ b/src/core/nonbonded_interactions/ljgen.cpp
@@ -54,10 +54,8 @@ int ljgen_set_params(int part_type_a, int part_type_b, double eps, double sig,
   data->ljgen.b1 = b1;
   data->ljgen.b2 = b2;
 #ifdef LJGEN_SOFTCORE
-  if (lambda >= 0.0 && lambda <= 1.0)
-    data->ljgen.lambda1 = lambda;
-  if (softrad >= 0.0)
-    data->ljgen.softrad = softrad;
+  data->ljgen.lambda1 = lambda;
+  data->ljgen.softrad = softrad;
 #endif
 
   /* broadcast interaction parameters */

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -295,13 +295,7 @@ IF LENNARD_JONES == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "epsilon": 0.,
-                "sigma": 0.,
-                "cutoff": 0.,
-                "shift": 0.,
-                "offset": 0.,
-                "min": 0.}
+            return {"offset": 0., "min": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -380,9 +374,7 @@ IF WCA == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "epsilon": 0.,
-                "sigma": 0.}
+            return {}
 
         def type_name(self):
             """Name of interaction type.
@@ -487,18 +479,7 @@ IF LENNARD_JONES_GENERIC == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "epsilon": 0.,
-                "sigma": 0.,
-                "cutoff": 0.,
-                "shift": 0.,
-                "offset": 0.,
-                "e1": 0,
-                "e2": 0,
-                "b1": 0.,
-                "b2": 0.,
-                "delta": 0.,
-                "lam": 0.}
+            return {"delta": 0., "lam": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -592,7 +573,7 @@ IF LJCOS:
                 Interaction length scale.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
-            offset : :obj:`float`
+            offset : :obj:`float`, optional
                 Offset distance of the interaction.
             """
             super().set_params(**kwargs)
@@ -608,12 +589,7 @@ IF LJCOS:
                     "Could not set Lennard-Jones Cosine parameters")
 
         def default_params(self):
-            return {
-                "epsilon": 0.,
-                "sigma": 0.,
-                "cutoff": 0.,
-                "offset": 0.,
-            }
+            return {"offset": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -670,7 +646,7 @@ IF LJCOS2:
                 Magnitude of the interaction.
             sigma : :obj:`float`
                 Interaction length scale.
-            offset : :obj:`float`
+            offset : :obj:`float`, optional
                 Offset distance of the interaction.
             width : :obj:`float`
                 Width of interaction.
@@ -688,11 +664,7 @@ IF LJCOS2:
                     "Could not set Lennard-Jones Cosine2 parameters")
 
         def default_params(self):
-            return {
-                "epsilon": 0.,
-                "sigma": 0.,
-                "offset": 0.,
-                "width": 0.}
+            return {"offset": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -755,10 +727,7 @@ IF HAT == 1:
                 raise Exception("Could not set Hat parameters")
 
         def default_params(self):
-            return {
-                "F_max": 0.,
-                "cutoff": 0.,
-            }
+            return {}
 
         def type_name(self):
             return "Hat"
@@ -839,14 +808,7 @@ IF GAY_BERNE:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "eps": 0.0,
-                "sig": 0.0,
-                "cut": 0.0,
-                "k1": 0.0,
-                "k2": 0.0,
-                "mu": 0.0,
-                "nu": 0.0}
+            return {}
 
         def type_name(self):
             """Name of interaction type.
@@ -994,13 +956,7 @@ IF SMOOTH_STEP == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "d": 0.,
-                "n": 10,
-                "eps": 0.,
-                "k0": 0.,
-                "sig": 0.,
-                "cutoff": 0.}
+            return {"n": 10, "k0": 0., "sig": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -1016,13 +972,13 @@ IF SMOOTH_STEP == 1:
             ----------
             d : :obj:`float`
                 Short range repulsion parameter.
-            n : :obj:`int`
+            n : :obj:`int`, optional
                 Exponent of short range repulsion.
             eps : :obj:`float`
                 Magnitude of the second (soft) repulsion.
-            k0 : :obj:`float`
+            k0 : :obj:`float`, optional
                 Exponential factor in second (soft) repulsion.
-            sig : :obj:`float`
+            sig : :obj:`float`, optional
                 Length scale of second (soft) repulsion.
             cutoff : :obj:`float`
                 Cutoff distance of the interaction.
@@ -1094,13 +1050,7 @@ IF BMHTF_NACL == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "a": 0.,
-                "b": 0.,
-                "c": 0.,
-                "d": 0.,
-                "sig": 0.,
-                "cutoff": 0.}
+            return {}
 
         def type_name(self):
             """Name of interaction type.
@@ -1189,11 +1139,7 @@ IF MORSE == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "eps": 0.,
-                "alpha": 0.,
-                "rmin": 0.,
-                "cutoff": 0.}
+            return {"cutoff": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -1213,7 +1159,7 @@ IF MORSE == 1:
                 Stiffness of the Morse interaction.
             rmin : :obj:`float`
                 Distance of potential minimum
-            cutoff : :obj:`float`
+            cutoff : :obj:`float`, optional
                 Cutoff distance of the interaction.
 
             """
@@ -1285,14 +1231,7 @@ IF BUCKINGHAM == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "a": 0.,
-                "b": 0.,
-                "c": 0.,
-                "d": 0.,
-                "cutoff": 0.,
-                "discont": 0.,
-                "shift": 0.}
+            return {"b": 0., "shift": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -1308,7 +1247,7 @@ IF BUCKINGHAM == 1:
             ----------
             a : :obj:`float`
                 Magnitude of the exponential part of the interaction.
-            b : :obj:`float`
+            b : :obj:`float`, optional
                 Exponent of the exponential part of the interaction.
             c : :obj:`float`
                 Prefactor of term decaying with the sixth power of distance.
@@ -1382,11 +1321,7 @@ IF SOFT_SPHERE == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "a": 0.,
-                "n": 0.,
-                "cutoff": 0.,
-                "offset": 0.}
+            return {"offset": 0.}
 
         def type_name(self):
             """Name of interaction type.
@@ -1474,14 +1409,7 @@ IF AFFINITY == 1:
                 raise Exception("Could not set Affinity parameters")
 
         def default_params(self):
-            return {
-                "affinity_type": 0,
-                "affinity_kappa": 0.,
-                "affinity_r0": 0.,
-                "affinity_Kon": 0.,
-                "affinity_Koff": 0.,
-                "affinity_maxBond": 0.,
-                "affinity_cut": 0.}
+            return {}
 
         def type_name(self):
             return "Affinity"
@@ -1525,11 +1453,7 @@ IF MEMBRANE_COLLISION == 1:
                 raise Exception("Could not set Membrane Collision parameters")
 
         def default_params(self):
-            return {
-                "a": 0.,
-                "n": 1.,
-                "cutoff": 0.,
-                "offset": 0.}
+            return {"offset": 0.}
 
         def type_name(self):
             return "MembraneCollision"
@@ -1581,9 +1505,7 @@ IF HERTZIAN == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "eps": 0.,
-                "sig": 1.}
+            return {}
 
         def type_name(self):
             """Name of interaction type.
@@ -1664,10 +1586,7 @@ IF GAUSSIAN == 1:
             """Python dictionary of default parameters.
 
             """
-            return {
-                "eps": 0.,
-                "sig": 1.,
-                "cutoff": 0.}
+            return {}
 
         def type_name(self):
             """Name of interaction type.
@@ -1833,8 +1752,7 @@ cdef class BondedInteraction:
         # Interaction id as argument
         if len(args) == 1 and is_valid_type(args[0], int):
             bond_id = args[0]
-            # Check, if the bond in Espresso core is really defined as a FENE
-            # bond
+            # Check if the bond type in Espresso core matches this class
             if bonded_ia_params[bond_id].type != self.type_number():
                 raise Exception(
                     "The bond with this id is not defined as a " + self.type_name() + " bond in the Espresso core.")
@@ -1860,7 +1778,7 @@ cdef class BondedInteraction:
 
         else:
             raise Exception(
-                "The constructor has to be called either with a bond id (as interger), or with a set of keyword arguments describing a new interaction")
+                "The constructor has to be called either with a bond id (as integer), or with a set of keyword arguments describing a new interaction")
 
     def __reduce__(self):
         return (self.__class__, (self._bond_id,))
@@ -2066,7 +1984,6 @@ class FeneBond(BondedInteraction):
 
         """
         self._params = {"r_0": 0.}
-        # Everything else has to be supplied by the user, anyway
 
     def _get_params_from_es_core(self):
         return \
@@ -2123,7 +2040,7 @@ class HarmonicBond(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"k": 0., "r_0": 0., "r_cut": 0.}
+        self._params = {"r_cut": 0.}
 
     def _get_params_from_es_core(self):
         return \
@@ -2165,7 +2082,7 @@ if ELECTROSTATICS:
             return {"prefactor"}
 
         def set_default_params(self):
-            self._params = {"prefactor": 1.}
+            self._params = {}
 
         def _get_params_from_es_core(self):
             return \
@@ -2209,7 +2126,7 @@ if ELECTROSTATICS:
             return {"q1q2"}
 
         def set_default_params(self):
-            self._params = {"q1q2": 1.}
+            self._params = {}
 
         def _get_params_from_es_core(self):
             return \
@@ -2261,8 +2178,7 @@ class ThermalizedBond(BondedInteraction):
         return {"temp_com", "gamma_com", "temp_distance", "gamma_distance"}
 
     def set_default_params(self):
-        self._params = {"temp_com": 1., "gamma_com": 1.,
-                        "temp_distance": 1., "gamma_distance": 1., "r_cut": 0.}
+        self._params = {"r_cut": 0.}
 
     def _get_params_from_es_core(self):
         return \
@@ -2322,14 +2238,13 @@ IF THOLE:
             super().set_params(**kwargs)
 
         def _set_params_in_es_core(self):
-            # Handle the case of shift="auto"
             if thole_set_params(self._part_types[0], self._part_types[1],
                                 self._params["scaling_coeff"],
                                 self._params["q1q2"]):
                 raise Exception("Could not set Thole parameters")
 
         def default_params(self):
-            return {"scaling_coeff": 0., "q1q2": 0.}
+            return {}
 
         def type_name(self):
             return "Thole"
@@ -2505,8 +2420,7 @@ IF BOND_CONSTRAINT == 1:
 
             """
             # TODO rationality of Default Parameters has to be checked
-            self._params = {"r": 0.,
-                            "ptol": 0.001,
+            self._params = {"ptol": 0.001,
                             "vtol": 0.001}
 
         def _get_params_from_es_core(self):
@@ -2563,7 +2477,7 @@ class Dihedral(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"mult'": 1, "bend": 0., "phase": 0.}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         return \
@@ -2624,7 +2538,7 @@ class _TabulatedBase(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {'min': -1., 'max': -1., 'energy': [], 'force': []}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         make_bond_type_exist(self._bond_id)
@@ -2833,7 +2747,7 @@ IF TABULATED == 1:
             """Set parameters that are not required to their default value.
 
             """
-            self._params = {'min': -1., 'max': -1, 'energy': [], 'force': []}
+            self._params = {}
 
         def _get_params_from_es_core(self):
             cdef IA_parameters * ia_params = get_ia_param_safe(
@@ -2989,7 +2903,7 @@ class AngleHarmonic(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"bend": 0, "phi0": 0}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         return \
@@ -3040,7 +2954,7 @@ class AngleCosine(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"bend": 0, "phi0": 0}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         return \
@@ -3091,7 +3005,7 @@ class AngleCossquare(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"bend": 0, "phi0": 0}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         return \
@@ -3173,7 +3087,7 @@ class IBM_Tribend(BondedInteraction):
         initializing reference state
     kb : :obj:`float`
         Bending modulus
-    refShape : :obj:`str`, \{'Flat', 'Initial'\}
+    refShape : :obj:`str`, optional, \{'Flat', 'Initial'\}
         Reference shape, default is ``'Flat'``
 
     """
@@ -3194,7 +3108,7 @@ class IBM_Tribend(BondedInteraction):
         return {"ind1", "ind2", "ind3", "ind4", "kb"}
 
     def set_default_params(self):
-        self._params = {"flat": False}
+        self._params = {"refShape": "Flat"}
 
     def _get_params_from_es_core(self):
         return \
@@ -3300,7 +3214,7 @@ class OifGlobalForces(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"A0_g": 1., "ka_g": 0., "V0": 1., "kv": 0.}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         return \
@@ -3369,8 +3283,7 @@ class OifLocalForces(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"r0": 1., "ks": 0., "kslin": 0.,
-                        "phi0": 0., "kb": 0., "A01": 0., "A02": 0., "kal": 0., "kvisc": 0.}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         return \
@@ -3474,10 +3387,7 @@ class QuarticBond(BondedInteraction):
         """Sets parameters that are not required to their default value.
 
         """
-        self._params = {"k0": 0.,
-                        "k1": 0.,
-                        "r": 0.,
-                        "r_cut": 0.}
+        self._params = {}
 
     def _get_params_from_es_core(self):
         return \

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -2626,12 +2626,6 @@ class _TabulatedBase(BondedInteraction):
         """
         self._params = {'min': -1., 'max': -1., 'energy': [], 'force': []}
 
-    def validate_params(self):
-        """Check that parameters are valid.
-
-        """
-        pass
-
     def _get_params_from_es_core(self):
         make_bond_type_exist(self._bond_id)
         res = \
@@ -2699,11 +2693,11 @@ class TabulatedDistance(_TabulatedBase):
         """
         return "TABULATED_DISTANCE"
 
-    def required_keys(self):
-        """Parameters that have to be set.
+    def validate_params(self):
+        """Check that parameters are valid.
 
         """
-        return {"min", "max", "energy", "force"}
+        pass
 
 
 class TabulatedAngle(_TabulatedBase):
@@ -2723,7 +2717,9 @@ class TabulatedAngle(_TabulatedBase):
     pi = 3.14159265358979
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, min=0., max=self.pi, **kwargs)
+        if len(args) == 0:
+            kwargs.update({"min": 0., "max": self.pi})
+        super().__init__(*args, **kwargs)
 
     def type_number(self):
         return BONDED_IA_TABULATED_ANGLE
@@ -2734,11 +2730,14 @@ class TabulatedAngle(_TabulatedBase):
         """
         return "TABULATED_ANGLE"
 
-    def required_keys(self):
-        """Parameters that have to be set.
+    def validate_params(self):
+        """Check that parameters are valid.
 
         """
-        return {"energy", "force"}
+        phi = [self._params["min"], self._params["max"]]
+        if abs(phi[0] - 0.) > 1e-5 or abs(phi[1] - self.pi) > 1e-5:
+            raise ValueError("Tabulated angle expects forces/energies "
+                             "within the range [0, pi], got " + str(phi))
 
 
 class TabulatedDihedral(_TabulatedBase):
@@ -2758,7 +2757,9 @@ class TabulatedDihedral(_TabulatedBase):
     pi = 3.14159265358979
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, min=0., max=2. * self.pi, **kwargs)
+        if len(args) == 0:
+            kwargs.update({"min": 0., "max": 2. * self.pi})
+        super().__init__(*args, **kwargs)
 
     def type_number(self):
         return BONDED_IA_TABULATED_DIHEDRAL
@@ -2769,11 +2770,14 @@ class TabulatedDihedral(_TabulatedBase):
         """
         return "TABULATED_DIHEDRAL"
 
-    def required_keys(self):
-        """Parameters that have to be set.
+    def validate_params(self):
+        """Check that parameters are valid.
 
         """
-        return {"energy", "force"}
+        phi = [self._params["min"], self._params["max"]]
+        if abs(phi[0] - 0.) > 1e-5 or abs(phi[1] - 2 * self.pi) > 1e-5:
+            raise ValueError("Tabulated dihedral expects forces/energies "
+                             "within the range [0, 2*pi], got " + str(phi))
 
 
 IF TABULATED == 1:

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -412,6 +412,11 @@ IF LENNARD_JONES_GENERIC == 1:
                 raise ValueError("Generic Lennard-Jones sigma has to be >=0")
             if self._params["cutoff"] < 0:
                 raise ValueError("Generic Lennard-Jones cutoff has to be >=0")
+            IF LJGEN_SOFTCORE:
+                if self._params["delta"] < 0:
+                    raise ValueError("Generic Lennard-Jones delta has to be >=0")
+                if self._params["lam"] < 0 or self._params["lam"] > 1:
+                    raise ValueError("Generic Lennard-Jones lam has to be in the range [0,1]")
             return True
 
         def _get_params_from_es_core(self):
@@ -479,7 +484,10 @@ IF LENNARD_JONES_GENERIC == 1:
             """Python dictionary of default parameters.
 
             """
-            return {"delta": 0., "lam": 0.}
+            IF LJGEN_SOFTCORE:
+                return {"delta": 0., "lam": 1.}
+            ELSE:
+                return {}
 
         def type_name(self):
             """Name of interaction type.
@@ -527,7 +535,10 @@ IF LENNARD_JONES_GENERIC == 1:
             """All parameters that can be set.
 
             """
-            return {"epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2", "delta", "lam"}
+            IF LJGEN_SOFTCORE:
+                return {"epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2", "delta", "lam"}
+            ELSE:
+                return {"epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2"}
 
         def required_keys(self):
             """Parameters that have to be set.

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -414,9 +414,11 @@ IF LENNARD_JONES_GENERIC == 1:
                 raise ValueError("Generic Lennard-Jones cutoff has to be >=0")
             IF LJGEN_SOFTCORE:
                 if self._params["delta"] < 0:
-                    raise ValueError("Generic Lennard-Jones delta has to be >=0")
+                    raise ValueError(
+                        "Generic Lennard-Jones delta has to be >=0")
                 if self._params["lam"] < 0 or self._params["lam"] > 1:
-                    raise ValueError("Generic Lennard-Jones lam has to be in the range [0,1]")
+                    raise ValueError(
+                        "Generic Lennard-Jones lam has to be in the range [0,1]")
             return True
 
         def _get_params_from_es_core(self):

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -313,13 +313,13 @@ IF LENNARD_JONES == 1:
             """All parameters that can be set.
 
             """
-            return "epsilon", "sigma", "cutoff", "shift", "offset", "min"
+            return {"epsilon", "sigma", "cutoff", "shift", "offset", "min"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "epsilon", "sigma", "cutoff", "shift"
+            return {"epsilon", "sigma", "cutoff", "shift"}
 
 IF WCA == 1:
 
@@ -394,13 +394,13 @@ IF WCA == 1:
             """All parameters that can be set.
 
             """
-            return "epsilon", "sigma"
+            return {"epsilon", "sigma"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "epsilon", "sigma"
+            return {"epsilon", "sigma"}
 
 IF LENNARD_JONES_GENERIC == 1:
 
@@ -546,13 +546,13 @@ IF LENNARD_JONES_GENERIC == 1:
             """All parameters that can be set.
 
             """
-            return "epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2", "delta", "lam"
+            return {"epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2", "delta", "lam"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2"
+            return {"epsilon", "sigma", "cutoff", "shift", "offset", "e1", "e2", "b1", "b2"}
 
 IF LJCOS:
 
@@ -625,13 +625,13 @@ IF LJCOS:
             """All parameters that can be set.
 
             """
-            return "epsilon", "sigma", "cutoff", "offset"
+            return {"epsilon", "sigma", "cutoff", "offset"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "epsilon", "sigma", "cutoff"
+            return {"epsilon", "sigma", "cutoff"}
 
 IF LJCOS2:
 
@@ -704,13 +704,13 @@ IF LJCOS2:
             """All parameters that can be set.
 
             """
-            return "epsilon", "sigma", "offset", "width"
+            return {"epsilon", "sigma", "offset", "width"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "epsilon", "sigma", "width"
+            return {"epsilon", "sigma", "width"}
 
 IF HAT == 1:
 
@@ -764,10 +764,10 @@ IF HAT == 1:
             return "Hat"
 
         def valid_keys(self):
-            return "F_max", "cutoff"
+            return {"F_max", "cutoff"}
 
         def required_keys(self):
-            return "F_max", "cutoff"
+            return {"F_max", "cutoff"}
 
 IF GAY_BERNE:
 
@@ -858,13 +858,13 @@ IF GAY_BERNE:
             """All parameters that can be set.
 
             """
-            return "eps", "sig", "cut", "k1", "k2", "mu", "nu"
+            return {"eps", "sig", "cut", "k1", "k2", "mu", "nu"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "eps", "sig", "cut", "k1", "k2", "mu", "nu"
+            return {"eps", "sig", "cut", "k1", "k2", "mu", "nu"}
 
 IF DPD:
 
@@ -936,10 +936,10 @@ IF DPD:
             return "DPD"
 
         def valid_keys(self):
-            return self.default_params().keys()
+            return {"weight_function", "gamma", "r_cut", "trans_weight_function", "trans_gamma", "trans_r_cut"}
 
         def required_keys(self):
-            return []
+            return set()
 
 IF SMOOTH_STEP == 1:
 
@@ -1034,13 +1034,13 @@ IF SMOOTH_STEP == 1:
             """All parameters that can be set.
 
             """
-            return "d", "n", "eps", "k0", "sig", "cutoff"
+            return {"d", "n", "eps", "k0", "sig", "cutoff"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "d", "eps", "cutoff"
+            return {"d", "eps", "cutoff"}
 
 IF BMHTF_NACL == 1:
 
@@ -1134,13 +1134,13 @@ IF BMHTF_NACL == 1:
             """All parameters that can be set.
 
             """
-            return "a", "b", "c", "d", "sig", "cutoff"
+            return {"a", "b", "c", "d", "sig", "cutoff"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "a", "b", "c", "d", "sig", "cutoff"
+            return {"a", "b", "c", "d", "sig", "cutoff"}
 
 IF MORSE == 1:
 
@@ -1223,13 +1223,13 @@ IF MORSE == 1:
             """All parameters that can be set.
 
             """
-            return "eps", "alpha", "rmin", "cutoff"
+            return {"eps", "alpha", "rmin", "cutoff"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "eps", "alpha", "rmin"
+            return {"eps", "alpha", "rmin"}
 
 IF BUCKINGHAM == 1:
 
@@ -1328,13 +1328,13 @@ IF BUCKINGHAM == 1:
             """All parameters that can be set.
 
             """
-            return "a", "b", "c", "d", "discont", "cutoff", "shift"
+            return {"a", "b", "c", "d", "discont", "cutoff", "shift"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "a", "c", "d", "discont", "cutoff"
+            return {"a", "c", "d", "discont", "cutoff"}
 
 IF SOFT_SPHERE == 1:
 
@@ -1416,13 +1416,13 @@ IF SOFT_SPHERE == 1:
             """All parameters that can be set.
 
             """
-            return "a", "n", "cutoff", "offset"
+            return {"a", "n", "cutoff", "offset"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "a", "n", "cutoff"
+            return {"a", "n", "cutoff"}
 
 IF AFFINITY == 1:
 
@@ -1487,10 +1487,10 @@ IF AFFINITY == 1:
             return "Affinity"
 
         def valid_keys(self):
-            return "affinity_type", "affinity_kappa", "affinity_r0", "affinity_Kon", "affinity_Koff", "affinity_maxBond", "affinity_cut"
+            return {"affinity_type", "affinity_kappa", "affinity_r0", "affinity_Kon", "affinity_Koff", "affinity_maxBond", "affinity_cut"}
 
         def required_keys(self):
-            return "affinity_type", "affinity_kappa", "affinity_r0", "affinity_Kon", "affinity_Koff", "affinity_maxBond", "affinity_cut"
+            return {"affinity_type", "affinity_kappa", "affinity_r0", "affinity_Kon", "affinity_Koff", "affinity_maxBond", "affinity_cut"}
 
 
 IF MEMBRANE_COLLISION == 1:
@@ -1535,10 +1535,10 @@ IF MEMBRANE_COLLISION == 1:
             return "MembraneCollision"
 
         def valid_keys(self):
-            return "a", "n", "cutoff", "offset"
+            return {"a", "n", "cutoff", "offset"}
 
         def required_keys(self):
-            return "a", "n", "cutoff"
+            return {"a", "n", "cutoff"}
 
 IF HERTZIAN == 1:
 
@@ -1610,13 +1610,13 @@ IF HERTZIAN == 1:
             """All parameters that can be set.
 
             """
-            return "eps", "sig"
+            return {"eps", "sig"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "eps", "sig"
+            return {"eps", "sig"}
 
 IF GAUSSIAN == 1:
 
@@ -1695,13 +1695,13 @@ IF GAUSSIAN == 1:
             """All parameters that can be set.
 
             """
-            return "eps", "sig", "cutoff"
+            return {"eps", "sig", "cutoff"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "eps", "sig", "cutoff"
+            return {"eps", "sig", "cutoff"}
 
 
 class NonBondedInteractionHandle:
@@ -2053,13 +2053,13 @@ class FeneBond(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "k", "d_r_max", "r_0"
+        return {"k", "d_r_max", "r_0"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "k", "d_r_max"
+        return {"k", "d_r_max"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -2111,13 +2111,13 @@ class HarmonicBond(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "k", "r_0", "r_cut"
+        return {"k", "r_0", "r_cut"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "k", "r_0"
+        return {"k", "r_0"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -2255,10 +2255,10 @@ class ThermalizedBond(BondedInteraction):
         return "THERMALIZED_DIST"
 
     def valid_keys(self):
-        return "temp_com", "gamma_com", "temp_distance", "gamma_distance", "r_cut"
+        return {"temp_com", "gamma_com", "temp_distance", "gamma_distance", "r_cut"}
 
     def required_keys(self):
-        return "temp_com", "gamma_com", "temp_distance", "gamma_distance"
+        return {"temp_com", "gamma_com", "temp_distance", "gamma_distance"}
 
     def set_default_params(self):
         self._params = {"temp_com": 1., "gamma_com": 1.,
@@ -2335,10 +2335,10 @@ IF THOLE:
             return "Thole"
 
         def valid_keys(self):
-            return "scaling_coeff", "q1q2"
+            return {"scaling_coeff", "q1q2"}
 
         def required_keys(self):
-            return "scaling_coeff", "q1q2"
+            return {"scaling_coeff", "q1q2"}
 
 IF ROTATION:
 
@@ -2376,13 +2376,13 @@ IF ROTATION:
             """All parameters that can be set.
 
             """
-            return "k1", "k2", "r_0", "r_cut"
+            return {"k1", "k2", "r_0", "r_cut"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "k1", "k2", "r_0"
+            return {"k1", "k2", "r_0"}
 
         def set_default_params(self):
             """Sets parameters that are not required to their default value.
@@ -2492,13 +2492,13 @@ IF BOND_CONSTRAINT == 1:
             """All parameters that can be set.
 
             """
-            return "r", "ptol", "vtol"
+            return {"r", "ptol", "vtol"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return "r"
+            return {"r"}
 
         def set_default_params(self):
             """Sets parameters that are not required to their default value.
@@ -2551,13 +2551,13 @@ class Dihedral(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "mult", "bend", "phase"
+        return {"mult", "bend", "phase"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "mult", "bend", "phase"
+        return {"mult", "bend", "phase"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -2612,13 +2612,13 @@ class _TabulatedBase(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "min", "max", "energy", "force"
+        return {"min", "max", "energy", "force"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "min", "max", "energy", "force"
+        return {"min", "max", "energy", "force"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -2703,7 +2703,7 @@ class TabulatedDistance(_TabulatedBase):
         """Parameters that have to be set.
 
         """
-        return "min", "max", "energy", "force"
+        return {"min", "max", "energy", "force"}
 
 
 class TabulatedAngle(_TabulatedBase):
@@ -2738,7 +2738,7 @@ class TabulatedAngle(_TabulatedBase):
         """Parameters that have to be set.
 
         """
-        return "energy", "force"
+        return {"energy", "force"}
 
 
 class TabulatedDihedral(_TabulatedBase):
@@ -2773,7 +2773,7 @@ class TabulatedDihedral(_TabulatedBase):
         """Parameters that have to be set.
 
         """
-        return "energy", "force"
+        return {"energy", "force"}
 
 
 IF TABULATED == 1:
@@ -2799,13 +2799,13 @@ IF TABULATED == 1:
             """All parameters that can be set.
 
             """
-            return "min", "max", "energy", "force"
+            return {"min", "max", "energy", "force"}
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return ["min", "max", "energy", "force"]
+            return {"min", "max", "energy", "force"}
 
         def set_params(self, **kwargs):
             """Set parameters for the TabulatedNonBonded interaction.
@@ -2882,13 +2882,13 @@ IF LENNARD_JONES == 1:
             """All parameters that can be set.
 
             """
-            return {}
+            return set()
 
         def required_keys(self):
             """Parameters that have to be set.
 
             """
-            return {}
+            return set()
 
         def set_default_params(self):
             """Sets parameters that are not required to their default value.
@@ -2925,13 +2925,13 @@ class Virtual(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return {}
+        return set()
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return []
+        return set()
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -2973,13 +2973,13 @@ class AngleHarmonic(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "bend", "phi0"
+        return {"bend", "phi0"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "bend", "phi0"
+        return {"bend", "phi0"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -3024,13 +3024,13 @@ class AngleCosine(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "bend", "phi0"
+        return {"bend", "phi0"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "bend", "phi0"
+        return {"bend", "phi0"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -3075,13 +3075,13 @@ class AngleCossquare(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "bend", "phi0"
+        return {"bend", "phi0"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "bend", "phi0"
+        return {"bend", "phi0"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -3130,10 +3130,10 @@ class IBM_Triel(BondedInteraction):
         return "IBM_Triel"
 
     def valid_keys(self):
-        return "ind1", "ind2", "ind3", "k1", "k2", "maxDist", "elasticLaw"
+        return {"ind1", "ind2", "ind3", "k1", "k2", "maxDist", "elasticLaw"}
 
     def required_keys(self):
-        return "ind1", "ind2", "ind3", "k1", "maxDist", "elasticLaw"
+        return {"ind1", "ind2", "ind3", "k1", "maxDist", "elasticLaw"}
 
     def set_default_params(self):
         self._params = {"k2": 0}
@@ -3184,10 +3184,10 @@ class IBM_Tribend(BondedInteraction):
         return "IBM_Tribend"
 
     def valid_keys(self):
-        return "ind1", "ind2", "ind3", "ind4", "kb", "refShape"
+        return {"ind1", "ind2", "ind3", "ind4", "kb", "refShape"}
 
     def required_keys(self):
-        return "ind1", "ind2", "ind3", "ind4", "kb"
+        return {"ind1", "ind2", "ind3", "ind4", "kb"}
 
     def set_default_params(self):
         self._params = {"flat": False}
@@ -3232,10 +3232,10 @@ class IBM_VolCons(BondedInteraction):
         return "IBM_VolCons"
 
     def valid_keys(self):
-        return "softID", "kappaV"
+        return {"softID", "kappaV"}
 
     def required_keys(self):
-        return "softID", "kappaV"
+        return {"softID", "kappaV"}
 
     def set_default_params(self):
         self._params = {}
@@ -3284,13 +3284,13 @@ class OifGlobalForces(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "A0_g", "ka_g", "V0", "kv"
+        return {"A0_g", "ka_g", "V0", "kv"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "A0_g", "ka_g", "V0", "kv"
+        return {"A0_g", "ka_g", "V0", "kv"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -3353,13 +3353,13 @@ class OifLocalForces(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "r0", "ks", "kslin", "phi0", "kb", "A01", "A02", "kal", "kvisc"
+        return {"r0", "ks", "kslin", "phi0", "kb", "A01", "A02", "kal", "kvisc"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "r0", "ks", "kslin", "phi0", "kb", "A01", "A02", "kal", "kvisc"
+        return {"r0", "ks", "kslin", "phi0", "kb", "A01", "A02", "kal", "kvisc"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.
@@ -3404,10 +3404,10 @@ IF MEMBRANE_COLLISION == 1:
             return "OIF_OUT_DIRECTION"
 
         def valid_keys(self):
-            return ""
+            return set()
 
         def required_keys(self):
-            return ""
+            return set()
 
         def set_default_params(self):
             self._params = {}
@@ -3458,13 +3458,13 @@ class QuarticBond(BondedInteraction):
         """All parameters that can be set.
 
         """
-        return "k0", "k1", "r", "r_cut"
+        return {"k0", "k1", "r", "r_cut"}
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return "k0", "k1", "r", "r_cut"
+        return {"k0", "k1", "r", "r_cut"}
 
     def set_default_params(self):
         """Sets parameters that are not required to their default value.

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -45,7 +45,7 @@ class ParticleProperties(ut.TestCase):
 
         return True
 
-    def paramaterKeys(self, bondObject):
+    def parameterKeys(self, bondObject):
         """
         Check :meth:`~espressomd.interactions.NonBondedInteraction.valid_keys`
         and :meth:`~espressomd.interactions.NonBondedInteraction.required_keys`
@@ -127,7 +127,7 @@ class ParticleProperties(ut.TestCase):
                 params.__str__() +
                 " vs. " +
                 outParams.__str__())
-            self.paramaterKeys(outBond)
+            self.parameterKeys(outBond)
 
         return func
 

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -32,7 +32,7 @@ class ParticleProperties(ut.TestCase):
     def bondsMatch(self, inType, outType, inParams, outParams):
         """Check, if the bond type set and gotten back as well as the bond
         parameters set and gotten back match. Only check keys present in
-        inParams.
+        ``inParams``.
         """
         if inType != outType:
             return False
@@ -45,16 +45,61 @@ class ParticleProperties(ut.TestCase):
 
         return True
 
+    def paramaterKeys(self, bondObject):
+        """
+        Check :meth:`~espressomd.interactions.NonBondedInteraction.valid_keys`
+        and :meth:`~espressomd.interactions.NonBondedInteraction.required_keys`
+        return sets, and that
+        :meth:`~espressomd.interactions.NonBondedInteraction.set_default_params`
+        returns a dictionary with the correct keys.
+
+        Parameters
+        ----------
+        bondObject: instance of a class derived from :class:`espressomd.interactions.BondedInteraction`
+            Object of the interaction to test, e.g.
+            :class:`~espressomd.interactions.FeneBond`
+        """
+        classname = bondObject.__class__.__name__
+        valid_keys = bondObject.valid_keys()
+        required_keys = bondObject.required_keys()
+        old_params = dict(bondObject.params)
+        bondObject.set_default_params()
+        default_keys = set(bondObject.params.keys())
+        bondObject.params = old_params
+        self.assertIsInstance(valid_keys, set,
+                              "{}.valid_keys() must return a set".format(
+                                  classname))
+        self.assertIsInstance(required_keys, set,
+                              "{}.required_keys() must return a set".format(
+                                  classname))
+        self.assertTrue(default_keys.issubset(valid_keys),
+                        "{}.set_default_params() has unknown parameters: {}".format(
+            classname, default_keys.difference(valid_keys)))
+        self.assertTrue(default_keys.isdisjoint(required_keys),
+                        "{}.set_default_params() has extra parameters: {}".format(
+            classname, default_keys.intersection(required_keys)))
+        self.assertSetEqual(default_keys, valid_keys - required_keys,
+                            "{}.set_default_params() should have keys: {}, got: {}".format(
+                                classname, valid_keys - required_keys, default_keys))
+
     def setUp(self):
         if not self.system.part.exists(self.pid):
             self.system.part.add(id=self.pid, pos=(0, 0, 0, 0))
 
     def generateTestForBondParams(_bondId, _bondClass, _params):
-        """Generates test cases for checking bond parameters set and gotten back
-        from Es actually match. Only keys which are present in _params are checked
-        1st arg: Id of the bonded ia in Espresso to test on, i.e., 0,2,1...
-        2nd: Class of the bond potential to test, ie.e, FeneBond, HarmonicBond
-        3rd: Bond parameters as dictionary, i.e., {"k"=1.,"r_0"=0}
+        """Generates test cases for checking bond parameters set and gotten
+        back from the espresso core actually match those in the Python classes.
+        Only keys which are present in ``_params`` are checked.
+
+        Parameters
+        ----------
+        _bondId: :obj:`int`
+            Identifier of the bonded IA in Espresso to test on, e.g. 0, 2, 1...
+        _bondClass: class derived from :class:`espressomd.interactions.BondedInteraction`
+            Class of the interaction to test, e.g.
+            :class:`~espressomd.interactions.FeneBond`
+        _params: :obj:`dict`
+            Bond parameters, e.g. ``{"k": 1., "r_0": 0}``
         """
         bondId = _bondId
         bondClass = _bondClass
@@ -82,6 +127,7 @@ class ParticleProperties(ut.TestCase):
                 params.__str__() +
                 " vs. " +
                 outParams.__str__())
+            self.paramaterKeys(outBond)
 
         return func
 

--- a/testsuite/python/interactions_non-bonded_interface.py
+++ b/testsuite/python/interactions_non-bonded_interface.py
@@ -44,7 +44,7 @@ class Non_bonded_interactionsTests(ut.TestCase):
 
         return True
 
-    def paramaterKeys(self, interObject):
+    def parameterKeys(self, interObject):
         """
         Check :meth:`~espressomd.interactions.NonBondedInteraction.valid_keys`
         and :meth:`~espressomd.interactions.NonBondedInteraction.required_keys`
@@ -131,7 +131,7 @@ class Non_bonded_interactionsTests(ut.TestCase):
                 params.__str__() +
                 " vs. " +
                 outParams.__str__())
-            self.paramaterKeys(outInter)
+            self.parameterKeys(outInter)
 
         return func
 

--- a/testsuite/python/interactions_non-bonded_interface.py
+++ b/testsuite/python/interactions_non-bonded_interface.py
@@ -28,7 +28,7 @@ class Non_bonded_interactionsTests(ut.TestCase):
     def intersMatch(self, inType, outType, inParams, outParams):
         """Check, if the interaction type set and gotten back as well as the
         bond parameters set and gotten back match. Only check keys present in
-        inParams.
+        ``inParams``.
         """
         if inType != outType:
             print("Type mismatch:", inType, outType)
@@ -44,14 +44,57 @@ class Non_bonded_interactionsTests(ut.TestCase):
 
         return True
 
+    def paramaterKeys(self, interObject):
+        """
+        Check :meth:`~espressomd.interactions.NonBondedInteraction.valid_keys`
+        and :meth:`~espressomd.interactions.NonBondedInteraction.required_keys`
+        return sets, and that
+        :meth:`~espressomd.interactions.NonBondedInteraction.default_params`
+        returns a dictionary with the correct keys.
+
+        Parameters
+        ----------
+        interObject: instance of a class derived from :class:`espressomd.interactions.NonBondedInteraction`
+            Object of the interaction to test, e.g.
+            :class:`~espressomd.interactions.LennardJonesInteraction`
+        """
+        classname = interObject.__class__.__name__
+        valid_keys = interObject.valid_keys()
+        required_keys = interObject.required_keys()
+        default_keys = set(interObject.default_params().keys())
+        self.assertIsInstance(valid_keys, set,
+                              "{}.valid_keys() must return a set".format(
+                                  classname))
+        self.assertIsInstance(required_keys, set,
+                              "{}.required_keys() must return a set".format(
+                                  classname))
+        self.assertTrue(default_keys.issubset(valid_keys),
+                        "{}.default_params() has unknown parameters: {}".format(
+            classname, default_keys.difference(valid_keys)))
+        self.assertTrue(default_keys.isdisjoint(required_keys),
+                        "{}.default_params() has extra parameters: {}".format(
+            classname, default_keys.intersection(required_keys)))
+        self.assertSetEqual(default_keys, valid_keys - required_keys,
+                            "{}.default_params() should have keys: {}, got: {}".format(
+                                classname, valid_keys - required_keys, default_keys))
+
     def generateTestForNon_bonded_interaction(
             _partType1, _partType2, _interClass, _params, _interName):
-        """Generates test cases for checking interaction parameters set and gotten back
-        from Es actually match. Only keys which are present in _params are checked
-        1st and 2nd arg: Particle type ids to check on
-        3rd: Class of the interaction to test, ie.e, FeneBond, HarmonicBond
-        4th: Interaction parameters as dictionary, i.e., {"k"=1.,"r_0"=0}
-        5th: Name of the interaction property to set (i.e. "lennardJones")
+        """Generates test cases for checking interaction parameters set and
+        gotten back from the espresso core actually match those in the Python
+        classes. Only keys which are present in ``_params`` are checked.
+
+        Parameters
+        ----------
+        _partType1, _partType2: :obj:`int`
+            Particle type ids to check on
+        _interClass: class derived from :class:`espressomd.interactions.NonBondedInteraction`
+            Class of the interaction to test, e.g.
+            :class:`~espressomd.interactions.LennardJonesInteraction`
+        _params: :obj:`dict`
+            Interaction parameters, e.g. ``{"k": 1., "r_0": 0}``
+        _interName: :obj:`str`
+            Name of the interaction property to set (e.g. ``"lennard_jones"``)
         """
         partType1 = _partType1
         partType2 = _partType2
@@ -88,6 +131,7 @@ class Non_bonded_interactionsTests(ut.TestCase):
                 params.__str__() +
                 " vs. " +
                 outParams.__str__())
+            self.paramaterKeys(outInter)
 
         return func
 


### PR DESCRIPTION
Fixes #3069

Change internals of bonded/non-bonded IA Python classes:
- `valid_keys()` and `required_keys()` now return sets instead of tuples/lists/strings (strings can lead to cryptic error messages since they are iterable)
- `default_params()` and `set_default_params()` now return values only for optional parameters
- wrong keys (typos or unknown keys) in optional parameters were fixed
- added tests for a few common IAs to check the new syntax and verify default parameters have the correct name and don't overlap with required parameters, which can't have default values
