### PR TITLE
Add new AMD GPU id to CI exclusion list

### DIFF
--- a/testsuite/python/unittest_decorators.py
+++ b/testsuite/python/unittest_decorators.py
@@ -54,6 +54,9 @@ def skipIfMissingGPU(skip_ci_amd=False):
         return unittest.skip("Skipping test: no GPU available")
     # special case for our CI infrastructure: disable specific GPU tests
     # for AMD GPUs, see https://github.com/espressomd/espresso/pull/2653
-    if skip_ci_amd and str(espressomd.cuda_init.CudaInitHandle().device_list[0]) == "Device 687f":
+    ci_amd_gpus = {"Device 687f", "Vega 10 XT [Radeon RX Vega 64]"}
+    devices = espressomd.cuda_init.CudaInitHandle().device_list
+    current_device_id = espressomd.cuda_init.CudaInitHandle().device
+    if skip_ci_amd and str(devices[current_device_id]) in ci_amd_gpus:
         return unittest.skip("Skipping test: AMD GPU")
     return _id

--- a/testsuite/python/unittest_decorators.py
+++ b/testsuite/python/unittest_decorators.py
@@ -17,6 +17,7 @@
 import sys
 import unittest
 import espressomd  # pylint: disable=import-error
+from espressomd.utils import to_str
 
 
 def _id(x):
@@ -57,6 +58,6 @@ def skipIfMissingGPU(skip_ci_amd=False):
     ci_amd_gpus = {"Device 687f", "Vega 10 XT [Radeon RX Vega 64]"}
     devices = espressomd.cuda_init.CudaInitHandle().device_list
     current_device_id = espressomd.cuda_init.CudaInitHandle().device
-    if skip_ci_amd and str(devices[current_device_id]) in ci_amd_gpus:
+    if skip_ci_amd and to_str(devices[current_device_id]) in ci_amd_gpus:
         return unittest.skip("Skipping test: AMD GPU")
     return _id


### PR DESCRIPTION
Fixes #3147, until a better solution is found to improve the reliability of Python tests running on GPUs