### PR TITLE
Cleanup cython

### DIFF
--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1366,7 +1366,7 @@ void remove_id_from_map(int part_id, int type) {
 int get_random_p_id(int type, int random_index_in_type_map) {
   if (random_index_in_type_map + 1 > particle_type_map.at(type).size())
     throw std::runtime_error("The provided index exceeds the number of "
-                             "particles listed in the type_map");
+                             "particle types listed in the particle_type_map");
   return *std::next(particle_type_map[type].begin(), random_index_in_type_map);
 }
 
@@ -1376,6 +1376,9 @@ void add_id_to_type_map(int part_id, int type) {
 }
 
 int number_of_particles_with_type(int type) {
+  if (particle_type_map.count(type) == 0)
+    throw std::runtime_error("The provided particle type does not exist in "
+                             "the particle_type_map");
   return static_cast<int>(particle_type_map.at(type).size());
 }
 

--- a/src/python/espressomd/__init__.py
+++ b/src/python/espressomd/__init__.py
@@ -20,11 +20,11 @@
 # Define the espressomd package
 
 # Initialize MPI, start the main loop on the slaves
-import espressomd._init
+from . import _init
 
-from espressomd.system import System
-from espressomd.code_info import features, all_features
-from espressomd.cuda_init import gpu_available
+from .system import System
+from .code_info import features, all_features
+from .cuda_init import gpu_available
 
 
 class FeaturesError(Exception):

--- a/src/python/espressomd/actors.pyx
+++ b/src/python/espressomd/actors.pyx
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 include "myconfig.pxi"
 from .highlander import ThereCanOnlyBeOne
-from .utils import handle_errors
+from .utils cimport handle_errors
 
 cdef class Actor:
 

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -22,9 +22,7 @@
 cimport numpy as np
 from espressomd.utils cimport *
 from .utils cimport Vector9d
-from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
-from libcpp.map cimport map  # import std::map as map
 
 cdef extern from "<array>" namespace "std" nogil:
     cdef cppclass array4 "std::array<double, 4>":

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -20,8 +20,7 @@
 # For C-extern Analysis
 
 cimport numpy as np
-from espressomd.utils cimport *
-from .utils cimport Vector9d
+from .utils cimport Vector3i, Vector3d, Vector9d, List
 from libcpp.vector cimport vector  # import std::vector as vector
 
 cdef extern from "<array>" namespace "std" nogil:

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -19,23 +19,19 @@
 # For C-extern Analysis
 include "myconfig.pxi"
 from . cimport analyze
-from . cimport particle_data
-from . import code_info
-from . import particle_data
 from libcpp.vector cimport vector  # import std::vector as vector
-from .interactions import *
-from espressomd.interactions cimport *
+from .interactions cimport BONDED_IA_NONE
+from .interactions cimport bonded_ia_params
 import numpy as np
 cimport numpy as np
-from globals cimport n_configs
 from .globals import Globals
 
 from collections import OrderedDict
 from .system import System
 from .utils import array_locked, is_valid_type
-from .utils cimport Vector3i, Vector3d, Vector9d, List, handle_errors, \
-    check_type_or_throw_except, \
-    create_nparray_from_double_array, \
+from .utils cimport Vector3i, Vector3d, Vector9d, List
+from .utils cimport handle_errors, check_type_or_throw_except
+from .utils cimport create_nparray_from_double_array, \
     create_nparray_from_int_list, \
     create_int_list_from_python_object
 
@@ -54,7 +50,7 @@ class Analysis:
     def append(self):
         """Append configuration for averaged analysis."""
         assert analyze.n_part, "No particles to append!"
-        if analyze.n_configs > 0:
+        if n_configs > 0:
             assert analyze.n_part_conf == analyze.n_part, \
                 "All configurations stored must have the same length"
 

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -32,7 +32,8 @@ from globals cimport n_configs
 from collections import OrderedDict
 from .system import System
 from .utils import array_locked, is_valid_type
-from .utils cimport handle_errors, check_type_or_throw_except, \
+from .utils cimport Vector3i, Vector3d, Vector9d, List, handle_errors, \
+    check_type_or_throw_except, \
     create_nparray_from_double_array, \
     create_nparray_from_int_list, \
     create_int_list_from_python_object

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -24,9 +24,7 @@ from . cimport particle_data
 from . import utils
 from . import code_info
 from . import particle_data
-from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
-from libcpp.map cimport map  # import std::map as map
 from .interactions import *
 from espressomd.interactions cimport *
 import numpy as np

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -19,9 +19,7 @@
 # For C-extern Analysis
 include "myconfig.pxi"
 from . cimport analyze
-from . cimport utils
 from . cimport particle_data
-from . import utils
 from . import code_info
 from . import particle_data
 from libcpp.vector cimport vector  # import std::vector as vector
@@ -31,11 +29,13 @@ import numpy as np
 cimport numpy as np
 from globals cimport n_configs
 
-from .utils import array_locked
-
 from collections import OrderedDict
 from .system import System
-from espressomd.utils import is_valid_type
+from .utils import array_locked, is_valid_type
+from .utils cimport handle_errors, check_type_or_throw_except, \
+    create_nparray_from_double_array, \
+    create_nparray_from_int_list, \
+    create_int_list_from_python_object
 
 
 class Analysis:

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -28,6 +28,7 @@ from espressomd.interactions cimport *
 import numpy as np
 cimport numpy as np
 from globals cimport n_configs
+from .globals import Globals
 
 from collections import OrderedDict
 from .system import System
@@ -845,7 +846,7 @@ class Analysis:
                 n_conf = n_configs
 
         if r_max is None:
-            r_max = min_box_l / 2.0
+            r_max = min(Globals().box_l) / 2
 
         cdef vector[double] rdf
         rdf.resize(r_bins)
@@ -920,7 +921,7 @@ class Analysis:
             raise ValueError("type_list_b has to be a list!")
 
         if r_max is None:
-            r_max = min_box_l / 2.0
+            r_max = min(Globals().box_l) / 2
 
         assert r_min >= 0.0, "r_min was chosen too small!"
         assert not log_flag or r_min != 0.0, "r_min cannot include zero"

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -23,8 +23,6 @@ from libcpp cimport bool
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 
-from .utils cimport Vector3i
-
 cdef extern from "communication.hpp":
     void mpi_bcast_cell_structure(int cs)
     int n_nodes

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -21,8 +21,8 @@ from . cimport cellsystem
 from . cimport integrate
 from globals cimport *
 import numpy as np
