### PR TITLE
Remove Python2-specific installation instructions

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -56,8 +56,7 @@ MPI
     environment that implements the MPI standard version 1.2.
 
 Python
-    ESPResSo's main user interface is via the Python scripting interface.
-    We strongly recommend Python 3. Python 2 support is about to be removed.
+    ESPResSo's main user interface is via the Python 3 scripting interface.
 
 Cython
     Cython is used for connecting the C++ core to Python.
@@ -68,10 +67,6 @@ Cython
 
 Installing Requirements on Ubuntu Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-These instructions pertain to Python 3. If you need to use the deprecated
-Python 2 support, leave out the `3` in the Python package names.
-I.e., use `python-numpy` rather than `python3-numpy`.
-
 
 To make ESPResSo run on 18.04 LTS, its dependencies can be
 installed with:
@@ -183,27 +178,15 @@ command in |es|'s source directory:
 
     pip3 install -r requirements.txt --user --upgrade
 
-Please note that on some systems, ``pip3`` has to be replaced by ``pip`` or ``pip2`` to install Python 2 versions of the packages.
-
 .. _Quick installation:
 
 Quick installation
 ------------------
 
 If you have installed the requirements (see section :ref:`Requirements`) in
-standard locations, compiling |es| is usually only a matter of
-creating a build directory and calling ``cmake`` and ``make`` in it.
-To choose the correct Python version, run
-
-.. code-block:: bash
-
-    python -V
-    python3 -V
-
-This shows which Python versions are available on your system. Then pass the
-one you'd like to use (we recommend Python 3) in the ``cmake`` command line,
-shown below (optional steps which modify the build process are commented out).
-
+standard locations, compiling |es| is usually only a matter of creating a build
+directory and calling ``cmake`` and ``make`` in it. See for example the command
+lines below (optional steps which modify the build process are commented out):
 
 .. code-block:: bash
 
@@ -211,7 +194,7 @@ shown below (optional steps which modify the build process are commented out).
     cd build
     #cp myconfig-default.hpp myconfig.hpp # use the default configuration as template
     #nano myconfig.hpp                    # edit to add/remove features as desired
-    cmake -DPYTHON_EXECUTABLE=`which python3` ..
+    cmake ..
     #ccmake . // in order to add/remove features like SCAFACOS or CUDA
     make
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -11,7 +11,7 @@ is tested and known to run on a number of platforms.
 Alternatively, people that want to use the newest features of |es| or that
 want to start contributing to the software can instead obtain the
 current development code via the version control system software  [2]_
-from |es| 's project page at Github  [3]_. This code might be not as well
+from |es|'s project page at Github  [3]_. This code might be not as well
 tested and documented as the release code; it is recommended to use this
 code only if you have already gained some experience in using |es|.
 
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 The following tools libraries, including header files, are required to be able
-to compile and use ESPResSo:
+to compile and use |es|:
 
 CMake
     The build system is based on CMake
@@ -43,20 +43,20 @@ C++ Compiler
     C++14 capable C++ compiler (e.g., gcc 5 or later)
 
 Boost
-    A number of advanced C++ features used by ESPResSo is provided by Boost.
+    A number of advanced C++ features used by |es| are provided by Boost.
     We strongly recommend to use at least boost 1.67.
 
 FFTW
-    For some algorithms (P\ :math:`^3`\ M), ESPResSo needs the FFTW library
+    For some algorithms (P\ :math:`^3`\ M), |es| needs the FFTW library
     version 3 or later  [5]_ for Fourier transforms, including header
     files.
 
 MPI
-    Because ESPResSo is parallelized with MPI, you need a working MPI
+    Because |es| is parallelized with MPI, you need a working MPI
     environment that implements the MPI standard version 1.2.
 
 Python
-    ESPResSo's main user interface is via the Python 3 scripting interface.
+    |es|'s main user interface is via the Python 3 scripting interface.
 
 Cython
     Cython is used for connecting the C++ core to Python.
@@ -68,8 +68,7 @@ Cython
 Installing Requirements on Ubuntu Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To make ESPResSo run on 18.04 LTS, its dependencies can be
-installed with:
+To make |es| run on 18.04 LTS, its dependencies can be installed with:
 
 .. code-block:: bash
 
@@ -227,7 +226,7 @@ command:
 
     ./pypresso <SCRIPT>
 
-where is ``<SCRIPT>`` is a ``python`` script which has to
+where ``<SCRIPT>`` is a ``python`` script which has to
 be written by the user. You can find some examples in the :file:`samples`
 folder of the source code directory. If you want to run in parallel, you should
 have compiled with *Open MPI*, and need to tell MPI to run in parallel. The actual
@@ -290,7 +289,7 @@ different configuration headers:
 
     #define LJCOS
 
-Then you can simply compile two different versions of via:
+Then you can simply compile two different versions of |es| via:
 
 .. code-block:: bash
 
@@ -302,7 +301,7 @@ Then you can simply compile two different versions of via:
     cmake ..
     make
 
-To see, what features were activated in :file:`myconfig.hpp`, run:
+To see what features were activated in :file:`myconfig.hpp`, run:
 
 .. code-block:: bash
 
