### PR TITLE
Propagate DPD RNG if Langevin active at the same time

### DIFF
--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -316,7 +316,8 @@ void integrate_vv(int n_steps, int reuse_forces) {
 void philox_counter_increment() {
   if (thermo_switch & THERMO_LANGEVIN) {
     langevin_rng_counter_increment();
-  } else if (thermo_switch & THERMO_DPD) {
+  }
+  if (thermo_switch & THERMO_DPD) {
 #ifdef DPD
     dpd_rng_counter_increment();
 #endif

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -205,7 +205,7 @@ cdef class Thermostat:
         lb_lbcoupling_set_gamma(0.0)
         return True
 
-    @AssertThermostatType(THERMO_LANGEVIN)
+    @AssertThermostatType(THERMO_LANGEVIN, THERMO_DPD)
     def set_langevin(self, kT=None, gamma=None, gamma_rotation=None,
                      act_on_virtual=False, seed=None):
         """
@@ -358,7 +358,7 @@ cdef class Thermostat:
             mpi_bcast_parameter(FIELD_LANGEVIN_GAMMA_ROTATION)
         return True
 
-    @AssertThermostatType(THERMO_LB)
+    @AssertThermostatType(THERMO_LB, THERMO_DPD)
     def set_lb(
         self,
         seed=None,

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -70,13 +70,15 @@ class DPDThermostat(ut.TestCase):
         self.assertTrue(v_total[1] < 1e-11)
         self.assertTrue(v_total[2] < 1e-11)
 
-    def test_single(self):
+    def single(self, with_langevin=False):
         """Test velocity distribution of a dpd fluid with a single type."""
         N = 200
         s = self.s
         s.part.add(pos=s.box_l * np.random.random((N, 3)))
         kT = 2.3
         gamma = 1.5
+        if with_langevin:
+            s.thermostat.set_langevin(kT=kT, gamma=gamma, seed=41)
         s.thermostat.set_dpd(kT=kT, seed=42)
         s.non_bonded_inter[0, 0].dpd.set_params(
             weight_function=0, gamma=gamma, r_cut=1.5,
@@ -93,6 +95,12 @@ class DPDThermostat(ut.TestCase):
         self.check_velocity_distribution(
             v_stored, v_minmax, bins, error_tol, kT)
         self.check_total_zero()
+
+    def test_single(self):
+        self.single()
+
+    def test_single_with_langevin(self):
+        self.single(True)
 
     def test_binary(self):
         """Test velocity distribution of binary dpd fluid"""

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -43,6 +43,7 @@ class DPDThermostat(ut.TestCase):
     def tearDown(self):
         s = self.s
         s.part.clear()
+        s.thermostat.turn_off()
 
     def check_velocity_distribution(self, vel, minmax, n_bins, error_tol, kT):
         """check the recorded particle distributions in velocity against a
@@ -72,7 +73,7 @@ class DPDThermostat(ut.TestCase):
 
     def single(self, with_langevin=False):
         """Test velocity distribution of a dpd fluid with a single type."""
-        N = 200
+        N = 250
         s = self.s
         s.part.add(pos=s.box_l * np.random.random((N, 3)))
         kT = 2.3


### PR DESCRIPTION
Since we switched to the counter based Philox RNG, the DPD thermostat was not propagated if also the Langevin thermostat was active.