### PR TITLE
Fix velocity Verlet setter

### DIFF
--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -50,6 +50,8 @@ cdef class Integrator:
         self._method = state['_method']
         if self._method == "STEEPEST_DESCENT":
             self.set_steepest_descent(state['_steepest_descent_params'])
+        elif self._method == "VV":
+            self.set_vv()
         elif self._method == "NVT":
             self.set_nvt()
         elif self._method == "NPT":
@@ -118,6 +120,7 @@ cdef class Integrator:
         Set the integration method to Velocity Verlet.
 
         """
+        integrate_set_nvt()
         self._method = "VV"
 
     def set_nvt(self):


### PR DESCRIPTION
Not for direct merging.

Fixes the bug found in #3271

When setting up a system with the NpT integrator, then switch to the VV integrator, the system keeps the NpT integrator in the core. To reproduce the error, take e.g. `samples/visualization_npt.py` and replace the call to `system.integrator.set_isotropic_npt` by the following:
```
system.integrator.set_isotropic_npt(ext_pressure=1.0, piston=0.01)
print(system.box_l)
system.integrator.set_vv()  # script interface: velocity Verlet, core: NpT
system.integrator.run(100)
print(system.box_l)
exit(0)  # exit now to avoid starting the visualizer
```
output:
```
[10. 10. 10.]
[10.00003915 10.00003915 10.00003915]
```
