### PR TITLE
Update requirements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,17 +93,6 @@ default:
     - docker
     - linux
 
-min_boost:
-  <<: *global_job_definition
-  stage: build
-  image: gitlab.icp.uni-stuttgart.de:4567/espressomd/docker/ubuntu-python3:min_boost
-  script:
-    - export with_cuda=false myconfig=maxset
-    - bash maintainer/CI/build_cmake.sh
-  tags:
-    - docker
-    - linux
-
 maxset:
   <<: *global_job_definition
   stage: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,10 +228,10 @@ if(WITH_CUDA)
   endif()
 endif(WITH_CUDA)
 
-find_package(PythonInterp 3.3 REQUIRED)
+find_package(PythonInterp 3.5 REQUIRED)
 
 if(WITH_PYTHON)
-  find_package(Cython 0.23 REQUIRED)
+  find_package(Cython 0.26 REQUIRED)
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c
             "import distutils.sysconfig as cg; print(cg.get_python_inc())"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 include(FeatureSummary)
 include(GNUInstallDirs)
 project(ESPResSo)
 include(cmake/FindPythonModule.cmake)
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.12")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
   cmake_policy(SET CMP0074 NEW)
 endif()
 
@@ -57,7 +57,7 @@ option(WITH_TESTS  "Enable tests"            ON)
 option(WITH_SCAFACOS "Build with Scafacos support" OFF)
 option(WITH_BENCHMARKS "Enable benchmarks"   OFF)
 option(WITH_VALGRIND_INSTRUMENTATION "Build with valgrind instrumentation markers" OFF)
-if(CMAKE_VERSION VERSION_GREATER 3.5.2 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   option(WITH_CLANG_TIDY "Run Clang-Tidy during compilation" OFF)
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
@@ -370,7 +370,7 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   set(BOOST_MINIMUM_VERSION "1.65.0")
-  if (CUDA_FOUND AND NOT CUDA_VERSION VERSION_LESS "9.0")
+  if (CUDA_FOUND AND CUDA_VERSION VERSION_GREATER_EQUAL "9.0")
     set(BOOST_MINIMUM_VERSION "1.66.0")
   endif()
 else()
@@ -384,7 +384,7 @@ endif()
 
 find_package(Boost ${BOOST_MINIMUM_VERSION} REQUIRED ${BOOST_COMPONENTS})
 
-if(Boost_VERSION VERSION_GREATER 106399 AND Boost_VERSION VERSION_LESS 106500)
+if(Boost_VERSION VERSION_GREATER_EQUAL 106400 AND Boost_VERSION VERSION_LESS 106500)
   # Boost 1.64 has incompatible Serialization and MPI modules, see
   # https://svn.boost.org/trac10/ticket/12723 . Some distributions, like Fedora,
   # have backported the patch.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     set(BOOST_MINIMUM_VERSION "1.66.0")
   endif()
 else()
-  set(BOOST_MINIMUM_VERSION "1.55.0")
+  set(BOOST_MINIMUM_VERSION "1.58.0")
 endif()
 
 # old Boost.MPI versions contain a use-after-free bug that seems to only cause crashes on 32-bit architectures

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -2,10 +2,4 @@ include(unit_test)
 
 add_subdirectory(python)
 add_subdirectory(cmake)
-
-if(${CMAKE_VERSION} VERSION_LESS "3.7.0")
-  add_custom_target(check_tutorials COMMAND echo "Target 'check_tutorials' requires CMake version 3.7.0 or above, currently using ${CMAKE_VERSION}")
-  add_custom_target(check_samples COMMAND echo "Target 'check_samples' requires CMake version 3.7.0 or above, currently using ${CMAKE_VERSION}")
-else()
-  add_subdirectory(scripts)
-endif()
+add_subdirectory(scripts)


### PR DESCRIPTION
Increase requirements of CMake, boost, Cython and Python, as discussed in [es meeting 2019-11-26](https://github.com/espressomd/espresso/wiki/Espresso-meeting-2019-11-26).

Closes #3090, Partial fix for #3093

Depends on espressomd/docker#149