### PR TITLE
Factor out and test memcpy serialization

### DIFF
--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -134,7 +134,8 @@ enum : unsigned {
   /// transfer \ref ParticleForce
   GHOSTTRANS_FORCE = 16u,
   /// resize the receiver particle arrays to the size of the senders
-  GHOSTTRANS_PARTNUM = 64u
+  GHOSTTRANS_PARTNUM = 64u,
+  GHOSTTRANS_BONDS = 128u
 };
 
 /** \name Data Types */

--- a/src/core/unit_tests/Particle_test.cpp
+++ b/src/core/unit_tests/Particle_test.cpp
@@ -29,6 +29,8 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 
+#include <utils/serialization/memcpy_archive.hpp>
+
 #include "Particle.hpp"
 #include "serialization/Particle.hpp"
 
@@ -80,4 +82,38 @@ BOOST_AUTO_TEST_CASE(serialization) {
 #ifdef EXCLUSIONS
   BOOST_CHECK(q.el == el);
 #endif
+}
+
+namespace Utils {
+template <>
+struct is_statically_serializable<ParticleProperties> : std::true_type {};
+} // namespace Utils
+
+BOOST_AUTO_TEST_CASE(properties_serialization) {
+  auto const expected_size =
+      Utils::MemcpyOArchive::packing_size<ParticleProperties>();
+
+  BOOST_CHECK_LE(expected_size, sizeof(ParticleProperties));
+
+  std::vector<char> buf(expected_size);
+
+  auto prop = ParticleProperties{};
+  prop.identity = 1234;
+
+  {
+    auto oa = Utils::MemcpyOArchive{Utils::make_span(buf)};
+
+    oa << prop;
+
+    BOOST_CHECK_EQUAL(oa.bytes_written(), expected_size);
+  }
+
+  {
+    auto ia = Utils::MemcpyIArchive{Utils::make_span(buf)};
+    ParticleProperties out;
+
+    ia >> out;
+    BOOST_CHECK_EQUAL(ia.bytes_read(), expected_size);
+    BOOST_CHECK_EQUAL(out.identity, prop.identity);
+  }
 }

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -143,8 +143,8 @@ public:
  * Can only process types that have a static serialization size,
  * e.g. that serialize to the same number of bytes independent of
  * the state of the object. This can either be automatically detected
- * for types that are trivially copyable, or by explicitly assuring
- * this by specializing @c is_statically_serializable to std::true_type.
+ * for types that are trivially copyable, or by explicitly assured
+ * by specializing @c is_statically_serializable to std::true_type.
  */
 class MemcpyIArchive : public detail::BasicMemcpyArchive<MemcpyIArchive> {
 private:

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -76,21 +76,30 @@ public:
     insert += bytes;
   }
 
