### PR TITLE
Update maintainer and CI shell scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,7 +132,7 @@ debian:10:
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/debian-python3:10
   script:
     - export with_cuda=false
-    - export myconfig=maxset make_check=false
+    - export myconfig=maxset make_check_python=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -143,7 +143,7 @@ opensuse:15.1:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/$CI_JOB_NAME
   script:
-    - export with_cuda=false myconfig=maxset make_check=false
+    - export with_cuda=false myconfig=maxset make_check_python=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -154,7 +154,7 @@ centos:7:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/centos-python3:7
   script:
-    - export with_cuda=false myconfig=maxset make_check=true
+    - export with_cuda=false myconfig=maxset make_check_python=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -165,7 +165,7 @@ fedora:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/centos-python3:next
   script:
-    - export with_cuda=false myconfig=maxset make_check=false
+    - export with_cuda=false myconfig=maxset make_check_python=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -217,7 +217,7 @@ tutorials-samples-maxset:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
-    - export myconfig=maxset with_coverage=false make_check=false
+    - export myconfig=maxset with_coverage=false make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -230,7 +230,7 @@ tutorials-samples-default:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
-    - export myconfig=default with_coverage=false make_check=false
+    - export myconfig=default with_coverage=false make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -245,7 +245,7 @@ tutorials-samples-empty:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
-    - export myconfig=empty with_coverage=false make_check=false
+    - export myconfig=empty with_coverage=false make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200 with_scafacos=false
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -260,7 +260,7 @@ tutorials-samples-no-gpu:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
-    - export myconfig=maxset with_coverage=false make_check=false
+    - export myconfig=maxset with_coverage=false make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=true test_timeout=1200 hide_gpu=true
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -274,7 +274,7 @@ installation:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:cuda-10.1
   script:
-    - export myconfig=maxset with_coverage=false make_check=false
+    - export myconfig=maxset with_coverage=false make_check_unit_tests=false make_check_python=false
     - export srcdir=${CI_PROJECT_DIR} test_timeout=1800
     - bash maintainer/CI/build_cmake.sh
     - cd build
@@ -317,7 +317,7 @@ ubuntu:wo-dependencies:
   stage: build
   image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:wo-dependencies
   script:
-    - export myconfig=maxset make_check=false
+    - export myconfig=maxset make_check_unit_tests=false make_check_python=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -388,7 +388,7 @@ osx-cuda:
   <<: *global_job_definition
   stage: build
   script:
-    - export with_ccache=false myconfig=maxset with_cuda=true make_check=false
+    - export with_ccache=false myconfig=maxset with_cuda=true make_check_unit_tests=false make_check_python=false
     - bash maintainer/CI/build_cmake.sh
   tags:
     - mac

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -1,6 +1,6 @@
 # Doxyfile 1.8.2
 
-@INCLUDE = @CMAKE_CURRENT_BINARY_DIR@/doxy-features
+@INCLUDE = "@CMAKE_CURRENT_BINARY_DIR@/doxy-features"
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -47,14 +47,14 @@ PROJECT_BRIEF          = "Extensible Simulation Package for Research on Soft Mat
 # exceed 55 pixels and the maximum width should not exceed 200 pixels.
 # Doxygen will copy the logo to the output directory.
 
-PROJECT_LOGO           = @CMAKE_SOURCE_DIR@/doc/logo/logo_48x48.png
+PROJECT_LOGO           = "@CMAKE_SOURCE_DIR@/doc/logo/logo_48x48.png"
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@
+OUTPUT_DIRECTORY       = "@CMAKE_CURRENT_BINARY_DIR@"
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -647,8 +647,8 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = @CMAKE_SOURCE_DIR@/src \
-                         @CMAKE_SOURCE_DIR@/doc/doxygen/main.dox
+INPUT                  = "@CMAKE_SOURCE_DIR@/src" \
+                         "@CMAKE_SOURCE_DIR@/doc/doxygen/main.dox"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -686,7 +686,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @CMAKE_SOURCE_DIR@/src/config/myconfig-default.hpp
+EXCLUDE                = "@CMAKE_SOURCE_DIR@/src/config/myconfig-default.hpp"
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -700,8 +700,8 @@ EXCLUDE_SYMLINKS       = NO
 # against the file with absolute path, so to exclude all test directories
 # for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = @CMAKE_SOURCE_DIR@/*/unit_tests/* \
