### PR TITLE
Factor out ParticleList

### DIFF
--- a/src/core/Cell.hpp
+++ b/src/core/Cell.hpp
@@ -107,10 +107,6 @@ public:
    * @brief All neighbors of the cell.
    */
   neighbors_type &neighbors() { return m_neighbors; }
-
-  void resize(size_t size) {
-    realloc_particlelist(static_cast<ParticleList *>(this), this->n = size);
-  }
 };
 
 #endif

--- a/src/core/Cell.hpp
+++ b/src/core/Cell.hpp
@@ -19,7 +19,8 @@
 #ifndef CORE_CELL_HPP
 #define CORE_CELL_HPP
 
-#include "particle_data.hpp"
+#include "Particle.hpp"
+#include "ParticleList.hpp"
 
 #include <utils/Span.hpp>
 

--- a/src/core/PartCfg.hpp
+++ b/src/core/PartCfg.hpp
@@ -23,6 +23,8 @@
 #include "ParticleCache.hpp"
 #include "cells.hpp"
 #include "grid.hpp"
+#include "particle_data.hpp"
+
 #include "serialization/Particle.hpp"
 #include <utils/SkipIterator.hpp>
 

--- a/src/core/ParticleList.hpp
+++ b/src/core/ParticleList.hpp
@@ -1,0 +1,24 @@
+#ifndef ESPRESSO_CORE_PARTICLE_LIST_HPP
+#define ESPRESSO_CORE_PARTICLE_LIST_HPP
+
+#include "Particle.hpp"
+
+#include <utils/Span.hpp>
+
+/** List of particles. The particle array is resized using a sophisticated
+ *  (we hope) algorithm to avoid unnecessary resizes.
+ *  Access using \ref realloc_particlelist, ...
+ */
+struct ParticleList {
+  ParticleList() : part{nullptr}, n{0}, max{0} {}
+  /** The particles payload */
+  Particle *part;
+  /** Number of particles contained */
+  int n;
+  /** Number of particles that fit in until a resize is needed */
+  int max;
+
+  Utils::Span<Particle> particles() { return {part, static_cast<size_t>(n)}; }
+};
+
+#endif