+private:
+  void read(void *data, size_t bytes) {
+    /* check that there is enough space left in the buffer */
+    assert((insert + bytes) <= buf.end());
+    std::memcpy(data, insert, bytes);
+    insert += bytes;
+  }
+
+  void write(const void *data, size_t bytes) {
+    /* check that there is enough space left in the buffer */
+    assert((insert + bytes) <= buf.end());
+    std::memcpy(insert, data, bytes);
+    insert += bytes;
+  }
+
+public:
   template <typename T>
   auto operator>>(T &value) -> std::enable_if_t<use_memcpy<T>::value> {
-    /* check that there is enough space left in the buffer */
-    assert((insert + sizeof(T)) <= buf.end());
-
-    std::memcpy(&value, insert, sizeof(T));
-    insert += sizeof(T);
+    read(&value, sizeof(T));
   }
 
   template <typename T>
   auto operator<<(T const &value) -> std::enable_if_t<use_memcpy<T>::value> {
-    /* check that there is enough space left in the buffer */
-    assert((insert + sizeof(T)) <= buf.end());
-    std::memcpy(insert, &value, sizeof(T));
-    insert += sizeof(T);
+    write(&value, sizeof(T));
   }
 
 private:

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2019 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ESPRESSO_MEMCPY_ARCHIVE_HPP
+#define ESPRESSO_MEMCPY_ARCHIVE_HPP
+
+#include <utils/Span.hpp>
+
+#include <boost/mpl/bool.hpp>
+#include <boost/optional.hpp>
+#include <boost/serialization/serialization.hpp>
+
+#include <cstring>
+
+namespace Utils {
+/** @brief Type trait to indicate that a type is
+ *         serializable with a static size, e.g. is
+ *         suitable for memcpy serialization. Only
+ *         specialize this to std::true_type if it is
+ *         guarantueed that serializing this type always
+ *         returns the same number of bytes, independent
+ *         of object state.
+ *
+ * @tparam T type under consideration.
+ */
+template <class T> struct is_statically_serializable : std::false_type {};
+
+namespace detail {
+/* Use serialize function only if the type is opt-in but not
+ * trivially copyable, in which case memcpy is more efficient. */
+template <class T>
+using use_serialize =
+    std::integral_constant<bool, not std::is_trivially_copyable<T>::value and
+                                     is_statically_serializable<T>::value>;
+
+struct SizeArchive {
+  using is_saving = boost::mpl::true_;
+  using is_loading = boost::mpl::false_;
+
+  size_t size = {};
+
+  template <typename T>
+  constexpr auto operator<<(T const &)
+      -> std::enable_if_t<std::is_trivially_copyable<T>::value> {
+    size += sizeof(T);
+  }
+
+  template <class T>
+  constexpr auto operator<<(T &v)
+      -> std::enable_if_t<detail::use_serialize<T>::value> {
+    boost::serialization::serialize(*this, v, 0);
+  }
+
+  template <class T> constexpr auto operator<<(boost::optional<T> &) {
+    operator<<(bool());
+    operator<<(T{});
+  }
+
+  template <class T> constexpr SizeArchive &operator&(T &t) {
+    operator<<(t);
+
+    return *this;
+  }
+};
+
+class BasicMemcpyArchive {
+  /** Buffer to write to */
+  Utils::Span<char> buf;
+  /** Current position in the buffer */
+  char *insert;
+
+public:
+  explicit BasicMemcpyArchive(Utils::Span<char> buf)
+      : buf(buf), insert(buf.data()) {}
+
+  size_t bytes_processed() const { return insert - buf.data(); }
+
+  template <typename T>
+  auto operator>>(T &value)
+      -> std::enable_if_t<std::is_trivially_copyable<T>::value> {
+    /* check that there is enough space left in the buffer */
+    assert((insert + sizeof(T)) <= buf.end());
+
+    std::memcpy(&value, insert, sizeof(T));
+    insert += sizeof(T);
+  }
+
+  template <typename T>
+  auto operator<<(T const &value)
+      -> std::enable_if_t<std::is_trivially_copyable<T>::value> {
+    /* check that there is enough space left in the buffer */
+    assert((insert + sizeof(T)) <= buf.end());
+    std::memcpy(insert, &value, sizeof(T));
+    insert += sizeof(T);
+  }
+
+  /**
+   * @brief Determine the static packing size of a type.
+   * @tparam T Type to consider.
+   * @return Packed size in bytes.
+   */
+  template <class T> static size_t packing_size() {
+    detail::SizeArchive sa{};
+    T t;
+    return (sa & t).size;
+  }
+};
+} // namespace detail
+
+/**
+ * @brief Archive that deserializes from a buffer via memcpy.
+ *
+ * Can only process types that have a static serialization size,
+ * e.g. that serialize to the same number of bytes independent of
+ * the state of the object. This can either be automatically detected
+ * for types that are trivially copyable, or by explicitly assuring
+ * this by specializing @c is_statically_serializable to std::true_type.
+ */
+class MemcpyIArchive : public detail::BasicMemcpyArchive {
+private:
+  using base_type = detail::BasicMemcpyArchive;
+
+public:
+  using is_loading = boost::mpl::true_;
+  using is_saving = boost::mpl::false_;
+
+  /**
+   * @param buf Buffer to read from.
+   */
+  explicit MemcpyIArchive(Utils::Span<char> buf)
+      : detail::BasicMemcpyArchive(buf) {}
+
+  /**
+   * @brief Number of bytes read from the buffer.
+   * @return Number of bytes read.
+   */
+  size_t bytes_read() const { return bytes_processed(); }
+
+  /** @copydoc base_type::packing_size */
+  using base_type::packing_size;
+  using base_type::operator>>;
+
+  template <class T>
+  auto operator>>(T &value)
+      -> std::enable_if_t<detail::use_serialize<T>::value> {
+    boost::serialization::serialize(*this, value, 0);
+  }
+
+  template <class T> void operator>>(boost::optional<T> &o) {
+    bool initialized{};
+    operator>>(initialized);
+    T val{};
+    operator>>(val);
+
+    if (initialized) {
+      o = val;
+    } else {
+      o = boost::none;
+    }
+  }
+
+  template <class T> MemcpyIArchive &operator&(T &value) {
+    operator>>(value);
+
+    return *this;
+  }
+};
+
+/**
+ * @brief Archive that serializes to a buffer via memcpy.
+ *
+ * @copydetails MemcpyIArchive
+ */
+class MemcpyOArchive : public detail::BasicMemcpyArchive {
+  using base_type = detail::BasicMemcpyArchive;
+
+public:
+  using is_loading = boost::mpl::false_;
+  using is_saving = boost::mpl::true_;
+
+  /**
+   * @param buf Buffer to write to.
+   */
+  explicit MemcpyOArchive(Utils::Span<char> buf)
+      : detail::BasicMemcpyArchive(buf) {}
+
+  /**
+   * @brief Number of bytes written to the buffer.
+   * @return Number of bytes written.
+   */
+  size_t bytes_written() const { return bytes_processed(); }
+
+  /** @copydoc base_type::packing_size */
+  using base_type::packing_size;
+  using base_type::operator<<;
+
+  template <typename T>
+  auto operator<<(T &value)
+      -> std::enable_if_t<detail::use_serialize<T>::value> {
+    boost::serialization::serialize(*this, value, 0);
+  }
+
+  template <class T> void operator<<(boost::optional<T> &o) {
+    operator<<(o.is_initialized());
+    operator<<(o.value_or(T{}));
+  }
+
+  template <class T> MemcpyOArchive &operator&(T &value) {
+    operator<<(value);
+
+    return *this;
+  }
+};
+} // namespace Utils
+
+#endif // ESPRESSO_MEMCPY_ARCHIVE_HPP

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -22,7 +22,8 @@
 #include <utils/Span.hpp>
 
 #include <boost/mpl/bool.hpp>
