### PR TITLE
Modernize GPU particle comm

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -131,6 +131,7 @@ if(CUDA)
     cuda_init.cpp
     cuda_init_cuda.cu
     cuda_interface.cpp
+          CudaHostAllocator.cu
     EspressoSystemInterface_cuda.cu
     actor/DipolarBarnesHut_cuda.cu
     actor/DipolarDirectSum_cuda.cu

--- a/src/core/CudaDeviceAllocator.hpp
+++ b/src/core/CudaDeviceAllocator.hpp
@@ -1,0 +1,52 @@
+#ifndef ESPRESSO_CUDA_DEVICE_ALLOCATOR_HPP
+#define ESPRESSO_CUDA_DEVICE_ALLOCATOR_HPP
+
+#include <utils/device_qualifier.hpp>
+
+#ifndef DEVICE_COMPILER
+#error "This header can only be used with a CUDA-capable compiler."
+#endif
+
+#include <thrust/device_free.h>
+#include <thrust/device_malloc.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_reference.h>
+
+/**
+ * @brief Allocator that uses CUDA to allocate GPU memory.
+ *
+ * This allocator uses thrust::malloc and thrust::free to
+ * manage device memory. To be able to have static containers
+ * for device memory, exceptions in deallocations are suppressed.
+ * This is needed because static containers may be destroyed after
+ * the CUDA system was teared down, leading to device_free to fail.
+ *
+ * @tparam T Type to allocate memory for.
+ */
+template <class T> struct CudaDeviceAllocator {
+  using value_type = T;
+  using pointer = thrust::device_ptr<T>;
+  using const_pointer = thrust::device_ptr<const T>;
+  using reference = thrust::device_reference<T>;
+  using const_reference = thrust::device_reference<const T>;
+
+  CudaDeviceAllocator() noexcept = default;
+  template <class U>
+  explicit CudaDeviceAllocator(const CudaDeviceAllocator<U> &) {}
+  template <class U> bool operator==(const CudaDeviceAllocator<U> &) const {
+    return true;
+  }
+  template <class U> bool operator!=(const CudaDeviceAllocator<U> &) const {
+    return false;
+  }
+
+  pointer allocate(const size_t n) const { return thrust::device_malloc<T>(n); }
+  void deallocate(pointer p, size_t) const noexcept {
+    try {
+      thrust::device_free(p);
+    } catch (thrust::system::system_error const &) {
+      ;
+    }
+  }
+};
+#endif

--- a/src/core/CudaHostAllocator.cu
+++ b/src/core/CudaHostAllocator.cu
@@ -1,0 +1,11 @@
+#include "CudaHostAllocator.hpp"
+
+void cuda_malloc_host(void **p, size_t n) {
+  cudaError_t error = cudaMallocHost(p, n);
+
+  if (error) {
+    throw std::bad_alloc();
+  }
+}
+
+void cuda_free_host(void *p) { cudaFreeHost(p); }

--- a/src/core/CudaHostAllocator.cu
+++ b/src/core/CudaHostAllocator.cu
@@ -1,6 +1,10 @@
 #include "CudaHostAllocator.hpp"
 
