### PR TITLE
Improve CMake logic for tutorials

### DIFF
--- a/doc/tutorials/01-lennard_jones/CMakeLists.txt
+++ b/doc/tutorials/01-lennard_jones/CMakeLists.txt
@@ -1,6 +1,6 @@
 configure_file(figures/lennard-jones-potential.png ${CMAKE_CURRENT_BINARY_DIR}/figures/lennard-jones-potential.png COPYONLY)
 configure_file(01-lennard_jones.ipynb ${CMAKE_CURRENT_BINARY_DIR}/01-lennard_jones.ipynb COPYONLY)
 
-add_custom_target(tutorials_01)
+add_custom_target(tutorial_01)
 
-nb_export(TUTORIAL tutorials_01 FILE "01-lennard_jones.ipynb" HTML_RUN VAR_SUBST)
+nb_export(TUTORIAL tutorial_01 FILE "01-lennard_jones.ipynb" HTML_RUN VAR_SUBST)

--- a/doc/tutorials/01-lennard_jones/CMakeLists.txt
+++ b/doc/tutorials/01-lennard_jones/CMakeLists.txt
@@ -2,5 +2,6 @@ configure_file(figures/lennard-jones-potential.png ${CMAKE_CURRENT_BINARY_DIR}/f
 configure_file(01-lennard_jones.ipynb ${CMAKE_CURRENT_BINARY_DIR}/01-lennard_jones.ipynb COPYONLY)
 
 add_custom_target(tutorial_01)
+add_dependencies(tutorials tutorial_01)
 
-nb_export(TUTORIAL tutorial_01 FILE "01-lennard_jones.ipynb" HTML_RUN VAR_SUBST)
+nb_export(TARGET tutorial_01 SUFFIX "" FILE "01-lennard_jones.ipynb" HTML_RUN VAR_SUBST)

--- a/doc/tutorials/01-lennard_jones/CMakeLists.txt
+++ b/doc/tutorials/01-lennard_jones/CMakeLists.txt
@@ -1,7 +1,8 @@
-configure_file(figures/lennard-jones-potential.png ${CMAKE_CURRENT_BINARY_DIR}/figures/lennard-jones-potential.png COPYONLY)
-configure_file(01-lennard_jones.ipynb ${CMAKE_CURRENT_BINARY_DIR}/01-lennard_jones.ipynb COPYONLY)
-
-add_custom_target(tutorial_01)
-add_dependencies(tutorials tutorial_01)
+configure_tutorial_target(
+  TARGET tutorial_01
+  DEPENDS
+  01-lennard_jones.ipynb
+  figures/lennard-jones-potential.png
+)
 
 nb_export(TARGET tutorial_01 SUFFIX "" FILE "01-lennard_jones.ipynb" HTML_RUN VAR_SUBST)

--- a/doc/tutorials/02-charged_system/CMakeLists.txt
+++ b/doc/tutorials/02-charged_system/CMakeLists.txt
@@ -11,8 +11,9 @@ configure_file(02-charged_system-1.ipynb ${CMAKE_CURRENT_BINARY_DIR}/02-charged_
 configure_file(02-charged_system-2.ipynb ${CMAKE_CURRENT_BINARY_DIR}/02-charged_system-2.ipynb COPYONLY)
 
 add_custom_target(tutorial_02)
+add_dependencies(tutorials tutorial_02)
 
-nb_export(TUTORIAL tutorial_02_1 FILE "02-charged_system-1.ipynb" HTML_RUN
+nb_export(TARGET tutorial_02 SUFFIX "1" FILE "02-charged_system-1.ipynb" HTML_RUN
           VAR_SUBST "num_steps_equilibration=200;num_configs=100;integ_steps_per_config=250")
-nb_export(TUTORIAL tutorial_02_2 FILE "02-charged_system-2.ipynb" HTML_RUN
+nb_export(TARGET tutorial_02 SUFFIX "2" FILE "02-charged_system-2.ipynb" HTML_RUN
           VAR_SUBST "num_steps_equilibration=200;num_configs=50;integ_steps_per_config=100")

--- a/doc/tutorials/02-charged_system/CMakeLists.txt
+++ b/doc/tutorials/02-charged_system/CMakeLists.txt
@@ -1,17 +1,18 @@
-configure_file(scripts/nacl.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/nacl.py COPYONLY)
-configure_file(scripts/nacl_units_confined.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/nacl_units_confined.py COPYONLY)
-configure_file(scripts/nacl_units_confined_vis.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/nacl_units_confined_vis.py COPYONLY)
-configure_file(scripts/nacl_units.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/nacl_units.py COPYONLY)
-configure_file(scripts/nacl_units_vis.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/nacl_units_vis.py COPYONLY)
-configure_file(figures/nacl-rdf.pdf ${CMAKE_CURRENT_BINARY_DIR}/figures/nacl-rdf.pdf COPYONLY)
-configure_file(figures/nacl_units_confined.jpg ${CMAKE_CURRENT_BINARY_DIR}/figures/nacl_units_confined.jpg COPYONLY)
-configure_file(figures/nacl_units.jpg ${CMAKE_CURRENT_BINARY_DIR}/figures/nacl_units.jpg COPYONLY)
-configure_file(figures/salt.png ${CMAKE_CURRENT_BINARY_DIR}/figures/salt.png COPYONLY)
-configure_file(02-charged_system-1.ipynb ${CMAKE_CURRENT_BINARY_DIR}/02-charged_system-1.ipynb COPYONLY)
-configure_file(02-charged_system-2.ipynb ${CMAKE_CURRENT_BINARY_DIR}/02-charged_system-2.ipynb COPYONLY)
-
-add_custom_target(tutorial_02)
-add_dependencies(tutorials tutorial_02)
+configure_tutorial_target(
+  TARGET tutorial_02
+  DEPENDS
+  02-charged_system-1.ipynb
+  02-charged_system-2.ipynb
+  figures/nacl-rdf.pdf
+  figures/nacl_units_confined.jpg
+  figures/nacl_units.jpg
+  figures/salt.png
+  scripts/nacl.py
+  scripts/nacl_units_confined.py
+  scripts/nacl_units_confined_vis.py
+  scripts/nacl_units.py
+  scripts/nacl_units_vis.py
+)
 
 nb_export(TARGET tutorial_02 SUFFIX "1" FILE "02-charged_system-1.ipynb" HTML_RUN
           VAR_SUBST "num_steps_equilibration=200;num_configs=100;integ_steps_per_config=250")

--- a/doc/tutorials/02-charged_system/CMakeLists.txt
+++ b/doc/tutorials/02-charged_system/CMakeLists.txt
@@ -10,9 +10,9 @@ configure_file(figures/salt.png ${CMAKE_CURRENT_BINARY_DIR}/figures/salt.png COP
 configure_file(02-charged_system-1.ipynb ${CMAKE_CURRENT_BINARY_DIR}/02-charged_system-1.ipynb COPYONLY)
 configure_file(02-charged_system-2.ipynb ${CMAKE_CURRENT_BINARY_DIR}/02-charged_system-2.ipynb COPYONLY)
 
-add_custom_target(tutorials_02)
+add_custom_target(tutorial_02)
 
-nb_export(TUTORIAL tutorials_02_1 FILE "02-charged_system-1.ipynb" HTML_RUN
+nb_export(TUTORIAL tutorial_02_1 FILE "02-charged_system-1.ipynb" HTML_RUN
           VAR_SUBST "num_steps_equilibration=200;num_configs=100;integ_steps_per_config=250")
-nb_export(TUTORIAL tutorials_02_2 FILE "02-charged_system-2.ipynb" HTML_RUN
+nb_export(TUTORIAL tutorial_02_2 FILE "02-charged_system-2.ipynb" HTML_RUN
           VAR_SUBST "num_steps_equilibration=200;num_configs=50;integ_steps_per_config=100")

--- a/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
+++ b/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
@@ -14,9 +14,9 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.cmake"
 )
 
-add_custom_target(tutorials_04)
+add_custom_target(tutorial_04)
 
-nb_export(TUTORIAL tutorials_04_1 FILE "04-lattice_boltzmann_part1.ipynb" HTML_RUN)
-nb_export(TUTORIAL tutorials_04_2 FILE "04-lattice_boltzmann_part2.ipynb" HTML_RUN)
-nb_export(TUTORIAL tutorials_04_3 FILE "04-lattice_boltzmann_part3.ipynb" HTML_RUN)
-nb_export(TUTORIAL tutorials_04_4 FILE "04-lattice_boltzmann_part4.ipynb" HTML_RUN ADD_SCRIPTS "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py")
+nb_export(TUTORIAL tutorial_04_1 FILE "04-lattice_boltzmann_part1.ipynb" HTML_RUN)
+nb_export(TUTORIAL tutorial_04_2 FILE "04-lattice_boltzmann_part2.ipynb" HTML_RUN)
+nb_export(TUTORIAL tutorial_04_3 FILE "04-lattice_boltzmann_part3.ipynb" HTML_RUN)
+nb_export(TUTORIAL tutorial_04_4 FILE "04-lattice_boltzmann_part4.ipynb" HTML_RUN ADD_SCRIPTS "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py")

--- a/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
+++ b/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
@@ -8,19 +8,11 @@ configure_file(figures/latticeboltzmann-momentumexchange.png ${CMAKE_CURRENT_BIN
 configure_file(figures/latticeboltzmann-grid.png ${CMAKE_CURRENT_BINARY_DIR}/figures/latticeboltzmann-grid.png COPYONLY)
 
 add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py"
-      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution.py"
-      COMMAND
-      "cp"
-      "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution.py"
-      "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py"
-      COMMAND
-      "sed"
-      "-n"
-      "-i"
-      "'/# Extract fluid velocity along the x-axis/,$$p;1i\\import matplotlib.pyplot as plt'"
-      "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py"
-      )
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/04-lattice_boltzmann_part4_solution.py"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.cmake"
+  COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.cmake"
+)
 
 add_custom_target(tutorials_04)
 

--- a/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
+++ b/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
@@ -15,8 +15,9 @@ add_custom_command(
 )
 
 add_custom_target(tutorial_04)
+add_dependencies(tutorials tutorial_04)
 
-nb_export(TUTORIAL tutorial_04_1 FILE "04-lattice_boltzmann_part1.ipynb" HTML_RUN)
-nb_export(TUTORIAL tutorial_04_2 FILE "04-lattice_boltzmann_part2.ipynb" HTML_RUN)
-nb_export(TUTORIAL tutorial_04_3 FILE "04-lattice_boltzmann_part3.ipynb" HTML_RUN)
-nb_export(TUTORIAL tutorial_04_4 FILE "04-lattice_boltzmann_part4.ipynb" HTML_RUN ADD_SCRIPTS "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py")
+nb_export(TARGET tutorial_04 SUFFIX "1" FILE "04-lattice_boltzmann_part1.ipynb" HTML_RUN)
+nb_export(TARGET tutorial_04 SUFFIX "2" FILE "04-lattice_boltzmann_part2.ipynb" HTML_RUN)
+nb_export(TARGET tutorial_04 SUFFIX "3" FILE "04-lattice_boltzmann_part3.ipynb" HTML_RUN)
+nb_export(TARGET tutorial_04 SUFFIX "4" FILE "04-lattice_boltzmann_part4.ipynb" HTML_RUN ADD_SCRIPTS "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py")

--- a/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
+++ b/doc/tutorials/04-lattice_boltzmann/CMakeLists.txt
@@ -1,11 +1,15 @@
-configure_file(04-lattice_boltzmann_part4.ipynb ${CMAKE_CURRENT_BINARY_DIR}/04-lattice_boltzmann_part4.ipynb COPYONLY)
-configure_file(04-lattice_boltzmann_part3.ipynb ${CMAKE_CURRENT_BINARY_DIR}/04-lattice_boltzmann_part3.ipynb COPYONLY)
-configure_file(04-lattice_boltzmann_part2.ipynb ${CMAKE_CURRENT_BINARY_DIR}/04-lattice_boltzmann_part2.ipynb COPYONLY)
-configure_file(04-lattice_boltzmann_part1.ipynb ${CMAKE_CURRENT_BINARY_DIR}/04-lattice_boltzmann_part1.ipynb COPYONLY)
-configure_file(scripts/04-lattice_boltzmann_part3_solution.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part3_solution.py COPYONLY)
-configure_file(scripts/04-lattice_boltzmann_part4_solution.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution.py COPYONLY)
-configure_file(figures/latticeboltzmann-momentumexchange.png ${CMAKE_CURRENT_BINARY_DIR}/figures/latticeboltzmann-momentumexchange.png COPYONLY)
-configure_file(figures/latticeboltzmann-grid.png ${CMAKE_CURRENT_BINARY_DIR}/figures/latticeboltzmann-grid.png COPYONLY)
+configure_tutorial_target(
+  TARGET tutorial_04
+  DEPENDS
+  04-lattice_boltzmann_part1.ipynb
+  04-lattice_boltzmann_part2.ipynb
+  04-lattice_boltzmann_part3.ipynb
+  04-lattice_boltzmann_part4.ipynb
+  figures/latticeboltzmann-grid.png
+  figures/latticeboltzmann-momentumexchange.png
+  scripts/04-lattice_boltzmann_part3_solution.py
+  scripts/04-lattice_boltzmann_part4_solution.py
+)
 
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py"
@@ -13,9 +17,6 @@ add_custom_command(
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.cmake"
   COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.cmake"
 )
-
-add_custom_target(tutorial_04)
-add_dependencies(tutorials tutorial_04)
 
 nb_export(TARGET tutorial_04 SUFFIX "1" FILE "04-lattice_boltzmann_part1.ipynb" HTML_RUN)
 nb_export(TARGET tutorial_04 SUFFIX "2" FILE "04-lattice_boltzmann_part2.ipynb" HTML_RUN)

--- a/doc/tutorials/04-lattice_boltzmann/scripts/04-lattice_boltzmann_part4_solution_cut.cmake
+++ b/doc/tutorials/04-lattice_boltzmann/scripts/04-lattice_boltzmann_part4_solution_cut.cmake
@@ -1,0 +1,7 @@
+# This code splits 04-lattice_boltzmann_part4_solution.py such that it can be
+# added to the tutorial without having two espressomd.System class instances
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/scripts/04-lattice_boltzmann_part4_solution.py" script_full)
+string(FIND "${script_full}" "# Extract fluid velocity along the x-axis" cut_position)
+string(SUBSTRING "${script_full}" ${cut_position} -1 script_cut)
+string(PREPEND script_cut "import matplotlib.pyplot as plt\n")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/scripts/04-lattice_boltzmann_part4_solution_cut.py" "${script_cut}")

--- a/doc/tutorials/05-raspberry_electrophoresis/CMakeLists.txt
+++ b/doc/tutorials/05-raspberry_electrophoresis/CMakeLists.txt
@@ -1,9 +1,10 @@
-configure_file(05-raspberry_electrophoresis.ipynb ${CMAKE_CURRENT_BINARY_DIR}/05-raspberry_electrophoresis.ipynb COPYONLY)
-configure_file(figures/raspberry_snapshot.png ${CMAKE_CURRENT_BINARY_DIR}/figures/raspberry_snapshot.png COPYONLY)
-configure_file(posVsTime_sample.dat ${CMAKE_CURRENT_BINARY_DIR}/posVsTime_sample.dat COPYONLY)
-
-add_custom_target(tutorial_05)
-add_dependencies(tutorials tutorial_05)
+configure_tutorial_target(
+  TARGET tutorial_05
+  DEPENDS
+  05-raspberry_electrophoresis.ipynb
+  figures/raspberry_snapshot.png
+  posVsTime_sample.dat
+)
 
 nb_export(TARGET tutorial_05 SUFFIX "" FILE 05-raspberry_electrophoresis.ipynb
           HTML_RUN VAR_SUBST "num_iterations=20;num_steps_per_iteration=20;'trajectory_file=\"posVsTime_sample.dat\"'")

--- a/doc/tutorials/05-raspberry_electrophoresis/CMakeLists.txt
+++ b/doc/tutorials/05-raspberry_electrophoresis/CMakeLists.txt
@@ -3,6 +3,7 @@ configure_file(figures/raspberry_snapshot.png ${CMAKE_CURRENT_BINARY_DIR}/figure
 configure_file(posVsTime_sample.dat ${CMAKE_CURRENT_BINARY_DIR}/posVsTime_sample.dat COPYONLY)
 
 add_custom_target(tutorial_05)
+add_dependencies(tutorials tutorial_05)
 
-nb_export(TUTORIAL tutorial_05 FILE 05-raspberry_electrophoresis.ipynb
+nb_export(TARGET tutorial_05 SUFFIX "" FILE 05-raspberry_electrophoresis.ipynb
           HTML_RUN VAR_SUBST "num_iterations=20;num_steps_per_iteration=20;'trajectory_file=\"posVsTime_sample.dat\"'")

--- a/doc/tutorials/05-raspberry_electrophoresis/CMakeLists.txt
+++ b/doc/tutorials/05-raspberry_electrophoresis/CMakeLists.txt
@@ -2,7 +2,7 @@ configure_file(05-raspberry_electrophoresis.ipynb ${CMAKE_CURRENT_BINARY_DIR}/05
 configure_file(figures/raspberry_snapshot.png ${CMAKE_CURRENT_BINARY_DIR}/figures/raspberry_snapshot.png COPYONLY)
 configure_file(posVsTime_sample.dat ${CMAKE_CURRENT_BINARY_DIR}/posVsTime_sample.dat COPYONLY)
 
-add_custom_target(tutorials_05)
+add_custom_target(tutorial_05)
 
-nb_export(TUTORIAL tutorials_05 FILE 05-raspberry_electrophoresis.ipynb
+nb_export(TUTORIAL tutorial_05 FILE 05-raspberry_electrophoresis.ipynb
           HTML_RUN VAR_SUBST "num_iterations=20;num_steps_per_iteration=20;'trajectory_file=\"posVsTime_sample.dat\"'")

--- a/doc/tutorials/06-active_matter/CMakeLists.txt
+++ b/doc/tutorials/06-active_matter/CMakeLists.txt
@@ -1,10 +1,23 @@
-file(COPY "EXERCISES" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-file(COPY "SOLUTIONS" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-file(COPY "FIGURES" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-
-configure_file(06-active_matter.ipynb ${CMAKE_CURRENT_BINARY_DIR}/06-active_matter.ipynb COPYONLY)
-
-add_custom_target(tutorial_06)
-add_dependencies(tutorials tutorial_06)
+configure_tutorial_target(
+  TARGET tutorial_06
+  DEPENDS
+  06-active_matter.ipynb
+  FIGURES/friction.svg
+  FIGURES/pusher-puller.svg
+  FIGURES/enhanced.svg
+  FIGURES/geometry.svg
+  FIGURES/rectify.svg
+  FIGURES/rectification.svg
+  FIGURES/flow_field.svg
+  EXERCISES/enhanced_diffusion.py
+  EXERCISES/flow_field.py
+  EXERCISES/rectification_geometry.py
+  EXERCISES/rectification_simulation.py
+  SOLUTIONS/enhanced_diffusion.py
+  SOLUTIONS/flow_field.py
+  SOLUTIONS/rectification_geometry.py
+  SOLUTIONS/rectification_simulation.py
+  SOLUTIONS/solutions.txt
+)
 
 nb_export(TARGET tutorial_06 SUFFIX "" FILE "06-active_matter.ipynb" HTML_RUN)

--- a/doc/tutorials/06-active_matter/CMakeLists.txt
+++ b/doc/tutorials/06-active_matter/CMakeLists.txt
@@ -5,5 +5,6 @@ file(COPY "FIGURES" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 configure_file(06-active_matter.ipynb ${CMAKE_CURRENT_BINARY_DIR}/06-active_matter.ipynb COPYONLY)
 
 add_custom_target(tutorial_06)
+add_dependencies(tutorials tutorial_06)
 
-nb_export(TUTORIAL tutorial_06 FILE "06-active_matter.ipynb" HTML_RUN)
+nb_export(TARGET tutorial_06 SUFFIX "" FILE "06-active_matter.ipynb" HTML_RUN)

--- a/doc/tutorials/06-active_matter/CMakeLists.txt
+++ b/doc/tutorials/06-active_matter/CMakeLists.txt
@@ -4,6 +4,6 @@ file(COPY "FIGURES" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 
 configure_file(06-active_matter.ipynb ${CMAKE_CURRENT_BINARY_DIR}/06-active_matter.ipynb COPYONLY)
 
-add_custom_target(tutorials_06)
+add_custom_target(tutorial_06)
 
-nb_export(TUTORIAL tutorials_06 FILE "06-active_matter.ipynb" HTML_RUN)
+nb_export(TUTORIAL tutorial_06 FILE "06-active_matter.ipynb" HTML_RUN)

--- a/doc/tutorials/07-electrokinetics/CMakeLists.txt
+++ b/doc/tutorials/07-electrokinetics/CMakeLists.txt
@@ -5,5 +5,6 @@ configure_file(figures/schlitzpore_3d.png ${CMAKE_CURRENT_BINARY_DIR}/figures/sc
 configure_file(07-electrokinetics.ipynb ${CMAKE_CURRENT_BINARY_DIR}/07-electrokinetics.ipynb COPYONLY)
 
 add_custom_target(tutorial_07)
+add_dependencies(tutorials tutorial_07)
 
-nb_export(TUTORIAL tutorial_07 FILE "07-electrokinetics.ipynb" HTML_RUN VAR_SUBST "integration_length=600;dt=0.5" ADD_SCRIPTS "scripts/eof_analytical.py;scripts/plot.py")
+nb_export(TARGET tutorial_07 SUFFIX "" FILE "07-electrokinetics.ipynb" HTML_RUN VAR_SUBST "integration_length=600;dt=0.5" ADD_SCRIPTS "scripts/eof_analytical.py;scripts/plot.py")

--- a/doc/tutorials/07-electrokinetics/CMakeLists.txt
+++ b/doc/tutorials/07-electrokinetics/CMakeLists.txt
@@ -1,10 +1,11 @@
-configure_file(scripts/eof_analytical.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/eof_analytical.py COPYONLY)
-configure_file(scripts/plot.py ${CMAKE_CURRENT_BINARY_DIR}/scripts/plot.py COPYONLY)
-configure_file(figures/profiles.png ${CMAKE_CURRENT_BINARY_DIR}/figures/profiles.png  COPYONLY)
-configure_file(figures/schlitzpore_3d.png ${CMAKE_CURRENT_BINARY_DIR}/figures/schlitzpore_3d.png COPYONLY)
-configure_file(07-electrokinetics.ipynb ${CMAKE_CURRENT_BINARY_DIR}/07-electrokinetics.ipynb COPYONLY)
-
-add_custom_target(tutorial_07)
-add_dependencies(tutorials tutorial_07)
+configure_tutorial_target(
+  TARGET tutorial_07
+  DEPENDS
+  07-electrokinetics.ipynb
+  figures/profiles.png
+  figures/schlitzpore_3d.png
+  scripts/eof_analytical.py
+  scripts/plot.py
+)
 
 nb_export(TARGET tutorial_07 SUFFIX "" FILE "07-electrokinetics.ipynb" HTML_RUN VAR_SUBST "integration_length=600;dt=0.5" ADD_SCRIPTS "scripts/eof_analytical.py;scripts/plot.py")

--- a/doc/tutorials/07-electrokinetics/CMakeLists.txt
+++ b/doc/tutorials/07-electrokinetics/CMakeLists.txt
@@ -4,6 +4,6 @@ configure_file(figures/profiles.png ${CMAKE_CURRENT_BINARY_DIR}/figures/profiles
 configure_file(figures/schlitzpore_3d.png ${CMAKE_CURRENT_BINARY_DIR}/figures/schlitzpore_3d.png COPYONLY)
 configure_file(07-electrokinetics.ipynb ${CMAKE_CURRENT_BINARY_DIR}/07-electrokinetics.ipynb COPYONLY)
 
-add_custom_target(tutorials_07)
+add_custom_target(tutorial_07)
 
-nb_export(TUTORIAL tutorials_07 FILE "07-electrokinetics.ipynb" HTML_RUN VAR_SUBST "integration_length=600;dt=0.5" ADD_SCRIPTS "scripts/eof_analytical.py;scripts/plot.py")
+nb_export(TUTORIAL tutorial_07 FILE "07-electrokinetics.ipynb" HTML_RUN VAR_SUBST "integration_length=600;dt=0.5" ADD_SCRIPTS "scripts/eof_analytical.py;scripts/plot.py")

--- a/doc/tutorials/08-visualization/CMakeLists.txt
+++ b/doc/tutorials/08-visualization/CMakeLists.txt
@@ -1,6 +1,3 @@
-configure_file(08-visualization.ipynb ${CMAKE_CURRENT_BINARY_DIR}/08-visualization.ipynb COPYONLY)
-
-add_custom_target(tutorial_08)
-add_dependencies(tutorials tutorial_08)
+configure_tutorial_target(TARGET tutorial_08 DEPENDS 08-visualization.ipynb)
 
 nb_export(TARGET tutorial_08 SUFFIX "" FILE "08-visualization.ipynb" HTML_RUN)

--- a/doc/tutorials/08-visualization/CMakeLists.txt
+++ b/doc/tutorials/08-visualization/CMakeLists.txt
@@ -1,5 +1,6 @@
 configure_file(08-visualization.ipynb ${CMAKE_CURRENT_BINARY_DIR}/08-visualization.ipynb COPYONLY)
 
 add_custom_target(tutorial_08)
+add_dependencies(tutorials tutorial_08)
 
-nb_export(TUTORIAL tutorial_08 FILE "08-visualization.ipynb" HTML_RUN)
+nb_export(TARGET tutorial_08 SUFFIX "" FILE "08-visualization.ipynb" HTML_RUN)

--- a/doc/tutorials/08-visualization/CMakeLists.txt
+++ b/doc/tutorials/08-visualization/CMakeLists.txt
@@ -1,5 +1,5 @@
 configure_file(08-visualization.ipynb ${CMAKE_CURRENT_BINARY_DIR}/08-visualization.ipynb COPYONLY)
 
-add_custom_target(tutorials_08)
+add_custom_target(tutorial_08)
 
-nb_export(TUTORIAL tutorials_08 FILE "08-visualization.ipynb" HTML_RUN)
+nb_export(TUTORIAL tutorial_08 FILE "08-visualization.ipynb" HTML_RUN)

--- a/doc/tutorials/11-ferrofluid/CMakeLists.txt
+++ b/doc/tutorials/11-ferrofluid/CMakeLists.txt
@@ -1,12 +1,13 @@
-configure_file(11-ferrofluid_part1.ipynb ${CMAKE_CURRENT_BINARY_DIR}/11-ferrofluid_part1.ipynb COPYONLY)
-configure_file(11-ferrofluid_part2.ipynb ${CMAKE_CURRENT_BINARY_DIR}/11-ferrofluid_part2.ipynb COPYONLY)
-configure_file(11-ferrofluid_part3.ipynb ${CMAKE_CURRENT_BINARY_DIR}/11-ferrofluid_part3.ipynb COPYONLY)
-configure_file(figures/Electro-Steric_Stabilization.jpg ${CMAKE_CURRENT_BINARY_DIR}/figures/Electro-Steric_Stabilization.jpg COPYONLY)
-configure_file(figures/Ferrofluid_Magnet_under_glass_edit.jpg ${CMAKE_CURRENT_BINARY_DIR}/figures/Ferrofluid_Magnet_under_glass_edit.jpg COPYONLY)
-configure_file(figures/headtotailconf.png ${CMAKE_CURRENT_BINARY_DIR}/figures/headtotailconf.png COPYONLY)
-
-add_custom_target(tutorial_11)
-add_dependencies(tutorials tutorial_11)
+configure_tutorial_target(
+  TARGET tutorial_11
+  DEPENDS
+  11-ferrofluid_part1.ipynb
+  11-ferrofluid_part2.ipynb
+  11-ferrofluid_part3.ipynb
+  figures/Electro-Steric_Stabilization.jpg
+  figures/Ferrofluid_Magnet_under_glass_edit.jpg
+  figures/headtotailconf.png
+)
 
 nb_export(TARGET tutorial_11 SUFFIX "1" FILE "11-ferrofluid_part1.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10")
 nb_export(TARGET tutorial_11 SUFFIX "2" FILE "11-ferrofluid_part2.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0,1,2,3,4.5,8];loops=100")

--- a/doc/tutorials/11-ferrofluid/CMakeLists.txt
+++ b/doc/tutorials/11-ferrofluid/CMakeLists.txt
@@ -6,7 +6,8 @@ configure_file(figures/Ferrofluid_Magnet_under_glass_edit.jpg ${CMAKE_CURRENT_BI
 configure_file(figures/headtotailconf.png ${CMAKE_CURRENT_BINARY_DIR}/figures/headtotailconf.png COPYONLY)
 
 add_custom_target(tutorial_11)
+add_dependencies(tutorials tutorial_11)
 
-nb_export(TUTORIAL tutorial_11_1 FILE "11-ferrofluid_part1.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10")
-nb_export(TUTORIAL tutorial_11_2 FILE "11-ferrofluid_part2.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0,1,2,3,4.5,8];loops=100")
-nb_export(TUTORIAL tutorial_11_3 FILE "11-ferrofluid_part3.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0.5,1,2,4,8];loops=200;loops_m=100")
+nb_export(TARGET tutorial_11 SUFFIX "1" FILE "11-ferrofluid_part1.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10")
+nb_export(TARGET tutorial_11 SUFFIX "2" FILE "11-ferrofluid_part2.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0,1,2,3,4.5,8];loops=100")
+nb_export(TARGET tutorial_11 SUFFIX "3" FILE "11-ferrofluid_part3.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0.5,1,2,4,8];loops=200;loops_m=100")

--- a/doc/tutorials/11-ferrofluid/CMakeLists.txt
+++ b/doc/tutorials/11-ferrofluid/CMakeLists.txt
@@ -5,8 +5,8 @@ configure_file(figures/Electro-Steric_Stabilization.jpg ${CMAKE_CURRENT_BINARY_D
 configure_file(figures/Ferrofluid_Magnet_under_glass_edit.jpg ${CMAKE_CURRENT_BINARY_DIR}/figures/Ferrofluid_Magnet_under_glass_edit.jpg COPYONLY)
 configure_file(figures/headtotailconf.png ${CMAKE_CURRENT_BINARY_DIR}/figures/headtotailconf.png COPYONLY)
 
-add_custom_target(tutorials_11)
+add_custom_target(tutorial_11)
 
-nb_export(TUTORIAL tutorials_11_1 FILE "11-ferrofluid_part1.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10")
-nb_export(TUTORIAL tutorials_11_2 FILE "11-ferrofluid_part2.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0,1,2,3,4.5,8];loops=100")
-nb_export(TUTORIAL tutorials_11_3 FILE "11-ferrofluid_part3.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0.5,1,2,4,8];loops=200;loops_m=100")
+nb_export(TUTORIAL tutorial_11_1 FILE "11-ferrofluid_part1.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10")
+nb_export(TUTORIAL tutorial_11_2 FILE "11-ferrofluid_part2.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0,1,2,3,4.5,8];loops=100")
+nb_export(TUTORIAL tutorial_11_3 FILE "11-ferrofluid_part3.ipynb" HTML_RUN VAR_SUBST "equil_steps=100;equil_rounds=10;alphas=[0.5,1,2,4,8];loops=200;loops_m=100")

--- a/doc/tutorials/12-constant_pH/CMakeLists.txt
+++ b/doc/tutorials/12-constant_pH/CMakeLists.txt
@@ -1,7 +1,4 @@
-configure_file(12-constant_pH.ipynb ${CMAKE_CURRENT_BINARY_DIR}/12-constant_pH.ipynb COPYONLY)
-
-add_custom_target(tutorial_12)
-add_dependencies(tutorials tutorial_12)
+configure_tutorial_target(TARGET tutorial_12 DEPENDS 12-constant_pH.ipynb)
 
 nb_export(TARGET tutorial_12 SUFFIX "" FILE "12-constant_pH.ipynb" HTML_RUN)
 

--- a/doc/tutorials/12-constant_pH/CMakeLists.txt
+++ b/doc/tutorials/12-constant_pH/CMakeLists.txt
@@ -1,6 +1,7 @@
 configure_file(12-constant_pH.ipynb ${CMAKE_CURRENT_BINARY_DIR}/12-constant_pH.ipynb COPYONLY)
 
 add_custom_target(tutorial_12)
+add_dependencies(tutorials tutorial_12)
 
-nb_export(TUTORIAL tutorial_12 FILE "12-constant_pH.ipynb" HTML_RUN)
+nb_export(TARGET tutorial_12 SUFFIX "" FILE "12-constant_pH.ipynb" HTML_RUN)
 

--- a/doc/tutorials/12-constant_pH/CMakeLists.txt
+++ b/doc/tutorials/12-constant_pH/CMakeLists.txt
@@ -1,6 +1,6 @@
 configure_file(12-constant_pH.ipynb ${CMAKE_CURRENT_BINARY_DIR}/12-constant_pH.ipynb COPYONLY)
 
-add_custom_target(tutorials_12)
+add_custom_target(tutorial_12)
 
-nb_export(TUTORIAL tutorials_12 FILE "12-constant_pH.ipynb" HTML_RUN)
+nb_export(TUTORIAL tutorial_12 FILE "12-constant_pH.ipynb" HTML_RUN)
 

--- a/doc/tutorials/CMakeLists.txt
+++ b/doc/tutorials/CMakeLists.txt
@@ -17,6 +17,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
+# Register a new tutorial target that depends on a list of files that need
+# to be copied from the source directory to the build directory. Make the
+# tutorial target a dependency of target `tutorials`.
+function(configure_tutorial_target)
+  cmake_parse_arguments(CONFIGURE "" "TARGET" "DEPENDS" ${ARGN})
+  set(TARGET_DEPENDENCIES "")
+  foreach(filepath ${CONFIGURE_DEPENDS})
+    list(APPEND TARGET_DEPENDENCIES "${CMAKE_CURRENT_BINARY_DIR}/${filepath}")
+    add_custom_command(
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${filepath}"
+      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${filepath}"
+      COMMAND ${CMAKE_COMMAND} -E copy
+              "${CMAKE_CURRENT_SOURCE_DIR}/${filepath}"
+              "${CMAKE_CURRENT_BINARY_DIR}/${filepath}"
+    )
+  endforeach(filepath)
+  add_custom_target(${CONFIGURE_TARGET} DEPENDS ${TARGET_DEPENDENCIES})
+  add_dependencies(tutorials ${CONFIGURE_TARGET})
+endfunction(configure_tutorial_target)
+
+
+# Convert a tutorial to the Python and HTML formats. Make these files
+# dependencies of targets `tutorials_html` and `tutorials_python`.
 function(NB_EXPORT)
   cmake_parse_arguments(NB_EXPORT "HTML_RUN" "FILE;TARGET;SUFFIX" "VAR_SUBST;ADD_SCRIPTS" ${ARGN})
 

--- a/doc/tutorials/CMakeLists.txt
+++ b/doc/tutorials/CMakeLists.txt
@@ -82,51 +82,51 @@ add_subdirectory(12-constant_pH)
 
 ### here: add the appropriate tutorial target after DEPENDS
 add_custom_target(tutorials DEPENDS
-  tutorials_01
-  tutorials_02
-  tutorials_04
-  tutorials_05
-  tutorials_06
-  tutorials_07
-  tutorials_08
-  tutorials_11
-  tutorials_12
+  tutorial_01
+  tutorial_02
+  tutorial_04
+  tutorial_05
+  tutorial_06
+  tutorial_07
+  tutorial_08
+  tutorial_11
+  tutorial_12
   )
 
 add_custom_target(tutorials_html DEPENDS
   tutorials
-  tutorials_01_html
-  tutorials_02_1_html
-  tutorials_02_2_html
-  tutorials_04_1_html
-  tutorials_04_2_html
-  tutorials_04_3_html
-  tutorials_04_4_html
-  tutorials_05_html
-  tutorials_06_html
-  tutorials_07_html
-  tutorials_08_html
-  tutorials_11_1_html
-  tutorials_11_2_html
-  tutorials_11_3_html
-  tutorials_12_html
+  tutorial_01_html
+  tutorial_02_1_html
+  tutorial_02_2_html
+  tutorial_04_1_html
+  tutorial_04_2_html
+  tutorial_04_3_html
+  tutorial_04_4_html
+  tutorial_05_html
+  tutorial_06_html
+  tutorial_07_html
+  tutorial_08_html
+  tutorial_11_1_html
+  tutorial_11_2_html
+  tutorial_11_3_html
+  tutorial_12_html
   )
 
 add_custom_target(tutorials_python_only DEPENDS
-  tutorials_01_python
-  tutorials_02_1_python
-  tutorials_02_2_python
-  tutorials_04_1_python
-  tutorials_04_2_python
-  tutorials_04_3_python
-  tutorials_04_4_python
-  tutorials_05_python
-  tutorials_07_python
-  tutorials_08_python
-  tutorials_11_1_python
-  tutorials_11_2_python
-  tutorials_11_3_python
-  tutorials_12_python
+  tutorial_01_python
+  tutorial_02_1_python
+  tutorial_02_2_python
+  tutorial_04_1_python
+  tutorial_04_2_python
+  tutorial_04_3_python
+  tutorial_04_4_python
+  tutorial_05_python
+  tutorial_07_python
+  tutorial_08_python
+  tutorial_11_1_python
+  tutorial_11_2_python
+  tutorial_11_3_python
+  tutorial_12_python
   )
 
 add_custom_target(tutorials_python DEPENDS

--- a/doc/tutorials/CMakeLists.txt
+++ b/doc/tutorials/CMakeLists.txt
@@ -18,9 +18,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 function(NB_EXPORT)
-  cmake_parse_arguments(NB_EXPORT "HTML_RUN" "FILE;TUTORIAL" "VAR_SUBST;ADD_SCRIPTS" ${ARGN})
+  cmake_parse_arguments(NB_EXPORT "HTML_RUN" "FILE;TARGET;SUFFIX" "VAR_SUBST;ADD_SCRIPTS" ${ARGN})
 
   set(NB_FILE "${CMAKE_CURRENT_BINARY_DIR}/${NB_EXPORT_FILE}")
+  set(DEPENDENCY_OF_TARGET "${NB_EXPORT_TARGET}")
+  if(NOT "${NB_EXPORT_SUFFIX}" STREQUAL "")
+    set(NB_EXPORT_TARGET "${NB_EXPORT_TARGET}_${NB_EXPORT_SUFFIX}")
+  endif()
   get_filename_component(NB_FILE_BASE ${NB_FILE} NAME_WE)
   get_filename_component(NB_FILE_EXT ${NB_FILE} EXT)
   set(HTML_FILE "${NB_FILE_BASE}.html")
@@ -63,9 +67,16 @@ function(NB_EXPORT)
     ${NB_FILE}
     )
 
-  add_custom_target("${NB_EXPORT_TUTORIAL}_html" DEPENDS ${HTML_FILE})
-  add_custom_target("${NB_EXPORT_TUTORIAL}_python" DEPENDS ${PY_FILE})
+  add_custom_target("${NB_EXPORT_TARGET}_html" DEPENDS ${HTML_FILE} ${DEPENDENCY_OF_TARGET})
+  add_custom_target("${NB_EXPORT_TARGET}_python" DEPENDS ${PY_FILE} ${DEPENDENCY_OF_TARGET})
+  add_dependencies(tutorials_html "${NB_EXPORT_TARGET}_html")
+  add_dependencies(tutorials_python "${NB_EXPORT_TARGET}_python")
 endfunction(NB_EXPORT)
+
+
+add_custom_target(tutorials)
+add_custom_target(tutorials_html)
+add_custom_target(tutorials_python)
 
 
 ### Here: add new directory
@@ -79,60 +90,6 @@ add_subdirectory(08-visualization)
 add_subdirectory(11-ferrofluid)
 add_subdirectory(12-constant_pH)
 
-
-### here: add the appropriate tutorial target after DEPENDS
-add_custom_target(tutorials DEPENDS
-  tutorial_01
-  tutorial_02
-  tutorial_04
-  tutorial_05
-  tutorial_06
-  tutorial_07
-  tutorial_08
-  tutorial_11
-  tutorial_12
-  )
-
-add_custom_target(tutorials_html DEPENDS
-  tutorials
-  tutorial_01_html
-  tutorial_02_1_html
-  tutorial_02_2_html
-  tutorial_04_1_html
-  tutorial_04_2_html
-  tutorial_04_3_html
-  tutorial_04_4_html
-  tutorial_05_html
-  tutorial_06_html
-  tutorial_07_html
-  tutorial_08_html
-  tutorial_11_1_html
-  tutorial_11_2_html
-  tutorial_11_3_html
-  tutorial_12_html
-  )
-
-add_custom_target(tutorials_python_only DEPENDS
-  tutorial_01_python
-  tutorial_02_1_python
-  tutorial_02_2_python
-  tutorial_04_1_python
-  tutorial_04_2_python
-  tutorial_04_3_python
-  tutorial_04_4_python
-  tutorial_05_python
-  tutorial_07_python
-  tutorial_08_python
-  tutorial_11_1_python
-  tutorial_11_2_python
-  tutorial_11_3_python
-  tutorial_12_python
-  )
-
-add_custom_target(tutorials_python DEPENDS
-  tutorials
-  tutorials_python_only
-  )
 
 configure_file(Readme.rst ${CMAKE_CURRENT_BINARY_DIR}/Readme.rst COPYONLY)
 configure_file(html_runner.py ${CMAKE_CURRENT_BINARY_DIR}/html_runner.py)

--- a/testsuite/scripts/tutorials/CMakeLists.txt
+++ b/testsuite/scripts/tutorials/CMakeLists.txt
@@ -17,7 +17,7 @@ set(TUTORIALS_DIR "${CMAKE_CURRENT_BINARY_DIR}/local_tutorials")
 add_custom_target(local_tutorials
                   COMMAND ${CMAKE_COMMAND} -E remove_directory ${TUTORIALS_DIR}  # cleanup
                   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/doc/tutorials ${TUTORIALS_DIR}
-                  DEPENDS tutorials_python_only)
+                  DEPENDS tutorials_python)
 
 tutorial_test(FILE test_01-lennard_jones.py)
 tutorial_test(FILE test_02-charged_system-1.py)


### PR DESCRIPTION
Description of changes:
- modifying a tutorial dependency (figure or script) in the source directory will automatically update it in the build directory (fixes #3472)
- tutorials are now fully independent of each other, e.g. `make tutorial_04` only re-generates files for tutorial 04 in the build directory
- the list of dependencies for targets `tutorials`, `tutorials_html`, `tutorials_python` are now automatically generated instead of being manually curated