### PR TITLE
CI: per-job timeouts and interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,7 +332,7 @@ ubuntu:armhf:
 
 ubuntu:i386:
   <<: *arch_definition
-  imeout: 1h
+  timeout: 1h
   only:
     - branches
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ stages:
     - staging.tmp
     - trying.tmp
   timeout: 1h
+  interruptible: true
 
 .notification_job_template: &notification_job_definition
   <<: *global_job_definition
@@ -20,6 +21,7 @@ stages:
     GIT_SUBMODULE_STRATEGY: none
   dependencies: []
   timeout: 15m
+  interruptible: false
   tags:
     - linux
 
@@ -506,6 +508,7 @@ check_with_odd_no_of_processors:
     - echo "$SSH_PRIVATE_KEY" > ${HOME}/.ssh/espresso_rsa && chmod 600 ${HOME}/.ssh/espresso_rsa
     - echo "$SSH_PUBLIC_KEY" > ${HOME}/.ssh/espresso_rsa.pub && chmod 600 ${HOME}/.ssh/espresso_rsa.pub
     - '[[ -f /.dockerenv ]] && echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config'
+  interruptible: false
   tags:
     - docker
     - linux

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,12 +12,14 @@ stages:
   except:
     - staging.tmp
     - trying.tmp
+  timeout: 1h
 
 .notification_job_template: &notification_job_definition
   <<: *global_job_definition
   variables:
     GIT_SUBMODULE_STRATEGY: none
   dependencies: []
+  timeout: 15m
   tags:
     - linux
 
@@ -314,6 +316,7 @@ rocm-maxset:
     - export OMPI_MCA_btl_vader_single_copy_mechanism=none
     - export myconfig=maxset
     - bash maintainer/CI/build_cmake.sh
+  timeout: 6h
   tags:
     - docker
     - linux
@@ -327,6 +330,7 @@ ubuntu:armhf:
 
 ubuntu:i386:
   <<: *arch_definition
+  imeout: 1h
   only:
     - branches
     - tags
@@ -368,6 +372,7 @@ clang:6.0:
   script:
     - export myconfig=maxset with_coverage=false with_static_analysis=true with_asan=true with_ubsan=true test_timeout=900
     - bash maintainer/CI/build_cmake.sh
+  timeout: 2h
   tags:
     - docker
     - linux


### PR DESCRIPTION
For consistency with https://github.com/espressomd/docker/pull/135