### PR TITLE
Refactor thermostats: RNG, callbacks and documentation

### DIFF
--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -1516,7 +1516,8 @@ INCLUDE_FILE_PATTERNS  = *.h *.hpp *.cuh
 # Use the PREDEFINED tag if you want to use a different macro definition that
 # overrules the definition found in the source code.
 
-EXPAND_AS_DEFINED      = NEW_PARAMLESS_OBSERVABLE
+EXPAND_AS_DEFINED      = NEW_PARAMLESS_OBSERVABLE \
+                         NEW_THERMOSTAT
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES (the default) then
 # doxygen's preprocessor will remove all references to function-like macros

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -106,7 +106,7 @@ A code snippet would look like::
     import espressomd
 
     system = espressomd.System()
-    system.thermostat.set_npt(kT=1.0, gamma0=1.0, gammav=1.0)
+    system.thermostat.set_npt(kT=1.0, gamma0=1.0, gammav=1.0, seed=42)
     system.integrator.set_isotropic_npt(ext_pressure=1.0, piston=1.0)
 
 The physical meaning of these parameters is described below:

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -171,6 +171,8 @@ The discretisation consists of the following steps (see :cite:`kolb99a` for a fu
    .. math:: \mathcal{P} = \mathcal{P}(x(t+dt),V(t+dt),f(x(t+dt)), v(t+dt/2))
    .. math:: \Pi(t+dt) = \Pi(t+dt/2) + (\mathcal{P}-P) dt/2 -\frac{\gamma^V}{Q}\Pi(t+dt/2) dt/2  +  \sqrt{k_B T \gamma^V dt} \overline{\eta}
 
+   with uncorrelated numbers :math:`\overline{\eta}` drawn from a random uniform process :math:`\eta(t)`
+
 6. Update the velocities
 
    .. math:: v(t+dt) = v(t+dt/2) + \frac{F(t+dt)}{m} dt/2
@@ -180,7 +182,7 @@ Notes:
 * The NpT algorithm is only tested for all 3 directions enabled for scaling. Usage of ``direction`` is considered an experimental feature.
 * In step 4, only those coordinates are scaled for which ``direction`` is set.
 * For the instantaneous pressure, the same limitations of applicability hold as described in :ref:`Pressure`.
-* The particle forces :math:`F` include interactions as well as a friction and noise term analogous to the terms in the :ref:`Langevin thermostat`.
+* The particle forces :math:`F` include interactions as well as a friction (:math:`\gamma^0`) and noise term (:math:`\sqrt{k_B T \gamma^0 dt} \overline{\eta}`) analogous to the terms in the :ref:`Langevin thermostat`.
 * The particle forces are only calculated in step 5 and then reused in step 1 of the next iteration. See :ref:`Velocity Verlet Algorithm` for the implications of that.
 
 .. _Rotational degrees of freedom and particle anisotropy:

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -419,7 +419,7 @@ For example::
     import espressomd
 
     system = espressomd.System()
-    system.thermostat.set_npt(kT=1.0, gamma0=1.0, gammav=1.0)
+    system.thermostat.set_npt(kT=1.0, gamma0=1.0, gammav=1.0, seed=41)
     system.integrator.set_isotropic_npt(ext_pressure=1.0, piston=1.0)
 
 For an explanation of the algorithm involved, see :ref:`Isotropic NPT integrator`.

--- a/samples/visualization_npt.py
+++ b/samples/visualization_npt.py
@@ -57,7 +57,7 @@ steepest_descent(system, f_max=0.0, gamma=30.0, max_steps=10000,
                  max_displacement=0.1)
 print("E after minimization:", system.analysis.energy()["total"])
 
-system.thermostat.set_npt(kT=2.0, gamma0=1.0, gammav=0.01)
+system.thermostat.set_npt(kT=2.0, gamma0=1.0, gammav=0.01, seed=42)
 system.integrator.set_isotropic_npt(ext_pressure=1.0, piston=0.01)
 
 

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -320,11 +320,16 @@ void philox_counter_increment() {
   if (thermo_switch & THERMO_BROWNIAN) {
     brownian_rng_counter_increment();
   }
-  if (thermo_switch & THERMO_DPD) {
-#ifdef DPD
-    dpd_rng_counter_increment();
-#endif
+#ifdef NPT
+  if (thermo_switch & THERMO_NPT_ISO) {
+    npt_iso_rng_counter_increment();
   }
+#endif
+#ifdef DPD
+  if (thermo_switch & THERMO_DPD) {
+    dpd_rng_counter_increment();
+  }
+#endif
   if (n_thermalized_bonds)
     thermalized_bond_rng_counter_increment();
 }

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -55,6 +55,9 @@ enum class RNGSalt : uint64_t {
   BROWNIAN_INC,
   BROWNIAN_ROT_INC,
   BROWNIAN_ROT_WALK,
+  NPTISO0_HALF_STEP1,
+  NPTISO0_HALF_STEP2,
+  NPTISOV,
   SALT_DPD,
   THERMALIZED_BOND
 };
@@ -86,6 +89,25 @@ Utils::Vector<uint64_t, 4> philox_4_uint64s(uint64_t counter, int key1,
 
   auto const res = rng_type{}(c, k);
   return {res[0], res[1], res[2], res[3]};
+}
+
+/**
+ * @brief Uniform noise.
+ *
+ * Mean = 0, variance = 1 / 12.
+ * This uses the Philox PRNG, the state is controlled
+ * by the counter, the salt and two keys.
+ * If any of the keys and salt differ, the noise is
+ * not correlated between two calls along the same counter
+ * sequence.
+ *
+ */
+template <RNGSalt salt> double noise(uint64_t counter, int key1, int key2 = 0) {
+
+  auto const noise = philox_4_uint64s<salt>(counter, key1, key2);
+
+  using Utils::uniform;
+  return uniform(noise[0]) - 0.5;
 }
 
 /**

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -113,6 +113,7 @@ template <RNGSalt salt> double noise(uint64_t counter, int key1, int key2 = 0) {
 /**
  * @brief 3d uniform vector noise.
  *
+ * Mean = 0, variance = 1 / 12.
  * This uses the Philox PRNG, the state is controlled
  * by the counter, the salt and two keys.
  * If any of the keys and salt differ, the noise is
@@ -133,7 +134,7 @@ Utils::Vector3d v_noise(uint64_t counter, int key1, int key2 = 0) {
 
 /** @brief Generator for Gaussian random 3d vector.
  *
- * Mean = 0, standard deviation = 1.0
+ * Mean = 0, standard deviation = 1.0.
  * Based on the Philox RNG using 4x64 bits.
  * The Box-Muller transform is used to convert from uniform to normal
  * distribution. The transform is only valid, if the uniformly distributed
@@ -233,8 +234,8 @@ void init_random_seed(int seed);
 } // namespace Random
 
 /**
- * @brief Draws a random real number from the uniform distribution in the range
- * [0,1)
+ * @brief Draws a random real number from the uniform distribution in the
+ * range [0,1) using the Mersenne twister.
  */
 inline double d_random() {
   using namespace Random;

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -82,6 +82,7 @@ IsotropicNptThermostat npt_iso = {};
 
 REGISTER_THERMOSTAT_CALLBACKS(langevin, THERMO_LANGEVIN)
 REGISTER_THERMOSTAT_CALLBACKS(brownian, THERMO_BROWNIAN)
+REGISTER_THERMOSTAT_CALLBACKS(npt_iso, THERMO_NPT_ISO)
 
 void thermo_init() {
   // Init thermalized bond despite of thermostat

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -114,9 +114,14 @@ public:
     }
     pref_noise_rotation = sigma(temperature, time_step, gamma_rotation);
   }
-  /** Calculate the noise standard deviation. */
+  /** Calculate the noise prefactor.
+   *  Evaluates the quantity @f$ \sqrt{2 k_B T \gamma / dt} / \sigma_\eta @f$
+   *  with @f$ \sigma_\eta @f$ the standard deviation of the random uniform
+   *  process @f$ \eta(t) @f$.
+   */
   static GammaType sigma(double kT, double time_step, GammaType const &gamma) {
-    constexpr auto const temp_coeff = 24.0;
+    // random uniform noise has variance 1/12
+    constexpr auto const temp_coeff = 2.0 * 12.0;
     return sqrt((temp_coeff * kT / time_step) * gamma);
   }
   /** @name Parameters */
@@ -128,11 +133,17 @@ public:
   /*@}*/
   /** @name Prefactors */
   /*@{*/
-  /** Prefactor for the friction. */
+  /** Prefactor for the friction.
+   *  Stores @f$ \gamma_{\text{trans}} @f$.
+   */
   GammaType pref_friction;
-  /** Prefactor for the translational velocity noise. */
+  /** Prefactor for the translational velocity noise.
+   *  Stores @f$ \sqrt{2 k_B T \gamma_{\text{trans}} / dt} / \sigma_\eta @f$.
+   */
   GammaType pref_noise;
-  /** Prefactor for the angular velocity noise. */
+  /** Prefactor for the angular velocity noise.
+   *  Stores @f$ \sqrt{2 k_B T \gamma_{\text{rot}} / dt} / \sigma_\eta @f$.
+   */
   GammaType pref_noise_rotation;
   /*@}*/
 };
@@ -172,12 +183,20 @@ public:
     sigma_pos_rotation = sigma(temperature, gamma_rotation);
 #endif // ROTATION
   }
