### PR TITLE
ESS2019 installation guide updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ endif(WITH_VALGRIND_INSTRUMENTATION)
 # MPI
 #
 
-find_package(MPI REQUIRED 3.0)
+find_package(MPI 3.0 REQUIRED)
 
 # CMake < 3.9
 if(NOT TARGET MPI::MPI_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ endif(WITH_VALGRIND_INSTRUMENTATION)
 # MPI
 #
 
-find_package(MPI REQUIRED)
+find_package(MPI REQUIRED 3.0)
 
 # CMake < 3.9
 if(NOT TARGET MPI::MPI_CXX)

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -114,6 +114,8 @@ ROCm SDK to make use of GPU computation:
     sudo apt update
     sudo apt install libnuma-dev rocm-dkms rocblas rocfft rocrand rocthrust
 
+After installing the ROCm SDK, please reboot your computer.
+
 .. _Installing Requirements on Mac OS X:
 
 Installing Requirements on Mac OS X
@@ -132,7 +134,8 @@ following commands:
     sudo port selfupdate
     sudo port install cmake python37 py37-cython py37-numpy \
       openmpi-default fftw-3 +openmpi boost +openmpi +python37 \
-      doxygen py37-opengl py37-sphinx py37-pip gsl hdf5 +openmpi
+      doxygen py37-opengl py37-sphinx py37-pip gsl hdf5 +openmpi \
+      py37-matplotlib py37-ipython py37-jupyter
     sudo port select --set cython cython37
     sudo port select --set python3 python37
     sudo port select --set pip pip37
@@ -145,12 +148,11 @@ Alternatively, you can use Homebrew.
     sudo xcode-select --install
     sudo xcodebuild -license accept
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    brew install cmake python@3 cython boost boost-mpi fftw \
-      doxygen gsl
-    brew install hdf5 --with-mpi
-    brew install numpy --without-python@2
-    ln -s /usr/local/bin/python2 /usr/local/bin/python
-    pip install --user PyOpenGL
+    brew install cmake python cython boost boost-mpi fftw \
+      doxygen gsl numpy ipython jupyter
+    brew install hdf5
+    brew link --force cython
+    pip install PyOpenGL matplotlib
 
 Note: If both MacPorts and Homebrew are installed, you will not be able to
 run |es|. Therefore, if you have both installed, please uninstall one

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -73,8 +73,8 @@ To make |es| run on 18.04 LTS, its dependencies can be installed with:
 .. code-block:: bash
 
     sudo apt install build-essential cmake cython3 python3-numpy \
-    libboost-all-dev openmpi-common fftw3-dev libhdf5-dev libhdf5-openmpi-dev \
-    doxygen python3-opengl python3-sphinx python3-pip libgsl-dev
+      libboost-all-dev openmpi-common fftw3-dev libhdf5-dev libhdf5-openmpi-dev \
+      python3-opengl libgsl-dev
 
 
 Optionally the ccmake utility can be installed for easier configuration:
@@ -88,7 +88,8 @@ are required:
 
 .. code-block:: bash
 
-    pip3 install --upgrade jupyter scipy matplotlib sphinxcontrib-bibtex numpydoc
+    sudo apt install python3-matplotlib python3-scipy \
+      ipython3 jupyter-notebook
 
 If your computer has an Nvidia graphics card, you should also download and install the
 CUDA SDK to make use of GPU computation:
@@ -174,7 +175,7 @@ If you want to install Homebrew, use the following commands.
 Installing Packages using MacPorts
 """"""""""""""""""""""""""""""""""
     
-Run thefollowing commands:
+Run the following commands:
 
 .. code-block:: bash
 
@@ -183,11 +184,10 @@ Run thefollowing commands:
     sudo port selfupdate
     sudo port install cmake python37 py37-cython py37-numpy \
       openmpi-default fftw-3 +openmpi boost +openmpi +python37 \
-      doxygen py37-opengl py37-sphinx py37-pip gsl hdf5 +openmpi \
+      doxygen py37-opengl py37-sphinx gsl hdf5 +openmpi \
       py37-matplotlib py37-ipython py37-jupyter
     sudo port select --set cython cython37
     sudo port select --set python3 python37
-    sudo port select --set pip pip37
     sudo port select --set mpi openmpi-mp
 
 
@@ -207,19 +207,6 @@ Installing CUDA
 
 If your Mac has an Nvidia graphics card, you should also download and install the
 CUDA SDK [6]_ to make use of GPU computation.
-
-.. _Installing python dependencies:
-
-Installing python dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-There are a few python packages needed to e.g. build the documentation.
-To install the required packages as a non-root user execute the following
-command in |es|'s source directory:
-
-.. code-block:: bash
-
-    pip3 install -r requirements.txt --user --upgrade
 
 .. _Quick installation:
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -121,11 +121,60 @@ After installing the ROCm SDK, please reboot your computer.
 Installing Requirements on Mac OS X
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To make |es| run on Mac OS X 10.9 or higher, its dependencies can be
-installed using MacPorts. First, download the installer package
-appropriate for your Mac OS X version from
-https://www.macports.org/install.php and install it. Then, run the
+Preparation
++++++++++++
+
+To make |es| run on Mac OS X 10.9 or higher, you need to install its
+dependencies. There are two possibilities for this, MacPorts and Homebrew.
+We recommend MacPorts, but if you already have Homebrew installed, you can use
+that too. To check whether you already have one or the other installed, run the
 following commands:
+
+.. code-block:: bash
+
+    test -e /opt/local/bin/port && echo "MacPorts is installed"
+    test -e /usr/local/bin/brew && echo "Homebrew is installed"
+
+If both are installed, you need to remove one of the two. To do that, run one
+of the following two commands:
+
+.. code-block:: bash
+
+    sudo port -f uninstall installed && rm -r /opt/local
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+
+If Homebrew is already installed, you should resolve any problems reported by
+the command
+
+.. code-block:: bash
+
+    brew doctor
+
+If Anaconda Python or the Python from www.python.org are installed, you
+will likely not be able to run |es|. Therefore, please uninstall them
+using the following commands:
+
+.. code-block:: bash
+
+    sudo rm -r ~/anaconda[23]
+    sudo rm -r /Library/Python
+
+If you want to install MacPorts, download the installer package
+appropriate for your Mac OS X version from
+https://www.macports.org/install.php and install it.
+
+If you want to install Homebrew, use the following commands.
+
+.. code-block:: bash
+
+    sudo xcode-select --install
+    sudo xcodebuild -license accept
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+Installing Packages using MacPorts
+++++++++++++++++++++++++++++++++++
+    
+Run thefollowing commands:
 
 .. code-block:: bash
 
@@ -141,27 +190,20 @@ following commands:
     sudo port select --set pip pip37
     sudo port select --set mpi openmpi-mp
 
-Alternatively, you can use Homebrew.
+
+Installing Packages using Homebrew
+++++++++++++++++++++++++++++++++++
 
 .. code-block:: bash
 
-    sudo xcode-select --install
-    sudo xcodebuild -license accept
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     brew install cmake python cython boost boost-mpi fftw \
       doxygen gsl numpy ipython jupyter
     brew install hdf5
     brew link --force cython
     pip install PyOpenGL matplotlib
 
-Note: If both MacPorts and Homebrew are installed, you will not be able to
-run |es|. Therefore, if you have both installed, please uninstall one
-or the other by running one of the following two commands:
-
-.. code-block:: bash
-
-    sudo port -f uninstall installed && rm -r /opt/local
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+Installing CUDA
++++++++++++++++
 
 If your Mac has an Nvidia graphics card, you should also download and install the
 CUDA SDK [6]_ to make use of GPU computation.

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -122,7 +122,7 @@ Installing Requirements on Mac OS X
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Preparation
-+++++++++++
+"""""""""""
 
 To make |es| run on Mac OS X 10.9 or higher, you need to install its
 dependencies. There are two possibilities for this, MacPorts and Homebrew.
@@ -172,7 +172,7 @@ If you want to install Homebrew, use the following commands.
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 Installing Packages using MacPorts
-++++++++++++++++++++++++++++++++++
+""""""""""""""""""""""""""""""""""
     
 Run thefollowing commands:
 
@@ -192,7 +192,7 @@ Run thefollowing commands:
 
 
 Installing Packages using Homebrew
-++++++++++++++++++++++++++++++++++
+""""""""""""""""""""""""""""""""""
 
 .. code-block:: bash
 
@@ -203,7 +203,7 @@ Installing Packages using Homebrew
     pip install PyOpenGL matplotlib
 
 Installing CUDA
-+++++++++++++++
+"""""""""""""""
 
 If your Mac has an Nvidia graphics card, you should also download and install the
 CUDA SDK [6]_ to make use of GPU computation.

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -66,7 +66,7 @@ Cython
 .. _Installing Requirements on Ubuntu Linux:
 
 Installing Requirements on Ubuntu Linux
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To make |es| run on 18.04 LTS, its dependencies can be installed with:
 
@@ -120,7 +120,7 @@ After installing the ROCm SDK, please reboot your computer.
 .. _Installing Requirements on Mac OS X:
 
 Installing Requirements on Mac OS X
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Preparation
 """""""""""
@@ -279,7 +279,7 @@ Configuring
 .. _myconfig.hpp\: Activating and deactivating features:
 
 :file:`myconfig.hpp`: Activating and deactivating features
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 |es| has a large number of features that can be compiled into the binary.
 However, it is not recommended to actually compile in all possible
@@ -348,7 +348,7 @@ and then in the Python interpreter:
 .. _Features:
 
 Features
-~~~~~~~~
+--------
 
 This chapter describes the features that can be activated in |es|. Even if
 possible, it is not recommended to activate all features, because this
@@ -563,7 +563,7 @@ Finally, there is a flag for debugging:
 
 
 Features marked as experimental
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Some of the above features are marked as EXPERIMENTAL. Activating these features can have unexpected side effects and some of them have known issues. If you activate any of these features, you should understand the corresponding source code and do extensive testing. Furthermore, it is necessary to define ``EXPERIMENTAL_FEATURES`` in :file:`myconfig.hpp`.
 
 
@@ -571,7 +571,7 @@ Some of the above features are marked as EXPERIMENTAL. Activating these features
 .. _cmake:
 
 cmake
-~~~~~
+^^^^^
 
 In order to build the first step is to create a build directory in which
 cmake can be executed. In cmake, the *source directory* (that contains
@@ -603,7 +603,7 @@ Afterwards |es| can be run via calling :file:`./pypresso` from the command line.
 .. _ccmake:
 
 ccmake
-~~~~~~
+^^^^^^
 
 Optionally and for easier use, the curses interface to cmake can be used
 to configure |es| interactively.


### PR DESCRIPTION
Lessons learned today:

- We require MPI 3 because we depend on const-correctness in a few places. That means that OpenMPI 1.6.5 and lower are not supported anymore.
- Installing the ROCm driver breaks access to /dev/kfd, causing hwloc initialization during `mpiexec` to hang. Rebooting helps.
- Add matplotlib, ipython and jupyter to the Mac install guide.
- Homebrew now defaults to Python 3, requires manually enabling cython, and it's unclear whether the hdf5 package still supports MPI (https://github.com/Homebrew/homebrew-core/issues/26974)
- Anaconda (~/anaconda[23]) and python.org packages (/Library/Python and /usr/local/bin) are also sources of conflict

Please tag for the 4.1.1 release