-                         @CMAKE_SOURCE_DIR@/*/tests/*
+EXCLUDE_PATTERNS       = "@CMAKE_SOURCE_DIR@/*/unit_tests/*" \
+                         "@CMAKE_SOURCE_DIR@/*/tests/*"
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -735,7 +735,7 @@ EXAMPLE_RECURSIVE      = YES
 # directories that contain image that are included in the documentation (see
 # the \image command).
 
-IMAGE_PATH             = @CMAKE_SOURCE_DIR@/doc/doxygen/figs
+IMAGE_PATH             = "@CMAKE_SOURCE_DIR@/doc/doxygen/figs"
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program

--- a/doc/sphinx/samples.py
+++ b/doc/sphinx/samples.py
@@ -1,3 +1,20 @@
+# Copyright (C) 2019 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import ast
 import textwrap

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -251,8 +251,9 @@ fi
 if [ ${run_checks} = true ]; then
     start "TEST"
 
-    # integration and unit tests
+    # unit tests and integration tests
     if [ ${make_check} = true ]; then
+        make -j${build_procs} check_unit_tests ${make_params} || exit 1
         if [ -z "${run_tests}" ]; then
             if [ ${check_odd_only} = true ]; then
                 make -j${build_procs} check_python_parallel_odd ${make_params} || exit 1
@@ -269,7 +270,6 @@ if [ ${run_checks} = true ]; then
                 ctest --timeout 60 --output-on-failure -R ${t} || exit 1
             done
         fi
-        make -j${build_procs} check_unit_tests ${make_params} || exit 1
     fi
 
     # tutorial tests

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -7,8 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-abort()
-{
+abort() {
     echo "An error occurred. Exiting..." >&2
     echo "Command that failed: ${BASH_COMMAND}" >&2
     exit 1
@@ -20,21 +19,21 @@ set -e
 # HELPER FUNCTIONS
 
 # output value of env variables
-function outp {
+outp() {
     for p in ${*}; do
         echo "  ${p}=${!p}"
     done
 }
 
 # start a block
-function start {
+start() {
     echo "=================================================="
     echo "START ${1}"
     echo "=================================================="
 }
 
 # end a block
-function end {
+end() {
     echo "=================================================="
     echo "END ${1}"
     echo "=================================================="
@@ -42,7 +41,7 @@ function end {
 
 # set a default value to empty environment variables
 # cast boolean values to true/false
-function set_default_value {
+set_default_value() {
     if [ "${#}" != 2 ]; then
         echo "set_default_value() takes 2 arguments (varname, default), got ${#}"
         exit 1
@@ -127,7 +126,7 @@ if [ -z "${cxx_flags}" ]; then
 fi
 
 if [ "${with_coverage}" = true ]; then
-    bash <(curl -s https://codecov.io/env) &> /dev/null
+    bash <(curl -s https://codecov.io/env) 1>/dev/null 2>&1
 fi
 
 cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=${check_procs} ${cmake_params}"
@@ -176,8 +175,8 @@ fi
 
 # load MPI module if necessary
 if [ -f "/etc/os-release" ]; then
-    grep -q suse /etc/os-release && source /etc/profile.d/modules.sh && module load gnu-openmpi
-    grep -q 'rhel\|fedora' /etc/os-release && for f in /etc/profile.d/*module*.sh; do source "${f}"; done && module load mpi
+    grep -q suse /etc/os-release && . /etc/profile.d/modules.sh && module load gnu-openmpi
+    grep -q 'rhel\|fedora' /etc/os-release && for f in /etc/profile.d/*module*.sh; do . "${f}"; done && module load mpi
 fi
 
 # CONFIGURE

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -242,7 +242,7 @@ end "BUILD"
 # check for exit function, which should never be called from shared library
 # can't do this on CUDA though because nvcc creates a host function that just calls exit for each device function
 if [ "${with_cuda}" = false ] || [ "$(echo ${NVCC} | grep -o clang)" = "clang" ]; then
-    if nm -o -C $(find . -name *.so) | grep '[^a-z]exit@@GLIBC'; then
+    if nm -o -C $(find . -name '*.so') | grep '[^a-z]exit@@GLIBC'; then
         echo "Found calls to exit() function in shared libraries."
         exit 1
     fi

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -21,7 +21,7 @@ set -e
 
 # output value of env variables
 function outp {
-    for p in $*; do
+    for p in ${*}; do
         echo "  ${p}=${!p}"
     done
 }
@@ -29,26 +29,26 @@ function outp {
 # start a block
 function start {
     echo "=================================================="
-    echo "START $1"
+    echo "START ${1}"
     echo "=================================================="
 }
 
 # end a block
 function end {
     echo "=================================================="
-    echo "END $1"
+    echo "END ${1}"
     echo "=================================================="
 }
 
 # set a default value to empty environment variables
 # cast boolean values to true/false
 function set_default_value {
-    if [ "$#" != 2 ]; then
-        echo "set_default_value() takes 2 arguments (varname, default), got $#"
+    if [ "${#}" != 2 ]; then
+        echo "set_default_value() takes 2 arguments (varname, default), got ${#}"
         exit 1
     fi
-    local -r varname="$1"
-    local -r default="$2"
+    local -r varname="${1}"
+    local -r default="${2}"
     local -r varname_alphabet=$(echo "${varname}" | tr -d '[:alnum:]_')
     if [ ! -z "${varname_alphabet}" ]; then
         echo "variable name '${varname}' contains unauthorized symbols"
@@ -235,7 +235,7 @@ end "CONFIGURE"
 # BUILD
 start "BUILD"
 
-make -k -j${build_procs} || make -k -j1 || exit $?
+make -k -j${build_procs} || make -k -j1 || exit ${?}
 
 end "BUILD"
 

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -126,7 +126,7 @@ if [ -z "${cxx_flags}" ]; then
 fi
 
 if [ "${with_coverage}" = true ]; then
-    bash <(curl -s https://codecov.io/env) &> /dev/null;
+    bash <(curl -s https://codecov.io/env) &> /dev/null
 fi
 
 cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DWARNINGS_ARE_ERRORS=ON -DTEST_NP:INT=${check_procs} ${cmake_params}"

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -87,10 +87,11 @@ set_default_value with_static_analysis false
 set_default_value myconfig "default"
 set_default_value build_procs 2
 set_default_value check_procs ${build_procs}
-set_default_value make_check true
 set_default_value check_odd_only false
 set_default_value check_gpu_only false
 set_default_value check_skip_long false
+set_default_value make_check_unit_tests true
+set_default_value make_check_python true
 set_default_value make_check_tutorials false
 set_default_value make_check_samples false
 set_default_value make_check_benchmarks false
@@ -101,7 +102,7 @@ set_default_value with_scafacos true
 set_default_value test_timeout 300
 set_default_value hide_gpu false
 
-if [ "${make_check}" = true ] || [ "${make_check_tutorials}" = true ] || [ "${make_check_samples}" = true ] || [ "${make_check_benchmarks}" = true ]; then
+if [ "${make_check_unit_tests}" = true ] || [ "${make_check_python}" = true ] || [ "${make_check_tutorials}" = true ] || [ "${make_check_samples}" = true ] || [ "${make_check_benchmarks}" = true ]; then
     run_checks=true
 else
     run_checks=false
@@ -153,7 +154,7 @@ elif [ -z "${builddir}" ]; then
 fi
 
 outp insource srcdir builddir \
-    make_check make_check_tutorials make_check_samples make_check_benchmarks \
+    make_check_unit_tests make_check_python make_check_tutorials make_check_samples make_check_benchmarks \
     cmake_params with_fftw \
     with_python_interface with_coverage \
     with_ubsan with_asan \
@@ -251,9 +252,13 @@ fi
 if [ "${run_checks}" = true ]; then
     start "TEST"
 
-    # unit tests and integration tests
-    if [ "${make_check}" = true ]; then
+    # unit tests
+    if [ "${make_check_unit_tests}" = true ]; then
         make -j${build_procs} check_unit_tests ${make_params} || exit 1
+    fi
+
+    # integration tests
+    if [ "${make_check_python}" = true ]; then
         if [ -z "${run_tests}" ]; then
             if [ "${check_odd_only}" = true ]; then
                 make -j${build_procs} check_python_parallel_odd ${make_params} || exit 1

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -55,12 +55,12 @@ function set_default_value {
         exit 1
     fi
     local -r value="${!varname}"
-    if [ "${default}" = true -o "${default}" = false ]; then
+    if [ "${default}" = true ] || [ "${default}" = false ]; then
         # cast boolean values to true/false
         local -r val=$(echo "${value}" | tr '[:upper:]' '[:lower:]')
-        if [ "${val}" = false -o "${val}" = "off" -o "${val}" = 0 -o "${val}" = "no" ]; then
+        if [ "${val}" = false ] || [ "${val}" = "off" ] || [ "${val}" = 0 ] || [ "${val}" = "no" ]; then
             eval "${varname}=false"
-        elif [ "${val}" = true -o "${val}" = "on" -o "${val}" = 1 -o "${val}" = "yes" ]; then
+        elif [ "${val}" = true ] || [ "${val}" = "on" ] || [ "${val}" = 1 ] || [ "${val}" = "yes" ]; then
             eval "${varname}=true"
         elif [ -z "${val}" ]; then
             eval "${varname}='${default}'"
@@ -101,7 +101,7 @@ set_default_value with_scafacos true
 set_default_value test_timeout 300
 set_default_value hide_gpu false
 
-if [ ${make_check} = true -o ${make_check_tutorials} = true -o ${make_check_samples} = true -o ${make_check_benchmarks} = true ]; then
+if [ ${make_check} = true ] || [ ${make_check_tutorials} = true ] || [ ${make_check_samples} = true ] || [ ${make_check_benchmarks} = true ]; then
     run_checks=true
 else
     run_checks=false
@@ -241,7 +241,7 @@ end "BUILD"
 
 # check for exit function, which should never be called from shared library
 # can't do this on CUDA though because nvcc creates a host function that just calls exit for each device function
-if [ ${with_cuda} = false -o "$(echo ${NVCC} | grep -o clang)" = "clang" ]; then
+if [ ${with_cuda} = false ] || [ "$(echo ${NVCC} | grep -o clang)" = "clang" ]; then
     if nm -o -C $(find . -name *.so) | grep '[^a-z]exit@@GLIBC'; then
         echo "Found calls to exit() function in shared libraries."
         exit 1

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2016-2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -18,20 +18,20 @@
 
 ENV_FILE=$(mktemp esXXXXXXX.env)
 
-cat > $ENV_FILE <<EOF
-insource=$insource
-cmake_params=$cmake_params
-with_fftw=$with_fftw
+cat > ${ENV_FILE} <<EOF
+insource=${insource}
+cmake_params=${cmake_params}
+with_fftw=${with_fftw}
 with_python_interface=true
-with_coverage=$with_coverage
-myconfig=$myconfig
-check_procs=$check_procs
-make_check=$make_check
+with_coverage=${with_coverage}
+myconfig=${myconfig}
+check_procs=${check_procs}
+make_check=${make_check}
 EOF
 
-if [ -z "$image" ]; then
+if [ -z "${image}" ]; then
     image=ubuntu
 fi
 
-image=espressomd/espresso-$image:latest
-docker run -u espresso --env-file $ENV_FILE -v ${PWD}:/travis -it $image /bin/bash -c "cp -r /travis .; cd travis && maintainer/CI/build_cmake.sh" || exit 1
+image=espressomd/espresso-${image}:latest
+docker run -u espresso --env-file ${ENV_FILE} -v ${PWD}:/travis -it ${image} /bin/bash -c "cp -r /travis .; cd travis && maintainer/CI/build_cmake.sh" || exit 1

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -18,7 +18,7 @@
 
 ENV_FILE=$(mktemp esXXXXXXX.env)
 
-cat > ${ENV_FILE} <<EOF
+cat > "${ENV_FILE}" <<EOF
 insource=${insource}
 cmake_params=${cmake_params}
 with_fftw=${with_fftw}
@@ -30,8 +30,8 @@ make_check=${make_check}
 EOF
 
 if [ -z "${image}" ]; then
-    image=ubuntu
+    image="ubuntu"
 fi
 
-image=espressomd/espresso-${image}:latest
-docker run -u espresso --env-file ${ENV_FILE} -v ${PWD}:/travis -it ${image} /bin/bash -c "cp -r /travis .; cd travis && maintainer/CI/build_cmake.sh" || exit 1
+image="espressomd/espresso-${image}:latest"
+docker run -u espresso --env-file "${ENV_FILE}" -v "${PWD}:/travis" -it "${image}" /bin/bash -c "cp -r /travis .; cd travis && maintainer/CI/build_cmake.sh" || exit 1

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -88,7 +88,7 @@ if [ "${?}" = "0" ]; then
         echo "${filepath_html}:\`${reference}\`" | tee -a doc_warnings.log~
     done
     # generate log file
-    n_warnings=$(cat doc_warnings.log~ | wc -l)
+    n_warnings=$(wc -l < doc_warnings.log~)
     echo "The Sphinx documentation contains ${n_warnings} broken links:" > doc_warnings.log
     cat doc_warnings.log~ >> doc_warnings.log
     rm doc_warnings.log~

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -22,7 +22,7 @@
 # broken links are found in .rst files, the putative line numbers are
 # printed, otherwise the .html files are printed without line number.
 
-[ -z "${srcdir}" ] && srcdir=`realpath ..`
+[ -z "${srcdir}" ] && srcdir=$(realpath ..)
 
 # Pattern for :class:`foo` commands to non-existent 'foo' classes/functions.
 # They are formatted by Sphinx just like regular links to functions, but are

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -38,7 +38,7 @@ fi
 
 n_warnings=0
 grep -qrP --include \*.html --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/
-if [ ${?} = "0" ]; then
+if [ "${?}" = "0" ]; then
     rm -f doc_warnings.log~
     touch doc_warnings.log~
     found="false"
@@ -56,10 +56,10 @@ if [ ${?} = "0" ]; then
         grep -Pq "(^_|\._)" <<< "${reference}"
         [ "${?}" = "0" ] && is_private="true"
         # filter out false positives
-        if [ ${is_standard_type_or_module} = "true" ] || [ ${is_private} = "true" ]; then
+        if [ "${is_standard_type_or_module}" = "true" ] || [ "${is_private}" = "true" ]; then
             continue
         fi
-        if [ ${found} = "false" ]; then
+        if [ "${found}" = "false" ]; then
             echo "The Sphinx documentation contains broken links:"
         fi
         found="true"
@@ -70,16 +70,16 @@ if [ ${?} = "0" ]; then
         if [ -f "${filepath_rst}" ]; then
             # look for the reference
             grep -q -F "\`${reference}\`" "${filepath_rst}"
-            if [ ${?} = "0" ]; then
+            if [ "${?}" = "0" ]; then
                 grep --color -FnHo -m 1 "\`${reference}\`" "${filepath_rst}" | tee -a doc_warnings.log~
                 continue
             fi
             # if not found, check if reference was shortened, for example
             # :class:`~espressomd.system.System` outputs a link named `System`
             grep -q -P "^[a-zA-Z0-9_]+$" <<< "${reference}"
-            if [ ${?} = "0" ]; then
+            if [ "${?}" = "0" ]; then
                 grep -q -P "\`~.+${reference}\`" "${filepath_rst}"
-                if [ ${?} = "0" ]; then
+                if [ "${?}" = "0" ]; then
                     grep --color -PnHo -m 1 "\`~.+${reference}\`" "${filepath_rst}" | tee -a doc_warnings.log~
                     continue
                 fi
@@ -102,7 +102,7 @@ fi
 #    * incorrect numpydoc syntax, e.g. ":rtype:`float`"
 # They are difficult to predict, so we leave them to the user's discretion
 grep -qrP --include \*.html --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
-if [ ${?} = "0" ]; then
+if [ "${?}" = "0" ]; then
     echo "Possibly errors:"
     grep -rP --color --include \*.html --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
 fi
@@ -111,7 +111,7 @@ if [ "${CI}" != "" ]; then
     "${srcdir}/maintainer/gh_post_docs_warnings.py" sphinx ${n_warnings} doc_warnings.log || exit 1
 fi
 
-if [ ${n_warnings} = "0" ]; then
+if [ "${n_warnings}" = "0" ]; then
     echo "Found no broken link requiring fixing."
     exit 0
 else

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -42,10 +42,9 @@ if [ "${?}" = "0" ]; then
     rm -f doc_warnings.log~
     touch doc_warnings.log~
     found="false"
-    grep -rPno --include \*.html --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/ | sort | uniq | while read -r line
-    do
+    grep -rPno --include \*.html --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/ | sort | uniq | while read -r line; do
         # extract link target
-        reference=$(echo "${line}" | sed -r 's|^.+<span class="pre">(.+)</span></code>$|\1|' | sed  's/()$//')
+        reference=$(echo "${line}" | sed -r 's|^.+<span class="pre">(.+)</span></code>$|\1|' | sed 's/()$//')
         # skip if broken link refers to a standard Python type or to a
         # class/function from an imported module other than espressomd
         is_standard_type_or_module="false"

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -37,12 +37,12 @@ if [ ! -f doc/sphinx/html/index.html ]; then
 fi
 
 n_warnings=0
-grep -qrP --include \*.html --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/
+grep -qrP --include='*.html' --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/
 if [ "${?}" = "0" ]; then
     rm -f doc_warnings.log~
     touch doc_warnings.log~
     found="false"
-    grep -rPno --include \*.html --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/ | sort | uniq | while read -r line; do
+    grep -rPno --include='*.html' --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/ | sort | uniq | while read -r line; do
         # extract link target
         reference=$(echo "${line}" | sed -r 's|^.+<span class="pre">(.+)</span></code>$|\1|' | sed 's/()$//')
         # skip if broken link refers to a standard Python type or to a
@@ -100,10 +100,10 @@ fi
 #    * incorrect syntax, e.g. "obj:float:"
 #    * incorrect numpydoc syntax, e.g. ":rtype:`float`"
 # They are difficult to predict, so we leave them to the user's discretion
-grep -qrP --include \*.html --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
+grep -qrP --include='*.html' --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
 if [ "${?}" = "0" ]; then
     echo "Possibly errors:"
-    grep -rP --color --include \*.html --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
+    grep -rP --color --include='*.html' --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
 fi
 
 if [ "${CI}" != "" ]; then

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -38,7 +38,7 @@ fi
 
 n_warnings=0
 grep -qrP --include \*.html --exclude-dir=_modules "${regex_sphinx_broken_link}" doc/sphinx/html/
-if [ $? = "0" ]; then
+if [ ${?} = "0" ]; then
     rm -f doc_warnings.log~
     touch doc_warnings.log~
     found="false"
@@ -50,11 +50,11 @@ if [ $? = "0" ]; then
         # class/function from an imported module other than espressomd
         is_standard_type_or_module="false"
         grep -Pq '^([a-zA-Z0-9_]+Error|[a-zA-Z0-9_]*Exception|(?!espressomd\.)[a-zA-Z0-9_]+\.[a-zA-Z0-9_\.]+)$' <<< "${reference}"
-        [ "$?" = "0" ] && is_standard_type_or_module="true"
+        [ "${?}" = "0" ] && is_standard_type_or_module="true"
         # private objects are not documented and cannot be linked
         is_private="false"
         grep -Pq "(^_|\._)" <<< "${reference}"
-        [ "$?" = "0" ] && is_private="true"
+        [ "${?}" = "0" ] && is_private="true"
         # filter out false positives
         if [ ${is_standard_type_or_module} = "true" ] || [ ${is_private} = "true" ]; then
             continue
@@ -70,16 +70,16 @@ if [ $? = "0" ]; then
         if [ -f "${filepath_rst}" ]; then
             # look for the reference
             grep -q -F "\`${reference}\`" "${filepath_rst}"
-            if [ $? = "0" ]; then
+            if [ ${?} = "0" ]; then
                 grep --color -FnHo -m 1 "\`${reference}\`" "${filepath_rst}" | tee -a doc_warnings.log~
                 continue
             fi
             # if not found, check if reference was shortened, for example
             # :class:`~espressomd.system.System` outputs a link named `System`
             grep -q -P "^[a-zA-Z0-9_]+$" <<< "${reference}"
-            if [ $? = "0" ]; then
+            if [ ${?} = "0" ]; then
                 grep -q -P "\`~.+${reference}\`" "${filepath_rst}"
-                if [ $? = "0" ]; then
+                if [ ${?} = "0" ]; then
                     grep --color -PnHo -m 1 "\`~.+${reference}\`" "${filepath_rst}" | tee -a doc_warnings.log~
                     continue
                 fi
@@ -102,7 +102,7 @@ fi
 #    * incorrect numpydoc syntax, e.g. ":rtype:`float`"
 # They are difficult to predict, so we leave them to the user's discretion
 grep -qrP --include \*.html --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
-if [ $? = "0" ]; then
+if [ ${?} = "0" ]; then
     echo "Possibly errors:"
     grep -rP --color --include \*.html --exclude-dir=_modules '(:py)?:[a-z]+:' doc/sphinx/html/
 fi

--- a/maintainer/CI/dox_warnings.sh
+++ b/maintainer/CI/dox_warnings.sh
@@ -69,8 +69,8 @@ grep -Prn '^[\ \t]*(?:\*?[\ \t]+)?[@\\]t?param(?:\[[in, out]+\])?[\ \t]+[a-zA-Z0
 rm -f dox_warnings.log
 
 # process warnings
-${srcdir}/maintainer/CI/dox_warnings.py
-n_warnings=${?}
+"${srcdir}/maintainer/CI/dox_warnings.py"
+n_warnings="${?}"
 
 if [ ! -f dox_warnings.log ]; then
     exit 1
@@ -80,10 +80,10 @@ fi
 cat dox_warnings.log
 
 if [ "${CI}" != "" ]; then
-    "${srcdir}/maintainer/gh_post_docs_warnings.py" doxygen ${n_warnings} dox_warnings.log || exit 1
+    "${srcdir}/maintainer/gh_post_docs_warnings.py" doxygen "${n_warnings}" dox_warnings.log || exit 1
 fi
 
-if [ ${n_warnings} = "0" ]; then
+if [ "${n_warnings}" = "0" ]; then
     echo "Found no warning requiring fixing."
     exit 0
 else

--- a/maintainer/CI/dox_warnings.sh
+++ b/maintainer/CI/dox_warnings.sh
@@ -19,13 +19,13 @@
 
 # This script generates a log of all Doxygen warnings that require fixing.
 
-dox_version=`doxygen --version`
+dox_version=$(doxygen --version)
 if [ "${dox_version}" != "1.8.13" ] && [ "${dox_version}" != "1.8.11" ]; then
     echo "Doxygen version ${dox_version} not supported"
     exit 1
 fi
 
-[ -z "${srcdir}" ] && srcdir=`realpath ..`
+[ -z "${srcdir}" ] && srcdir=$(realpath ..)
 
 # prepare Doxyfile for the XML version
 cp doc/doxygen/Doxyfile doc/doxygen/Doxyfile.bak

--- a/maintainer/CI/dox_warnings.sh
+++ b/maintainer/CI/dox_warnings.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) 2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/CI/dox_warnings.sh
+++ b/maintainer/CI/dox_warnings.sh
@@ -70,7 +70,7 @@ rm -f dox_warnings.log
 
 # process warnings
 ${srcdir}/maintainer/CI/dox_warnings.py
-n_warnings=$?
+n_warnings=${?}
 
 if [ ! -f dox_warnings.log ]; then
     exit 1

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -78,7 +78,7 @@ pylint_command () {
     fi
 }
 pylint_command --score=no --reports=no --output-format=text src doc maintainer testsuite samples | tee pylint.log
-errors=$(grep -P '^[a-z]+/.+?.py:[0-9]+:[0-9]+: [CRWEF][0-9]+:' pylint.log  | wc -l)
+errors=$(grep -Pc '^[a-z]+/.+?.py:[0-9]+:[0-9]+: [CRWEF][0-9]+:' pylint.log)
 
 if [ "${CI}" != "" ]; then
     maintainer/gh_post_pylint.py "${errors}" pylint.log || exit 1

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -46,7 +46,7 @@ fi
 
 find . \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' -o -name '*.cuh' \) -not -path './libs/*' | xargs -r -n 5 -P 8 "${CLANGFORMAT}" -i -style=file || exit 3
 find . \( -name '*.py' -o -name '*.pyx' -o -name '*.pxd' \) -not -path './libs/*' | xargs -r -n 5 -P 8 "${AUTOPEP8}" --ignore=E266,W291,W293 --in-place --aggressive || exit 3
-find . -type f -executable ! -name '*.sh' ! -name '*.py' ! -name '*.sh.in' ! -name pypresso.cmakein  -not -path './.git/*' | xargs -r -n 5 -P 8 chmod -x || exit 3
+find . -type f -executable ! -name '*.sh' ! -name '*.py' ! -name '*.sh.in' ! -name pypresso.cmakein -not -path './.git/*' | xargs -r -n 5 -P 8 chmod -x || exit 3
 
 if [ "${CI}" != "" ]; then
     git --no-pager diff > style.patch

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -32,20 +32,20 @@ fi
 CLANGFORMAT="$(which clang-format-${CLANG_FORMAT_VER})"
 if [ "${CLANGFORMAT}" = "" ]; then
     CLANGFORMAT="$(which clang-format)"
-    if ! ${CLANGFORMAT} --version | grep -qEo "version ${CLANG_FORMAT_VER}\.[0-9]+"; then
+    if ! "${CLANGFORMAT}" --version | grep -qEo "version ${CLANG_FORMAT_VER}\.[0-9]+"; then
         echo "Could not find clang-format ${CLANG_FORMAT_VER}. ${CLANGFORMAT} is $(${CLANGFORMAT} --version | grep -Eo '[0-9\.]{5}' | head -n 1)."
         exit 2
     fi
 fi
 
 AUTOPEP8="$(which autopep8)"
-if ! ${AUTOPEP8} --version 2>&1 | grep -qFo "autopep8 ${AUTOPEP8_VER} (pycodestyle: ${PYCODESTYLE_VER})"; then
+if ! "${AUTOPEP8}" --version 2>&1 | grep -qFo "autopep8 ${AUTOPEP8_VER} (pycodestyle: ${PYCODESTYLE_VER})"; then
     echo -e "Could not find autopep8 ${AUTOPEP8_VER} with pycodestyle ${PYCODESTYLE_VER}\n${AUTOPEP8} is $(${AUTOPEP8} --version 2>&1)"
     exit 2
 fi
 
-find . \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' -o -name '*.cuh' \) -not -path './libs/*' | xargs -r -n 5 -P 8 ${CLANGFORMAT} -i -style=file || exit 3
-find . \( -name '*.py' -o -name '*.pyx' -o -name '*.pxd' \) -not -path './libs/*' | xargs -r -n 5 -P 8 ${AUTOPEP8} --ignore=E266,W291,W293 --in-place --aggressive || exit 3
+find . \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' -o -name '*.cuh' \) -not -path './libs/*' | xargs -r -n 5 -P 8 "${CLANGFORMAT}" -i -style=file || exit 3
+find . \( -name '*.py' -o -name '*.pyx' -o -name '*.pxd' \) -not -path './libs/*' | xargs -r -n 5 -P 8 "${AUTOPEP8}" --ignore=E266,W291,W293 --in-place --aggressive || exit 3
 find . -type f -executable ! -name '*.sh' ! -name '*.py' ! -name '*.sh.in' ! -name pypresso.cmakein  -not -path './.git/*' | xargs -r -n 5 -P 8 chmod -x || exit 3
 
 if [ "${CI}" != "" ]; then
@@ -53,7 +53,7 @@ if [ "${CI}" != "" ]; then
     maintainer/gh_post_style_patch.py || exit 1
 fi
 git diff-index --quiet HEAD --
-if [ ${?} = 1 ]; then
+if [ "${?}" = 1 ]; then
     if [ "${CI}" != "" ]; then
         echo "Failed style check. Download ${CI_JOB_URL}/artifacts/raw/style.patch to see which changes are necessary." >&2
     else
@@ -82,7 +82,7 @@ errors=$(grep -P '^[a-z]+/.+?.py:[0-9]+:[0-9]+: [CRWEF][0-9]+:' pylint.log  | wc
 if [ "${CI}" != "" ]; then
     maintainer/gh_post_pylint.py "${errors}" pylint.log || exit 1
 fi
-if [ ${errors} != 0 ]; then
+if [ "${errors}" != 0 ]; then
   echo "Failed pylint check: ${errors} errors" >&2
   exit 1
 else

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -22,40 +22,40 @@ CLANG_FORMAT_VER=6.0
 AUTOPEP8_VER=1.3.4
 PYCODESTYLE_VER=2.3.1
 
-if ! git diff-index --quiet HEAD -- && [ "$1" != "-f" ]; then
+if ! git diff-index --quiet HEAD -- && [ "${1}" != "-f" ]; then
     echo "Warning, your working tree is not clean. Please commit your changes."
     echo "You can also call this script with the -f flag to proceed anyway, but"
     echo "you will then be unable to revert the formatting changes later."
     exit 1
 fi
 
-CLANGFORMAT="$(which clang-format-$CLANG_FORMAT_VER)"
-if [ "$CLANGFORMAT" = "" ]; then
+CLANGFORMAT="$(which clang-format-${CLANG_FORMAT_VER})"
+if [ "${CLANGFORMAT}" = "" ]; then
     CLANGFORMAT="$(which clang-format)"
-    if ! $CLANGFORMAT --version | grep -qEo "version $CLANG_FORMAT_VER\.[0-9]+"; then
-        echo "Could not find clang-format $CLANG_FORMAT_VER. $CLANGFORMAT is $($CLANGFORMAT --version | grep -Eo '[0-9\.]{5}' | head -n 1)."
+    if ! ${CLANGFORMAT} --version | grep -qEo "version ${CLANG_FORMAT_VER}\.[0-9]+"; then
+        echo "Could not find clang-format ${CLANG_FORMAT_VER}. ${CLANGFORMAT} is $(${CLANGFORMAT} --version | grep -Eo '[0-9\.]{5}' | head -n 1)."
         exit 2
     fi
 fi
 
 AUTOPEP8="$(which autopep8)"
-if ! $AUTOPEP8 --version 2>&1 | grep -qFo "autopep8 $AUTOPEP8_VER (pycodestyle: $PYCODESTYLE_VER)"; then
-    echo -e "Could not find autopep8 $AUTOPEP8_VER with pycodestyle $PYCODESTYLE_VER\n$AUTOPEP8 is $($AUTOPEP8 --version 2>&1)"
+if ! ${AUTOPEP8} --version 2>&1 | grep -qFo "autopep8 ${AUTOPEP8_VER} (pycodestyle: ${PYCODESTYLE_VER})"; then
+    echo -e "Could not find autopep8 ${AUTOPEP8_VER} with pycodestyle ${PYCODESTYLE_VER}\n${AUTOPEP8} is $(${AUTOPEP8} --version 2>&1)"
     exit 2
 fi
 
-find . \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' -o -name '*.cuh' \) -not -path './libs/*' | xargs -r -n 5 -P 8 $CLANGFORMAT -i -style=file || exit 3
-find . \( -name '*.py' -o -name '*.pyx' -o -name '*.pxd' \) -not -path './libs/*' | xargs -r -n 5 -P 8 $AUTOPEP8 --ignore=E266,W291,W293 --in-place --aggressive || exit 3
+find . \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' -o -name '*.cuh' \) -not -path './libs/*' | xargs -r -n 5 -P 8 ${CLANGFORMAT} -i -style=file || exit 3
+find . \( -name '*.py' -o -name '*.pyx' -o -name '*.pxd' \) -not -path './libs/*' | xargs -r -n 5 -P 8 ${AUTOPEP8} --ignore=E266,W291,W293 --in-place --aggressive || exit 3
 find . -type f -executable ! -name '*.sh' ! -name '*.py' ! -name '*.sh.in' ! -name pypresso.cmakein  -not -path './.git/*' | xargs -r -n 5 -P 8 chmod -x || exit 3
 
-if [ "$CI" != "" ]; then
+if [ "${CI}" != "" ]; then
     git --no-pager diff > style.patch
     maintainer/gh_post_style_patch.py || exit 1
 fi
 git diff-index --quiet HEAD --
-if [ $? = 1 ]; then
-    if [ "$CI" != "" ]; then
-        echo "Failed style check. Download $CI_JOB_URL/artifacts/raw/style.patch to see which changes are necessary." >&2
+if [ ${?} = 1 ]; then
+    if [ "${CI}" != "" ]; then
+        echo "Failed style check. Download ${CI_JOB_URL}/artifacts/raw/style.patch to see which changes are necessary." >&2
     else
         echo "Failed style check" >&2
     fi
@@ -66,11 +66,11 @@ fi
 
 pylint_command () {
     if hash pylint 2> /dev/null; then
-        pylint "$@"
+        pylint "${@}"
     elif hash pylint3 2> /dev/null; then
-        pylint3 "$@"
+        pylint3 "${@}"
     elif hash pylint-3 2> /dev/null; then
-        pylint-3 "$@"
+        pylint-3 "${@}"
     else
         echo "pylint not found" >&2
         exit 1
@@ -79,8 +79,8 @@ pylint_command () {
 pylint_command --score=no --reports=no --output-format=text src doc maintainer testsuite samples | tee pylint.log
 errors=$(grep -P '^[a-z]+/.+?.py:[0-9]+:[0-9]+: [CRWEF][0-9]+:' pylint.log  | wc -l)
 
-if [ "$CI" != "" ]; then
-    maintainer/gh_post_pylint.py ${errors} pylint.log || exit 1
+if [ "${CI}" != "" ]; then
+    maintainer/gh_post_pylint.py "${errors}" pylint.log || exit 1
 fi
 if [ ${errors} != 0 ]; then
   echo "Failed pylint check: ${errors} errors" >&2

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # Copyright (C) 2018-2019 The ESPResSo project
 #
 # This file is part of ESPResSo.
@@ -40,7 +40,8 @@ fi
 
 AUTOPEP8="$(which autopep8)"
 if ! "${AUTOPEP8}" --version 2>&1 | grep -qFo "autopep8 ${AUTOPEP8_VER} (pycodestyle: ${PYCODESTYLE_VER})"; then
-    echo -e "Could not find autopep8 ${AUTOPEP8_VER} with pycodestyle ${PYCODESTYLE_VER}\n${AUTOPEP8} is $(${AUTOPEP8} --version 2>&1)"
+    echo "Could not find autopep8 ${AUTOPEP8_VER} with pycodestyle ${PYCODESTYLE_VER}"
+    echo "${AUTOPEP8} is $(${AUTOPEP8} --version 2>&1)"
     exit 2
 fi
 

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -15,7 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+
+# Add copyright header to C++, CUDA, Doxygen, Python and shell files.
 
 cd "$(git rev-parse --show-toplevel)"
 

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -48,4 +48,3 @@ for f in $(echo ${cpp_files}); do
   cp "${tmp}" "${f}"
 done
 rm "${tmp}"
-

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -27,7 +27,7 @@ cpp_files=$(echo ${files_to_check} | tr " " "\n" | grep -P '\.([c|h]pp|cuh?|dox)
 
 tmp=$(mktemp)
 # process python/cython/bash files
-for f in $(echo ${py_files}); do
+for f in ${py_files}; do
   head -n1 "${f}" | grep -q '^#!'
   if [ "${?}" = 0 ]; then
     # preserve shebang on first line
@@ -40,7 +40,7 @@ for f in $(echo ${py_files}); do
   cp "${tmp}" "${f}"
 done
 # process c++/cuda/doxygen files
-for f in $(echo ${cpp_files}); do
+for f in ${cpp_files}; do
   (echo '/*'
    sed -e 's/^/ * /' maintainer/header_template.txt | sed 's/ $//'
    echo ' */'

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -29,7 +29,7 @@ tmp=$(mktemp)
 # process python/cython/bash files
 for f in $(echo ${py_files}); do
   head -n1 ${f} | grep -q '^#!'
