### PR TITLE
py: ParticleSlice fixes

### DIFF
--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -11,7 +11,7 @@ For understanding this chapter, it is helpful to be aware of the Python classes 
 
 * :class:`espressomd.particle_data.ParticleHandle` provides access to a single particle in the simulation.
 * :class:`espressomd.particle_data.ParticleList` provides access to all particles in the simulation
-* :class:`espressomd.particle_data.ParticleSlice` provides access to a subset of particles in the simulation identified by a list of ids.
+* :class:`espressomd.particle_data.ParticleSlice` provides access to a subset of particles in the simulation identified by a list of ids or an instance of :class:`slice` or :class:`range`.
 
 in almost no case have these classes to be instantiated explicitly by the user.
 Rather, access is provided via the :attr:`espressomd.system.System.part` attribute.
@@ -85,11 +85,18 @@ The :class:`espressomd.particle_data.ParticleList` support slicing similarly to 
     print(sysstem.part[:].pos)
     system.part[:].q = 0
 
-To access particles with indices ranging from 0 to 9, use::
+To access particles with ids ranging from 0 to 9, use::
 
     system.part[0:10].pos
 
 Note that, like in other cases in Python, the lower bound is inclusive and the upper bound is non-inclusive.
+It is also possible to get a slice containing particles of specific ids::
+
+    system.part[[1, 4, 3]]
+
+would contain the particles with ids 1, 4, and 3 in that specific order.
+
+
 Setting slices can be done by
 
 - supplying a *single value* that is assigned to each entry of the slice, e.g.::

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -29,7 +29,7 @@
 # not enclosed within <a href="..."></a> tags. Sphinx doesn't use line
 # wrapping, so these broken links can be found via text search. The first
 # negative lookahead filters out common Python types (for performance reasons).
-regex_sphinx_broken_link='<code class=\"xref py py-[a-z]+ docutils literal notranslate\"><span class=\"pre\">(?!(int|float|bool|str|object|list|tuple|dict|(?:numpy\.|np\.)?(?:nd)?array)<)[^<>]+?</span></code>(?!</a>)'
+regex_sphinx_broken_link='<code class=\"xref py py-[a-z]+ docutils literal notranslate\"><span class=\"pre\">(?!(int|float|complex|bool|str|bytes|array|bytearray|memoryview|object|list|tuple|range|slice|dict|set|frozenset|(?:numpy\.|np\.)?(?:nd)?array)<)[^<>]+?</span></code>(?!</a>)'
 
 if [ ! -f doc/sphinx/html/index.html ]; then
     echo "Please run Sphinx first."

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -1126,13 +1126,12 @@ class Analysis:
                 type, 1, int, "particle type has to be an int")
             if (type < 0 or type >= analyze.max_seen_particle_type):
                 raise ValueError("Particle type", type, "does not exist!")
-        selection = np.in1d(self._system.part[:].type, p_type)
-
-        cm = np.mean(self._system.part[selection].pos, axis=0)
+        selection = self._system.part.select(lambda p: (p.type in p_type))
+        cm = np.mean(selection.pos, axis=0)
         mat = np.zeros(shape=(3, 3))
         for i, j in np.ndindex((3, 3)):
-            mat[i, j] = np.mean(((self._system.part[selection].pos)[:, i] - cm[i]) * (
-                (self._system.part[selection].pos)[:, j] - cm[j]))
+            mat[i, j] = np.mean(((selection.pos)[:, i] - cm[i]) * (
+                (selection.pos)[:, j] - cm[j]))
         w, v = np.linalg.eig(mat)
         # return eigenvalue/vector tuples in order of increasing eigenvalues
         order = np.argsort(np.abs(w))[::-1]

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -156,7 +156,7 @@ cdef class ParticleHandle:
 
         def __get__(self):
             self.update_particle_data()
-            return make_array_locked(unfolded_position(< Vector3d > self.particle_data.r.p, < Vector3i > self.particle_data.l.i, box_geo.length()))
+            return make_array_locked(unfolded_position( < Vector3d > self.particle_data.r.p, < Vector3i > self.particle_data.l.i, box_geo.length()))
 
     property pos_folded:
         """
@@ -1555,15 +1555,57 @@ cdef class _ParticleSliceImpl:
     """
 
     def __cinit__(self, slice_, prefetch_chunk_size=10000):
+        # Chunk size for pre-fetch cache
         self._chunk_size = prefetch_chunk_size
 