-  /** Calculate the noise standard deviation. */
+  /** Calculate the noise prefactor.
+   *  Evaluates the quantity @f$ \sqrt{2 k_B T / \gamma} / \sigma_\eta @f$
+   *  with @f$ \sigma_\eta @f$ the standard deviation of the random gaussian
+   *  process @f$ \eta(t) @f$.
+   */
   static GammaType sigma(double kT, GammaType const &gamma) {
     constexpr auto const temp_coeff = 2.0;
     return sqrt(Utils::hadamard_division(temp_coeff * kT, gamma));
   }
-  /** Calculate the noise standard deviation. */
+  /** Calculate the noise prefactor.
+   *  Evaluates the quantity @f$ \sqrt{k_B T} / \sigma_\eta @f$
+   *  with @f$ \sigma_\eta @f$ the standard deviation of the random gaussian
+   *  process @f$ \eta(t) @f$.
+   */
   static double sigma(double kT) {
     constexpr auto const temp_coeff = 1.0;
     return sqrt(temp_coeff * kT);
@@ -227,31 +246,49 @@ public:
 #ifdef NPT
     assert(piston > 0.0);
     auto const half_time_step = time_step / 2.0;
-    pref1 = -gamma0 * half_time_step;
-    pref2 = sigma(temperature, gamma0);
-    pref3 = -gammav * half_time_step / piston;
-    pref4 = sigma(temperature, gammav);
+    pref_rescale_0 = -gamma0 * half_time_step;
+    pref_noise_0 = sigma(temperature, gamma0);
+    pref_rescale_V = -gammav * half_time_step / piston;
+    pref_noise_V = sigma(temperature, gammav);
 #endif
   }
