### PR TITLE
core: remove linear momentum prediction.

### DIFF
--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -391,8 +391,6 @@ void mpi_gather_stats(int job, void *result, void *result_t, void *result_nb,
     pressure_calc((double *)result, (double *)result_t, (double *)result_nb,
                   (double *)result_t_nb, 1);
     break;
-  case 4:
-    break;
   case 6:
     mpi_call(mpi_gather_stats_slave, -1, 6);
     lb_calc_fluid_momentum((double *)result, lbpar, lbfields, lblattice);
@@ -429,8 +427,6 @@ void mpi_gather_stats_slave(int, int job) {
     /* calculate and reduce (sum up) virials, revert velocities half a timestep
      * for 'analyze p_inst' */
     pressure_calc(nullptr, nullptr, nullptr, nullptr, 1);
-    break;
-  case 4:
     break;
   case 6:
     lb_calc_fluid_momentum(nullptr, lbpar, lbfields, lblattice);

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -392,9 +392,6 @@ void mpi_gather_stats(int job, void *result, void *result_t, void *result_nb,
                   (double *)result_t_nb, 1);
     break;
   case 4:
-    mpi_call(mpi_gather_stats_slave, -1, 4);
-    predict_momentum_particles((double *)result,
-                               cell_structure.local_cells().particles());
     break;
   case 6:
     mpi_call(mpi_gather_stats_slave, -1, 6);
@@ -434,8 +431,6 @@ void mpi_gather_stats_slave(int, int job) {
     pressure_calc(nullptr, nullptr, nullptr, nullptr, 1);
     break;
   case 4:
-    predict_momentum_particles(nullptr,
-                               cell_structure.local_cells().particles());
     break;
   case 6:
     lb_calc_fluid_momentum(nullptr, lbpar, lbfields, lblattice);

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -198,7 +198,6 @@ void mpi_bcast_max_seen_particle_type(int s);
  *           using \ref pressure_calc.
  *      \arg \c 3 calculate and reduce (sum up) instantaneous pressure,
  *           using \ref pressure_calc.
- *      \arg \c 4 use \ref predict_momentum_particles
  *      \arg \c 6 use \ref lb_calc_fluid_momentum
  *      \arg \c 8 use \ref lb_collect_boundary_forces
  *  \param result where to store the gathered value(s):

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -86,28 +86,27 @@ double mindist(PartCfg &partCfg, IntList const &set1, IntList const &set2) {
   return std::sqrt(mindist2);
 }
 
-void predict_momentum_particles(double *result,
-                                const ParticleRange &particles) {
-  double momentum[3] = {0.0, 0.0, 0.0};
+Utils::Vector3d local_particle_momentum() {
+  auto const particles = local_cells.particles();
+  auto const momentum =
+      std::accumulate(particles.begin(), particles.end(), Utils::Vector3d{},
+                      [](Utils::Vector3d &m, Particle const &p) {
+                        return std::move(m) + p.p.mass * p.m.v;
+                      });
 
-  for (auto const &p : particles) {
-    auto const mass = p.p.mass;
-
-    momentum[0] += mass * (p.m.v[0] + p.f.f[0] * 0.5 * time_step / p.p.mass);
-    momentum[1] += mass * (p.m.v[1] + p.f.f[1] * 0.5 * time_step / p.p.mass);
-    momentum[2] += mass * (p.m.v[2] + p.f.f[2] * 0.5 * time_step / p.p.mass);
-  }
-
-  MPI_Reduce(momentum, result, 3, MPI_DOUBLE, MPI_SUM, 0, comm_cart);
+  return momentum;
 }
+
+REGISTER_CALLBACK_REDUCTION(local_particle_momentum,
+                            std::plus<Utils::Vector3d>())
 
 Utils::Vector3d calc_linear_momentum(int include_particles,
                                      int include_lbfluid) {
   Utils::Vector3d linear_momentum{};
   if (include_particles) {
-    Utils::Vector3d momentum_particles{};
-    mpi_gather_stats(4, momentum_particles.data(), nullptr, nullptr, nullptr);
-    linear_momentum += momentum_particles;
+    linear_momentum +=
+        mpi_call(::Communication::Result::reduction,
+                 std::plus<Utils::Vector3d>(), local_particle_momentum);
   }
   if (include_lbfluid) {
     linear_momentum += lb_lbfluid_calc_fluid_momentum();

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -217,11 +217,6 @@ void angularmomentum(PartCfg &, int type, double *com);
  */
 void momentofinertiamatrix(PartCfg &partCfg, int type, double *MofImatrix);
 
-/** Calculate momentum of all particles in the simulation box.
- *  \param result Momentum of particles.
- */
-void predict_momentum_particles(double *result, const ParticleRange &particles);
-
 /** Calculate total momentum of the system (particles & LB fluid).
  *  Inputs are bools to include particles and fluid in the linear momentum
  *  calculation

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -130,6 +130,8 @@ class TestLB:
                                    delta=self.params["mass_prec_per_node"])
 
             # check momentum conservation
+            # NOTE: this particle momentum prediction is due to the missing f/2 part in the
+            #       LB fluid.
             particle_momentum = np.sum(
                 [p.mass * p.v + 0.5 * p.f * self.system.time_step for p in self.system.part], axis=0)
             fluid_momentum = self.system.analysis.linear_momentum(False, True)

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -130,7 +130,8 @@ class TestLB:
                                    delta=self.params["mass_prec_per_node"])
 
             # check momentum conservation
-            particle_momentum = np.sum([p.mass * p.v + 0.5 * p.f * self.system.time_step for p in self.system.part], axis=0)
+            particle_momentum = np.sum(
+                [p.mass * p.v + 0.5 * p.f * self.system.time_step for p in self.system.part], axis=0)
             fluid_momentum = self.system.analysis.linear_momentum(False, True)
             np.testing.assert_allclose(
                 particle_momentum + fluid_momentum, self.tot_mom,

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -130,8 +130,10 @@ class TestLB:
                                    delta=self.params["mass_prec_per_node"])
 
             # check momentum conservation
+            particle_momentum = np.sum([p.mass * p.v + 0.5 * p.f * self.system.time_step for p in self.system.part], axis=0)
+            fluid_momentum = self.system.analysis.linear_momentum(False, True)
             np.testing.assert_allclose(
-                self.system.analysis.linear_momentum(), self.tot_mom,
+                particle_momentum + fluid_momentum, self.tot_mom,
                 atol=self.params['mom_prec'])
 
             # Calc particle temperature


### PR DESCRIPTION
Currently the particle momentum is calculated a timestep ahead in time. This PR removes this odd behavior.