### PR TITLE
Rotation params

### DIFF
--- a/samples/visualization_constraints.py
+++ b/samples/visualization_constraints.py
@@ -52,6 +52,7 @@ visualizer = espressomd.visualization_opengl.openGLLive(
     system,
     background_color=[1, 1, 1],
     drag_enabled=True,
+    quality_constraints=200,
     rasterize_resolution=50.0,
     rasterize_pointsize=5,
     camera_position=[150, 25, 25],
@@ -104,7 +105,7 @@ elif args.shape == "Slitpore":
 elif args.shape == "HollowConicalFrustum":
     system.constraints.add(shape=espressomd.shapes.HollowConicalFrustum(
         r1=12, r2=8, length=15.0, thickness=3,
-        axis=[0.0, 0.0, 1.0], center=[25, 25, 25], direction=1),
+        axis=[0.0, 1.0, 1.0], center=[25, 25, 25], direction=1),
         particle_type=0, penetrable=True)
 
 else:

--- a/src/shapes/unit_tests/CMakeLists.txt
+++ b/src/shapes/unit_tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(unit_test)
 unit_test(NAME Wall_test SRC Wall_test.cpp DEPENDS shapes utils)
-unit_test(NAME ConicalFrustum_test SRC HollowConicalFrustum_test.cpp DEPENDS shapes utils)
+unit_test(NAME HollowConicalFrustum_test SRC HollowConicalFrustum_test.cpp DEPENDS shapes utils)
 unit_test(NAME Union_test SRC Union_test.cpp DEPENDS shapes utils)
 unit_test(NAME Ellipsoid_test SRC Ellipsoid_test.cpp DEPENDS shapes utils)

--- a/src/shapes/unit_tests/HollowConicalFrustum_test.cpp
+++ b/src/shapes/unit_tests/HollowConicalFrustum_test.cpp
@@ -24,7 +24,8 @@
 
 #define BOOST_TEST_MODULE Cone test
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/included/unit_test.hpp>
+
+#include <boost/test/unit_test.hpp>
 #include <shapes/HollowConicalFrustum.hpp>
 #include <utils/Vector.hpp>
 
