### PR TITLE
Fix mpiio with stdlibc++ range checking

### DIFF
--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -446,7 +446,7 @@ void mpi_mpiio_common_read(const char *filename, unsigned fields) {
 
     for (int i = 0; i < nlocalpart; ++i) {
       int blen = boff[i + 1] - boff[i];
-      if(blen) {
+      if (blen) {
         auto &bl = local_particles[id[i]]->bl;
         bl.resize(blen);
         std::copy_n(&bond[boff[i]], blen, bl.begin());

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -446,9 +446,11 @@ void mpi_mpiio_common_read(const char *filename, unsigned fields) {
 
     for (int i = 0; i < nlocalpart; ++i) {
       int blen = boff[i + 1] - boff[i];
-      auto &bl = local_particles[id[i]]->bl;
-      bl.resize(blen);
-      std::copy_n(&bond[boff[i]], blen, bl.begin());
+      if(blen) {
+        auto &bl = local_particles[id[i]]->bl;
+        bl.resize(blen);
+        std::copy_n(&bond[boff[i]], blen, bl.begin());
+      }
     }
   }
 

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -446,11 +446,9 @@ void mpi_mpiio_common_read(const char *filename, unsigned fields) {
 
     for (int i = 0; i < nlocalpart; ++i) {
       int blen = boff[i + 1] - boff[i];
-      if (blen) {
-        auto &bl = local_particles[id[i]]->bl;
-        bl.resize(blen);
-        std::copy_n(&bond[boff[i]], blen, bl.begin());
-      }
+      auto &bl = local_particles[id[i]]->bl;
+      bl.resize(blen);
+      std::copy_n(bond.begin() + boff[i], blen, bl.begin());
     }
   }
 


### PR DESCRIPTION
Fixes #3230. Reported by @junghans.

When mpiio was used but no bonds were present, we would still try to copy zero bonds from a zero-length vector. This triggered an assertion when stdlibc++ range checking was enabled.

Please tag for cherry-picking into 4.1.1.