### PR TITLE
Core: do_non_bonded, capture by reference rather than value

### DIFF
--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -905,7 +905,7 @@ inline bool do_nonbonded(Particle const &p1, Particle const &p2) {
   /* check for particle 2 in particle 1's exclusion list. The exclusion list is
      symmetric, so this is sufficient. */
   return std::none_of(p1.el.begin(), p1.el.end(),
-                      [p2](int id) { return p2.p.identity == id; });
+                      [&p2](int id) { return p2.p.identity == id; });
 }
 #endif
 


### PR DESCRIPTION
This fixes a performance regression from #3077, I think.
Time per step fro lj benchmark went down from 0.78 to 0.38 ms