### PR TITLE
Correct conditional availability of ek_print_vtk_lbforce_density

### DIFF
--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -3608,8 +3608,8 @@ LOOKUP_TABLE default\n",
 }
 
 int ek_print_vtk_lbforce_density(char *filename) {
-#ifndef EK_DEBUG
-  return 1;
+#if !defined(VIRTUAL_SITES_INERTIALESS_TRACERS) && !defined(EK_DEBUG)
+  throw std::runtime_error("Please rebuild Espresso with EK_DEBUG");
 #else
 
   FILE *fp = fopen(filename, "w");


### PR DESCRIPTION
It should not silently do nothing if _EK_DEBUG_ is not enabled. Alternatively, _VIRTUAL_SITES_INERTIALESS_TRACERS_ suffices too.

This is actually a bug fix and should go into Espresso 4.1. It's trivial though and cannot break anything as this function is not called by any test or other code, even though it is available from the Python interface.