### PR TITLE
List Python3 dependencies

### DIFF
--- a/doc/sphinx/README.rst
+++ b/doc/sphinx/README.rst
@@ -1,24 +1,18 @@
 How to get started with SPHINX
 ==============================
 
-#. Install the latest stable sphinx version via pip:
+#. Install the latest stable sphinx version and the bibtex extension via pip:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    pip2 install git+https://github.com/sphinx-doc/sphinx@stable --user --upgrade
-
-#. Install a bibtex extension to Sphinx:
-
-.. code-block:: bash
-
-    pip2 install sphinxcontrib-bibtex --user --upgrade
+       pip3 install --user --upgrade 'sphinx>=1.6.6,!=2.1.0' 'sphinxcontrib-bibtex>=0.3.5'
 
 #. Compile the ``sphinx`` target in your build directory (that can take some time
    since we depend on finishing the build of the interface):
 
-.. code-block:: bash
+   .. code-block:: bash
 
-      make sphinx
+         make sphinx
 
 #. In the directory :file:`doc/sphinx` you can find all the source rst files for the user guide.
    You can change those files and rerun ``make sphinx``.

--- a/doc/sphinx/contributing.rst
+++ b/doc/sphinx/contributing.rst
@@ -99,9 +99,9 @@ safely removed if you're planning on installing dependencies via ``pip``:
 
 .. code-block:: bash
 
-   pip install --upgrade --user -r requirements.txt
+   pip3 install --upgrade --user -r requirements.txt
 
-Note that some distributions now use ``pip`` for Python3 and ``pip2`` for
+Note that some distributions now use ``pip3`` for Python3 and ``pip2`` for
 Python2.
 
 

--- a/doc/sphinx/contributing.rst
+++ b/doc/sphinx/contributing.rst
@@ -84,22 +84,26 @@ Required Development Tools
    distributed versioning control system git_ and a GitHub account to fork the
    `espressomd/espresso <https://github.com/espressomd/espresso>`_ repository
 
--  To build the sphinx documentation, you will need the Python packages listed
-   in :file:`requirements.txt` in the top-level source directory. To install
-   them, use:
-
-   .. code-block:: bash
-
-      pip install --upgrade --user -r requirements.txt
-
-   Note that some distributions now use ``pip`` for Python3 and ``pip2`` for
-   Python2.
+-  To build the user documentation, you will need Sphinx_.
 
 -  To build the tutorials, you will need LaTeX and Jupyter.
 
--  To compile the Doxygen code documentation, you will need the tool doxygen_.
+-  To build the core documentation, you will need Doxygen_.
 
 All of these tools should be easy to install on most Unix operating systems.
+
+You can find all Python dependencies of |es| in :file:`requirements.txt` in the
+top-level source directory. Several optional packages for graphics, external
+devices and continuous integration (CI) are not strictly essential and can be
+safely removed if you're planning on installing dependencies via ``pip``:
+
+.. code-block:: bash
+
+   pip install --upgrade --user -r requirements.txt
+
+Note that some distributions now use ``pip`` for Python3 and ``pip2`` for
+Python2.
+
 
 .. _Building the User's guide:
 
@@ -117,4 +121,6 @@ in :ref:`Installation` and then the documentation with ``make sphinx``.
 
 .. _git: http://git-scm.com/
 
-.. _doxygen: http://www.doxygen.org/
+.. _Doxygen: http://www.doxygen.org/
+
+.. _Sphinx: https://www.sphinx-doc.org/en/master/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,15 @@
+# required scientific packages
+numpy>=1.11.0
+h5py>=2.6.0
 # optional scientific packages
+scipy>=0.17.0
 MDAnalysis>=0.16
 pint>=0.9
+# optional graphical packages
+matplotlib>=1.5.1
+# CI-related
+requests>=2.9.1 # to post on GitHub as espresso-ci
+lxml>=3.5.0 # to deploy tutorials
 # sphinx and its dependencies
 sphinx>=1.6.6,!=2.1.0
 sphinxcontrib-bibtex>=0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
-sphinx>=1.6.6,!=2.1.0
-sphinxcontrib-bibtex>=0.3.5
+# optional scientific packages
 MDAnalysis>=0.16
 pint>=0.9
+# sphinx and its dependencies
+sphinx>=1.6.6,!=2.1.0
+sphinxcontrib-bibtex>=0.3.5
+# pep8 and its dependencies
 autopep8==1.3.4
 pycodestyle==2.3.1
+# pylint and its dependencies
 pylint>=2.2.2
 astroid>=2.1.0
 isort>=4.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,13 @@ MDAnalysis>=0.16
 pint>=0.9
 # optional graphical packages
 matplotlib>=1.5.1
+vtk>=7.1.1
+PyOpenGL>=3.1.0
+mayavi>=4.5.0
+pyface
+pygame>=1.9.6
+traits>=4.6.0
+traitsui>=4.5.1
 # CI-related
 requests>=2.9.1 # to post on GitHub as espresso-ci
 lxml>=3.5.0 # to deploy tutorials

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ h5py>=2.6.0
 scipy>=0.17.0
 MDAnalysis>=0.16
 pint>=0.9
-# optional graphical packages
+# optional packages for graphics and external devices
 matplotlib>=1.5.1
 vtk>=7.1.1
 PyOpenGL>=3.1.0


### PR DESCRIPTION
Follow-up to #3093

List the minimal version numbers that are supported for dependent Python modules.

Please note `requirements.txt` does not have to list strict dependencies, optional packages are also allowed. Comments after a package name must have a whitespace before the `#` symbol.