### PR TITLE
Fallthrough and remove duplicate line

### DIFF
--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -218,7 +218,6 @@ void topology_init(int cs, double range, CellPList *local) {
 bool topology_check_resort(int cs, bool local_resort) {
   switch (cs) {
   case CELL_STRUCTURE_DOMDEC:
-    return boost::mpi::all_reduce(comm_cart, local_resort, std::logical_or<>());
   case CELL_STRUCTURE_NSQUARE:
   case CELL_STRUCTURE_LAYERED:
     return boost::mpi::all_reduce(comm_cart, local_resort, std::logical_or<>());


### PR DESCRIPTION
Description of changes:
 - Remove a duplicated line in `topology_check_resort` by falling through as done for other cell systems in this function.


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
