### PR TITLE
Simplify CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,12 +125,10 @@ no_rotation:
 
 ### Builds with different Distributions
 
-#debian:8 removed: similar to ubuntu:1404
-
-debian:9:
+debian:10:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/debian-python3:9
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/debian-python3:10
   script:
     - export with_cuda=false
     - export myconfig=maxset make_check=false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,7 @@ fedora:
 cuda10-maxset:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:10.1
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
     - export myconfig=maxset with_coverage=false test_timeout=900 srcdir=${CI_PROJECT_DIR}
     - export cmake_params="-DIPYTHON_EXECUTABLE=$(which jupyter)"
@@ -394,9 +394,9 @@ intel:18:
 check_sphinx:
   <<: *global_job_definition
   stage: additional_checks
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   needs:
-    - cuda-maxset
+    - cuda10-maxset
   when: on_success
   script:
     - sed -i 's/ or "DISPLAY" in os.environ/ or True/' ${CI_PROJECT_DIR}/src/python/espressomd/visualization.pyx

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -399,7 +399,7 @@ check_sphinx:
   script:
     - sed -i 's/ or "DISPLAY" in os.environ/ or True/' ${CI_PROJECT_DIR}/src/python/espressomd/visualization.pyx
     - cd ${CI_PROJECT_DIR}/build
-    - make -t && make sphinx
+    - make -t && rm src/python/espressomd/visualization.* && make sphinx
     - bash ../maintainer/CI/doc_warnings.sh
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,7 +195,7 @@ cuda10-maxset:
     - linux
     - cuda
 
-cuda-maxset:
+cuda9-maxset:
   <<: *global_job_definition
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
@@ -216,7 +216,7 @@ cuda-maxset:
 tutorials-samples-maxset:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
     - export myconfig=maxset with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
@@ -229,7 +229,7 @@ tutorials-samples-maxset:
 tutorials-samples-default:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
     - export myconfig=default with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
@@ -244,7 +244,7 @@ tutorials-samples-default:
 tutorials-samples-empty:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
     - export myconfig=empty with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
@@ -259,7 +259,7 @@ tutorials-samples-empty:
 tutorials-samples-no-gpu:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:tutorials
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
     - export myconfig=maxset with_coverage=false make_check=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200 hide_gpu=true
@@ -415,7 +415,7 @@ check_sphinx:
 run_tutorials:
   <<: *global_job_definition
   stage: additional_checks
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:10.1
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   needs:
     - cuda10-maxset
   when: on_success
@@ -441,7 +441,7 @@ check_doxygen:
   stage: additional_checks
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   needs:
-    - cuda-maxset
+    - cuda9-maxset
   when: on_success
   script:
     - cd ${CI_PROJECT_DIR}/build
@@ -460,7 +460,7 @@ check_cuda_maxset_no_gpu:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   when: on_success
   needs: 
-    - cuda-maxset
+    - cuda9-maxset
   script:
     - export CUDA_VISIBLE_DEVICES=""
     - cd ${CI_PROJECT_DIR}/build
@@ -476,7 +476,7 @@ check_with_odd_no_of_processors:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   when: on_success
   needs: 
-    - cuda-maxset
+    - cuda9-maxset
   script:
     - cd ${CI_PROJECT_DIR}/build
     - cmake -DTEST_NP=3 .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -436,13 +436,15 @@ run_tutorials:
     - linux
     - cuda
 
-check_doxygen:
+run_doxygen:
   <<: *global_job_definition
   stage: additional_checks
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
   needs:
     - cuda9-maxset
   when: on_success
+  only:
+    - python
   script:
     - cd ${CI_PROJECT_DIR}/build
     - make -t && make doxygen
@@ -517,7 +519,7 @@ deploy_sphinx_documentation:
 deploy_doxygen_documentation:
   extends: .deploy_base
   dependencies:
