### PR TITLE
Document Correlator.result()

### DIFF
--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -760,9 +760,10 @@ used in the Green-Kubo relations. In general, time correlation functions
 are of the form
 
 .. math::
+   :label: eq_correlation_def
 
-   C(\tau) = \left<A\left(t\right) \otimes B\left(t+\tau\right)\right>\,,
-   \label{eq:corr.def}
+   C(\tau) = \left<A\left(t\right) \otimes B\left(t+\tau\right)\right>
+
 
 where :math:`t` is time, :math:`\tau` is the lag time (time difference)
 between the measurements of (vector) observables :math:`A` and
@@ -841,6 +842,8 @@ found its way to the Fluorescence Correlation Spectroscopy
 Smit :cite:`frenkel02b` describes its application for the
 special case of the velocity autocorrelation function.
 
+.. _fig_correlator_scheme:
+
 .. figure:: figures/correlator_scheme.png
    :scale: 50 %
    :alt: Schematic representation of buffers in the correlator.
@@ -848,17 +851,17 @@ special case of the velocity autocorrelation function.
    Schematic representation of buffers in the correlator.
 
 Let us consider a set of :math:`N` observable values as schematically
-shown in figure [fig:dataSet], where a value of index :math:`i` was
-measured in time :math:`i\delta t`. We are interested in computing the
-correlation function according to equation  for a range lag times
-:math:`\tau = (i-j)\delta t` between the measurements :math:`i` and
-:math:`j`. To simplify the notation, we further drop :math:`\delta t`
-when referring to observables and lag times.
+shown in figure :ref:`fig_correlator_scheme`, where a value of index :math:`i` was
+measured at times :math:`i\delta t`. We are interested in computing the
+correlation function according to :ref:`eq_correlation_def` for a range 
+of lag times :math:`\tau = (i-j)\delta t` between the measurements 
+:math:`i` and :math:`j`. To simplify the notation, we drop
+:math:`\delta t` when referring to observables and lag times.
 
 The trivial implementation takes all possible pairs of values
 corresponding to lag times
 :math:`\tau \in [{\tau_{\mathrm{min}}}:{\tau_{\mathrm{max}}}]`. Without
-loss of generality, let us further consider
+loss of generality, we consider
 :math:`{\tau_{\mathrm{min}}}=0`. The computational effort for such an
 algorithm scales as
 :math:`{\cal O} \bigl({\tau_{\mathrm{max}}}^2\bigr)`. As a rule of
@@ -866,8 +869,10 @@ thumb, this is feasible if :math:`{\tau_{\mathrm{max}}}< 10^3`. The
 multiple tau correlator provides a solution to compute the correlation
 functions for arbitrary range of the lag times by coarse-graining the
 high :math:`\tau` values. It applies the naive algorithm to a relatively
-small range of lag times :math:`\tau \in [0:p-1]`. This we refer to as
-compression level 0. To compute the correlations for lag times
+small range of lag times :math:`\tau \in [0:p-1]` 
+(:math:`p` corresponds to parameter ``tau_lin``). 
+This we refer to as compression level 0. 
+To compute the correlations for lag times
 :math:`\tau \in [p:2(p-1)]`, the original data are first coarse-grained,
 so that :math:`m` values of the original data are compressed to produce
 a single data point in the higher compression level. Thus the lag time

--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -760,7 +760,6 @@ used in the Green-Kubo relations. In general, time correlation functions
 are of the form
 
 .. math::
-   :label: eq_correlation_def
 
    C(\tau) = \left<A\left(t\right) \otimes B\left(t+\tau\right)\right>
 
@@ -851,9 +850,9 @@ special case of the velocity autocorrelation function.
    Schematic representation of buffers in the correlator.
 
 Let us consider a set of :math:`N` observable values as schematically
-shown in figure :ref:`fig_correlator_scheme`, where a value of index :math:`i` was
+shown in the figure above, where a value of index :math:`i` was
 measured at times :math:`i\delta t`. We are interested in computing the
-correlation function according to :ref:`eq_correlation_def` for a range 
+correlation function for a range 
 of lag times :math:`\tau = (i-j)\delta t` between the measurements 
 :math:`i` and :math:`j`. To simplify the notation, we drop
 :math:`\delta t` when referring to observables and lag times.

--- a/src/core/accumulators/Correlator.hpp
+++ b/src/core/accumulators/Correlator.hpp
@@ -222,20 +222,6 @@ public:
 
   int get_correlation_time(double *correlation_time);
 
-  /** The function to process a new datapoint of A and B
-   *
-   * First the function finds out if it necessary to make some space for the new
-   * entries of A and B.
-   * Then, if necessary, it compresses old Values of A and B to make for the new
-   * value. Finally
-   * The new values of A and B are stored in A[newest[0]] and B[newest[0]],
-   * where the newest indices
-   * have been increased before. Finally the correlation estimate is updated.
-   * TODO: Not all
-   * the correlation estimates have to be updated.
-   *
-   */
-
   /** Return correlation result */
   std::vector<double> get_correlation();
 

--- a/src/python/espressomd/accumulators.py
+++ b/src/python/espressomd/accumulators.py
@@ -236,6 +236,18 @@ class Correlator(ScriptInterfaceHelper):
     _so_creation_policy = "LOCAL"
 
     def result(self):
+        """
+        Returns
+        -------
+        
+        numpy.ndarray
+            The result of the correlation function as a 2d-array. 
+            The first column contains the values of the lag time tau.
+            The second column contains the number of values used to
+            perform the averaging of the correlation. Further columns contain 
+            the values of the correlation function. The number of these columns
+            is the dimension of the output of the correlation operation.
+        """
         res = np.array(self.call_method("get_correlation"))
         return res.reshape((self.n_result, 2 + self.dim_corr))
 


### PR DESCRIPTION
Fixes #2997 

Description of changes:
 - Document `result` method of `Correlator` class. Documentation done by @christophlohrmann.