-from espressomd.utils cimport handle_errors
-from espressomd.utils import is_valid_type
+from .utils cimport handle_errors
+from .utils import is_valid_type
 
 cdef class CellSystem:
     def set_domain_decomposition(self, use_verlet_lists=True,

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -16,19 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from grid cimport node_grid
-from . cimport cellsystem
+from .grid cimport node_grid
 from . cimport integrate
-from globals cimport *
+from .globals cimport FIELD_SKIN, FIELD_NODEGRID, FIELD_MAXNUMCELLS, FIELD_MINNUMCELLS
+from .globals cimport max_cut, verlet_reuse, n_layers, dd, cell_structure, \
+    min_num_cells, max_num_cells, skin
+from .globals cimport mpi_bcast_parameter, calc_processor_min_num_cells
 import numpy as np
 from .utils cimport handle_errors
 from .utils import is_valid_type
 
 cdef class CellSystem:
     def set_domain_decomposition(self, use_verlet_lists=True,
-                                 fully_connected=[False,
-                                                  False,
-                                                  False]):
+                                 fully_connected=[False, False, False]):
         """
         Activates domain decomposition cell system.
 

--- a/src/python/espressomd/checkpointing.py
+++ b/src/python/espressomd/checkpointing.py
@@ -21,7 +21,7 @@ import inspect
 import os
 import re
 import signal
-from espressomd.utils import is_valid_type
+from .utils import is_valid_type
 
 try:
     import cPickle as pickle

--- a/src/python/espressomd/collision_detection.pyx
+++ b/src/python/espressomd/collision_detection.pyx
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from .script_interface import ScriptInterfaceHelper, script_interface_register
-from .utils import handle_errors, to_str
+from .utils import to_str
+from .utils cimport handle_errors
 from .interactions import BondedInteraction, BondedInteractions
 
 

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -14,8 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import espressomd.interactions
-from espressomd import has_features
+from . import interactions
+from .__init__ import has_features
 
 # Dict with Drude type infos
 drude_dict = {}
@@ -203,7 +203,7 @@ def setup_and_add_drude_exclusion_bonds(system, verbose=False):
         #...exclusions with core
         qd = drude_dict[td]["q"]  # Drude charge
         qc = drude_dict[td]["qc"]  # Core charge
-        subtr_sr_bond = espressomd.interactions.BondedCoulombSRBond(
+        subtr_sr_bond = interactions.BondedCoulombSRBond(
             q1q2=-qd * qc)
         system.bonded_inter.add(subtr_sr_bond)
         drude_dict[td]["subtr_sr_bonds_drude-core"] = subtr_sr_bond
@@ -250,7 +250,7 @@ def setup_intramol_exclusion_bonds(system, mol_drude_types, mol_core_types,
             #...excluding the Drude core partner
             if drude_dict[td]["core_type"] != tc:
                 qd = drude_dict[td]["q"]  # Drude charge
-                subtr_sr_bond = espressomd.interactions.BondedCoulombSRBond(
+                subtr_sr_bond = interactions.BondedCoulombSRBond(
                     q1q2=-qd * qp)
                 system.bonded_inter.add(subtr_sr_bond)
                 drude_dict[td]["subtr_sr_bonds_intramol"][

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -35,29 +35,35 @@ def add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
     """
     Adds a Drude particle with specified id, type, and mass to the system.
     Checks if different Drude particles have different types.
-    Collects types/charges/polarizations/Thole factors for intramol. core-Drude short-range exclusion and Thole interaction.
+    Collects types/charges/polarizations/Thole factors for intramolecular
+    core-Drude short-range exclusion and Thole interaction.
 
     Attributes
     ----------
 
-    system : Instance of :attr:`espressomd.system.System`
-    harmonic_bond: This method adds this harmonic bond to between Drude particle and core
-    thermalized_bond: This method adds this thermalized_bond to between Drude particle and core
-    p_core: The existing core particle
+    system : :class:`espressomd.system.System`
+    harmonic_bond: :class:`espressomd.interactions.HarmonicBond`
+        Add this harmonic bond to between Drude particle and core
+    thermalized_bond: :class:`espressomd.interactions.ThermalizedBond`
+        Add this thermalized_bond to between Drude particle and core
+    p_core: :class:`espressomd.particle_data.ParticleHandle`
+        The existing core particle
     id_drude: :obj:`int`
-              This method creates the Drude particle and assigns this id.
+        This method creates the Drude particle and assigns this id.
     type_drude: :obj:`int`
-                The type of the newly created Drude particle
+        The type of the newly created Drude particle
     alpha : :obj:`float`
-            The polarizability in units of inverse volume. Related to the charge of the Drude particle.
+        The polarizability in units of inverse volume. Related to the charge
+        of the Drude particle.
     mass_drude : :obj:`float`
-                 The mass of the newly created Drude particle
+        The mass of the newly created Drude particle
     coulomb_prefactor : :obj:`float`
-                        Required to calculate the charge of the Drude particle.
+        Required to calculate the charge of the Drude particle.
     thole_damping : :obj:`float`
-                    Thole damping factor of the Drude pair. Comes to effect if add_all_thole() method is used.
+        Thole damping factor of the Drude pair. Comes to effect if
+        :meth:`add_all_thole()` method is used.
     verbose : :obj:`bool`
-             Turns on verbosity.
+        Turns on verbosity.
 
     """
 
@@ -132,13 +138,13 @@ def add_thole_pair_damping(system, t1, t2, verbose=False):
     Attributes
     ----------
 
-    system : Instance of :attr:`espressomd.system.System`
+    system : :class:`espressomd.system.System`
     t1 : :obj:`int`
         Type 1
     t2 : :obj:`int`
         Type 2
     verbose : :obj:`bool`
-             Turns on verbosity.
+        Turns on verbosity.
 
     """
 
@@ -155,14 +161,15 @@ def add_thole_pair_damping(system, t1, t2, verbose=False):
 
 def add_all_thole(system, verbose=False):
     """
-    Calls add_thole_pair_damping() for all necessary combinations to create the interactions.
+    Calls :meth:`add_thole_pair_damping()` for all necessary combinations to
+    create the interactions.
 
     Attributes
     ----------
 
-    system : Instance of :attr:`espressomd.system.System`
+    system : :class:`espressomd.system.System`
     verbose : :obj:`bool`
-             Turns on verbosity.
+        Turns on verbosity.
 
     """
 
@@ -191,9 +198,9 @@ def setup_and_add_drude_exclusion_bonds(system, verbose=False):
     Attributes
     ----------
 
-    system : Instance of :attr:`espressomd.system.System`
+    system : :class:`espressomd.system.System`
     verbose: :obj:`bool`