-    - check_doxygen
+    - run_doxygen
   script:
     - cd ${CI_PROJECT_DIR}/build/doc/doxygen/html &&
       rsync -avz --delete -e "ssh -i ${HOME}/.ssh/espresso_rsa" ./ espresso@elk.icp.uni-stuttgart.de:/home/espresso/public_html/html/dox

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -459,7 +459,7 @@ Scafacos Electrostatics
 -----------------------
 
 Espresso can use the electrostatics methods from the SCAFACOS *Scalable
-fast Coulomb solvers* library. The specific methods available depend on the compile-time options of the library, and can be queried using :meth:`espressomd.scafacos.ScafacosConnector.available_methods`
+fast Coulomb solvers* library. The specific methods available depend on the compile-time options of the library, and can be queried using :meth:`espressomd.scafacos.available_methods`
 
 To use SCAFACOS, create an instance of :class:`espressomd.electrostatics.Scafacos` and add it to the list of active actors. Three parameters have to be specified:
 

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -31,9 +31,6 @@
 # negative lookahead filters out common Python types (for performance reasons).
 regex_sphinx_broken_link='<code class=\"xref py py-[a-z]+ docutils literal notranslate\"><span class=\"pre\">(?!(int|float|bool|str|object|list|tuple|dict|(?:numpy\.|np\.)?(?:nd)?array)<)[^<>]+?</span></code>(?!</a>)'
 
-# list of espresso modules not compiled in CI (scafacos)
-regex_ignored_es_features_ci='(espressomd\.)?(([a-z]+\.)?[sS]cafacos)'
-
 if [ ! -f doc/sphinx/html/index.html ]; then
     echo "Please run Sphinx first."
     exit 1
@@ -54,18 +51,12 @@ if [ $? = "0" ]; then
         is_standard_type_or_module="false"
         grep -Pq '^([a-zA-Z0-9_]+Error|[a-zA-Z0-9_]*Exception|(?!espressomd\.)[a-zA-Z0-9_]+\.[a-zA-Z0-9_\.]+)$' <<< "${reference}"
         [ "$?" = "0" ] && is_standard_type_or_module="true"
-        # skip espresso modules not compiled in CI
-        is_es_feature_skipped="false"
-        if [ "${CI}" != "" ]; then
-            grep -Pq "^${regex_ignored_es_features_ci}" <<< "${reference}"
-            [ "$?" = "0" ] && is_es_feature_skipped="true"
-        fi
         # private objects are not documented and cannot be linked
         is_private="false"
         grep -Pq "(^_|\._)" <<< "${reference}"
         [ "$?" = "0" ] && is_private="true"
         # filter out false positives
-        if [ ${is_standard_type_or_module} = "true" ] || [ ${is_es_feature_skipped} = "true" ] || [ ${is_private} = "true" ]; then
+        if [ ${is_standard_type_or_module} = "true" ] || [ ${is_private} = "true" ]; then
             continue
         fi
         if [ ${found} = "false" ]; then
@@ -102,11 +93,6 @@ if [ $? = "0" ]; then
     echo "The Sphinx documentation contains ${n_warnings} broken links:" > doc_warnings.log
     cat doc_warnings.log~ >> doc_warnings.log
     rm doc_warnings.log~
-    # warn user about ignored features in CI
-    grep -Pq "${regex_ignored_es_features_ci}" doc_warnings.log
-    if [ "$?" = "0" ] && [ "${CI}" = "" ]; then
-        echo "(Note that feature Scafacos is ignored in CI)"
-    fi
 fi
 
 # Find malformed reSt roles, appearing as raw text in the HTML output:

--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -34,7 +34,7 @@ cdef class mayaviLive:
     This class provides live visualization using Enthought Mayavi.  Use the
     update method to push your current simulation state after integrating. If
     you run your integrate loop in a separate thread, you can call
-    run_gui_event_loop in your main thread to be able to interact with the GUI.
+    :meth:`start` in your main thread to be able to interact with the GUI.
 
     Parameters
     ----------

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -25,8 +25,9 @@ class openGLLive:
     This class provides live visualization using pyOpenGL.
     Use the update method to push your current simulation state after
     integrating. Modify the appearance with a list of keywords.
