### PR TITLE
testsuite: Fixed engine_lb test return code

### DIFF
--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -200,8 +200,10 @@ void integrate_vv(int n_steps, int reuse_forces) {
     thermo_cool_down();
 
     ESPRESSO_PROFILER_MARK_END("Initial Force Calculation");
-    if (n_part > 0)
-      lb_lbcoupling_activate();
+  }
+
+  if (n_part > 0) {
+    lb_lbcoupling_activate();
   }
 
   if (check_runtime_errors(comm_cart))


### PR DESCRIPTION
@christophlohrmann could you please have a look at why the test fails? It's the `f_swim` case that does not conserve momentum, not the drift velocity case as we thought...