-  if [ $? = 0 ]; then
+  if [ ${?} = 0 ]; then
     # preserve shebang on first line
     (head -n1 ${f}
      sed -e 's/^/# /' maintainer/header_template.txt | sed 's/ $//'

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -20,14 +20,14 @@
 # This needs to be run from the top-level directory
 
 # Get files without headers
-all_files=`maintainer/files_with_header.sh`
-files_to_check=`grep -iL copyright ${all_files}`
-py_files=`echo ${files_to_check} | tr " " "\n" | grep -P '\.(pyx?|pxd|sh)$'`
-cpp_files=`echo ${files_to_check} | tr " " "\n" | grep -P '\.([c|h]pp|cuh?|dox)$'`
+all_files=$(maintainer/files_with_header.sh)
+files_to_check=$(grep -iL copyright ${all_files})
+py_files=$(echo ${files_to_check} | tr " " "\n" | grep -P '\.(pyx?|pxd|sh)$')
+cpp_files=$(echo ${files_to_check} | tr " " "\n" | grep -P '\.([c|h]pp|cuh?|dox)$')
 
-tmp=`mktemp`
+tmp=$(mktemp)
 # process python/cython/bash files
-for f in `echo ${py_files}`; do
+for f in $(echo ${py_files}); do
   head -n1 ${f} | grep -q '^#!'
   if [ $? = 0 ]; then
     # preserve shebang on first line
@@ -40,7 +40,7 @@ for f in `echo ${py_files}`; do
   cp ${tmp} ${f}
 done
 # process c++/cuda/doxygen files
-for f in `echo ${cpp_files}`; do
+for f in $(echo ${cpp_files}); do
   (echo '/*'
    sed -e 's/^/ * /' maintainer/header_template.txt | sed 's/ $//'
    echo ' */'

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) 2018-2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# This needs to be run from the top-level directory
+cd "$(git rev-parse --show-toplevel)"
 
 # Get files without headers
 all_files=$(maintainer/files_with_header.sh)

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -28,24 +28,24 @@ cpp_files=$(echo ${files_to_check} | tr " " "\n" | grep -P '\.([c|h]pp|cuh?|dox)
 tmp=$(mktemp)
 # process python/cython/bash files
 for f in $(echo ${py_files}); do
-  head -n1 ${f} | grep -q '^#!'
-  if [ ${?} = 0 ]; then
+  head -n1 "${f}" | grep -q '^#!'
+  if [ "${?}" = 0 ]; then
     # preserve shebang on first line
-    (head -n1 ${f}
+    (head -n1 "${f}"
      sed -e 's/^/# /' maintainer/header_template.txt | sed 's/ $//'
-     tail -n+2 ${f}) > ${tmp}
+     tail -n+2 "${f}") > "${tmp}"
   else
-    (sed -e 's/^/# /' maintainer/header_template.txt | sed 's/ $//'; cat ${f}) > ${tmp}
+    (sed -e 's/^/# /' maintainer/header_template.txt | sed 's/ $//'; cat "${f}") > "${tmp}"
   fi
-  cp ${tmp} ${f}
+  cp "${tmp}" "${f}"
 done
 # process c++/cuda/doxygen files
 for f in $(echo ${cpp_files}); do
   (echo '/*'
    sed -e 's/^/ * /' maintainer/header_template.txt | sed 's/ $//'
    echo ' */'
-   cat ${f}) > ${tmp}
-  cp ${tmp} ${f}
+   cat "${f}") > "${tmp}"
+  cp "${tmp}" "${f}"
 done
-rm ${tmp}
+rm "${tmp}"
 

--- a/maintainer/benchmarks/runner.sh
+++ b/maintainer/benchmarks/runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2018-2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2018-2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -49,7 +49,7 @@ mkdir "${build_dir}"
 cd "${build_dir}"
 
 # check for unstaged changes
-if [ "$(git diff-index HEAD -- ${directories})" ]; then
+if [ ! -z "$(git status --porcelain -- ${directories})" ]; then
   echo "fatal: you have unstaged changes, please commit or stash them:"
   git diff-index --name-only HEAD -- ${directories}
   exit 1
@@ -57,7 +57,7 @@ fi
 
 cleanup() {
   # restore files in source directory
-  git checkout HEAD ${directories}
+  git checkout HEAD -- ${directories}
 }
 
 # prepare output files
@@ -69,7 +69,7 @@ EOF
 # run benchmarks
 for commit in ${commits}; do
   echo "### commit ${commit}" >> benchmarks.log
-  git checkout ${commit} ${directories}
+  git checkout ${commit} -- ${directories}
   bash ../maintainer/benchmarks/runner.sh
   sed -ri "s/^/\"${commit}\",/" benchmarks.csv
   tail -n +2 benchmarks.csv >> benchmarks_suite.csv

--- a/maintainer/files_with_header.sh
+++ b/maintainer/files_with_header.sh
@@ -18,12 +18,12 @@
 #
 
 git ls-files --exclude-standard |
-egrep -v '\.(blk|gz|data|dat|tab|chk|jpg|png|pdf|fig|gif|xcf|bib|vtf|vtk|svg|ico|eps)$' |
-egrep -v '^testsuite/configs/|^old/|^cmake/|^libs/' |
-egrep -v '(ChangeLog|AUTHORS|COPYING|NEWS|README|INSTALL)' |
-egrep -v '(\.gitignore|pkgIndex\.tcl)' |
-egrep -v '(config/config\.guess|config/config\.sub|config/install-sh)' |
-egrep -v '(Doxyfile|latexmk\.1|latexmkrc|assemble_quickref\.awk|doc/misc/homepage/palette\.html)' |
-egrep -v '(src/features\.def)' |
-egrep -v '(featurelist)' |
-egrep -v '(\.cproject|\.project|\.settings)'
+grep -vE '\.(blk|gz|data|dat|tab|chk|jpg|png|pdf|fig|gif|xcf|bib|vtf|vtk|svg|ico|eps)$' |
+grep -vE '^testsuite/configs/|^old/|^cmake/|^libs/' |
+grep -vE '(ChangeLog|AUTHORS|COPYING|NEWS|README|INSTALL)' |
+grep -vE '(\.gitignore|pkgIndex\.tcl)' |
+grep -vE '(config/config\.guess|config/config\.sub|config/install-sh)' |
+grep -vE '(Doxyfile|latexmk\.1|latexmkrc|assemble_quickref\.awk|doc/misc/homepage/palette\.html)' |
+grep -vE '(src/features\.def)' |
+grep -vE '(featurelist)' |
+grep -vE '(\.cproject|\.project|\.settings)'

--- a/maintainer/files_with_header.sh
+++ b/maintainer/files_with_header.sh
@@ -18,10 +18,11 @@
 #
 
 git ls-files --exclude-standard |
-grep -vE '\.(blk|gz|data|dat|tab|chk|jpg|png|pdf|fig|gif|xcf|bib|vtf|vtk|svg|ico|eps)$' |
+grep -vE '\.(blk|gz|npz|data|dat|tab|chk|jpg|png|pdf|fig|gif|xcf|css|bib|vtf|vtk|svg|ico|eps|rst|ipynb)$' |
 grep -vE '^testsuite/configs/|^old/|^cmake/|^libs/' |
 grep -vE '(ChangeLog|AUTHORS|COPYING|NEWS|README|INSTALL)' |
-grep -vE '(\.gitignore)' |
+grep -vE '(\.gitmodules|\.github|\.gitignore|\.codecov\.yml|\.gitlab-ci\.yml|\.travis\.yml|bors\.toml)' |
+grep -vE '(\.clang-format|\.clang-tidy|\.pylintrc|tools/ubsan-suppressions\.txt)' |
 grep -vE '(Doxyfile|latexmk\.1|latexmkrc|assemble_quickref\.awk|doc/misc/homepage/palette\.html)' |
 grep -vE '(src/config/features\.def)' |
 grep -vE '(featurelist)' |

--- a/maintainer/files_with_header.sh
+++ b/maintainer/files_with_header.sh
@@ -21,9 +21,8 @@ git ls-files --exclude-standard |
 grep -vE '\.(blk|gz|data|dat|tab|chk|jpg|png|pdf|fig|gif|xcf|bib|vtf|vtk|svg|ico|eps)$' |
 grep -vE '^testsuite/configs/|^old/|^cmake/|^libs/' |
 grep -vE '(ChangeLog|AUTHORS|COPYING|NEWS|README|INSTALL)' |
-grep -vE '(\.gitignore|pkgIndex\.tcl)' |
-grep -vE '(config/config\.guess|config/config\.sub|config/install-sh)' |
+grep -vE '(\.gitignore)' |
 grep -vE '(Doxyfile|latexmk\.1|latexmkrc|assemble_quickref\.awk|doc/misc/homepage/palette\.html)' |
-grep -vE '(src/features\.def)' |
+grep -vE '(src/config/features\.def)' |
 grep -vE '(featurelist)' |
 grep -vE '(\.cproject|\.project|\.settings)'

--- a/maintainer/files_with_header.sh
+++ b/maintainer/files_with_header.sh
@@ -16,7 +16,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+
+# List all files that are eligible for a copyright header.
 
 git ls-files --exclude-standard |
 grep -vE '\.(blk|gz|npz|data|dat|tab|chk|jpg|png|pdf|fig|gif|xcf|css|bib|vtf|vtk|svg|ico|eps|rst|ipynb)$' |

--- a/maintainer/files_with_header.sh
+++ b/maintainer/files_with_header.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # Copyright (C) 2012-2019 The ESPResSo project
 # Copyright (C) 2012 Olaf Lenz
 #

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -27,12 +27,12 @@ current_year=$(date +%Y)
 echo "Examining ${num_files} files."
 echo
 
-missing_current_copyright=$(egrep -IL "Copyright.*${current_year}" ${files})
+missing_current_copyright=$(grep -ILE "Copyright.*${current_year}" ${files})
 
 echo "Copyright disclaimer missing the current year ${current_year}"
 echo "--------------------------------------------------"
 if [ -n "${missing_current_copyright}" ]; then
-    egrep -Il "Copyright" ${missing_current_copyright}
+    grep -IlE "Copyright" ${missing_current_copyright}
 else
     echo "NONE"
 fi
@@ -41,7 +41,7 @@ echo
 echo "Missing copyright disclaimer"
 echo "----------------------------"
 if [ -n "${missing_current_copyright}" ]; then
-    egrep -IL "Copyright" ${missing_current_copyright}
+    grep -ILE "Copyright" ${missing_current_copyright}
 else
     echo "NONE"
 fi
@@ -49,7 +49,7 @@ echo
 
 echo "Missing GPL/simple header"
 echo "-------------------------"
-nolicense=$(egrep -IL "((ESPResSo|This program) is free software|Copying and distribution of this file)" ${files})
+nolicense=$(grep -ILE "((ESPResSo|This program) is free software|Copying and distribution of this file)" ${files})
 if [ -n "${nolicense}" ]; then
     echo ${nolicense}
 else

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -21,18 +21,18 @@
 #
 
 files=$(sh maintainer/files_with_header.sh)
-num_files=$(echo $files | wc -w)
+num_files=$(echo ${files} | wc -w)
 current_year=$(date +%Y)
 
-echo "Examining $num_files files."
+echo "Examining ${num_files} files."
 echo
 
-missing_current_copyright=$(egrep -IL "Copyright.*$current_year" $files)
+missing_current_copyright=$(egrep -IL "Copyright.*${current_year}" ${files})
 
-echo "Copyright disclaimer missing the current year $current_year"
+echo "Copyright disclaimer missing the current year ${current_year}"
 echo "--------------------------------------------------"
-if [ -n "$missing_current_copyright" ]; then
-    egrep -Il "Copyright" $missing_current_copyright
+if [ -n "${missing_current_copyright}" ]; then
+    egrep -Il "Copyright" ${missing_current_copyright}
 else
     echo "NONE"
 fi
@@ -40,8 +40,8 @@ echo
 
 echo "Missing copyright disclaimer"
 echo "----------------------------"
-if [ -n "$missing_current_copyright" ]; then
-    egrep -IL "Copyright" $missing_current_copyright
+if [ -n "${missing_current_copyright}" ]; then
+    egrep -IL "Copyright" ${missing_current_copyright}
 else
     echo "NONE"
 fi
@@ -49,15 +49,15 @@ echo
 
 echo "Missing GPL/simple header"
 echo "-------------------------"
-nolicense=$(egrep -IL "((ESPResSo|This program) is free software|Copying and distribution of this file)" $files)
-if [ -n "$nolicense" ]; then
-    echo $nolicense
+nolicense=$(egrep -IL "((ESPResSo|This program) is free software|Copying and distribution of this file)" ${files})
+if [ -n "${nolicense}" ]; then
+    echo ${nolicense}
 else
     echo "NONE"
 fi
 echo
 
-if [ -n "$nolicense" ] || [ -n "$missing_current_copyright" ]; then
+if [ -n "${nolicense}" ] || [ -n "${missing_current_copyright}" ]; then
   exit 1
 fi  
     

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -16,9 +16,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# check for missing GPL and copyright headers
-#
+
+
+# Check for missing GPL and copyright headers
 
 files=$(maintainer/files_with_header.sh)
 num_files=$(echo ${files} | wc -w)

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) 2012-2019 The ESPResSo project
 # Copyright (C) 2012 Olaf Lenz
 #

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2012-2019 The ESPResSo project
 # Copyright (C) 2012 Olaf Lenz
 #