-#include <boost/optional.hpp>
+#include <boost/serialization/is_bitwise_serializable.hpp>
+#include <boost/serialization/nvp.hpp>
 #include <boost/serialization/serialization.hpp>
 
 #include <cstring>
@@ -38,47 +39,26 @@ namespace Utils {
  *
  * @tparam T type under consideration.
  */
-template <class T> struct is_statically_serializable : std::false_type {};
+template <class T>
+struct is_statically_serializable
+    : std::integral_constant<
+          bool, std::is_trivially_copyable<T>::value or
+                    boost::serialization::is_bitwise_serializable<T>::value> {};
 
 namespace detail {
+/* Use memcpy for packing */
+template <class T>
+using use_memcpy = std::integral_constant<
+    bool, std::is_trivially_copyable<T>::value or
+              boost::serialization::is_bitwise_serializable<T>::value>;
 /* Use serialize function only if the type is opt-in but not
  * trivially copyable, in which case memcpy is more efficient. */
 template <class T>
 using use_serialize =
-    std::integral_constant<bool, not std::is_trivially_copyable<T>::value and
+    std::integral_constant<bool, not use_memcpy<T>::value and
                                      is_statically_serializable<T>::value>;
 
-struct SizeArchive {
-  using is_saving = boost::mpl::true_;
-  using is_loading = boost::mpl::false_;
-
-  size_t size = {};
-
-  template <typename T>
-  constexpr auto operator<<(T const &)
-      -> std::enable_if_t<std::is_trivially_copyable<T>::value> {
-    size += sizeof(T);
-  }
-
-  template <class T>
-  constexpr auto operator<<(T &v)
-      -> std::enable_if_t<detail::use_serialize<T>::value> {
-    boost::serialization::serialize(*this, v, 0);
-  }
-
-  template <class T> constexpr auto operator<<(boost::optional<T> &) {
-    operator<<(bool());
-    operator<<(T{});
-  }
-
-  template <class T> constexpr SizeArchive &operator&(T &t) {
-    operator<<(t);
-
-    return *this;
-  }
-};
-
-class BasicMemcpyArchive {
+template <class Derived> class BasicMemcpyArchive {
   /** Buffer to write to */
   Utils::Span<char> buf;
   /** Current position in the buffer */
@@ -88,11 +68,16 @@ public:
   explicit BasicMemcpyArchive(Utils::Span<char> buf)
       : buf(buf), insert(buf.data()) {}
 
+  size_t get_library_version() const { return 4; }
+
   size_t bytes_processed() const { return insert - buf.data(); }
+  void skip(size_t bytes) {
+    assert((insert + bytes) <= buf.end());
+    insert += bytes;
+  }
 
   template <typename T>
-  auto operator>>(T &value)
-      -> std::enable_if_t<std::is_trivially_copyable<T>::value> {
+  auto operator>>(T &value) -> std::enable_if_t<use_memcpy<T>::value> {
     /* check that there is enough space left in the buffer */
     assert((insert + sizeof(T)) <= buf.end());
 
@@ -101,12 +86,44 @@ public:
   }
 
   template <typename T>
-  auto operator<<(T const &value)
-      -> std::enable_if_t<std::is_trivially_copyable<T>::value> {
+  auto operator<<(T const &value) -> std::enable_if_t<use_memcpy<T>::value> {
     /* check that there is enough space left in the buffer */
     assert((insert + sizeof(T)) <= buf.end());
     std::memcpy(insert, &value, sizeof(T));
     insert += sizeof(T);
+  }
+
+private:
+  template <class T> void process(T &value) {
+    auto const old_pos = insert;
+    boost::serialization::serialize_adl(*static_cast<Derived *>(this), value,
+                                        4);
+    auto const new_pos = insert;
+    assert((new_pos - old_pos) <= sizeof(T));
+
+    auto const padding_size = sizeof(T) - (new_pos - old_pos);
+    skip(padding_size);
+  }
+
+public:
+  template <class T>
+  auto operator>>(T &value)
+      -> std::enable_if_t<detail::use_serialize<T>::value> {
+    process(value);
+  }
+
+  template <class T>
+  auto operator<<(T &value)
+      -> std::enable_if_t<detail::use_serialize<T>::value> {
+    process(value);
+  }
+
+  template <class T> void operator<<(const boost::serialization::nvp<T> &nvp) {
+    operator<<(nvp.const_value());
+  }
+
+  template <class T> void operator>>(const boost::serialization::nvp<T> &nvp) {
+    operator>>(nvp.value());
   }
 
   /**
@@ -114,10 +131,8 @@ public:
    * @tparam T Type to consider.
    * @return Packed size in bytes.
    */
-  template <class T> static size_t packing_size() {
-    detail::SizeArchive sa{};
-    T t;
-    return (sa & t).size;
+  template <class T> static constexpr size_t packing_size() {
+    return sizeof(T);
   }
 };
 } // namespace detail
@@ -131,9 +146,9 @@ public:
  * for types that are trivially copyable, or by explicitly assuring
  * this by specializing @c is_statically_serializable to std::true_type.
  */
-class MemcpyIArchive : public detail::BasicMemcpyArchive {
+class MemcpyIArchive : public detail::BasicMemcpyArchive<MemcpyIArchive> {
 private:
-  using base_type = detail::BasicMemcpyArchive;
+  using base_type = detail::BasicMemcpyArchive<MemcpyIArchive>;
 
 public:
   using is_loading = boost::mpl::true_;
@@ -142,8 +157,7 @@ public:
   /**
    * @param buf Buffer to read from.
    */
-  explicit MemcpyIArchive(Utils::Span<char> buf)
-      : detail::BasicMemcpyArchive(buf) {}
+  explicit MemcpyIArchive(Utils::Span<char> buf) : base_type(buf) {}
 
   /**
    * @brief Number of bytes read from the buffer.
@@ -154,25 +168,6 @@ public:
   /** @copydoc base_type::packing_size */
   using base_type::packing_size;
   using base_type::operator>>;
-
-  template <class T>
-  auto operator>>(T &value)
-      -> std::enable_if_t<detail::use_serialize<T>::value> {
-    boost::serialization::serialize(*this, value, 0);
-  }
-
-  template <class T> void operator>>(boost::optional<T> &o) {
-    bool initialized{};
-    operator>>(initialized);
-    T val{};
-    operator>>(val);
-
-    if (initialized) {
-      o = val;
-    } else {
-      o = boost::none;
-    }
-  }
 
   template <class T> MemcpyIArchive &operator&(T &value) {
     operator>>(value);
@@ -186,8 +181,8 @@ public:
  *
  * @copydetails MemcpyIArchive
  */
-class MemcpyOArchive : public detail::BasicMemcpyArchive {
-  using base_type = detail::BasicMemcpyArchive;
+class MemcpyOArchive : public detail::BasicMemcpyArchive<MemcpyOArchive> {
+  using base_type = detail::BasicMemcpyArchive<MemcpyOArchive>;
 
 public:
   using is_loading = boost::mpl::false_;
@@ -196,8 +191,7 @@ public:
   /**
    * @param buf Buffer to write to.
    */
-  explicit MemcpyOArchive(Utils::Span<char> buf)
-      : detail::BasicMemcpyArchive(buf) {}
+  explicit MemcpyOArchive(Utils::Span<char> buf) : base_type(buf) {}
 
   /**
    * @brief Number of bytes written to the buffer.
@@ -208,17 +202,6 @@ public:
   /** @copydoc base_type::packing_size */
   using base_type::packing_size;
   using base_type::operator<<;
-
-  template <typename T>
-  auto operator<<(T &value)
-      -> std::enable_if_t<detail::use_serialize<T>::value> {
-    boost::serialization::serialize(*this, value, 0);
-  }
-
-  template <class T> void operator<<(boost::optional<T> &o) {
-    operator<<(o.is_initialized());
-    operator<<(o.value_or(T{}));
-  }
 
   template <class T> MemcpyOArchive &operator&(T &value) {
     operator<<(value);

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ unit_test(NAME quaternion_test SRC quaternion_test.cpp DEPENDS utils)
 unit_test(NAME mask_test SRC mask_test.cpp DEPENDS utils)
 unit_test(NAME type_traits_test SRC type_traits_test.cpp DEPENDS utils)
 unit_test(NAME uniform_test SRC uniform_test.cpp DEPENDS utils)
+unit_test(NAME memcpy_archive_test SRC memcpy_archive_test.cpp DEPENDS utils)
 
 unit_test(NAME gather_buffer_test SRC gather_buffer_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
 unit_test(NAME scatter_buffer_test SRC scatter_buffer_test.cpp DEPENDS utils Boost::mpi MPI::MPI_CXX NUM_PROC 4)

--- a/src/utils/tests/memcpy_archive_test.cpp
+++ b/src/utils/tests/memcpy_archive_test.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2019 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE memcpy archive test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include "utils/serialization/memcpy_archive.hpp"
+
+#include <boost/optional.hpp>
+#include <utils/Vector.hpp>
+
+#include <vector>
+
+struct NonTrivial {
+  boost::optional<Utils::Vector3d> ov;
+
+  template <class Archive> void serialize(Archive &ar, long int) { ar &ov; }
+};
+
+using OpVec = boost::optional<Utils::Vector3d>;
+
+namespace Utils {
+template <> struct is_statically_serializable<NonTrivial> : std::true_type {};
+} // namespace Utils
+
+BOOST_AUTO_TEST_CASE(packing_size_test) {
+  BOOST_CHECK_EQUAL(Utils::MemcpyIArchive::packing_size<int>(), sizeof(int));
+
+  {
+    BOOST_CHECK_EQUAL(Utils::MemcpyIArchive::packing_size<NonTrivial>(),
+                      Utils::MemcpyIArchive::packing_size<OpVec>());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(optional_packing) {
+  std::vector<char> buf(2 * Utils::MemcpyOArchive::packing_size<OpVec>());
+
+  const OpVec active = Utils::Vector3d{1., 2., 3.};
+  const OpVec inactive = boost::none;
+  {
+    auto oa = Utils::MemcpyOArchive{Utils::make_span(buf)};
+    auto in1 = active;
+    auto in2 = inactive;
+    oa << in1;
+    oa << in2;
+
+    BOOST_CHECK_EQUAL(oa.bytes_written(), buf.size());
+  }
+
+  {
+    auto ia = Utils::MemcpyIArchive{Utils::make_span(buf)};
+    OpVec out1, out2;
+    ia >> out1;
+    ia >> out2;
+
+    BOOST_CHECK_EQUAL(ia.bytes_read(), buf.size());
+
+    BOOST_CHECK(out1 == active);
+    BOOST_CHECK(out2 == inactive);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(non_trivial_packing) {
+  static_assert(not std::is_trivially_copyable<NonTrivial>::value, "");
+
+  std::vector<char> buf(2 * Utils::MemcpyOArchive::packing_size<NonTrivial>());
+
+  auto const active = NonTrivial{Utils::Vector3d{1., 2., 3.}};
+  auto const inactive = NonTrivial{boost::none};
+
+  {
+    auto oa = Utils::MemcpyOArchive{Utils::make_span(buf)};
+    auto in1 = active;
+    auto in2 = inactive;
+    oa << in1;
+    oa << in2;
+
+    BOOST_CHECK_EQUAL(oa.bytes_written(), buf.size());
+  }
+
+  {
+    auto ia = Utils::MemcpyIArchive{Utils::make_span(buf)};
+    NonTrivial out1, out2;
+    ia >> out1;
+    ia >> out2;
+
+    BOOST_CHECK_EQUAL(ia.bytes_read(), buf.size());
+
+    BOOST_CHECK(out1.ov == active.ov);
+    BOOST_CHECK(out2.ov == inactive.ov);
+  }
+}


### PR DESCRIPTION
Description of changes:
 - This splits off the memcpy serialization used in the ghost communication and adds unit test
   for it.
 - Added customization point to opt-in to memcpy serialization for types that are not [TriviallyCopyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable), but serializes
 to a bounded size, like `boost::optional`. This is so we can use `optional` and `variant` in `ParticleProperties`, which is planned.
