### PR TITLE
Update array_properties.py

### DIFF
--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -119,6 +119,12 @@ class ArrayPropertyTest(ut.TestCase):
         cpy = np.copy(v)
         self.assertTrue(cpy.flags.writeable)
 
+    def setUp(self):
+        self.system.box_l = [12.0, 12.0, 12.0]
+
+    def tearDown(self):
+        self.system.actors.clear()
+
     def test_common(self):
 
         # Check for exception for various operators
@@ -275,8 +281,6 @@ class ArrayPropertyTest(ut.TestCase):
         self.locked_operators(lbf[0, 0, 0].stress)
         self.locked_operators(lbf[0, 0, 0].stress_neq)
         self.locked_operators(lbf[0, 0, 0].population)
-
-        self.system.actors.clear()
 
     @utx.skipIfMissingFeatures(["LANGEVIN_PER_PARTICLE",
                                 "PARTICLE_ANISOTROPY"])

--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -268,14 +268,14 @@ class ArrayPropertyTest(ut.TestCase):
     def test_lb(self):
         lbf = lb.LBFluid(agrid=0.5, dens=1, visc=1, tau=0.01)
         self.system.actors.add(lbf)
-    
+
         # Check for exception for various operators
         # LB
         self.locked_operators(lbf[0, 0, 0].velocity)
         self.locked_operators(lbf[0, 0, 0].stress)
         self.locked_operators(lbf[0, 0, 0].stress_neq)
         self.locked_operators(lbf[0, 0, 0].population)
-        
+
         self.system.actors.clear()
 
     @utx.skipIfMissingFeatures(["LANGEVIN_PER_PARTICLE",

--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -86,8 +86,6 @@ class ArrayPropertyTest(ut.TestCase):
     system.time_step = 0.01
     system.cell_system.skin = 0.01
     system.part.add(pos=[0, 0, 0])
-    lbf = lb.LBFluid(agrid=0.5, dens=1, visc=1, tau=0.01)
-    system.actors.add(lbf)
 
     def locked_operators(self, v):
         with self.assertRaises(ValueError):
@@ -268,12 +266,17 @@ class ArrayPropertyTest(ut.TestCase):
         self.set_copy(self.system.part[0].gamma_rot)
 
     def test_lb(self):
+        lbf = lb.LBFluid(agrid=0.5, dens=1, visc=1, tau=0.01)
+        self.system.actors.add(lbf)
+    
         # Check for exception for various operators
         # LB
-        self.locked_operators(self.lbf[0, 0, 0].velocity)
-        self.locked_operators(self.lbf[0, 0, 0].stress)
-        self.locked_operators(self.lbf[0, 0, 0].stress_neq)
-        self.locked_operators(self.lbf[0, 0, 0].population)
+        self.locked_operators(lbf[0, 0, 0].velocity)
+        self.locked_operators(lbf[0, 0, 0].stress)
+        self.locked_operators(lbf[0, 0, 0].stress_neq)
+        self.locked_operators(lbf[0, 0, 0].population)
+        
+        self.system.actors.clear()
 
     @utx.skipIfMissingFeatures(["LANGEVIN_PER_PARTICLE",
                                 "PARTICLE_ANISOTROPY"])


### PR DESCRIPTION
In the ArrayPropertyTest class, the lbf actor setup was moved to the test_lb() method, which was the only test using the actor. The actor is now removed after the test. This fixes an issue in test_partial_periodic() when changing the system's periodicity. The error which occured can be seen in event.cpp, function on_cell_structure_change(). This, however, didn't cause the test to fail because the error was not handled by Python. It did cause the test to fail during development of the Stokesian Dynamics functionality, when a handle_errors() was added into globals.pyx.

This replaces my two previos change suggestions on the file. Sorry for the confusion.