### PR TITLE
Remove infinite loop in linear polymer

### DIFF
--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -177,6 +177,7 @@ draw_polymer_positions(PartCfg &partCfg, int const n_polymers,
   // create remaining monomers' positions by backtracking.
   for (int p = 0; p < n_polymers; ++p) {
     for (int attempts_poly = 0; attempts_poly < max_tries; attempts_poly++) {
+      int rejections = 0;
       while (positions[p].size() < beads_per_chain) {
         auto pos = draw_valid_monomer_position(p, positions[p].size());
 
@@ -186,6 +187,11 @@ draw_polymer_positions(PartCfg &partCfg, int const n_polymers,
         } else if (not positions[p].empty()) {
           /* Go back one position and try again */
           positions[p].pop_back();
+          rejections++;
+          if (rejections > max_tries) {
+            /* Give up for this try. */
+            break;
+          }
         } else {
           /* Give up for this try. */
           break;

--- a/testsuite/python/polymer_linear.py
+++ b/testsuite/python/polymer_linear.py
@@ -185,7 +185,6 @@ class LinearPolymerPositions(ut.TestCase):
 
         z_components = positions[:, :, 2][0]
         for z in z_components:
-            print(z)
             self.assertGreaterEqual(z, 0.5 * self.box_l)
 
         # assert that illegal start position raises error

--- a/testsuite/python/polymer_linear.py
+++ b/testsuite/python/polymer_linear.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest as ut
 import numpy as np
+import random
 import espressomd
 from espressomd import polymer
 import espressomd.shapes
@@ -33,10 +34,9 @@ class LinearPolymerPositions(ut.TestCase):
     """
 
     box_l = 15
-    seed = 23
+    seed = random.randint(0, 1000)
 
     system = espressomd.System(box_l=[box_l, box_l, box_l])
-    np.random.seed(1234)
 
     def assertShape(self, positions, n_poly, n_mono):
         """


### PR DESCRIPTION
Description of changes:
- fix infinite loop in `draw_polymer_positions()` (regression from #3484)
- remove fixed seed in the `polymer_linear.py` test that used to hide a bug in the previous implementation of `draw_polymer_positions()`