-             Turns on verbosity.
+        Turns on verbosity.
 
     """
 
@@ -232,12 +239,15 @@ def setup_intramol_exclusion_bonds(system, mol_drude_types, mol_core_types,
     Attributes
     ----------
 
-    system : Instance of :attr:`espressomd.system.System`
-    mol_drude_types : List of types of Drude particles within the molecule
-    mol_core_types : List of types of core particles within the molecule
-    mol_core_partial_charges : List of partial charges of core particles within the molecule
+    system : :class:`espressomd.system.System`
+    mol_drude_types :
+        List of types of Drude particles within the molecule
+    mol_core_types :
+        List of types of core particles within the molecule
+    mol_core_partial_charges :
+        List of partial charges of core particles within the molecule
     verbose : :obj:`bool`
-             Turns on verbosity.
+        Turns on verbosity.
 
     """
 
@@ -268,11 +278,13 @@ def add_intramol_exclusion_bonds(system, drude_ids, core_ids, verbose=False):
     Attributes
     ----------
 
-    system : Instance of :attr:`espressomd.system.System`
-    drude_ids : IDs of Drude particles within a molecule.
-    core_ids : IDs of core particles within a molecule.
+    system : :class:`espressomd.system.System`
+    drude_ids :
+        IDs of Drude particles within a molecule.
+    core_ids :
+        IDs of core particles within a molecule.
     verbose : :obj:`bool`
-             Turns on verbosity.
+        Turns on verbosity.
 
     """
 

--- a/src/python/espressomd/electrokinetics.pxd
+++ b/src/python/espressomd/electrokinetics.pxd
@@ -17,8 +17,6 @@
 include "myconfig.pxi"
 from libcpp cimport bool
 
-from .utils cimport Vector3i
-
 IF ELECTROKINETICS and CUDA:
     cdef extern from "grid_based_algorithms/electrokinetics.hpp":
 

--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -26,9 +26,9 @@ from . import utils
 import os
 import tempfile
 import shutil
-from .utils cimport Vector6d
+from .utils import is_valid_type
+from .utils cimport Vector3i, Vector6d, handle_errors
 import numpy as np
-from espressomd.utils import is_valid_type
 
 IF ELECTROKINETICS:
     cdef class Electrokinetics(HydrodynamicInteraction):

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -18,7 +18,7 @@
 #
 
 include "myconfig.pxi"
-from espressomd.electrostatics cimport *
+from .electrostatics cimport *
 from libcpp.vector cimport vector
 from libcpp cimport bool
 from .utils cimport Vector3d

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -20,10 +20,9 @@
 
 include "myconfig.pxi"
 from espressomd.system cimport *
-from espressomd.utils cimport check_range_or_except, check_type_or_throw_except
 from espressomd.electrostatics cimport *
 from libcpp.vector cimport vector
-from utils cimport Vector3d
+from .utils cimport Vector3d
 
 IF ELECTROSTATICS and P3M:
 

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -16,12 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Handling of electrostatics
 
 include "myconfig.pxi"
-from espressomd.system cimport *
 from espressomd.electrostatics cimport *
 from libcpp.vector cimport vector
+from libcpp cimport bool
 from .utils cimport Vector3d
 
 IF ELECTROSTATICS and P3M:

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -20,9 +20,9 @@
 
 include "myconfig.pxi"
 from espressomd.system cimport *
-from espressomd.utils cimport *
+from espressomd.utils cimport check_range_or_except, check_type_or_throw_except
 from espressomd.electrostatics cimport *
-from libcpp cimport vector
+from libcpp.vector cimport vector
 from utils cimport Vector3d
 
 IF ELECTROSTATICS and P3M:

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -19,10 +19,10 @@
 
 from . cimport utils
 include "myconfig.pxi"
-from espressomd cimport actors
+from . cimport actors
 from . import actors
 import numpy as np
-from espressomd.utils cimport handle_errors, check_type_or_throw_except, check_range_or_except
+from .utils cimport handle_errors, check_type_or_throw_except, check_range_or_except
 
 IF ELECTROSTATICS and P3M:
     from espressomd.electrostatics import check_neutrality

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -22,7 +22,7 @@ include "myconfig.pxi"
 from espressomd cimport actors
 from . import actors
 import numpy as np
-from espressomd.utils cimport handle_errors
+from espressomd.utils cimport handle_errors, check_type_or_throw_except, check_range_or_except
 
 IF ELECTROSTATICS and P3M:
     from espressomd.electrostatics import check_neutrality

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -21,8 +21,8 @@
 include "myconfig.pxi"
 from espressomd.system cimport *
 cimport numpy as np
-from espressomd.utils cimport *
 from espressomd.utils import is_valid_type, to_str
+from espressomd.utils cimport handle_errors
 
 cdef extern from "SystemInterface.hpp":
     cdef cppclass SystemInterface:

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -16,13 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Handling of electrostatics
 
 include "myconfig.pxi"
-from espressomd.system cimport *
 cimport numpy as np
 from espressomd.utils import is_valid_type, to_str
 from espressomd.utils cimport handle_errors
+from libcpp cimport bool
 
 cdef extern from "SystemInterface.hpp":
     cdef cppclass SystemInterface:

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -19,8 +19,8 @@
 
 include "myconfig.pxi"
 cimport numpy as np
-from espressomd.utils import is_valid_type, to_str
-from espressomd.utils cimport handle_errors
+from .utils import is_valid_type, to_str
+from .utils cimport handle_errors
 from libcpp cimport bool
 
 cdef extern from "SystemInterface.hpp":

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -26,8 +26,8 @@ import numpy as np
 IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
     from . cimport scafacos
-from espressomd.utils cimport handle_errors
-from espressomd.utils import is_valid_type, to_str
+from .utils cimport handle_errors
+from .utils import is_valid_type, to_str
 from . cimport checks
 from .analyze cimport partCfg, PartCfg
 from .particle_data cimport particle

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -18,10 +18,8 @@
 #
 from cython.operator cimport dereference
 include "myconfig.pxi"
-from espressomd cimport actors
-from . import actors
-cimport grid
-cimport globals
+from .actors cimport Actor
+from .grid cimport box_geo
 import numpy as np
 IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
@@ -52,7 +50,7 @@ IF ELECTROSTATICS == 1:
                     you are doing.
                     """)
 