@@ -562,8 +561,7 @@ are ever modified by the build process.
     cmake ..
     make
 
-Afterwards Espresso can be run via calling :file:`./pypresso` from the command
-line.
+Afterwards |es| can be run via calling :file:`./pypresso` from the command line.
 
 .. _ccmake:
 
@@ -575,9 +573,8 @@ to configure |es| interactively.
 
 **Example:**
 
-Alternatively to the previous example, instead of cmake, the ccmake executable is
-called in the build directory to configure ESPResSo,
-followed by a call to make:
+Alternatively to the previous example, instead of cmake, the ccmake executable
+is called in the build directory to configure |es|, followed by a call to make:
 
 .. code-block:: bash
 
@@ -698,7 +695,7 @@ introduction, see the tutorials, which are also part of the
 distribution. To use |es|, you need to import the espressomd module in your
 Python script. To this end, the folder containing the python module
 needs to be in the Python search path. The module is located in the
-src/python folder under the build directory. A convenient way to run
+:file:`src/python` folder under the build directory. A convenient way to run
 python with the correct path is to use the pypresso script located in
 the build directory.
 
@@ -706,14 +703,13 @@ the build directory.
 
     ./pypresso simulation.py
 
-The ``pypresso`` script is just a wrapper in order to expose our
-self built python modules to the systems python interpreter by
-modifying the  ``$PYTHONPATH``.
-Please see the following chapters describing how to actually write
-a simulation script for |es|.
+The ``pypresso`` script is just a wrapper in order to expose the |es| python
+module to the system's python interpreter by modifying the ``$PYTHONPATH``.
+Please see the following chapter :ref:`Setting up the system` describing how
+to actually write a simulation script for |es|.
 
-Running the Jupyter interpreter requires using the ipypresso script, which is
-also located in the build directory (its name comes from the IPython
+Running the Jupyter interpreter requires using the ``ipypresso`` script, which
+is also located in the build directory (its name comes from the IPython
 interpreter, today known as Jupyter). To run the tutorials, you will need
 to start the Jupyter interpreter in notebook mode:
 
@@ -766,7 +762,7 @@ Debugging |es|
 --------------
 
 Exceptional situations occur in every program.  If |es| crashes with a
-segmentation fault that means that there was a memory fault in the
+segmentation fault, that means that there was a memory fault in the
 simulation core which requires running the program in a debugger.  The
 ``pypresso`` executable file is actually not a program but a script
 which sets the Python path appropriately and starts the Python

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -32,11 +32,11 @@ for further calculations, you should explicitly make a copy e.g. via
 * :py:attr:`~espressomd.system.System.periodicity`
 
     (int[3]) Specifies periodicity for the three directions. |es| can be instructed
-    to treat some dimensions as non-periodic. Per default espresso assumes periodicity in
-    all directions which equals setting this variable to [1,1,1]. A
-    dimension is specified as non-periodic via setting the periodicity
-    variable for this dimension to 0. E.g. Periodicity only in z-direction
-    is obtained by [0,0,1]. Caveat: Be aware of the fact that making a
+    to treat some dimensions as non-periodic. By default |es| assumes periodicity in
+    all directions which equals setting this variable to ``[True, True, True]``.
+    A dimension is specified as non-periodic via setting the periodicity
+    variable for this dimension to ``False``. E.g. Periodicity only in z-direction
+    is obtained by ``[False, False, True]``. Caveat: Be aware of the fact that making a
     dimension non-periodic does not hinder particles from leaving the box in
     this direction. In this case for keeping particles in the simulation box
     a constraint has to be set.
@@ -52,9 +52,9 @@ for further calculations, you should explicitly make a copy e.g. via
 * :py:attr:`~espressomd.system.System.min_global_cut`
 
     (float) Minimal total cutoff for real space. Effectively, this plus the
-    :py:attr:`~espressomd.cellsystem.CellSystem.skin` is the minimally possible cell size. Espresso typically determines
-    this value automatically, but some algorithms, virtual sites, require
-    you to specify it manually.
+    :py:attr:`~espressomd.cellsystem.CellSystem.skin` is the minimally possible
+    cell size. |es| typically determines this value automatically, but some
+    algorithms, virtual sites, require you to specify it manually.
 
 * :py:attr:`~espressomd.system.System.max_cut_bonded`
 
@@ -105,7 +105,7 @@ The properties of the cell system can be accessed by
     * :py:attr:`~espressomd.cellsystem.CellSystem.max_num_cells`
 
     (int) Maximal number of cells for the link cell algorithm. Reasonable
-    values are between 125 and 1000, or for some problems :math:`n_part / nnodes`.
+    values are between 125 and 1000, or for some problems ``n_part / nnodes``.
 
     * :py:attr:`~espressomd.cellsystem.CellSystem.min_num_cells`
 
@@ -496,8 +496,7 @@ the device id as key and the device name as its' value.
 Selection of CUDA device
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you start ``pypresso`` your first GPU should
-be selected.
+When you start ``pypresso`` your first GPU should be selected.
 If you wanted to use the second GPU, this can be done
 by setting :attr:`espressomd.cuda_init.CudaInitHandle.device` as follows::
 


### PR DESCRIPTION
These instructions have become obsolete in release 4.1