### PR TITLE
Default values for particle is_virtual and ext_flag when not compiled in

### DIFF
--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -167,6 +167,9 @@ struct ParticleProperties {
   /** External torque, apply if \ref ParticleProperties::ext_flag == 16. */
   Utils::Vector3d ext_torque = {0, 0, 0};
 #endif
+#else
+  static constexpr const uint8_t ext_flag =
+      0; // no external forces and fixed coordinates
 #endif
 
 #ifdef ENGINE

--- a/src/core/collision.hpp
+++ b/src/core/collision.hpp
@@ -131,11 +131,9 @@ inline void detect_collision(Particle const &p1, Particle const &p2,
     if (!glue_to_surface_criterion(p1, p2))
       return;
 
-#ifdef VIRTUAL_SITES_RELATIVE
   // Ignore virtual particles
   if ((p1.p.is_virtual) || (p2.p.is_virtual))
     return;
-#endif
 
   // Check, if there's already a bond between the particles
   if (pair_bond_exists_on(p1, p2, collision_params.bond_centers))

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -61,6 +61,8 @@ struct CUDA_particle_data {
   int identity;
 #ifdef VIRTUAL_SITES
   bool is_virtual;
+#else
+  static constexpr const bool is_virtual = false;
 #endif
 
   /** particle momentum struct velocity p.m->v*/

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -371,10 +371,8 @@ inline void add_bonded_energy(Particle const *const p1) {
  *  @param[in] p1   particle for which to calculate energies
  */
 inline void add_kinetic_energy(Particle const &p1) {
-#ifdef VIRTUAL_SITES
   if (p1.p.is_virtual)
     return;
-#endif
 
   /* kinetic energy */
   if (not p1.p.is_virtual)

--- a/src/core/integrators/steepest_descent.cpp
+++ b/src/core/integrators/steepest_descent.cpp
@@ -49,15 +49,10 @@ bool steepest_descent_step(const ParticleRange &particles) {
 
     // For all Cartesian coordinates
     for (int j = 0; j < 3; j++) {
-#ifdef EXTERNAL_FORCES
       // Skip, if coordinate is fixed
       if (!(p.p.ext_flag & COORD_FIXED(j)))
-#endif
-#ifdef VIRTUAL_SITES
         // Skip positional increments of virtual particles
-        if (!p.p.is_virtual)
-#endif
-        {
+        if (!p.p.is_virtual) {
           // Square of force on particle
           f += Utils::sqr(p.f.f[j]);
 

--- a/src/core/integrators/velocity_verlet_inline.hpp
+++ b/src/core/integrators/velocity_verlet_inline.hpp
@@ -37,16 +37,11 @@ inline void velocity_verlet_propagate_vel_pos(const ParticleRange &particles) {
     propagate_omega_quat_particle(p);
 #endif
 
-// Don't propagate translational degrees of freedom of vs
-#ifdef VIRTUAL_SITES
+    // Don't propagate translational degrees of freedom of vs
     if (p.p.is_virtual)
       continue;
-#endif
     for (int j = 0; j < 3; j++) {
-#ifdef EXTERNAL_FORCES
-      if (!(p.p.ext_flag & COORD_FIXED(j)))
-#endif
-      {
+      if (!(p.p.ext_flag & COORD_FIXED(j))) {
         /* Propagate velocities: v(t+0.5*dt) = v(t) + 0.5 * dt * a(t) */
         p.m.v[j] += 0.5 * time_step * p.f.f[j] / p.p.mass;
 
@@ -78,14 +73,10 @@ velocity_verlet_propagate_vel_final(const ParticleRange &particles) {
       continue;
 #endif
     for (int j = 0; j < 3; j++) {
-#ifdef EXTERNAL_FORCES
       if (!(p.p.ext_flag & COORD_FIXED(j))) {
-#endif
         /* Propagate velocity: v(t+dt) = v(t+0.5*dt) + 0.5*dt * a(t+dt) */
         p.m.v[j] += 0.5 * time_step * p.f.f[j] / p.p.mass;
-#ifdef EXTERNAL_FORCES
       }
-#endif
     }
   }
 }

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -36,15 +36,11 @@ void velocity_verlet_npt_propagate_vel_final(const ParticleRange &particles) {
   nptiso.p_vel[0] = nptiso.p_vel[1] = nptiso.p_vel[2] = 0.0;
 
   for (auto &p : particles) {
-#ifdef VIRTUAL_SITES
     // Virtual sites are not propagated during integration
     if (p.p.is_virtual)
       continue;
-#endif
     for (int j = 0; j < 3; j++) {
-#ifdef EXTERNAL_FORCES
       if (!(p.p.ext_flag & COORD_FIXED(j))) {
-#endif
         if (nptiso.geometry & nptiso.nptgeom_dir[j]) {
           nptiso.p_vel[j] += Utils::sqr(p.m.v[j] * time_step) * p.p.mass;
           p.m.v[j] += 0.5 * time_step / p.p.mass * p.f.f[j] +
@@ -114,14 +110,10 @@ void velocity_verlet_npt_propagate_pos(const ParticleRange &particles) {
 
   /* propagate positions while rescaling positions and velocities */
   for (auto &p : particles) {
-#ifdef VIRTUAL_SITES
     if (p.p.is_virtual)
       continue;
-#endif
     for (int j = 0; j < 3; j++) {
-#ifdef EXTERNAL_FORCES
       if (!(p.p.ext_flag & COORD_FIXED(j))) {
-#endif
         if (nptiso.geometry & nptiso.nptgeom_dir[j]) {
           {
             p.r.p[j] = scal[1] * (p.r.p[j] + scal[2] * p.m.v[j] * time_step);
@@ -171,16 +163,11 @@ void velocity_verlet_npt_propagate_vel(const ParticleRange &particles) {
     propagate_omega_quat_particle(p);
 #endif
 
-#ifdef VIRTUAL_SITES
     // Don't propagate translational degrees of freedom of vs
     if (p.p.is_virtual)
       continue;
-#endif
     for (int j = 0; j < 3; j++) {
-#ifdef EXTERNAL_FORCES
-      if (!(p.p.ext_flag & COORD_FIXED(j)))
-#endif
-      {
+      if (!(p.p.ext_flag & COORD_FIXED(j))) {
 #ifdef NPT
         if (integ_switch == INTEG_METHOD_NPT_ISO &&
             (nptiso.geometry & nptiso.nptgeom_dir[j])) {

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -67,6 +67,8 @@ enum {
 /** \ref ParticleProperties::ext_flag "ext_flag" mask to check whether any of
  *  the coordinates is fixed. */
 #define COORDS_FIX_MASK (COORD_FIXED(0) | COORD_FIXED(1) | COORD_FIXED(2))
+#else
+#define COORD_FIXED(coord) (0)
 #endif
 
 /************************************************


### PR DESCRIPTION
They are set static constexpr const false and 0, respectively. This saves a number of ifdefs, mainly in the integrator code