### PR TITLE
P3M GPU: don't use mesh sizes with radix > 5 on AMD GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ if(WITH_CUDA)
       find_package(HIP MODULE)
       message(STATUS "Found HIP compiler: ${HIP_HIPCC_EXECUTABLE}")
       set(CUDA 1)
+      set(HIP 1)
       list(APPEND HIP_HCC_FLAGS "-Wno-macro-redefined -Wno-duplicate-decl-specifier -std=c++14")
 
       find_library(ROCFFT_LIB name "rocfft" PATHS "${HIP_ROOT_DIR}/lib")

--- a/cmake/cmake_config.cmakein
+++ b/cmake/cmake_config.cmakein
@@ -3,6 +3,8 @@
 
 #cmakedefine CUDA
 
+#cmakedefine HIP
+
 #cmakedefine FFTW
 
 #cmakedefine H5MD

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -1787,6 +1787,16 @@ int p3m_adaptive_tune(char **log) {
     if (tmp_mesh[2] % 2)
       tmp_mesh[2]++;
 
+#ifdef HIP
+    if (tmp_mesh[0] % 7 == 0 || tmp_mesh[0] % 11 == 0 ||
+        tmp_mesh[0] % 13 == 0 || tmp_mesh[1] % 7 == 0 ||
+        tmp_mesh[1] % 11 == 0 || tmp_mesh[1] % 13 == 0 ||
+        tmp_mesh[2] % 7 == 0 || tmp_mesh[2] % 11 == 0 ||
+        tmp_mesh[2] % 13 == 0) {
+      continue;
+    }
+#endif
+
     tmp_time =
         p3m_m_time(log, tmp_mesh, cao_min, cao_max, &tmp_cao, r_cut_iL_min,
                    r_cut_iL_max, &tmp_r_cut_iL, &tmp_alpha_L, &tmp_accuracy);

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -1788,6 +1788,9 @@ int p3m_adaptive_tune(char **log) {
       tmp_mesh[2]++;
 
 #ifdef HIP
+    // When running on HIP, we don't support mesh sizes whose prime factors are
+    // not 2, 3 or 5. So we skip the other supported prime factors during
+    // tuning.
     if (tmp_mesh[0] % 7 == 0 || tmp_mesh[0] % 11 == 0 ||
         tmp_mesh[0] % 13 == 0 || tmp_mesh[1] % 7 == 0 ||
         tmp_mesh[1] % 11 == 0 || tmp_mesh[1] % 13 == 0 ||

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -1791,11 +1791,11 @@ int p3m_adaptive_tune(char **log) {
     // When running on HIP, we don't support mesh sizes whose prime factors are
     // not 2, 3 or 5. So we skip the other supported prime factors during
     // tuning.
-    if (tmp_mesh[0] % 7 == 0 || tmp_mesh[0] % 11 == 0 ||
-        tmp_mesh[0] % 13 == 0 || tmp_mesh[1] % 7 == 0 ||
-        tmp_mesh[1] % 11 == 0 || tmp_mesh[1] % 13 == 0 ||
-        tmp_mesh[2] % 7 == 0 || tmp_mesh[2] % 11 == 0 ||
-        tmp_mesh[2] % 13 == 0) {
+    if (tune_mesh && (tmp_mesh[0] % 7 == 0 || tmp_mesh[0] % 11 == 0 ||
+                      tmp_mesh[0] % 13 == 0 || tmp_mesh[1] % 7 == 0 ||
+                      tmp_mesh[1] % 11 == 0 || tmp_mesh[1] % 13 == 0 ||
+                      tmp_mesh[2] % 7 == 0 || tmp_mesh[2] % 11 == 0 ||
+                      tmp_mesh[2] % 13 == 0)) {
       continue;
     }
 #endif

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -751,7 +751,7 @@ void p3m_gpu_init(int cao, const int mesh[3], double alpha) {
       if (mesh[0] % 7 == 0 || mesh[0] % 11 == 0 || mesh[0] % 13 == 0 ||
           mesh[1] % 7 == 0 || mesh[1] % 11 == 0 || mesh[1] % 13 == 0 ||
           mesh[2] % 7 == 0 || mesh[2] % 11 == 0 || mesh[2] % 13 == 0) {
-        throw std::string("Mesh size not supported");
+        throw std::runtime_error("Mesh size not supported");
       }
 #endif
 
@@ -774,7 +774,7 @@ void p3m_gpu_init(int cao, const int mesh[3], double alpha) {
                       FFT_PLAN_FORW_FLAG) != CUFFT_SUCCESS ||
           cufftPlan3d(&(p3m_gpu_fft_plans.back_plan), mesh[0], mesh[1], mesh[2],
                       FFT_PLAN_BACK_FLAG) != CUFFT_SUCCESS) {
-        throw std::string("Unable to create fft plan");
+        throw std::runtime_error("Unable to create fft plan");
       }
     }
 

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -744,6 +744,14 @@ void p3m_gpu_init(int cao, const int mesh[3], double alpha) {
     }
 
     if ((p3m_gpu_data_initialized == 0) && (p3m_gpu_data.mesh_size > 0)) {
+#if defined(__HIPCC__) and not defined(__CUDACC__)
+      if (mesh[0] % 7 == 0 || mesh[0] % 11 == 0 || mesh[0] % 13 == 0 ||
+          mesh[1] % 7 == 0 || mesh[1] % 11 == 0 || mesh[1] % 13 == 0 ||
+          mesh[2] % 7 == 0 || mesh[2] % 11 == 0 || mesh[2] % 13 == 0) {
+        throw std::string("Mesh size not supported");
+      }
+#endif
+
       /** Size of the complex mesh Nx * Ny * ( Nz / 2 + 1 ) */
       const int cmesh_size = p3m_gpu_data.mesh[0] * p3m_gpu_data.mesh[1] *
                              (p3m_gpu_data.mesh[2] / 2 + 1);

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -745,6 +745,9 @@ void p3m_gpu_init(int cao, const int mesh[3], double alpha) {
 
     if ((p3m_gpu_data_initialized == 0) && (p3m_gpu_data.mesh_size > 0)) {
 #if defined(__HIPCC__) and not defined(__CUDACC__)
+      // rocFFT gives wrong P3M results for mesh sizes whose prime factors are
+      // not 2, 3 or 5. So we check for the other supported prime factors and
+      // throw an error if they are used with HIP.
       if (mesh[0] % 7 == 0 || mesh[0] % 11 == 0 || mesh[0] % 13 == 0 ||
           mesh[1] % 7 == 0 || mesh[1] % 11 == 0 || mesh[1] % 13 == 0 ||
           mesh[2] % 7 == 0 || mesh[2] % 11 == 0 || mesh[2] % 13 == 0) {

--- a/src/core/grid_based_algorithms/fd-electrostatics_cuda.cu
+++ b/src/core/grid_based_algorithms/fd-electrostatics_cuda.cu
@@ -75,7 +75,7 @@ FdElectrostatics::FdElectrostatics(InputParameters inputParameters,
                                parameters.dim_y * (parameters.dim_x / 2 + 1)));
 
   if (cudaGetLastError() != cudaSuccess) {
-    throw "Failed to allocate\n";
+    throw std::runtime_error("Failed to allocate");
   }
 
   cuda_safe_mem(cudaMemcpyToSymbol(HIP_SYMBOL(fde_parameters_gpu), &parameters,
@@ -94,20 +94,20 @@ FdElectrostatics::FdElectrostatics(InputParameters inputParameters,
 
   if (cufftPlan3d(&plan_fft, parameters.dim_z, parameters.dim_y,
                   parameters.dim_x, CUFFT_R2C) != CUFFT_SUCCESS) {
-    throw std::string("Unable to create fft plan");
+    throw std::runtime_error("Unable to create fft plan");
   }
 
   if (cufftSetStream(plan_fft, cuda_stream) != CUFFT_SUCCESS) {
-    throw std::string("Unable to assign FFT to cuda stream");
+    throw std::runtime_error("Unable to assign FFT to cuda stream");
   }
 
   if (cufftPlan3d(&plan_ifft, parameters.dim_z, parameters.dim_y,
                   parameters.dim_x, CUFFT_C2R) != CUFFT_SUCCESS) {
-    throw std::string("Unable to create ifft plan");
+    throw std::runtime_error("Unable to create ifft plan");
   }
 
   if (cufftSetStream(plan_ifft, cuda_stream) != CUFFT_SUCCESS) {
-    throw std::string("Unable to assign FFT to cuda stream");
+    throw std::runtime_error("Unable to assign FFT to cuda stream");
   }
 
   initialized = true;

--- a/src/core/grid_based_algorithms/fd-electrostatics_cuda.cu
+++ b/src/core/grid_based_algorithms/fd-electrostatics_cuda.cu
@@ -5,6 +5,7 @@
 #include "cuda_utils.hpp"
 #include "cufft_wrapper.hpp"
 #include "grid_based_algorithms/fd-electrostatics.cuh"
+#include <stdexcept>
 #include <string>
 //#include <cuda_interface.hpp>
 #include <cstdio>

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -132,7 +132,6 @@ class CoulombCloudWall(ut.TestCase):
         self.S.integrator.run(0)
         self.compare("p3m", energy=True, prefactor=3)
 
-    @utx.skipIfMissingGPU(skip_ci_amd=True)
     def test_p3m_gpu(self):
             self.S.actors.add(
                 espressomd.electrostatics.P3MGPU(

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -132,6 +132,7 @@ class CoulombCloudWall(ut.TestCase):
         self.S.integrator.run(0)
         self.compare("p3m", energy=True, prefactor=3)
 
+    @utx.skipIfMissingGPU()
     def test_p3m_gpu(self):
             self.S.actors.add(
                 espressomd.electrostatics.P3MGPU(

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -91,7 +91,7 @@ class CoulombCloudWall(ut.TestCase):
         self.S.integrator.run(0)
         self.compare("p3m", energy=True)
 
-    @utx.skipIfMissingGPU(skip_ci_amd=True)
+    @utx.skipIfMissingGPU()
     def test_p3m_gpu(self):
             self.S.actors.add(
                 espressomd.electrostatics.P3MGPU(

--- a/testsuite/python/coulomb_tuning.py
+++ b/testsuite/python/coulomb_tuning.py
@@ -78,7 +78,6 @@ class CoulombCloudWallTune(ut.TestCase):
         self.system.integrator.run(0)
         self.compare("p3m")
 
-    @utx.skipIfMissingGPU(skip_ci_amd=True)
     def test_p3m_gpu(self):
         # We have to add some tolerance here, because the reference
         # system is not homogeneous

--- a/testsuite/python/coulomb_tuning.py
+++ b/testsuite/python/coulomb_tuning.py
@@ -78,6 +78,7 @@ class CoulombCloudWallTune(ut.TestCase):
         self.system.integrator.run(0)
         self.compare("p3m")
 
+    @utx.skipIfMissingGPU()
     def test_p3m_gpu(self):
         # We have to add some tolerance here, because the reference
         # system is not homogeneous

--- a/testsuite/python/unittest_decorators.py
+++ b/testsuite/python/unittest_decorators.py
@@ -48,16 +48,11 @@ def skipIfMissingModules(*args):
     return _id
 
 
-def skipIfMissingGPU(skip_ci_amd=False):
+def skipIfMissingGPU():
     """Unittest skipIf decorator for missing GPU."""
 
     if not espressomd.gpu_available():
         return unittest.skip("Skipping test: no GPU available")
-    # special case for our CI infrastructure: disable specific GPU tests
-    # for AMD GPUs, see https://github.com/espressomd/espresso/pull/2653
-    ci_amd_gpus = {"Device 687f", "Vega 10 XT [Radeon RX Vega 64]"}
     devices = espressomd.cuda_init.CudaInitHandle().device_list
     current_device_id = espressomd.cuda_init.CudaInitHandle().device
-    if skip_ci_amd and to_str(devices[current_device_id]) in ci_amd_gpus:
-        return unittest.skip("Skipping test: AMD GPU")
     return _id


### PR DESCRIPTION
This fixes the problem that P3M tuning sometimes produced parameters that didn't give correct results. For reasons not entirely clear to me, P3M and rocFFT produce wrong results when using mesh sizes that have prime factors greater than 5. For other reasons not clear to me, such mesh sizes are only chosen by the tuning when multiple instances of Espresso are running simultaneously (see https://github.com/espressomd/espresso/issues/3147#issuecomment-530761965).

This is the real fix for #3147. I ran it 100 times. Previously I would get about 10 failures, now I get zero.