-        id_list = np.arange(max_seen_particle + 1)
-        self.id_selection = id_list[slice_]
-        mask = np.empty(len(self.id_selection), dtype=np.bool)
-        cdef int i
-        for i in range(len(self.id_selection) - 1, -1, -1):
-            mask[i] = particle_exists(i)
-        self.id_selection = self.id_selection[mask]
+        # We distinguish two cases:
+        # * ranges and slices only specify lower and upper bounds for particle
+        #   ids and optionally a step. Gaps in the id range are tolerated.
+        # * Explicit list/tuple/ndarray containing particle ids. Here
+        #   all particles have to exist and the result maintains the order
+        #   specified in the list.
+        if isinstance(slice_, (slice, range)):
+            self.id_selection = self._id_selection_from_slice(slice_)
+        elif isinstance(slice_, (list, tuple, np.ndarray)):
+            self._validate_pid_list(slice_)
+            self.id_selection = np.array(slice_, dtype=int)
+        else:
+            raise TypeError(
+                "ParticleSlice must be initialized with an instance of slice or range, or with a list, tuple, or ndarray of ints, but got {} of type {}".foormat((str(slice_), str(type(slice_)))))
+
+    def _id_selection_from_slice(self, slice_):
+        """Returns an ndarray of particle ids to be included in the
+        ParticleSlice for a given range or slice object.
+        """
+        # Prevent negative bounds
+        if (not slice_.start is None and slice_.start < 0) or\
+           (not slice_.stop is None and slice_.stop < 0):
+            raise IndexError(
+                "Negative start and end ids are not supported on ParticleSlice")
+
+        # We start with a full list of possible particle ids and then 
+        # remove ids of non-existing particles
+        id_list = np.arange(max_seen_particle + 1, dtype=int)
+        id_list = id_list[slice_]
+
+        # Generate a mask which will remove ids of non-existing particles
+        mask = np.empty(len(id_list), dtype=np.bool)
+        mask[:] = True
+        for i, id in enumerate(id_list):
+            if not particle_exists(id):
+                mask[i] = False
+        # Return the id list filtered by the mask
+        return id_list[mask]
+
+    def _validate_pid_list(self, pid_list):
+        """Check that all entries are integers and the corresponding particles exist. Throw, otherwise."""
+        # Check that all entries are some flavor of integer
+        for pid in pid_list:
+            if not is_valid_type(pid, int):
+                raise TypeError(
+                    "Particle id must be an integer but got " + str(pid))
+            if not particle_exists(pid):
+                raise IndexError("Particle does not exist " + str(pid))
 
     def __iter__(self):
         return self._id_gen()
@@ -1682,19 +1724,12 @@ cdef class ParticleList:
     # Retrieve a particle
 
     def __getitem__(self, key):
-        if isinstance(key, slice):
+        # Single particle id results in a ParticleHandle, everything else
+        # in a ParticleSlice
+        if is_valid_type(key, int):
+            return ParticleHandle(key)
+        else:
             return ParticleSlice(key)
-
-        try:
-            if isinstance(key, range):
-                return ParticleSlice(key)
-        except BaseException:
-            pass
-
-        if isinstance(key, (tuple, list, np.ndarray)):
-            return ParticleSlice(np.array(key))
-
-        return ParticleHandle(key)
 
     # __getstate__ and __setstate__ define the pickle interaction
     def __getstate__(self):
@@ -2026,8 +2061,7 @@ Set quat and scalar dipole moment (dipm) instead.")
         # Ids of the selected particles
         ids = []
         # Did we get a function as argument?
-        if len(args) == 1 and len(kwargs) == 0 and isinstance(
-                args[0], types.FunctionType):
+        if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
             # Go over all particles and pass them to the user-provided function
             for p in self:
                 if args[0](p):
@@ -2086,6 +2120,10 @@ def _add_particle_slice_properties():
         """
 
         N = len(particle_slice.id_selection)
+
+        if N == 0:
+            raise AttributeError(
+                "Cannot set properties of an empty ParticleSlice")
 
         # Special attributes
         if attribute == "bonds":

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1571,7 +1571,7 @@ cdef class _ParticleSliceImpl:
             self.id_selection = np.array(slice_, dtype=int)
         else:
             raise TypeError(
-                "ParticleSlice must be initialized with an instance of slice or range, or with a list, tuple, or ndarray of ints, but got {} of type {}".foormat((str(slice_), str(type(slice_)))))
+                "ParticleSlice must be initialized with an instance of slice or range, or with a list, tuple, or ndarray of ints, but got {} of type {}".format((str(slice_), str(type(slice_)))))
 
     def _id_selection_from_slice(self, slice_):
         """Returns an ndarray of particle ids to be included in the

--- a/testsuite/python/cluster_analysis.py
+++ b/testsuite/python/cluster_analysis.py
@@ -138,7 +138,7 @@ class ClusterAnalysis(ut.TestCase):
 
             # Radius of gyration
             rg = 0.
-            com_particle = self.es.part[len(self.es.part) / 2]
+            com_particle = self.es.part[len(self.es.part) // 2]
             for p in c.particles():
                 rg += self.es.distance(p, com_particle)**2
             rg /= len(self.es.part)


### PR DESCRIPTION
* Return correct elements if particle numbering is non-contigeous
* Prevent slicing with negative indices due unclear outcome
* Maintain order created by slicing, e.g.[9:0:-1]
* Require that all particles exist when passing an explicit list of ids
* Maintain order for explicit list of ids (system.part[[3,2,5,1]]
* More rigorous testing

Fixes #3363 
