### PR TITLE
Update CI build workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,7 +249,7 @@ tutorials-samples-empty:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
     - export myconfig=empty with_coverage=false make_check=false
-    - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
+    - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200 with_scafacos=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ style:
 style_doxygen:
   <<: *global_job_definition
   stage: prepare
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-9.0
   dependencies: []
   script:
     - mkdir build
@@ -174,7 +174,7 @@ fedora:
     - docker
     - linux
 
-#ubuntu:1604 not needed: used in cuda:9.0
+#ubuntu:1604 not needed: used in ubuntu-python3:cuda-9.0
 #ubuntu:1804 not needed: default used in non-CUDA builds
 #ubuntu:1904 not needed: base image for builds on different architectures
 
@@ -200,7 +200,7 @@ cuda10-maxset:
 cuda9-maxset:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-9.0
   script:
     - export myconfig=maxset with_coverage=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
     - sed -i 's/ or "DISPLAY" in os.environ/ or True/' src/python/espressomd/visualization.pyx
@@ -275,7 +275,7 @@ tutorials-samples-no-gpu:
 empty:
   <<: *global_job_definition
   stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-9.0
   script:
     - export myconfig=empty
     - bash maintainer/CI/build_cmake.sh
@@ -444,7 +444,7 @@ run_tutorials:
 run_doxygen:
   <<: *global_job_definition
   stage: additional_checks
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-9.0
   needs:
     - cuda9-maxset
   when: on_success
@@ -464,7 +464,7 @@ run_doxygen:
 check_cuda_maxset_no_gpu:
   <<: *global_job_definition
   stage: additional_checks
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-9.0
   when: on_success
   needs: 
     - cuda9-maxset
@@ -480,7 +480,7 @@ check_cuda_maxset_no_gpu:
 check_with_odd_no_of_processors:
   <<: *global_job_definition
   stage: additional_checks 
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-9.0
   when: on_success
   needs: 
     - cuda9-maxset
@@ -497,7 +497,7 @@ check_with_odd_no_of_processors:
 .deploy_base:
   <<: *global_job_definition
   stage: deploy
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/cuda:9.0
+  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-9.0
   only:
     - python
   before_script:

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -162,32 +162,6 @@ outp insource srcdir builddir \
     build_procs check_procs \
     with_cuda with_ccache
 
