### PR TITLE
CMake minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if(WITH_PYTHON)
     execute_process(
       COMMAND
         ${PYTHON_EXECUTABLE} -c
-        "import distutils.sysconfig as cg; print(cg.get_python_lib(1,0,prefix='${CMAKE_INSTALL_EXEC_PREFIX}'))"
+        "import distutils.sysconfig as cg; print(cg.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True, standard_lib=False).replace('${CMAKE_INSTALL_PREFIX}/', '', 1))"
       OUTPUT_VARIABLE PYTHON_INSTDIR
       OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif(NOT PYTHON_INSTDIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@
 
 cmake_minimum_required(VERSION 3.4)
 include(FeatureSummary)
+include(GNUInstallDirs)
 project(ESPResSo)
 include(cmake/FindPythonModule.cmake)
 if(NOT ${CMAKE_VERSION} VERSION_LESS "3.12")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,10 +399,6 @@ endif()
 # Paths
 #
 
-if(NOT DEFINED BINDIR)
-  set(BINDIR "bin")
-endif(NOT DEFINED BINDIR)
-
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTDIR}/espressomd")
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 enable_language(CXX)
 
-set(PROJECT_VERSION "5.0-dev")
+set(PROJECT_VERSION "4.2-dev")
 
 #
 # CMake internal vars

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -24,11 +24,11 @@ endif( )
 option(INSTALL_PYPRESSO "Install pypresso script, not needed when Espresso is installed in /usr" ON)
 if(INSTALL_PYPRESSO)
   install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pypresso
-        DESTINATION ${BINDIR})
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   if( IPYTHON_EXECUTABLE )
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/ipypresso
-          DESTINATION ${BINDIR})
+          DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif( )
 endif(INSTALL_PYPRESSO)
 

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -128,4 +128,4 @@ endforeach(auxfile)
 
 # Install Python files
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} DESTINATION ${PYTHON_INSTDIR}
-        FILES_MATCHING PATTERN "*.py")
+        FILES_MATCHING PATTERN "*.py" PATTERN "CMakeFiles" EXCLUDE)

--- a/testsuite/cmake/BashUnitTests.sh
+++ b/testsuite/cmake/BashUnitTests.sh
@@ -353,7 +353,27 @@ function assert_file_exists() {
   fi
 }
 
-## @brief Check if two variables are identical
+## @brief Check if two strings are identical
+## @param $1 Obtained result
+## @param $2 Expected result
+## @param $3 Message on failure (optional)
+function assert_string_equal() {
+  local -r result=$1
+  local -r expected=$2
+  local message=$3
+  if [ -z "${message}" ]
+  then
+    message="${result} != ${expected}"
+  fi
+  if [ "${result}" = "${expected}" ]
+  then
+    log_success
+  else
+    log_failure "${message}"
+  fi
+}
+
+## @brief Check if two integers are identical
 ## @param $1 Obtained result
 ## @param $2 Expected result
 ## @param $3 Message on failure (optional)

--- a/testsuite/cmake/CMakeLists.txt
+++ b/testsuite/cmake/CMakeLists.txt
@@ -11,15 +11,12 @@ function(CMAKE_TEST)
   set(cmake_tests ${cmake_tests} ${TEST_FILE} PARENT_SCOPE)
 endfunction(CMAKE_TEST)
 
-if(WITH_PYTHON AND PYTHONINTERP_FOUND)
-  # obtain Python*_SITEARCH without find_package(Python*)
-  execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils import sysconfig as sc;print(sc.get_python_lib(prefix='', plat_specific=True, standard_lib=False))"
-    OUTPUT_VARIABLE Python_SITEARCH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils import sysconfig as sc;print(sc.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True, standard_lib=False))"
+  OUTPUT_VARIABLE PYTHON_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  cmake_test(FILE test_install.sh DEPENDENCIES BashUnitTests.sh)
-endif()
+cmake_test(FILE test_install.sh DEPENDENCIES BashUnitTests.sh)
 
 add_custom_target(setup_install COMMAND make install WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_custom_target(check_cmake_install COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -C serial --output-on-failure)

--- a/testsuite/cmake/CMakeLists.txt
+++ b/testsuite/cmake/CMakeLists.txt
@@ -11,10 +11,7 @@ function(CMAKE_TEST)
   set(cmake_tests ${cmake_tests} ${TEST_FILE} PARENT_SCOPE)
 endfunction(CMAKE_TEST)
 
-execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils import sysconfig as sc;print(sc.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True, standard_lib=False))"
-  OUTPUT_VARIABLE PYTHON_DIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(PYTHON_DIR ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTDIR})
 
 cmake_test(FILE test_install.sh DEPENDENCIES BashUnitTests.sh)
 

