### PR TITLE
Sphinx: fix code samples (instantiation and naming of System())

### DIFF
--- a/doc/sphinx/advanced_methods.rst
+++ b/doc/sphinx/advanced_methods.rst
@@ -98,12 +98,12 @@ Several modes are available for different types of binding.
 
         n_angle_bonds = 181  # 0 to 180 degrees in one degree steps
         for i in range(0, res, 1):
-            self.s.bonded_inter[i] = Angle_Harmonic(
+            self.system.bonded_inter[i] = Angle_Harmonic(
                 bend=1, phi0=float(i) / (res - 1) * np.pi)
 
         # Create the bond passed to bond_centers here and add it to the system
 
-        self.s.collision_detection.set_params(mode="bind_three_particles",
+        self.system.collision_detection.set_params(mode="bind_three_particles",
             bond_centers=<BOND_CENTERS>, bond_three_particles=0,
             three_particle_binding_angle_resolution=res, distance=<CUTOFF>)
 
@@ -188,7 +188,7 @@ The bending modulus is ``kb``.
 where ``softID`` identifies the soft particle and ``kv`` is a volumetric spring constant.
 Note that the :class:`espressomd.interactions.IBM_VolCons` ``bond`` does not need a bond partner. It is added to a particle as follows::
 
-    s.part[0].add_bond((Volcons,))
+    system.part[0].add_bond((Volcons,))
 
 The comma is needed to force Python to create a tuple containing a single item.
 
@@ -1326,13 +1326,13 @@ Initialization
 ::
 
     import espressomd
-    sys = espressomd.System(box_l=[10.0, 10.0, 10.0])
-    sys.time_step = 0.0
-    sys.cell_system.skin = 0.4
+    system = espressomd.System(box_l=[10.0, 10.0, 10.0])
+    system.time_step = 0.0
+    system.cell_system.skin = 0.4
     ek = espressomd.electrokinetics.Electrokinetics(agrid=1.0, lb_density=1.0,
         viscosity=1.0, friction=1.0, T=1.0, prefactor=1.0,
         stencil='linkcentered', advection=True, fluid_coupling='friction')
-    sys.actors.add(ek)
+    system.actors.add(ek)
 
 .. note:: Features ``ELECTROKINETICS`` and ``CUDA`` required
 

--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -87,8 +87,7 @@ or a position coordinate when used with a vector ``pos``.
 For example, ::
 
     >>> import espressomd
-    >>> system = espressomd.System()
-    >>> system.box_l = [100, 100, 100]
+    >>> system = espressomd.System(box_l=[100, 100, 100])
     >>> for i in range(10):
     ...     system.part.add(id=i, pos=[1.0, 1.0, i**2], type=0)
     >>> system.analysis.dist_to(id=4)
@@ -126,9 +125,7 @@ group.
 
 Two arrays are returned corresponding to the normalized distribution and the bins midpoints, for example ::
 
-    >>> system = espressomd.System()
-    >>> box_l = 10.
-    >>> system.box_l = [box_l, box_l, box_l]
+    >>> system = espressomd.System(box_l=[10, 10, 10])
     >>> for i in range(5):
     ...     system.part.add(id=i, pos=i * system.box_l, type=0)
     >>> bins, count = system.analysis.distribution(type_list_a=[0], type_list_b=[0],

--- a/doc/sphinx/lb.rst
+++ b/doc/sphinx/lb.rst
@@ -26,13 +26,12 @@ Setting up a LB fluid
 The following minimal example illustrates how to use the LBM in |es|::
 
     import espressomd
-    sys = espressomd.System()
-    sys.box_l = [10, 20, 30]
-    sys.time_step = 0.01
-    sys.cell_system.skin = 0.4
+    system = espressomd.System(box_l=[10, 20, 30])
+    system.time_step = 0.01
+    system.cell_system.skin = 0.4
     lb = espressomd.lb.LBFluid(agrid=1.0, dens=1.0, visc=1.0, tau=0.01)
-    sys.actors.add(lb)
-    sys.integrator.run(100)
+    system.actors.add(lb)
+    system.integrator.run(100)
 
 To use the GPU accelerated variant, replace line 5 in the example above by::
 
@@ -119,7 +118,7 @@ the center of mass, causing errors in the calculation of velocities and
 diffusion coefficients. The correct way to restart an LB simulation is to first
 load in the particles with the correct forces, and use::
 
-    sys.integrator.run(steps=number_of_steps, reuse_forces=True)
+    system.integrator.run(steps=number_of_steps, reuse_forces=True)
 
 upon the first call ``integrator.run``. This causes the
 old forces to be reused and thus conserves momentum.
@@ -168,7 +167,7 @@ multiple particles can interact via hydrodynamic interactions. As friction in mo
 accompanied by fluctuations, the particle-fluid coupling has to be activated through
 the :ref:`LB thermostat` (See more detailed description there). A short example is::
 
-    sys.thermostat.set_lb(LB_fluid=lbf, seed=123, gamma=1.5)
+    system.thermostat.set_lb(LB_fluid=lbf, seed=123, gamma=1.5)
 
 where ``lbf`` is an instance of either :class:`espressomd.lb.LBFluid` or :class:`espressomd.lb.LBFluidGPU`, 
 ``gamma`` the friction coefficient and ``seed`` the seed for the random number generator involved 
@@ -268,13 +267,12 @@ information on CUDA support see section :ref:`GPU Acceleration with CUDA`.
 The following minimal example demonstrates how to use the GPU implementation of the LBM in analogy to the example for the CPU given in section :ref:`Setting up a LB fluid`::
 
     import espressomd
-    sys = espressomd.System()
-    sys.box_l = [10, 20, 30]
-    sys.time_step = 0.01
-    sys.cell_system.skin = 0.4
+    system = espressomd.System(box_l=[10, 20, 30])
+    system.time_step = 0.01
+    system.cell_system.skin = 0.4
     lb = espressomd.lb.LBFluidGPU(agrid=1.0, dens=1.0, visc=1.0, tau=0.01)
-    sys.actors.add(lb)
-    sys.integrator.run(100)
+    system.actors.add(lb)
+    system.integrator.run(100)
 
 For boundary conditions analogous to the CPU
 implementation, the feature ``LB_BOUNDARIES_GPU`` has to be activated.
@@ -349,13 +347,12 @@ The following example sets up a system consisting of a spherical boundary in the
 
     from espressomd import System, lb, lbboundaries, shapes
 
-    sys = System()
-    sys.box_l = [64, 64, 64]
-    sys.time_step = 0.01
-    sys.cell_system.skin = 0.4
+    system = System(box_l=[64, 64, 64])
+    system.time_step = 0.01
+    system.cell_system.skin = 0.4
 
     lb = lb.LBFluid(agrid=1.0, dens=1.0, visc=1.0, tau=0.01)
-    sys.actors.add(lb)
+    system.actors.add(lb)
 
     v = [0, 0, 0.01]  # the boundary slip
     walls = [None] * 4
@@ -377,9 +374,9 @@ The following example sets up a system consisting of a spherical boundary in the
 
     sphere_shape = shapes.Sphere(radius=5.5, center=[33, 33, 33], direction=1)
     sphere = lbboundaries.LBBoundary(shape=sphere_shape)
-    sys.lbboundaries.add(sphere)
+    system.lbboundaries.add(sphere)
 
-    sys.integrator.run(4000)
+    system.integrator.run(4000)
 
     print(sphere.get_force())
 

--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -308,10 +308,10 @@ To switch the active scheme, the attribute :attr:`espressomd.system.System.virtu
     import espressomd
     from espressomd.virtual_sites import VirtualSitesOff, VirtualSitesRelative
 
-    s = espressomd.System()
-    s.virtual_sites = VirtualSitesRelative(have_velocity=True, have_quaternion=False)
+    system = espressomd.System()
+    system.virtual_sites = VirtualSitesRelative(have_velocity=True, have_quaternion=False)
     # or
-    s.virtual_sites = VirtualSitesOff()
+    system.virtual_sites = VirtualSitesOff()
 
 By default, :class:`espressomd.virtual_sites.VirtualSitesOff` is selected. This means that virtual particles are not touched during integration.
 The ``have_velocity`` parameter determines whether or not the velocity of virtual sites is calculated, which carries a performance cost.

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -204,8 +204,8 @@ In this way, just compiling in the ``ROTATION`` feature no longer changes the ph
 The rotation of a particle is controlled via the :attr:`espressomd.particle_data.ParticleHandle.rotation` property. E.g., the following code adds a particle with rotation enabled on the x axis::
 
     import espressomd
-    s = espressomd.System()
-    s.part.add(pos=(0, 0, 0), rotation=(1, 0, 0))
+    system = espressomd.System()
+    system.part.add(pos=(0, 0, 0), rotation=(1, 0, 0))
 
 Notes:
 

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -318,7 +318,7 @@ thermalization of the particle coupling. The magnitude of the frictional couplin
 the parameter ``gamma``.
 To enable the LB thermostat, use::
 
-    sys.thermostat.set_lb(LB_fluid=lbf, seed=123, gamma=1.5)
+    system.thermostat.set_lb(LB_fluid=lbf, seed=123, gamma=1.5)
 
 
 No other thermostatting mechanism is necessary


### PR DESCRIPTION
Description of changes:
 - `lb.rst` contained outdated code for instantiating the `System`-class, namely missing the mandatory `box_l` parameter, only trying to set it afterwards.
 - Fixed that there and in all other places that I found via a quick search.
 - While at it, I renamed the occurrences of instances of `System` that were not called `system`, to match the naming convention of #1845.



