### PR TITLE
utils: Re-add uniform test + docstring

### DIFF
--- a/src/utils/include/utils/uniform.hpp
+++ b/src/utils/include/utils/uniform.hpp
@@ -24,6 +24,14 @@
 namespace Utils {
 /**
  * @brief Uniformly map unsigned integer to double.
+ *
+ * This maps a unsigned integer to the double interval
+ * (0., 1.], where 0. is mapped to the smallest representable
+ * value larger than 0., and the maximal integer value is
+ * mapped to 1.
+ *
+ * @param in Unsigned integer value
+ * @return Mapped floating point value.
  */
 constexpr inline double uniform(uint64_t in) {
   auto constexpr const max = std::numeric_limits<uint64_t>::max();

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ unit_test(NAME rotation_matrix_test SRC rotation_matrix_test.cpp DEPENDS utils)
 unit_test(NAME quaternion_test SRC quaternion_test.cpp DEPENDS utils)
 unit_test(NAME mask_test SRC mask_test.cpp DEPENDS utils)
 unit_test(NAME type_traits_test SRC type_traits_test.cpp DEPENDS utils)
+unit_test(NAME uniform_test SRC uniform_test.cpp DEPENDS utils)
 
 unit_test(NAME gather_buffer_test SRC gather_buffer_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
 unit_test(NAME scatter_buffer_test SRC scatter_buffer_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX NUM_PROC 4)

--- a/src/utils/tests/uniform_test.cpp
+++ b/src/utils/tests/uniform_test.cpp
@@ -22,9 +22,12 @@
 #include <utils/uniform.hpp>
 
 BOOST_AUTO_TEST_CASE(limits) {
+  /* 0 maps to epsilon */
   BOOST_CHECK_SMALL(Utils::uniform(0ul),
                     std::numeric_limits<double>::epsilon());
+  /* numeric_limits<>::max() maps to 1. */
   BOOST_CHECK_EQUAL(1., Utils::uniform(std::numeric_limits<uint64_t>::max()));
+  /* linearity */
   BOOST_CHECK_EQUAL(Utils::uniform(0ul) - Utils::uniform(5ul),
                     Utils::uniform(10000ul) - Utils::uniform(10005ul));
 }


### PR DESCRIPTION
Description of changes:
 - The Utils::uniform test was moved to  the correct place and
   readded to the build system.
 - Docstring
