### PR TITLE
OpenGL sphinx doc: particle_type_materials fix

### DIFF
--- a/doc/sphinx/visualization.rst
+++ b/doc/sphinx/visualization.rst
@@ -205,7 +205,7 @@ used, which are indexed circularly by the numerical particle type::
     visualizer = visualization.openGLLive(system,
                                           particle_coloring='type',
                                           particle_type_colors=[[1, 1, 1], [0, 0, 1]],
-                                          particle_type_materials=[steel, bright])
+                                          particle_type_materials=["steel", "bright"])
 
 Materials are stored in :attr:`espressomd.visualization_opengl.openGLLive.materials`.
 

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -103,7 +103,7 @@ class openGLLive:
         * ``'node'``: Color according to the node the particle is on.
     particle_type_colors : array_like :obj:`float`, optional
         Colors for particle types.
-    particle_type_materials : :obj:`str`, optional
+    particle_type_materials : array_like :obj:`str`, optional
         Materials of the particle types.
     particle_charge_colors : (2,) array_like of :obj:`float`, optional
         Two colors for min/max charged particles.


### PR DESCRIPTION
Corrects a small bug in the OpenGL visualization tutorial: `particle_type_materials` expects strings. Also, the corresponding docstring should have an `array_like`.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
