### PR TITLE
cmake: add soversion to libH5mdCore

### DIFF
--- a/src/core/io/writer/CMakeLists.txt
+++ b/src/core/io/writer/CMakeLists.txt
@@ -8,5 +8,6 @@ target_include_directories(H5mdCore SYSTEM PUBLIC
 target_include_directories(H5mdCore PUBLIC SYSTEM ${HDF5_INCLUDE_DIRS})
 target_link_libraries(H5mdCore PUBLIC EspressoConfig EspressoCore ${HDF5_LIBRARIES} MPI::MPI_CXX Boost::filesystem)
 target_compile_definitions(H5mdCore PUBLIC H5XX_USE_MPI)
+set_target_properties(H5mdCore PROPERTIES SOVERSION ${SOVERSION})
 install(TARGETS H5mdCore LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 endif()


### PR DESCRIPTION
Just #2946 again, not why it didn't make it in v4.1 