### PR TITLE
P3m halo refactor

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -79,6 +79,7 @@ set(EspressoCore_SRC
   electrostatics_magnetostatics/mmm2d.cpp
   electrostatics_magnetostatics/mmm-common.cpp
   electrostatics_magnetostatics/p3m-common.cpp
+  electrostatics_magnetostatics/p3m_send_mesh.cpp
   electrostatics_magnetostatics/p3m.cpp
   electrostatics_magnetostatics/p3m-dipolar.cpp
   electrostatics_magnetostatics/p3m_gpu.cpp

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -96,28 +96,6 @@ typedef struct {
   int q_21_off;
 } p3m_local_mesh;
 
-/** Structure for send/recv meshes. */
-typedef struct {
-  /** dimension of sub meshes to send. */
-  int s_dim[6][3];
-  /** left down corners of sub meshes to send. */
-  int s_ld[6][3];
-  /** up right corners of sub meshes to send. */
-  int s_ur[6][3];
-  /** sizes for send buffers. */
-  int s_size[6];
-  /** dimension of sub meshes to recv. */
-  int r_dim[6][3];
-  /** left down corners of sub meshes to recv. */
-  int r_ld[6][3];
-  /** up right corners of sub meshes to recv. */
-  int r_ur[6][3];
-  /** sizes for recv buffers. */
-  int r_size[6];
-  /** maximal size for send/recv buffers. */
-  int max;
-} p3m_send_mesh;
-
 /** Structure to hold P3M parameters and some dependent variables. */
 typedef struct {
   /** tuning or production? */

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -771,12 +771,13 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
   if (dp3m.sum_mu2 > 0) {
     /* Gather information for FFT grid inside the nodes domain (inner local
      * mesh) and perform forward 3D FFT (Charge Assignment Mesh). */
-    dp3m.sm.gather_grid(dp3m.rs_mesh_dip[0].data(), comm_cart,
+    std::array<double *, 3> meshes = {dp3m.rs_mesh_dip[0].data(),
+                                      dp3m.rs_mesh_dip[1].data(),
+                                      dp3m.rs_mesh_dip[2].data()};
+
+    dp3m.sm.gather_grid(Utils::make_span(meshes), comm_cart,
                         dp3m.local_mesh.dim);
-    dp3m.sm.gather_grid(dp3m.rs_mesh_dip[1].data(), comm_cart,
-                        dp3m.local_mesh.dim);
-    dp3m.sm.gather_grid(dp3m.rs_mesh_dip[2].data(), comm_cart,
-                        dp3m.local_mesh.dim);
+
     fft_perform_forw(dp3m.rs_mesh_dip[0].data(), dp3m.fft, comm_cart);
     fft_perform_forw(dp3m.rs_mesh_dip[1].data(), dp3m.fft, comm_cart);
     fft_perform_forw(dp3m.rs_mesh_dip[2].data(), dp3m.fft, comm_cart);
@@ -988,11 +989,11 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
         fft_perform_back(dp3m.rs_mesh_dip[2].data(), false, dp3m.fft,
                          comm_cart);
         /* redistribute force component mesh */
-        dp3m.sm.spread_grid(dp3m.rs_mesh_dip[0].data(), comm_cart,
-                            dp3m.local_mesh.dim);
-        dp3m.sm.spread_grid(dp3m.rs_mesh_dip[1].data(), comm_cart,
-                            dp3m.local_mesh.dim);
-        dp3m.sm.spread_grid(dp3m.rs_mesh_dip[2].data(), comm_cart,
+        std::array<double *, 3> meshes = {dp3m.rs_mesh_dip[0].data(),
+                                          dp3m.rs_mesh_dip[1].data(),
+                                          dp3m.rs_mesh_dip[2].data()};
+
+        dp3m.sm.spread_grid(Utils::make_span(meshes), comm_cart,
                             dp3m.local_mesh.dim);
         /* Assign force component from mesh to particle */
         dp3m_assign_forces_dip(

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -63,16 +63,6 @@ using Utils::sinc;
  * DEFINES
  ************************************************/
 
-/** @name MPI tags for the dipole-dipole p3m communications */
-/*@{*/
-/** Tag for communication in dp3m_init() -> dp3m_calc_send_mesh(). */
-#define REQ_P3M_INIT_D 2001
-/** Tag for communication in dp3m_gather_fft_grid(). */
-#define REQ_P3M_GATHER_D 2011
-/** Tag for communication in dp3m_spread_force_grid(). */
-#define REQ_P3M_SPREAD_D 2021
-/*@}*/
-
 /************************************************
  * variables
  ************************************************/
@@ -81,13 +71,6 @@ dp3m_data_struct dp3m;
 
 /** \name Private Functions */
 /*@{*/
-
-/** Calculate for magnetic dipoles the properties of the send/recv sub-meshes
- *  of the local FFT mesh.
- *  In order to calculate the recv sub-meshes there is a communication of
- *  the margins between neighbouring nodes.
- */
-static void dp3m_calc_send_mesh();
 
 /** Initialize for magnetic dipoles the (inverse) mesh constant @ref
  *  P3MParameters::a "a" (@ref P3MParameters::ai "ai") and the
@@ -106,18 +89,6 @@ static void dp3m_init_a_ai_cao_cut();
  *  @ref dp3m_scaleby_box_l() whenever the box size changes.
  */
 static void dp3m_calc_lm_ld_pos();
-
-/** Gather FFT grid.
- *  After the charge assignment Each node needs to gather the
- *  information for the FFT grid in his spatial domain.
- */
-static void dp3m_gather_fft_grid(double *mesh);
-
-/** Spread force grid.
- *  After the k-space calculations each node needs to get all force
- *  information to reassign the forces from the grid to the particles.
- */
-static void dp3m_spread_force_grid(double *mesh);
 
 /** realloc charge assignment fields. */
 static void dp3m_realloc_ca_fields(int newsize);
@@ -337,10 +308,7 @@ void dp3m_init() {
 
     dp3m_calc_local_ca_mesh();
 
-    dp3m_calc_send_mesh();
-
-    dp3m.send_grid.resize(dp3m.sm.max);
-    dp3m.recv_grid.resize(dp3m.sm.max);
+    dp3m.sm.resize(comm_cart, dp3m.local_mesh);
 
     /* fix box length dependent constants */
     dp3m_scaleby_box_l();
@@ -370,17 +338,6 @@ void dp3m_init() {
 
     dp3m_count_magnetic_particles();
   }
-}
-
-void dp3m_free_dipoles() {
-  for (auto &i : dp3m.rs_mesh_dip)
-    i.resize(0);
-  dp3m.ca_frac.resize(0);
-  dp3m.ca_fmp.resize(0);
-  dp3m.send_grid.resize(0);
-  dp3m.recv_grid.resize(0);
-  free(dp3m.rs_mesh);
-  dp3m.ks_mesh.resize(0);
 }
 
 double dp3m_average_dipolar_self_energy(double box_l, int mesh) {
@@ -814,9 +771,12 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
   if (dp3m.sum_mu2 > 0) {
     /* Gather information for FFT grid inside the nodes domain (inner local
      * mesh) and perform forward 3D FFT (Charge Assignment Mesh). */
-    dp3m_gather_fft_grid(dp3m.rs_mesh_dip[0].data());
-    dp3m_gather_fft_grid(dp3m.rs_mesh_dip[1].data());
-    dp3m_gather_fft_grid(dp3m.rs_mesh_dip[2].data());
+    dp3m.sm.gather_grid(dp3m.rs_mesh_dip[0].data(), comm_cart,
+                        dp3m.local_mesh.dim);
+    dp3m.sm.gather_grid(dp3m.rs_mesh_dip[1].data(), comm_cart,
+                        dp3m.local_mesh.dim);
+    dp3m.sm.gather_grid(dp3m.rs_mesh_dip[2].data(), comm_cart,
+                        dp3m.local_mesh.dim);
     fft_perform_forw(dp3m.rs_mesh_dip[0].data(), dp3m.fft, comm_cart);
     fft_perform_forw(dp3m.rs_mesh_dip[1].data(), dp3m.fft, comm_cart);
     fft_perform_forw(dp3m.rs_mesh_dip[2].data(), dp3m.fft, comm_cart);
@@ -944,7 +904,7 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
         /* Back FFT force component mesh */
         fft_perform_back(dp3m.rs_mesh, false, dp3m.fft, comm_cart);
         /* redistribute force component mesh */
-        dp3m_spread_force_grid(dp3m.rs_mesh);
+        dp3m.sm.spread_grid(dp3m.rs_mesh, comm_cart, dp3m.local_mesh.dim);
         /* Assign force component from mesh to particle */
         P3M_assign_torques(dipole_prefac *
                                (2 * Utils::pi() / box_geo.length()[0]),
@@ -1028,9 +988,12 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
         fft_perform_back(dp3m.rs_mesh_dip[2].data(), false, dp3m.fft,
                          comm_cart);
         /* redistribute force component mesh */
-        dp3m_spread_force_grid(dp3m.rs_mesh_dip[0].data());
-        dp3m_spread_force_grid(dp3m.rs_mesh_dip[1].data());
-        dp3m_spread_force_grid(dp3m.rs_mesh_dip[2].data());
+        dp3m.sm.spread_grid(dp3m.rs_mesh_dip[0].data(), comm_cart,
+                            dp3m.local_mesh.dim);
+        dp3m.sm.spread_grid(dp3m.rs_mesh_dip[1].data(), comm_cart,
+                            dp3m.local_mesh.dim);
+        dp3m.sm.spread_grid(dp3m.rs_mesh_dip[2].data(), comm_cart,
+                            dp3m.local_mesh.dim);
         /* Assign force component from mesh to particle */
         dp3m_assign_forces_dip(
             dipole_prefac * pow(2 * Utils::pi() / box_geo.length()[0], 2), d_rs,
@@ -1123,95 +1086,6 @@ double calc_surface_term(bool force_flag, bool energy_flag,
 #endif
 
   return en;
-}
-
-/************************************************************/
-
-void dp3m_gather_fft_grid(double *themesh) {
-  int s_dir, r_dir, evenodd;
-  MPI_Status status;
-
-  auto const node_neighbors = calc_node_neighbors(comm_cart);
-  auto const node_pos = calc_node_pos(comm_cart);
-
-  /* direction loop */
-  for (s_dir = 0; s_dir < 6; s_dir++) {
-    if (s_dir % 2 == 0)
-      r_dir = s_dir + 1;
-    else
-      r_dir = s_dir - 1;
-    /* pack send block */
-    if (dp3m.sm.s_size[s_dir] > 0)
-      fft_pack_block(themesh, dp3m.send_grid.data(), dp3m.sm.s_ld[s_dir],
-                     dp3m.sm.s_dim[s_dir], dp3m.local_mesh.dim, 1);
-
-    /* communication */
-    if (node_neighbors[s_dir] != this_node) {
-      for (evenodd = 0; evenodd < 2; evenodd++) {
-        if ((node_pos[s_dir / 2] + evenodd) % 2 == 0) {
-          if (dp3m.sm.s_size[s_dir] > 0)
-            MPI_Send(dp3m.send_grid.data(), dp3m.sm.s_size[s_dir], MPI_DOUBLE,
-                     node_neighbors[s_dir], REQ_P3M_GATHER_D, comm_cart);
-        } else {
-          if (dp3m.sm.r_size[r_dir] > 0)
-            MPI_Recv(dp3m.recv_grid.data(), dp3m.sm.r_size[r_dir], MPI_DOUBLE,
-                     node_neighbors[r_dir], REQ_P3M_GATHER_D, comm_cart,
-                     &status);
-        }
-      }
-    } else {
-      std::swap(dp3m.send_grid, dp3m.recv_grid);
-    }
-    /* add recv block */
-    if (dp3m.sm.r_size[r_dir] > 0) {
-      p3m_add_block(dp3m.recv_grid.data(), themesh, dp3m.sm.r_ld[r_dir],
-                    dp3m.sm.r_dim[r_dir], dp3m.local_mesh.dim);
-    }
-  }
-}
-
-/************************************************************/
-
-void dp3m_spread_force_grid(double *themesh) {
-  int s_dir, r_dir, evenodd;
-  MPI_Status status;
-
-  auto const node_neighbors = calc_node_neighbors(comm_cart);
-  auto const node_pos = calc_node_pos(comm_cart);
-
-  /* direction loop */
-  for (s_dir = 5; s_dir >= 0; s_dir--) {
-    if (s_dir % 2 == 0)
-      r_dir = s_dir + 1;
-    else
-      r_dir = s_dir - 1;
-    /* pack send block */
-    if (dp3m.sm.s_size[s_dir] > 0)
-      fft_pack_block(themesh, dp3m.send_grid.data(), dp3m.sm.r_ld[r_dir],
-                     dp3m.sm.r_dim[r_dir], dp3m.local_mesh.dim, 1);
-    /* communication */
-    if (node_neighbors[r_dir] != this_node) {
-      for (evenodd = 0; evenodd < 2; evenodd++) {
-        if ((node_pos[r_dir / 2] + evenodd) % 2 == 0) {
-          if (dp3m.sm.r_size[r_dir] > 0)
-            MPI_Send(dp3m.send_grid.data(), dp3m.sm.r_size[r_dir], MPI_DOUBLE,
-                     node_neighbors[r_dir], REQ_P3M_SPREAD_D, comm_cart);
-        } else {
-          if (dp3m.sm.s_size[s_dir] > 0)
-            MPI_Recv(dp3m.recv_grid.data(), dp3m.sm.s_size[s_dir], MPI_DOUBLE,
-                     node_neighbors[s_dir], REQ_P3M_SPREAD_D, comm_cart,
-                     &status);
-        }
-      }
-    } else {
-      std::swap(dp3m.send_grid, dp3m.recv_grid);
-    }
-    /* un pack recv block */
-    if (dp3m.sm.s_size[s_dir] > 0) {
-      fft_unpack_block(dp3m.recv_grid.data(), themesh, dp3m.sm.s_ld[s_dir],
-                       dp3m.sm.s_dim[s_dir], dp3m.local_mesh.dim, 1);
-    }
-  }
 }
 
 /*****************************************************************************/
@@ -2265,97 +2139,6 @@ bool dp3m_sanity_checks(const Utils::Vector3i &grid) {
   }
 
   return ret;
-}
-
-/*****************************************************************************/
-
-void dp3m_calc_send_mesh() {
-  int i, j, evenodd;
-  int done[3] = {0, 0, 0};
-  MPI_Status status;
-  /* send grids */
-  for (i = 0; i < 3; i++) {
-    for (j = 0; j < 3; j++) {
-      /* left */
-      dp3m.sm.s_ld[i * 2][j] = 0 + done[j] * dp3m.local_mesh.margin[j * 2];
-      if (j == i)
-        dp3m.sm.s_ur[i * 2][j] = dp3m.local_mesh.margin[j * 2];
-      else
-        dp3m.sm.s_ur[i * 2][j] = dp3m.local_mesh.dim[j] -
-                                 done[j] * dp3m.local_mesh.margin[(j * 2) + 1];
-      /* right */
-      if (j == i)
-        dp3m.sm.s_ld[(i * 2) + 1][j] = dp3m.local_mesh.in_ur[j];
-      else
-        dp3m.sm.s_ld[(i * 2) + 1][j] =
-            0 + done[j] * dp3m.local_mesh.margin[j * 2];
-      dp3m.sm.s_ur[(i * 2) + 1][j] =
-          dp3m.local_mesh.dim[j] -
-          done[j] * dp3m.local_mesh.margin[(j * 2) + 1];
-    }
-    done[i] = 1;
-  }
-  dp3m.sm.max = 0;
-  for (i = 0; i < 6; i++) {
-    dp3m.sm.s_size[i] = 1;
-    for (j = 0; j < 3; j++) {
-      dp3m.sm.s_dim[i][j] = dp3m.sm.s_ur[i][j] - dp3m.sm.s_ld[i][j];
-      dp3m.sm.s_size[i] *= dp3m.sm.s_dim[i][j];
-    }
-    if (dp3m.sm.s_size[i] > dp3m.sm.max)
-      dp3m.sm.max = dp3m.sm.s_size[i];
-  }
-  /* communication */
-  auto const node_neighbors = calc_node_neighbors(comm_cart);
-  auto const node_pos = calc_node_pos(comm_cart);
-
-  for (i = 0; i < 6; i++) {
-    if (i % 2 == 0)
-      j = i + 1;
-    else
-      j = i - 1;
-    if (node_neighbors[i] != this_node) {
-      /* two step communication: first all even positions than all odd */
-      for (evenodd = 0; evenodd < 2; evenodd++) {
-        if ((node_pos[i / 2] + evenodd) % 2 == 0)
-          MPI_Send(&(dp3m.local_mesh.margin[i]), 1, MPI_INT, node_neighbors[i],
-                   REQ_P3M_INIT_D, comm_cart);
-        else
-          MPI_Recv(&(dp3m.local_mesh.r_margin[j]), 1, MPI_INT,
-                   node_neighbors[j], REQ_P3M_INIT_D, comm_cart, &status);
-      }
-    } else {
-      dp3m.local_mesh.r_margin[j] = dp3m.local_mesh.margin[i];
-    }
-  }
-  /* recv grids */
-  for (i = 0; i < 3; i++)
-    for (j = 0; j < 3; j++) {
-      if (j == i) {
-        dp3m.sm.r_ld[i * 2][j] =
-            dp3m.sm.s_ld[i * 2][j] + dp3m.local_mesh.margin[2 * j];
-        dp3m.sm.r_ur[i * 2][j] =
-            dp3m.sm.s_ur[i * 2][j] + dp3m.local_mesh.r_margin[2 * j];
-        dp3m.sm.r_ld[(i * 2) + 1][j] = dp3m.sm.s_ld[(i * 2) + 1][j] -
-                                       dp3m.local_mesh.r_margin[(2 * j) + 1];
-        dp3m.sm.r_ur[(i * 2) + 1][j] =
-            dp3m.sm.s_ur[(i * 2) + 1][j] - dp3m.local_mesh.margin[(2 * j) + 1];
-      } else {
-        dp3m.sm.r_ld[i * 2][j] = dp3m.sm.s_ld[i * 2][j];
-        dp3m.sm.r_ur[i * 2][j] = dp3m.sm.s_ur[i * 2][j];
-        dp3m.sm.r_ld[(i * 2) + 1][j] = dp3m.sm.s_ld[(i * 2) + 1][j];
-        dp3m.sm.r_ur[(i * 2) + 1][j] = dp3m.sm.s_ur[(i * 2) + 1][j];
-      }
-    }
-  for (i = 0; i < 6; i++) {
-    dp3m.sm.r_size[i] = 1;
-    for (j = 0; j < 3; j++) {
-      dp3m.sm.r_dim[i][j] = dp3m.sm.r_ur[i][j] - dp3m.sm.r_ld[i][j];
-      dp3m.sm.r_size[i] *= dp3m.sm.r_dim[i][j];
-    }
-    if (dp3m.sm.r_size[i] > dp3m.sm.max)
-      dp3m.sm.max = dp3m.sm.r_size[i];
-  }
 }
 
 /************************************************/

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -56,7 +56,7 @@ struct dp3m_data_struct {
   /** real space mesh (local) for CA/FFT.*/
   double *rs_mesh;
   /** real space mesh (local) for CA/FFT of the dipolar field.*/
-  std::vector<std::vector<double>> rs_mesh_dip{3};
+  std::array<std::vector<double>, 3> rs_mesh_dip;
   /** k-space mesh (local) for k-space calculation and FFT.*/
   std::vector<double> ks_mesh;
 

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -94,11 +94,6 @@ struct dp3m_data_struct {
   /** send/recv mesh sizes */
   p3m_send_mesh sm;
 
-  /** Field to store grid points to send. */
-  std::vector<double> send_grid;
-  /** Field to store grid points to recv */
-  std::vector<double> recv_grid;
-
   /* Stores the value of the energy correction due to MS effects */
   double energy_correction;
 

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -40,6 +40,7 @@
 #include "electrostatics_magnetostatics/dipole.hpp"
 #include "fft.hpp"
 #include "p3m-common.hpp"
+#include "p3m_send_mesh.hpp"
 
 #include <ParticleRange.hpp>
 #include <utils/constants.hpp>

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -63,16 +63,6 @@ using Utils::strcat_alloc;
  ************************************************/
 p3m_data_struct p3m;
 
-/** @name MPI tags for the charge-charge p3m communications */
-/*@{*/
-/** Tag for communication in p3m_init() -> p3m_calc_send_mesh(). */
-#define REQ_P3M_INIT 200
-/** Tag for communication in p3m_gather_fft_grid(). */
-#define REQ_P3M_GATHER 201
-/** Tag for communication in p3m_spread_force_grid(). */
-#define REQ_P3M_SPREAD 202
-/*@}*/
-
 /* @name Index helpers for direct and reciprocal space
  * After the FFT the data is in order YZX, which
  * means that Y is the slowest changing index.

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -39,6 +39,7 @@
 
 #include "fft.hpp"
 #include "p3m-common.hpp"
+#include "p3m_send_mesh.hpp"
 
 #include <ParticleRange.hpp>
 #include <utils/constants.hpp>
@@ -99,11 +100,6 @@ struct p3m_data_struct {
 
   /** send/recv mesh sizes */
   p3m_send_mesh sm;
-
-  /** vector to store grid points to send. */
-  std::vector<double> send_grid;
-  /** vector to store grid points to recv */
-  std::vector<double> recv_grid;
 
   fft_data_struct fft;
 };
@@ -282,9 +278,6 @@ inline double p3m_pair_energy(double chgfac, double dist) {
   }
   return 0.0;
 }
-
-/** Clean up P3M memory allocations. */
-void p3m_free();
 
 #endif /* of ifdef P3M */
 

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
@@ -1,0 +1,171 @@
+//
+// Created by florian on 17.11.19.
+//
+
+#include "p3m_send_mesh.hpp"
+#include "fft.hpp"
+
+#include <utils/mpi/cart_comm.hpp>
+
+void p3m_send_mesh::resize(const boost::mpi::communicator &comm,
+                           const p3m_local_mesh &local_mesh) {
+  int done[3] = {0, 0, 0};
+  /* send grids */
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      /* left */
+      s_ld[i * 2][j] = 0 + done[j] * local_mesh.margin[j * 2];
+      if (j == i)
+        s_ur[i * 2][j] = local_mesh.margin[j * 2];
+      else
+        s_ur[i * 2][j] =
+            local_mesh.dim[j] - done[j] * local_mesh.margin[(j * 2) + 1];
+      /* right */
+      if (j == i)
+        s_ld[(i * 2) + 1][j] = local_mesh.in_ur[j];
+      else
+        s_ld[(i * 2) + 1][j] = 0 + done[j] * local_mesh.margin[j * 2];
+      s_ur[(i * 2) + 1][j] =
+          local_mesh.dim[j] - done[j] * local_mesh.margin[(j * 2) + 1];
+    }
+    done[i] = 1;
+  }
+  max = 0;
+  for (int i = 0; i < 6; i++) {
+    s_size[i] = 1;
+    for (int j = 0; j < 3; j++) {
+      s_dim[i][j] = s_ur[i][j] - s_ld[i][j];
+      s_size[i] *= s_dim[i][j];
+    }
+    if (s_size[i] > max)
+      max = s_size[i];
+  }
+  /* communication */
+  auto const node_neighbors = Utils::Mpi::cart_neighbors<3>(comm);
+  auto const node_pos = Utils::Mpi::cart_coords<3>(comm, comm.rank());
+
+  int r_margin[6];
+  for (int i = 0; i < 6; i++) {
+    auto const j = (i % 2 == 0) ? i + 1 : i - 1;
+
+    if (node_neighbors[i] != comm.rank()) {
+      /* two step communication: first all even positions than all odd */
+      for (int evenodd = 0; evenodd < 2; evenodd++) {
+        if ((node_pos[i / 2] + evenodd) % 2 == 0)
+          MPI_Send(&(local_mesh.margin[i]), 1, MPI_INT, node_neighbors[i],
+                   REQ_P3M_INIT, comm);
+        else
+          MPI_Recv(&(r_margin[j]), 1, MPI_INT, node_neighbors[j], REQ_P3M_INIT,
+                   comm, MPI_STATUS_IGNORE);
+      }
+    } else {
+      r_margin[j] = local_mesh.margin[i];
+    }
+  }
+  /* recv grids */
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++) {
+      if (j == i) {
+        r_ld[i * 2][j] = s_ld[i * 2][j] + local_mesh.margin[2 * j];
+        r_ur[i * 2][j] = s_ur[i * 2][j] + r_margin[2 * j];
+        r_ld[(i * 2) + 1][j] = s_ld[(i * 2) + 1][j] - r_margin[(2 * j) + 1];
+        r_ur[(i * 2) + 1][j] =
+            s_ur[(i * 2) + 1][j] - local_mesh.margin[(2 * j) + 1];
+      } else {
+        r_ld[i * 2][j] = s_ld[i * 2][j];
+        r_ur[i * 2][j] = s_ur[i * 2][j];
+        r_ld[(i * 2) + 1][j] = s_ld[(i * 2) + 1][j];
+        r_ur[(i * 2) + 1][j] = s_ur[(i * 2) + 1][j];
+      }
+    }
+  for (int i = 0; i < 6; i++) {
+    r_size[i] = 1;
+    for (int j = 0; j < 3; j++) {
+      r_dim[i][j] = r_ur[i][j] - r_ld[i][j];
+      r_size[i] *= r_dim[i][j];
+    }
+    if (r_size[i] > max)
+      max = r_size[i];
+  }
+
+  send_grid.resize(max);
+  recv_grid.resize(max);
+}
+
+void p3m_send_mesh::gather_grid(double *themesh,
+                                const boost::mpi::communicator &comm,
+                                const int dim[3]) {
+  auto const node_neighbors = Utils::Mpi::cart_neighbors<3>(comm);
+  auto const node_pos = Utils::Mpi::cart_coords<3>(comm, comm.rank());
+
+  /* direction loop */
+  for (int s_dir = 0; s_dir < 6; s_dir++) {
+    auto const r_dir = (s_dir % 2 == 0) ? s_dir + 1 : s_dir - 1;
+
+    /* pack send block */
+    if (s_size[s_dir] > 0)
+      fft_pack_block(themesh, send_grid.data(), s_ld[s_dir], s_dim[s_dir], dim,
+                     1);
+
+    /* communication */
+    if (node_neighbors[s_dir] != comm.rank()) {
+      for (int evenodd = 0; evenodd < 2; evenodd++) {
+        if ((node_pos[s_dir / 2] + evenodd) % 2 == 0) {
+          if (s_size[s_dir] > 0)
+            MPI_Send(send_grid.data(), s_size[s_dir], MPI_DOUBLE,
+                     node_neighbors[s_dir], REQ_P3M_GATHER, comm);
+        } else {
+          if (r_size[r_dir] > 0)
+            MPI_Recv(recv_grid.data(), r_size[r_dir], MPI_DOUBLE,
+                     node_neighbors[r_dir], REQ_P3M_GATHER, comm,
+                     MPI_STATUS_IGNORE);
+        }
+      }
+    } else {
+      std::swap(send_grid, recv_grid);
+    }
+    /* add recv block */
+    if (r_size[r_dir] > 0) {
+      p3m_add_block(recv_grid.data(), themesh, r_ld[r_dir], r_dim[r_dir], dim);
+    }
+  }
+}
+
+void p3m_send_mesh::spread_grid(double *themesh,
+                                const boost::mpi::communicator &comm,
+                                const int dim[3]) {
+  auto const node_neighbors = Utils::Mpi::cart_neighbors<3>(comm);
+  auto const node_pos = Utils::Mpi::cart_coords<3>(comm, comm.rank());
+
+  /* direction loop */
+  for (int s_dir = 5; s_dir >= 0; s_dir--) {
+    auto const r_dir = (s_dir % 2 == 0) ? s_dir + 1 : s_dir - 1;
+
+    /* pack send block */
+    if (s_size[s_dir] > 0)
+      fft_pack_block(themesh, send_grid.data(), r_ld[r_dir], r_dim[r_dir], dim,
+                     1);
+    /* communication */
+    if (node_neighbors[r_dir] != comm.rank()) {
+      for (int evenodd = 0; evenodd < 2; evenodd++) {
+        if ((node_pos[r_dir / 2] + evenodd) % 2 == 0) {
+          if (r_size[r_dir] > 0)
+            MPI_Send(send_grid.data(), r_size[r_dir], MPI_DOUBLE,
+                     node_neighbors[r_dir], REQ_P3M_SPREAD, comm);
+        } else {
+          if (s_size[s_dir] > 0)
+            MPI_Recv(recv_grid.data(), s_size[s_dir], MPI_DOUBLE,
+                     node_neighbors[s_dir], REQ_P3M_SPREAD, comm,
+                     MPI_STATUS_IGNORE);
+        }
+      }
+    } else {
+      std::swap(send_grid, recv_grid);
+    }
+    /* un pack recv block */
+    if (s_size[s_dir] > 0) {
+      fft_unpack_block(recv_grid.data(), themesh, s_ld[s_dir], s_dim[s_dir],
+                       dim, 1);
+    }
+  }
+}

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
@@ -19,6 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "p3m_send_mesh.hpp"
+
+#ifdef P3M
 #include "fft.hpp"
 
 #include <utils/mpi/cart_comm.hpp>
@@ -172,3 +174,5 @@ void p3m_send_mesh::spread_grid(Utils::Span<double *> meshes,
     }
   }
 }
+
+#endif

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
@@ -1,7 +1,23 @@
-//
-// Created by florian on 17.11.19.
-//
-
+/*
+ * Copyright (C) 2010-2019 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "p3m_send_mesh.hpp"
 #include "fft.hpp"
 

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
@@ -22,6 +22,9 @@
 #define ESPRESSO_P3M_SEND_MESH_HPP
 
 #include "p3m-common.hpp"
+
+#include <utils/Span.hpp>
+
 #include <boost/mpi/communicator.hpp>
 
 #include <vector>
@@ -60,10 +63,18 @@ class p3m_send_mesh {
 public:
   void resize(const boost::mpi::communicator &comm,
               const p3m_local_mesh &local_mesh);
-  void gather_grid(double *themesh, const boost::mpi::communicator &comm,
-                   const int dim[3]);
-  void spread_grid(double *themesh, const boost::mpi::communicator &comm,
-                   const int dim[3]);
+  void gather_grid(Utils::Span<double *> meshes,
+                   const boost::mpi::communicator &comm, const int *dim);
+  void gather_grid(double *mesh, const boost::mpi::communicator &comm,
+                   const int *dim) {
+    gather_grid(Utils::make_span(&mesh, 1), comm, dim);
+  }
+  void spread_grid(Utils::Span<double *> meshes,
+                   const boost::mpi::communicator &comm, const int *dim);
+  void spread_grid(double *mesh, const boost::mpi::communicator &comm,
+                   const int *dim) {
+    spread_grid(Utils::make_span(&mesh, 1), comm, dim);
+  }
 };
 
 #endif // ESPRESSO_P3M_SEND_MESH_HPP

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
@@ -23,6 +23,8 @@
 
 #include "p3m-common.hpp"
 
+#ifdef P3M
+
 #include <utils/Span.hpp>
 
 #include <boost/mpi/communicator.hpp>
@@ -77,4 +79,5 @@ public:
   }
 };
 
+#endif
 #endif // ESPRESSO_P3M_SEND_MESH_HPP

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
@@ -1,0 +1,52 @@
+//
+// Created by florian on 17.11.19.
+//
+
+#ifndef ESPRESSO_P3M_SEND_MESH_HPP
+#define ESPRESSO_P3M_SEND_MESH_HPP
+
+#include "p3m-common.hpp"
+#include <boost/mpi/communicator.hpp>
+
+#include <vector>
+
+/** Structure for send/recv meshes. */
+struct p3m_send_mesh {
+  enum Requests {
+    REQ_P3M_INIT = 200,
+    REQ_P3M_GATHER = 201,
+    REQ_P3M_SPREAD = 202
+  };
+  /** dimension of sub meshes to send. */
+  int s_dim[6][3];
+  /** left down corners of sub meshes to send. */
+  int s_ld[6][3];
+  /** up right corners of sub meshes to send. */
+  int s_ur[6][3];
+  /** sizes for send buffers. */
+  int s_size[6];
+  /** dimension of sub meshes to recv. */
+  int r_dim[6][3];
+  /** left down corners of sub meshes to recv. */
+  int r_ld[6][3];
+  /** up right corners of sub meshes to recv. */
+  int r_ur[6][3];
+  /** sizes for recv buffers. */
+  int r_size[6];
+  /** maximal size for send/recv buffers. */
+  int max;
+
+  /** vector to store grid points to send. */
+  std::vector<double> send_grid;
+  /** vector to store grid points to recv */
+  std::vector<double> recv_grid;
+
+  void resize(const boost::mpi::communicator &comm,
+              const p3m_local_mesh &local_mesh);
+  void gather_grid(double *themesh, const boost::mpi::communicator &comm,
+                   const int dim[3]);
+  void spread_grid(double *themesh, const boost::mpi::communicator &comm,
+                   const int dim[3]);
+};
+
+#endif // ESPRESSO_P3M_SEND_MESH_HPP

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
@@ -1,7 +1,23 @@
-//
-// Created by florian on 17.11.19.
-//
-
+/*
+ * Copyright (C) 2010-2019 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef ESPRESSO_P3M_SEND_MESH_HPP
 #define ESPRESSO_P3M_SEND_MESH_HPP
 

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 /** Structure for send/recv meshes. */
-struct p3m_send_mesh {
+class p3m_send_mesh {
   enum Requests {
     REQ_P3M_INIT = 200,
     REQ_P3M_GATHER = 201,
@@ -41,6 +41,7 @@ struct p3m_send_mesh {
   /** vector to store grid points to recv */
   std::vector<double> recv_grid;
 
+public:
   void resize(const boost::mpi::communicator &comm,
               const p3m_local_mesh &local_mesh);
   void gather_grid(double *themesh, const boost::mpi::communicator &comm,

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -67,14 +67,7 @@ Utils::Vector3i calc_node_pos(const boost::mpi::communicator &comm) {
 
 Utils::Vector<int, 6>
 calc_node_neighbors(const boost::mpi::communicator &comm) {
-  using std::get;
-  using Utils::Mpi::cart_shift;
-
-  return {
-      get<1>(cart_shift(comm, 0, -1)), get<1>(cart_shift(comm, 0, +1)),
-      get<1>(cart_shift(comm, 1, -1)), get<1>(cart_shift(comm, 1, +1)),
-      get<1>(cart_shift(comm, 2, -1)), get<1>(cart_shift(comm, 2, +1)),
-  };
+  return Utils::Mpi::cart_neighbors<3>(comm);
 }
 
 LocalBox<double> regular_decomposition(const BoxGeometry &box,

--- a/src/utils/include/utils/mpi/cart_comm.hpp
+++ b/src/utils/include/utils/mpi/cart_comm.hpp
@@ -98,6 +98,29 @@ inline std::pair<int, int> cart_shift(boost::mpi::communicator const &comm,
 
   return {src, dst};
 }
+
+/**
+ * @brief Calculates the numbers of the nearest neighbors for a node.
+ *
+ * @tparam dim Dimension of the communicator
+ * @param comm Cartesian communicator
+ *
+ * @return Ranks of 2*dim neighbors
+ */
+template <size_t dim>
+Utils::Vector<int, 2 * dim>
+cart_neighbors(const boost::mpi::communicator &comm) {
+  using std::get;
+
+  Vector<int, 2 * dim> ret;
+
+  for (size_t i = 0; i < dim; i++) {
+    ret[2 * i + 0] = get<1>(cart_shift(comm, i, -1));
+    ret[2 * i + 1] = get<1>(cart_shift(comm, i, +1));
+  }
+
+  return ret;
+}
 } // namespace Mpi
 } // namespace Utils
 


### PR DESCRIPTION
- Factor out almost identical halo comm from p3m and dp3m
- Switch from odd/even communication to MPI_Sendrecv
- Support communicating multiple meshes at once.
