### PR TITLE
Cleanup cython further

### DIFF
--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -19,7 +19,6 @@
 
 # For C-extern Analysis
 
-cimport numpy as np
 from .utils cimport Vector3i, Vector3d, Vector9d, List
 from libcpp.vector cimport vector  # import std::vector as vector
 

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -22,6 +22,7 @@
 from libcpp cimport bool
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
+from .utils cimport Vector3i
 
 cdef extern from "communication.hpp":
     void mpi_bcast_cell_structure(int cs)
@@ -34,6 +35,12 @@ cdef extern from "cells.hpp":
     int CELL_STRUCTURE_NSQUARE
     int CELL_STRUCTURE_LAYERED
 
+    ctypedef struct CellStructure:
+        int type
+        bool use_verlet_list
+
+    CellStructure cell_structure
+
     vector[pair[int, int]] mpi_get_pairs(double distance)
 
 cdef extern from "layered.hpp":
@@ -42,3 +49,14 @@ cdef extern from "layered.hpp":
 
 cdef extern from "tuning.hpp":
     cdef void c_tune_skin "tune_skin" (double min_skin, double max_skin, double tol, int int_steps, bool adjust_max_skin)
+
+cdef extern from "domain_decomposition.hpp":
+    ctypedef struct  DomainDecomposition:
+        int cell_grid[3]
+        double cell_size[3]
+        bool fully_connected[3]
+
+    extern DomainDecomposition dd
+    extern int max_num_cells
+    extern int min_num_cells
+    int calc_processor_min_num_cells(const Vector3i & grid)

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -17,8 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# @TODO: shouldn't these global definitions be used via global_variables?
-
 from libcpp cimport bool
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -19,9 +19,10 @@
 from .grid cimport node_grid
 from . cimport integrate
 from .globals cimport FIELD_SKIN, FIELD_NODEGRID, FIELD_MAXNUMCELLS, FIELD_MINNUMCELLS
-from .globals cimport max_cut, verlet_reuse, n_layers, dd, cell_structure, \
-    min_num_cells, max_num_cells, skin
-from .globals cimport mpi_bcast_parameter, calc_processor_min_num_cells
+from .globals cimport max_cut, verlet_reuse, skin
+from .globals cimport mpi_bcast_parameter
+from .cellsystem cimport dd, cell_structure, min_num_cells, max_num_cells, n_layers_
+from .cellsystem cimport calc_processor_min_num_cells
 import numpy as np
 from .utils cimport handle_errors
 from .utils import is_valid_type
@@ -117,7 +118,7 @@ cdef class CellSystem:
 
         if cell_structure.type == CELL_STRUCTURE_LAYERED:
             s["type"] = "layered"
-            s["n_layers"] = n_layers
+            s["n_layers"] = n_layers_
         if cell_structure.type == CELL_STRUCTURE_DOMDEC:
             s["type"] = "domain_decomposition"
         if cell_structure.type == CELL_STRUCTURE_NSQUARE:
@@ -144,7 +145,7 @@ cdef class CellSystem:
 
         if cell_structure.type == CELL_STRUCTURE_LAYERED:
             s["type"] = "layered"
-            s["n_layers"] = n_layers
+            s["n_layers"] = n_layers_
         if cell_structure.type == CELL_STRUCTURE_DOMDEC:
             s["type"] = "domain_decomposition"
         if cell_structure.type == CELL_STRUCTURE_NSQUARE:

--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -23,7 +23,6 @@ IF CUDA:
     from .lb cimport lb_lbfluid_set_lattice_switch
     from .lb cimport GPU
 from . import utils
-import os
 import tempfile
 import shutil
 from .utils import is_valid_type

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -18,7 +18,6 @@
 #
 
 include "myconfig.pxi"
-cimport numpy as np
 from .utils import is_valid_type, to_str
 from .utils cimport handle_errors
 from libcpp cimport bool
@@ -118,7 +117,6 @@ IF ELECTROSTATICS:
                 alpha = params["alpha"]
                 p3m_gpu_init(cao, mesh, alpha)
 
-        # Convert C arguments into numpy array
         cdef inline python_p3m_set_mesh_offset(mesh_off):
             cdef double mesh_offset[3]
             mesh_offset[0] = mesh_off[0]

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -18,7 +18,6 @@
 #
 include "myconfig.pxi"
 from libcpp cimport bool
-from .utils cimport Vector3i
 
 cdef extern from "global.hpp":
     int FIELD_BOXL