@@ -20,7 +20,7 @@
 # check for missing GPL and copyright headers
 #
 
-files=$(sh maintainer/files_with_header.sh)
+files=$(maintainer/files_with_header.sh)
 num_files=$(echo ${files} | wc -w)
 current_year=$(date +%Y)
 

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -20,14 +20,14 @@
 # check for missing GPL and copyright headers
 #
 
-files=`sh maintainer/files_with_header.sh`
-num_files=`echo $files | wc -w`
-current_year=`date +%Y`
+files=$(sh maintainer/files_with_header.sh)
+num_files=$(echo $files | wc -w)
+current_year=$(date +%Y)
 
 echo "Examining $num_files files."
 echo
 
-missing_current_copyright=`egrep -IL "Copyright.*$current_year" $files`
+missing_current_copyright=$(egrep -IL "Copyright.*$current_year" $files)
 
 echo "Copyright disclaimer missing the current year $current_year"
 echo "--------------------------------------------------"
@@ -49,7 +49,7 @@ echo
 
 echo "Missing GPL/simple header"
 echo "-------------------------"
-nolicense=`egrep -IL "((ESPResSo|This program) is free software|Copying and distribution of this file)" $files`
+nolicense=$(egrep -IL "((ESPResSo|This program) is free software|Copying and distribution of this file)" $files)
 if [ -n "$nolicense" ]; then
     echo $nolicense
 else

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -x
+#!/bin/bash
 # Copyright (C) 2012-2019 The ESPResSo project
 # Copyright (C) 2012 Olaf Lenz
 #