--- a/testsuite/cmake/test_install.sh
+++ b/testsuite/cmake/test_install.sh
@@ -21,16 +21,22 @@ source BashUnitTests.sh
 
 # test installation and Python bindings
 function test_install() {
-  local -r site_package_espressomd="@CMAKE_INSTALL_PREFIX@/@Python_SITEARCH@/espressomd"
+  local -r site_package_espressomd="$(realpath '@CMAKE_INSTALL_PREFIX@/@Python_SITEARCH@/espressomd')"
+
+  # check Python files were installed in espressomd
   local -r filepaths=("@CMAKE_INSTALL_FULL_BINDIR@/pypresso" \
                       "${site_package_espressomd}/EspressoCore.so" \
                       "${site_package_espressomd}/_init.so" \
                       "${site_package_espressomd}/__init__.py"
                      )
-
   for filepath in ${filepaths[@]}; do
     assert_file_exists "${filepath}"
   done
+
+  # check no Python file was installed outside espressomd
+  paths=$(find "@CMAKE_INSTALL_PREFIX@" -path "${site_package_espressomd}" -prune -o \( -name '*.py' -o -name '*.so' \) -print)
+  count=$(echo "${paths}" | wc -l)
+  assert_string_equal "${paths}" "" "${count} files were installed in the wrong directories:"$'\n'"${paths}"
 
   # check the espressomd module can be imported from pypresso
   assert_return_code "@CMAKE_INSTALL_FULL_BINDIR@/pypresso" -c "import espressomd"

--- a/testsuite/cmake/test_install.sh
+++ b/testsuite/cmake/test_install.sh
@@ -21,20 +21,18 @@ source BashUnitTests.sh
 
 # test installation and Python bindings
 function test_install() {
-  local -r site_package_espressomd="$(realpath '@CMAKE_INSTALL_PREFIX@/@Python_SITEARCH@/espressomd')"
-
   # check Python files were installed in espressomd
   local -r filepaths=("@CMAKE_INSTALL_FULL_BINDIR@/pypresso" \
-                      "${site_package_espressomd}/EspressoCore.so" \
-                      "${site_package_espressomd}/_init.so" \
-                      "${site_package_espressomd}/__init__.py"
+                      "@PYTHON_DIR@/espressomd/EspressoCore.so" \
+                      "@PYTHON_DIR@/espressomd/_init.so" \
+                      "@PYTHON_DIR@/espressomd/__init__.py"
                      )
   for filepath in ${filepaths[@]}; do
     assert_file_exists "${filepath}"
   done
 
   # check no Python file was installed outside espressomd
-  paths=$(find "@CMAKE_INSTALL_PREFIX@" -path "${site_package_espressomd}" -prune -o \( -name '*.py' -o -name '*.so' \) -print)
+  paths=$(find "@CMAKE_INSTALL_PREFIX@" -path "@PYTHON_DIR@/espressomd" -prune -o \( -name '*.py' -o -name '*.so' \) -print)
   count=$(echo "${paths}" | wc -l)
   assert_string_equal "${paths}" "" "${count} files were installed in the wrong directories:"$'\n'"${paths}"
 

--- a/testsuite/cmake/test_install.sh
+++ b/testsuite/cmake/test_install.sh
@@ -21,18 +21,19 @@ source BashUnitTests.sh
 
 # test installation and Python bindings
 function test_install() {
-  local filepaths=("@CMAKE_INSTALL_PREFIX@/bin/pypresso" \
-                   "@CMAKE_INSTALL_PREFIX@/@Python_SITEARCH@/espressomd/EspressoCore.so" \
-                   "@CMAKE_INSTALL_PREFIX@/@Python_SITEARCH@/espressomd/_init.so" \
-                   "@CMAKE_INSTALL_PREFIX@/@Python_SITEARCH@/espressomd/__init__.py"
-                  )
+  local -r site_package_espressomd="@CMAKE_INSTALL_PREFIX@/@Python_SITEARCH@/espressomd"
+  local -r filepaths=("@CMAKE_INSTALL_FULL_BINDIR@/pypresso" \
+                      "${site_package_espressomd}/EspressoCore.so" \
+                      "${site_package_espressomd}/_init.so" \
+                      "${site_package_espressomd}/__init__.py"
+                     )
 
   for filepath in ${filepaths[@]}; do
     assert_file_exists "${filepath}"
   done
 
   # check the espressomd module can be imported from pypresso
-  assert_return_code "@CMAKE_INSTALL_PREFIX@/bin/pypresso" -c "import espressomd"
+  assert_return_code "@CMAKE_INSTALL_FULL_BINDIR@/pypresso" -c "import espressomd"
 }
 
 # run tests


### PR DESCRIPTION
Description of changes:
- change next milestone to 4.2
- load `GNUInstallDirs` to make standard GNU paths accessible from CMake variables
- simplify CMake logic and install in `python3.X` folder instead of the deprecated `python3` folder
- add extra check to make sure install paths are correctly configured (all python and shared object files must be inside the package `espressomd`)