@@ -57,18 +56,6 @@ cdef extern from "integrate.hpp":
     extern double skin
     extern bool set_py_interrupt
 
-cdef extern from "domain_decomposition.hpp":
-    ctypedef struct  DomainDecomposition:
-        int cell_grid[3]
-        double cell_size[3]
-        bool fully_connected[3]
-
-    extern DomainDecomposition dd
-    extern int max_num_cells
-    extern int min_num_cells
-    int calc_processor_min_num_cells(const Vector3i & grid)
-
-
 cdef extern from "particle_data.hpp":
     extern int n_part
 
@@ -78,16 +65,6 @@ cdef extern from "nonbonded_interactions/nonbonded_interaction_data.hpp":
     extern double min_global_cut
     double recalc_maximal_cutoff_bonded()
     double recalc_maximal_cutoff_nonbonded()
-
-cdef extern from "cells.hpp":
-    ctypedef struct CellStructure:
-        int type
-        bool use_verlet_list
-
-    CellStructure cell_structure
-
-cdef extern from "layered.hpp":
-    extern int n_layers
 
 cdef extern from "rattle.hpp":
     extern int n_rigidbonds

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -54,7 +54,6 @@ cdef extern from "integrate.hpp":
     extern double sim_time
     extern double verlet_reuse
     extern double skin
-    extern bool set_py_interrupt
 
 cdef extern from "particle_data.hpp":
     extern int n_part
@@ -69,18 +68,8 @@ cdef extern from "nonbonded_interactions/nonbonded_interaction_data.hpp":
 cdef extern from "rattle.hpp":
     extern int n_rigidbonds
 
-
 cdef extern from "tuning.hpp":
     extern int timing_samples
-
-
-cdef extern from "npt.hpp":
-    ctypedef struct nptiso_struct:
-        double p_ext
-        double p_inst
-        double p_diff
-        double piston
-    extern nptiso_struct nptiso
 
 cdef extern from "object-in-fluid/oif_global_forces.hpp":
     int max_oif_objects

--- a/src/python/espressomd/integrate.pxd
+++ b/src/python/espressomd/integrate.pxd
@@ -29,6 +29,7 @@ cdef extern from "integrate.hpp" nogil:
     cdef int integrate_set_steepest_descent(const double f_max, const double gamma,
                                             const int max_steps, const double max_displacement)
     cdef extern cbool skin_set
+    cdef extern cbool set_py_interrupt
     cdef void integrate_set_bd()
 
 IF NPT:

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -19,7 +19,7 @@
 from cpython.exc cimport PyErr_CheckSignals, PyErr_SetInterrupt
 include "myconfig.pxi"
 from .utils cimport handle_errors, check_type_or_throw_except