-void cuda_malloc_host(void **p, size_t n) {
+#include "cuda_wrapper.hpp"
+
+#include <stdexcept>
+
+void cuda_malloc_host(void **p, std::size_t n) {
   cudaError_t error = cudaMallocHost(p, n);
 
   if (error) {

--- a/src/core/CudaHostAllocator.hpp
+++ b/src/core/CudaHostAllocator.hpp
@@ -1,11 +1,10 @@
 #ifndef ESPRESSO_CUDA_HOST_ALLOCATOR_HPP
 #define ESPRESSO_CUDA_HOST_ALLOCATOR_HPP
 
-#include <stdexcept>
 #include <type_traits>
 #include <vector>
 
-void cuda_malloc_host(void **p, size_t n);
+void cuda_malloc_host(void **p, std::size_t n);
 void cuda_free_host(void *p);
 
 /**
@@ -32,15 +31,15 @@ template <class T> struct CudaHostAllocator {
     return false;
   }
 
-  T *allocate(const size_t n) const {
-    T *result(0);
+  T *allocate(const std::size_t n) const {
+    T *result{};
 
     cuda_malloc_host(reinterpret_cast<void **>(&result),
                      n * sizeof(value_type));
 
     return result;
   }
-  void deallocate(T *const p, size_t) const noexcept { cuda_free_host(p); }
+  void deallocate(T *const p, std::size_t) const noexcept { cuda_free_host(p); }
 };
 
 template <class T> using pinned_vector = std::vector<T, CudaHostAllocator<T>>;

--- a/src/core/CudaHostAllocator.hpp
+++ b/src/core/CudaHostAllocator.hpp
@@ -1,0 +1,47 @@
+#ifndef ESPRESSO_CUDA_HOST_ALLOCATOR_HPP
+#define ESPRESSO_CUDA_HOST_ALLOCATOR_HPP
+
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+void cuda_malloc_host(void **p, size_t n);
+void cuda_free_host(void *p);
+
+/**
+ * @brief Allocator that uses CUDA to allocate CPU memory.
+ *
+ * Using the CUDA allocator can have performance benefits,
+ * because it returns pinned memory that is suitable for
+ * DMA.
+ *
+ * @tparam T Type to allocate memory for.
+ */
+template <class T> struct CudaHostAllocator {
+  using value_type = T;
+  using pointer = T *;
+  using reference = T &;
+  using const_reference = std::add_const_t<reference>;
+
+  CudaHostAllocator() noexcept = default;
+  template <class U> explicit CudaHostAllocator(const CudaHostAllocator<U> &) {}
+  template <class U> bool operator==(const CudaHostAllocator<U> &) const {
+    return true;
+  }
+  template <class U> bool operator!=(const CudaHostAllocator<U> &) const {
+    return false;
+  }
+
+  T *allocate(const size_t n) const {
+    T *result(0);
+
+    cuda_malloc_host(reinterpret_cast<void **>(&result),
+                     n * sizeof(value_type));
+
+    return result;
+  }
+  void deallocate(T *const p, size_t) const noexcept { cuda_free_host(p); }
+};
+
+template <class T> using pinned_vector = std::vector<T, CudaHostAllocator<T>>;
+#endif

--- a/src/core/EspressoSystemInterface.cpp
+++ b/src/core/EspressoSystemInterface.cpp
@@ -33,8 +33,7 @@ void EspressoSystemInterface::gatherParticles() {
   if (m_gpu) {
     if (gpu_get_global_particle_vars_pointer_host()->communication_enabled) {
       copy_part_data_to_gpu(cell_structure.local_cells().particles());
-      reallocDeviceMemory(
-          gpu_get_global_particle_vars_pointer_host()->number_of_particles);
+      reallocDeviceMemory(gpu_get_particle_pointer().size());
       if (m_splitParticleStructGpu && (this_node == 0))
         split_particle_struct();
     }

--- a/src/core/EspressoSystemInterface.hpp
+++ b/src/core/EspressoSystemInterface.hpp
@@ -151,7 +151,7 @@ public:
 
   unsigned int npart_gpu() override {
 #ifdef CUDA
-    return m_gpu_npart;
+    return gpu_get_particle_pointer().size();
 #else
     return 0;
 #endif
@@ -160,8 +160,8 @@ public:
 protected:
   static EspressoSystemInterface *m_instance;
   EspressoSystemInterface()
-      : m_gpu_npart(0), m_gpu(false), m_r_gpu_begin(nullptr),
-        m_r_gpu_end(nullptr), m_dip_gpu_begin(nullptr), m_dip_gpu_end(nullptr),
+      : m_gpu(false), m_r_gpu_begin(nullptr), m_r_gpu_end(nullptr),
+        m_dip_gpu_begin(nullptr), m_dip_gpu_end(nullptr),
         m_v_gpu_begin(nullptr), m_v_gpu_end(nullptr), m_q_gpu_begin(nullptr),
         m_q_gpu_end(nullptr), m_director_gpu_begin(nullptr),
         m_director_gpu_end(nullptr), m_needsParticleStructGpu(false),

--- a/src/core/EspressoSystemInterface.hpp
+++ b/src/core/EspressoSystemInterface.hpp
@@ -175,8 +175,7 @@ protected:
     if (!gpu_get_global_particle_vars_pointer_host()->communication_enabled) {
       gpu_init_particle_comm();
       cuda_bcast_global_part_params();
-      reallocDeviceMemory(
-          gpu_get_global_particle_vars_pointer_host()->number_of_particles);
+      reallocDeviceMemory(gpu_get_particle_pointer().size());
     }
   };
   void reallocDeviceMemory(int n);

--- a/src/core/EspressoSystemInterface_cuda.cu
+++ b/src/core/EspressoSystemInterface_cuda.cu
@@ -169,7 +169,8 @@ void EspressoSystemInterface::reallocDeviceMemory(int n) {
 }
 
 void EspressoSystemInterface::split_particle_struct() {
-  int n = gpu_get_global_particle_vars_pointer_host()->number_of_particles;
+  auto device_particles = gpu_get_particle_pointer();
+  int n = device_particles.size();
   if (n == 0)
     return;
 
@@ -178,27 +179,27 @@ void EspressoSystemInterface::split_particle_struct() {
 
   if (m_needsQGpu && m_needsRGpu)
     hipLaunchKernelGGL(split_kernel_rq, dim3(grid), dim3(block), 0, 0,
-                       gpu_get_particle_pointer(), m_r_gpu_begin, m_q_gpu_begin,
+                       device_particles.data(), m_r_gpu_begin, m_q_gpu_begin,
                        n);
   if (m_needsQGpu && !m_needsRGpu)
     hipLaunchKernelGGL(split_kernel_q, dim3(grid), dim3(block), 0, 0,
-                       gpu_get_particle_pointer(), m_q_gpu_begin, n);
+                       device_particles.data(), m_q_gpu_begin, n);
   if (!m_needsQGpu && m_needsRGpu)
     hipLaunchKernelGGL(split_kernel_r, dim3(grid), dim3(block), 0, 0,
-                       gpu_get_particle_pointer(), m_r_gpu_begin, n);
+                       device_particles.data(), m_r_gpu_begin, n);
 #ifdef CUDA
   if (m_needsVGpu)
     hipLaunchKernelGGL(split_kernel_v, dim3(grid), dim3(block), 0, 0,
-                       gpu_get_particle_pointer(), m_v_gpu_begin, n);
+                       device_particles.data(), m_v_gpu_begin, n);
 #endif
 #ifdef DIPOLES
   if (m_needsDipGpu)
     hipLaunchKernelGGL(split_kernel_dip, dim3(grid), dim3(block), 0, 0,
-                       gpu_get_particle_pointer(), m_dip_gpu_begin, n);
+                       device_particles.data(), m_dip_gpu_begin, n);
 
 #endif
 
   if (m_needsDirectorGpu)
     hipLaunchKernelGGL(split_kernel_director, dim3(grid), dim3(block), 0, 0,
-                       gpu_get_particle_pointer(), m_director_gpu_begin, n);
+                       device_particles.data(), m_director_gpu_begin, n);
 }

--- a/src/core/EspressoSystemInterface_cuda.cu
+++ b/src/core/EspressoSystemInterface_cuda.cu
@@ -20,7 +20,6 @@
 #include "cuda_wrapper.hpp"
 
 #include "EspressoSystemInterface.hpp"
-#include "cuda_init.hpp"
 #include "cuda_interface.hpp"
 #include "cuda_utils.hpp"
 #include "errorhandling.hpp"

--- a/src/core/actor/DipolarBarnesHut.hpp
+++ b/src/core/actor/DipolarBarnesHut.hpp
@@ -54,11 +54,11 @@ public:
     if (!s.requestDipGpu())
       std::cerr << "DipolarBarnesHut needs access to dipoles on GPU!"
                 << std::endl;
-
-    allocBHmemCopy(s.npart_gpu(), &m_bh_data);
   };
 
   void computeForces(SystemInterface &s) override {
+    allocBHmemCopy(s.npart_gpu(), &m_bh_data);
+
     fillConstantPointers(s.rGpuBegin(), s.dipGpuBegin(), m_bh_data);
     initBHgpu(m_bh_data.blocks);
     buildBoxBH(m_bh_data.blocks);
@@ -73,6 +73,8 @@ public:
     }
   };
   void computeEnergy(SystemInterface &s) override {
+    allocBHmemCopy(s.npart_gpu(), &m_bh_data);
+
     fillConstantPointers(s.rGpuBegin(), s.dipGpuBegin(), m_bh_data);
     initBHgpu(m_bh_data.blocks);
     buildBoxBH(m_bh_data.blocks);

--- a/src/core/actor/DipolarBarnesHut_cuda.cu
+++ b/src/core/actor/DipolarBarnesHut_cuda.cu
@@ -1191,6 +1191,9 @@ void setBHPrecision(float *epssq, float *itolsq) {
 // An allocation of the GPU device memory and an initialization where it is
 // needed.
 void allocBHmemCopy(int nbodies, BHData *bh_data) {
+  if (bh_data->nbodies == nbodies)
+    return;
+
   bh_data->nbodies = nbodies;
 
   int devID = -1;

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -22,6 +22,7 @@
 #include "config.hpp"
 #include "debug.hpp"
 
+#include "ParticleRange.hpp"
 #include "cuda_init.hpp"
 #include "cuda_interface.hpp"
 #include "cuda_utils.hpp"
@@ -278,7 +279,7 @@ void copy_part_data_to_gpu(ParticleRange particles) {
 
 /** setup and call kernel to copy particle forces to host
  */
-void copy_forces_from_GPU(ParticleRange particles) {
+void copy_forces_from_GPU(const ParticleRange &particles) {
   if (global_part_vars_host.communication_enabled == 1 &&
       global_part_vars_host.number_of_particles) {
 

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -83,6 +83,21 @@ void _cuda_check_errors(const dim3 &block, const dim3 &grid,
   }
 }
 
+/**
+ * @brief Resize a @ref device_vector.
+ *
+ * Due to a bug in thrust (https://github.com/thrust/thrust/issues/939),
+ * resizing or appending to default constructed containers causes undefined
+ * behavior by dereferencing a null-pointer for certain types. This
+ * function is used instead of the resize member function to side-step
+ * the problem. This is done by replacing the existing vector by a new
+ * one constructed with the desired size if resizing from capacity zero.
+ * Behaves as-if vec.resize(n) was called.
+ *
+ * @tparam T Type contained in the vector.
+ * @param vec Vector To resize.
+ * @param n Desired new size of the element.
+ */
 template <class T> void resize_or_replace(device_vector<T> &vec, size_t n) {
   if (vec.capacity() == 0) {
     vec = device_vector<T>(n);

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -27,8 +27,6 @@
 #include "cuda_interface.hpp"
 #include "cuda_utils.hpp"
 #include "errorhandling.hpp"
-#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
-#include "particle_data.hpp"
 
 #include "CudaDeviceAllocator.hpp"
 #include "CudaHostAllocator.hpp"
@@ -181,9 +179,9 @@ void copy_forces_from_GPU(ParticleRange &particles) {
 
       cudaDeviceSynchronize();
     }
-    using Utils::make_span;
-    cuda_mpi_send_forces(particles, make_span(particle_forces_host),
-                         make_span(particle_torques_host));
+    cuda_mpi_send_forces(
+        particles, {particle_forces_host.data(), particle_forces_host.size()},
+        {particle_torques_host.data(), particle_torques_host.size()});
   }
 }
 

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -138,8 +138,9 @@ void gpu_change_number_of_part_to_comm() {
 
   if (global_part_vars_host.number_of_particles != n_part &&
       global_part_vars_host.communication_enabled == 1 && this_node == 0) {
+    -0
 
-    global_part_vars_host.number_of_particles = n_part;
+     global_part_vars_host.number_of_particles = n_part;
 
     // if the arrays exists free them to prevent memory leaks
     particle_forces_host.clear();
@@ -224,7 +225,7 @@ float *gpu_get_particle_torque_pointer() {
 void copy_part_data_to_gpu(ParticleRange particles) {
   if (global_part_vars_host.communication_enabled == 1 &&
       global_part_vars_host.number_of_particles) {
-    cuda_mpi_get_particles(particles, particle_data_host.data());
+    cuda_mpi_get_particles(particles, particle_data_host);
 
     /* get espressomd particle values */
     if (this_node == 0) {

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -322,15 +322,6 @@ void copy_energy_from_GPU() {
 }
 
 /** @name Generic copy functions from and to device */
-/*@{*/
-void cuda_copy_to_device(void *host_data, void *device_data, size_t n) {
-  cuda_safe_mem(cudaMemcpy(host_data, device_data, n, cudaMemcpyHostToDevice));
-}
-
-void cuda_copy_to_host(void *host_device, void *device_host, size_t n) {
-  cuda_safe_mem(
-      cudaMemcpy(host_device, device_host, n, cudaMemcpyDeviceToHost));
-}
 
 void _cuda_safe_mem(cudaError_t CU_err, const char *file, unsigned int line) {
   if (cudaSuccess != CU_err) {

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -84,7 +84,7 @@ static void pack_particles(ParticleRange particles,
   }
 }
 
-void cuda_mpi_get_particles(ParticleRange particles,
+void cuda_mpi_get_particles(const ParticleRange &particles,
                             CUDA_particle_data *particle_data_host) {
   auto const n_part = particles.size();
 
@@ -169,5 +169,7 @@ void copy_CUDA_energy_to_energy(CUDA_energy energy_host) {
   if (energy.n_dipolar >= 2)
     energy.dipolar[1] += energy_host.dipolar;
 }
+
+void cuda_bcast_global_part_params() { mpi_bcast_cuda_global_part_vars(); }
 
 #endif /* ifdef CUDA */

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -132,7 +132,7 @@ static void add_forces_and_torques(ParticleRange particles,
   }
 }
 
-void cuda_mpi_send_forces(ParticleRange particles,
+void cuda_mpi_send_forces(const ParticleRange &particles,
                           Utils::Span<float> host_forces,
                           Utils::Span<float> host_torques) {
   auto const n_elements = 3 * particles.size();

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -84,8 +84,9 @@ static void pack_particles(ParticleRange particles,
   }
 }
 
-void cuda_mpi_get_particles(const ParticleRange &particles,
-                            CUDA_particle_data *particle_data_host) {
+void cuda_mpi_get_particles(
+    const ParticleRange &particles,
+    pinned_vector<CUDA_particle_data> &particle_data_host) {
   auto const n_part = particles.size();
 
   if (this_node > 0) {
@@ -96,10 +97,12 @@ void cuda_mpi_get_particles(const ParticleRange &particles,
 
     Utils::Mpi::gather_buffer(buffer.data(), buffer.size(), comm_cart);
   } else {
-    /* Pack own particles */
-    pack_particles(particles, particle_data_host);
+    particle_data_host.resize(n_part);
 
-    Utils::Mpi::gather_buffer(particle_data_host, n_part, comm_cart);
+    /* Pack own particles */
+    pack_particles(particles, particle_data_host.data());
+
+    Utils::Mpi::gather_buffer(particle_data_host, comm_cart);
   }
 }
 

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -118,8 +118,8 @@ void cuda_mpi_get_particles(ParticleRange particles,
  *                this is only touched if ROTATION is active.
  */
 static void add_forces_and_torques(ParticleRange particles,
-                                   const std::vector<float> &forces,
-                                   const std::vector<float> &torques) {
+                                   Utils::Span<const float> forces,
+                                   Utils::Span<const float> torques) {
   int i = 0;
   for (auto &part : particles) {
     for (int j = 0; j < 3; j++) {
@@ -133,8 +133,8 @@ static void add_forces_and_torques(ParticleRange particles,
 }
 
 void cuda_mpi_send_forces(ParticleRange particles,
-                          std::vector<float> &host_forces,
-                          std::vector<float> &host_torques) {
+                          Utils::Span<float> host_forces,
+                          Utils::Span<float> host_torques) {
   auto const n_elements = 3 * particles.size();
 
   if (this_node > 0) {

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -30,12 +30,6 @@
 #include <utils/mpi/gather_buffer.hpp>
 #include <utils/mpi/scatter_buffer.hpp>
 
-#ifdef ENGINE
-static void cuda_mpi_send_v_cs_slave(ParticleRange particles);
-#endif
-
-void cuda_bcast_global_part_params() { mpi_bcast_cuda_global_part_vars(); }
-
 /* TODO: We should only transfer data for enabled methods,
          not for those that are barely compiled in. (fw)
 */

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -142,8 +142,8 @@ void copy_part_data_to_gpu(ParticleRange particles);
  * This is a collective call.
  */
 void cuda_mpi_send_forces(ParticleRange particles,
-                          std::vector<float> &host_forces,
-                          std::vector<float> &host_torques);
+                          Utils::Span<float> host_forces,
+                          Utils::Span<float> host_torques);
 void cuda_bcast_global_part_params();
 void cuda_copy_to_device(void *host_data, void *device_data, size_t n);
 void cuda_copy_to_host(void *host_device, void *device_host, size_t n);

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -23,6 +23,7 @@
 
 #ifdef CUDA
 
+#include "CudaHostAllocator.hpp"
 #include "ParticleRange.hpp"
 
 #include <utils/Span.hpp>
@@ -124,8 +125,9 @@ float *gpu_get_particle_torque_pointer();
 void gpu_change_number_of_part_to_comm();
 void gpu_init_particle_comm();
 
-void cuda_mpi_get_particles(const ParticleRange &particles,
-                            CUDA_particle_data *particle_data_host);
+void cuda_mpi_get_particles(
+    const ParticleRange &particles,
+    pinned_vector<CUDA_particle_data> &particle_data_host);
 void copy_part_data_to_gpu(ParticleRange particles);
 
 /**

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -107,7 +107,7 @@ typedef struct {
   unsigned int communication_enabled;
 } CUDA_global_part_vars;
 
-void copy_forces_from_GPU(ParticleRange particles);
+void copy_forces_from_GPU(ParticleRange &particles);
 void copy_energy_from_GPU();
 void copy_CUDA_energy_to_energy(CUDA_energy energy_host);
 void clear_energy_on_GPU();

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -100,8 +100,6 @@ typedef struct {
  *  one individual particle.
  */
 typedef struct {
-  unsigned int number_of_particles;
-
   /** Boolean flag to indicate if particle info should be communicated
    *  between the cpu and gpu
    */
@@ -114,7 +112,7 @@ void copy_CUDA_energy_to_energy(CUDA_energy energy_host);
 void clear_energy_on_GPU();
 
 CUDA_global_part_vars *gpu_get_global_particle_vars_pointer_host();
-CUDA_particle_data *gpu_get_particle_pointer();
+Utils::Span<CUDA_particle_data> gpu_get_particle_pointer();
 float *gpu_get_particle_force_pointer();
 #ifdef ROTATION
 float *gpu_get_particle_torque_pointer();
@@ -122,7 +120,6 @@ float *gpu_get_particle_torque_pointer();
 
 CUDA_energy *gpu_get_energy_pointer();
 float *gpu_get_particle_torque_pointer();
-void gpu_change_number_of_part_to_comm();
 void gpu_init_particle_comm();
 
 void cuda_mpi_get_particles(

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -145,8 +145,6 @@ void cuda_mpi_send_forces(const ParticleRange &particles,
                           Utils::Span<float> host_forces,
                           Utils::Span<float> host_torques);
 void cuda_bcast_global_part_params();
-void cuda_copy_to_device(void *host_data, void *device_data, size_t n);
-void cuda_copy_to_host(void *host_device, void *device_host, size_t n);
 #endif /* ifdef CUDA */
 
 #endif /* ifdef CUDA_INTERFACE_HPP */

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -124,8 +124,8 @@ float *gpu_get_particle_torque_pointer();
 void gpu_change_number_of_part_to_comm();
 void gpu_init_particle_comm();
 
-void cuda_mpi_get_particles(ParticleRange particles,
-                            CUDA_particle_data *host_result);
+void cuda_mpi_get_particles(const ParticleRange &particles,
+                            CUDA_particle_data *particle_data_host);
 void copy_part_data_to_gpu(ParticleRange particles);
 
 /**

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -141,7 +141,7 @@ void copy_part_data_to_gpu(ParticleRange particles);
  *
  * This is a collective call.
  */
-void cuda_mpi_send_forces(ParticleRange particles,
+void cuda_mpi_send_forces(const ParticleRange &particles,
                           Utils::Span<float> host_forces,
                           Utils::Span<float> host_torques);
 void cuda_bcast_global_part_params();

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -95,8 +95,6 @@ typedef struct {
   float bonded, non_bonded, coulomb, dipolar;
 } CUDA_energy;
 
-extern CUDA_particle_data *particle_data_host;
-
 /** Global variables associated with all of the particles and not with
  *  one individual particle.
  */
@@ -115,7 +113,6 @@ void copy_CUDA_energy_to_energy(CUDA_energy energy_host);
 void clear_energy_on_GPU();
 
 CUDA_global_part_vars *gpu_get_global_particle_vars_pointer_host();
-CUDA_global_part_vars *gpu_get_global_particle_vars_pointer();
 CUDA_particle_data *gpu_get_particle_pointer();
 float *gpu_get_particle_force_pointer();
 #ifdef ROTATION

--- a/src/core/cuda_wrapper.hpp
+++ b/src/core/cuda_wrapper.hpp
@@ -61,6 +61,7 @@
 #define cudaMemcpyToSymbol hipMemcpyToSymbol
 #define cudaMemGetInfo hipMemGetInfo
 #define cudaMemset hipMemset
+#define cudaMemsetAsync hipMemsetAsync
 #define cudaSetDevice hipSetDevice
 #define cudaStreamCreate hipStreamCreate
 #define cudaStreamDestroy hipStreamDestroy

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -549,8 +549,7 @@ void p3m_gpu_init(int cao, const int mesh[3], double alpha) {
     espressoSystemInterface.requestParticleStructGpu();
 
     int reinit_if = 0, mesh_changed = 0;
-    p3m_gpu_data.n_part =
-        gpu_get_global_particle_vars_pointer_host()->number_of_particles;
+    p3m_gpu_data.n_part = gpu_get_particle_pointer().size();
 
     if ((p3m_gpu_data_initialized == 0) || (p3m_gpu_data.alpha != alpha)) {
       p3m_gpu_data.alpha = alpha;
@@ -690,14 +689,11 @@ void p3m_gpu_init(int cao, const int mesh[3], double alpha) {
  *  \brief The long range part of the P3M algorithm.
  */
 void p3m_gpu_add_farfield_force() {
-  CUDA_particle_data *lb_particle_gpu;
-  float *lb_particle_force_gpu;
+  auto device_particles = gpu_get_particle_pointer();
+  CUDA_particle_data *lb_particle_gpu = device_particles.data();
+  p3m_gpu_data.n_part = device_particles.size();
 
-  lb_particle_gpu = gpu_get_particle_pointer();
-  lb_particle_force_gpu = gpu_get_particle_force_pointer();
-
-  p3m_gpu_data.n_part =
-      gpu_get_global_particle_vars_pointer_host()->number_of_particles;
+  float *lb_particle_force_gpu = gpu_get_particle_force_pointer();
 
   if (p3m_gpu_data.n_part == 0)
     return;

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -214,9 +214,6 @@ void on_particle_change() {
   reinit_electrostatics = true;
   reinit_magnetostatics = true;
 
-#ifdef CUDA
-  lb_lbfluid_invalidate_particle_allocation();
-#endif
   invalidate_obs();
 
   /* the particle information is no longer valid */

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -70,10 +70,6 @@ static bool reinit_thermo = true;
 static int reinit_electrostatics = false;
 static int reinit_magnetostatics = false;
 
-#ifdef CUDA
-static int reinit_particle_comm_gpu = true;
-#endif
-
 #if defined(OPEN_MPI) &&                                                       \
     (OMPI_MAJOR_VERSION == 2 && OMPI_MINOR_VERSION <= 1 ||                     \
      OMPI_MAJOR_VERSION == 3 &&                                                \
@@ -88,7 +84,6 @@ static int reinit_particle_comm_gpu = true;
 #endif
 
 void on_program_start() {
-
 #ifdef CUDA
   cuda_init();
 #endif
@@ -122,11 +117,8 @@ void on_integration_start() {
   /********************************************/
   /* end sanity checks                        */
   /********************************************/
+
 #ifdef CUDA
-  if (reinit_particle_comm_gpu) {
-    gpu_change_number_of_part_to_comm();
-    reinit_particle_comm_gpu = false;
-  }
   MPI_Bcast(gpu_get_global_particle_vars_pointer_host(),
             sizeof(CUDA_global_part_vars), MPI_BYTE, 0, comm_cart);
 #endif
@@ -225,9 +217,6 @@ void on_particle_change() {
 #ifdef CUDA
   lb_lbfluid_invalidate_particle_allocation();
 #endif
-#ifdef CUDA
-  reinit_particle_comm_gpu = true;
-#endif
   invalidate_obs();
 
   /* the particle information is no longer valid */
@@ -253,9 +242,6 @@ void on_coulomb_change() {
      since the required cutoff might have reduced. */
   on_short_range_ia_change();
 
-#ifdef CUDA
-  reinit_particle_comm_gpu = true;
-#endif
   recalc_forces = true;
 }
 

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -2133,8 +2133,10 @@ void ek_calculate_electrostatic_coupling() {
                           (threads_per_block * blocks_per_grid_y);
   dim3 dim_grid = make_uint3(blocks_per_grid_x, blocks_per_grid_y, 1);
 
+  auto device_particles = gpu_get_particle_pointer();
+
   KERNELCALL(ek_spread_particle_force, dim_grid, threads_per_block,
-             gpu_get_particle_pointer(), gpu_get_particle_force_pointer(),
+             device_particles.data(), gpu_get_particle_force_pointer(),
              ek_lbparameters_gpu);
 }
 
@@ -2169,7 +2171,7 @@ void ek_integrate_electrostatics() {
                         (threads_per_block * blocks_per_grid_y);
     dim_grid = make_uint3(blocks_per_grid_x, blocks_per_grid_y, 1);
 
-    particle_data_gpu = gpu_get_particle_pointer();
+    particle_data_gpu = gpu_get_particle_pointer().data();
 
     KERNELCALL(ek_gather_particle_charge_density, dim_grid, threads_per_block,
                particle_data_gpu, ek_lbparameters_gpu);
@@ -3965,7 +3967,7 @@ struct ek_charge_of_particle {
 };
 
 ekfloat ek_get_particle_charge() {
-  particle_data_gpu = gpu_get_particle_pointer();
+  particle_data_gpu = gpu_get_particle_pointer().data();
   thrust::device_ptr<CUDA_particle_data> ptr(particle_data_gpu);
   ekfloat particle_charge = thrust::transform_reduce(
       ptr, ptr + lbpar_gpu.number_of_particles, ek_charge_of_particle(), 0.0f,

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -1836,13 +1836,14 @@ __global__ void ek_gather_species_charge_density() {
 
 __global__ void
 ek_gather_particle_charge_density(CUDA_particle_data *particle_data,
+                                  size_t number_of_particles,
                                   LB_parameters_gpu *ek_lbparameters_gpu) {
   unsigned int index = ek_getThreadIndex();
   int lowernode[3];
   float cellpos[3];
   float gridpos;
 
-  if (index < ek_lbparameters_gpu->number_of_particles) {
+  if (index < number_of_particles) {
     gridpos = particle_data[index].p[0] / ek_parameters_gpu->agrid - 0.5f;
     lowernode[0] = (int)floorf(gridpos);
     cellpos[0] = gridpos - lowernode[0];
@@ -1921,7 +1922,7 @@ ek_gather_particle_charge_density(CUDA_particle_data *particle_data,
 
 __global__ void
 ek_spread_particle_force(CUDA_particle_data *particle_data,
-                         float *particle_forces,
+                         size_t number_of_particles, float *particle_forces,
                          LB_parameters_gpu *ek_lbparameters_gpu) {
 
   unsigned int index = ek_getThreadIndex();
@@ -1929,7 +1930,7 @@ ek_spread_particle_force(CUDA_particle_data *particle_data,
   float cellpos[3];
   float gridpos;
 
-  if (index < ek_lbparameters_gpu->number_of_particles) {
+  if (index < number_of_particles) {
     gridpos = particle_data[index].p[0] / ek_parameters_gpu->agrid - 0.5f;
     lowernode[0] = (int)floorf(gridpos);
     cellpos[0] = gridpos - (float)(lowernode[0]);
@@ -2128,16 +2129,15 @@ void ek_calculate_electrostatic_coupling() {
   if ((!ek_parameters.es_coupling) || (!ek_initialized))
     return;
 
-  int blocks_per_grid_x = (lbpar_gpu.number_of_particles +
-                           threads_per_block * blocks_per_grid_y - 1) /
-                          (threads_per_block * blocks_per_grid_y);
+  auto device_particles = gpu_get_particle_pointer();
+  int blocks_per_grid_x =
+      (device_particles.size() + threads_per_block * blocks_per_grid_y - 1) /
+      (threads_per_block * blocks_per_grid_y);
   dim3 dim_grid = make_uint3(blocks_per_grid_x, blocks_per_grid_y, 1);
 
-  auto device_particles = gpu_get_particle_pointer();
-
   KERNELCALL(ek_spread_particle_force, dim_grid, threads_per_block,
-             device_particles.data(), gpu_get_particle_force_pointer(),
-             ek_lbparameters_gpu);
+             device_particles.data(), device_particles.size(),
+             gpu_get_particle_force_pointer(), ek_lbparameters_gpu);
 }
 
 void ek_integrate_electrostatics() {
@@ -2163,18 +2163,19 @@ void ek_integrate_electrostatics() {
                ek_parameters.charge_potential_buffer);
   }
 
-  if (lbpar_gpu.number_of_particles !=
-      0) // TODO make it an if number_of_charged_particles != 0
+  auto device_particles = gpu_get_particle_pointer();
+  if (not device_particles
+              .empty()) // TODO make it an if number_of_charged_particles != 0
   {
-    blocks_per_grid_x = (lbpar_gpu.number_of_particles +
-                         threads_per_block * blocks_per_grid_y - 1) /
-                        (threads_per_block * blocks_per_grid_y);
+    blocks_per_grid_x =
+        (device_particles.size() + threads_per_block * blocks_per_grid_y - 1) /
+        (threads_per_block * blocks_per_grid_y);
     dim_grid = make_uint3(blocks_per_grid_x, blocks_per_grid_y, 1);
 
-    particle_data_gpu = gpu_get_particle_pointer().data();
+    particle_data_gpu = device_particles.data();
 
     KERNELCALL(ek_gather_particle_charge_density, dim_grid, threads_per_block,
-               particle_data_gpu, ek_lbparameters_gpu);
+               particle_data_gpu, device_particles.size(), ek_lbparameters_gpu);
   }
 
   electrostatics->calculatePotential();
@@ -3805,8 +3806,6 @@ void ek_print_lbpar() {
   printf("    unsigned int dim_y = %d;\n", lbpar_gpu.dim_y);
   printf("    unsigned int dim_z = %d;\n", lbpar_gpu.dim_z);
   printf("    unsigned int number_of_nodes = %d;\n", lbpar_gpu.number_of_nodes);
-  printf("    unsigned int number_of_particles = %d;\n",
-         lbpar_gpu.number_of_particles);
   printf("    int calc_val = %d;\n", lbpar_gpu.calc_val);
   printf("    int external_force_density = %d;\n",
          lbpar_gpu.external_force_density);
@@ -3967,11 +3966,11 @@ struct ek_charge_of_particle {
 };
 
 ekfloat ek_get_particle_charge() {
-  particle_data_gpu = gpu_get_particle_pointer().data();
-  thrust::device_ptr<CUDA_particle_data> ptr(particle_data_gpu);
+  auto device_particles = gpu_get_particle_pointer();
   ekfloat particle_charge = thrust::transform_reduce(
-      ptr, ptr + lbpar_gpu.number_of_particles, ek_charge_of_particle(), 0.0f,
-      thrust::plus<ekfloat>());
+      thrust::device_ptr<CUDA_particle_data>(device_particles.begin()),
+      thrust::device_ptr<CUDA_particle_data>(device_particles.end()),
+      ek_charge_of_particle(), 0.0f, thrust::plus<ekfloat>());
   return particle_charge;
 }
 

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -118,12 +118,6 @@ void lb_lbfluid_on_integration_start() {
   }
 }
 
-void lb_lbfluid_invalidate_particle_allocation() {
-#ifdef CUDA
-  lb_reinit_particles_gpu.invalidate();
-#endif
-}
-
 /** (Re-)initialize the fluid. */
 void lb_lbfluid_reinit_parameters() {
   if (lattice_switch == ActiveLB::GPU) {

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -112,14 +112,7 @@ void lb_lbfluid_sanity_checks() {
 
 void lb_lbfluid_on_integration_start() {
   lb_lbfluid_sanity_checks();
-  if (lattice_switch == ActiveLB::GPU) {
-#ifdef CUDA
-    if (this_node == 0 and lb_reinit_particles_gpu()) {
-      lb_realloc_particles_gpu();
-      lb_reinit_particles_gpu.validate();
-    }
-#endif
-  } else if (lattice_switch == ActiveLB::CPU) {
+  if (lattice_switch == ActiveLB::CPU) {
     halo_communication(&update_halo_comm,
                        reinterpret_cast<char *>(lbfluid[0].data()));
   }

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -135,11 +135,6 @@ void lb_lbfluid_set_kT(double kT);
 void lb_lbfluid_sanity_checks();
 
 /**
- * @brief Invalidate the particle allocation on the GPU.
- */
-void lb_lbfluid_invalidate_particle_allocation();
-
-/**
  * @brief Set the LB density for a single node.
  */
 void lb_lbnode_set_density(const Utils::Vector3i &ind, double density);

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -77,8 +77,6 @@ LB_parameters_gpu lbpar_gpu = {
     0,
     // number_of_nodes
     0,
-    // number_of_particles
-    0,
 #ifdef LB_BOUNDARIES_GPU
     // number_of_boundnodes
     0,

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -44,8 +44,6 @@
 #include <cmath>
 #include <cstdlib>
 
-LB_particle_allocation_state lb_reinit_particles_gpu;
-
 LB_parameters_gpu lbpar_gpu = {
     // rho
     0.0,

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -122,13 +122,6 @@ void lattice_boltzmann_update_gpu() {
   }
 }
 
-/** (Re-)allocation of the memory needed for the particles (CPU part) */
-void lb_realloc_particles_gpu() {
-  lbpar_gpu.number_of_particles = n_part;
-
-  lb_realloc_particles_GPU_leftovers(&lbpar_gpu);
-}
-
 /** (Re-)initialize the fluid according to the given value of rho. */
 void lb_reinit_fluid_gpu() {
 
@@ -226,8 +219,6 @@ void lb_reinit_parameters_gpu() {
 void lb_init_gpu() {
   /** set parameters for transfer to gpu */
   lb_reinit_parameters_gpu();
-
-  lb_realloc_particles_gpu();
 
   lb_init_GPU(&lbpar_gpu);
 

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -197,10 +197,6 @@ void lb_reinit_fluid_gpu();
 /** Reset the forces on the fluid nodes */
 void reset_LB_force_densities_GPU(bool buffer = true);
 
-/** (Re-)initialize the particle array */
-void lb_realloc_particles_gpu();
-void lb_realloc_particles_GPU_leftovers(LB_parameters_gpu *lbpar_gpu);
-
 void lb_init_GPU(LB_parameters_gpu *lbpar_gpu);
 void lb_integrate_GPU();
 

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -95,7 +95,6 @@ struct LB_parameters_gpu {
   unsigned int dim_z;
 
   unsigned int number_of_nodes;
-  unsigned int number_of_particles;
 #ifdef LB_BOUNDARIES_GPU
   unsigned int number_of_boundnodes;
 #endif

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -2191,18 +2191,17 @@ __global__ void integrate(LB_nodes_gpu n_a, LB_nodes_gpu n_b, LB_rho_v_gpu *d_v,
  * interpolation
  */
 template <std::size_t no_of_neighbours>
-__global__ void
-calc_fluid_particle_ia(LB_nodes_gpu n_a, CUDA_particle_data *particle_data,
-                       float *particle_force, LB_node_force_density_gpu node_f,
-                       LB_rho_v_gpu *d_v, bool couple_virtual,
-                       uint64_t philox_counter, float friction) {
+__global__ void calc_fluid_particle_ia(
+    LB_nodes_gpu n_a, Utils::Span<CUDA_particle_data> particle_data,
+    float *particle_force, LB_node_force_density_gpu node_f, LB_rho_v_gpu *d_v,
+    bool couple_virtual, uint64_t philox_counter, float friction) {
 
   unsigned int part_index = blockIdx.y * gridDim.x * blockDim.x +
                             blockDim.x * blockIdx.x + threadIdx.x;
   Utils::Array<unsigned int, no_of_neighbours> node_index;
   Utils::Array<float, no_of_neighbours> delta;
   float delta_j[3];
-  if (part_index < para->number_of_particles) {
+  if (part_index < particle_data.size()) {
 #if defined(VIRTUAL_SITES)
     if (!particle_data[part_index].is_virtual || couple_virtual)
 #endif
@@ -2210,15 +2209,15 @@ calc_fluid_particle_ia(LB_nodes_gpu n_a, CUDA_particle_data *particle_data,
       /* force acting on the particle. delta_j will be used later to compute the
        * force that acts back onto the fluid. */
       calc_viscous_force<no_of_neighbours>(
-          n_a, delta, particle_data, particle_force, part_index, delta_j,
+          n_a, delta, particle_data.data(), particle_force, part_index, delta_j,
           node_index, d_v, 0, philox_counter, friction);
       calc_node_force<no_of_neighbours>(delta, delta_j, node_index, node_f);
 
 #ifdef ENGINE
       if (particle_data[part_index].swim.swimming) {
         calc_viscous_force<no_of_neighbours>(
-            n_a, delta, particle_data, particle_force, part_index, delta_j,
-            node_index, d_v, 1, philox_counter, friction);
+            n_a, delta, particle_data.data(), particle_force, part_index,
+            delta_j, node_index, d_v, 1, philox_counter, friction);
         calc_node_force<no_of_neighbours>(delta, delta_j, node_index, node_f);
       }
 #endif
@@ -2474,12 +2473,6 @@ void lb_reinit_GPU(LB_parameters_gpu *lbpar_gpu) {
              device_rho_v, node_f, gpu_check);
 }
 
-void lb_realloc_particles_GPU_leftovers(LB_parameters_gpu *lbpar_gpu) {
-  // copy parameters, especially number of parts to gpu mem
-  cuda_safe_mem(cudaMemcpyToSymbol(HIP_SYMBOL(para), lbpar_gpu,
-                                   sizeof(LB_parameters_gpu)));
-}
-
 #ifdef LB_BOUNDARIES_GPU
 /** Setup and call boundaries from the host
  *  @param host_n_lb_boundaries        Number of LB boundaries
@@ -2581,13 +2574,15 @@ void lb_reinit_extern_nodeforce_GPU(LB_parameters_gpu *lbpar_gpu) {
  */
 template <std::size_t no_of_neighbours>
 void lb_calc_particle_lattice_ia_gpu(bool couple_virtual, double friction) {
-  if (lbpar_gpu.number_of_particles) {
+  auto device_particles = gpu_get_particle_pointer();
+
+  if (not device_particles.empty()) {
     /* call of the particle kernel */
     /* values for the particle kernel */
     int threads_per_block_particles = 64;
     int blocks_per_grid_particles_y = 4;
     int blocks_per_grid_particles_x =
-        (lbpar_gpu.number_of_particles +
+        (device_particles.size() +
          threads_per_block_particles * blocks_per_grid_particles_y - 1) /
         (threads_per_block_particles * blocks_per_grid_particles_y);
     dim3 dim_grid_particles =
@@ -2595,16 +2590,15 @@ void lb_calc_particle_lattice_ia_gpu(bool couple_virtual, double friction) {
     if (lbpar_gpu.kT > 0.0) {
       assert(rng_counter_coupling_gpu);
       KERNELCALL(calc_fluid_particle_ia<no_of_neighbours>, dim_grid_particles,
-                 threads_per_block_particles, *current_nodes,
-                 gpu_get_particle_pointer(), gpu_get_particle_force_pointer(),
-                 node_f, device_rho_v, couple_virtual,
-                 rng_counter_coupling_gpu->value(), friction);
+                 threads_per_block_particles, *current_nodes, device_particles,
+                 gpu_get_particle_force_pointer(), node_f, device_rho_v,
+                 couple_virtual, rng_counter_coupling_gpu->value(), friction);
     } else {
       // We use a dummy value for the RNG counter if no temperature is set.
       KERNELCALL(calc_fluid_particle_ia<no_of_neighbours>, dim_grid_particles,
-                 threads_per_block_particles, *current_nodes,
-                 gpu_get_particle_pointer(), gpu_get_particle_force_pointer(),
-                 node_f, device_rho_v, couple_virtual, 0, friction);
+                 threads_per_block_particles, *current_nodes, device_particles,
+                 gpu_get_particle_force_pointer(), node_f, device_rho_v,
+                 couple_virtual, 0, friction);
     }
   }
 }

--- a/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
+++ b/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
@@ -100,8 +100,7 @@ void IBM_ForcesIntoFluid_GPU(ParticleRange particles) {
   // (2) Copy forces to the GPU
   // (3) interpolate on the LBM grid and spread forces
 
-  const int numParticles =
-      gpu_get_global_particle_vars_pointer_host()->number_of_particles;
+  const int numParticles = gpu_get_particle_pointer().size();
 
   // Storage only needed on master and allocated only once at the first time
   // step if ( IBM_ParticleDataInput_host == nullptr && this_node == 0 )
@@ -125,7 +124,7 @@ void IBM_ForcesIntoFluid_GPU(ParticleRange particles) {
     int threads_per_block_particles = 64;
     int blocks_per_grid_particles_y = 4;
     int blocks_per_grid_particles_x =
-        (lbpar_gpu.number_of_particles +
+        (numParticles +
          threads_per_block_particles * blocks_per_grid_particles_y - 1) /
         (threads_per_block_particles * blocks_per_grid_particles_y);
     dim3 dim_grid_particles =
@@ -273,8 +272,7 @@ void ParticleVelocitiesFromLB_GPU(ParticleRange particles) {
   // (2) transfer velocities back to CPU
   // (3) spread velocities to local cells via MPI
 
-  const int numParticles =
-      gpu_get_global_particle_vars_pointer_host()->number_of_particles;
+  const int numParticles = gpu_get_particle_pointer().size();
 
   // **** GPU stuff only on master ****
   if (this_node == 0 && numParticles > 0) {
@@ -282,7 +280,7 @@ void ParticleVelocitiesFromLB_GPU(ParticleRange particles) {
     int threads_per_block_particles = 64;
     int blocks_per_grid_particles_y = 4;
     int blocks_per_grid_particles_x =
-        (lbpar_gpu.number_of_particles +
+        (numParticles +
          threads_per_block_particles * blocks_per_grid_particles_y - 1) /
         (threads_per_block_particles * blocks_per_grid_particles_y);
     dim3 dim_grid_particles =

--- a/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
+++ b/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
@@ -39,20 +39,6 @@
 // To avoid include of communication.hpp in cuda file
 extern int this_node;
 
-// ****** Kernel functions for internal use ********
-__global__ void ResetLBForces_Kernel(LB_node_force_density_gpu node_f,
-                                     const LB_parameters_gpu *const paraP);
-__global__ void ParticleVelocitiesFromLB_Kernel(
-    LB_nodes_gpu n_curr,
-    const IBM_CUDA_ParticleDataInput *const particles_input,
-    IBM_CUDA_ParticleDataOutput *const particles_output,
-    LB_node_force_density_gpu node_f, const float *const lb_boundary_velocity,
-    const LB_parameters_gpu *const para);
-__global__ void
-ForcesIntoFluid_Kernel(const IBM_CUDA_ParticleDataInput *const particle_input,
-                       LB_node_force_density_gpu node_f,
-                       const LB_parameters_gpu *const paraP);
-
 // ***** Other functions for internal use *****
 void InitCUDA_IBM(const int numParticles);
 
@@ -72,130 +58,6 @@ extern LB_nodes_gpu *current_nodes;
 // but point into device memory.
 LB_parameters_gpu *para_gpu = nullptr;
 float *lb_boundary_velocity_IBM = nullptr;
-
-/** Call a kernel to reset the forces on the LB nodes to the external force. */
-void IBM_ResetLBForces_GPU() {
-  if (this_node == 0) {
-    // Setup for kernel call
-    int threads_per_block = 64;
-    int blocks_per_grid_y = 4;
-    int blocks_per_grid_x = (lbpar_gpu.number_of_nodes +
-                             threads_per_block * blocks_per_grid_y - 1) /
-                            (threads_per_block * blocks_per_grid_y);
-    dim3 dim_grid = make_uint3(blocks_per_grid_x, blocks_per_grid_y, 1);
-
-    KERNELCALL(ResetLBForces_Kernel, dim_grid, threads_per_block, node_f,
-               para_gpu);
-  }
-}
-
-/** Transfer particle forces into the LB fluid.
- *  Called from @ref integrate.
- *  This must be the first CUDA-IBM function to be called because it also does
- *  some initialization.
- */
-void IBM_ForcesIntoFluid_GPU(ParticleRange particles) {
-  // This function does
-  // (1) Gather forces from all particles via MPI
-  // (2) Copy forces to the GPU
-  // (3) interpolate on the LBM grid and spread forces
-
-  const int numParticles = gpu_get_particle_pointer().size();
-
-  // Storage only needed on master and allocated only once at the first time
-  // step if ( IBM_ParticleDataInput_host == nullptr && this_node == 0 )
-  if (IBM_ParticleDataInput_host == NULL ||
-      numParticles != IBM_numParticlesCache)
-    InitCUDA_IBM(numParticles);
-
-  // We gather particle positions and forces from all nodes
-  IBM_cuda_mpi_get_particles(particles);
-
-  // ***** GPU stuff only on master *****
-  if (this_node == 0 && numParticles > 0) {
-
-    // Copy data to device
-    cuda_safe_mem(cudaMemcpy(IBM_ParticleDataInput_device,
-                             IBM_ParticleDataInput_host,
-                             numParticles * sizeof(IBM_CUDA_ParticleDataInput),
-                             cudaMemcpyHostToDevice));
-
-    // Kernel call for spreading the forces on the LB grid
-    int threads_per_block_particles = 64;
-    int blocks_per_grid_particles_y = 4;
-    int blocks_per_grid_particles_x =
-        (numParticles +
-         threads_per_block_particles * blocks_per_grid_particles_y - 1) /
-        (threads_per_block_particles * blocks_per_grid_particles_y);
-    dim3 dim_grid_particles =
-        make_uint3(blocks_per_grid_particles_x, blocks_per_grid_particles_y, 1);
-
-    KERNELCALL(ForcesIntoFluid_Kernel, dim_grid_particles,
-               threads_per_block_particles, IBM_ParticleDataInput_device,
-               node_f, para_gpu);
-  }
-}
-
-void InitCUDA_IBM(const int numParticles) {
-
-  if (this_node == 0) // GPU only on master
-  {
-
-    // Check if we have to delete
-    if (IBM_ParticleDataInput_host != NULL) {
-      delete[] IBM_ParticleDataInput_host;
-      delete[] IBM_ParticleDataOutput_host;
-      cuda_safe_mem(cudaFree(IBM_ParticleDataInput_device));
-      cuda_safe_mem(cudaFree(IBM_ParticleDataOutput_device));
-      cuda_safe_mem(cudaFree(lb_boundary_velocity_IBM));
-    }
-
-    // Back and forth communication of positions and velocities
-    IBM_ParticleDataInput_host = new IBM_CUDA_ParticleDataInput[numParticles];
-    cuda_safe_mem(
-        cudaMalloc((void **)&IBM_ParticleDataInput_device,
-                   numParticles * sizeof(IBM_CUDA_ParticleDataInput)));
-    cuda_safe_mem(
-        cudaMalloc((void **)&IBM_ParticleDataOutput_device,
-                   numParticles * sizeof(IBM_CUDA_ParticleDataOutput)));
-    IBM_ParticleDataOutput_host = new IBM_CUDA_ParticleDataOutput[numParticles];
-
-    // Use LB parameters
-    lb_get_para_pointer(&para_gpu);
-
-    // Copy boundary velocities to the GPU
-    // First put them into correct format
-#ifdef LB_BOUNDARIES_GPU
-    float *host_lb_boundary_velocity =
-        new float[3 * (LBBoundaries::lbboundaries.size() + 1)];
-
-    for (int n = 0; n < LBBoundaries::lbboundaries.size(); n++) {
-      host_lb_boundary_velocity[3 * n + 0] =
-          LBBoundaries::lbboundaries[n]->velocity()[0];
-      host_lb_boundary_velocity[3 * n + 1] =
-          LBBoundaries::lbboundaries[n]->velocity()[1];
-      host_lb_boundary_velocity[3 * n + 2] =
-          LBBoundaries::lbboundaries[n]->velocity()[2];
-    }
-
-    host_lb_boundary_velocity[3 * LBBoundaries::lbboundaries.size() + 0] = 0.0f;
-    host_lb_boundary_velocity[3 * LBBoundaries::lbboundaries.size() + 1] = 0.0f;
-    host_lb_boundary_velocity[3 * LBBoundaries::lbboundaries.size() + 2] = 0.0f;
-
-    cuda_safe_mem(
-        cudaMalloc((void **)&lb_boundary_velocity_IBM,
-                   3 * LBBoundaries::lbboundaries.size() * sizeof(float)));
-    cuda_safe_mem(
-        cudaMemcpy(lb_boundary_velocity_IBM, host_lb_boundary_velocity,
-                   3 * LBBoundaries::lbboundaries.size() * sizeof(float),
-                   cudaMemcpyHostToDevice));
-
-    delete[] host_lb_boundary_velocity;
-#endif
-
-    IBM_numParticlesCache = numParticles;
-  }
-}
 
 /** @copybrief calc_m_from_n
  *
@@ -263,54 +125,16 @@ __device__ void Calc_m_from_n_IBM(const LB_nodes_gpu n_a,
              n_a.vd[18 * para.number_of_nodes + index]);
 }
 
-/** Call a kernel function to interpolate the velocity at each IBM particle's
- *  position. Store velocity in the particle data structure.
- */
-void ParticleVelocitiesFromLB_GPU(ParticleRange particles) {
-  // This function performs three steps:
-  // (1) interpolate velocities on GPU
-  // (2) transfer velocities back to CPU
-  // (3) spread velocities to local cells via MPI
-
-  const int numParticles = gpu_get_particle_pointer().size();
-
-  // **** GPU stuff only on master ****
-  if (this_node == 0 && numParticles > 0) {
-    // Kernel call
-    int threads_per_block_particles = 64;
-    int blocks_per_grid_particles_y = 4;
-    int blocks_per_grid_particles_x =
-        (numParticles +
-         threads_per_block_particles * blocks_per_grid_particles_y - 1) /
-        (threads_per_block_particles * blocks_per_grid_particles_y);
-    dim3 dim_grid_particles =
-        make_uint3(blocks_per_grid_particles_x, blocks_per_grid_particles_y, 1);
-    KERNELCALL(ParticleVelocitiesFromLB_Kernel, dim_grid_particles,
-               threads_per_block_particles, *current_nodes,
-               IBM_ParticleDataInput_device, IBM_ParticleDataOutput_device,
-               node_f, lb_boundary_velocity_IBM, para_gpu);
-
-    // Copy velocities from device to host
-    cuda_safe_mem(cudaMemcpy(IBM_ParticleDataOutput_host,
-                             IBM_ParticleDataOutput_device,
-                             numParticles * sizeof(IBM_CUDA_ParticleDataOutput),
-                             cudaMemcpyDeviceToHost));
-  }
-
-  // ***** Back to all nodes ****
-  // Spread using MPI
-  IBM_cuda_mpi_send_velocities(particles);
-}
-
 __global__ void
 ForcesIntoFluid_Kernel(const IBM_CUDA_ParticleDataInput *const particle_input,
+                       size_t number_of_particles,
                        LB_node_force_density_gpu node_f,
                        const LB_parameters_gpu *const paraP) {
   const unsigned int particleIndex = blockIdx.y * gridDim.x * blockDim.x +
                                      blockDim.x * blockIdx.x + threadIdx.x;
   const LB_parameters_gpu &para = *paraP;
 
-  if (particleIndex < para.number_of_particles &&
+  if (particleIndex < number_of_particles &&
       particle_input[particleIndex].is_virtual) {
 
     //    const float factor = powf( para.agrid,2)*para.tau*para.tau; --> Old
@@ -390,6 +214,7 @@ ForcesIntoFluid_Kernel(const IBM_CUDA_ParticleDataInput *const particle_input,
 __global__ void ParticleVelocitiesFromLB_Kernel(
     LB_nodes_gpu n_curr,
     const IBM_CUDA_ParticleDataInput *const particles_input,
+    size_t number_of_particles,
     IBM_CUDA_ParticleDataOutput *const particles_output,
     LB_node_force_density_gpu node_f, const float *const lb_boundary_velocity,
     const LB_parameters_gpu *const paraP) {
@@ -399,7 +224,7 @@ __global__ void ParticleVelocitiesFromLB_Kernel(
 
   const LB_parameters_gpu &para = *paraP;
 
-  if (particleIndex < para.number_of_particles &&
+  if (particleIndex < number_of_particles &&
       particles_input[particleIndex].is_virtual) {
 
     // Get position
@@ -530,6 +355,170 @@ __global__ void ResetLBForces_Kernel(LB_node_force_density_gpu node_f,
       node_f.force_density[2 * para.number_of_nodes + index] = 0.0f;
     }
   }
+}
+
+/** Call a kernel to reset the forces on the LB nodes to the external force. */
+void IBM_ResetLBForces_GPU() {
+  if (this_node == 0) {
+    // Setup for kernel call
+    int threads_per_block = 64;
+    int blocks_per_grid_y = 4;
+    int blocks_per_grid_x = (lbpar_gpu.number_of_nodes +
+                             threads_per_block * blocks_per_grid_y - 1) /
+                            (threads_per_block * blocks_per_grid_y);
+    dim3 dim_grid = make_uint3(blocks_per_grid_x, blocks_per_grid_y, 1);
+
+    KERNELCALL(ResetLBForces_Kernel, dim_grid, threads_per_block, node_f,
+               para_gpu);
+  }
+}
+
+/** Transfer particle forces into the LB fluid.
+ *  Called from @ref integrate.
+ *  This must be the first CUDA-IBM function to be called because it also does
+ *  some initialization.
+ */
+void IBM_ForcesIntoFluid_GPU(ParticleRange particles) {
+  // This function does
+  // (1) Gather forces from all particles via MPI
+  // (2) Copy forces to the GPU
+  // (3) interpolate on the LBM grid and spread forces
+
+  const int numParticles = gpu_get_particle_pointer().size();
+
+  // Storage only needed on master and allocated only once at the first time
+  // step if ( IBM_ParticleDataInput_host == nullptr && this_node == 0 )
+  if (IBM_ParticleDataInput_host == NULL ||
+      numParticles != IBM_numParticlesCache)
+    InitCUDA_IBM(numParticles);
+
+  // We gather particle positions and forces from all nodes
+  IBM_cuda_mpi_get_particles(particles);
+
+  // ***** GPU stuff only on master *****
+  if (this_node == 0 && numParticles > 0) {
+
+    // Copy data to device
+    cuda_safe_mem(cudaMemcpy(IBM_ParticleDataInput_device,
+                             IBM_ParticleDataInput_host,
+                             numParticles * sizeof(IBM_CUDA_ParticleDataInput),
+                             cudaMemcpyHostToDevice));
+
+    // Kernel call for spreading the forces on the LB grid
+    int threads_per_block_particles = 64;
+    int blocks_per_grid_particles_y = 4;
+    int blocks_per_grid_particles_x =
+        (numParticles +
+         threads_per_block_particles * blocks_per_grid_particles_y - 1) /
+        (threads_per_block_particles * blocks_per_grid_particles_y);
+    dim3 dim_grid_particles =
+        make_uint3(blocks_per_grid_particles_x, blocks_per_grid_particles_y, 1);
+
+    KERNELCALL(ForcesIntoFluid_Kernel, dim_grid_particles,
+               threads_per_block_particles, IBM_ParticleDataInput_device,
+               numParticles, node_f, para_gpu);
+  }
+}
+
+void InitCUDA_IBM(const int numParticles) {
+
+  if (this_node == 0) // GPU only on master
+  {
+
+    // Check if we have to delete
+    if (IBM_ParticleDataInput_host != NULL) {
+      delete[] IBM_ParticleDataInput_host;
+      delete[] IBM_ParticleDataOutput_host;
+      cuda_safe_mem(cudaFree(IBM_ParticleDataInput_device));
+      cuda_safe_mem(cudaFree(IBM_ParticleDataOutput_device));
+      cuda_safe_mem(cudaFree(lb_boundary_velocity_IBM));
+    }
+
+    // Back and forth communication of positions and velocities
+    IBM_ParticleDataInput_host = new IBM_CUDA_ParticleDataInput[numParticles];
+    cuda_safe_mem(
+        cudaMalloc((void **)&IBM_ParticleDataInput_device,
+                   numParticles * sizeof(IBM_CUDA_ParticleDataInput)));
+    cuda_safe_mem(
+        cudaMalloc((void **)&IBM_ParticleDataOutput_device,
+                   numParticles * sizeof(IBM_CUDA_ParticleDataOutput)));
+    IBM_ParticleDataOutput_host = new IBM_CUDA_ParticleDataOutput[numParticles];
+
+    // Use LB parameters
+    lb_get_para_pointer(&para_gpu);
+
+    // Copy boundary velocities to the GPU
+    // First put them into correct format
+#ifdef LB_BOUNDARIES_GPU
+    float *host_lb_boundary_velocity =
+        new float[3 * (LBBoundaries::lbboundaries.size() + 1)];
+
+    for (int n = 0; n < LBBoundaries::lbboundaries.size(); n++) {
+      host_lb_boundary_velocity[3 * n + 0] =
+          LBBoundaries::lbboundaries[n]->velocity()[0];
+      host_lb_boundary_velocity[3 * n + 1] =
+          LBBoundaries::lbboundaries[n]->velocity()[1];
+      host_lb_boundary_velocity[3 * n + 2] =
+          LBBoundaries::lbboundaries[n]->velocity()[2];
+    }
+
+    host_lb_boundary_velocity[3 * LBBoundaries::lbboundaries.size() + 0] = 0.0f;
+    host_lb_boundary_velocity[3 * LBBoundaries::lbboundaries.size() + 1] = 0.0f;
+    host_lb_boundary_velocity[3 * LBBoundaries::lbboundaries.size() + 2] = 0.0f;
+
+    cuda_safe_mem(
+        cudaMalloc((void **)&lb_boundary_velocity_IBM,
+                   3 * LBBoundaries::lbboundaries.size() * sizeof(float)));
+    cuda_safe_mem(
+        cudaMemcpy(lb_boundary_velocity_IBM, host_lb_boundary_velocity,
+                   3 * LBBoundaries::lbboundaries.size() * sizeof(float),
+                   cudaMemcpyHostToDevice));
+
+    delete[] host_lb_boundary_velocity;
+#endif
+
+    IBM_numParticlesCache = numParticles;
+  }
+}
+
+/** Call a kernel function to interpolate the velocity at each IBM particle's
+ *  position. Store velocity in the particle data structure.
+ */
+void ParticleVelocitiesFromLB_GPU(ParticleRange particles) {
+  // This function performs three steps:
+  // (1) interpolate velocities on GPU
+  // (2) transfer velocities back to CPU
+  // (3) spread velocities to local cells via MPI
+
+  const int numParticles = gpu_get_particle_pointer().size();
+
+  // **** GPU stuff only on master ****
+  if (this_node == 0 && numParticles > 0) {
+    // Kernel call
+    int threads_per_block_particles = 64;
+    int blocks_per_grid_particles_y = 4;
+    int blocks_per_grid_particles_x =
+        (numParticles +
+         threads_per_block_particles * blocks_per_grid_particles_y - 1) /
+        (threads_per_block_particles * blocks_per_grid_particles_y);
+    dim3 dim_grid_particles =
+        make_uint3(blocks_per_grid_particles_x, blocks_per_grid_particles_y, 1);
+    KERNELCALL(ParticleVelocitiesFromLB_Kernel, dim_grid_particles,
+               threads_per_block_particles, *current_nodes,
+               IBM_ParticleDataInput_device, numParticles,
+               IBM_ParticleDataOutput_device, node_f, lb_boundary_velocity_IBM,
+               para_gpu);
+
+    // Copy velocities from device to host
+    cuda_safe_mem(cudaMemcpy(IBM_ParticleDataOutput_host,
+                             IBM_ParticleDataOutput_device,
+                             numParticles * sizeof(IBM_CUDA_ParticleDataOutput),
+                             cudaMemcpyDeviceToHost));
+  }
+
+  // ***** Back to all nodes ****
+  // Spread using MPI
+  IBM_cuda_mpi_send_velocities(particles);
 }
 
 #endif

--- a/src/utils/include/utils/mpi/gather_buffer.hpp
+++ b/src/utils/include/utils/mpi/gather_buffer.hpp
@@ -89,9 +89,9 @@ int gather_buffer(T *buffer, int n_elem, boost::mpi::communicator comm,
  * @param comm The MPI communicator.
  * @param root The rank where the data should be gathered.
  */
-template <typename T>
-void gather_buffer(std::vector<T> &buffer, boost::mpi::communicator comm,
-                   int root = 0) {
+template <typename T, class Allocator>
+void gather_buffer(std::vector<T, Allocator> &buffer,
+                   boost::mpi::communicator comm, int root = 0) {
   auto const n_elem = buffer.size();
 
   if (comm.rank() == root) {


### PR DESCRIPTION
Fixes #

Description of changes:
 - Replaced manual memory management by vectors
 - Two special allocators to make this possible
 - Buffer size is adapted on-demand, so the state tracking
   code could be simplified
 - General cleanup, removal of unused stuff
