### PR TITLE
Fix issue in a docstring for recent sphinx versions

### DIFF
--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -310,8 +310,8 @@ class ParticleBodyAngularVelocities(Observable):
 
     """Calculates the angular velocity (omega) in the particles'  body-fixed frame of reference.
 
-   For each particle, the body-fixed frame of reference is obtained from the particle's
-   orientation stored in the quaternions.
+    For each particle, the body-fixed frame of reference is obtained from the particle's
+    orientation stored in the quaternions.
 
     Parameters
     ----------

--- a/src/python/espressomd/observables.py
+++ b/src/python/espressomd/observables.py
@@ -289,7 +289,6 @@ class MagneticDipoleMoment(Observable):
 
 @script_interface_register
 class ParticleAngularVelocities(Observable):
-    _so_name = "Observables::ParticleAngularVelocities"
 
     """Calculates the angular velocity (omega) in the spaced-fixed frame of reference
 
@@ -303,11 +302,12 @@ class ParticleAngularVelocities(Observable):
           The ids of (existing) particles to take into account.
 
     """
+    _so_name = "Observables::ParticleAngularVelocities"
 
 
 @script_interface_register
 class ParticleBodyAngularVelocities(Observable):
-    _so_name = "Observables::ParticleBodyAngularVelocities"
+
     """Calculates the angular velocity (omega) in the particles'  body-fixed frame of reference.
 
    For each particle, the body-fixed frame of reference is obtained from the particle's
@@ -319,6 +319,7 @@ class ParticleBodyAngularVelocities(Observable):
           The ids of (existing) particles to take into account.
 
     """
+    _so_name = "Observables::ParticleBodyAngularVelocities"
 
 
 @script_interface_register


### PR DESCRIPTION
Fixes error `/builds/espressomd/docker/espresso/build/src/python/espressomd/observables.py:docstring of espressomd.observables.ParticleBodyAngularVelocities._so_name:7:Unexpected section title.` ([jobs/203441](https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/203441)) that is currently blocking CI on espressomd/docker
