### PR TITLE
P3M pressure+dipole term refactoring

### DIFF
--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -75,9 +75,10 @@ void calc_pressure_long_range(Observable_stat &virials,
     break;
   case COULOMB_P3M: {
     p3m_charge_assign(particles);
-    virials.coulomb[1] = p3m_calc_kspace_forces(false, true, particles);
-    p3m_charge_assign(particles);
-    p3m_calc_kspace_stress(p_tensor.coulomb + 9);
+    auto const p3m_stress = p3m_calc_kspace_stress();
+    std::copy_n(p3m_stress.data(), 9, p_tensor.coulomb + 9);
+    virials.coulomb[1] = p3m_stress[0] + p3m_stress[4] + p3m_stress[8];
+
     break;
   }
 #endif

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -1294,8 +1294,26 @@ void ELC_P3M_self_forces(const ParticleRange &particles) {
 
 ////////////////////////////////////////////////////////////////////////////////////
 
+namespace {
+void assign_image_charge(const Particle &p) {
+  if (p.r.p[2] < elc_params.space_layer) {
+    auto const q_eff = elc_params.delta_mid_bot * p.p.q;
+    auto const pos = Utils::Vector3d{p.r.p[0], p.r.p[1], -p.r.p[2]};
+
+    p3m_assign_charge(q_eff, pos, -1);
+  }
+
+  if (p.r.p[2] > (elc_params.h - elc_params.space_layer)) {
+    auto const q_eff = elc_params.delta_mid_top * p.p.q;
+    auto const pos =
+        Utils::Vector3d{p.r.p[0], p.r.p[1], 2 * elc_params.h - p.r.p[2]};
+
+    p3m_assign_charge(q_eff, pos, -1);
+  }
+}
+} // namespace
+
 void ELC_p3m_charge_assign_both(const ParticleRange &particles) {
-  Utils::Vector3d pos;
   /* charged particle counter, charge fraction counter */
   int cp_cnt = 0;
   /* prepare local FFT mesh */
@@ -1305,22 +1323,7 @@ void ELC_p3m_charge_assign_both(const ParticleRange &particles) {
   for (auto &p : particles) {
     if (p.p.q != 0.0) {
       p3m_assign_charge(p.p.q, p.r.p, cp_cnt);
-
-      if (p.r.p[2] < elc_params.space_layer) {
-        double q = elc_params.delta_mid_bot * p.p.q;
-        pos[0] = p.r.p[0];
-        pos[1] = p.r.p[1];
-        pos[2] = -p.r.p[2];
-        p3m_assign_charge(q, pos, -1);
-      }
-
-      if (p.r.p[2] > (elc_params.h - elc_params.space_layer)) {
-        double q = elc_params.delta_mid_top * p.p.q;
-        pos[0] = p.r.p[0];
-        pos[1] = p.r.p[1];
-        pos[2] = 2 * elc_params.h - p.r.p[2];
-        p3m_assign_charge(q, pos, -1);
-      }
+      assign_image_charge(p);
 
       cp_cnt++;
     }
@@ -1329,29 +1332,13 @@ void ELC_p3m_charge_assign_both(const ParticleRange &particles) {
 }
 
 void ELC_p3m_charge_assign_image(const ParticleRange &particles) {
-  Utils::Vector3d pos;
   /* prepare local FFT mesh */
   for (int i = 0; i < p3m.local_mesh.size; i++)
     p3m.rs_mesh[i] = 0.0;
 
   for (auto &p : particles) {
     if (p.p.q != 0.0) {
-
-      if (p.r.p[2] < elc_params.space_layer) {
-        double q = elc_params.delta_mid_bot * p.p.q;
-        pos[0] = p.r.p[0];
-        pos[1] = p.r.p[1];
-        pos[2] = -p.r.p[2];
-        p3m_assign_charge(q, pos, -1);
-      }
-
-      if (p.r.p[2] > (elc_params.h - elc_params.space_layer)) {
-        double q = elc_params.delta_mid_top * p.p.q;
-        pos[0] = p.r.p[0];
-        pos[1] = p.r.p[1];
-        pos[2] = 2 * elc_params.h - p.r.p[2];
-        p3m_assign_charge(q, pos, -1);
-      }
+      assign_image_charge(p);
     }
   }
 }

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -54,9 +54,9 @@ struct dp3m_data_struct {
   /** local mesh. */
   p3m_local_mesh local_mesh;
   /** real space mesh (local) for CA/FFT.*/
-  double *rs_mesh;
+  fft_vector<double> rs_mesh;
   /** real space mesh (local) for CA/FFT of the dipolar field.*/
-  std::array<std::vector<double>, 3> rs_mesh_dip;
+  std::array<fft_vector<double>, 3> rs_mesh_dip;
   /** k-space mesh (local) for k-space calculation and FFT.*/
   std::vector<double> ks_mesh;
 

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -196,7 +196,8 @@ template <int cao>
 static void p3m_do_charge_assign(const ParticleRange &particles);
 
 template <int cao>
-void p3m_do_assign_charge(double q, Utils::Vector3d &real_pos, int cp_cnt);
+void p3m_do_assign_charge(double q, const Utils::Vector3d &real_pos,
+                          int cp_cnt);
 
 p3m_data_struct::p3m_data_struct() {
   /* local_mesh is uninitialized */
@@ -426,7 +427,7 @@ template <int cao> void p3m_do_charge_assign(const ParticleRange &particles) {
 }
 
 /* Template wrapper for p3m_do_assign_charge() */
-void p3m_assign_charge(double q, Utils::Vector3d &real_pos, int cp_cnt) {
+void p3m_assign_charge(double q, const Utils::Vector3d &real_pos, int cp_cnt) {
   switch (p3m.params.cao) {
   case 1:
     p3m_do_assign_charge<1>(q, real_pos, cp_cnt);
@@ -453,7 +454,8 @@ void p3m_assign_charge(double q, Utils::Vector3d &real_pos, int cp_cnt) {
 }
 
 template <int cao>
-void p3m_do_assign_charge(double q, Utils::Vector3d &real_pos, int cp_cnt) {
+void p3m_do_assign_charge(double q, const Utils::Vector3d &real_pos,
+                          int cp_cnt) {
   auto const inter = not(p3m.params.inter == 0);
   /* distance to nearest mesh point */
   double dist[3];

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -57,11 +57,9 @@ struct p3m_data_struct {
   /** local mesh. */
   p3m_local_mesh local_mesh;
   /** real space mesh (local) for CA/FFT.*/
-  double *rs_mesh;
-  /** k-space mesh (local) for k-space calculation and FFT.*/
-  std::vector<double> ks_mesh;
+  fft_vector<double> rs_mesh;
   /** mesh (local) for the electric field.*/
-  std::array<std::vector<double>, 3> E_mesh;
+  std::array<fft_vector<double>, 3> E_mesh;
 
   /** number of charged particles (only on master node). */
   int sum_qpart;

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -188,7 +188,7 @@ void p3m_charge_assign(const ParticleRange &particles);
  *                        is not stored in the @ref p3m_data_struct::ca_frac
  *                        "ca_frac" arrays
  */
-void p3m_assign_charge(double q, Utils::Vector3d &real_pos, int cp_cnt);
+void p3m_assign_charge(double q, const Utils::Vector3d &real_pos, int cp_cnt);
 
 /** Shrink wrap the charge grid */
 void p3m_shrink_wrap_charge_grid(int n_charges);

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -60,6 +60,8 @@ struct p3m_data_struct {
   double *rs_mesh;
   /** k-space mesh (local) for k-space calculation and FFT.*/
   std::vector<double> ks_mesh;
+  /** mesh (local) for the electric field.*/
+  std::array<std::vector<double>, 3> E_mesh;
 
   /** number of charged particles (only on master node). */
   int sum_qpart;

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -164,7 +164,7 @@ double p3m_calc_kspace_forces(bool force_flag, bool energy_flag,
                               const ParticleRange &particles);
 
 /** Compute the k-space part of the stress tensor **/
-void p3m_calc_kspace_stress(double *stress);
+Utils::Vector9d p3m_calc_kspace_stress();
 
 /** Sanity checks */
 bool p3m_sanity_checks();

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
@@ -169,7 +169,7 @@ void p3m_send_mesh::spread_grid(Utils::Span<double *> meshes,
     /* un pack recv block */
     if (s_size[s_dir] > 0) {
       for (size_t i = 0; i < meshes.size(); i++) {
-        fft_unpack_block(recv_grid.data() + i * r_size[s_dir], meshes[i],
+        fft_unpack_block(recv_grid.data() + i * s_size[s_dir], meshes[i],
                          s_ld[s_dir], s_dim[s_dir], dim, 1);
       }
     }


### PR DESCRIPTION
Description of changes:
 - Avoid unneeded energy calculation in pressure calculation
 - Removed some code duplication from ELC
 - Reduce number of mesh passes in P3M
 - Do not overwrite charge density grid during force calculation
 - Core loop cleanup
 - Reduced number of communication steps