-  /** Calculate the noise standard deviation. */
+  /** Calculate the noise prefactor.
+   *  Evaluates the quantity @f$ \sqrt{2 k_B T \gamma dt / 2} / \sigma_\eta @f$
+   *  with @f$ \sigma_\eta @f$ the standard deviation of the random uniform
+   *  process @f$ \eta(t) @f$.
+   */
   static double sigma(double kT, double gamma) {
+    // random uniform noise has variance 1/12; the temperature
+    // coefficient of 2 is canceled out by the half time step
     constexpr auto const temp_coeff = 12.0;
     return sqrt(temp_coeff * temperature * gamma * time_step);
   }
   /** @name Parameters */
   /*@{*/
-  /** Friction coefficient @f$ \gamma_0 @f$ */
+  /** Friction coefficient of the particles @f$ \gamma^0 @f$ */
   double gamma0;
-  /** Friction coefficient @f$ \gamma_V @f$ */
+  /** Friction coefficient for the box @f$ \gamma^V @f$ */
   double gammav;
   /*@}*/
 #ifdef NPT
   /** @name Prefactors */
   /*@{*/
-  double pref1;
-  double pref2;
-  double pref3;
-  double pref4;
+  /** %Particle velocity rescaling at half the time step.
+   *  Stores @f$ \gamma^{0}\cdot\frac{dt}{2} @f$.
+   */
+  double pref_rescale_0;
+  /** %Particle velocity rescaling noise standard deviation.
+   *  Stores @f$ \sqrt{k_B T \gamma^{0} dt} / \sigma_\eta @f$.
+   */
+  double pref_noise_0;
+  /** Volume rescaling at half the time step.
+   *  Stores @f$ \frac{\gamma^{V}}{Q}\cdot\frac{dt}{2} @f$.
+   */
+  double pref_rescale_V;
+  /** Volume rescaling noise standard deviation.
+   *  Stores @f$ \sqrt{k_B T \gamma^{V} dt} / \sigma_\eta @f$.
+   */
+  double pref_noise_V;
   /*@}*/
 #endif
 };
