### PR TITLE
Disable Sphinx multiprocessing

### DIFF
--- a/doc/sphinx/CMakeLists.txt
+++ b/doc/sphinx/CMakeLists.txt
@@ -1,6 +1,4 @@
-include(ProcessorCount)
 find_package(Sphinx 1.6.6)
-ProcessorCount(N)
 if(SPHINX_FOUND)
     # configured documentation tools and
     # intermediate build results
@@ -81,7 +79,6 @@ if(SPHINX_FOUND)
             ${EXCLUDE}
         COMMAND
         ${SPHINX_EXECUTABLE}
-            -j ${N}
             -q
             -W
             -b html


### PR DESCRIPTION
Fixes espressomd/docker#151

Sphinx v2.3.1 generates a warning when running in parallel with plugin `sphinxcontrib.bibtex`.