-# check indentation of python files
-pep8_command () {
-    if hash pep8 2> /dev/null; then
-        pep8 "$@"
-    elif hash pycodestyle 2> /dev/null; then
-        pycodestyle "$@"
-    elif hash pycodestyle-3 2> /dev/null; then
-        pycodestyle-3 "$@"
-    else
-        echo "pep8 not found";
-        exit 1
-    fi
-}
-
-pep8_command --filename=*.pyx,*.pxd,*.py --select=E111 "${srcdir}/src/python/espressomd/"
-ec=$?
-if [ ${ec} -eq 0 ]; then
-    echo ""
-    echo "Indentation in Python files correct..."
-    echo ""
-else
-    echo ""
-    echo "Error: Python files are not indented the right way. Please use 4 spaces per indentation level!"
-    echo ""
-    exit ${ec}
-fi
 # enforce style rules
 pylint_command () {
     if hash pylint 2> /dev/null; then

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -97,6 +97,7 @@ set_default_value make_check_benchmarks false
 set_default_value with_cuda true
 set_default_value build_type "Debug"
 set_default_value with_ccache false
+set_default_value with_scafacos true
 set_default_value test_timeout 300
 set_default_value hide_gpu false
 
@@ -106,8 +107,8 @@ else
     run_checks=false
 fi
 
-# If there are no user-provided flags they
-# are added according to ${with_coverage}.
+# If there are no user-provided flags, default
+# ones are added according to ${with_coverage}
 nvcc_flags=${cxx_flags}
 if [ -z "${cxx_flags}" ]; then
     if ${with_coverage}; then
@@ -128,12 +129,15 @@ if [ ${with_coverage} = true ]; then
     bash <(curl -s https://codecov.io/env) &> /dev/null;
 fi
 
-cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=${check_procs} ${cmake_params} -DWITH_SCAFACOS=ON"
+cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=${check_procs} ${cmake_params}"
 cmake_params="${cmake_params} -DCMAKE_CXX_FLAGS=${cxx_flags} -DCUDA_NVCC_FLAGS=${nvcc_flags}"
 cmake_params="${cmake_params} -DCMAKE_INSTALL_PREFIX=/tmp/espresso-unit-tests"
 cmake_params="${cmake_params} -DTEST_TIMEOUT=${test_timeout}"
 if [ ${with_ccache} = true ]; then
     cmake_params="${cmake_params} -DWITH_CCACHE=ON"
+fi
+if [ ${with_scafacos} = true ]; then
+    cmake_params="${cmake_params} -DWITH_SCAFACOS=ON"
 fi
 
 command -v nvidia-smi && nvidia-smi || true

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -162,25 +162,6 @@ outp insource srcdir builddir \
     build_procs check_procs \
     with_cuda with_ccache
 
-# enforce style rules
-pylint_command () {
-    if hash pylint 2> /dev/null; then
-        pylint "$@"
-    elif hash pylint3 2> /dev/null; then
-        pylint3 "$@"
-    elif hash pylint-3 2> /dev/null; then
-        pylint-3 "$@"
-    else
-        echo "pylint not found";
-        exit 1
-    fi
-}
-if [ $(pylint_command --version | grep -o 'pylint.*[0-9]\.[0-9]\.[0-9]' | awk '{ print $2 }' | cut -d'.' -f2) -gt 6 ]; then
-    score_option='--score=no'
-else
-    score_option=''
-fi
-
 if [ ${insource} = false ]; then
     if [ ! -d "${builddir}" ]; then
         echo "Creating ${builddir}..."

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -36,3 +36,24 @@ if [ "$CI" != "" ]; then
     maintainer/gh_post_style_patch.py
 fi
 
+# enforce style rules
+pylint_command () {
+    if hash pylint 2> /dev/null; then
+        pylint "$@"
+    elif hash pylint3 2> /dev/null; then
+        pylint3 "$@"
+    elif hash pylint-3 2> /dev/null; then
+        pylint-3 "$@"
+    else
+        echo "pylint not found";
+        exit 1
+    fi
+}
+pylint_command --score=no --reports=no --disable=all --enable=W0614,R1714,R1701,C0325,W0611,C0303 $(find ./src -name '*.py*') | tee pylint.log
+errors=$(grep -P '^[a-z]+/.+?.py:[0-9]+:[0-9]+: [CRWEF][0-9]+:' pylint.log  | wc -l)
+if [ ${errors} != 0 ]; then
+  echo "pylint found ${errors} errors"
+  exit 1;
+else
+  echo "pylint found no error"
+fi

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -36,24 +36,3 @@ if [ "$CI" != "" ]; then
     maintainer/gh_post_style_patch.py
 fi
 
-# enforce style rules
-pylint_command () {
-    if hash pylint 2> /dev/null; then
-        pylint "$@"
-    elif hash pylint3 2> /dev/null; then
-        pylint3 "$@"
-    elif hash pylint-3 2> /dev/null; then
-        pylint-3 "$@"
-    else
-        echo "pylint not found";
-        exit 1
-    fi
-}
-pylint_command --score=no --reports=no --disable=all --enable=W0614,R1714,R1701,C0325,W0611,C0303 $(find ./src -name '*.py*') | tee pylint.log
-errors=$(grep -P '^[a-z]+/.+?.py:[0-9]+:[0-9]+: [CRWEF][0-9]+:' pylint.log  | wc -l)
-if [ ${errors} != 0 ]; then
-  echo "pylint found ${errors} errors"
-  exit 1;
-else
-  echo "pylint found no error"
-fi

--- a/src/config/check_myconfig.py
+++ b/src/config/check_myconfig.py
@@ -54,7 +54,7 @@ def handle_unknown(f, all_features):
     for d in all_features:
         dist = damerau_levenshtein_distance(f, d)
         if dist < max_dist:
-            min_dist = dist
+            max_dist = dist
             match = d
 
     if match:


### PR DESCRIPTION
Description of changes:
- decouple style checking from compilation
   - delete the obsolete indentation check from the build script (redundant with `autopep8`)
   - move the currently unused `pylint` check logic from the build script to the style script
     (commit f2ea574 removes it, will be re-enabled in espresso 5)
- add a scafacos switch to fix #3195 and fix #3201
- use the new docker image nomenclature