@@ -51,7 +51,7 @@ echo "Missing GPL/simple header"
 echo "-------------------------"
 nolicense=$(grep -ILE "((ESPResSo|This program) is free software|Copying and distribution of this file)" ${files})
 if [ -n "${nolicense}" ]; then
-    echo ${nolicense}
+    ls -1 ${nolicense}
 else
     echo "NONE"
 fi

--- a/maintainer/find_missing_header.sh
+++ b/maintainer/find_missing_header.sh
@@ -1,21 +1,21 @@
 #! /bin/bash -x
 # Copyright (C) 2012-2019 The ESPResSo project
 # Copyright (C) 2012 Olaf Lenz
-#  
+#
 # This file is part of ESPResSo.
-#  
+#
 # ESPResSo is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#  
+#
 # ESPResSo is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # check for missing GPL and copyright headers
 #
@@ -59,5 +59,4 @@ echo
 
 if [ -n "${nolicense}" ] || [ -n "${missing_current_copyright}" ]; then
   exit 1
-fi  
-    
+fi

--- a/maintainer/find_potentially_missing_authors.sh
+++ b/maintainer/find_potentially_missing_authors.sh
@@ -22,13 +22,11 @@
 
 # This has to be run from the root directory of the source tree
 
-git log|
-grep -i ^author|
-cut -f2- -d\ |
-sed -e 's/ <.*//'|
-sort -u|
-while read author
-do 
-  grep -i "${author}" AUTHORS >/dev/null || echo "Missing: ${author}"
-done
-
+git log |
+  grep -i ^author |
+  cut -f2- -d\  |
+  sed -e 's/ <.*//' |
+  sort -u |
+  while read author; do
+    grep -i "${author}" AUTHORS >/dev/null || echo "Missing: ${author}"
+  done

--- a/maintainer/find_potentially_missing_authors.sh
+++ b/maintainer/find_potentially_missing_authors.sh
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
 
 # This gets a tentative list of authors that are missing from the AUTHORS file
 # based on git commits. The output has to be checked manually, because

--- a/maintainer/find_potentially_missing_authors.sh
+++ b/maintainer/find_potentially_missing_authors.sh
@@ -29,6 +29,6 @@ sed -e 's/ <.*//'|
 sort -u|
 while read author
 do 
-  grep -i "$author" AUTHORS >/dev/null || echo Missing: $author
+  grep -i "${author}" AUTHORS >/dev/null || echo Missing: ${author}
 done
 

--- a/maintainer/find_potentially_missing_authors.sh
+++ b/maintainer/find_potentially_missing_authors.sh
@@ -29,6 +29,6 @@ sed -e 's/ <.*//'|
 sort -u|
 while read author
 do 
-  grep -i "${author}" AUTHORS >/dev/null || echo Missing: ${author}
+  grep -i "${author}" AUTHORS >/dev/null || echo "Missing: ${author}"
 done
 

--- a/maintainer/find_potentially_missing_authors.sh
+++ b/maintainer/find_potentially_missing_authors.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # Copyright (C) 2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/find_potentially_missing_authors.sh
+++ b/maintainer/find_potentially_missing_authors.sh
@@ -21,7 +21,7 @@
 # based on git commits. The output has to be checked manually, because
 # users have committed under different spellings and abbreviations.
 
-# This has to be run from the root directory of the source tree
+cd "$(git rev-parse --show-toplevel)"
 
 git log |
   grep -i ^author |

--- a/maintainer/gh_close_issue.sh
+++ b/maintainer/gh_close_issue.sh
@@ -22,10 +22,10 @@ ISSUE_NUMBER=$(curl -s -G https://api.github.com/search/issues \
      --data-urlencode "q=${CI_PIPELINE_ID} org:espressomd repo:espresso is:open is:issue in:body" | jq '.items[0] .number')
 
 if [ "${ISSUE_NUMBER}" != "null" ]; then
-curl -s "https://api.github.com/repos/espressomd/espresso/issues/${ISSUE_NUMBER}" \
-     -H "Accept: application/vnd.github.full+json" \
-     -H "Content-Type: application/json" \
-     -H "Authorization: token ${GITHUB_TOKEN}" \
-     -X PATCH \
-     -d "{\"state\": \"closed\" }"
+    curl -s "https://api.github.com/repos/espressomd/espresso/issues/${ISSUE_NUMBER}" \
+         -H "Accept: application/vnd.github.full+json" \
+         -H "Content-Type: application/json" \
+         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -X PATCH \
+         -d "{\"state\": \"closed\" }"
 fi

--- a/maintainer/gh_close_issue.sh
+++ b/maintainer/gh_close_issue.sh
@@ -21,11 +21,11 @@ ISSUE_NUMBER=$(curl -s -G https://api.github.com/search/issues \
      --data-urlencode "q=\"CI failed for merged PR\" org:espressomd repo:espresso is:open is:issue in:title" \
      --data-urlencode "q=${CI_PIPELINE_ID} org:espressomd repo:espresso is:open is:issue in:body" | jq '.items[0] .number')
 
-if [ "$ISSUE_NUMBER" != "null" ]; then
-curl -s "https://api.github.com/repos/espressomd/espresso/issues/$ISSUE_NUMBER" \
+if [ "${ISSUE_NUMBER}" != "null" ]; then
+curl -s "https://api.github.com/repos/espressomd/espresso/issues/${ISSUE_NUMBER}" \
      -H "Accept: application/vnd.github.full+json" \
      -H "Content-Type: application/json" \
-     -H "Authorization: token $GITHUB_TOKEN" \
+     -H "Authorization: token ${GITHUB_TOKEN}" \
      -X PATCH \
      -d "{\"state\": \"closed\" }"
 fi

--- a/maintainer/gh_close_issue.sh
+++ b/maintainer/gh_close_issue.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) 2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/gh_close_issue.sh
+++ b/maintainer/gh_close_issue.sh
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 ISSUE_NUMBER=$(curl -s -G https://api.github.com/search/issues \
      --data-urlencode "q=\"CI failed for merged PR\" org:espressomd repo:espresso is:open is:issue in:title" \

--- a/maintainer/gh_create_issue.sh
+++ b/maintainer/gh_create_issue.sh
@@ -22,6 +22,6 @@ URL=$(echo "https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${
 curl -s "https://api.github.com/repos/espressomd/espresso/issues" \
      -H "Accept: application/vnd.github.full+json" \
      -H "Content-Type: application/json" \
-     -H "Authorization: token $GITHUB_TOKEN" \
+     -H "Authorization: token ${GITHUB_TOKEN}" \
      -X POST \
-     -d "{\"title\": \"CI build failed for merged PR\", \"body\": \"$URL\" }"
+     -d "{\"title\": \"CI build failed for merged PR\", \"body\": \"${URL}\" }"

--- a/maintainer/gh_create_issue.sh
+++ b/maintainer/gh_create_issue.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-URL=$(echo "https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}")
+URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}"
 
 curl -s "https://api.github.com/repos/espressomd/espresso/issues" \
      -H "Accept: application/vnd.github.full+json" \

--- a/maintainer/gh_create_issue.sh
+++ b/maintainer/gh_create_issue.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) 2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/gh_create_issue.sh
+++ b/maintainer/gh_create_issue.sh
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}"
 

--- a/maintainer/gh_post_pylint.py
+++ b/maintainer/gh_post_pylint.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import re
 import os

--- a/maintainer/gh_post_status.sh
+++ b/maintainer/gh_post_status.sh
@@ -20,7 +20,7 @@
 [ "${#}" -eq 1 ] || exit -1
 
 GIT_COMMIT=$(git rev-parse HEAD)
-URL=$(echo "https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}")
+URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}"
 STATUS="${1}"
 curl "https://api.github.com/repos/espressomd/espresso/statuses/${GIT_COMMIT}?access_token=${GITHUB_TOKEN}" \
      -H "Content-Type: application/json" \

--- a/maintainer/gh_post_status.sh
+++ b/maintainer/gh_post_status.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) 2017,2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/gh_post_status.sh
+++ b/maintainer/gh_post_status.sh
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 [ "${#}" -eq 1 ] || exit -1
 

--- a/maintainer/gh_post_status.sh
+++ b/maintainer/gh_post_status.sh
@@ -17,12 +17,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-[ "$#" -eq 1 ] || exit -1
+[ "${#}" -eq 1 ] || exit -1
 
 GIT_COMMIT=$(git rev-parse HEAD)
 URL=$(echo "https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}")
-STATUS="$1"
-curl "https://api.github.com/repos/espressomd/espresso/statuses/$GIT_COMMIT?access_token=$GITHUB_TOKEN" \
+STATUS="${1}"
+curl "https://api.github.com/repos/espressomd/espresso/statuses/${GIT_COMMIT}?access_token=${GITHUB_TOKEN}" \
      -H "Content-Type: application/json" \
      -X POST \
-     -d "{\"state\": \"$STATUS\", \"context\": \"ICP GitLab CI\", \"target_url\": \"$URL\"}"
+     -d "{\"state\": \"${STATUS}\", \"context\": \"ICP GitLab CI\", \"target_url\": \"${URL}\"}"

--- a/maintainer/gh_post_style_patch.py
+++ b/maintainer/gh_post_style_patch.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import os
 import requests

--- a/maintainer/git2changelog.py
+++ b/maintainer/git2changelog.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
 import re
 import os
 

--- a/maintainer/missing_tests.sh
+++ b/maintainer/missing_tests.sh
@@ -15,7 +15,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+
+# Detect python tests that are not included in CMakeLists.txt. Run this script
+# in the folders for python, sample, tutorial and benchmark testsuite folders.
 
 for T in *.py; do
     if grep -qF " ${T}" CMakeLists.txt; then

--- a/maintainer/missing_tests.sh
+++ b/maintainer/missing_tests.sh
@@ -19,15 +19,15 @@
 
 for T in *.py;
 do
-	if grep -q "$T" CMakeLists.txt; then
+	if grep -q "${T}" CMakeLists.txt; then
 		continue;
 	else
-		GIT_STATUS=$(git status --porcelain -- "$T")
-		if [[ $GIT_STATUS == ??* ]]; then
-			echo "File '$T' is not tracked."
+		GIT_STATUS=$(git status --porcelain -- "${T}")
+		if [[ ${GIT_STATUS} == ??* ]]; then
+			echo "File '${T}' is not tracked."
 			continue;
 		else
-			echo "File '$T' is missing in CMakeLists.txt.";			
+			echo "File '${T}' is missing in CMakeLists.txt.";			
 		fi
 	fi
 done

--- a/maintainer/missing_tests.sh
+++ b/maintainer/missing_tests.sh
@@ -17,19 +17,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-for T in *.py;
-do
-	if grep -q "${T}" CMakeLists.txt; then
-		continue;
-	else
-		GIT_STATUS=$(git status --porcelain -- "${T}")
-		if [[ ${GIT_STATUS} == ??* ]]; then
-			echo "File '${T}' is not tracked."
-			continue;
-		else
-			echo "File '${T}' is missing in CMakeLists.txt.";			
-		fi
-	fi
+for T in *.py; do
+    if grep -q "${T}" CMakeLists.txt; then
+        continue
+    else
+        GIT_STATUS=$(git status --porcelain -- "${T}")
+        if [[ ${GIT_STATUS} == ??* ]]; then
+            echo "File '${T}' is not tracked."
+            continue
+        else
+            echo "File '${T}' is missing in CMakeLists.txt."
+        fi
+    fi
 done