@@ -296,13 +333,13 @@ friction_therm0_nptiso(IsotropicNptThermostat const &npt_iso,
   constexpr auto const salt =
       (step == 1) ? RNGSalt::NPTISO0_HALF_STEP1 : RNGSalt::NPTISO0_HALF_STEP2;
   if (thermo_switch & THERMO_NPT_ISO) {
-    if (npt_iso.pref2 > 0.0) {
-      return npt_iso.pref1 * vel +
-             npt_iso.pref2 *
+    if (npt_iso.pref_noise_0 > 0.0) {
+      return npt_iso.pref_rescale_0 * vel +
+             npt_iso.pref_noise_0 *
                  Random::v_noise<salt>(npt_iso.rng_counter->value(),
                                        p_identity);
     }
-    return npt_iso.pref1 * vel;
+    return npt_iso.pref_rescale_0 * vel;
   }
   return {};
 }
@@ -313,12 +350,12 @@ friction_therm0_nptiso(IsotropicNptThermostat const &npt_iso,
 inline double friction_thermV_nptiso(IsotropicNptThermostat const &npt_iso,
                                      double p_diff) {
   if (thermo_switch & THERMO_NPT_ISO) {
-    if (npt_iso.pref4 > 0.0) {
-      return npt_iso.pref3 * p_diff +
-             npt_iso.pref4 * Random::noise<RNGSalt::NPTISOV>(
-                                 npt_iso.rng_counter->value(), 0);
+    if (npt_iso.pref_noise_V > 0.0) {
+      return npt_iso.pref_rescale_V * p_diff +
+             npt_iso.pref_noise_V * Random::noise<RNGSalt::NPTISOV>(
+                                        npt_iso.rng_counter->value(), 0);
     }
-    return npt_iso.pref3 * p_diff;
+    return npt_iso.pref_rescale_V * p_diff;
   }
   return 0.0;
 }

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -47,4 +47,5 @@ unit_test(NAME grid_test SRC grid_test.cpp DEPENDS EspressoCore)
 unit_test(NAME BoxGeometry_test SRC BoxGeometry_test.cpp DEPENDS EspressoCore)
 unit_test(NAME LocalBox_test SRC LocalBox_test.cpp DEPENDS EspressoCore)
 unit_test(NAME thermostats_test SRC thermostats_test.cpp DEPENDS EspressoCore)
+unit_test(NAME random_test SRC random_test.cpp DEPENDS EspressoCore)
 

--- a/src/core/unit_tests/random_test.cpp
+++ b/src/core/unit_tests/random_test.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Unit tests for random number generators. */
+
+#define BOOST_TEST_MODULE PRNG test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <tuple>
+
+#include <utils/Vector.hpp>
+
+#include "random.hpp"
+#include "random_test.hpp"
+
+BOOST_AUTO_TEST_CASE(test_noise_uniform) {
+  double mean, var;
+  Utils::Matrix<double, 3, 3> cov;
+  std::tie(mean, var, cov) = noise_stats(
+      [](int i) -> Utils::Vector3d {
+        return Random::v_noise<RNGSalt::LANGEVIN>(i, 0);
+      },
+      10'000'000);
+  noise_check_stats(1.0 / 12.0, mean, var, cov);
+  noise_check_correlation(cov);
+}
+
+BOOST_AUTO_TEST_CASE(test_noise_gaussian) {
+  double mean, var;
+  Utils::Matrix<double, 3, 3> cov;
+  std::tie(mean, var, cov) = noise_stats(
+      [](int i) -> Utils::Vector3d {
+        return Random::v_noise_g<RNGSalt::BROWNIAN_WALK>(i, 0);
+      },
+      10'000'000);
+  noise_check_stats(1.0, mean, var, cov);
+  noise_check_correlation(cov);
+}

--- a/src/core/unit_tests/random_test.cpp
+++ b/src/core/unit_tests/random_test.cpp
@@ -60,6 +60,24 @@ BOOST_AUTO_TEST_CASE(test_noise_statistics) {
   BOOST_CHECK_EQUAL(correlation[x][y], correlation[y][x]);
 }
 
+BOOST_AUTO_TEST_CASE(test_noise_uniform_1d) {
+  constexpr size_t const sample_size = 4'000'000;
+
+  int counter = 0;
+  std::vector<double> means, variances;
+  std::vector<std::vector<double>> covariance;
+  std::vector<std::vector<double>> correlation;
+  std::tie(means, variances, covariance, correlation) = noise_statistics(
+      std::function<std::vector<VariantVectorXd>()>(
+          [&counter]() -> std::vector<VariantVectorXd> {
+            return {{Random::noise<RNGSalt::NPTISOV>(counter++, 0)}};
+          }),
+      sample_size);
+  // check pooled mean and variance
+  BOOST_CHECK_SMALL(std::abs(means[0]), 2e-4);
+  BOOST_CHECK_CLOSE(variances[0] * 12.0, 1.0, 0.05);
+}
+
 BOOST_AUTO_TEST_CASE(test_noise_uniform_3d) {
   constexpr size_t const sample_size = 4'000'000;
   constexpr size_t const x = 0, y = 1, z = 2;

--- a/src/core/unit_tests/random_test.hpp
+++ b/src/core/unit_tests/random_test.hpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Helper functions to compute random numbers covariance in a single pass */
+
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+#include <boost/accumulators/statistics/variates/covariate.hpp>
+#include <boost/test/unit_test.hpp>
+#include <tuple>
+
+#include <utils/Vector.hpp>
+
+#include "random.hpp"
+
+/** Draw a large sample of 3D vectors from a PRNG and compute the following
+ *  statistics: pooled mean, pooled variance, covariance matrix between axes.
+ */
+template <typename NoiseFunction>
+std::tuple<double, double, Utils::Matrix<double, 3, 3>>
+noise_stats(NoiseFunction noise_function, size_t sample_size) {
+  namespace ba = boost::accumulators;
+  namespace bt = boost::accumulators::tag;
+  ba::accumulator_set<double, ba::stats<bt::mean, bt::variance(ba::lazy)>>
+      acc_all, acc_x, acc_y, acc_z;
+  ba::accumulator_set<double, ba::stats<bt::covariance<double, bt::covariate1>>>
+      acc_xy, acc_xz, acc_yz;
+  for (int i = 0; i < sample_size; ++i) {
+    auto const noise = noise_function(i);
+    acc_x(noise[0]);
+    acc_y(noise[1]);
+    acc_z(noise[2]);
+    acc_xy(noise[0], ba::covariate1 = noise[1]);
+    acc_xz(noise[0], ba::covariate1 = noise[2]);
+    acc_yz(noise[1], ba::covariate1 = noise[2]);
+    acc_all(noise[0]);
+    acc_all(noise[1]);
+    acc_all(noise[2]);
+  }
+  auto const mean = ba::mean(acc_all);
+  auto const variance = ba::variance(acc_all);
+  auto const cov_xx = ba::variance(acc_x);
+  auto const cov_yy = ba::variance(acc_y);
+  auto const cov_zz = ba::variance(acc_z);
+  auto const cov_xy = ba::covariance(acc_xy);
+  auto const cov_xz = ba::covariance(acc_xz);
+  auto const cov_yz = ba::covariance(acc_yz);
+  return std::make_tuple(mean, variance,
+                         Utils::Matrix<double, 3, 3>{{cov_xx, cov_xy, cov_xz},
+                                                     {cov_xy, cov_yy, cov_yz},
+                                                     {cov_xz, cov_yz, cov_zz}});
+}
+
+void noise_check_stats(double expected_variance, double mean, double variance,
+                       Utils::Matrix<double, 3, 3> const &cov) {
+  auto const x = 0, y = 1, z = 2;
+  // check total mean and variance
+  BOOST_CHECK_SMALL(std::abs(mean), 1e-4);
+  BOOST_CHECK_CLOSE(variance, expected_variance, 2e-2);
+  // check variance per axis
+  BOOST_CHECK_CLOSE(cov[x][x], expected_variance, 5e-2);
+  BOOST_CHECK_CLOSE(cov[y][y], expected_variance, 5e-2);
+  BOOST_CHECK_CLOSE(cov[z][z], expected_variance, 5e-2);
+}
+
+void noise_check_correlation(Utils::Matrix<double, 3, 3> const &cov) {
+  auto const x = 0, y = 1, z = 2;
+  // check the 3 axes are not correlated (Pearson correlation coefficient)
+  auto const corrcoeff_xy = cov[x][y] / sqrt(cov[x][x] * cov[y][y]);
+  auto const corrcoeff_xz = cov[x][z] / sqrt(cov[x][x] * cov[z][z]);
+  auto const corrcoeff_yz = cov[y][z] / sqrt(cov[y][y] * cov[z][z]);
+  BOOST_CHECK_SMALL(std::abs(corrcoeff_xy), 1e-3);
+  BOOST_CHECK_SMALL(std::abs(corrcoeff_xz), 1e-3);
+  BOOST_CHECK_SMALL(std::abs(corrcoeff_yz), 1e-3);
+}

--- a/src/core/unit_tests/random_test.hpp
+++ b/src/core/unit_tests/random_test.hpp
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef CORE_UNIT_TESTS_RANDOM_TEST_HPP
+#define CORE_UNIT_TESTS_RANDOM_TEST_HPP
 
 /* Helper functions to compute random numbers covariance in a single pass */
 
@@ -23,69 +25,155 @@
 #include <boost/accumulators/statistics.hpp>
 #include <boost/accumulators/statistics/variates/covariate.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/variant.hpp>
+#include <functional>
 #include <tuple>
 
 #include <utils/Vector.hpp>
 
 #include "random.hpp"
 
-/** Draw a large sample of 3D vectors from a PRNG and compute the following
- *  statistics: pooled mean, pooled variance, covariance matrix between axes.
+namespace Utils {
+using VariantVectorXd = boost::variant<double, Vector2d, Vector3d, Vector4d>;
+} // namespace Utils
+
+using Utils::VariantVectorXd;
+
+namespace {
+
+using Utils::Vector;
+
+class visitor_size : public boost::static_visitor<size_t> {
+public:
+  template <size_t N> size_t operator()(Vector<double, N> const &v) const {
+    return v.size();
+  }
+  size_t operator()(double v) const { return 1; }
+};
+
+class visitor_get : public boost::static_visitor<double> {
+public:
+  template <size_t N>
+  double operator()(Vector<double, N> const &v, size_t i) const {
+    return v[i];
+  }
+  double operator()(double v, size_t i) const {
+    assert(i == 0);
+    return v;
+  }
+};
+
+size_t get_size(VariantVectorXd const &vec) {
+  return boost::apply_visitor(visitor_size(), vec);
+}
+
+double get_value(VariantVectorXd const &vec, size_t i) {
+  return boost::apply_visitor(
+      std::bind(visitor_get(), std::placeholders::_1, i), vec);
+}
+
+template <typename T> auto square_matrix(size_t N) {
+  return std::vector<std::vector<T>>(N, std::vector<T>(N));
+}
+
+} // namespace
+
+/** Draw a large sample of 3D vectors from PRNGs and compute statistics.
+ *  Parameter @p noise_function is a generator that returns @f N @f vectors
+ *  of size @f M_i @f. The following statistics are evaluated: @f N @f means
+ *  and @f N @f variances (samples are uncorrelated across axes, so pooling
+ *  them is fine), and a covariance and a correlation matrix of size
+ *  @f \sum M_i @f.
  */
-template <typename NoiseFunction>
-std::tuple<double, double, Utils::Matrix<double, 3, 3>>
-noise_stats(NoiseFunction noise_function, size_t sample_size) {
+std::tuple<std::vector<double>, std::vector<double>,
+           std::vector<std::vector<double>>, std::vector<std::vector<double>>>
+noise_statistics(std::function<std::vector<VariantVectorXd>()> noise_function,
+                 size_t sample_size) {
+
+  // get size of the arrays and size of the triangular correlation matrix
+  auto const first_value = noise_function();
+  auto const n_vectors = first_value.size();
+  std::vector<size_t> dimensions(n_vectors);
+  std::transform(first_value.begin(), first_value.end(), dimensions.begin(),
+                 [](auto const &element) { return get_size(element); });
+  auto const matrix_dim = std::accumulate(dimensions.begin(), dimensions.end(),
+                                          0, std::plus<size_t>());
+
+  // set up boost accumulators
   namespace ba = boost::accumulators;
   namespace bt = boost::accumulators::tag;
-  ba::accumulator_set<double, ba::stats<bt::mean, bt::variance(ba::lazy)>>
-      acc_all, acc_x, acc_y, acc_z;
-  ba::accumulator_set<double, ba::stats<bt::covariance<double, bt::covariate1>>>
-      acc_xy, acc_xz, acc_yz;
-  for (int i = 0; i < sample_size; ++i) {
-    auto const noise = noise_function(i);
-    acc_x(noise[0]);
-    acc_y(noise[1]);
-    acc_z(noise[2]);
-    acc_xy(noise[0], ba::covariate1 = noise[1]);
-    acc_xz(noise[0], ba::covariate1 = noise[2]);
-    acc_yz(noise[1], ba::covariate1 = noise[2]);
-    acc_all(noise[0]);
-    acc_all(noise[1]);
-    acc_all(noise[2]);
+  using stat_variance = ba::stats<bt::mean, bt::variance(ba::lazy)>;
+  using stat_covariance = ba::stats<bt::covariance<double, bt::covariate1>>;
+  using boost_variance = ba::accumulator_set<double, stat_variance>;
+  using boost_covariance = ba::accumulator_set<double, stat_covariance>;
+  std::vector<boost_variance> acc_variance(n_vectors);
+  auto acc_covariance = ::square_matrix<boost_covariance>(matrix_dim);
+
+  // accumulate
+  for (size_t step = 0; step < sample_size; ++step) {
+    auto const noise_tuple = noise_function();
+    // for each vector, pool the random numbers of all columns
+    for (size_t vec1 = 0; vec1 < dimensions.size(); ++vec1) {
+      for (size_t col1 = 0; col1 < dimensions[vec1]; ++col1) {
+        acc_variance[vec1](::get_value(noise_tuple[vec1], col1));
+      }
+    }
+    // fill the covariance matrix (upper triangle)
+    size_t index1 = 0;
+    for (size_t vec1 = 0; vec1 < dimensions.size(); ++vec1) {
+      for (size_t col1 = 0; col1 < dimensions[vec1]; ++col1) {
+        size_t index2 = index1;
+        for (size_t vec2 = vec1; vec2 < dimensions.size(); ++vec2) {
+          for (size_t col2 = (vec2 == vec1) ? col1 : 0; col2 < dimensions[vec2];
+               ++col2) {
+            acc_covariance[index1][index2](
+                ::get_value(noise_tuple[vec1], col1),
+                ba::covariate1 = ::get_value(noise_tuple[vec2], col2));
+            index2++;
+          }
+        }
+        index1++;
+      }
+    }
   }
-  auto const mean = ba::mean(acc_all);
-  auto const variance = ba::variance(acc_all);
-  auto const cov_xx = ba::variance(acc_x);
-  auto const cov_yy = ba::variance(acc_y);
-  auto const cov_zz = ba::variance(acc_z);
-  auto const cov_xy = ba::covariance(acc_xy);
-  auto const cov_xz = ba::covariance(acc_xz);
-  auto const cov_yz = ba::covariance(acc_yz);
-  return std::make_tuple(mean, variance,
-                         Utils::Matrix<double, 3, 3>{{cov_xx, cov_xy, cov_xz},
-                                                     {cov_xy, cov_yy, cov_yz},
-                                                     {cov_xz, cov_yz, cov_zz}});
+
+  // compute statistics
+  std::vector<double> means(n_vectors);
+  std::vector<double> variances(n_vectors);
+  for (size_t i = 0; i < n_vectors; ++i) {
+    means[i] = ba::mean(acc_variance[i]);
+    variances[i] = ba::variance(acc_variance[i]);
+  }
+  auto covariance = ::square_matrix<double>(matrix_dim);
+  for (size_t i = 0; i < matrix_dim; ++i) {
+    for (size_t j = i; j < matrix_dim; ++j) {
+      covariance[i][j] = covariance[j][i] =
+          ba::covariance(acc_covariance[i][j]);
+    }
+  }
+  auto correlation = ::square_matrix<double>(matrix_dim);
+  for (size_t i = 0; i < matrix_dim; ++i) {
+    for (size_t j = i; j < matrix_dim; ++j) {
+      correlation[i][j] = correlation[j][i] =
+          covariance[i][j] / sqrt(covariance[i][i] * covariance[j][j]);
+    }
+  }
+
+  return std::make_tuple(means, variances, covariance, correlation);
 }
 
-void noise_check_stats(double expected_variance, double mean, double variance,
-                       Utils::Matrix<double, 3, 3> const &cov) {
-  auto const x = 0, y = 1, z = 2;
-  // check total mean and variance
-  BOOST_CHECK_SMALL(std::abs(mean), 1e-4);
-  BOOST_CHECK_CLOSE(variance, expected_variance, 2e-2);
-  // check variance per axis
-  BOOST_CHECK_CLOSE(cov[x][x], expected_variance, 5e-2);
-  BOOST_CHECK_CLOSE(cov[y][y], expected_variance, 5e-2);
-  BOOST_CHECK_CLOSE(cov[z][z], expected_variance, 5e-2);
+boost::test_tools::predicate_result correlation_almost_equal(
+    std::vector<std::vector<double>> const &correlation_matrix, size_t i,
+    size_t j, double reference, double threshold) {
+  auto const value = correlation_matrix[i][j];
+  auto const diff = std::abs(value - reference);
+  if (diff > threshold) {
+    boost::test_tools::predicate_result res(false);
+    res.message() << "The correlation coefficient M[" << i << "][" << j << "]{"
+                  << value << "} differs from " << reference << " by " << diff
+                  << " (> " << threshold << ")";
+    return res;
+  }
+  return true;
 }
-
-void noise_check_correlation(Utils::Matrix<double, 3, 3> const &cov) {
-  auto const x = 0, y = 1, z = 2;
-  // check the 3 axes are not correlated (Pearson correlation coefficient)
-  auto const corrcoeff_xy = cov[x][y] / sqrt(cov[x][x] * cov[y][y]);
-  auto const corrcoeff_xz = cov[x][z] / sqrt(cov[x][x] * cov[z][z]);
-  auto const corrcoeff_yz = cov[y][z] / sqrt(cov[y][y] * cov[z][z]);
-  BOOST_CHECK_SMALL(std::abs(corrcoeff_xy), 1e-3);
-  BOOST_CHECK_SMALL(std::abs(corrcoeff_xz), 1e-3);
-  BOOST_CHECK_SMALL(std::abs(corrcoeff_yz), 1e-3);
-}
+#endif

--- a/src/python/espressomd/thermostat.pxd
+++ b/src/python/espressomd/thermostat.pxd
@@ -53,11 +53,14 @@ cdef extern from "thermostat.hpp":
 
     void langevin_set_rng_state(stdint.uint64_t counter)
     void brownian_set_rng_state(stdint.uint64_t counter)
+    void npt_iso_set_rng_state(stdint.uint64_t counter)
     cbool langevin_is_seed_required()
     cbool brownian_is_seed_required()
+    cbool npt_iso_is_seed_required()
 
     stdint.uint64_t langevin_get_rng_state()
     stdint.uint64_t brownian_get_rng_state()
+    stdint.uint64_t npt_iso_get_rng_state()
 
 cdef extern from "Globals.hpp":
     # links intern C-struct with python object

--- a/testsuite/python/integrator_npt.py
+++ b/testsuite/python/integrator_npt.py
@@ -29,7 +29,6 @@ class IntegratorNPT(ut.TestCase):
     """This compares pressure and compressibility of a LJ system against
        expected values."""
     S = espressomd.System(box_l=[1.0, 1.0, 1.0])
-    S.seed = S.cell_system.get_state()['n_nodes'] * [1234]
     p_ext = 2.0
 
     def setUp(self):
@@ -68,11 +67,10 @@ class IntegratorNPT(ut.TestCase):
 
         avp /= (n / skip_p)
         Vs = np.array(ls)**3
-        compressibility = pow(np.std(Vs), 2) / np.average(Vs)
-        print(avp, compressibility)
+        compressibility = np.var(Vs) / np.average(Vs)
 
-        self.assertAlmostEqual(2.0, avp, delta=0.02)
-        self.assertAlmostEqual(0.2, compressibility, delta=0.02)
+        self.assertAlmostEqual(avp, 2.0, delta=0.02)
+        self.assertAlmostEqual(compressibility, 0.32, delta=0.02)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/integrator_npt.py
+++ b/testsuite/python/integrator_npt.py
@@ -39,8 +39,7 @@ class IntegratorNPT(ut.TestCase):
         self.S.time_step = 0.01
         self.S.cell_system.skin = 0.25
 
-        data = np.genfromtxt(tests_common.abspath(
-            "data/npt_lj_system.data"))
+        data = np.genfromtxt(tests_common.abspath("data/npt_lj_system.data"))
 
         # Input format: id pos f
         for particle in data:
@@ -51,7 +50,7 @@ class IntegratorNPT(ut.TestCase):
         self.S.non_bonded_inter[0, 0].lennard_jones.set_params(
             epsilon=1, sigma=1, cutoff=1.12246, shift=0.25)
 
-        self.S.thermostat.set_npt(kT=1.0, gamma0=2, gammav=0.004)
+        self.S.thermostat.set_npt(kT=1.0, gamma0=2, gammav=0.004, seed=42)
         self.S.integrator.set_isotropic_npt(
             ext_pressure=self.p_ext, piston=0.0001)
 

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -141,7 +141,7 @@ if 'LB.OFF' in modes:
     elif 'THERM.BD' in modes:
         system.thermostat.set_brownian(kT=1.0, gamma=2.0, seed=42)
     elif 'THERM.NPT' in modes and has_features('NPT'):
-        system.thermostat.set_npt(kT=1.0, gamma0=2.0, gammav=0.1)
+        system.thermostat.set_npt(kT=1.0, gamma0=2.0, gammav=0.1, seed=42)
     elif 'THERM.DPD' in modes and has_features('DPD'):
         system.thermostat.set_dpd(kT=1.0, seed=42)
     # set integrator

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -187,6 +187,7 @@ class CheckpointTest(ut.TestCase):
     def test_thermostat_NPT(self):
         thmst = system.thermostat.get_state()[0]
         self.assertEqual(thmst['type'], 'NPT_ISO')
+        self.assertEqual(thmst['seed'], 42)
         self.assertEqual(thmst['gamma0'], 2.0)
         self.assertEqual(thmst['gammav'], 0.1)
 


### PR DESCRIPTION
Description of changes:
- switch NPT thermostat RNG from Mersenne twister to Philox (fixes #3119)
- add extra RNG correlation checks in unit tests using boost accumulators
- make thermostats object-oriented and generate their MPI callbacks with macros
