### PR TITLE
MMM2D

### DIFF
--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -129,6 +129,8 @@ struct CellPList {
   Cell **begin() { return cell; }
   Cell **end() { return cell + n; }
 
+  Cell *operator[](int i) { return assert(i < n), cell[i]; }
+
   Cell **cell;
   int n;
   int max;

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -108,11 +108,11 @@ double cutoff(const Utils::Vector3d &box_l) {
   switch (coulomb.method) {
   case COULOMB_MMM1D:
     return std::numeric_limits<double>::infinity();
+  case COULOMB_MMM2D:
+    return std::numeric_limits<double>::min();
 #ifdef P3M
   case COULOMB_ELC_P3M:
     return std::max(elc_params.space_layer, p3m.params.r_cut_iL * box_l[0]);
-  case COULOMB_MMM2D:
-    return layer_h - skin;
   case COULOMB_P3M_GPU:
   case COULOMB_P3M:
     /* do not use precalculated r_cut here, might not be set yet */

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -229,9 +229,6 @@ void on_resort_particles(const ParticleRange &particles) {
     ELC_on_resort_particles();
     break;
 #endif
-  case COULOMB_MMM2D:
-    MMM2D_on_resort_particles(particles);
-    break;
   default:
     break;
   }

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -1070,7 +1070,6 @@ void ELC_add_force(const ParticleRange &particles) {
     setup_P(p, omega, particles);
     distribute(4);
     add_P_force(particles);
-    checkpoint("************distri p", p, 0, 2);
   }
 
   for (q = 1; uy * (q - 1) < elc_params.far_cut && q <= n_scycache; q++) {
@@ -1078,7 +1077,6 @@ void ELC_add_force(const ParticleRange &particles) {
     setup_Q(q, omega, particles);
     distribute(4);
     add_Q_force(particles);
-    checkpoint("************distri q", 0, q, 2);
   }
 
   for (p = 1; ux * (p - 1) < elc_params.far_cut && p <= n_scxcache; p++) {
@@ -1090,7 +1088,6 @@ void ELC_add_force(const ParticleRange &particles) {
       setup_PQ(p, q, omega, particles);
       distribute(8);
       add_PQ_force(p, q, omega, particles);
-      checkpoint("************distri pq", p, q, 4);
     }
   }
 
@@ -1113,14 +1110,12 @@ double ELC_energy(const ParticleRange &particles) {
     setup_P(p, omega, particles);
     distribute(4);
     eng += P_energy(omega);
-    checkpoint("E************distri p", p, 0, 2);
   }
   for (q = 1; uy * (q - 1) < elc_params.far_cut && q <= n_scycache; q++) {
     omega = C_2PI * uy * q;
     setup_Q(q, omega, particles);
     distribute(4);
     eng += Q_energy(omega);
-    checkpoint("E************distri q", 0, q, 2);
   }
   for (p = 1; ux * (p - 1) < elc_params.far_cut && p <= n_scxcache; p++) {
     for (q = 1; Utils::sqr(ux * (p - 1)) + Utils::sqr(uy * (q - 1)) <
@@ -1131,7 +1126,6 @@ double ELC_energy(const ParticleRange &particles) {
       setup_PQ(p, q, omega, particles);
       distribute(8);
       eng += PQ_energy(omega);
-      checkpoint("E************distri pq", p, q, 4);
     }
   }
   /* we count both i<->j and j<->i, so return just half of it */

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -39,9 +39,6 @@
 
 #ifdef P3M
 
-// #define CHECKPOINTS
-// #define LOG_FORCES
-
 /****************************************
  * LOCAL DEFINES
  ****************************************/
@@ -238,37 +235,6 @@ void distribute(int size) {
   copy_vec(send_buf, gblcblk, size);
   MPI_Allreduce(send_buf, gblcblk, size, MPI_DOUBLE, MPI_SUM, comm_cart);
 }
-
-#ifdef CHECKPOINTS
-static void checkpoint(char *text, int p, int q, int e_size) {
-  int c, i;
-  fprintf(stderr, "%d: %s %d %d\n", this_node, text, p, q);
-
-  fprintf(stderr, "partblk\n");
-  for (c = 0; c < n_localpart; c++) {
-    fprintf(stderr, "%d", c);
-    for (i = 0; i < e_size; i++)
-      fprintf(stderr, " %10.3g", block(partblk.data(), c, 2 * e_size)[i]);
-    fprintf(stderr, " m");
-    for (i = 0; i < e_size; i++)
-      fprintf(stderr, " %10.3g",
-              block(partblk.data(), c, 2 * e_size)[i + e_size]);
-    fprintf(stderr, "\n");
-  }
-  fprintf(stderr, "\n");
-
-  fprintf(stderr, "gblcblk\n");
-  for (i = 0; i < e_size; i++)
-    fprintf(stderr, " %10.3g", gblcblk[i]);
-  fprintf(stderr, " m");
-  for (i = 0; i < e_size; i++)
-    fprintf(stderr, " %10.3g", gblcblk[i + e_size]);
-  fprintf(stderr, "\n");
-}
-
-#else
-#define checkpoint(text, p, q, size)
-#endif
 
 #ifdef LOG_FORCES
 static void clear_log_forces(char *where, const ParticleRange &particles) {

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -236,20 +236,6 @@ void distribute(int size) {
   MPI_Allreduce(send_buf, gblcblk, size, MPI_DOUBLE, MPI_SUM, comm_cart);
 }
 
-#ifdef LOG_FORCES
-static void clear_log_forces(char *where, const ParticleRange &particles) {
-  fprintf(stderr, "%s\n", where);
-  for (auto &p : particles) {
-    fprintf(stderr, "%d %g %g %g\n", p.p.identity, p.f.f[0], p.f.f[1],
-            p.f.f[2]);
-    for (int j = 0; j < 3; j++)
-      p.f.f[j] = 0;
-  }
-}
-#else
-#define clear_log_forces(w, particles)
-#endif
-
 /*****************************************************************/
 /* dipole terms */
 /*****************************************************************/
@@ -1019,16 +1005,8 @@ void ELC_add_force(const ParticleRange &particles) {
 
   prepare_scx_cache(particles);
   prepare_scy_cache(particles);
-
-  clear_log_forces("start", particles);
-
   add_dipole_force(particles);
-
-  clear_log_forces("dipole", particles);
-
   add_z_force(particles);
-
-  clear_log_forces("z_force", particles);
 
   /* the second condition is just for the case of numerical accident */
   for (p = 1; ux * (p - 1) < elc_params.far_cut && p <= n_scxcache; p++) {
@@ -1056,8 +1034,6 @@ void ELC_add_force(const ParticleRange &particles) {
       add_PQ_force(p, q, omega, particles);
     }
   }
-
-  clear_log_forces("end", particles);
 }
 
 double ELC_energy(const ParticleRange &particles) {

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -252,7 +252,8 @@ static void setup_Q(int q, double omega, double fac);
 static void add_Q_force();
 static double Q_energy(double omega);
 /** p,q <> 0 per frequency code */
-static void setup_PQ(int p, int q, double omega, double fac);
+static void setup_PQ(int p, int q, double omega, double fac,
+                     const int n_localpart);
 static void add_PQ_force(int p, int q, double omega);
 static double PQ_energy(double omega);
 
@@ -615,8 +616,8 @@ static double z_energy(const ParticleRange &particles) {
   return eng;
 }
 
-static void setup(int p, double omega, double fac, int n_sccache,
-                  Utils::Span<const SCCache> sccache) {
+static void setup(int p, double omega, double fac,
+                  Utils::Span<const SCCache> sccache, const int n_localpart) {
   int np, c, i, ic, o = (p - 1) * n_localpart;
   Particle *part;
   double pref = coulomb.prefactor * 4 * M_PI * ux * uy * fac * fac;
@@ -737,12 +738,12 @@ static void setup(int p, double omega, double fac, int n_sccache,
 /* PoQ exp sum */
 /*****************************************************************/
 static void setup_P(int p, double omega, double fac) {
-  setup(p, omega, fac, n_scxcache, scxcache);
+  setup(p, omega, fac, scxcache, n_localpart);
 }
 
 /* compare setup_P */
 static void setup_Q(int q, double omega, double fac) {
-  setup(q, omega, fac, n_scycache, scycache);
+  setup(q, omega, fac, scycache, n_localpart);
 }
 
 template <size_t dir> static void add_force() {
@@ -821,7 +822,8 @@ static double Q_energy(double omega) {
 /*****************************************************************/
 
 /* compare setup_P */
-static void setup_PQ(int p, int q, double omega, double fac) {
+static void setup_PQ(int p, int q, double omega, double fac,
+                     const int n_localpart) {
   int np, c, i, ic, ox = (p - 1) * n_localpart, oy = (q - 1) * n_localpart;
   Particle *part;
   double pref = coulomb.prefactor * 8 * M_PI * ux * uy * fac * fac;
@@ -1077,7 +1079,7 @@ static void add_force_contribution(int p, int q,
   } else {
     omega = C_2PI * sqrt(Utils::sqr(ux * p) + Utils::sqr(uy * q));
     fac = exp(-omega * layer_h);
-    setup_PQ(p, q, omega, fac);
+    setup_PQ(p, q, omega, fac, n_localpart);
     if (mmm2d_params.dielectric_contrast_on)
       gather_image_contributions(4);
     else
@@ -1122,7 +1124,7 @@ static double energy_contribution(int p, int q,
   } else {
     omega = C_2PI * sqrt(Utils::sqr(ux * p) + Utils::sqr(uy * q));
     fac = exp(-omega * layer_h);
-    setup_PQ(p, q, omega, fac);
+    setup_PQ(p, q, omega, fac, n_localpart);
     if (mmm2d_params.dielectric_contrast_on)
       gather_image_contributions(4);
     else

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -42,6 +42,7 @@
 
 #include <boost/range/algorithm/transform.hpp>
 
+#include <boost/range/numeric.hpp>
 #include <cmath>
 #include <mpi.h>
 #include <numeric>
@@ -504,31 +505,29 @@ static void setup_z_force() {
 
   /* calculate local cellblks. partblks don't make sense */
   for (int c = 1; c <= local_cells.n; c++) {
-    auto np = cells[c].n;
-    auto part = cells[c].part;
-    lclcblk[size * c] = 0;
-    for (int i = 0; i < np; i++) {
-      lclcblk[size * c] += part[i].p.q;
-    }
-    lclcblk[size * c] *= pref;
+    auto cell = local_cells[c - 1];
+
+    lclcblk[size * c] = pref * boost::accumulate(cell->particles(), 0.,
+                                                 [](double Q, auto const &p) {
+                                                   return Q + p.p.q;
+                                                 });
+
     lclcblk[size * c + 1] = lclcblk[size * c];
   }
 }
 
 static void add_z_force(const ParticleRange &particles) {
-  double add;
-  double *othcblk;
-  int size = 2;
+  auto constexpr size = 2;
   double field_tot = 0;
 
   /* Const. potential: subtract global dipole moment */
   if (mmm2d_params.const_pot) {
-    double gbl_dm_z = 0;
     double lcl_dm_z = 0;
     for (auto const &p : particles) {
       lcl_dm_z += p.p.q * (p.r.p[2] + p.l.i[2] * box_geo.length()[2]);
     }
 
+    double gbl_dm_z = 0;
     MPI_Allreduce(&lcl_dm_z, &gbl_dm_z, 1, MPI_DOUBLE, MPI_SUM, comm_cart);
 
     coulomb.field_induced =
@@ -538,21 +537,19 @@ static void add_z_force(const ParticleRange &particles) {
   }
 
   for (int c = 1; c <= local_cells.n; c++) {
-    othcblk = block(gblcblk, c - 1, size);
-    add = othcblk[QQEQQP] - othcblk[QQEQQM];
-    auto np = cells[c].n;
-    auto part = cells[c].part;
-    for (int i = 0; i < np; i++) {
-      part[i].f.f[2] += part[i].p.q * (add + field_tot);
+    auto othcblk = block(gblcblk, c - 1, size);
+    auto const add = othcblk[QQEQQP] - othcblk[QQEQQM];
+    auto cell = local_cells[c - 1];
+
+    for (auto &p : cell->particles()) {
+      p.f.f[2] += p.p.q * (add + field_tot);
     }
   }
 }
 
 static void setup_z_energy() {
-  int np, c, i;
-  double pref = -coulomb.prefactor * C_2PI * ux * uy;
-  Particle *part;
-  int e_size = 2, size = 4;
+  const double pref = -coulomb.prefactor * C_2PI * ux * uy;
+  constexpr int e_size = 2, size = 4;
 
   if (this_node == 0)
     /* the lowest lclcblk does not contain anything, since there are no charges
@@ -564,14 +561,15 @@ static void setup_z_energy() {
     clear_vec(abventry(lclcblk, local_cells.n + 1, e_size), e_size);
 
   /* calculate local cellblks. partblks don't make sense */
-  for (c = 1; c <= local_cells.n; c++) {
-    np = cells[c].n;
-    part = cells[c].part;
+  for (int c = 1; c <= local_cells.n; c++) {
+    auto cell = local_cells[c - 1];
+
     clear_vec(blwentry(lclcblk, c, e_size), e_size);
-    for (i = 0; i < np; i++) {
-      lclcblk[size * c + ABEQQP] += part[i].p.q;
-      lclcblk[size * c + ABEQZP] += part[i].p.q * part[i].r.p[2];
+    for (auto const &p : cell->particles()) {
+      lclcblk[size * c + ABEQQP] += p.p.q;
+      lclcblk[size * c + ABEQZP] += p.p.q * p.r.p[2];
     }
+
     scale_vec(pref, blwentry(lclcblk, c, e_size), e_size);
     /* just to be able to use the standard distribution. Here below
        and above terms are the same */
@@ -581,18 +579,15 @@ static void setup_z_energy() {
 }
 
 static double z_energy(const ParticleRange &particles) {
-  int np, c, i;
-  Particle *part;
-  double *othcblk;
-  int size = 4;
+  constexpr int size = 4;
   double eng = 0;
-  for (c = 1; c <= local_cells.n; c++) {
-    othcblk = block(gblcblk, c - 1, size);
-    np = cells[c].n;
-    part = cells[c].part;
-    for (i = 0; i < np; i++) {
-      eng += part[i].p.q * (part[i].r.p[2] * othcblk[ABEQQP] - othcblk[ABEQZP] -
-                            part[i].r.p[2] * othcblk[ABEQQM] + othcblk[ABEQZM]);
+  for (int c = 1; c <= local_cells.n; c++) {
+    auto othcblk = block(gblcblk, c - 1, size);
+    auto cell = local_cells[c - 1];
+
+    for (auto const &p : cell->particles()) {
+      eng += p.p.q * (p.r.p[2] * othcblk[ABEQQP] - othcblk[ABEQZP] -
+                      p.r.p[2] * othcblk[ABEQQM] + othcblk[ABEQZM]);
     }
   }
 
@@ -619,19 +614,15 @@ static double z_energy(const ParticleRange &particles) {
 
 static void setup(int p, double omega, double fac,
                   Utils::Span<const SCCache> sccache, const int n_localpart) {
-  int np, c, i, ic, o = (p - 1) * n_localpart;
-  Particle *part;
-  double pref = coulomb.prefactor * 4 * M_PI * ux * uy * fac * fac;
-  double h = box_geo.length()[2];
-  double fac_imgsum = 1 / (1 - mmm2d_params.delta_mult * exp(-omega * 2 * h));
-  double fac_delta_mid_bot = mmm2d_params.delta_mid_bot * fac_imgsum;
-  double fac_delta_mid_top = mmm2d_params.delta_mid_top * fac_imgsum;
-  double fac_delta = mmm2d_params.delta_mult * fac_imgsum;
-  double layer_top;
-  double e, e_di_l, e_di_h;
-  double *llclcblk;
-  double *lclimgebot = nullptr, *lclimgetop = nullptr;
-  int e_size = 2, size = 4;
+  auto const o = (p - 1) * n_localpart;
+  const double pref = coulomb.prefactor * 4 * M_PI * ux * uy * fac * fac;
+  const double h = box_geo.length()[2];
+  const double fac_imgsum =
+      1 / (1 - mmm2d_params.delta_mult * exp(-omega * 2 * h));
+  const double fac_delta_mid_bot = mmm2d_params.delta_mid_bot * fac_imgsum;
+  const double fac_delta_mid_top = mmm2d_params.delta_mid_top * fac_imgsum;
+  const double fac_delta = mmm2d_params.delta_mult * fac_imgsum;
+  constexpr int e_size = 2, size = 4;
 
   if (mmm2d_params.dielectric_contrast_on)
     clear_vec(lclimge, size);
@@ -640,81 +631,82 @@ static void setup(int p, double omega, double fac,
     /* on the lowest node, clear the lclcblk below, which only contains the
        images of the lowest layer
        if there is dielectric contrast, otherwise it is empty */
-    lclimgebot = block(lclcblk, 0, size);
     clear_vec(blwentry(lclcblk, 0, e_size), e_size);
   }
   if (this_node == n_nodes - 1) {
     /* same for the top node */
-    lclimgetop = block(lclcblk, local_cells.n + 1, size);
     clear_vec(abventry(lclcblk, local_cells.n + 1, e_size), e_size);
   }
 
-  layer_top = local_geo.my_left()[2] + layer_h;
-  ic = 0;
-  for (c = 1; c <= local_cells.n; c++) {
-    np = cells[c].n;
-    part = cells[c].part;
-    llclcblk = block(lclcblk, c, size);
+  auto layer_top = local_geo.my_left()[2] + layer_h;
+  int ic = 0;
+  for (int c = 1; c <= local_cells.n; c++) {
+    auto llclcblk = block(lclcblk, c, size);
 
     clear_vec(llclcblk, size);
 
-    for (i = 0; i < np; i++) {
-      e = exp(omega * (part[i].r.p[2] - layer_top));
+    auto cell = local_cells[c - 1];
+    for (auto const &p : cell->particles()) {
+      auto const e = exp(omega * (p.r.p[2] - layer_top));
 
-      partblk[size * ic + POQESM] = part[i].p.q * sccache[o + ic].s / e;
-      partblk[size * ic + POQESP] = part[i].p.q * sccache[o + ic].s * e;
-      partblk[size * ic + POQECM] = part[i].p.q * sccache[o + ic].c / e;
-      partblk[size * ic + POQECP] = part[i].p.q * sccache[o + ic].c * e;
+      partblk[size * ic + POQESM] = p.p.q * sccache[o + ic].s / e;
+      partblk[size * ic + POQESP] = p.p.q * sccache[o + ic].s * e;
+      partblk[size * ic + POQECM] = p.p.q * sccache[o + ic].c / e;
+      partblk[size * ic + POQECP] = p.p.q * sccache[o + ic].c * e;
 
       /* take images due to different dielectric constants into account */
       if (mmm2d_params.dielectric_contrast_on) {
+        double e_di_l;
         if (c == 1 && this_node == 0) {
           /* There are image charges at -(2h+z) and -(2h-z) etc. layer_h
              included due to the shift in z */
-          e_di_l = (exp(omega * (-part[i].r.p[2] - 2 * h + layer_h)) *
+          e_di_l = (exp(omega * (-p.r.p[2] - 2 * h + layer_h)) *
                         mmm2d_params.delta_mid_bot +
-                    exp(omega * (part[i].r.p[2] - 2 * h + layer_h))) *
+                    exp(omega * (p.r.p[2] - 2 * h + layer_h))) *
                    fac_delta;
 
-          e = exp(omega * (-part[i].r.p[2])) * mmm2d_params.delta_mid_bot;
-
-          lclimgebot[POQESP] += part[i].p.q * sccache[o + ic].s * e;
-          lclimgebot[POQECP] += part[i].p.q * sccache[o + ic].c * e;
-        } else
+          auto const e = exp(omega * (-p.r.p[2])) * mmm2d_params.delta_mid_bot;
+          auto lclimgebot = block(lclcblk, 0, size);
+          lclimgebot[POQESP] += p.p.q * sccache[o + ic].s * e;
+          lclimgebot[POQECP] += p.p.q * sccache[o + ic].c * e;
+        } else {
           /* There are image charges at -(z) and -(2h-z) etc. layer_h included
            * due to the shift in z */
-          e_di_l = (exp(omega * (-part[i].r.p[2] + layer_h)) +
-                    exp(omega * (part[i].r.p[2] - 2 * h + layer_h)) *
+          e_di_l = (exp(omega * (-p.r.p[2] + layer_h)) +
+                    exp(omega * (p.r.p[2] - 2 * h + layer_h)) *
                         mmm2d_params.delta_mid_top) *
                    fac_delta_mid_bot;
+        }
 
+        double e_di_h;
         if (c == local_cells.n && this_node == n_nodes - 1) {
           /* There are image charges at (3h-z) and (h+z) from the top layer etc.
              layer_h included due to the shift in z */
-          e_di_h = (exp(omega * (part[i].r.p[2] - 3 * h + 2 * layer_h)) *
+          e_di_h = (exp(omega * (p.r.p[2] - 3 * h + 2 * layer_h)) *
                         mmm2d_params.delta_mid_top +
-                    exp(omega * (-part[i].r.p[2] - h + 2 * layer_h))) *
+                    exp(omega * (-p.r.p[2] - h + 2 * layer_h))) *
                    fac_delta;
 
           /* There are image charges at (h-z) layer_h included due to the shift
            * in z */
-          e = exp(omega * (part[i].r.p[2] - h + layer_h)) *
-              mmm2d_params.delta_mid_top;
+          auto e = exp(omega * (p.r.p[2] - h + layer_h)) *
+                   mmm2d_params.delta_mid_top;
 
-          lclimgetop[POQESM] += part[i].p.q * sccache[o + ic].s * e;
-          lclimgetop[POQECM] += part[i].p.q * sccache[o + ic].c * e;
+          auto lclimgetop = block(lclcblk, local_cells.n + 1, size);
+          lclimgetop[POQESM] += p.p.q * sccache[o + ic].s * e;
+          lclimgetop[POQECM] += p.p.q * sccache[o + ic].c * e;
         } else
           /* There are image charges at (h-z) and (h+z) from the top layer etc.
              layer_h included due to the shift in z */
-          e_di_h = (exp(omega * (part[i].r.p[2] - h + 2 * layer_h)) +
-                    exp(omega * (-part[i].r.p[2] - h + 2 * layer_h)) *
+          e_di_h = (exp(omega * (p.r.p[2] - h + 2 * layer_h)) +
+                    exp(omega * (-p.r.p[2] - h + 2 * layer_h)) *
                         mmm2d_params.delta_mid_bot) *
                    fac_delta_mid_top;
 
-        lclimge[POQESP] += part[i].p.q * sccache[o + ic].s * e_di_l;
-        lclimge[POQECP] += part[i].p.q * sccache[o + ic].c * e_di_l;
-        lclimge[POQESM] += part[i].p.q * sccache[o + ic].s * e_di_h;
-        lclimge[POQECM] += part[i].p.q * sccache[o + ic].c * e_di_h;
+        lclimge[POQESP] += p.p.q * sccache[o + ic].s * e_di_l;
+        lclimge[POQECP] += p.p.q * sccache[o + ic].c * e_di_l;
+        lclimge[POQESM] += p.p.q * sccache[o + ic].s * e_di_h;
+        lclimge[POQECM] += p.p.q * sccache[o + ic].c * e_di_h;
       }
 
       add_vec(llclcblk, llclcblk, block(partblk, ic, size), size);
@@ -751,20 +743,19 @@ template <size_t dir> static void add_force() {
   constexpr const auto size = 4;
 
   auto ic = 0;
-  for (int c = 1; c <= local_cells.n; c++) {
-    auto const np = cells[c].n;
-    auto const part = cells[c].part;
-    auto const othcblk = block(gblcblk, c - 1, size);
+  for (int c = 0; c < local_cells.n; c++) {
+    auto const othcblk = block(gblcblk, c, size);
 
-    for (int i = 0; i < np; i++) {
-      part[i].f.f[dir] += partblk[size * ic + POQESM] * othcblk[POQECP] -
-                          partblk[size * ic + POQECM] * othcblk[POQESP] +
-                          partblk[size * ic + POQESP] * othcblk[POQECM] -
-                          partblk[size * ic + POQECP] * othcblk[POQESM];
-      part[i].f.f[2] += partblk[size * ic + POQECM] * othcblk[POQECP] +
-                        partblk[size * ic + POQESM] * othcblk[POQESP] -
-                        partblk[size * ic + POQECP] * othcblk[POQECM] -
-                        partblk[size * ic + POQESP] * othcblk[POQESM];
+    auto cell = local_cells[c];
+    for (auto &p : cell->particles()) {
+      p.f.f[dir] += partblk[size * ic + POQESM] * othcblk[POQECP] -
+                    partblk[size * ic + POQECM] * othcblk[POQESP] +
+                    partblk[size * ic + POQESP] * othcblk[POQECM] -
+                    partblk[size * ic + POQECP] * othcblk[POQESM];
+      p.f.f[2] += partblk[size * ic + POQECM] * othcblk[POQECP] +
+                  partblk[size * ic + POQESM] * othcblk[POQESP] -
+                  partblk[size * ic + POQECP] * othcblk[POQECM] -
+                  partblk[size * ic + POQESP] * othcblk[POQESM];
       ic++;
     }
   }
@@ -774,17 +765,15 @@ static void add_P_force() { add_force<0>(); }
 static void add_Q_force() { add_force<1>(); }
 
 static double P_energy(double omega) {
-  int np, c, i, ic;
-  double *othcblk;
-  int size = 4;
+  const int size = 4;
   double eng = 0;
   double pref = 1 / omega;
 
-  ic = 0;
-  for (c = 1; c <= local_cells.n; c++) {
-    np = cells[c].n;
-    othcblk = block(gblcblk, c - 1, size);
-    for (i = 0; i < np; i++) {
+  auto ic = 0;
+  for (int c = 0; c < local_cells.n; c++) {
+    auto const othcblk = block(gblcblk, c, size);
+    auto cell = local_cells[c];
+    for (int i = 0; i < cell->particles().size(); i++) {
       eng += pref * (partblk[size * ic + POQECM] * othcblk[POQECP] +
                      partblk[size * ic + POQESM] * othcblk[POQESP] +
                      partblk[size * ic + POQECP] * othcblk[POQECM] +
@@ -796,18 +785,16 @@ static double P_energy(double omega) {
 }
 
 static double Q_energy(double omega) {
-  int np, c, i, ic;
-  double *othcblk;
-  int size = 4;
+  constexpr int size = 4;
   double eng = 0;
-  double pref = 1 / omega;
+  const double pref = 1 / omega;
 
-  ic = 0;
-  for (c = 1; c <= local_cells.n; c++) {
-    np = cells[c].n;
-    othcblk = block(gblcblk, c - 1, size);
+  auto ic = 0;
+  for (int c = 0; c < local_cells.n; c++) {
+    auto cell = local_cells[c];
+    auto othcblk = block(gblcblk, c, size);
 
-    for (i = 0; i < np; i++) {
+    for (int i = 0; i < cell->particles().size(); i++) {
       eng += pref * (partblk[size * ic + POQECM] * othcblk[POQECP] +
                      partblk[size * ic + POQESM] * othcblk[POQESP] +
                      partblk[size * ic + POQECP] * othcblk[POQECM] +

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -1188,13 +1188,10 @@ double MMM2D_add_far(int f, int e, const ParticleRange &particles) {
       undone[p] = q;
     }
   }
-  // printf("yyyy\n");
   /* clean up left overs */
   for (p = n_scxcache; p >= 0; p--) {
     q = undone[p];
-    // fprintf(stderr, "left over %d\n", q);
     for (; q >= 0; q--) {
-      // printf("xxxxx %d %d\n", p, q);
       if (f)
         add_force_contribution(p, q, particles);
       if (e)
@@ -1212,14 +1209,10 @@ static int MMM2D_tune_far(double error) {
   do {
     err = exp(-2 * M_PI * mmm2d_params.far_cut * min_far) / min_far *
           (C_2PI * mmm2d_params.far_cut + 2 * (ux + uy) + 1 / min_far);
-    // fprintf(stderr, "far tuning: %f -> %f, %f\n", mmm2d_params.far_cut, err,
-    // min_far);
     mmm2d_params.far_cut += min_inv_boxl;
   } while (err > error && mmm2d_params.far_cut * layer_h < MAXIMAL_FAR_CUT);
   if (mmm2d_params.far_cut * layer_h >= MAXIMAL_FAR_CUT)
     return ERROR_FARC;
-  // fprintf(stderr, "far cutoff %g %g %g\n", mmm2d_params.far_cut, err,
-  // min_far);
   mmm2d_params.far_cut -= min_inv_boxl;
   mmm2d_params.far_cut2 = Utils::sqr(mmm2d_params.far_cut);
   return 0;
@@ -1267,8 +1260,6 @@ static int MMM2D_tune_near(double error) {
   if (P == MAXIMAL_B_CUT)
     return ERROR_BESSEL;
 
-  // fprintf(stderr, "bessel cutoff %d %g\n", P, err);
-
   besselCutoff.resize(P);
   for (p = 1; p < P; p++)
     besselCutoff[p - 1] = (int)floor(((double)P) / (2 * p)) + 1;
@@ -1295,7 +1286,6 @@ static int MMM2D_tune_near(double error) {
   } while (err > 0.1 * part_error && n < MAXIMAL_POLYGAMMA);
   if (n == MAXIMAL_POLYGAMMA)
     return ERROR_POLY;
-  // fprintf(stderr, "polygamma cutoff %d %g\n", n, err);
 
   return 0;
 }
@@ -1400,7 +1390,6 @@ void add_mmm2d_coulomb_pair_force(double pref, Utils::Vector3d const &d,
       F[1] += c * k1ySum;
       F[2] += d[2] * c * k1Sum;
     }
-    // fprintf(stderr, " bessel force %f %f %f\n", F[0], F[1], F[2]);
   }
 
   /* complex sum */
@@ -1437,7 +1426,6 @@ void add_mmm2d_coulomb_pair_force(double pref, Utils::Vector3d const &d,
       ztn_i = ztn_r * zet2_i + ztn_i * zet2_r;
       ztn_r = tmp_r;
     }
-    // fprintf(stderr, "complex force %f %f %f %d\n", F[0], F[1], F[2], end);
   }
 
   /* psi sum */
@@ -1468,7 +1456,6 @@ void add_mmm2d_coulomb_pair_force(double pref, Utils::Vector3d const &d,
 
       uxrho_2nm2 = uxrho_2n;
     }
-    // fprintf(stderr, "    psi force %f %f %f %d\n", F[0], F[1], F[2], n);
   }
 
   F *= ux;
@@ -1534,7 +1521,6 @@ inline double calc_mmm2d_copy_pair_energy(Utils::Vector3d const &d) {
       c = 4 * cos(freq * d[0]);
       eng += c * k0Sum;
     }
-    // fprintf(stderr, " bessel energy %f\n", eng);
   }
 
   /* complex sum */
@@ -1568,7 +1554,6 @@ inline double calc_mmm2d_copy_pair_energy(Utils::Vector3d const &d) {
       ztn_i = ztn_r * zet2_i + ztn_i * zet2_r;
       ztn_r = tmp_r;
     }
-    // fprintf(stderr, "complex energy %f %d\n", eng, end);
   }
 
   /* psi sum */
@@ -1591,7 +1576,6 @@ inline double calc_mmm2d_copy_pair_energy(Utils::Vector3d const &d) {
         break;
       uxrho_2n *= uxrho2;
     }
-    // fprintf(stderr, "    psi energy %f %d\n", eng, n);
   }
 
   eng *= ux;
@@ -1791,7 +1775,6 @@ void MMM2D_dielectric_layers_force_contribution() {
     npl = celll->n;
 
     for (i = 0; i < npl; i++) {
-      // printf("enter mmm2d_dielectric %f \n",my_left[2]);
       force = {};
       p1 = &pl[i];
       for (j = 0; j < npl; j++) {

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -1831,10 +1831,10 @@ double MMM2D_dielectric_layers_energy_contribution() {
         Utils::Vector3d d;
         layered_get_mi_vector(d.data(), p1.r.p.data(), a);
         auto const dist2 = d.norm2();
-        auto const charge_factor = mmm2d_params.delta_mid_bot * p1.p.q * p2.p.q;
+        auto const charge_factor = mmm2d_params.delta_mid_top * p1.p.q * p2.p.q;
         /* last term removes unwanted 2 pi |z| part (cancels due to charge
          * neutrality) */
-        eng += mmm2d_coulomb_pair_energy(charge_factor, d, sqrt(dist2)) +
+        eng += mmm2d_coulomb_pair_energy(charge_factor, d, sqrt(dist2)) -
                pref * charge_factor * d[2];
       }
     }

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -384,9 +384,9 @@ inline void add_vec(double *pdc_d, double const *pdc_s1, double const *pdc_s2,
 template <class OutRange, class T, class InRange1, class InRange2>
 void addscale_vec(OutRange out, T scale, InRange1 in1, InRange2 in2) {
   assert(in2.size() == out.size());
-  boost::transform(in1, in2, out.begin(), [scale](auto const&a, auto const&b) {
-      return scale * a + b;
-  } );
+  boost::transform(
+      in1, in2, out.begin(),
+      [scale](auto const &a, auto const &b) { return scale * a + b; });
 }
 
 /** pdc_d = scale*pdc_s1 + pdc_s2 */
@@ -396,14 +396,12 @@ inline void addscale_vec(double *pdc_d, double scale, double const *pdc_s1,
   using Utils::make_span;
 
   addscale_vec(make_span(pdc_d, size), scale, make_const_span(pdc_s1, size),
-          make_const_span(pdc_s2, size));
+               make_const_span(pdc_s2, size));
 }
 
-template<class OutRange, class T>
-void scale_vec(T scale, OutRange out) {
-  boost::transform(out, out.begin(), [scale](auto const&e) {
-    return scale * e;
-  });
+template <class OutRange, class T> void scale_vec(T scale, OutRange out) {
+  boost::transform(out, out.begin(),
+                   [scale](auto const &e) { return scale * e; });
 }
 
 /** pdc_d = scale*pdc */
@@ -447,8 +445,8 @@ void gather_image_contributions(int e_size) {
   Utils::VectorXd<8> recvbuf;
 
   /* collect the image charge contributions with at least a layer distance */
-  boost::mpi::all_reduce(comm_cart, lclimge.data(), 2 * e_size,
-                         recvbuf.data(), std::plus<>{});
+  boost::mpi::all_reduce(comm_cart, lclimge.data(), 2 * e_size, recvbuf.data(),
+                         std::plus<>{});
 
   if (this_node == 0)
     /* the gblcblk contains all contributions from layers deeper than one layer
@@ -459,7 +457,8 @@ void gather_image_contributions(int e_size) {
 
   if (this_node == n_nodes - 1)
     /* same for the top node */
-    copy_vec(abventry(gblcblk, local_cells.n - 1, e_size), recvbuf.data() + e_size, e_size);
+    copy_vec(abventry(gblcblk, local_cells.n - 1, e_size),
+             recvbuf.data() + e_size, e_size);
 }
 
 /* the data transfer routine for the lclcblks itself */

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -33,7 +33,6 @@
 #include "errorhandling.hpp"
 #include "grid.hpp"
 #include "integrate.hpp"
-#include "layered.hpp"
 #include "mmm-common.hpp"
 #include "particle_data.hpp"
 #include "specfunc.hpp"
@@ -119,6 +118,9 @@ static DoubleList bon;
 /*@{*/
 static double ux, ux2, uy, uy2, uz;
 /*@}*/
+
+static double layer_h;
+extern int n_layers;
 
 /** maximal z for near formula, minimal z for far formula.
     Is identical in the theory, but with the Verlet tricks
@@ -269,6 +271,7 @@ void MMM2D_setup_constants() {
   uy = 1 / box_geo.length()[1];
   uy2 = uy * uy;
   uz = 1 / box_geo.length()[2];
+  layer_h = local_geo.length()[2] / local_cells.n;
 
   switch (cell_structure.type) {
   case CELL_STRUCTURE_NSQUARE:

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -1185,7 +1185,7 @@ double MMM2D_add_far(bool calc_forces, bool calc_energies,
       q = n_scycache;
     } else {
       int const q2 = mmm2d_params.far_cut2 - Utils::sqr(ux * (p - 1));
-      q = 1 + (q2 > 0) ? (int)ceil(box_geo.length()[1] * sqrt(q2)) : 0;
+      q = 1 + ((q2 > 0) ? (int)ceil(box_geo.length()[1] * sqrt(q2)) : 0);
       /* just to be on the safe side... */
       if (q > n_scycache)
         q = n_scycache;

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -127,9 +127,6 @@ static double ux, ux2, uy, uy2, uz;
 static double max_near, min_far;
 /*@}*/
 
-///
-static double self_energy;
-
 MMM2D_struct mmm2d_params = {1e100, 10, 1, false, false, false, 0, 1, 1, 1};
 
 /** return codes for \ref MMM2D_tune_near and \ref MMM2D_tune_far */
@@ -232,8 +229,8 @@ double MMM2D_self_energy(const ParticleRange &particles);
 /*@{*/
 
 /** sin/cos storage */
-static void prepare_scx_cache();
-static void prepare_scy_cache();
+static void prepare_scx_cache(const ParticleRange &particles);
+static void prepare_scy_cache(const ParticleRange &particles);
 /** clear the image contributions if there is no dielectric contrast and no
  * image charges */
 static void clear_image_contributions(int size);
@@ -310,11 +307,13 @@ static SCCache sc(double arg) { return {sin(arg), cos(arg)}; }
 
 template <size_t dir>
 static void prepare_sc_cache(std::vector<SCCache> &sccache, double u,
-                             int n_sccache) {
-  for (int freq = 1; freq <= n_sccache; freq++) {
-    auto const o = sccache.begin() + (freq - 1) * n_localpart;
+                             int n_sccache, const ParticleRange &particles) {
+  sccache.resize(n_sccache * particles.size());
 
-    boost::transform(local_cells.particles(), o,
+  for (int freq = 1; freq <= n_sccache; freq++) {
+    auto const o = sccache.begin() + (freq - 1) * particles.size();
+
+    boost::transform(particles, o,
         [pref = C_2PI * u * freq](const Particle &p) {
           auto const arg = pref * p.r.p[dir];
           return sc(arg);
@@ -322,12 +321,12 @@ static void prepare_sc_cache(std::vector<SCCache> &sccache, double u,
   }
 }
 
-static void prepare_scx_cache() {
-  prepare_sc_cache<0>(scxcache, ux, n_scxcache);
+static void prepare_scx_cache(const ParticleRange &particles) {
+  prepare_sc_cache<0>(scxcache, ux, n_scxcache, particles);
 }
 
-static void prepare_scy_cache() {
-  prepare_sc_cache<1>(scycache, uy, n_scycache);
+static void prepare_scy_cache(const ParticleRange &particles) {
+  prepare_sc_cache<1>(scycache, uy, n_scycache, particles);
 }
 
 /*****************************************************************/
@@ -1138,6 +1137,14 @@ double MMM2D_add_far(int f, int e, const ParticleRange &particles) {
   int p, q;
   double R, dR, q2;
 
+  n_localpart = cells_get_n_particles();
+  n_scxcache = (int)(ceil(mmm2d_params.far_cut / ux) + 1);
+  n_scycache = (int)(ceil(mmm2d_params.far_cut / uy) + 1);
+
+  partblk.resize(n_localpart * 8);
+  lclcblk.resize(cells.size() * 8);
+  gblcblk.resize(n_layers * 8);
+
   // It's not really far...
   auto eng = e ? MMM2D_self_energy(local_cells.particles()) : 0;
 
@@ -1146,8 +1153,8 @@ double MMM2D_add_far(int f, int e, const ParticleRange &particles) {
 
   auto undone = std::vector<int>(n_scxcache + 1);
 
-  prepare_scx_cache();
-  prepare_scy_cache();
+  prepare_scx_cache(local_cells.particles());
+  prepare_scy_cache(local_cells.particles());
 
   /* complicated loop. We work through the p,q vectors in rings
      from outside to inside to avoid problems with cancellation */
@@ -1730,22 +1737,6 @@ void MMM2D_init() {
       }
     }
   }
-}
-
-void MMM2D_on_resort_particles(const ParticleRange &particles) {
-  /* if we need MMM2D far formula, allocate caches */
-  if (cell_structure.type == CELL_STRUCTURE_LAYERED) {
-    n_localpart = cells_get_n_particles();
-    n_scxcache = (int)(ceil(mmm2d_params.far_cut / ux) + 1);
-    n_scycache = (int)(ceil(mmm2d_params.far_cut / uy) + 1);
-    scxcache.resize(n_scxcache * n_localpart);
-    scycache.resize(n_scycache * n_localpart);
-
-    partblk.resize(n_localpart * 8);
-    lclcblk.resize(cells.size() * 8);
-    gblcblk.resize(n_layers * 8);
-  }
-  MMM2D_self_energy(particles);
 }
 
 void MMM2D_dielectric_layers_force_contribution() {

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -812,44 +812,38 @@ static double Q_energy(double omega) {
 /* compare setup_P */
 static void setup_PQ(int p, int q, double omega, double fac,
                      const int n_localpart) {
-  int np, c, i, ic, ox = (p - 1) * n_localpart, oy = (q - 1) * n_localpart;
+  int np, ox = (p - 1) * n_localpart, oy = (q - 1) * n_localpart;
   Particle *part;
-  double pref = coulomb.prefactor * 8 * M_PI * ux * uy * fac * fac;
-  double h = box_geo.length()[2];
-  double fac_imgsum = 1 / (1 - mmm2d_params.delta_mult * exp(-omega * 2 * h));
-  double fac_delta_mid_bot = mmm2d_params.delta_mid_bot * fac_imgsum;
-  double fac_delta_mid_top = mmm2d_params.delta_mid_top * fac_imgsum;
-  double fac_delta = mmm2d_params.delta_mult * fac_imgsum;
-  double layer_top;
-  double e, e_di_l, e_di_h;
-  double *llclcblk;
-  double *lclimgebot = nullptr, *lclimgetop = nullptr;
-  int e_size = 4, size = 8;
+  const double pref = coulomb.prefactor * 8 * M_PI * ux * uy * fac * fac;
+  const double h = box_geo.length()[2];
+  const double fac_imgsum = 1 / (1 - mmm2d_params.delta_mult * exp(-omega * 2 * h));
+  const double fac_delta_mid_bot = mmm2d_params.delta_mid_bot * fac_imgsum;
+  const double fac_delta_mid_top = mmm2d_params.delta_mid_top * fac_imgsum;
+  const double fac_delta = mmm2d_params.delta_mult * fac_imgsum;
+  constexpr int e_size = 4, size = 8;
 
   if (mmm2d_params.dielectric_contrast_on)
     clear_vec(lclimge, size);
 
   if (this_node == 0) {
-    lclimgebot = block(lclcblk, 0, size);
     clear_vec(blwentry(lclcblk, 0, e_size), e_size);
   }
 
   if (this_node == n_nodes - 1) {
-    lclimgetop = block(lclcblk, local_cells.n + 1, size);
     clear_vec(abventry(lclcblk, local_cells.n + 1, e_size), e_size);
   }
 
-  layer_top = local_geo.my_left()[2] + layer_h;
-  ic = 0;
-  for (c = 1; c <= local_cells.n; c++) {
+  auto layer_top = local_geo.my_left()[2] + layer_h;
+  int ic = 0;
+  for (int c = 1; c <= local_cells.n; c++) {
     np = cells[c].n;
     part = cells[c].part;
-    llclcblk = block(lclcblk, c, size);
+    auto const llclcblk = block(lclcblk, c, size);
 
     clear_vec(llclcblk, size);
 
-    for (i = 0; i < np; i++) {
-      e = exp(omega * (part[i].r.p[2] - layer_top));
+    for (int i = 0; i < np; i++) {
+      auto const e = exp(omega * (part[i].r.p[2] - layer_top));
 
       partblk[size * ic + PQESSM] =
           scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q / e;
@@ -870,45 +864,49 @@ static void setup_PQ(int p, int q, double omega, double fac,
           scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e;
 
       if (mmm2d_params.dielectric_contrast_on) {
+        double e_di_l;
         if (c == 1 && this_node == 0) {
           e_di_l = (exp(omega * (-part[i].r.p[2] - 2 * h + layer_h)) *
                         mmm2d_params.delta_mid_bot +
                     exp(omega * (part[i].r.p[2] - 2 * h + layer_h))) *
                    fac_delta;
 
-          e = exp(omega * (-part[i].r.p[2])) * mmm2d_params.delta_mid_bot;
+          auto const e_di = exp(omega * (-part[i].r.p[2])) * mmm2d_params.delta_mid_bot;
 
+          auto const lclimgebot = block(lclcblk, 0, size);
           lclimgebot[PQESSP] +=
-              scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e;
+              scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e_di;
           lclimgebot[PQESCP] +=
-              scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e;
+              scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e_di;
           lclimgebot[PQECSP] +=
-              scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e;
+              scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e_di;
           lclimgebot[PQECCP] +=
-              scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e;
+              scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e_di;
         } else
           e_di_l = (exp(omega * (-part[i].r.p[2] + layer_h)) +
                     exp(omega * (part[i].r.p[2] - 2 * h + layer_h)) *
                         mmm2d_params.delta_mid_top) *
                    fac_delta_mid_bot;
 
+        double e_di_h;
         if (c == local_cells.n && this_node == n_nodes - 1) {
           e_di_h = (exp(omega * (part[i].r.p[2] - 3 * h + 2 * layer_h)) *
                         mmm2d_params.delta_mid_top +
                     exp(omega * (-part[i].r.p[2] - h + 2 * layer_h))) *
                    fac_delta;
 
-          e = exp(omega * (part[i].r.p[2] - h + layer_h)) *
+          auto const e_di = exp(omega * (part[i].r.p[2] - h + layer_h)) *
               mmm2d_params.delta_mid_top;
 
+          auto const lclimgetop = block(lclcblk, local_cells.n + 1, size);
           lclimgetop[PQESSM] +=
-              scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e;
+              scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e_di;
           lclimgetop[PQESCM] +=
-              scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e;
+              scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e_di;
           lclimgetop[PQECSM] +=
-              scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e;
+              scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e_di;
           lclimgetop[PQECCM] +=
-              scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e;
+              scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e_di;
         } else
           e_di_h = (exp(omega * (part[i].r.p[2] - h + 2 * layer_h)) +
                     exp(omega * (-part[i].r.p[2] - h + 2 * layer_h)) *

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -41,6 +41,8 @@
 #include <utils/constants.hpp>
 #include <utils/math/sqr.hpp>
 
+#include <boost/range/algorithm/transform.hpp>
+
 #include <cmath>
 #include <mpi.h>
 #include <numeric>
@@ -221,7 +223,7 @@ static void prepareBernoulliNumbers(int nmax);
 static int MMM2D_tune_near(double error);
 
 /** energy of all local particles with their copies */
-void MMM2D_self_energy(const ParticleRange &particles);
+double MMM2D_self_energy(const ParticleRange &particles);
 
 /*@}*/
 
@@ -310,19 +312,13 @@ template <size_t dir>
 static void prepare_sc_cache(std::vector<SCCache> &sccache, double u,
                              int n_sccache) {
   for (int freq = 1; freq <= n_sccache; freq++) {
-    auto const pref = C_2PI * u * freq;
-    auto const o = (freq - 1) * n_localpart;
+    auto const o = sccache.begin() + (freq - 1) * n_localpart;
 
-    int ic = 0;
-    for (int c = 1; c <= n_layers; c++) {
-      auto const np = cells[c].n;
-      auto part = cells[c].part;
-      for (int i = 0; i < np; i++) {
-        auto const arg = pref * part[i].r.p[dir];
-        sccache[o + ic] = sc(arg);
-        ic++;
-      }
-    }
+    boost::transform(local_cells.particles(), o,
+        [pref = C_2PI * u * freq](const Particle &p) {
+          auto const arg = pref * p.r.p[dir];
+          return sc(arg);
+    });
   }
 }
 
@@ -1143,7 +1139,7 @@ double MMM2D_add_far(int f, int e, const ParticleRange &particles) {
   double R, dR, q2;
 
   // It's not really far...
-  auto eng = e ? self_energy : 0;
+  auto eng = e ? MMM2D_self_energy(local_cells.particles()) : 0;
 
   if (mmm2d_params.far_cut == 0.0)
     return 0.5 * eng;
@@ -1602,19 +1598,17 @@ double mmm2d_coulomb_pair_energy(double charge_factor,
   return 0.0;
 }
 
-void MMM2D_self_energy(const ParticleRange &particles) {
+double MMM2D_self_energy(const ParticleRange &particles) {
   Utils::Vector3d dv{};
   double seng = coulomb.prefactor * calc_mmm2d_copy_pair_energy(dv);
 
   /* this one gives twice the real self energy, as it is used
      in the far formula which counts everything twice and in
      the end divides by two*/
-
-  auto parts = particles;
-  self_energy = std::accumulate(parts.begin(), parts.end(), 0.0,
-                                [seng](double sum, Particle const &p) {
-                                  return sum + seng * Utils::sqr(p.p.q);
-                                });
+  return std::accumulate(particles.begin(), particles.end(), 0.0,
+                         [seng](double sum, Particle const &p) {
+                           return sum + seng * Utils::sqr(p.p.q);
+                         });
 }
 
 /****************************************

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -873,101 +873,102 @@ static void setup_PQ(int p, int q, double omega, double fac,
   auto layer_top = local_geo.my_left()[2] + layer_h;
   int ic = 0;
   for (int c = 1; c <= local_cells.n; c++) {
-    np = cells[c].n;
-    part = cells[c].part;
     auto const llclcblk = block(lclcblk, c, size);
 
     clear_vec(llclcblk, size);
 
-    for (int i = 0; i < np; i++) {
-      auto const e = exp(omega * (part[i].r.p[2] - layer_top));
+    auto cell = local_cells[c - 1];
+    for (auto const &p : cell->particles()) {
+      auto const e = exp(omega * (p.r.p[2] - layer_top));
 
       partblk[size * ic + PQESSM] =
-          scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q / e;
+          scxcache[ox + ic].s * scycache[oy + ic].s * p.p.q / e;
       partblk[size * ic + PQESCM] =
-          scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q / e;
+          scxcache[ox + ic].s * scycache[oy + ic].c * p.p.q / e;
       partblk[size * ic + PQECSM] =
-          scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q / e;
+          scxcache[ox + ic].c * scycache[oy + ic].s * p.p.q / e;
       partblk[size * ic + PQECCM] =
-          scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q / e;
+          scxcache[ox + ic].c * scycache[oy + ic].c * p.p.q / e;
 
       partblk[size * ic + PQESSP] =
-          scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e;
+          scxcache[ox + ic].s * scycache[oy + ic].s * p.p.q * e;
       partblk[size * ic + PQESCP] =
-          scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e;
+          scxcache[ox + ic].s * scycache[oy + ic].c * p.p.q * e;
       partblk[size * ic + PQECSP] =
-          scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e;
+          scxcache[ox + ic].c * scycache[oy + ic].s * p.p.q * e;
       partblk[size * ic + PQECCP] =
-          scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e;
+          scxcache[ox + ic].c * scycache[oy + ic].c * p.p.q * e;
 
       if (mmm2d_params.dielectric_contrast_on) {
         double e_di_l;
         if (c == 1 && this_node == 0) {
-          e_di_l = (exp(omega * (-part[i].r.p[2] - 2 * h + layer_h)) *
+          e_di_l = (exp(omega * (-p.r.p[2] - 2 * h + layer_h)) *
                         mmm2d_params.delta_mid_bot +
-                    exp(omega * (part[i].r.p[2] - 2 * h + layer_h))) *
+                    exp(omega * (p.r.p[2] - 2 * h + layer_h))) *
                    fac_delta;
 
           auto const e_di =
-              exp(omega * (-part[i].r.p[2])) * mmm2d_params.delta_mid_bot;
+              exp(omega * (-p.r.p[2])) * mmm2d_params.delta_mid_bot;
 
           auto const lclimgebot = block(lclcblk, 0, size);
           lclimgebot[PQESSP] +=
-              scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e_di;
+              scxcache[ox + ic].s * scycache[oy + ic].s * p.p.q * e_di;
           lclimgebot[PQESCP] +=
-              scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e_di;
+              scxcache[ox + ic].s * scycache[oy + ic].c * p.p.q * e_di;
           lclimgebot[PQECSP] +=
-              scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e_di;
+              scxcache[ox + ic].c * scycache[oy + ic].s * p.p.q * e_di;
           lclimgebot[PQECCP] +=
-              scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e_di;
-        } else
-          e_di_l = (exp(omega * (-part[i].r.p[2] + layer_h)) +
-                    exp(omega * (part[i].r.p[2] - 2 * h + layer_h)) *
+              scxcache[ox + ic].c * scycache[oy + ic].c * p.p.q * e_di;
+        } else {
+          e_di_l = (exp(omega * (-p.r.p[2] + layer_h)) +
+                    exp(omega * (p.r.p[2] - 2 * h + layer_h)) *
                         mmm2d_params.delta_mid_top) *
                    fac_delta_mid_bot;
+        }
 
         double e_di_h;
         if (c == local_cells.n && this_node == n_nodes - 1) {
-          e_di_h = (exp(omega * (part[i].r.p[2] - 3 * h + 2 * layer_h)) *
+          e_di_h = (exp(omega * (p.r.p[2] - 3 * h + 2 * layer_h)) *
                         mmm2d_params.delta_mid_top +
-                    exp(omega * (-part[i].r.p[2] - h + 2 * layer_h))) *
+                    exp(omega * (-p.r.p[2] - h + 2 * layer_h))) *
                    fac_delta;
 
-          auto const e_di = exp(omega * (part[i].r.p[2] - h + layer_h)) *
+          auto const e_di = exp(omega * (p.r.p[2] - h + layer_h)) *
                             mmm2d_params.delta_mid_top;
 
           auto const lclimgetop = block(lclcblk, local_cells.n + 1, size);
           lclimgetop[PQESSM] +=
-              scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e_di;
+              scxcache[ox + ic].s * scycache[oy + ic].s * p.p.q * e_di;
           lclimgetop[PQESCM] +=
-              scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e_di;
+              scxcache[ox + ic].s * scycache[oy + ic].c * p.p.q * e_di;
           lclimgetop[PQECSM] +=
-              scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e_di;
+              scxcache[ox + ic].c * scycache[oy + ic].s * p.p.q * e_di;
           lclimgetop[PQECCM] +=
-              scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e_di;
-        } else
-          e_di_h = (exp(omega * (part[i].r.p[2] - h + 2 * layer_h)) +
-                    exp(omega * (-part[i].r.p[2] - h + 2 * layer_h)) *
+              scxcache[ox + ic].c * scycache[oy + ic].c * p.p.q * e_di;
+        } else {
+          e_di_h = (exp(omega * (p.r.p[2] - h + 2 * layer_h)) +
+                    exp(omega * (-p.r.p[2] - h + 2 * layer_h)) *
                         mmm2d_params.delta_mid_bot) *
                    fac_delta_mid_top;
+        }
 
         lclimge[PQESSP] +=
-            scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e_di_l;
+            scxcache[ox + ic].s * scycache[oy + ic].s * p.p.q * e_di_l;
         lclimge[PQESCP] +=
-            scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e_di_l;
+            scxcache[ox + ic].s * scycache[oy + ic].c * p.p.q * e_di_l;
         lclimge[PQECSP] +=
-            scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e_di_l;
+            scxcache[ox + ic].c * scycache[oy + ic].s * p.p.q * e_di_l;
         lclimge[PQECCP] +=
-            scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e_di_l;
+            scxcache[ox + ic].c * scycache[oy + ic].c * p.p.q * e_di_l;
 
         lclimge[PQESSM] +=
-            scxcache[ox + ic].s * scycache[oy + ic].s * part[i].p.q * e_di_h;
+            scxcache[ox + ic].s * scycache[oy + ic].s * p.p.q * e_di_h;
         lclimge[PQESCM] +=
-            scxcache[ox + ic].s * scycache[oy + ic].c * part[i].p.q * e_di_h;
+            scxcache[ox + ic].s * scycache[oy + ic].c * p.p.q * e_di_h;
         lclimge[PQECSM] +=
-            scxcache[ox + ic].c * scycache[oy + ic].s * part[i].p.q * e_di_h;
+            scxcache[ox + ic].c * scycache[oy + ic].s * p.p.q * e_di_h;
         lclimge[PQECCM] +=
-            scxcache[ox + ic].c * scycache[oy + ic].c * part[i].p.q * e_di_h;
+            scxcache[ox + ic].c * scycache[oy + ic].c * p.p.q * e_di_h;
       }
 
       add_vec(llclcblk, llclcblk, block(partblk, ic, size), size);
@@ -990,46 +991,40 @@ static void setup_PQ(int p, int q, double omega, double fac,
 }
 
 static void add_PQ_force(int p, int q, double omega) {
-  int np, c, i, ic;
-  Particle *part;
-  double pref_x = C_2PI * ux * p / omega;
-  double pref_y = C_2PI * uy * q / omega;
-  double *othcblk;
-  int size = 8;
+  const double pref_x = C_2PI * ux * p / omega;
+  const double pref_y = C_2PI * uy * q / omega;
+  constexpr int size = 8;
 
-  ic = 0;
-  for (c = 1; c <= local_cells.n; c++) {
-    np = cells[c].n;
-    part = cells[c].part;
-    othcblk = block(gblcblk, c - 1, size);
+  int ic = 0;
+  for (int c = 1; c <= local_cells.n; c++) {
+    auto othcblk = block(gblcblk, c - 1, size);
 
-    for (i = 0; i < np; i++) {
-      part[i].f.f[0] +=
-          pref_x * (partblk[size * ic + PQESCM] * othcblk[PQECCP] +
-                    partblk[size * ic + PQESSM] * othcblk[PQECSP] -
-                    partblk[size * ic + PQECCM] * othcblk[PQESCP] -
-                    partblk[size * ic + PQECSM] * othcblk[PQESSP] +
-                    partblk[size * ic + PQESCP] * othcblk[PQECCM] +
-                    partblk[size * ic + PQESSP] * othcblk[PQECSM] -
-                    partblk[size * ic + PQECCP] * othcblk[PQESCM] -
-                    partblk[size * ic + PQECSP] * othcblk[PQESSM]);
-      part[i].f.f[1] +=
-          pref_y * (partblk[size * ic + PQECSM] * othcblk[PQECCP] +
-                    partblk[size * ic + PQESSM] * othcblk[PQESCP] -
-                    partblk[size * ic + PQECCM] * othcblk[PQECSP] -
-                    partblk[size * ic + PQESCM] * othcblk[PQESSP] +
-                    partblk[size * ic + PQECSP] * othcblk[PQECCM] +
-                    partblk[size * ic + PQESSP] * othcblk[PQESCM] -
-                    partblk[size * ic + PQECCP] * othcblk[PQECSM] -
-                    partblk[size * ic + PQESCP] * othcblk[PQESSM]);
-      part[i].f.f[2] += (partblk[size * ic + PQECCM] * othcblk[PQECCP] +
-                         partblk[size * ic + PQECSM] * othcblk[PQECSP] +
-                         partblk[size * ic + PQESCM] * othcblk[PQESCP] +
-                         partblk[size * ic + PQESSM] * othcblk[PQESSP] -
-                         partblk[size * ic + PQECCP] * othcblk[PQECCM] -
-                         partblk[size * ic + PQECSP] * othcblk[PQECSM] -
-                         partblk[size * ic + PQESCP] * othcblk[PQESCM] -
-                         partblk[size * ic + PQESSP] * othcblk[PQESSM]);
+    auto cell = local_cells[c - 1];
+    for (auto &p : cell->particles()) {
+      p.f.f[0] += pref_x * (partblk[size * ic + PQESCM] * othcblk[PQECCP] +
+                            partblk[size * ic + PQESSM] * othcblk[PQECSP] -
+                            partblk[size * ic + PQECCM] * othcblk[PQESCP] -
+                            partblk[size * ic + PQECSM] * othcblk[PQESSP] +
+                            partblk[size * ic + PQESCP] * othcblk[PQECCM] +
+                            partblk[size * ic + PQESSP] * othcblk[PQECSM] -
+                            partblk[size * ic + PQECCP] * othcblk[PQESCM] -
+                            partblk[size * ic + PQECSP] * othcblk[PQESSM]);
+      p.f.f[1] += pref_y * (partblk[size * ic + PQECSM] * othcblk[PQECCP] +
+                            partblk[size * ic + PQESSM] * othcblk[PQESCP] -
+                            partblk[size * ic + PQECCM] * othcblk[PQECSP] -
+                            partblk[size * ic + PQESCM] * othcblk[PQESSP] +
+                            partblk[size * ic + PQECSP] * othcblk[PQECCM] +
+                            partblk[size * ic + PQESSP] * othcblk[PQESCM] -
+                            partblk[size * ic + PQECCP] * othcblk[PQECSM] -
+                            partblk[size * ic + PQESCP] * othcblk[PQESSM]);
+      p.f.f[2] += (partblk[size * ic + PQECCM] * othcblk[PQECCP] +
+                   partblk[size * ic + PQECSM] * othcblk[PQECSP] +
+                   partblk[size * ic + PQESCM] * othcblk[PQESCP] +
+                   partblk[size * ic + PQESSM] * othcblk[PQESSP] -
+                   partblk[size * ic + PQECCP] * othcblk[PQECCM] -
+                   partblk[size * ic + PQECSP] * othcblk[PQECSM] -
+                   partblk[size * ic + PQESCP] * othcblk[PQESCM] -
+                   partblk[size * ic + PQESSP] * othcblk[PQESSM]);
       ic++;
     }
   }
@@ -1042,8 +1037,8 @@ static double PQ_energy(double omega) {
 
   int ic = 0;
   for (int c = 1; c <= local_cells.n; c++) {
-    int np = cells[c].n;
-    double *othcblk = block(gblcblk, c - 1, size);
+    int np = local_cells[c - 1]->particles().size();
+    auto const *othcblk = block(gblcblk, c - 1, size);
 
     for (int i = 0; i < np; i++) {
       eng += pref * (partblk[size * ic + PQECCM] * othcblk[PQECCP] +

--- a/src/core/electrostatics_magnetostatics/mmm2d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.cpp
@@ -487,10 +487,8 @@ void distribute(int e_size, double fac) {
 /*****************************************************************/
 
 static void setup_z_force() {
-  int np, c, i;
-  double pref = coulomb.prefactor * C_2PI * ux * uy;
-  Particle *part;
-  int e_size = 1, size = 2;
+  const double pref = coulomb.prefactor * C_2PI * ux * uy;
+  constexpr int e_size = 1, size = 2;
 
   /* there is NO contribution from images here, unlike claimed in Tyagi et al.
      Please refer to the Entropy
@@ -505,11 +503,11 @@ static void setup_z_force() {
   }
 
   /* calculate local cellblks. partblks don't make sense */
-  for (c = 1; c <= local_cells.n; c++) {
-    np = cells[c].n;
-    part = cells[c].part;
+  for (int c = 1; c <= local_cells.n; c++) {
+    auto np = cells[c].n;
+    auto part = cells[c].part;
     lclcblk[size * c] = 0;
-    for (i = 0; i < np; i++) {
+    for (int i = 0; i < np; i++) {
       lclcblk[size * c] += part[i].p.q;
     }
     lclcblk[size * c] *= pref;

--- a/src/core/electrostatics_magnetostatics/mmm2d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.hpp
@@ -115,10 +115,6 @@ int MMM2D_sanity_checks();
 /// initialize the MMM2D constants
 void MMM2D_init();
 
-/** if the number of particles has changed (even per node),
-    the particle buffers for the coefficients have to be resized. */
-void MMM2D_on_resort_particles(const ParticleRange &particles);
-
 /** energy contribution from dielectric layers */
 double MMM2D_dielectric_layers_energy_contribution();
 

--- a/src/core/electrostatics_magnetostatics/mmm2d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm2d.hpp
@@ -89,16 +89,17 @@ int MMM2D_set_params(double maxPWerror, double far_cut, double delta_top,
                      double delta_bot, bool const_pot, double pot_diff);
 
 /** the general long range force/energy calculation */
-double MMM2D_add_far(int f, int e, const ParticleRange &particles);
+double MMM2D_add_far(bool calc_forces, bool calc_energies,
+                     const ParticleRange &particles);
 
 /** the actual long range force calculation */
 inline void MMM2D_add_far_force(const ParticleRange &particles) {
-  MMM2D_add_far(1, 0, particles);
+  MMM2D_add_far(true, false, particles);
 }
 
 /** the actual long range energy calculation */
 inline double MMM2D_far_energy(const ParticleRange &particles) {
-  return MMM2D_add_far(0, 1, particles);
+  return MMM2D_add_far(false, true, particles);
 }
 
 /** pairwise calculated parts of MMM2D force (near neighbors) */

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -76,10 +76,11 @@
 #define LAYERED_BTM_NEIGHBOR                                                   \
   ((layered_flags & LAYERED_BTM_MASK) != LAYERED_BOTTOM)
 
-int layered_flags = 0;
-int n_layers = -1, determine_n_layers = 1;
-double layer_h = 0, layer_h_i = 0;
+static int layered_flags = 0;
+int n_layers = -1;
+int determine_n_layers = 1;
 
+static double layer_h = 0, layer_h_i = 0;
 static int btm, top;
 
 Cell *layered_position_to_cell(const Utils::Vector3d &pos) {

--- a/src/core/layered.hpp
+++ b/src/core/layered.hpp
@@ -34,9 +34,6 @@
 /** number of layers, i. e. cells, per node */
 extern int n_layers, determine_n_layers;
 
-/** height of the layers, i. e. box_l[2]/n_nodes */
-extern double layer_h, layer_h_i;
-
 /// free all data structure that belong to this cell system
 void layered_topology_release();
 

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -446,6 +446,8 @@ struct ParticleList {
   int n;
   /** Number of particles that fit in until a resize is needed */
   int max;
+
+  Utils::Span<Particle> particles() { return {part, static_cast<size_t>(n)}; }
 };
 
 /************************************************


### PR DESCRIPTION
Closes #3022

Description of changes:
 - Replaced direct cell access in mmm2d by using `local_cells`
 - Removed two globals from the layered cellsystem

This was the last direct usage of the cells outside of the cell systems,
which makes it now possible to hide how the actual storage is implemented.