--- a/src/core/ParticleList.hpp
+++ b/src/core/ParticleList.hpp
@@ -21,10 +21,10 @@ struct ParticleList {
 
   Utils::Span<Particle> particles() { return {part, static_cast<size_t>(n)}; }
 
-  int resize(int size) {
-/** granularity of the particle buffers in particles */
-    constexpr int PART_INCREMENT  = 8;
+  /** granularity of the particle buffers in particles */
+  static constexpr int INCREMENT = 8;
 
+  int resize(int size) {
     assert(size >= 0);
     int old_max = max;
     Particle *old_start = part;
@@ -35,12 +35,10 @@ struct ParticleList {
         max = 0;
       else
         /* shrink not as fast, just lose half, rounded up */
-        max =
-            PART_INCREMENT *
-            (((max + size + 1) / 2 + PART_INCREMENT - 1) / PART_INCREMENT);
+        max = INCREMENT * (((max + size + 1) / 2 + INCREMENT - 1) / INCREMENT);
     } else
       /* round up */
-      max = PART_INCREMENT * ((size + PART_INCREMENT - 1) / PART_INCREMENT);
+      max = INCREMENT * ((size + INCREMENT - 1) / INCREMENT);
     if (max != old_max)
       part = Utils::realloc(part, sizeof(Particle) * max);
     return part != old_start;
@@ -49,9 +47,9 @@ struct ParticleList {
 
 /** Allocate storage for local particles and ghosts. This version
     does \em not care for the bond information to be freed if necessary.
-    \param plist the list on which to operate
+    \param l the list on which to operate
     \param size the size to provide at least. It is rounded
-    up to multiples of \ref PART_INCREMENT.
+    up to multiples of \ref ParticleList::INCREMENT.
     \return true iff particle addresses have changed */
 inline int realloc_particlelist(ParticleList *l, int size) {
   return assert(l), l->resize(size);

--- a/src/core/ParticleList.hpp
+++ b/src/core/ParticleList.hpp
@@ -4,6 +4,7 @@
 #include "Particle.hpp"
 
 #include <utils/Span.hpp>
+#include <utils/memory.hpp>
 
 /** List of particles. The particle array is resized using a sophisticated
  *  (we hope) algorithm to avoid unnecessary resizes.
@@ -19,6 +20,41 @@ struct ParticleList {
   int max;
 
   Utils::Span<Particle> particles() { return {part, static_cast<size_t>(n)}; }
+
+  int resize(int size) {
+/** granularity of the particle buffers in particles */
+    constexpr int PART_INCREMENT  = 8;
+
+    assert(size >= 0);
+    int old_max = max;
+    Particle *old_start = part;
+
+    if (size < max) {
+      if (size == 0)
+        /* to be able to free an array again */
+        max = 0;
+      else
+        /* shrink not as fast, just lose half, rounded up */
+        max =
+            PART_INCREMENT *
+            (((max + size + 1) / 2 + PART_INCREMENT - 1) / PART_INCREMENT);
+    } else
+      /* round up */
+      max = PART_INCREMENT * ((size + PART_INCREMENT - 1) / PART_INCREMENT);
+    if (max != old_max)
+      part = Utils::realloc(part, sizeof(Particle) * max);
+    return part != old_start;
+  }
 };
+
+/** Allocate storage for local particles and ghosts. This version
+    does \em not care for the bond information to be freed if necessary.
+    \param plist the list on which to operate
+    \param size the size to provide at least. It is rounded
+    up to multiples of \ref PART_INCREMENT.
+    \return true iff particle addresses have changed */
+inline int realloc_particlelist(ParticleList *l, int size) {
+  return assert(l), l->resize(size);
+}
 
 #endif

--- a/src/core/ParticleList.hpp
+++ b/src/core/ParticleList.hpp
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2010-2019 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef ESPRESSO_CORE_PARTICLE_LIST_HPP
 #define ESPRESSO_CORE_PARTICLE_LIST_HPP
 
@@ -24,7 +44,16 @@ struct ParticleList {
   /** granularity of the particle buffers in particles */
   static constexpr int INCREMENT = 8;
 
-  int resize(int size) {
+  /**
+   * @brief Allocate storage for local particles and ghosts.
+   *
+   * This version does \em not care for the bond information to be freed if
+   * necessary.
+   *     @param size the size to provide at least. It is rounded
+   *     up to multiples of @ref ParticleList::INCREMENT.
+   *     @return true iff particle addresses have changed
+   */
+  int realloc(int size) {
     assert(size >= 0);
     int old_max = max;
     Particle *old_start = part;
@@ -43,14 +72,11 @@ struct ParticleList {
       part = Utils::realloc(part, sizeof(Particle) * max);
     return part != old_start;
   }
+
+  int resize(int size) { return realloc(this->n = size); }
 };
 
-/** Allocate storage for local particles and ghosts. This version
-    does \em not care for the bond information to be freed if necessary.
-    \param l the list on which to operate
-    \param size the size to provide at least. It is rounded
-    up to multiples of \ref ParticleList::INCREMENT.
-    \return true iff particle addresses have changed */
+/** @copydoc ParticleList::resize */
 inline int realloc_particlelist(ParticleList *l, int size) {
   return assert(l), l->resize(size);
 }

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -410,7 +410,7 @@ void cells_resort_particles(int global_flag) {
   resort_particles = Cells::RESORT_NONE;
   rebuild_verletlist = true;
 
-  realloc_particlelist(&displaced_parts, 0);
+  displaced_parts.clear();
 
   on_resort_particles(local_cells.particles());
 }

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -38,6 +38,7 @@
 #include "layered.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "nsquare.hpp"
+#include "particle_data.hpp"
 
 #include <utils/NoOp.hpp>
 #include <utils/mpi/gather_buffer.hpp>

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -27,9 +27,9 @@
 #include "event.hpp"
 #include "grid.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
+#include "particle_data.hpp"
 #include "rotation.hpp"
 #include "virtual_sites/VirtualSitesRelative.hpp"
-#include "particle_data.hpp"
 
 #include <utils/mpi/all_compare.hpp>
 #include <utils/mpi/gather_buffer.hpp>

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "collision.hpp"
+
+#ifdef COLLISION_DETECTION
 #include "Particle.hpp"
 #include "cells.hpp"
 #include "communication.hpp"
@@ -27,6 +29,7 @@
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "rotation.hpp"
 #include "virtual_sites/VirtualSitesRelative.hpp"
+#include "particle_data.hpp"
 
 #include <utils/mpi/all_compare.hpp>
 #include <utils/mpi/gather_buffer.hpp>
@@ -36,8 +39,6 @@
 #include <boost/serialization/serialization.hpp>
 
 #include <vector>
-
-#ifdef COLLISION_DETECTION
 
 /// Data type holding the info about a single collision
 typedef struct {

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -27,6 +27,7 @@
 #include "cuda_utils.hpp"
 #include "errorhandling.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
+#include "particle_data.hpp"
 
 #include <utils/constants.hpp>
 

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -29,6 +29,7 @@
 #include "cells.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
+#include "particle_data.hpp"
 
 void check_particle_consistency() {
   int n, c;

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -28,6 +28,7 @@
 #include "communication.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
+#include "particle_data.hpp"
 
 #include "serialization/ParticleList.hpp"
 #include <utils/index.hpp>

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -700,7 +700,7 @@ void move_if_local(ParticleList &src, ParticleList &rest) {
     }
   }
 
-  realloc_particlelist(&src, src.n = 0);
+  src.resize(0);
 }
 
 /**
@@ -761,7 +761,7 @@ void exchange_neighbors(ParticleList *pl, const Utils::Vector3i &grid) {
       Utils::Mpi::sendrecv(comm_cart, node_neighbors[2 * dir], 0, send_buf,
                            node_neighbors[2 * dir], 0, recv_buf);
 
-      realloc_particlelist(&send_buf, 0);
+      send_buf.clear();
 
       move_if_local(recv_buf, *pl);
     } else {
@@ -784,8 +784,8 @@ void exchange_neighbors(ParticleList *pl, const Utils::Vector3i &grid) {
       move_if_local(recv_buf_l, *pl);
       move_if_local(recv_buf_r, *pl);
 
-      realloc_particlelist(&send_buf_l, 0);
-      realloc_particlelist(&send_buf_r, 0);
+      send_buf_l.clear();
+      send_buf_r.clear();
     }
   }
 }

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -29,6 +29,7 @@
 #include "errorhandling.hpp"
 #include "grid.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
+#include "particle_data.hpp"
 
 #include <utils/constants.hpp>
 

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -44,6 +44,7 @@
 #include "errorhandling.hpp"
 #include "global.hpp"
 #include "grid.hpp"
+#include "particle_data.hpp"
 
 DLC_struct dlc_params = {1e100, 0, 0, 0, 0};
 

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -65,6 +65,7 @@
 #include "EspressoSystemInterface.hpp"
 #include "electrostatics_magnetostatics/coulomb.hpp"
 #include "global.hpp"
+#include "particle_data.hpp"
 
 #include <utils/math/int_pow.hpp>
 using Utils::int_pow;

--- a/src/core/electrostatics_magnetostatics/scafacos.cpp
+++ b/src/core/electrostatics_magnetostatics/scafacos.cpp
@@ -41,6 +41,7 @@
 #include "global.hpp"
 #include "grid.hpp"
 #include "integrate.hpp"
+#include "particle_data.hpp"
 #include "tuning.hpp"
 
 #include "electrostatics_magnetostatics/coulomb.hpp"

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -61,6 +61,7 @@
 #include "object-in-fluid/oif_local_forces.hpp"
 #include "object-in-fluid/out_direction.hpp"
 #include "thermostat.hpp"
+#include "particle_data.hpp"
 
 #ifdef DIPOLES
 #include "electrostatics_magnetostatics/dipole_inline.hpp"

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -60,8 +60,8 @@
 #include "object-in-fluid/oif_global_forces.hpp"
 #include "object-in-fluid/oif_local_forces.hpp"
 #include "object-in-fluid/out_direction.hpp"
-#include "thermostat.hpp"
 #include "particle_data.hpp"
+#include "thermostat.hpp"
 
 #ifdef DIPOLES
 #include "electrostatics_magnetostatics/dipole_inline.hpp"

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -193,11 +193,12 @@ void prepare_send_buffer(GhostCommunication *gc, int data_parts) {
 
 static void prepare_ghost_cell(Cell *cell, int size) {
   using Utils::make_span;
-  auto const old_cap = cell->max;
+  auto const old_cap = cell->capacity();
 
   /* reset excess particles */
-  if (size < cell->max) {
-    for (auto &p : make_span<Particle>(cell->part + size, cell->max - size)) {
+  if (size < cell->capacity()) {
+    for (auto &p :
+         make_span<Particle>(cell->part + size, cell->capacity() - size)) {
       p = Particle{};
       p.l.ghost = true;
     }
@@ -207,8 +208,9 @@ static void prepare_ghost_cell(Cell *cell, int size) {
   cell->resize(size);
 
   /* initialize new particles */
-  if (old_cap < cell->max) {
-    auto new_parts = make_span(cell->part + old_cap, cell->max - old_cap);
+  if (old_cap < cell->capacity()) {
+    auto new_parts =
+        make_span(cell->part + old_cap, cell->capacity() - old_cap);
     std::uninitialized_fill(new_parts.begin(), new_parts.end(), Particle{});
     for (auto &p : new_parts) {
       p.l.ghost = true;

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -28,6 +28,7 @@
 #include "Particle.hpp"
 #include "communication.hpp"
 #include "errorhandling.hpp"
+#include "particle_data.hpp"
 
 #include <algorithm>
 #include <cstdio>

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -37,6 +37,8 @@
 #include "rattle.hpp"
 #include "thermostat.hpp"
 #include "tuning.hpp"
+#include "particle_data.hpp"
+
 #include <utils/mpi/all_compare.hpp>
 
 #include <boost/functional/hash.hpp>

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -34,10 +34,10 @@
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "npt.hpp"
 #include "object-in-fluid/oif_global_forces.hpp"
+#include "particle_data.hpp"
 #include "rattle.hpp"
 #include "thermostat.hpp"
 #include "tuning.hpp"
-#include "particle_data.hpp"
 
 #include <utils/mpi/all_compare.hpp>
 

--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -28,6 +28,7 @@
 #include "lb_interpolation.hpp"
 #include "lbgpu.hpp"
 #include "random.hpp"
+#include "particle_data.hpp"
 
 #include <profiler/profiler.hpp>
 #include <utils/Counter.hpp>

--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -27,8 +27,8 @@
 #include "lb_interface.hpp"
 #include "lb_interpolation.hpp"
 #include "lbgpu.hpp"
-#include "random.hpp"
 #include "particle_data.hpp"
+#include "random.hpp"
 
 #include <profiler/profiler.hpp>
 #include <utils/Counter.hpp>

--- a/src/core/immersed_boundary/ImmersedBoundaries.cpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.cpp
@@ -25,6 +25,7 @@
 #include "communication.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
+#include "particle_data.hpp"
 
 #include <utils/constants.hpp>
 

--- a/src/core/integrators/steepest_descent.cpp
+++ b/src/core/integrators/steepest_descent.cpp
@@ -24,8 +24,8 @@
 #include "communication.hpp"
 #include "event.hpp"
 #include "integrate.hpp"
-#include "rotation.hpp"
 #include "particle_data.hpp"
+#include "rotation.hpp"
 
 #include <utils/math/sqr.hpp>
 

--- a/src/core/integrators/steepest_descent.cpp
+++ b/src/core/integrators/steepest_descent.cpp
@@ -25,6 +25,7 @@
 #include "event.hpp"
 #include "integrate.hpp"
 #include "rotation.hpp"
+#include "particle_data.hpp"
 
 #include <utils/math/sqr.hpp>
 

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -27,8 +27,8 @@
 #include "integrate.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "npt.hpp"
-#include "thermostat.hpp"
 #include "particle_data.hpp"
+#include "thermostat.hpp"
 
 #include <utils/math/sqr.hpp>
 

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -20,7 +20,6 @@
 #include "config.hpp"
 
 #ifdef NPT
-#include "Particle.hpp"
 #include "ParticleRange.hpp"
 #include "cells.hpp"
 #include "communication.hpp"
@@ -29,7 +28,9 @@
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "npt.hpp"
 #include "thermostat.hpp"
-#include "utils/math/sqr.hpp"
+#include "particle_data.hpp"
+
+#include <utils/math/sqr.hpp>
 
 void velocity_verlet_npt_propagate_vel_final(const ParticleRange &particles) {
   nptiso.p_vel[0] = nptiso.p_vel[1] = nptiso.p_vel[2] = 0.0;

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -57,6 +57,7 @@
 #include "event.hpp"
 #include "integrate.hpp"
 #include "mpiio.hpp"
+#include "particle_data.hpp"
 
 #include <mpi.h>
 

--- a/src/core/layered.cpp
+++ b/src/core/layered.cpp
@@ -482,6 +482,6 @@ void layered_exchange_and_sort_particles(int global_flag,
     }
   }
 
-  realloc_particlelist(&recv_buf_up, 0);
-  realloc_particlelist(&recv_buf_dn, 0);
+  recv_buf_up.clear();
+  recv_buf_dn.clear();
 }

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -168,7 +168,7 @@ void nsq_exchange_particles(int global_flag, ParticleList *displaced_parts) {
     auto const target_node = (p.identity() % n_nodes);
     send_buf.at(target_node).emplace_back(std::move(p));
   }
-  realloc_particlelist(displaced_parts, displaced_parts->n = 0);
+  displaced_parts->resize(0);
 
   /* Exchange particles */
   std::vector<std::vector<Particle>> recv_buf(n_nodes);

--- a/src/core/object-in-fluid/oif_global_forces.cpp
+++ b/src/core/object-in-fluid/oif_global_forces.cpp
@@ -25,6 +25,7 @@
 #include "errorhandling.hpp"
 #include "grid.hpp"
 #include "grid_based_algorithms/lb_interface.hpp"
+#include "particle_data.hpp"
 
 #include <utils/math/triangle_functions.hpp>
 using Utils::angle_btw_triangles;

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -561,12 +561,12 @@ void update_local_particles(ParticleList *pl) {
 }
 
 void append_unindexed_particle(ParticleList *l, Particle &&part) {
-  realloc_particlelist(l, ++l->n);
+  l->resize(l->n + 1);
   new (&(l->part[l->n - 1])) Particle(std::move(part));
 }
 
 Particle *append_indexed_particle(ParticleList *l, Particle &&part) {
-  auto const re = realloc_particlelist(l, ++l->n);
+  auto const re = l->resize(l->n + 1);
   auto p = new (&(l->part[l->n - 1])) Particle(std::move(part));
 
   assert(p->p.identity <= max_seen_particle);
@@ -582,7 +582,7 @@ Particle *move_unindexed_particle(ParticleList *dl, ParticleList *sl, int i) {
   assert(sl->n > 0);
   assert(i < sl->n);
 
-  realloc_particlelist(dl, ++dl->n);
+  dl->resize(dl->n + 1);
   auto dst = &dl->part[dl->n - 1];
   auto src = &sl->part[i];
   auto end = &sl->part[sl->n - 1];
@@ -592,14 +592,14 @@ Particle *move_unindexed_particle(ParticleList *dl, ParticleList *sl, int i) {
     new (src) Particle(std::move(*end));
   }
 
-  realloc_particlelist(sl, --sl->n);
+  sl->resize(sl->n - 1);
   return dst;
 }
 
 Particle *move_indexed_particle(ParticleList *dl, ParticleList *sl, int i) {
   assert(sl->n > 0);
   assert(i < sl->n);
-  int re = realloc_particlelist(dl, ++dl->n);
+  int re = dl->resize(dl->n + 1);
   Particle *dst = &dl->part[dl->n - 1];
   Particle *src = &sl->part[i];
   Particle *end = &sl->part[sl->n - 1];
@@ -617,7 +617,7 @@ Particle *move_indexed_particle(ParticleList *dl, ParticleList *sl, int i) {
     new (src) Particle(std::move(*end));
   }
 
-  if (realloc_particlelist(sl, --sl->n)) {
+  if (sl->resize(sl->n - 1)) {
     update_local_particles(sl);
   } else if (src != end) {
     local_particles[src->p.identity] = src;
@@ -652,7 +652,7 @@ Particle extract_indexed_particle(ParticleList *sl, int i) {
     new (src) Particle(std::move(*end));
   }
 
-  if (realloc_particlelist(sl, --sl->n)) {
+  if (sl->resize(sl->n - 1)) {
     update_local_particles(sl);
   } else if (src != end) {
     local_particles[src->p.identity] = src;
@@ -1325,7 +1325,7 @@ void send_particles(ParticleList *particles, int node) {
     free_particle(&particles->part[pc]);
   }
 
-  realloc_particlelist(particles, particles->n = 0);
+  particles->clear();
 }
 
 void recv_particles(ParticleList *particles, int node) {

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -25,8 +25,8 @@
  */
 #include "particle_data.hpp"
 
-#include "Particle.hpp"
 #include "PartCfg.hpp"
+#include "Particle.hpp"
 #include "bonded_interactions/bonded_interaction_data.hpp"
 #include "cells.hpp"
 #include "communication.hpp"
@@ -543,8 +543,7 @@ void realloc_local_particles(int part) {
 
   if (part >= max_local_particles) {
     /* round up part + 1 in granularity INCREMENT */
-    max_local_particles =
-        INCREMENT * ((part + INCREMENT) / INCREMENT);
+    max_local_particles = INCREMENT * ((part + INCREMENT) / INCREMENT);
     local_particles = Utils::realloc(local_particles,
                                      sizeof(Particle *) * max_local_particles);
 

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -37,6 +37,7 @@
 #include "config.hpp"
 
 #include "Particle.hpp"
+#include "ParticleList.hpp"
 
 #include <utils/List.hpp>
 #include <utils/Span.hpp>
@@ -76,26 +77,6 @@ enum {
 #endif
 
 #endif
-
-/************************************************
- * data types
- ************************************************/
-
-/** List of particles. The particle array is resized using a sophisticated
- *  (we hope) algorithm to avoid unnecessary resizes.
- *  Access using \ref realloc_particlelist, ...
- */
-struct ParticleList {
-  ParticleList() : part{nullptr}, n{0}, max{0} {}
-  /** The particles payload */
-  Particle *part;
-  /** Number of particles contained */
-  int n;
-  /** Number of particles that fit in until a resize is needed */
-  int max;
-
-  Utils::Span<Particle> particles() { return {part, static_cast<size_t>(n)}; }
-};
 
 /************************************************
  * exported variables

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -112,14 +112,6 @@ void free_particle(Particle *part);
 /*    Functions acting on Particle Lists        */
 /************************************************/
 
-/** Allocate storage for local particles and ghosts. This version
-    does \em not care for the bond information to be freed if necessary.
-    \param plist the list on which to operate
-    \param size the size to provide at least. It is rounded
-    up to multiples of \ref PART_INCREMENT.
-    \return true iff particle addresses have changed */
-int realloc_particlelist(ParticleList *plist, int size);
-
 /** Append a particle at the end of a particle List.
     reallocates particles if necessary!
     This procedure does not care for \ref local_particles.

--- a/src/core/rattle.cpp
+++ b/src/core/rattle.cpp
@@ -34,6 +34,7 @@ int n_rigidbonds = 0;
 #include "grid.hpp"
 #include "integrate.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
+#include "particle_data.hpp"
 
 #include <utils/constants.hpp>
 

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -43,6 +43,7 @@
 #include "global.hpp"
 #include "grid_based_algorithms/lb_interface.hpp"
 #include "integrate.hpp"
+#include "particle_data.hpp"
 #include "thermostat.hpp"
 
 #include <utils/constants.hpp>

--- a/src/core/serialization/ParticleList.hpp
+++ b/src/core/serialization/ParticleList.hpp
@@ -28,7 +28,7 @@ void load(Archive &ar, ParticleList &pl, const unsigned int /* version */) {
   int size;
   ar >> size;
 
-  realloc_particlelist(&pl, pl.n = size);
+  pl.resize(size);
   for (int i = 0; i < size; i++) {
     ar >> pl.part[i];
   }

--- a/src/core/unit_tests/link_cell_test.cpp
+++ b/src/core/unit_tests/link_cell_test.cpp
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_CASE(link_cell) {
 
     c.m_neighbors = Neighbors<Cell *>(neighbors, {});
 
-    c.part = new Particle[n_part_per_cell];
-    c.n = c.max = n_part_per_cell;
+    c.resize(n_part_per_cell);
+    std::uninitialized_fill(c.part, c.part + c.n, Particle());
 
     for (unsigned i = 0; i < n_part_per_cell; ++i) {
       c.part[i].p.identity = id++;
@@ -86,8 +86,4 @@ BOOST_AUTO_TEST_CASE(link_cell) {
       BOOST_CHECK((it->first == i) && (it->second == j));
       ++it;
     }
-
-  for (auto &c : cells) {
-    delete[] c.part;
-  }
 }

--- a/src/core/unit_tests/verlet_ia_test.cpp
+++ b/src/core/unit_tests/verlet_ia_test.cpp
@@ -70,8 +70,8 @@ BOOST_AUTO_TEST_CASE(verlet_ia) {
 
     c.m_neighbors = Neighbors<Cell *>(neighbors, {});
 
-    c.part = new Particle[n_part_per_cell];
-    c.n = c.max = n_part_per_cell;
+    c.resize(n_part_per_cell);
+    std::uninitialized_fill(c.part, c.part + c.n, Particle());
 
     for (unsigned i = 0; i < n_part_per_cell; ++i) {
       c.part[i].p.identity = id++;
@@ -146,8 +146,4 @@ BOOST_AUTO_TEST_CASE(verlet_ia) {
                           [](int count) { return count == 1; }));
 
   check_pairs(n_part, pairs);
-
-  for (auto &c : cells) {
-    delete[] c.part;
-  }
 }


### PR DESCRIPTION
Follow up on #3251.

Description of changes:
 - Pulling `ParticleList` out of `particle_data.hpp` to get better
   header disentanglement.