-    cdef class ElectrostaticInteraction(actors.Actor):
+    cdef class ElectrostaticInteraction(Actor):
         def _tune(self):
             raise Exception(
                 "Subclasses of ElectrostaticInteraction must define the "
@@ -639,7 +637,7 @@ IF ELECTROSTATICS and MMM1D_GPU:
             default_params = self.default_params()
 
             self.thisptr.set_params(
-                grid.box_geo.length()[2], coulomb.prefactor,
+                box_geo.length()[2], coulomb.prefactor,
                 self._params["maxPWerror"], self._params["far_switch_radius"],
                 self._params["bessel_cutoff"])
 
@@ -682,7 +680,7 @@ IF ELECTROSTATICS:
 
             # Explicit constructor needed due to multiple inheritance
             def __init__(self, *args, **kwargs):
-                actors.Actor.__init__(self, *args, **kwargs)
+                Actor.__init__(self, *args, **kwargs)
 
             def _activate_method(self):
                 check_neutrality(self._params)

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -19,7 +19,7 @@
 include "myconfig.pxi"
 from libcpp cimport bool
 from interactions cimport ImmersedBoundaries
-from utils cimport Vector3i
+from .utils cimport Vector3i
 
 cdef extern from "global.hpp":
     int FIELD_BOXL

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -18,7 +18,6 @@
 #
 include "myconfig.pxi"
 from libcpp cimport bool
-from interactions cimport ImmersedBoundaries
 from .utils cimport Vector3i
 
 cdef extern from "global.hpp":
@@ -49,7 +48,6 @@ cdef extern from "global.hpp":
     void mpi_bcast_parameter(int p)
 
 cdef extern from "communication.hpp":
-    extern int n_nodes
     void mpi_set_time_step(double time_step) except +
 
 cdef extern from "integrate.hpp":
@@ -77,28 +75,12 @@ cdef extern from "particle_data.hpp":
     extern bool swimming_particles_exist
 
 cdef extern from "nonbonded_interactions/nonbonded_interaction_data.hpp":
-    double dpd_gamma
-    double dpd_r_cut
     extern double max_cut
     extern int max_seen_particle
     extern int max_seen_particle_type
-    extern double max_cut_nonbonded
     extern double min_global_cut
     double recalc_maximal_cutoff_bonded()
     double recalc_maximal_cutoff_nonbonded()
-
-cdef extern from "thermostat.hpp":
-    extern double nptiso_gamma0
-    extern double nptiso_gammav
-    extern double temperature
-    extern int thermo_switch
-
-cdef extern from "dpd.hpp":
-    extern int dpd_wf
-    extern double dpd_tgamma
-    extern double dpd_tr_cut
-    extern int dpd_twf
-
 
 cdef extern from "cells.hpp":
     ctypedef struct CellStructure:
@@ -125,12 +107,6 @@ cdef extern from "npt.hpp":
         double p_diff
         double piston
     extern nptiso_struct nptiso
-
-cdef extern from "statistics.hpp":
-    extern int n_configs
-
-cdef extern from "immersed_boundaries.hpp":
-    extern ImmersedBoundaries immersed_boundaries
 
 cdef extern from "object-in-fluid/oif_global_forces.hpp":
     int max_oif_objects

--- a/src/python/espressomd/globals.pyx
+++ b/src/python/espressomd/globals.pyx
@@ -16,14 +16,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 
-cimport grid
-from globals cimport time_step
-from globals cimport mpi_set_time_step
-from globals cimport min_global_cut
-from globals cimport sim_time
-from globals cimport timing_samples
-from globals cimport forcecap_set
-from globals cimport forcecap_get
+from .grid cimport box_geo
+from .globals cimport time_step
+from .globals cimport mpi_set_time_step
+from .globals cimport min_global_cut
+from .globals cimport sim_time
+from .globals cimport timing_samples
+from .globals cimport forcecap_set
+from .globals cimport forcecap_get
 from .utils import array_locked
 from .utils cimport Vector3d, make_array_locked
 
@@ -38,11 +38,11 @@ cdef class Globals:
                     raise ValueError(
                         "Box length must be > 0  in all directions")
                 temp_box_l[i] = _box_l[i]
-            grid.box_geo.set_length(temp_box_l)
+            box_geo.set_length(temp_box_l)
             mpi_bcast_parameter(FIELD_BOXL)
 
         def __get__(self):
-            return make_array_locked(< Vector3d > grid.box_geo.length())
+            return make_array_locked(< Vector3d > box_geo.length())
 
     property time_step:
         def __set__(self, time_step):
@@ -65,7 +65,7 @@ cdef class Globals:
     property periodicity:
         def __set__(self, _periodic):
             for i in range(3):
-                grid.box_geo.set_periodic(i, _periodic[i])
+                box_geo.set_periodic(i, _periodic[i])
 
             mpi_bcast_parameter(FIELD_PERIODIC)
 
@@ -73,7 +73,7 @@ cdef class Globals:
             periodicity = np.zeros(3)
 
             for i in range(3):
-                periodicity[i] = grid.box_geo.periodic(i)
+                periodicity[i] = box_geo.periodic(i)
 
             return array_locked(periodicity)
 

--- a/src/python/espressomd/globals.pyx
+++ b/src/python/espressomd/globals.pyx
@@ -24,8 +24,8 @@ from globals cimport sim_time
 from globals cimport timing_samples
 from globals cimport forcecap_set
 from globals cimport forcecap_get
-from espressomd.utils import array_locked, is_valid_type
-from espressomd.utils cimport Vector3d, make_array_locked
+from .utils import array_locked
+from .utils cimport Vector3d, make_array_locked
 
 cdef class Globals:
     property box_l:

--- a/src/python/espressomd/grid.pxd
+++ b/src/python/espressomd/grid.pxd
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from libcpp cimport bool
 
-from utils cimport Vector3i, Vector3d
+from .utils cimport Vector3i, Vector3d
 
 cdef extern from "grid.hpp":
     Vector3i node_grid

--- a/src/python/espressomd/integrate.pxd
+++ b/src/python/espressomd/integrate.pxd
@@ -43,21 +43,5 @@ cdef inline int _integrate(int nSteps, cbool recalc_forces, int reuse_forces):
     with nogil:
         return python_integrate(nSteps, recalc_forces, reuse_forces)
 
-cdef extern from "RuntimeError.hpp" namespace "ErrorHandling::RuntimeError":
-    cdef cppclass ErrorLevel:
-        pass
-
-cdef extern from "RuntimeError.hpp" namespace "ErrorHandling::RuntimeError::ErrorLevel":
-    cdef ErrorLevel WARNING
-    cdef ErrorLevel ERROR
-
-cdef extern from "RuntimeError.hpp" namespace "ErrorHandling":
-    cdef cppclass RuntimeError:
-        string format()
-        ErrorLevel level()
-
-cdef extern from "errorhandling.hpp" namespace "ErrorHandling":
-    cdef vector[RuntimeError]mpi_gather_runtime_errors()
-
 cdef extern from "communication.hpp":
     int mpi_steepest_descent(int max_steps)

--- a/src/python/espressomd/integrate.pxd
+++ b/src/python/espressomd/integrate.pxd
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from libcpp.string cimport string  # import std::string as string
-from libcpp.vector cimport vector  # import std::vector as vector
 from libcpp cimport bool as cbool
 
 include "myconfig.pxi"

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -19,7 +19,7 @@
 from cpython.exc cimport PyErr_CheckSignals, PyErr_SetInterrupt
 include "myconfig.pxi"
 import espressomd.code_info
-from espressomd.utils cimport check_type_or_throw_except, handle_errors
+from espressomd.utils cimport handle_errors, check_type_or_throw_except
 cimport globals
 
 cdef class IntegratorHandle:

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -18,9 +18,8 @@
 #
 from cpython.exc cimport PyErr_CheckSignals, PyErr_SetInterrupt
 include "myconfig.pxi"
-import espressomd.code_info
-from espressomd.utils cimport handle_errors, check_type_or_throw_except
-cimport globals
+from .utils cimport handle_errors, check_type_or_throw_except
+from . cimport globals
 
 cdef class IntegratorHandle:
     """

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -25,8 +25,8 @@ from libcpp cimport bool as cbool
 from libc cimport stdint
 
 include "myconfig.pxi"
-from espressomd.system cimport *
 cimport numpy as np
+
 # force include of config.hpp
 cdef extern from "config.hpp":
     pass
@@ -546,7 +546,7 @@ cdef extern from "immersed_boundary/ImmersedBoundaries.hpp":
 cdef extern from "immersed_boundary/ibm_triel.hpp":
     int IBM_Triel_SetParams(const int bond_type, const int ind1, const int ind2, const int ind3, const double max, const tElasticLaw elasticLaw, const double k1, const double k2)
 cdef extern from "immersed_boundary/ibm_tribend.hpp":
-    int IBM_Tribend_SetParams(const int bond_type, const int ind1, const int ind2, const int ind3, const int ind4, const double kb, const bool flat)
+    int IBM_Tribend_SetParams(const int bond_type, const int ind1, const int ind2, const int ind3, const int ind4, const double kb, const cbool flat)
 
 IF ROTATION:
     cdef extern from "bonded_interactions/harmonic_dumbbell.hpp":

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -20,6 +20,7 @@
 # Handling of interactions
 
 from libcpp.string cimport string
+from libcpp.vector cimport vector
 from libcpp cimport bool as cbool
 from libc cimport stdint
 
@@ -29,8 +30,6 @@ cimport numpy as np
 # force include of config.hpp
 cdef extern from "config.hpp":
     pass
-
-from espressomd.utils cimport *
 
 cdef extern from "TabulatedPotential.hpp":
     struct TabulatedPotential:

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -543,6 +543,9 @@ cdef extern from "immersed_boundary/ImmersedBoundaries.hpp":
     cppclass ImmersedBoundaries:
         void volume_conservation_set_params(const int bond_type, const int softID, const double kappaV)
 
+cdef extern from "immersed_boundaries.hpp":
+    extern ImmersedBoundaries immersed_boundaries
+
 cdef extern from "immersed_boundary/ibm_triel.hpp":
     int IBM_Triel_SetParams(const int bond_type, const int ind1, const int ind2, const int ind3, const double max, const tElasticLaw elasticLaw, const double k1, const double k2)
 cdef extern from "immersed_boundary/ibm_tribend.hpp":

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -20,7 +20,7 @@ from libcpp.string cimport string
 import collections
 
 include "myconfig.pxi"
-from globals cimport immersed_boundaries
+from .globals cimport immersed_boundaries
 from .utils import requires_experimental_features, is_valid_type
 from .utils cimport check_type_or_throw_except
 

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -20,10 +20,9 @@ from libcpp.string cimport string
 import collections
 
 include "myconfig.pxi"
-from . import utils
-from espressomd.utils import is_valid_type
 from globals cimport immersed_boundaries
-from .utils import requires_experimental_features
+from .utils import requires_experimental_features, is_valid_type
+from .utils cimport check_type_or_throw_except
 
 
 cdef class NonBondedInteraction:
@@ -2124,7 +2123,7 @@ class ThermalizedBond(BondedInteraction):
             raise ValueError(
                 "A seed has to be given as keyword argument on first activation of the thermalized bond")
         if self.params["seed"] is not None:
-            utils.check_type_or_throw_except(
+            check_type_or_throw_except(
                 self.params["seed"], 1, int, "seed must be a positive integer")
             if self.params["seed"] < 0:
                 raise ValueError("seed must be a positive integer")

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -20,7 +20,6 @@ from libcpp.string cimport string
 import collections
 
 include "myconfig.pxi"
-from .globals cimport immersed_boundaries
 from .utils import requires_experimental_features, is_valid_type
 from .utils cimport check_type_or_throw_except
 

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -29,7 +29,7 @@ from . import cuda_init
 from copy import deepcopy
 from . import utils
 from .utils import array_locked, is_valid_type
-from .utils cimport make_array_locked, numeric_limits
+from .utils cimport Vector3i, Vector3d, Vector6d, Vector19d, make_array_locked
 cimport globals
 
 

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -30,7 +30,7 @@ from copy import deepcopy
 from . import utils
 from .utils import array_locked, is_valid_type
 from .utils cimport Vector3i, Vector3d, Vector6d, Vector19d, make_array_locked
-cimport globals
+from .globals cimport time_step
 
 
 def _construct(cls, params):
@@ -288,8 +288,8 @@ cdef class HydrodynamicInteraction(Actor):
 
         def __set__(self, tau):
             lb_lbfluid_set_tau(tau)
-            if globals.time_step > 0.0:
-                check_tau_time_step_consistency(tau, globals.time_step)
+            if time_step > 0.0:
+                check_tau_time_step_consistency(tau, time_step)
 
     property agrid:
         def __get__(self):

--- a/src/python/espressomd/magnetostatic_extensions.pxd
+++ b/src/python/espressomd/magnetostatic_extensions.pxd
@@ -20,7 +20,6 @@
 
 include "myconfig.pxi"
 from espressomd.system cimport *
-from espressomd.utils cimport *
 
 IF DIPOLES and DP3M:
 

--- a/src/python/espressomd/magnetostatic_extensions.pxd
+++ b/src/python/espressomd/magnetostatic_extensions.pxd
@@ -16,10 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Handling of electrostatics
 
 include "myconfig.pxi"
-from espressomd.system cimport *
 
 IF DIPOLES and DP3M:
 

--- a/src/python/espressomd/magnetostatic_extensions.pyx
+++ b/src/python/espressomd/magnetostatic_extensions.pyx
@@ -20,6 +20,7 @@
 from . cimport utils
 include "myconfig.pxi"
 from .actors import Actor
+from espressomd.utils cimport handle_errors, check_range_or_except, check_type_or_throw_except
 
 IF DIPOLES and DP3M:
     class MagnetostaticExtension(Actor):

--- a/src/python/espressomd/magnetostatic_extensions.pyx
+++ b/src/python/espressomd/magnetostatic_extensions.pyx
@@ -20,7 +20,7 @@
 from . cimport utils
 include "myconfig.pxi"
 from .actors import Actor
-from espressomd.utils cimport handle_errors, check_range_or_except, check_type_or_throw_except
+from .utils cimport handle_errors, check_range_or_except, check_type_or_throw_except
 
 IF DIPOLES and DP3M:
     class MagnetostaticExtension(Actor):

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 include "myconfig.pxi"
 
-
 IF DIPOLES == 1:
     cdef extern from "communication.hpp":
         void mpi_bcast_coulomb_params()

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -25,8 +25,8 @@ IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
     from . cimport scafacos
 
-from espressomd.utils cimport handle_errors
-from espressomd.utils import is_valid_type, to_str
+from .utils cimport handle_errors
+from .utils import is_valid_type, to_str
 
 IF DIPOLES == 1:
     cdef class MagnetostaticInteraction(Actor):

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -19,7 +19,6 @@
 include "myconfig.pxi"
 from .utils import requires_experimental_features
 import numpy as np
-from globals cimport temperature
 from .actors cimport Actor
 IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -18,7 +18,7 @@
 #
 # Here we create something to handle particles
 cimport numpy as np
-from espressomd.utils cimport Vector4d, Vector3d, Vector3i, List, Span
+from .utils cimport Vector4d, Vector3d, Vector3i, List, Span
 from libcpp cimport bool
 from libcpp.vector cimport vector  # import std::vector as vector
 from libc cimport stdint

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -196,14 +196,6 @@ cdef extern from "particle_data.hpp":
 
     const particle & get_particle_data(int id) except +
 
-# This ugly function is only needed because of a bug in cython:
-# c.f. https://github.com/cython/cython/blob/f568e1463e4dc9d45325713cce740ace182d7874/Cython/Utility/ModuleSetupCode.c#L424
-# c.f. https://github.com/cython/cython/issues/1519
-# It was fixed in cython 0.26, once we require that version, we can remove
-# this.
-cdef inline const particle * get_particle_data_ptr(const particle & p):
-    return & p
-
 cdef extern from "virtual_sites.hpp":
     IF VIRTUAL_SITES_RELATIVE == 1:
         void vs_relate_to(int part_num, int relate_to)

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from espressomd.system cimport *
 # Here we create something to handle particles
 cimport numpy as np
 from espressomd.utils cimport Vector4d, Vector3d, Vector3i, List, Span

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -20,7 +20,6 @@ from espressomd.system cimport *
 # Here we create something to handle particles
 cimport numpy as np
 from espressomd.utils cimport Vector4d, Vector3d, Vector3i, List, Span
-from espressomd.utils import array_locked
 from libcpp cimport bool
 from libcpp.vector cimport vector  # import std::vector as vector
 from libc cimport stdint

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -22,7 +22,7 @@ cimport numpy as np
 from espressomd.utils cimport Vector4d, Vector3d, Vector3i, List, Span
 from espressomd.utils import array_locked
 from libcpp cimport bool
-from libcpp.memory cimport unique_ptr
+from libcpp.vector cimport vector  # import std::vector as vector
 from libc cimport stdint
 
 include "myconfig.pxi"

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -25,12 +25,16 @@ from .interactions import BondedInteraction
 from .interactions import BondedInteractions
 from .interactions cimport bonded_ia_params
 from copy import copy
-from globals cimport max_seen_particle, time_step, n_part, n_rigidbonds, max_seen_particle_type, swimming_particles_exist, FIELD_SWIMMING_PARTICLES_EXIST, mpi_bcast_parameter
+from .globals cimport FIELD_SWIMMING_PARTICLES_EXIST
+from .globals cimport max_seen_particle, max_seen_particle_type, time_step, \
+    n_part, n_rigidbonds, swimming_particles_exist
+from .globals cimport mpi_bcast_parameter
 import collections
 import functools
 import types
 from .utils import nesting_level, array_locked, is_valid_type
-from .utils cimport make_array_locked, make_const_span, Vector3i, Vector3d, Vector4d, List, check_type_or_throw_except
+from .utils cimport make_array_locked, make_const_span, check_type_or_throw_except
+from .utils cimport Vector3i, Vector3d, Vector4d, List
 from .grid cimport box_geo, folded_position, unfolded_position
 
 

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -20,8 +20,6 @@ include "myconfig.pxi"
 
 cimport numpy as np
 import numpy as np
-from . cimport utils
-from espressomd.utils cimport *
 from . cimport particle_data
 from .interactions import BondedInteraction
 from .interactions import BondedInteractions
@@ -31,8 +29,8 @@ from globals cimport max_seen_particle, time_step, n_part, n_rigidbonds, max_see
 import collections
 import functools
 import types
-from espressomd.utils import nesting_level, array_locked, is_valid_type
-from espressomd.utils cimport make_array_locked
+from .utils import nesting_level, array_locked, is_valid_type
+from .utils cimport make_array_locked, make_const_span, Vector3i, Vector3d, Vector4d, List, check_type_or_throw_except
 from .grid cimport box_geo, folded_position, unfolded_position
 
 

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -56,7 +56,7 @@ cdef class ParticleHandle:
         self._id = _id
 
     cdef int update_particle_data(self) except -1:
-        self.particle_data = get_particle_data_ptr(get_particle_data(self._id))
+        self.particle_data = &get_particle_data(self._id)
 
     def __str__(self):
         res = collections.OrderedDict()

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -22,8 +22,8 @@ from . cimport polymer
 import numpy as np
 from espressomd import System
 from espressomd.interactions import BondedInteraction
-from espressomd.utils import check_type_or_throw_except, array_locked
-from espressomd.utils cimport make_Vector3d
+from .utils cimport make_Vector3d, check_type_or_throw_except
+from .utils import array_locked
 
 
 def validate_params(_params, default):

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -20,8 +20,8 @@
 include "myconfig.pxi"
 from . cimport polymer
 import numpy as np
-from espressomd import System
-from espressomd.interactions import BondedInteraction
+from .system import System
+from .interactions import BondedInteraction
 from .utils cimport make_Vector3d, check_type_or_throw_except
 from .utils import array_locked
 

--- a/src/python/espressomd/profiler.pyx
+++ b/src/python/espressomd/profiler.pyx
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-cimport c_profiler
+from . cimport c_profiler
 
 
 def begin_section(name):

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 include "myconfig.pxi"
 from libcpp.vector cimport vector
-from libcpp.string cimport string
 from libcpp.memory cimport unique_ptr
 from cython.operator cimport dereference as deref
 import numpy as np

--- a/src/python/espressomd/scafacos.pyx
+++ b/src/python/espressomd/scafacos.pyx
@@ -17,13 +17,12 @@
 """Code shared by charge and dipole methods based on the SCAFACOS library."""
 
 
-from espressomd.actors cimport Actor
+from .actors cimport Actor
 from libcpp.string cimport string  # import std::string
-cimport electrostatics
-cimport magnetostatics
-from espressomd.utils import to_char_pointer, to_str
-
-from espressomd.utils cimport handle_errors
+from . cimport electrostatics
+from . cimport magnetostatics
+from .utils import to_char_pointer, to_str
+from .utils cimport handle_errors
 
 
 include "myconfig.pxi"

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -27,7 +27,7 @@ from libcpp cimport bool
 
 from boost cimport string_ref
 
-from utils cimport Span
+from .utils cimport Span
 
 cdef extern from "ScriptInterface.hpp" namespace "ScriptInterface":
     void initialize()

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -14,10 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from espressomd.utils import to_char_pointer, to_str, handle_errors
 import numpy as np
-from espressomd.utils import is_valid_type, array_locked
-from espressomd.utils cimport Vector3d, make_array_locked
+from .utils import to_char_pointer, to_str
+from .utils cimport Vector3d, make_array_locked, handle_errors
 
 cdef class PObjectId:
     """Python interface to a core ObjectId object."""

--- a/src/python/espressomd/system.pxd
+++ b/src/python/espressomd/system.pxd
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 include "myconfig.pxi"
-import particle_data
 from libcpp cimport bool
 
 cdef extern from "grid.hpp":

--- a/src/python/espressomd/system.pxd
+++ b/src/python/espressomd/system.pxd
@@ -18,16 +18,10 @@
 #
 include "myconfig.pxi"
 import particle_data
-from libcpp.vector cimport vector
 from libcpp cimport bool
 
 cdef extern from "grid.hpp":
     cdef void rescale_boxl(int dir, double d_new)
-
-
-from libcpp.string cimport string  # import std::string as string
-from libcpp.vector cimport vector  # import std::vector as vector
-ctypedef vector[string] string_vec
 
 cdef extern from "rotate_system.hpp":
     void rotate_system(double phi, double theta, double alpha)

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -47,6 +47,7 @@ if LB_BOUNDARIES or LB_BOUNDARIES_GPU:
     from .lbboundaries import LBBoundaries
     from .ekboundaries import EKBoundaries
 from .comfixed import ComFixed
+from .utils cimport handle_errors
 from globals cimport max_seen_particle
 from .globals import Globals
 IF VIRTUAL_SITES:
@@ -444,4 +445,5 @@ cdef class System:
         """
         self.check_valid_type(type)
         number = number_of_particles_with_type(type)
+        handle_errors("")
         return int(number)

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -19,11 +19,10 @@
 from libcpp cimport bool
 include "myconfig.pxi"
 
-from globals cimport *
 import numpy as np
 import collections
 
-from grid cimport get_mi_vector, box_geo
+from .grid cimport get_mi_vector, box_geo
 from . cimport integrate
 from . import interactions
 from . import integrate
@@ -32,7 +31,7 @@ from . cimport cuda_init
 from . import particle_data
 from . import cuda_init
 from . import code_info
-from .utils cimport numeric_limits, make_array_locked, make_Vector3d, Vector3d
+from .utils cimport make_array_locked, make_Vector3d, Vector3d
 from .lb cimport lb_lbfluid_get_tau
 from .lb cimport lb_lbfluid_get_lattice_switch
 from .lb cimport NONE
@@ -41,24 +40,21 @@ from .cellsystem import CellSystem
 from .analyze import Analysis
 from .galilei import GalileiTransform
 from .constraints import Constraints
-
 from .accumulators import AutoUpdateAccumulators
 if LB_BOUNDARIES or LB_BOUNDARIES_GPU:
     from .lbboundaries import LBBoundaries
     from .ekboundaries import EKBoundaries
 from .comfixed import ComFixed
-from .utils cimport handle_errors
-from globals cimport max_seen_particle
 from .globals import Globals
+from .globals cimport FIELD_SIMTIME, FIELD_MAX_OIF_OBJECTS
+from .globals cimport max_seen_particle_type, integ_switch, max_oif_objects, sim_time
+from .globals cimport recalc_maximal_cutoff_bonded, recalc_maximal_cutoff_nonbonded, mpi_bcast_parameter
+from .utils cimport handle_errors
 IF VIRTUAL_SITES:
-    from espressomd.virtual_sites import ActiveVirtualSitesHandle, VirtualSitesOff
+    from .virtual_sites import ActiveVirtualSitesHandle, VirtualSitesOff
 
 IF COLLISION_DETECTION == 1:
     from .collision_detection import CollisionDetection
-
-import sys
-import random  # for true random numbers from os.urandom()
-cimport tuning
 
 
 setable_properties = ["box_l", "min_global_cut", "periodicity", "time",
@@ -407,7 +403,7 @@ cdef class System:
     def _is_valid_type(self, current_type):
         return not (isinstance(current_type, int)
                     or current_type < 0
-                    or current_type > globals.max_seen_particle_type)
+                    or current_type > max_seen_particle_type)
 
     def check_valid_type(self, current_type):
         if self._is_valid_type(current_type):

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -232,7 +232,6 @@ cdef class System:
         """
 
         def __set__(self, _periodic):
-            global periodic
             if len(_periodic) != 3:
                 raise ValueError(
                     "periodicity must be of length 3, got length " + str(len(_periodic)))

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -49,7 +49,6 @@ if LB_BOUNDARIES or LB_BOUNDARIES_GPU:
 from .comfixed import ComFixed
 from globals cimport max_seen_particle
 from .globals import Globals
-from espressomd.utils import array_locked, is_valid_type
 IF VIRTUAL_SITES:
     from espressomd.virtual_sites import ActiveVirtualSitesHandle, VirtualSitesOff
 

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -17,15 +17,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from functools import wraps
-from . cimport thermostat
 include "myconfig.pxi"
-from globals cimport *
+from .globals cimport(
+    FIELD_BROWNIAN_GAMMA, FIELD_BROWNIAN_GAMMA_ROTATION, FIELD_LANGEVIN_GAMMA,
+    FIELD_LANGEVIN_GAMMA_ROTATION, FIELD_NPTISO_G0, FIELD_NPTISO_GV,
+    FIELD_TEMPERATURE, FIELD_THERMO_SWITCH, FIELD_THERMO_VIRTUAL
+)
+from .globals cimport nptiso
+from .globals cimport mpi_bcast_parameter
 import numpy as np
 from . cimport utils
-from .lb cimport *
 from .lb import HydrodynamicInteraction
 from .lb cimport lb_lbcoupling_set_gamma
 from .lb cimport lb_lbcoupling_get_gamma
+from .lb cimport lb_lbcoupling_set_rng_state
+from .lb cimport lb_lbcoupling_get_rng_state
+from .lb cimport lb_lbcoupling_is_seed_required
+from .lb cimport lb_lbfluid_get_kT
 
 
 def AssertThermostatType(*allowedthermostats):

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -18,11 +18,12 @@
 #
 from functools import wraps
 include "myconfig.pxi"
-from .globals cimport(
-    FIELD_BROWNIAN_GAMMA, FIELD_BROWNIAN_GAMMA_ROTATION, FIELD_LANGEVIN_GAMMA,
-    FIELD_LANGEVIN_GAMMA_ROTATION, FIELD_NPTISO_G0, FIELD_NPTISO_GV,
+from .globals cimport FIELD_BROWNIAN_GAMMA, FIELD_LANGEVIN_GAMMA, \
     FIELD_TEMPERATURE, FIELD_THERMO_SWITCH, FIELD_THERMO_VIRTUAL
-)
+IF NPT:
+    from .globals cimport FIELD_NPTISO_G0, FIELD_NPTISO_GV
+IF ROTATION:
+    from .globals cimport FIELD_LANGEVIN_GAMMA_ROTATION, FIELD_BROWNIAN_GAMMA_ROTATION
 from .globals cimport nptiso
 from .globals cimport mpi_bcast_parameter
 import numpy as np

--- a/src/python/espressomd/version.pyx
+++ b/src/python/espressomd/version.pyx
@@ -21,13 +21,13 @@ from .utils import to_str
 def major():
     """Prints the major version of ESPResSo.
     """
-    return ESPRESSO_VERSION_MAJOR
+    return ESPRESSO_VERSION_MAJOR  # pylint: disable=undefined-variable
 
 
 def minor():
     """Prints the minor version of ESPResSo.
     """
-    return ESPRESSO_VERSION_MINOR
+    return ESPRESSO_VERSION_MINOR  # pylint: disable=undefined-variable
 
 
 def friendly():
@@ -40,14 +40,14 @@ def git_branch():
     """Git branch of the build if known, otherwise
        empty.
     """
-    return to_str(GIT_BRANCH)
+    return to_str(GIT_BRANCH)  # pylint: disable=undefined-variable
 
 
 def git_commit():
     """Git commit of the build if known, otherwise
        empty.
     """
-    return to_str(GIT_COMMIT_HASH)
+    return to_str(GIT_COMMIT_HASH)  # pylint: disable=undefined-variable
 
 
 def git_state():
@@ -56,4 +56,4 @@ def git_state():
        was not changed from :meth:`git_commit()`,
        "DIRTY" otherwise.
     """
-    return to_str(GIT_STATE)
+    return to_str(GIT_STATE)  # pylint: disable=undefined-variable

--- a/src/python/espressomd/version.pyx
+++ b/src/python/espressomd/version.pyx
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from espressomd.utils import to_str
+from .utils import to_str
 
 
 def major():

--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -207,7 +207,7 @@ cdef class mayaviLive:
         # Using (additional) untyped variables and python constructs in the loop
         # will slow it down considerably.
         for i in range(N):
-            p = get_particle_data_ptr(get_particle_data(i))
+            p = &get_particle_data(i)
             if not p:
                 continue
 
@@ -254,8 +254,8 @@ cdef class mayaviLive:
             i = bonds[3 * n]
             j = bonds[3 * n + 1]
             t = bonds[3 * n + 2]
-            p1 = get_particle_data_ptr(get_particle_data(i))
-            p2 = get_particle_data_ptr(get_particle_data(j))
+            p1 = &get_particle_data(i)
+            p2 = &get_particle_data(j)
             bond_coords[n, :3] = numpy.array([p1.r.p[0], p1.r.p[1], p1.r.p[2]])
             bond_coords[n, 3:6] = make_array_locked( < const Vector3d > get_mi_vector(Vector3d(p2.r.p), Vector3d(p1.r.p), box_geo))
             bond_coords[n, 6] = t

--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -21,9 +21,9 @@ from libcpp cimport bool
 from libcpp.vector cimport vector
 from .particle_data import ParticleHandle
 from .particle_data cimport *
-from .interactions cimport *
 from .interactions import NonBondedInteractions
 from .interactions cimport BONDED_IA_DIHEDRAL, BONDED_IA_TABULATED_DIHEDRAL
+from .interactions cimport IA_parameters, get_ia_param, bonded_ia_params
 from .grid cimport get_mi_vector, box_geo
 from .utils cimport make_array_locked
 

--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -26,6 +26,7 @@ from .system cimport *
 from .interactions import NonBondedInteractions
 from .interactions cimport BONDED_IA_DIHEDRAL, BONDED_IA_TABULATED_DIHEDRAL
 from .grid cimport get_mi_vector, box_geo
+from .utils cimport make_array_locked
 
 include "myconfig.pxi"
 

--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -22,7 +22,6 @@ from libcpp.vector cimport vector
 from .particle_data import ParticleHandle
 from .particle_data cimport *
 from .interactions cimport *
-from .system cimport *
 from .interactions import NonBondedInteractions
 from .interactions cimport BONDED_IA_DIHEDRAL, BONDED_IA_TABULATED_DIHEDRAL
 from .grid cimport get_mi_vector, box_geo

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -31,8 +31,8 @@ from matplotlib.pyplot import imsave
 include "myconfig.pxi"
 from copy import deepcopy
 import espressomd
-from espressomd.particle_data import ParticleHandle
-from espressomd.interactions cimport BONDED_IA_DIHEDRAL, BONDED_IA_TABULATED_DIHEDRAL
+from .particle_data import ParticleHandle
+from .interactions cimport BONDED_IA_DIHEDRAL, BONDED_IA_TABULATED_DIHEDRAL
 
 
 class openGLLive:


### PR DESCRIPTION
Description of changes:
- remove Cython 0.26 workaround (cf74585)
- replace most wildcard imports in the Cython code by explicit imports
- remove obsolete or unused global variables from `globals.pxd`
- resolve a few issues (fixes #3494, fixes #3495)
- use relative imports