### PR TITLE
CI: The cuda no_gpu test doesn't need a gpu runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -478,7 +478,6 @@ check_cuda_maxset_no_gpu:
   tags:
     - docker
     - linux
-    - cuda
 
 
 check_with_odd_no_of_processors:


### PR DESCRIPTION
Fixes #

Description of changes:
 - 


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
