### PR TITLE
Re-enable CMake option WITH_PYTHON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,7 @@ set(CMAKE_FIND_FRAMEWORK LAST)
 # User input options
 ######################################################################
 
-set(WITH_PYTHON yes)
-
+option(WITH_PYTHON "Build with Python bindings"  ON)
 option(WITH_GSL    "Build with GSL support"  ON)
 option(WITH_CUDA   "Build with GPU support"  ON)
 option(WITH_HDF5   "Build with HDF5 support" ON)
@@ -528,7 +527,9 @@ if(WITH_TESTS)
     set(WITH_UNIT_TESTS ON)
   endif(Boost_UNIT_TEST_FRAMEWORK_FOUND)
   add_custom_target(check)
-  add_subdirectory(testsuite)
+  if(WITH_PYTHON)
+    add_subdirectory(testsuite)
+  endif(WITH_PYTHON)
 endif(WITH_TESTS)
 
 if(WITH_BENCHMARKS)


### PR DESCRIPTION
When looking for errors in the core with Clangs' scan-build tool, it is convenient to disable Cython, whose generated C++ code triggers many warnings that are outside our control. With this change, scan-build works out-of-the-box with our CMake logic:

```bash
# all reports
scan-build cmake .. -DWITH_CUDA=OFF
# skip Cython reports
scan-build cmake .. -DWITH_CUDA=OFF -DWITH_PYTHON=OFF
# build
scan-build -k -o static-analysis/ make -j$(nproc)
scan-build -k -o static-analysis/ make -j$(nproc) check_unit_tests
```
