### PR TITLE
Remove unused force reduction function

### DIFF
--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -365,21 +365,6 @@ void cell_cell_transfer(GhostCommunication *gc, int data_parts) {
   }
 }
 
-void reduce_forces_sum(void *add, void *to, int const *const len,
-                       MPI_Datatype *type) {
-  auto *cadd = static_cast<ParticleForce *>(add),
-       *cto = static_cast<ParticleForce *>(to);
-  int const clen = *len / sizeof(ParticleForce);
-
-  if (*type != MPI_BYTE || (*len % sizeof(ParticleForce)) != 0) {
-    fprintf(stderr, "%d: transfer data type wrong\n", this_node);
-    errexit();
-  }
-
-  for (int i = 0; i < clen; i++)
-    cto[i] += cadd[i];
-}
-
 static int is_send_op(int comm_type, int node) {
   return ((comm_type == GHOST_SEND) || (comm_type == GHOST_RDCE) ||
           (comm_type == GHOST_BCST && node == this_node));


### PR DESCRIPTION
The function `reduce_forces_sum` was made obsolete by a538ebb

Fixes #

Description of changes:
 - Remove unused function


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
