### PR TITLE
Clean-up data_parts for ghost communication

### DIFF
--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -232,8 +232,7 @@ int dd_fill_comm_cell_lists(Cell **part_lists, int const lc[3],
 /** Create communicators for cell structure domain decomposition. (see \ref
  *  GhostCommunicator)
  */
-void dd_prepare_comm(GhostCommunicator *comm, int data_parts,
-                     const Utils::Vector3i &grid) {
+void dd_prepare_comm(GhostCommunicator *comm, const Utils::Vector3i &grid) {
   int dir, lr, i, cnt, num, n_comm_cells[3];
   int lc[3], hc[3], done[3] = {0, 0, 0};
 
@@ -595,11 +594,8 @@ void dd_topology_init(CellPList *old, const Utils::Vector3i &grid,
   dd_mark_cells();
 
   /* create communicators */
-  const int exchange_data = (GHOSTTRANS_PROPRTS | GHOSTTRANS_POSITION);
-
-  dd_prepare_comm(&cell_structure.exchange_ghosts_comm, exchange_data, grid);
-  dd_prepare_comm(&cell_structure.collect_ghost_force_comm, GHOSTTRANS_FORCE,
-                  grid);
+  dd_prepare_comm(&cell_structure.exchange_ghosts_comm, grid);
+  dd_prepare_comm(&cell_structure.collect_ghost_force_comm, grid);
 
   /* collect forces has to be done in reverted order! */
   dd_revert_comm_order(&cell_structure.collect_ghost_force_comm);

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -446,12 +446,6 @@ void on_ghost_flags_change() {
 #endif
   if (thermo_switch & THERMO_DPD)
     ghosts_have_v = true;
-#ifdef VIRTUAL_SITES
-  // If they have velocities, VIRTUAL_SITES need v to update v of virtual sites
-  if (virtual_sites()->get_have_velocity()) {
-    ghosts_have_v = true;
-  };
-#endif
   // THERMALIZED_DIST_BOND needs v to calculate v_com and v_dist for thermostats
   if (n_thermalized_bonds) {
     ghosts_have_v = true;

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -161,7 +161,8 @@ void free_comm(GhostCommunicator *gcr) {
     ghost_comm.part_lists.clear();
 }
 
-static int calc_transmit_size(GhostCommunication &ghost_comm, int data_parts) {
+static int calc_transmit_size(GhostCommunication &ghost_comm,
+                              unsigned int data_parts) {
   int n_buffer_new;
 
   if (data_parts & GHOSTTRANS_PARTNUM)
@@ -196,7 +197,7 @@ static int calc_transmit_size(GhostCommunication &ghost_comm, int data_parts) {
 
 static void prepare_send_buffer(CommBuf &send_buffer,
                                 GhostCommunication &ghost_comm,
-                                int data_parts) {
+                                unsigned int data_parts) {
   /* reallocate send buffer */
   send_buffer.resize(calc_transmit_size(ghost_comm, data_parts));
   send_buffer.bonds().clear();
@@ -270,13 +271,14 @@ static void prepare_ghost_cell(Cell *cell, int size) {
 
 static void prepare_recv_buffer(CommBuf &recv_buffer,
                                 GhostCommunication &ghost_comm,
-                                int data_parts) {
+                                unsigned int data_parts) {
   /* reallocate recv buffer */
   recv_buffer.resize(calc_transmit_size(ghost_comm, data_parts));
 }
 
 static void put_recv_buffer(CommBuf &recv_buffer,
-                            GhostCommunication &ghost_comm, int data_parts) {
+                            GhostCommunication &ghost_comm,
+                            unsigned int data_parts) {
   /* put back data */
   auto archiver = Archiver{Utils::make_span(recv_buffer)};
   auto bond_archiver = BondArchiver{recv_buffer.bonds()};
@@ -335,7 +337,8 @@ static void add_forces_from_recv_buffer(CommBuf &recv_buffer,
   }
 }
 
-static void cell_cell_transfer(GhostCommunication &ghost_comm, int data_parts) {
+static void cell_cell_transfer(GhostCommunication &ghost_comm,
+                               unsigned int data_parts) {
   /* transfer data */
   int const offset = ghost_comm.part_lists.size() / 2;
   for (int pl = 0; pl < offset; pl++) {
@@ -400,10 +403,10 @@ static bool is_poststorable(GhostCommunication const &ghost_comm) {
   return is_recv_op(comm_type, node) && poststore;
 }
 
-void ghost_communicator(GhostCommunicator *gcr, int data_parts) {
+void ghost_communicator(GhostCommunicator *gcr, unsigned int data_parts) {
   static CommBuf send_buffer, recv_buffer;
 
-  /* if ghosts should have uptodate velocities, they have to be updated like
+  /* if ghosts should have up-to-date velocities, they have to be updated like
    * positions (except for shifting...) */
   if (ghosts_have_v && (data_parts & GHOSTTRANS_POSITION))
     data_parts |= GHOSTTRANS_MOMENTUM;

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -125,22 +125,21 @@ further details.
 /** \name Transfer data classes, for \ref GhostCommunication::type */
 /************************************************************/
 /*@{*/
-/// transfer \ref ParticleProperties
-#define GHOSTTRANS_PROPRTS 1
-/// transfer \ref ParticlePosition
-#define GHOSTTRANS_POSITION 2
-/// transfer \ref ParticleMomentum
-#define GHOSTTRANS_MOMENTUM 8
-/// transfer \ref ParticleForce
-#define GHOSTTRANS_FORCE 16
-
-/// resize the receiver particle arrays to the size of the senders
-#define GHOSTTRANS_PARTNUM 64
-
-#ifdef ENGINE
-/// transfer \ref ParticleParametersSwimming
-#define GHOSTTRANS_SWIMMING 128
-#endif
+enum : unsigned {
+  GHOSTTRANS_NONE = 0u,
+  /// transfer \ref ParticleProperties
+  GHOSTTRANS_PROPRTS = 1u,
+  /// transfer \ref ParticlePosition
+  GHOSTTRANS_POSITION = 2u,
+  /// transfer \ref ParticleMomentum
+  GHOSTTRANS_MOMENTUM = 8u,
+  /// transfer \ref ParticleForce
+  GHOSTTRANS_FORCE = 16u,
+  /// resize the receiver particle arrays to the size of the senders
+  GHOSTTRANS_PARTNUM = 64u,
+  /// transfer \ref ParticleParametersSwimming
+  GHOSTTRANS_SWIMMING = 128u
+};
 /*@}*/
 
 /** \name Data Types */
@@ -182,7 +181,7 @@ void free_comm(GhostCommunicator *gcr);
 /**
  * @brief Do a ghost communication with caller specified data parts.
  */
-void ghost_communicator(GhostCommunicator *gcr, int data_parts);
+void ghost_communicator(GhostCommunicator *gcr, unsigned int data_parts);
 
 /*@}*/
 

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -122,9 +122,7 @@ further details.
 #define GHOST_PSTSTORE 32
 /*@}*/
 
-/** \name Transfer data classes, for \ref GhostCommunication::type */
-/************************************************************/
-/*@{*/
+/** Transfer data classes, for \ref ghost_communicator */
 enum : unsigned {
   GHOSTTRANS_NONE = 0u,
   /// transfer \ref ParticleProperties
@@ -140,7 +138,6 @@ enum : unsigned {
   /// transfer \ref ParticleParametersSwimming
   GHOSTTRANS_SWIMMING = 128u
 };
-/*@}*/
 
 /** \name Data Types */
 /************************************************************/

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -42,7 +42,7 @@ void nsq_topology_release() {
   free_comm(&cell_structure.collect_ghost_force_comm);
 }
 
-static void nsq_prepare_comm(GhostCommunicator *comm, int data_parts) {
+static void nsq_prepare_comm(GhostCommunicator *comm) {
   int n;
   /* no need for comm for only 1 node */
   if (n_nodes == 1) {
@@ -109,9 +109,8 @@ void nsq_topology_init(CellPList *old) {
   local->m_neighbors = Neighbors<Cell *>(red_neighbors, black_neighbors);
 
   /* create communicators */
-  nsq_prepare_comm(&cell_structure.exchange_ghosts_comm,
-                   GHOSTTRANS_PROPRTS | GHOSTTRANS_POSITION);
-  nsq_prepare_comm(&cell_structure.collect_ghost_force_comm, GHOSTTRANS_FORCE);
+  nsq_prepare_comm(&cell_structure.exchange_ghosts_comm);
+  nsq_prepare_comm(&cell_structure.collect_ghost_force_comm);
 
   /* here we just decide what to transfer where */
   if (n_nodes > 1) {

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -45,7 +45,6 @@ void set_virtual_sites(std::shared_ptr<VirtualSites> const &v) {
   m_virtual_sites = v;
   recalc_forces = true;
   invalidate_obs();
-  on_ghost_flags_change();
 }
 
 #ifdef VIRTUAL_SITES_RELATIVE

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -33,10 +33,14 @@
 
 void VirtualSitesRelative::update(bool recalc_positions) const {
   // Ghost update logic
-  if (n_nodes > 0) {
+  if (n_nodes > 1) {
+    auto const data_parts =
+        (recalc_positions ? GHOSTTRANS_POSITION : 0) |
+        (get_have_velocity() ? (GHOSTTRANS_POSITION | GHOSTTRANS_MOMENTUM)
+                             : 0);
+
     if (recalc_positions or get_have_velocity()) {
-      ghost_communicator(&cell_structure.exchange_ghosts_comm,
-                         GHOSTTRANS_POSITION);
+      ghost_communicator(&cell_structure.exchange_ghosts_comm, data_parts);
     }
   }
   for (auto &p : local_cells.particles()) {

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -35,9 +35,9 @@ void VirtualSitesRelative::update(bool recalc_positions) const {
   // Ghost update logic
   if (n_nodes > 1) {
     auto const data_parts =
-        (recalc_positions ? GHOSTTRANS_POSITION : 0) |
+        (recalc_positions ? GHOSTTRANS_POSITION : GHOSTTRANS_NONE) |
         (get_have_velocity() ? (GHOSTTRANS_POSITION | GHOSTTRANS_MOMENTUM)
-                             : 0);
+                             : GHOSTTRANS_NONE);
 
     if (recalc_positions or get_have_velocity()) {
       ghost_communicator(&cell_structure.exchange_ghosts_comm, data_parts);


### PR DESCRIPTION
Description of changes:
 - Removed data_parts left-overs from cell systems
 - Tuned GHOSTTRANS_* constants into enum
 - Calculate data_parts for vs relative on the fly.