-
-

--- a/maintainer/missing_tests.sh
+++ b/maintainer/missing_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2017-2019 The ESPResSo project
 #
 # This file is part of ESPResSo.

--- a/maintainer/missing_tests.sh
+++ b/maintainer/missing_tests.sh
@@ -18,7 +18,7 @@
 #
 
 for T in *.py; do
-    if grep -q "${T}" CMakeLists.txt; then
+    if grep -qF " ${T}" CMakeLists.txt; then
         continue
     else
         GIT_STATUS=$(git status --porcelain -- "${T}")

--- a/maintainer/missing_tests.sh
+++ b/maintainer/missing_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Copyright (C) 2017-2019 The ESPResSo project
 #
 # This file is part of ESPResSo.
@@ -18,14 +18,14 @@
 
 
 # Detect python tests that are not included in CMakeLists.txt. Run this script
-# in the folders for python, sample, tutorial and benchmark testsuite folders.
+# in the testsuite folders for python, sample, tutorial and benchmark tests.
 
 for T in *.py; do
     if grep -qF " ${T}" CMakeLists.txt; then
         continue
     else
-        GIT_STATUS=$(git status --porcelain -- "${T}")
-        if [[ ${GIT_STATUS} == ??* ]]; then
+        tracked_status=$(git ls-files -- "${T}")
+        if [ -z "${tracked_status}" ]; then
             echo "File '${T}' is not tracked."
             continue
         else

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -34,23 +34,23 @@ current_year=$(date +%Y)
 echo "Examining ${num_files} files."
 
 echo "Files with copyright disclaimer(s)..."
-files=$(grep -lE "Copyright" ${files})
-num_files=$(echo ${files} | wc -w)
+disclaimer_files=$(grep -lE "Copyright" ${files})
+num_files=$(echo ${disclaimer_files} | wc -w)
 echo "  ${num_files} files."
 
 echo "Files that are missing the current year (${current_year}) in the copyright disclaimer(s)..."
-files=$(grep -LE "Copyright.*${current_year}" ${files})
-for file in ${files}; do
-    echo "  ${file}"
-done
-
-noyear_files=$(grep -lE "Copyright.*The ESPResSo project" ${files})
-echo "  Adding current year to project copyright disclaimer..."
-echo "    \"${current_year}\""
-for file in ${noyear_files}; do
-    echo "    ${file}"
-    sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-${current_year} The ESPR/" "${file}"
-done
+noyear_files=$(grep -LE "Copyright.*${current_year}" ${disclaimer_files})
+if [ ! -z "${noyear_files}" ]; then
+    for file in ${noyear_files}; do
+        echo "  ${file}"
+    done
+    noyear_files=$(grep -lE "Copyright.*The ESPResSo project" ${noyear_files})
+    echo "  Adding current year to project copyright disclaimer..."
+    for file in ${noyear_files}; do
+        echo "    ${file}"
+        sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-${current_year} The ESPR/" "${file}"
+    done
+fi
 
 noproject_files=$(grep -LE "Copyright.*The ESPResSo project" ${files})
 echo "Files that are missing the project copyright disclaimer..."

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -49,7 +49,7 @@ echo "  Adding current year to project copyright disclaimer..."
 echo "    \"${current_year}\""
 for file in ${noyear_files}; do
     echo "    ${file}"
-    sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-${current_year} The ESPR/" ${file}
+    sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-${current_year} The ESPR/" "${file}"
 done
 
 noproject_files=$(egrep -L "Copyright.*The ESPResSo project" ${files})
@@ -62,8 +62,8 @@ echo "    \"${disclaimer}\""
 tmpfile=$(mktemp)
 for file in ${noproject_files}; do
     echo "    ${file}"
-    perl -pe "if (!\$done) { s/^(.*)Copyright/\1${disclaimer}\n\1Copyright/ and \$done=1; }" ${file} > ${tmpfile}
-    cat ${tmpfile} > ${file}
+    perl -pe "if (!\$done) { s/^(.*)Copyright/\1${disclaimer}\n\1Copyright/ and \$done=1; }" "${file}" > "${tmpfile}"
+    cat "${tmpfile}" > "${file}"
 done
-rm ${tmpfile}
+rm "${tmpfile}"
 

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # Copyright (C) 2018-2019 The ESPResSo project
 # Copyright (C) 2012,2013,2014 Olaf Lenz
 #
@@ -27,7 +28,7 @@
 #
 # To review the diff:
 # $> git diff --word-diff-regex=. -U0 | grep -Po 'Copyright.+' | sort | uniq
-files=$(sh maintainer/files_with_header.sh)
+files=$(maintainer/files_with_header.sh)
 num_files=$(echo ${files} | wc -w)
 current_year=$(date +%Y)
 

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -27,24 +27,24 @@
 #
 # To review the diff:
 # $> git diff --word-diff-regex=. -U0 | grep -Po 'Copyright.+' | sort | uniq
-files=`sh maintainer/files_with_header.sh`
-num_files=`echo $files | wc -w`
-current_year=`date +%Y`
+files=$(sh maintainer/files_with_header.sh)
+num_files=$(echo $files | wc -w)
+current_year=$(date +%Y)
 
 echo "Examining $num_files files."
 
 echo "Files with copyright disclaimer(s)..."
-files=`egrep -l "Copyright" $files`
-num_files=`echo $files | wc -w`
+files=$(egrep -l "Copyright" $files)
+num_files=$(echo $files | wc -w)
 echo "  $num_files files."
 
 echo "Files that are missing the current year ($current_year) in the copyright disclaimer(s)..."
-files=`egrep -L "Copyright.*$current_year" $files`
+files=$(egrep -L "Copyright.*$current_year" $files)
 for file in $files; do
     echo "  $file"
 done
 
-noyear_files=`egrep -l "Copyright.*The ESPResSo project" $files`
+noyear_files=$(egrep -l "Copyright.*The ESPResSo project" $files)
 echo "  Adding current year to project copyright disclaimer..."
 echo "    \"$current_year\""
 for file in $noyear_files; do
@@ -52,14 +52,14 @@ for file in $noyear_files; do
     sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-$current_year The ESPR/" $file
 done
 
-noproject_files=`egrep -L "Copyright.*The ESPResSo project" $files`
+noproject_files=$(egrep -L "Copyright.*The ESPResSo project" $files)
 echo "Files that are missing the project copyright disclaimer..."
-num_files=`echo $noproject_files | wc -w`
+num_files=$(echo $noproject_files | wc -w)
 echo "  $num_files files."
 echo "  Adding project copyright disclaimer..."
 disclaimer="Copyright (C) $current_year The ESPResSo project"
 echo "    \"$disclaimer\""
-tmpfile=`mktemp`
+tmpfile=$(mktemp)
 for file in $noproject_files; do
     echo "    $file"
     perl -pe "if (!\$done) { s/^(.*)Copyright/\1$disclaimer\n\1Copyright/ and \$done=1; }" $file > $tmpfile

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -28,42 +28,42 @@
 # To review the diff:
 # $> git diff --word-diff-regex=. -U0 | grep -Po 'Copyright.+' | sort | uniq
 files=$(sh maintainer/files_with_header.sh)
-num_files=$(echo $files | wc -w)
+num_files=$(echo ${files} | wc -w)
 current_year=$(date +%Y)
 
-echo "Examining $num_files files."
+echo "Examining ${num_files} files."
 
 echo "Files with copyright disclaimer(s)..."
-files=$(egrep -l "Copyright" $files)
-num_files=$(echo $files | wc -w)
-echo "  $num_files files."
+files=$(egrep -l "Copyright" ${files})
+num_files=$(echo ${files} | wc -w)
+echo "  ${num_files} files."
 
-echo "Files that are missing the current year ($current_year) in the copyright disclaimer(s)..."
-files=$(egrep -L "Copyright.*$current_year" $files)
-for file in $files; do
-    echo "  $file"
+echo "Files that are missing the current year (${current_year}) in the copyright disclaimer(s)..."
+files=$(egrep -L "Copyright.*${current_year}" ${files})
+for file in ${files}; do
+    echo "  ${file}"
 done
 
-noyear_files=$(egrep -l "Copyright.*The ESPResSo project" $files)
+noyear_files=$(egrep -l "Copyright.*The ESPResSo project" ${files})
 echo "  Adding current year to project copyright disclaimer..."
-echo "    \"$current_year\""
-for file in $noyear_files; do
-    echo "    $file"
-    sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-$current_year The ESPR/" $file
+echo "    \"${current_year}\""
+for file in ${noyear_files}; do
+    echo "    ${file}"
+    sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-${current_year} The ESPR/" ${file}
 done
 
-noproject_files=$(egrep -L "Copyright.*The ESPResSo project" $files)
+noproject_files=$(egrep -L "Copyright.*The ESPResSo project" ${files})
 echo "Files that are missing the project copyright disclaimer..."
-num_files=$(echo $noproject_files | wc -w)
-echo "  $num_files files."
+num_files=$(echo ${noproject_files} | wc -w)
+echo "  ${num_files} files."
 echo "  Adding project copyright disclaimer..."
-disclaimer="Copyright (C) $current_year The ESPResSo project"
-echo "    \"$disclaimer\""
+disclaimer="Copyright (C) ${current_year} The ESPResSo project"
+echo "    \"${disclaimer}\""
 tmpfile=$(mktemp)
-for file in $noproject_files; do
-    echo "    $file"
-    perl -pe "if (!\$done) { s/^(.*)Copyright/\1$disclaimer\n\1Copyright/ and \$done=1; }" $file > $tmpfile
-    cat $tmpfile > $file
+for file in ${noproject_files}; do
+    echo "    ${file}"
+    perl -pe "if (!\$done) { s/^(.*)Copyright/\1${disclaimer}\n\1Copyright/ and \$done=1; }" ${file} > ${tmpfile}
+    cat ${tmpfile} > ${file}
 done
-rm $tmpfile
+rm ${tmpfile}
 

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -34,17 +34,17 @@ current_year=$(date +%Y)
 echo "Examining ${num_files} files."
 
 echo "Files with copyright disclaimer(s)..."
-files=$(egrep -l "Copyright" ${files})
+files=$(grep -lE "Copyright" ${files})
 num_files=$(echo ${files} | wc -w)
 echo "  ${num_files} files."
 
 echo "Files that are missing the current year (${current_year}) in the copyright disclaimer(s)..."
-files=$(egrep -L "Copyright.*${current_year}" ${files})
+files=$(grep -LE "Copyright.*${current_year}" ${files})
 for file in ${files}; do
     echo "  ${file}"
 done
 
-noyear_files=$(egrep -l "Copyright.*The ESPResSo project" ${files})
+noyear_files=$(grep -lE "Copyright.*The ESPResSo project" ${files})
 echo "  Adding current year to project copyright disclaimer..."
 echo "    \"${current_year}\""
 for file in ${noyear_files}; do
@@ -52,7 +52,7 @@ for file in ${noyear_files}; do
     sed -i -r -e "s/Copyright \(C\) ([0-9,]*)(-20[0-9][0-9])? .*The ESPR/Copyright (C) \1-${current_year} The ESPR/" "${file}"
 done
 
-noproject_files=$(egrep -L "Copyright.*The ESPResSo project" ${files})
+noproject_files=$(grep -LE "Copyright.*The ESPResSo project" ${files})
 echo "Files that are missing the project copyright disclaimer..."
 num_files=$(echo ${noproject_files} | wc -w)
 echo "  ${num_files} files."

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -66,4 +66,3 @@ for file in ${noproject_files}; do
     cat "${tmpfile}" > "${file}"
 done
 rm "${tmpfile}"
-

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -16,7 +16,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+
 # Add current year to copyright header
 #
 # 1. Find files that do have copyright disclaimers
@@ -28,6 +29,7 @@
 #
 # To review the diff:
 # $> git diff --word-diff-regex=. -U0 | grep -Po 'Copyright.+' | sort | uniq
+
 files=$(maintainer/files_with_header.sh)
 num_files=$(echo ${files} | wc -w)
 current_year=$(date +%Y)

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Copyright (C) 2010-2019 The ESPResSo project
 # 
 # Copying and distribution of this file, with or without modification,

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -29,9 +29,9 @@ fi
 export LD_PRELOAD
 if [ "@WITH_UBSAN@" = "ON" ]; then
   if [ "@WARNINGS_ARE_ERRORS@" = "ON" ]; then
-    export UBSAN_OPTIONS="halt_on_error=1 print_stacktrace=1 suppressions=@CMAKE_SOURCE_DIR@/tools/ubsan-suppressions.txt $UBSAN_OPTIONS"
+    export UBSAN_OPTIONS="halt_on_error=1 print_stacktrace=1 suppressions=\"@CMAKE_SOURCE_DIR@/tools/ubsan-suppressions.txt\" $UBSAN_OPTIONS"
   else