-    Timed callbacks can be registered via the register_callback method.
-    Keyboad callbacks via  keyboardManager.register_button().
+    Timed callbacks can be registered via the :meth:`register_callback` method
+    and keyboard callbacks via :meth:`keyboardManager.register_button()
+    <espressomd.visualization_opengl.KeyboardManager.register_button>`.
 
     Parameters
     ----------
@@ -61,29 +62,29 @@ class openGLLive:
     far_cut_distance : :obj:`float`, optional
         The distance from the viewer to the far clipping plane.
     camera_position : :obj:`str` or (3,) array_like of :obj:`float`, optional
-        Initial camera position. ``auto`` (default) for shiftet position in z-direction.
+        Initial camera position. Use ``'auto'`` (default) for shifted position in z-direction.
     camera_target : :obj:`str` or (3,) array_like of :obj:`float`, optional
-        Initial camera target. ``auto`` (default) to look towards the system center.
+        Initial camera target. Use ``'auto'`` (default) to look towards the system center.
     camera_right : (3,) array_like of :obj:`float`, optional
-        Camera right vector in system coordinates. Default is [1, 0, 0]
+        Camera right vector in system coordinates. Default is ``[1, 0, 0]``
     particle_sizes : :obj:`str` or array_like :obj:`float` or callable, optional
-        auto (default): The Lennard-Jones sigma value of the
-        self-interaction is used for the particle diameter.
-        callable: A lambda function with one argument. Internally,
-        the numerical particle type is passed to the lambda
-        function to determine the particle radius.  list: A list
-        of particle radii, indexed by the particle type.
+        * ``'auto'`` (default): The Lennard-Jones sigma value of the
+          self-interaction is used for the particle diameter.
+        * callable: A lambda function with one argument. Internally,
+          the numerical particle type is passed to the lambda
+          function to determine the particle radius.
+        * list: A list of particle radii, indexed by the particle type.
     particle_coloring : :obj:`str`, optional
-        auto (default): Colors of charged particles are
-        specified by particle_charge_colors, neutral particles
-        by particle_type_colors. charge: Minimum and maximum
-        charge of all particles is determined by the
-        visualizer. All particles are colored by a linear
-        interpolation of the two colors given by
-        particle_charge_colors according to their charge. type:
-        Particle colors are specified by particle_type_colors,
-        indexed by their numerical particle type.
-        node: Color according to the node the particle is on.
+        * ``'auto'`` (default): Colors of charged particles are
+          specified by ``particle_charge_colors``, neutral particles
+          by ``particle_type_colors``.
+        * ``'charge'``: Minimum and maximum charge of all particles is determined by the
+          visualizer. All particles are colored by a linear
+          interpolation of the two colors given by
+          ``particle_charge_colors`` according to their charge.
+        * ``'type'``: Particle colors are specified by ``particle_type_colors``,
+          indexed by their numerical particle type.
+        * ``'node'``: Color according to the node the particle is on.
     particle_type_colors : array_like :obj:`float`, optional
         Colors for particle types.
     particle_type_materials : :obj:`str`, optional


### PR DESCRIPTION
Description of changes:
- use fewer docker images (`cuda:10.1`, `cuda:tutorials`, `ubuntu-python3:18.04` were merged into the new `ubuntu-python3:cuda-10.1` in espressomd/docker#134)
- generate the Sphinx website in a container with ScaFaCoS
   * reduces the number of regexes in the Sphinx check script
   * simplifies the release checklist: no need to manually build the documentation on a machine with ScaFaCoS installed, instead just post the sphinx artifacts of the release branch CI
- don't build the Doxygen website in PRs: the job cannot fail and doesn't provide any feedback, there is already another job `style_doxygen` that provides feedback
- upgrade Debian9 job to Debian10