### PR TITLE
Fix Constraint checkpointing

### DIFF
--- a/src/core/field_coupling/fields/Interpolated.hpp
+++ b/src/core/field_coupling/fields/Interpolated.hpp
@@ -108,7 +108,7 @@ public:
   template <class Q = T>
   typename std::enable_if<codim == 1, std::vector<Q>>::type
   field_data_flat() const {
-    T const *data = reinterpret_cast<const T *>(m_global_field.data());
+    auto const *data = reinterpret_cast<T const *>(m_global_field.data());
     return std::vector<T>(data, data + m_global_field.num_elements());
   }
 

--- a/src/core/field_coupling/fields/Interpolated.hpp
+++ b/src/core/field_coupling/fields/Interpolated.hpp
@@ -104,26 +104,10 @@ public:
     return {m_global_field.shape(), m_global_field.shape() + 3};
   }
 
-  /** Serialize scalar field */
-  template <class Q = T>
-  typename std::enable_if<codim == 1, std::vector<Q>>::type
-  field_data_flat() const {
+  /** Serialize field */
+  std::vector<T> field_data_flat() const {
     auto const *data = reinterpret_cast<T const *>(m_global_field.data());
-    return std::vector<T>(data, data + m_global_field.num_elements());
-  }
-
-  /** Serialize vector field */
-  template <class Q = T>
-  typename std::enable_if<codim != 1, std::vector<Q>>::type
-  field_data_flat() const {
-    auto const &data = m_global_field.data();
-    std::vector<T> data_flat(codim * m_global_field.num_elements());
-    for (size_t i = 0; i < m_global_field.num_elements(); ++i) {
-      for (size_t j = 0; j < codim; ++j) {
-        data_flat[i * codim + j] = data[i][j];
-      }
-    }
-    return data_flat;
+    return std::vector<T>(data, data + codim * m_global_field.num_elements());
   }
 
   /*

--- a/src/core/field_coupling/fields/Interpolated.hpp
+++ b/src/core/field_coupling/fields/Interpolated.hpp
@@ -51,13 +51,20 @@ void deep_copy(boost::multi_array<T, 3> &dst,
 } // namespace detail
 
 /**
- * @brief A vector field interpolated from a regular grid.
+ *  @brief A vector or scalar field interpolated from a regular grid.
  *
- * This is an interpolation wrapper around a boost::multi_array,
- * which can be evaluated on any point in space by spline interpolation.
+ *  This is an interpolation wrapper around a boost::multi_array,
+ *  which can be evaluated on any point in space by spline interpolation.
+ *
+ *  @tparam T      Underlying type of the field values, see @ref value_type
+ *  @tparam codim  Dimension of the field: 3 for a vector field,
+ *                 1 for a scalar field.
  */
 template <typename T, size_t codim> class Interpolated {
 public:
+  /** Type of the values, usually @ref Utils::Vector<T, 3> for vector fields
+   *  and @p T for scalar fields
+   */
   using value_type =
       typename Utils::decay_to_scalar<Utils::Vector<T, codim>>::type;
   using jacobian_type = detail::jacobian_type<T, codim>;
@@ -95,6 +102,28 @@ public:
   Utils::Vector3d origin() const { return m_origin; }
   Utils::Vector3i shape() const {
     return {m_global_field.shape(), m_global_field.shape() + 3};
+  }
+
+  /** Serialize scalar field */
+  template <class Q = T>
+  typename std::enable_if<codim == 1, std::vector<Q>>::type
+  field_data_flat() const {
+    T const *data = reinterpret_cast<const T *>(m_global_field.data());
+    return std::vector<T>(data, data + m_global_field.num_elements());
+  }
+
+  /** Serialize vector field */
+  template <class Q = T>
+  typename std::enable_if<codim != 1, std::vector<Q>>::type
+  field_data_flat() const {
+    auto const &data = m_global_field.data();
+    std::vector<T> data_flat(codim * m_global_field.num_elements());
+    for (size_t i = 0; i < m_global_field.num_elements(); ++i) {
+      for (size_t j = 0; j < codim; ++j) {
+        data_flat[i * codim + j] = data[i][j];
+      }
+    }
+    return data_flat;
   }
 
   /*

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -104,7 +104,7 @@ class ShapeBasedConstraint(Constraint):
         only useful if penetrable is ``True``.
     particle_type : int
         Interaction type of the constraint.
-    particle_velocity : array of :obj:`float`
+    particle_velocity : array_like of :obj:`float`
         Interaction velocity of the boundary
     penetrable : :obj:`bool`
         Whether particles are allowed to penetrate the constraint.
@@ -190,7 +190,7 @@ class HomogeneousMagneticField(Constraint):
     """
     Attributes
     ----------
-    H : array of :obj:`float`
+    H : (3,) array_like of :obj:`float`
         Magnetic field vector. Describes both field direction and
         strength of the magnetic field (via length of the vector).
 
@@ -214,17 +214,27 @@ class _Interpolated(Constraint):
     box, e.g. the most up right back point has to be at least at
     box + 0.5 * grid_spacing. There are convenience functions on this
     class that can calculate the required grid dimensions and the coordinates.
-    See also the examples on ForceField.
+
+    Arguments
+    ----------
+    field : (M, N, O, P) array_like of :obj:`float`
+        The actual field on a grid of size (M, N, O) with dimension P.
+    grid_spacing : (3,) array_like of :obj:`float`
+        Spacing of the grid points.
 
     Attributes
     ----------
 
-    field_data: array_like :obj:`float`
-        The actual field. Please be aware that depending on the interpolation
+    field : (M, N, O, P) array_like of :obj:`float`
+        The actual field on a grid of size (M, N, O) with dimension P.
+        Please be aware that depending on the interpolation
         order additional points are used on the boundaries.
 
-    grid_spacing: array_like :obj:`float`
-        The spacing of the grid points.
+    grid_spacing : array_like of :obj:`float`
+        Spacing of the grid points.
+
+    origin : (3,) array_like of :obj:`float`
+        Coordinates of the grid origin.
 
     """
 
@@ -324,11 +334,15 @@ class ForceField(_Interpolated):
     """
     A generic tabulated force field that applies a per-particle scaling factor.
 
-    Attributes
+    Arguments
     ----------
+    field : (M, N, O, 3) array_like of :obj:`float`
+        Forcefield amplitude on a grid of size (M, N, O).
+    grid_spacing : (3,) array_like of :obj:`float`
+        Spacing of the grid points.
     default_scale : :obj:`float`
         Scaling factor for particles that have no individual scaling factor.
-    particle_scales: array_like (:obj:`int`, :obj:`float`)
+    particle_scales : array_like of (:obj:`int`, :obj:`float`)
         A list of tuples of ids and scaling factors. For
         particles in the list the interaction is scaled with
         their individual scaling factor before it is applied.
@@ -346,17 +360,20 @@ class ForceField(_Interpolated):
 class PotentialField(_Interpolated):
 
     """
-    A generic tabulated force field that applies a per particle
+    A generic tabulated force field that applies a per-particle
     scaling factor. The forces are calculated numerically from
     the data by finite differences. The potential is interpolated
     from the provided data.
 
-    Attributes
+    Arguments
     ----------
+    field : (M, N, O, 1) array_like of :obj:`float`
+        Potential on a grid of size (M, N, O).
+    grid_spacing : (3,) array_like of :obj:`float`
+        Spacing of the grid points.
     default_scale : :obj:`float`
-        Scaling factor for particles that have no
-        individual scaling factor.
-    particle_scales: array_like (:obj:`int`, :obj:`float`)
+        Scaling factor for particles that have no individual scaling factor.
+    particle_scales : array_like (:obj:`int`, :obj:`float`)
         A list of tuples of ids and scaling factors. For
         particles in the list the interaction is scaled with
         their individual scaling factor before it is applied.
@@ -378,9 +395,9 @@ class Gravity(Constraint):
 
     :math:`F = m \\cdot g`
 
-    Attributes
+    Arguments
     ----------
-    g : array of :obj:`float`
+    g : (3,) array_like of :obj:`float`
         The gravitational acceleration.
 
     """
@@ -413,9 +430,9 @@ class LinearElectricPotential(Constraint):
 
     where :math:`q` is the charge of the particle.
 
-    Attributes
+    Arguments
     ----------
-    E : array of :obj:`float`
+    E : array_like of :obj:`float`
         The electric field.
 
     phi0 : :obj:`float`
@@ -456,16 +473,16 @@ class ElectricPlaneWave(Constraint):
     This can be used to generate a homogeneous AC
     field by setting k to zero.
 
-    Attributes
+    Arguments
     ----------
-    E0 : array of :obj:`float`
-        The amplitude of the electric field.
-    k  : array of :obj:`float`
+    E0 : array_like of :obj:`float`
+        Amplitude of the electric field.
+    k  : array_like of :obj:`float`
         Wave vector of the wave
     omega : :obj:`float`
         Frequency of the wave
-    phi : :obj:`float`
-        Optional phase shift, defaults to 0.
+    phi : :obj:`float`, optional
+        Phase shift
 
     """
 
@@ -507,6 +524,15 @@ class FlowField(_Interpolated):
 
     where :math:`v` is the velocity of the particle.
 
+    Arguments
+    ----------
+    field : (M, N, O, 3) array_like of :obj:`float`
+        Field velocity on a grid of size (M, N, O)
+    grid_spacing : (3,) array_like of :obj:`float`
+        Spacing of the grid points.
+    gamma : :obj:`float`
+        Coupling constant
+
     """
 
     def __init__(self, **kwargs):
@@ -529,10 +555,10 @@ class HomogeneousFlowField(Constraint):
 
     Attributes
     ----------
-    gamma : :obj:`float`
-        The coupling constant
     u : (3,) array_like of :obj:`float`
-        The velocity of the field.
+        Field velocity.
+    gamma : :obj:`float`
+        Coupling constant
 
     """
 
@@ -561,6 +587,12 @@ class ElectricPotential(_Interpolated):
 
     where :math:`q` is the charge of the particle.
 
+    Arguments
+    ----------
+    field : (M, N, O, 1) array_like of :obj:`float`
+        Field velocity on a grid of size (M, N, O)
+    grid_spacing : (3,) array_like of :obj:`float`
+        Spacing of the grid points.
 
     """
 

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -228,11 +228,14 @@ class _Interpolated(Constraint):
 
     """
 
-    def __init__(self, field, **kwargs):
-        shape, codim = self._unpack_dims(field)
-
-        super().__init__(_field_shape=shape, _field_codim=codim,
-                         _field_data=field.flatten(), **kwargs)
+    def __init__(self, **kwargs):
+        if "oid" not in kwargs:
+            field = kwargs.pop("field")
+            shape, codim = self._unpack_dims(field)
+            super().__init__(_field_shape=shape, _field_codim=codim,
+                             _field_data=field.flatten(), **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     @classmethod
     def required_dims(cls, box_size, grid_spacing):
@@ -332,8 +335,8 @@ class ForceField(_Interpolated):
 
     """
 
-    def __init__(self, field, **kwargs):
-        super().__init__(field, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     _codim = 3
     _so_name = "Constraints::ForceField"
@@ -360,8 +363,8 @@ class PotentialField(_Interpolated):
 
     """
 
-    def __init__(self, field, **kwargs):
-        super().__init__(field, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     _codim = 1
     _so_name = "Constraints::PotentialField"
@@ -382,8 +385,10 @@ class Gravity(Constraint):
 
     """
 
-    def __init__(self, g):
-        super().__init__(value=g)
+    def __init__(self, **kwargs):
+        if "oid" not in kwargs:
+            kwargs["value"] = kwargs.pop("g")
+        super().__init__(**kwargs)
 
     @property
     def g(self):
@@ -418,8 +423,11 @@ class LinearElectricPotential(Constraint):
 
     """
 
-    def __init__(self, E, phi0=0):
-        super().__init__(A=-E, b=phi0)
+    def __init__(self, phi0=0, **kwargs):
+        if "oid" not in kwargs:
+            kwargs["A"] = -np.array(kwargs.pop("E"))
+            kwargs["b"] = phi0
+        super().__init__(**kwargs)
 
     @property
     def E(self):
@@ -463,9 +471,13 @@ class ElectricPlaneWave(Constraint):
 
     _so_name = "Constraints::ElectricPlaneWave"
 
-    def __init__(self, E0, k, omega, phi=0):
-        super().__init__(amplitude=E0, wave_vector=k, frequency=omega,
-                         phase=phi)
+    def __init__(self, phi=0, **kwargs):
+        if "oid" not in kwargs:
+            kwargs["amplitude"] = kwargs.pop("E0")
+            kwargs["wave_vector"] = kwargs.pop("k")
+            kwargs["frequency"] = kwargs.pop("omega")
+            kwargs["phase"] = phi
+        super().__init__(**kwargs)
 
     @property
     def E0(self):
@@ -497,8 +509,8 @@ class FlowField(_Interpolated):
 
     """
 
-    def __init__(self, field, **kwargs):
-        super().__init__(field, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     _codim = 3
     _so_name = "Constraints::FlowField"
@@ -524,8 +536,10 @@ class HomogeneousFlowField(Constraint):
 
     """
 
-    def __init__(self, u, gamma):
-        super().__init__(value=u, gamma=gamma)
+    def __init__(self, **kwargs):
+        if "oid" not in kwargs:
+            kwargs["value"] = kwargs.pop("u")
+        super().__init__(**kwargs)
 
     @property
     def u(self):
@@ -550,8 +564,8 @@ class ElectricPotential(_Interpolated):
 
     """
 
-    def __init__(self, field, **kwargs):
-        super().__init__(field, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     _codim = 1
     _so_name = "Constraints::ElectricPotential"

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -75,12 +75,33 @@ if OIF_GLOBAL_FORCES:
 cdef bool _system_created = False
 
 cdef class System:
-    """ The base class for espressomd.system.System().
+    """The espresso system class.
 
     .. note:: every attribute has to be declared at the class level.
               This means that methods cannot define an attribute by using
               ``self.new_attr = somevalue`` without declaring it inside this
               indentation level, either as method, property or reference.
+
+    Attributes
+    ----------
+    globals : :class:`espressomd.globals.Globals`
+    actors : :class:`espressomd.actors.Actors`
+    analysis : :class:`espressomd.analyze.Analysis`
+    auto_update_accumulators : :class:`espressomd.accumulators.AutoUpdateAccumulators`
+    bonded_inter : :class:`espressomd.interactions.BondedInteractions`
+    cell_system : :class:`espressomd.cellsystem.CellSystem`
+    collision_detection : :class:`espressomd.collision_detection.CollisionDetection`
+    comfixed : :class:`espressomd.comfixed.ComFixed`
+    constraints : :class:`espressomd.constraints.Constraints`
+    cuda_init_handle : :class:`espressomd.cuda_init.CudaInitHandle`
+    galilei : :class:`espressomd.galilei.GalileiTransform`
+    integrator : :class:`espressomd.integrate.Integrator`
+    lbboundaries : :class:`espressomd.lbboundaries.LBBoundaries`
+    ekboundaries : :class:`espressomd.ekboundaries.EKBoundaries`
+    minimize_energy : :class:`espressomd.minimize_energy.MinimizeEnergy`
+    non_bonded_inter : :class:`espressomd.interactions.NonBondedInteractions`
+    part : :class:`espressomd.particle_data.ParticleList`
+    thermostat : :class:`espressomd.thermostat.Thermostat`
 
     """
     cdef public:

--- a/src/script_interface/constraints/fields.hpp
+++ b/src/script_interface/constraints/fields.hpp
@@ -141,13 +141,8 @@ struct field_params_impl<Interpolated<T, codim>> {
              [this_]() { return this_().shape(); }},
             {"_field_codim", AutoParameter::read_only,
              []() { return static_cast<int>(codim); }},
-            {"_field_data", AutoParameter::read_only, [this_]() {
-               auto &field_data = this_().field_data();
-               auto data_ptr =
-                   reinterpret_cast<const double *>(field_data.data());
-               return std::vector<double>(
-                   data_ptr, data_ptr + codim * field_data.num_elements());
-             }}};
+            {"_field_data", AutoParameter::read_only,
+             [this_]() { return this_().field_data_flat(); }}};
   }
 };
 

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -98,6 +98,14 @@ struct vector_conversion_visitor : boost::static_visitor<Utils::Vector<T, N>> {
     return ret;
   }
 
+  Utils::Vector<T, N>
+  operator()(std::vector<T, std::allocator<T>> const &v) const {
+    if (N != v.size()) {
+      throw boost::bad_get{};
+    }
+    return Utils::Vector<T, N>(v);
+  }
+
   template <typename U> Utils::Vector<T, N> operator()(U const &) const {
     throw boost::bad_get{};
   }

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -117,11 +117,16 @@ system.constraints.add(constraints.Gravity(g=[1., 2., 3.]))
 system.constraints.add(constraints.HomogeneousMagneticField(H=[1., 2., 3.]))
 system.constraints.add(
     constraints.HomogeneousFlowField(u=[1., 2., 3.], gamma=2.3))
-field_data = constraints.ElectricPotential.field_from_fn(
+pot_field_data = constraints.ElectricPotential.field_from_fn(
     system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
-checkpoint.register("field_data")
+checkpoint.register("pot_field_data")
 system.constraints.add(constraints.PotentialField(
-    field=field_data, grid_spacing=np.ones(3), default_scale=1.6))
+    field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6))
+vec_field_data = constraints.ForceField.field_from_fn(
+    system.box_l, np.ones(3), lambda x: 10 * np.ones(3) - x)
+checkpoint.register("vec_field_data")
+system.constraints.add(constraints.ForceField(
+    field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4))
 if espressomd.has_features("ELECTROSTATICS"):
     system.constraints.add(constraints.ElectricPlaneWave(
         E0=[1., -2., 3.], k=[-.1, .2, .3], omega=5., phi=1.4))

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -30,6 +30,7 @@ if espressomd.has_features("LB_BOUNDARIES") or espressomd.has_features("LB_BOUND
 import espressomd.lb
 import espressomd.electrokinetics
 from espressomd.shapes import Wall, Sphere
+from espressomd import constraints
 
 modes = {x for mode in set("@TEST_COMBINATION@".upper().split('-'))
          for x in [mode, mode.split('.')[0]]}
@@ -108,9 +109,22 @@ acc.update()
 
 system.auto_update_accumulators.add(acc)
 
+# constraints
 system.constraints.add(shape=Sphere(center=system.box_l / 2, radius=0.1),
                        particle_type=17)
 system.constraints.add(shape=Wall(normal=[1. / np.sqrt(3)] * 3, dist=0.5))
+system.constraints.add(constraints.Gravity(g=[1., 2., 3.]))
+system.constraints.add(constraints.HomogeneousMagneticField(H=[1., 2., 3.]))
+system.constraints.add(
+    constraints.HomogeneousFlowField(u=[1., 2., 3.], gamma=2.3))
+system.constraints.add(constraints.ElectricPlaneWave(
+    E0=[1., -2., 3.], k=[-.1, .2, .3], omega=5., phi=1.4))
+field_data = constraints.ElectricPotential.field_from_fn(
+    system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
+checkpoint.register("field_data")
+system.constraints.add(
+    constraints.ElectricPotential(field=field_data, grid_spacing=np.ones(3)))
+
 
 if 'LBTHERM' not in modes:
     system.thermostat.set_langevin(kT=1.0, gamma=2.0, seed=42)

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -117,13 +117,14 @@ system.constraints.add(constraints.Gravity(g=[1., 2., 3.]))
 system.constraints.add(constraints.HomogeneousMagneticField(H=[1., 2., 3.]))
 system.constraints.add(
     constraints.HomogeneousFlowField(u=[1., 2., 3.], gamma=2.3))
-system.constraints.add(constraints.ElectricPlaneWave(
-    E0=[1., -2., 3.], k=[-.1, .2, .3], omega=5., phi=1.4))
 field_data = constraints.ElectricPotential.field_from_fn(
     system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
 checkpoint.register("field_data")
-system.constraints.add(
-    constraints.ElectricPotential(field=field_data, grid_spacing=np.ones(3)))
+system.constraints.add(constraints.PotentialField(
+    field=field_data, grid_spacing=np.ones(3), default_scale=1.6))
+if espressomd.has_features("ELECTROSTATICS"):
+    system.constraints.add(constraints.ElectricPlaneWave(
+        E0=[1., -2., 3.], k=[-.1, .2, .3], omega=5., phi=1.4))
 
 
 if 'LBTHERM' not in modes:

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -231,7 +231,7 @@ class CheckpointTest(ut.TestCase):
     def test_constraints(self):
         from espressomd import constraints
         self.assertEqual(len(system.constraints),
-                         7 - int(not espressomd.has_features("ELECTROSTATICS")))
+                         8 - int(not espressomd.has_features("ELECTROSTATICS")))
         c = system.constraints
 
         self.assertEqual(type(c[0].shape), Sphere)
@@ -258,16 +258,26 @@ class CheckpointTest(ut.TestCase):
         np.testing.assert_allclose(np.copy(c[5].origin), [-0.5, -0.5, -0.5])
         np.testing.assert_allclose(np.copy(c[5].grid_spacing), np.ones(3))
         ref_pot = constraints.PotentialField(
-            field=field_data, grid_spacing=np.ones(3), default_scale=1.6)
+            field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6)
         np.testing.assert_allclose(np.copy(c[5].field), np.copy(ref_pot.field),
                                    atol=1e-10)
 
+        self.assertEqual(type(c[6]), constraints.ForceField)
+        self.assertEqual(c[6].field.shape, (14, 16, 18, 3))
+        self.assertAlmostEqual(c[6].default_scale, 1.4, delta=1E-10)
+        np.testing.assert_allclose(np.copy(c[6].origin), [-0.5, -0.5, -0.5])
+        np.testing.assert_allclose(np.copy(c[6].grid_spacing), np.ones(3))
+        ref_vec = constraints.ForceField(
+            field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4)
+        np.testing.assert_allclose(np.copy(c[6].field), np.copy(ref_vec.field),
+                                   atol=1e-10)
+
         if espressomd.has_features("ELECTROSTATICS"):
-            self.assertEqual(type(c[6]), constraints.ElectricPlaneWave)
-            np.testing.assert_allclose(np.copy(c[6].E0), [1., -2., 3.])
-            np.testing.assert_allclose(np.copy(c[6].k), [-.1, .2, .3])
-            self.assertAlmostEqual(c[6].omega, 5., delta=1E-10)
-            self.assertAlmostEqual(c[6].phi, 1.4, delta=1E-10)
+            self.assertEqual(type(c[7]), constraints.ElectricPlaneWave)
+            np.testing.assert_allclose(np.copy(c[7].E0), [1., -2., 3.])
+            np.testing.assert_allclose(np.copy(c[7].k), [-.1, .2, .3])
+            self.assertAlmostEqual(c[7].omega, 5., delta=1E-10)
+            self.assertAlmostEqual(c[7].phi, 1.4, delta=1E-10)
 
 if __name__ == '__main__':
     ut.main()

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -229,16 +229,42 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(type(system.lbboundaries[0].shape), Wall)
 
     def test_constraints(self):
-        self.assertEqual(len(system.constraints), 2)
-        c0 = system.constraints[0]
-        c1 = system.constraints[1]
-        self.assertEqual(type(c0.shape), Sphere)
-        self.assertAlmostEqual(c0.shape.radius, 0.1, delta=1E-10)
-        self.assertEqual(c0.particle_type, 17)
+        from espressomd import constraints
+        self.assertEqual(len(system.constraints), 7)
+        c = system.constraints
+
+        self.assertEqual(type(c[0].shape), Sphere)
+        self.assertAlmostEqual(c[0].shape.radius, 0.1, delta=1E-10)
+        self.assertEqual(c[0].particle_type, 17)
         
-        self.assertEqual(type(c1.shape), Wall)
-        np.testing.assert_allclose(np.copy(c1.shape.normal),
+        self.assertEqual(type(c[1].shape), Wall)
+        np.testing.assert_allclose(np.copy(c[1].shape.normal),
                                    [1. / np.sqrt(3)] * 3)
+
+        self.assertEqual(type(c[2]), constraints.Gravity)
+        np.testing.assert_allclose(np.copy(c[2].g), [1., 2., 3.])
+
+        self.assertEqual(type(c[3]), constraints.HomogeneousMagneticField)
+        np.testing.assert_allclose(np.copy(c[3].H), [1., 2., 3.])
+
+        self.assertEqual(type(c[4]), constraints.HomogeneousFlowField)
+        np.testing.assert_allclose(np.copy(c[4].u), [1., 2., 3.])
+        self.assertAlmostEqual(c[4].gamma, 2.3, delta=1E-10)
+
+        self.assertEqual(type(c[5]), constraints.ElectricPlaneWave)
+        np.testing.assert_allclose(np.copy(c[5].E0), [1., -2., 3.])
+        np.testing.assert_allclose(np.copy(c[5].k), [-.1, .2, .3])
+        self.assertAlmostEqual(c[5].omega, 5., delta=1E-10)
+        self.assertAlmostEqual(c[5].phi, 1.4, delta=1E-10)
+
+        self.assertEqual(type(c[6]), constraints.ElectricPotential)
+        self.assertEqual(c[6].field.shape, (14, 16, 18, 1))
+        np.testing.assert_allclose(np.copy(c[6].origin), [-0.5, -0.5, -0.5])
+        np.testing.assert_allclose(np.copy(c[6].grid_spacing), np.ones(3))
+        ref_pot = constraints.ElectricPotential(
+            field=field_data, grid_spacing=np.ones(3))
+        np.testing.assert_allclose(np.copy(c[6].field), np.copy(ref_pot.field),
+                                   atol=1e-10)
 
 if __name__ == '__main__':
     ut.main()


### PR DESCRIPTION
Fixes #2943

Enable checkpointing of all `Constraint` classes which are not based on shapes. This also solves the iterator issue in #2943.

API change: it is now required to instantiate all `Constraint` classes with named arguments instead of positional arguments.
