### PR TITLE
ROCm 3.0 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,11 @@ if(WITH_CUDA)
       message(STATUS "Found HIP compiler: ${HIP_HIPCC_EXECUTABLE}")
       set(CUDA 1)
       set(HIP 1)
-      list(APPEND HIP_HCC_FLAGS "-Wno-macro-redefined -Wno-duplicate-decl-specifier -std=c++14")
+      list(APPEND HIP_HCC_FLAGS "-I${HIP_ROOT_DIR}/include -Wno-c99-designator -Wno-macro-redefined -Wno-duplicate-decl-specifier -std=c++14")
+      list(APPEND HIP_HCC_FLAGS "-pedantic -Wall -Wextra -Wno-sign-compare -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter -Wno-missing-braces -Wno-gnu-anonymous-struct -Wno-nested-anon-types -Wno-gnu-zero-variadic-macro-arguments")
+      if(WARNINGS_ARE_ERRORS)
+        list(APPEND HIP_HCC_FLAGS "-Werror")
+      endif()
 
       find_library(ROCFFT_LIB name "rocfft" PATHS "${HIP_ROOT_DIR}/lib")
 

--- a/src/core/actor/Mmm1dgpuForce_cuda.cu
+++ b/src/core/actor/Mmm1dgpuForce_cuda.cu
@@ -31,6 +31,7 @@
 // the code is mostly multi-GPU capable, but ESPResSo is not yet
 const int deviceCount = 1;
 float multigpu_factors[] = {1.0};
+#undef cudaSetDevice
 #define cudaSetDevice(d)
 
 #include "EspressoSystemInterface.hpp"

--- a/src/core/curand_wrapper.hpp
+++ b/src/core/curand_wrapper.hpp
@@ -42,7 +42,7 @@ public:
 
 __forceinline__ __device__ uint4 curand_Philox4x32_10(uint4 counter,
                                                       uint2 key) {
-  philox4x32_10_stateless *e;
+  philox4x32_10_stateless *e = nullptr;
   return (*e)(counter, key);
 }
 


### PR DESCRIPTION
They dropped `${HIP_ROOT_DIR}/include` from the default include path. Also, I have changed compiler warnings to be consistent with the host compiler.