@@ -32,6 +33,8 @@ BOOST_AUTO_TEST_CASE(dist_function) {
   constexpr double L = 8.0;
   constexpr double R1 = 2.0;
   constexpr double R2 = 3.0;
+
+  constexpr double eps = 100 * std::numeric_limits<double>::epsilon();
 
   {
     Shapes::HollowConicalFrustum c;
@@ -45,24 +48,24 @@ BOOST_AUTO_TEST_CASE(dist_function) {
     double dist;
 
     c.calculate_dist(pos, dist, vec);
-    BOOST_TEST(dist == 2.0, boost::test_tools::tolerance(1e-7));
-    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+    BOOST_CHECK_CLOSE(dist, 2.0, eps);
+    BOOST_CHECK_CLOSE(dist, vec.norm(), eps);
 
     pos = {{R1, 0.0, L / 2.0}};
     c.calculate_dist(pos, dist, vec);
-    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
-    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+    BOOST_CHECK_SMALL(dist, eps);
+    BOOST_CHECK_CLOSE(dist, vec.norm(), eps);
 
     pos = {{3.0, 0.0, -L / 2.0}};
     c.calculate_dist(pos, dist, vec);
-    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
-    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+    BOOST_CHECK_SMALL(dist, eps);
+    BOOST_CHECK_CLOSE(dist, vec.norm(), eps);
 
     c.set_thickness(1.0);
     c.set_r2(R1);
     pos = {{R1 + 1.0, 0.0, L / 2.0}};
     c.calculate_dist(pos, dist, vec);
-    BOOST_TEST(dist == .5, boost::test_tools::tolerance(1e-7));
+    BOOST_CHECK_CLOSE(dist, .5, eps);
   }
   {
     Shapes::HollowConicalFrustum c;
@@ -76,17 +79,17 @@ BOOST_AUTO_TEST_CASE(dist_function) {
     double dist;
 
     c.calculate_dist(pos, dist, vec);
-    BOOST_TEST(dist == 2.0, boost::test_tools::tolerance(1e-7));
-    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+    BOOST_CHECK_CLOSE(dist, 2.0, eps);
+    BOOST_CHECK_CLOSE(dist, vec.norm(), eps);
 
     pos = {{L / 2.0, R1, 0.0}};
     c.calculate_dist(pos, dist, vec);
-    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
-    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+    BOOST_CHECK_SMALL(dist, eps);
+    BOOST_CHECK_CLOSE(dist, vec.norm(), eps);
 
     pos = {{-L / 2.0, R2, 0.0}};
     c.calculate_dist(pos, dist, vec);
-    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
-    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+    BOOST_CHECK_SMALL(dist, eps);
+    BOOST_CHECK_CLOSE(dist, vec.norm(), eps);
   }
 }

--- a/src/shapes/unit_tests/HollowConicalFrustum_test.cpp
+++ b/src/shapes/unit_tests/HollowConicalFrustum_test.cpp
@@ -24,41 +24,69 @@
 
 #define BOOST_TEST_MODULE Cone test
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <shapes/HollowConicalFrustum.hpp>
 #include <utils/Vector.hpp>
 
 BOOST_AUTO_TEST_CASE(dist_function) {
   constexpr double L = 8.0;
   constexpr double R1 = 2.0;
+  constexpr double R2 = 3.0;
 
-  Shapes::HollowConicalFrustum c;
-  c.set_r1(R1);
-  c.set_r2(3.0);
-  c.set_length(L);
-  c.set_axis(Utils::Vector3d{0, 0, 1});
+  {
+    Shapes::HollowConicalFrustum c;
+    c.set_r1(R1);
+    c.set_r2(R2);
+    c.set_length(L);
+    c.set_axis(Utils::Vector3d{0, 0, 1});
 
-  auto pos = Utils::Vector3d{0.0, 0.0, L / 2.0};
-  Utils::Vector3d vec;
-  double dist;
+    auto pos = Utils::Vector3d{0.0, 0.0, L / 2.0};
+    Utils::Vector3d vec;
+    double dist;
 
-  c.calculate_dist(pos, dist, vec);
-  BOOST_CHECK_CLOSE(dist, 2.0, 1e-7);
-  BOOST_CHECK_CLOSE(dist, vec.norm(), 1e-7);
+    c.calculate_dist(pos, dist, vec);
+    BOOST_TEST(dist == 2.0, boost::test_tools::tolerance(1e-7));
+    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
 
-  pos = {{R1, 0.0, L / 2.0}};
-  c.calculate_dist(pos, dist, vec);
-  BOOST_CHECK_CLOSE(dist, 0.0, 1e-7);
-  BOOST_CHECK_CLOSE(dist, vec.norm(), 1e-7);
+    pos = {{R1, 0.0, L / 2.0}};
+    c.calculate_dist(pos, dist, vec);
+    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
+    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
 
-  pos = {{3.0, 0.0, -L / 2.0}};
-  c.calculate_dist(pos, dist, vec);
-  BOOST_CHECK_CLOSE(dist, 0.0, 1e-7);
-  BOOST_CHECK_CLOSE(dist, vec.norm(), 1e-7);
+    pos = {{3.0, 0.0, -L / 2.0}};
+    c.calculate_dist(pos, dist, vec);
+    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
+    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
 
-  c.set_thickness(1.0);
-  c.set_r2(R1);
-  pos = {{R1 + 1.0, 0.0, L / 2.0}};
-  c.calculate_dist(pos, dist, vec);
-  BOOST_CHECK_CLOSE(dist, .5, 1e-7);
+    c.set_thickness(1.0);
+    c.set_r2(R1);
+    pos = {{R1 + 1.0, 0.0, L / 2.0}};
+    c.calculate_dist(pos, dist, vec);
+    BOOST_TEST(dist == .5, boost::test_tools::tolerance(1e-7));
+  }
+  {
+    Shapes::HollowConicalFrustum c;
+    c.set_r1(R1);
+    c.set_r2(R2);
+    c.set_length(L);
+    c.set_axis(Utils::Vector3d{1, 0, 0});
+
+    auto pos = Utils::Vector3d{L / 2.0, 0.0, 0.0};
+    Utils::Vector3d vec;
+    double dist;
+
+    c.calculate_dist(pos, dist, vec);
+    BOOST_TEST(dist == 2.0, boost::test_tools::tolerance(1e-7));
+    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+
+    pos = {{L / 2.0, R1, 0.0}};
+    c.calculate_dist(pos, dist, vec);
+    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
+    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+
+    pos = {{-L / 2.0, R2, 0.0}};
+    c.calculate_dist(pos, dist, vec);
+    BOOST_TEST(dist == 0.0, boost::test_tools::tolerance(1e-7));
+    BOOST_TEST(dist == vec.norm(), boost::test_tools::tolerance(1e-7));
+  }
 }

--- a/src/utils/include/utils/math/vec_rotate.hpp
+++ b/src/utils/include/utils/math/vec_rotate.hpp
@@ -60,7 +60,7 @@ inline Vector3d vec_rotate(const Vector3d &axis, double alpha,
 inline std::tuple<double, Vector3d>
 rotation_params(Vector3d const &vec, Vector3d const &target_vec) {
   auto const theta =
-      std::acos(vec * target_vec) / (vec.norm() * target_vec.norm());
+      std::acos(vec * target_vec / (vec.norm() * target_vec.norm()));
   auto const rotation_axis = Utils::vector_product(vec, target_vec).normalize();
   return std::make_tuple(theta, rotation_axis);
 }

--- a/src/utils/tests/vec_rotate_test.cpp
+++ b/src/utils/tests/vec_rotate_test.cpp
@@ -19,7 +19,8 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
-#include "utils/math/vec_rotate.hpp"
+#include <utils/constants.hpp>
+#include <utils/math/vec_rotate.hpp>
 using Utils::vec_rotate;
 
 #include <cmath>
@@ -44,4 +45,16 @@ BOOST_AUTO_TEST_CASE(rotation) {
   auto const rel_diff = (expected - is).norm() / expected.norm();
 
   BOOST_CHECK(rel_diff < std::numeric_limits<double>::epsilon());
+}
+
+BOOST_AUTO_TEST_CASE(rotation_params) {
+  Utils::Vector3d v1 = {1.0, 0.0, 0.0};
+  Utils::Vector3d v2 = {1.0, 1.0, 0.0};
+
+  double angle;
+  Utils::Vector3d rotation_axis;
+  std::tie(angle, rotation_axis) = Utils::rotation_params(v1, v2);
+  BOOST_CHECK_CLOSE(angle, Utils::pi() / 4.0, 1e-7);
+  BOOST_CHECK_SMALL((rotation_axis * v1), 1e-7);
+  BOOST_CHECK_SMALL((rotation_axis * v2), 1e-7);
 }


### PR DESCRIPTION
Fixes #3550

Description of changes:
 - fixing utils function ```rotation_params``` that returned wrong results if the input vector's norm was not unity