-    export UBSAN_OPTIONS="print_stacktrace=1 suppressions=@CMAKE_SOURCE_DIR@/tools/ubsan-suppressions.txt $UBSAN_OPTIONS"
+    export UBSAN_OPTIONS="print_stacktrace=1 suppressions=\"@CMAKE_SOURCE_DIR@/tools/ubsan-suppressions.txt\" $UBSAN_OPTIONS"
   fi
 fi
 if [ "@WITH_ASAN@" = "ON" ]; then
@@ -51,55 +51,55 @@ if [ "@WITH_MSAN@" = "ON" ] && [ "@WARNINGS_ARE_ERRORS@" = "ON" ]; then
   export MSAN_OPTIONS="halt_on_error=1 $MSAN_OPTIONS"
 fi
 
-case $1 in
+case "$1" in
     --gdb)
         shift
         [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"\$@\"'" --args "@PYTHON_EXECUTABLE@" "$@"
-        exec gdb --args @PYTHON_FRONTEND@ "$@"
+        exec gdb --args "@PYTHON_FRONTEND@" "$@"
         ;;
     --lldb)
         shift
-        exec lldb -- @PYTHON_FRONTEND@ "$@"
+        exec lldb -- "@PYTHON_FRONTEND@" "$@"
         ;;
     --valgrind)
         shift
-        exec valgrind --leak-check=full @PYTHON_FRONTEND@ "$@"
+        exec valgrind --leak-check=full "@PYTHON_FRONTEND@" "$@"
         ;;
     --cuda-gdb)
         shift
-        exec cuda-gdb --args @PYTHON_FRONTEND@ "$@"
+        exec cuda-gdb --args "@PYTHON_FRONTEND@" "$@"
         ;;
     --cuda-memcheck)
         shift
-        exec cuda-memcheck @PYTHON_FRONTEND@ "$@"
+        exec cuda-memcheck "@PYTHON_FRONTEND@" "$@"
         ;;
     --gdb=*)
         options="${1#*=}"
         shift
         [ "@PYTHON_FRONTEND@" = "@IPYTHON_EXECUTABLE@" ] && exec gdb -ex "set print thread-events off" -ex "set exec-wrapper sh -c 'exec \"@IPYTHON_EXECUTABLE@\" \"\$@\"'" ${options} --args "@PYTHON_EXECUTABLE@" "$@"
-        exec gdb ${options} --args @PYTHON_FRONTEND@ "$@"
+        exec gdb ${options} --args "@PYTHON_FRONTEND@" "$@"
         ;;
     --lldb=*)
         options="${1#*=}"
         shift
-        exec lldb ${options} -- @PYTHON_FRONTEND@ "$@"
+        exec lldb ${options} -- "@PYTHON_FRONTEND@" "$@"
         ;;
     --valgrind=*)
         options="${1#*=}"
         shift
-        exec valgrind ${options} @PYTHON_FRONTEND@ "$@"
+        exec valgrind ${options} "@PYTHON_FRONTEND@" "$@"
         ;;
     --cuda-gdb=*)
         options="${1#*=}"
         shift
-        exec cuda-gdb ${options} --args @PYTHON_FRONTEND@ "$@"
+        exec cuda-gdb ${options} --args "@PYTHON_FRONTEND@" "$@"
         ;;
     --cuda-memcheck=*)
         options="${1#*=}"
         shift
-        exec cuda-memcheck ${options} @PYTHON_FRONTEND@ "$@"
+        exec cuda-memcheck ${options} "@PYTHON_FRONTEND@" "$@"
         ;;
     *)
-        exec @PYTHON_FRONTEND@ "$@"
+        exec "@PYTHON_FRONTEND@" "$@"
         ;;
 esac

--- a/src/utils/include/utils/mask.hpp
+++ b/src/utils/include/utils/mask.hpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2019 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef ESPRESSO_MASK_HPP
 #define ESPRESSO_MASK_HPP
 

--- a/testsuite/cmake/BashUnitTests.sh
+++ b/testsuite/cmake/BashUnitTests.sh
@@ -420,8 +420,8 @@ function assert_return_code() {
   if [ "${retcode}" -eq "0" ]; then
     log_success
   else
-    local message="non-zero return code (${retcode}) for command \`$*\`"
-    local logfile=$(cat "${TMPNAME}" | sed 's/^/        /')
+    local -r message="non-zero return code (${retcode}) for command \`$*\`"
+    local -r logfile=$(sed 's/^/        /' < "${TMPNAME}")
     log_failure "${message}"$'\n'"${logfile}"
   fi
 }