-from . cimport globals
+from . cimport integrate
 
 cdef class IntegratorHandle:
     """
@@ -194,9 +194,9 @@ cdef class Integrator:
 
         _integrate(steps, recalc_forces, reuse_forces)
 
-        if globals.set_py_interrupt:
+        if integrate.set_py_interrupt:
             PyErr_SetInterrupt()
-            globals.set_py_interrupt = False
+            integrate.set_py_interrupt = False
             PyErr_CheckSignals()
 
         handle_errors("Encountered errors during integrate")

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -25,7 +25,6 @@ from libcpp cimport bool as cbool
 from libc cimport stdint
 
 include "myconfig.pxi"
-cimport numpy as np
 
 # force include of config.hpp
 cdef extern from "config.hpp":

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -26,7 +26,6 @@ from libc cimport stdint
 from .actors cimport Actor
 from . cimport cuda_init
 from . import cuda_init
-from copy import deepcopy
 from . import utils
 from .utils import array_locked, is_valid_type
 from .utils cimport Vector3i, Vector3d, Vector6d, Vector19d, make_array_locked

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -53,7 +53,6 @@ IF DIPOLES == 1:
     IF(DIPOLAR_BARNES_HUT == 1):
         cdef extern from "actor/DipolarBarnesHut.hpp":
             void activate_dipolar_barnes_hut(float epssq, float itolsq)
-            # void activate_dipolar_barnes_hut()
             void deactivate_dipolar_barnes_hut()
 
 IF DP3M == 1:
@@ -71,7 +70,4 @@ IF DP3M == 1:
         ctypedef struct dp3m_data_struct:
             P3MParameters params
 
-        # links intern C-struct with python object
         cdef extern dp3m_data_struct dp3m
-
-        # Convert C arguments into numpy array

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -18,7 +18,6 @@
 #
 include "myconfig.pxi"
 from .utils import requires_experimental_features
-import numpy as np
 from .actors cimport Actor
 IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
@@ -442,4 +441,3 @@ IF DIPOLES == 1:
                 self.set_magnetostatics_prefactor()
                 activate_dipolar_barnes_hut(
                     self._params["epssq"], self._params["itolsq"])
-                # activate_dipolar_barnes_hut()

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Here we create something to handle particles
-cimport numpy as np
 from .utils cimport Vector4d, Vector3d, Vector3i, List, Span
 from libcpp cimport bool
 from libcpp.vector cimport vector  # import std::vector as vector

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -28,7 +28,6 @@ from copy import copy
 from .globals cimport max_seen_particle_type, n_part, n_rigidbonds
 import collections
 import functools
-import types
 from .utils import nesting_level, array_locked, is_valid_type
 from .utils cimport make_array_locked, make_const_span, check_type_or_throw_except
 from .utils cimport Vector3i, Vector3d, Vector4d, List

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -25,8 +25,7 @@ from .interactions import BondedInteraction
 from .interactions import BondedInteractions
 from .interactions cimport bonded_ia_params
 from copy import copy
-from .globals cimport max_seen_particle_type, n_part, \
-    n_rigidbonds
+from .globals cimport max_seen_particle_type, n_part, n_rigidbonds
 import collections
 import functools
 import types

--- a/src/python/espressomd/thermostat.pxd
+++ b/src/python/espressomd/thermostat.pxd
@@ -74,3 +74,11 @@ cdef extern from "Globals.hpp":
     cdef extern langevin_thermostat_struct langevin
     cdef extern brownian_thermostat_struct brownian
     cdef extern npt_iso_thermostat_struct npt_iso
+
+cdef extern from "npt.hpp":
+    ctypedef struct nptiso_struct:
+        double p_ext
+        double p_inst
+        double p_diff
+        double piston
+    extern nptiso_struct nptiso

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -26,7 +26,6 @@ IF ROTATION:
     from .globals cimport FIELD_LANGEVIN_GAMMA_ROTATION, FIELD_BROWNIAN_GAMMA_ROTATION
 from .thermostat cimport nptiso
 from .globals cimport mpi_bcast_parameter
-import numpy as np
 from . cimport utils
 from .lb import HydrodynamicInteraction
 from .lb cimport lb_lbcoupling_set_gamma

--- a/src/python/espressomd/thermostat.pyx
+++ b/src/python/espressomd/thermostat.pyx
@@ -24,7 +24,7 @@ IF NPT:
     from .globals cimport FIELD_NPTISO_G0, FIELD_NPTISO_GV
 IF ROTATION:
     from .globals cimport FIELD_LANGEVIN_GAMMA_ROTATION, FIELD_BROWNIAN_GAMMA_ROTATION
-from .globals cimport nptiso
+from .thermostat cimport nptiso
 from .globals cimport mpi_bcast_parameter
 import numpy as np
 from . cimport utils

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -22,9 +22,6 @@ cimport numpy as np
 from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
 
-cdef extern from "stdlib.h":
-    void free(void * ptr)
-
 cdef extern from "utils/List.hpp" namespace "Utils":
     cppclass List[T]:
         List()
@@ -80,15 +77,6 @@ cdef extern from "errorhandling.hpp" namespace "ErrorHandling":
     cdef vector[RuntimeError] mpi_gather_runtime_errors()
 
 cpdef handle_errors(msg)
-
-# https://github.com/cython/cython/blob/master/Cython/Includes/libcpp/limits.pxd
-cdef extern from "<limits>" namespace "std" nogil:
-    cdef cppclass numeric_limits[T]:
-        @staticmethod
-        T epsilon()
-
-        @staticmethod
-        T max()
 
 cdef extern from "utils/Vector.hpp" namespace "Utils":
     cppclass Vector2d:

--- a/src/python/espressomd/visualization_opengl.pyx
+++ b/src/python/espressomd/visualization_opengl.pyx
@@ -29,7 +29,6 @@ import matplotlib
 from matplotlib.pyplot import imsave
 
 include "myconfig.pxi"
-from copy import deepcopy
 import espressomd
 from .particle_data import ParticleHandle
 from .interactions cimport BONDED_IA_DIHEDRAL, BONDED_IA_TABULATED_DIHEDRAL


### PR DESCRIPTION
Follow-up to #3496

Reflect in the Python interface all dependency inversions that recently took place in the core.