### PR TITLE
Python arguments

### DIFF
--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -445,7 +445,7 @@ cdef class System:
 
         """
 
-        cdef Vector3d mi_vec = get_mi_vector(make_Vector3d(p2.pos), make_Vector3d(p1.pos), box_geo)
+        cdef Vector3d mi_vec = get_mi_vector(make_Vector3d(p1.pos), make_Vector3d(p2.pos), box_geo)
 
         return make_array_locked(mi_vec)
 

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -427,7 +427,7 @@ class DPDThermostat(ut.TestCase):
         stress = np.zeros([3, 3])
 
         for pair in pairs:
-            dist = s.distance_vec(pair[0], pair[1])
+            dist = s.distance_vec(pair[1], pair[0])
             if np.linalg.norm(dist) < r_cut:
                 vel_diff = pair[1].v - pair[0].v
                 stress += calc_stress(dist, vel_diff)

--- a/testsuite/python/interactions_bond_angle.py
+++ b/testsuite/python/interactions_bond_angle.py
@@ -108,14 +108,14 @@ class InteractionsAngleBondTest(ut.TestCase):
             for p, sign in [[p1, -1], [p2, +1]]:
                 # Check that force is perpendicular
                 self.assertAlmostEqual(
-                    np.dot(p.f, self.system.distance_vec(p0, p)), 0,
+                    np.dot(p.f, self.system.distance_vec(p, p0)), 0,
                     delta=1E-12, msg="The force is not perpendicular")
                 # Check that force has correct magnitude
                 self.assertAlmostEqual(np.linalg.norm(p.f), np.abs(
                     f_ref) / self.system.distance(p0, p), delta=1E-11)
                 # Check that force decreases the quantity abs(phi - phi0)
                 if np.abs(phi_diff) > 1E-12:  # sign undefined for phi = phi0
-                    force_axis = np.cross(self.system.distance_vec(p, p0), p.f)
+                    force_axis = np.cross(self.system.distance_vec(p0, p), p.f)
                     self.assertEqual(
                         np.sign(phi_diff),
                         np.sign(sign * np.dot(force_axis, self.axis)),
@@ -139,8 +139,8 @@ class InteractionsAngleBondTest(ut.TestCase):
             # and r_p2 =r_p1 +r_{p1,p2} and r_p3 =r_p1 +r_{p1,p3}
             # P_ij =1/V (F_p2 r_{p1,p2} + F_p3 r_{p1,p3})
             p_tensor_expected = \
-                np.outer(p1.f, self.system.distance_vec(p0, p1)) \
-                + np.outer(p2.f, self.system.distance_vec(p0, p2))
+                np.outer(p1.f, self.system.distance_vec(p1, p0)) \
+                + np.outer(p2.f, self.system.distance_vec(p2, p0))
             p_tensor_expected /= self.system.volume()
             np.testing.assert_allclose(
                 self.system.analysis.stress_tensor()["bonded"],

--- a/testsuite/python/interactions_non-bonded.py
+++ b/testsuite/python/interactions_non-bonded.py
@@ -685,7 +685,7 @@ class InteractionsNonBondedTest(ut.TestCase):
             advance_and_rotate_part(p2)
             self.system.integrator.run(recalc_forces=True, steps=0)
 
-            r = self.system.distance_vec(p1, p2)
+            r = self.system.distance_vec(p2, p1)
             director1 = p1.director
             director2 = p2.director
 

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -115,7 +115,7 @@ def verify_lj_forces(system, tolerance, ids_to_skip=()):
             continue
 
         # Distance and distance vec
-        v_d = dist_vec(p0, p1)
+        v_d = dist_vec(p1, p0)
         d = norm(v_d)
 
         # calc and add expected lj force

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -81,7 +81,7 @@ def lj_force_vector(v_d, d, lj_params):
     if d >= lj_params["cutoff"]:
         return np.zeros(3)
 
-    return 4. * lj_params["epsilon"] * v_d * (-12.0 * d**-14 + 6.0 * d**-8)
+    return 4. * lj_params["epsilon"] * v_d * (12.0 * d**-14 - 6.0 * d**-8)
 
 
 def verify_lj_forces(system, tolerance, ids_to_skip=()):
@@ -115,7 +115,7 @@ def verify_lj_forces(system, tolerance, ids_to_skip=()):
             continue
 
         # Distance and distance vec
-        v_d = dist_vec(p1, p0)
+        v_d = dist_vec(p0, p1)
         d = norm(v_d)
 
         # calc and add expected lj force

--- a/testsuite/python/virtual_sites_relative.py
+++ b/testsuite/python/virtual_sites_relative.py
@@ -58,8 +58,8 @@ class VirtualSites(ut.TestCase):
         rel = self.system.part[vs_r[0]]
 
         # Distance
-        d = self.system.distance(rel, vs)
-        v_d = self.system.distance_vec(rel, vs)
+        d = self.system.distance(vs, rel)
+        v_d = self.system.distance_vec(vs, rel)
         # Check distance
         self.assertAlmostEqual(d, vs_r[1], places=6)
 
@@ -161,7 +161,7 @@ class VirtualSites(ut.TestCase):
             self.assertEqual(vs_r[0], 1)
             # distance
             self.assertAlmostEqual(vs_r[1], system.distance(
-                system.part[1], system.part[cur_id]), places=6)
+                system.part[cur_id], system.part[1]), places=6)
             cur_id += 1
 
         # Move central particle and Check vs placement
@@ -199,9 +199,9 @@ class VirtualSites(ut.TestCase):
             # Expected torque
             # Radial components of forces on a rigid body add to the torque
             t_exp = np.cross(system.distance_vec(
-                system.part[1], system.part[2]), f2)
+                system.part[2], system.part[1]), f2)
             t_exp += np.cross(system.distance_vec(
-                system.part[1], system.part[3]), f3)
+                system.part[3], system.part[1]), f3)
             # Check
             self.assertLessEqual(np.linalg.norm(t_exp - t), 1E-6)
 
@@ -346,8 +346,8 @@ class VirtualSites(ut.TestCase):
         # expected stress
         s_expected = 1. / system.volume() * (
             np.outer(system.part[1].ext_force, system.distance_vec(
-                system.part[1], system.part[0]))
-            + np.outer(system.part[2].ext_force, system.distance_vec(system.part[2], system.part[0])))
+                system.part[0], system.part[1]))
+            + np.outer(system.part[2].ext_force, system.distance_vec(system.part[0], system.part[2])))
         np.testing.assert_allclose(stress_total, s_expected, atol=1E-5)
         np.testing.assert_allclose(stress_vs, s_expected, atol=1E-5)
         np.testing.assert_allclose(stress_vs_total, s_expected, atol=1E-5)


### PR DESCRIPTION
Following the email discussion, @bindgens1 made the changes to adopt a consistent calling convention for the sign of the function distance_vec. In C++, it goes along "get_mi_vector(a, b) returns a-b". The Python interface in system.pyx changed the order of the arguments, which makes the debugging of testcases very hard.

With this pull request, all usage of `espressomd.system.distance_vec` returns the vector "position of first argument - position of second argument", modulo minimal image of course.

The consistency will be very useful to use when we add "velocity_difference" with the Lees-Edwards feature.

Description of changes:
 - Modify the calling convention in system.pyx for the function distance_vec
 - Modify the tests in consequence


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