--- a/testsuite/cmake/BashUnitTests.sh
+++ b/testsuite/cmake/BashUnitTests.sh
@@ -198,10 +198,10 @@ function try_catch_silent() {
 ## @returns Error code returned by the command
 function try_catch_capture_output() {
   detect_open_mpi || return 1
-  rm -f ${TMPNAME}
+  rm -f "${TMPNAME}"
   (
     set -e  # exit from current subshell on first error
-    "${@}" 2>>${TMPNAME} 1>>${TMPNAME}
+    "${@}" 2>>"${TMPNAME}" 1>>"${TMPNAME}"
   )
   return ${?}
 }
@@ -227,7 +227,7 @@ function run_set_up() {
 ## @brief Run the tear_down() function if it exists
 ## @returns Error code returned by tear_down()
 function run_tear_down() {
-  rm -f ${TMPNAME}
+  rm -f "${TMPNAME}"
   if [ "$(type -t tear_down)" = "function" ]
   then
     try_catch tear_down
@@ -272,7 +272,7 @@ readonly TMPNAME=$(mktemp -u)
 ## Print the test name and clear @ref error_log
 ## @param $1 Test name
 function start_test_block() {
-  local label=${1}
+  local label="${1}"
   echo -n "${label} "
   error_log=()
 }
@@ -297,7 +297,7 @@ function log_success() {
 ## @brief Log a failed assertion
 ## @param $* Description of the failure
 function log_failure() {
-  local message=${*}
+  local message="${*}"
   echo -n 'x'
   error_log+=("${message}")
   error_counter=$((error_counter + 1))
@@ -339,8 +339,8 @@ function run_test_suite() {
 ## @param $1 Filepath
 ## @param $2 Message on failure (optional)
 function assert_file_exists() {
-  local -r filepath=${1}
-  local message=${2}
+  local -r filepath="${1}"
+  local message="${2}"
   if [ -z "${message}" ]
   then
     message="file not found: ${filepath}"
@@ -358,9 +358,9 @@ function assert_file_exists() {
 ## @param $2 Expected result
 ## @param $3 Message on failure (optional)
 function assert_string_equal() {
-  local -r result=${1}
-  local -r expected=${2}
-  local message=${3}
+  local -r result="${1}"
+  local -r expected="${2}"
+  local message="${3}"
   if [ -z "${message}" ]
   then
     message="${result} != ${expected}"
@@ -378,9 +378,9 @@ function assert_string_equal() {
 ## @param $2 Expected result
 ## @param $3 Message on failure (optional)
 function assert_equal() {
-  local -r result=${1}
-  local -r expected=${2}
-  local message=${3}
+  local -r result="${1}"
+  local -r expected="${2}"
+  local message="${3}"
   if [ -z "${message}" ]
   then
     message="${result} != ${expected}"
@@ -397,8 +397,8 @@ function assert_equal() {
 ## @param $1 Obtained result
 ## @param $2 Message on failure (optional)
 function assert_non_zero() {
-  local -r result=${1}
-  local message=${2}
+  local -r result="${1}"
+  local message="${2}"
   if [ -z "${message}" ]
   then
     message="${result} == 0"
@@ -415,8 +415,8 @@ function assert_non_zero() {
 ## @param $1 Obtained result
 ## @param $2 Message on failure (optional)
 function assert_zero() {
-  local -r result=${1}
-  local message=${2}
+  local -r result="${1}"
+  local message="${2}"
   if [ -z "${message}" ]
   then
     message="${result} != 0"
@@ -441,7 +441,7 @@ function assert_return_code() {
     log_success
   else
     local message="non-zero return code (${retcode}) for command \`$*\`"
-    local logfile=$(cat ${TMPNAME} | sed 's/^/        /')
+    local logfile=$(cat "${TMPNAME}" | sed 's/^/        /')
     log_failure "${message}"$'\n'"${logfile}"
   fi
 }

--- a/testsuite/cmake/BashUnitTests.sh
+++ b/testsuite/cmake/BashUnitTests.sh
@@ -171,9 +171,9 @@ function try_catch() {
   detect_open_mpi || return 1
   (
     set -e  # exit from current subshell on first error
-    "$@"
+    "${@}"
   )
-  return $?
+  return ${?}
 }
 
 ## @brief Try/Catch statement in Bash without output to the terminal
@@ -185,9 +185,9 @@ function try_catch_silent() {
   detect_open_mpi || return 1
   (
     set -e  # exit from current subshell on first error
-    "$@" 1>/dev/null 2>/dev/null
+    "${@}" 1>/dev/null 2>/dev/null
   )
-  return $?
+  return ${?}
 }
 
 ## @brief Try/Catch statement in Bash while logging stdout/stderr
@@ -201,9 +201,9 @@ function try_catch_capture_output() {
   rm -f ${TMPNAME}
   (
     set -e  # exit from current subshell on first error
-    "$@" 2>>${TMPNAME} 1>>${TMPNAME}
+    "${@}" 2>>${TMPNAME} 1>>${TMPNAME}
   )
-  return $?
+  return ${?}
 }
 
 ## @}
@@ -214,7 +214,7 @@ function run_set_up() {
   if [ "$(type -t set_up)" = "function" ]
   then
     try_catch set_up
-    local -r retcode=$?
+    local -r retcode=${?}
     if [ "${retcode}" -ne "0" ]
     then
       stderr "Failed to run set_up()"
@@ -231,7 +231,7 @@ function run_tear_down() {
   if [ "$(type -t tear_down)" = "function" ]
   then
     try_catch tear_down
-    local retcode=$?
+    local retcode=${?}
     if [ "${retcode}" -ne "0" ]
     then
       stderr "Failed to run tear_down()"
@@ -272,7 +272,7 @@ readonly TMPNAME=$(mktemp -u)
 ## Print the test name and clear @ref error_log
 ## @param $1 Test name
 function start_test_block() {
-  local label=$1
+  local label=${1}
   echo -n "${label} "
   error_log=()
 }
@@ -297,7 +297,7 @@ function log_success() {
 ## @brief Log a failed assertion
 ## @param $* Description of the failure
 function log_failure() {
-  local message=$*
+  local message=${*}
   echo -n 'x'
   error_log+=("${message}")
   error_counter=$((error_counter + 1))
@@ -339,8 +339,8 @@ function run_test_suite() {
 ## @param $1 Filepath
 ## @param $2 Message on failure (optional)
 function assert_file_exists() {
-  local -r filepath=$1
-  local message=$2
+  local -r filepath=${1}
+  local message=${2}
   if [ -z "${message}" ]
   then
     message="file not found: ${filepath}"
@@ -358,9 +358,9 @@ function assert_file_exists() {
 ## @param $2 Expected result
 ## @param $3 Message on failure (optional)
 function assert_string_equal() {
-  local -r result=$1
-  local -r expected=$2
-  local message=$3
+  local -r result=${1}
+  local -r expected=${2}
+  local message=${3}
   if [ -z "${message}" ]
   then
     message="${result} != ${expected}"
@@ -378,9 +378,9 @@ function assert_string_equal() {
 ## @param $2 Expected result
 ## @param $3 Message on failure (optional)
 function assert_equal() {
-  local -r result=$1
-  local -r expected=$2
-  local message=$3
+  local -r result=${1}
+  local -r expected=${2}
+  local message=${3}
   if [ -z "${message}" ]
   then
     message="${result} != ${expected}"
@@ -397,8 +397,8 @@ function assert_equal() {
 ## @param $1 Obtained result
 ## @param $2 Message on failure (optional)
 function assert_non_zero() {
-  local -r result=$1
-  local message=$2
+  local -r result=${1}
+  local message=${2}
   if [ -z "${message}" ]
   then
     message="${result} == 0"
@@ -415,8 +415,8 @@ function assert_non_zero() {
 ## @param $1 Obtained result
 ## @param $2 Message on failure (optional)
 function assert_zero() {
-  local -r result=$1
-  local message=$2
+  local -r result=${1}
+  local message=${2}
   if [ -z "${message}" ]
   then
     message="${result} != 0"
@@ -434,8 +434,8 @@ function assert_zero() {
 ## Cannot be used in a script run by Open MPI (see \ref TryCatch).
 ## @param $@ Command to run, possibly with modifiers
 function assert_return_code() {
-  try_catch_capture_output "$@"
-  local -r retcode=$?
+  try_catch_capture_output "${@}"
+  local -r retcode=${?}
   if [ "${retcode}" -eq "0" ]
   then
     log_success

--- a/testsuite/cmake/BashUnitTests.sh
+++ b/testsuite/cmake/BashUnitTests.sh
@@ -117,11 +117,9 @@ function stderr() {
 ## If functions named `test_*` are already declared in the current environment,
 ## stop unit testing now. We don't want to run them and create side effects.
 function check_namespace() {
-  if [ ! -z "$(declare -F | sed -r 's/declare +-f +//' | grep -P '^test_')" ]
-  then
+  if [ ! -z "$(declare -F | sed -r 's/declare +-f +//' | grep -P '^test_')" ]; then
     stderr 'Functions named test_* already exist:'
-    for test in $(declare -F | sed -r 's/declare +-f +//' | grep -P "^test_")
-    do
+    for test in $(declare -F | sed -r 's/declare +-f +//' | grep -P "^test_"); do
       stderr "  ${test}"
     done
     exit 1
@@ -153,8 +151,7 @@ check_namespace
 function detect_open_mpi() {
   if [ -z "${OMPI_COMM_WORLD_SIZE}" ] && [ -z "${OMPI_COMM_WORLD_RANK}" ] \
   && [ -z "${OMPI_COMM_WORLD_LOCAL_RANK}" ] && [ -z "${OMPI_UNIVERSE_SIZE}" ] \
-  && [ -z "${OMPI_COMM_WORLD_LOCAL_SIZE}" ] && [ -z "${OMPI_COMM_WORLD_NODE_RANK}" ]
-  then
+  && [ -z "${OMPI_COMM_WORLD_LOCAL_SIZE}" ] && [ -z "${OMPI_COMM_WORLD_NODE_RANK}" ]; then
     return 0
   else
     error_log+=("Runtime error: cannot run this job from MPI, there is a conflict with")
@@ -211,8 +208,7 @@ function try_catch_capture_output() {
 ## @brief Run the set_up() function if it exists
 ## @returns Error code returned by setUp()
 function run_set_up() {
-  if [ "$(type -t set_up)" = "function" ]
-  then
+  if [ "$(type -t set_up)" = "function" ]; then
     try_catch set_up
     local -r retcode=${?}
     if [ "${retcode}" -ne "0" ]
@@ -228,12 +224,10 @@ function run_set_up() {
 ## @returns Error code returned by tear_down()
 function run_tear_down() {
   rm -f "${TMPNAME}"
-  if [ "$(type -t tear_down)" = "function" ]
-  then
+  if [ "$(type -t tear_down)" = "function" ]; then
     try_catch tear_down
     local retcode=${?}
-    if [ "${retcode}" -ne "0" ]
-    then
+    if [ "${retcode}" -ne "0" ]; then
       stderr "Failed to run tear_down()"
       exit ${retcode}
     fi
@@ -243,8 +237,7 @@ function run_tear_down() {
 
 ## @brief Run the tests
 function run_tests() {
-  for test in $(declare -F | sed -r 's/declare +-f +//' | grep -P "^test_")
-  do
+  for test in $(declare -F | sed -r 's/declare +-f +//' | grep -P "^test_"); do
     start_test_block "${test#test_}"
     ${test}
     end_test_block
@@ -282,8 +275,7 @@ function start_test_block() {
 ## Print a newline character and print all error messages in @ref error_log
 function end_test_block() {
   echo ""
-  for (( i=0; i<${#error_log[@]}; i++ ));
-  do
+  for (( i=0; i<${#error_log[@]}; i++ )); do
     stderr "    ${error_log[i]}"
   done
 }
@@ -319,8 +311,7 @@ function run_test_suite() {
   run_set_up
   run_tests
   run_tear_down
-  if [ "${error_counter}" -ne 0 ]
-  then
+  if [ "${error_counter}" -ne 0 ]; then
     stderr "Found ${error_counter} errors in ${total_tests} tests"
     exit 1
   else
@@ -341,12 +332,10 @@ function run_test_suite() {
 function assert_file_exists() {
   local -r filepath="${1}"
   local message="${2}"
-  if [ -z "${message}" ]
-  then
+  if [ -z "${message}" ]; then
     message="file not found: ${filepath}"
   fi
-  if [ -f "${filepath}" ]
-  then
+  if [ -f "${filepath}" ]; then
     log_success
   else
     log_failure "${message}"
@@ -361,12 +350,10 @@ function assert_string_equal() {
   local -r result="${1}"
   local -r expected="${2}"
   local message="${3}"
-  if [ -z "${message}" ]
-  then
+  if [ -z "${message}" ]; then
     message="${result} != ${expected}"
   fi
-  if [ "${result}" = "${expected}" ]
-  then
+  if [ "${result}" = "${expected}" ]; then
     log_success
   else
     log_failure "${message}"
@@ -381,12 +368,10 @@ function assert_equal() {
   local -r result="${1}"
   local -r expected="${2}"
   local message="${3}"
-  if [ -z "${message}" ]
-  then
+  if [ -z "${message}" ]; then
     message="${result} != ${expected}"
   fi
-  if [ "${result}" -eq "${expected}" ]
-  then
+  if [ "${result}" -eq "${expected}" ]; then
     log_success
   else
     log_failure "${message}"
@@ -399,12 +384,10 @@ function assert_equal() {
 function assert_non_zero() {
   local -r result="${1}"
   local message="${2}"
-  if [ -z "${message}" ]
-  then
+  if [ -z "${message}" ]; then
     message="${result} == 0"
   fi
-  if [ "${result}" -ne "0" ]
-  then
+  if [ "${result}" -ne "0" ]; then
     log_success
   else
     log_failure "${message}"
@@ -417,12 +400,10 @@ function assert_non_zero() {
 function assert_zero() {
   local -r result="${1}"
   local message="${2}"
-  if [ -z "${message}" ]
-  then
+  if [ -z "${message}" ]; then
     message="${result} != 0"
   fi
-  if [ "${result}" -eq "0" ]
-  then
+  if [ "${result}" -eq "0" ]; then
     log_success
   else
     log_failure "${message}"
@@ -436,8 +417,7 @@ function assert_zero() {
 function assert_return_code() {
   try_catch_capture_output "${@}"
   local -r retcode=${?}
-  if [ "${retcode}" -eq "0" ]
-  then
+  if [ "${retcode}" -eq "0" ]; then
     log_success
   else
     local message="non-zero return code (${retcode}) for command \`$*\`"

--- a/testsuite/cmake/BashUnitTests.sh
+++ b/testsuite/cmake/BashUnitTests.sh
@@ -107,7 +107,7 @@
 
 ## @brief Print message to stderr
 ## @param $1 Message to display
-function stderr() {
+stderr() {
   local message=$1
   echo "${message}" 1>&2
 }
@@ -116,7 +116,7 @@ function stderr() {
 ##
 ## If functions named `test_*` are already declared in the current environment,
 ## stop unit testing now. We don't want to run them and create side effects.
-function check_namespace() {
+check_namespace() {
   if [ ! -z "$(declare -F | sed -r 's/declare +-f +//' | grep -P '^test_')" ]; then
     stderr 'Functions named test_* already exist:'
     for test in $(declare -F | sed -r 's/declare +-f +//' | grep -P "^test_"); do
@@ -148,7 +148,7 @@ check_namespace
 ## variables](https://www.open-mpi.org/faq/?category=running#mpi-environmental-variables)
 ## that can easily be checked for.
 ## @returns 1 if MPI is used, 0 otherwise
-function detect_open_mpi() {
+detect_open_mpi() {
   if [ -z "${OMPI_COMM_WORLD_SIZE}" ] && [ -z "${OMPI_COMM_WORLD_RANK}" ] \
   && [ -z "${OMPI_COMM_WORLD_LOCAL_RANK}" ] && [ -z "${OMPI_UNIVERSE_SIZE}" ] \
   && [ -z "${OMPI_COMM_WORLD_LOCAL_SIZE}" ] && [ -z "${OMPI_COMM_WORLD_NODE_RANK}" ]; then
@@ -164,7 +164,7 @@ function detect_open_mpi() {
 ##
 ## @param $@ Command to run, possibly with modifiers
 ## @returns Error code returned by the command
-function try_catch() {
+try_catch() {
   detect_open_mpi || return 1
   (
     set -e  # exit from current subshell on first error
@@ -178,7 +178,7 @@ function try_catch() {
 ## Run a command in a subshell, exiting the subshell on first error.
 ## @param $@ Command to run, possibly with modifiers
 ## @returns Error code returned by the command
-function try_catch_silent() {
+try_catch_silent() {
   detect_open_mpi || return 1
   (
     set -e  # exit from current subshell on first error
@@ -193,7 +193,7 @@ function try_catch_silent() {
 ## logging stdout/stderr to the temporary file at #TMPNAME.
 ## @param $@ Command to run, possibly with modifiers
 ## @returns Error code returned by the command
-function try_catch_capture_output() {
+try_catch_capture_output() {
   detect_open_mpi || return 1
   rm -f "${TMPNAME}"
   (
@@ -207,7 +207,7 @@ function try_catch_capture_output() {
 
 ## @brief Run the set_up() function if it exists
 ## @returns Error code returned by setUp()
-function run_set_up() {
+run_set_up() {
   if [ "$(type -t set_up)" = "function" ]; then
     try_catch set_up
     local -r retcode=${?}
@@ -222,7 +222,7 @@ function run_set_up() {
 
 ## @brief Run the tear_down() function if it exists
 ## @returns Error code returned by tear_down()
-function run_tear_down() {
+run_tear_down() {
   rm -f "${TMPNAME}"
   if [ "$(type -t tear_down)" = "function" ]; then
     try_catch tear_down
@@ -236,7 +236,7 @@ function run_tear_down() {
 }
 
 ## @brief Run the tests
-function run_tests() {
+run_tests() {
   for test in $(declare -F | sed -r 's/declare +-f +//' | grep -P "^test_"); do
     start_test_block "${test#test_}"
     ${test}
@@ -273,7 +273,7 @@ function start_test_block() {
 ## @brief End a test
 ##
 ## Print a newline character and print all error messages in @ref error_log
-function end_test_block() {
+end_test_block() {
   echo ""
   for (( i=0; i<${#error_log[@]}; i++ )); do
     stderr "    ${error_log[i]}"
@@ -281,14 +281,14 @@ function end_test_block() {
 }
 
 ## @brief Log a successful assertion
-function log_success() {
+log_success() {
   echo -n '.'
   total_tests=$((total_tests + 1))
 }
 
 ## @brief Log a failed assertion
 ## @param $* Description of the failure
-function log_failure() {
+log_failure() {
   local message="${*}"
   echo -n 'x'
   error_log+=("${message}")
@@ -307,7 +307,7 @@ function log_failure() {
 ## @{
 
 ## @brief Run the setup, tests, teardown
-function run_test_suite() {
+run_test_suite() {
   run_set_up
   run_tests
   run_tear_down
@@ -329,7 +329,7 @@ function run_test_suite() {
 ## @brief Check if a file exists
 ## @param $1 Filepath
 ## @param $2 Message on failure (optional)
-function assert_file_exists() {
+assert_file_exists() {
   local -r filepath="${1}"
   local message="${2}"
   if [ -z "${message}" ]; then
@@ -346,7 +346,7 @@ function assert_file_exists() {
 ## @param $1 Obtained result
 ## @param $2 Expected result
 ## @param $3 Message on failure (optional)
-function assert_string_equal() {
+assert_string_equal() {
   local -r result="${1}"
   local -r expected="${2}"
   local message="${3}"
@@ -364,7 +364,7 @@ function assert_string_equal() {
 ## @param $1 Obtained result
 ## @param $2 Expected result
 ## @param $3 Message on failure (optional)
-function assert_equal() {
+assert_equal() {
   local -r result="${1}"
   local -r expected="${2}"
   local message="${3}"
@@ -381,7 +381,7 @@ function assert_equal() {
 ## @brief Check if a variable is non-zero
 ## @param $1 Obtained result
 ## @param $2 Message on failure (optional)
-function assert_non_zero() {
+assert_non_zero() {
   local -r result="${1}"
   local message="${2}"
   if [ -z "${message}" ]; then
@@ -397,7 +397,7 @@ function assert_non_zero() {
 ## @brief Check if a variable is zero
 ## @param $1 Obtained result
 ## @param $2 Message on failure (optional)
-function assert_zero() {
+assert_zero() {
   local -r result="${1}"
   local message="${2}"
   if [ -z "${message}" ]; then
@@ -414,7 +414,7 @@ function assert_zero() {
 ##
 ## Cannot be used in a script run by Open MPI (see \ref TryCatch).
 ## @param $@ Command to run, possibly with modifiers
-function assert_return_code() {
+assert_return_code() {
   try_catch_capture_output "${@}"
   local -r retcode=${?}
   if [ "${retcode}" -eq "0" ]; then

--- a/testsuite/cmake/test_install.sh
+++ b/testsuite/cmake/test_install.sh
@@ -27,7 +27,7 @@ function test_install() {
                       "@PYTHON_DIR@/espressomd/_init.so" \
                       "@PYTHON_DIR@/espressomd/__init__.py"
                      )
-  for filepath in ${filepaths[@]}; do
+  for filepath in "${filepaths[@]}"; do
     assert_file_exists "${filepath}"
   done
 


### PR DESCRIPTION
Fixes #3242

Description of changes:
- reduce number of shellcheck warnings from 238 down to 104
   - rules: `SC2002 SC2006 SC2061 SC2063 SC2086 SC2116 SC2148 SC2166 SC2196`
   - 50 of the remaining warnings are false positives from `build_cmake.sh` (`SC2086 SC2154`)
- refactor outdated maintainer shell scripts
- remove deprecated shell syntax and shell commands
- use POSIX alternatives to bashisms when the change is trivial
- quote string variables to guard against whitespace-related issues
- start unit tests before integration tests
- run unit tests for all operating systems (Debian, OpenSUSE, Fedora)

Notes:
- `shellcheck` is unsuitable for CI in its current form (e.g. no rule whitelisting capability)
- the shell scripts now have an homogeneous syntax and few linter warnings, which is desirable if we decide to port them to Python in the future