### PR TITLE
core: particle_data: Fixed removal of bonds to deleted particles.

### DIFF
--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1071,7 +1071,7 @@ void local_remove_particle(int part) {
         cell = c;
         position = i;
       } else {
-        remove_all_bonds_to(p, i);
+        remove_all_bonds_to(p, part);
       }
     }
   }

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -271,6 +271,18 @@ class ParticleProperties(ut.TestCase):
             # Cause a different mpi callback to uncover deadlock immediately
             _ = getattr(s.part[:], p)
 
+    def test_remove_particle(self):
+        """Tests that if a particle is removed,
+        it no longer exists and bonds to the removed particle are
+        also removed."""
+
+        p1 = self.system.part[self.pid]
+        p2 = self.system.part.add(pos=p1.pos, bonds=[(self.f1, p1.id)])
+
+        p1.remove()
+        self.assertFalse(self.system.part.exists(self.pid))
+        self.assertEqual(len(p2.bonds), 0)
+
     def test_zz_remove_all(self):
         for id in self.system.part[:].id:
             self.system.part[id].remove()


### PR DESCRIPTION
Fixes #3350.

Description of changes:
 - When removing particles, bonds to the particle are removed also.
   This was broken and the wrong bonds were removed. This fixes this.

This bug was possible to write down because particle ids are `int` and not
an explicit type.
