### PR TITLE
remove undocumented side effect in MC moves

### DIFF
--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -632,17 +632,8 @@ Utils::Vector3d ReactionAlgorithm::get_random_position_in_box() {
         std::sqrt(m_uniform_real_distribution(
             m_generator)); // for uniform disk point picking in cylinder
     double phi = 2.0 * Utils::pi() * m_uniform_real_distribution(m_generator);
-    out_pos[0] = random_radius * cos(phi);
-    out_pos[1] = random_radius * sin(phi);
-    while (std::pow(out_pos[0], 2) + std::pow(out_pos[1], 2) <=
-           std::pow(exclusion_radius, 2)) {
-      random_radius =
-          cyl_radius * std::sqrt(m_uniform_real_distribution(m_generator));
-      out_pos[0] = random_radius * cos(phi);
-      out_pos[1] = random_radius * sin(phi);
-    }
-    out_pos[0] += cyl_x;
-    out_pos[1] += cyl_y;
+    out_pos[0] = cyl_x+random_radius * cos(phi);
+    out_pos[1] = cyl_y+random_radius * sin(phi);
     out_pos[2] = box_geo.length()[2] * m_uniform_real_distribution(m_generator);
   } else if (box_has_wall_constraints) {
     out_pos[0] = box_geo.length()[0] * m_uniform_real_distribution(m_generator);

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -632,8 +632,8 @@ Utils::Vector3d ReactionAlgorithm::get_random_position_in_box() {
         std::sqrt(m_uniform_real_distribution(
             m_generator)); // for uniform disk point picking in cylinder
     double phi = 2.0 * Utils::pi() * m_uniform_real_distribution(m_generator);
-    out_pos[0] = cyl_x+random_radius * cos(phi);
-    out_pos[1] = cyl_y+random_radius * sin(phi);
+    out_pos[0] = cyl_x + random_radius * cos(phi);
+    out_pos[1] = cyl_y + random_radius * sin(phi);
     out_pos[2] = box_geo.length()[2] * m_uniform_real_distribution(m_generator);
   } else if (box_has_wall_constraints) {
     out_pos[0] = box_geo.length()[0] * m_uniform_real_distribution(m_generator);


### PR DESCRIPTION
This part of the code was useful when sampling around a cylinder is performed.
Since it is undocumented and not always desired I remove it.