### PR TITLE
testsuite: increase error bounds for test of electrophoresis sample.

### DIFF
--- a/testsuite/scripts/samples/test_electrophoresis.py
+++ b/testsuite/scripts/samples/test_electrophoresis.py
@@ -29,7 +29,7 @@ class Sample(ut.TestCase):
 
     def test_persistence_length(self):
         self.assertAlmostEqual(sample.persistence_length, 28., delta=3)
-        self.assertAlmostEqual(sample.persistence_length_obs, 32., delta=2)
+        self.assertAlmostEqual(sample.persistence_length_obs, 32., delta=3)
 
     def test_mobility(self):
         self.assertAlmostEqual(sample.mu, 1.02, delta=0.02)


### PR DESCRIPTION
Fixes #3415 