### PR TITLE
Virtual Sites Cleanup

### DIFF
--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -309,12 +309,11 @@ To switch the active scheme, the attribute :attr:`espressomd.system.System.virtu
     from espressomd.virtual_sites import VirtualSitesOff, VirtualSitesRelative
 
     system = espressomd.System()
-    system.virtual_sites = VirtualSitesRelative(have_velocity=True, have_quaternion=False)
+    system.virtual_sites = VirtualSitesRelative(have_quaternion=False)
     # or
     system.virtual_sites = VirtualSitesOff()
 
 By default, :class:`espressomd.virtual_sites.VirtualSitesOff` is selected. This means that virtual particles are not touched during integration.
-The ``have_velocity`` parameter determines whether or not the velocity of virtual sites is calculated, which carries a performance cost.
 The ``have_quaternion`` parameter determines whether the quaternion of the virtual particle is updated (useful in combination with the
 :attr:`espressomd.particle_data.ParticleHandle.vs_quat` property of the virtual particle which defines the orientation of the virtual particle
 in the body fixed frame of the related real particle.

--- a/doc/tutorials/05-raspberry_electrophoresis/05-raspberry_electrophoresis.ipynb
+++ b/doc/tutorials/05-raspberry_electrophoresis/05-raspberry_electrophoresis.ipynb
@@ -294,7 +294,7 @@
    "outputs": [],
    "source": [
     "# Select the desired implementation for virtual sites\n",
-    "system.virtual_sites = VirtualSitesRelative(have_velocity=True)\n",
+    "system.virtual_sites = VirtualSitesRelative()\n",
     "# Setting min_global_cut is necessary when there is no interaction defined with a range larger than\n",
     "# the colloid such that the virtual particles are able to communicate their forces to the real particle\n",
     "# at the center of the colloid\n",

--- a/samples/drude_bmimpf6.py
+++ b/samples/drude_bmimpf6.py
@@ -75,7 +75,7 @@ box_l = box_volume**(1. / 3.)
 print("\n-->Ion pairs:", n_ionpairs, "Box size:", box_l)
 
 system = espressomd.System(box_l=[box_l, box_l, box_l])
-system.virtual_sites = VirtualSitesRelative(have_velocity=True)
+system.virtual_sites = VirtualSitesRelative()
 
 if args.visu:
     d_scale = 0.988 * 0.5

--- a/samples/rigid_body.py
+++ b/samples/rigid_body.py
@@ -32,8 +32,7 @@ import espressomd.rotation
 
 
 system = espressomd.System(box_l=[10.0] * 3)
-system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative(
-    have_velocity=True)
+system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative()
 system.time_step = 0.01
 system.thermostat.set_langevin(kT=1.0, gamma=20.0, seed=42)
 

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -423,7 +423,7 @@ unsigned global_ghost_flags() {
 
 void update_dependent_particles() {
 #ifdef VIRTUAL_SITES
-  virtual_sites()->update(true);
+  virtual_sites()->update();
   cells_update_ghosts(global_ghost_flags());
 #endif
 

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -320,6 +320,9 @@ static bool is_poststorable(GhostCommunication const &ghost_comm) {
 }
 
 void ghost_communicator(GhostCommunicator *gcr, unsigned int data_parts) {
+  if (GHOSTTRANS_NONE == data_parts)
+    return;
+
   static CommBuf send_buffer, recv_buffer;
 
   for (auto it = gcr->comm.begin(); it != gcr->comm.end(); ++it) {

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -182,7 +182,7 @@ int integrate(int n_steps, int reuse_forces) {
     lb_lbcoupling_deactivate();
 
 #ifdef VIRTUAL_SITES
-    virtual_sites()->update(true);
+    virtual_sites()->update();
 #endif
 
     // Communication step: distribute ghost positions
@@ -239,7 +239,7 @@ int integrate(int n_steps, int reuse_forces) {
 #endif
 
 #ifdef VIRTUAL_SITES
-    virtual_sites()->update(true);
+    virtual_sites()->update();
 #endif
 
     // Communication step: distribute ghost positions
@@ -292,8 +292,7 @@ int integrate(int n_steps, int reuse_forces) {
 #endif
 
 #ifdef VIRTUAL_SITES
-  // VIRTUAL_SITES update vel
-  virtual_sites()->update(false); // Recalc positions = false
+  virtual_sites()->update();
 #endif
 
   /* verlet list statistics */

--- a/src/core/integrators/brownian_inline.hpp
+++ b/src/core/integrators/brownian_inline.hpp
@@ -507,11 +507,8 @@ inline void brownian_dynamics_propagator(BrownianThermostat const &brownian,
                                          const ParticleRange &particles) {
   for (auto &p : particles) {
     // Don't propagate translational degrees of freedom of vs
-#ifdef VIRTUAL_SITES
     extern bool thermo_virtual;
-    if (!(p.p.is_virtual) or thermo_virtual)
-#endif
-    {
+    if (!(p.p.is_virtual) or thermo_virtual) {
       p.r.p += bd_drag(brownian.gamma, p, time_step);
       p.m.v = bd_drag_vel(brownian.gamma, p);
       p.r.p += bd_random_walk(brownian, p, time_step);

--- a/src/core/integrators/velocity_verlet_inline.hpp
+++ b/src/core/integrators/velocity_verlet_inline.hpp
@@ -67,11 +67,10 @@ inline void
 velocity_verlet_propagate_vel_final(const ParticleRange &particles) {
 
   for (auto &p : particles) {
-#ifdef VIRTUAL_SITES
     // Virtual sites are not propagated during integration
     if (p.p.is_virtual)
       continue;
-#endif
+
     for (int j = 0; j < 3; j++) {
       if (!(p.p.ext_flag & COORD_FIXED(j))) {
         /* Propagate velocity: v(t+dt) = v(t+0.5*dt) + 0.5*dt * a(t+dt) */

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -190,7 +190,7 @@ void init_virials(Observable_stat *stat) {
   Dipole::pressure_n();
 #endif
 #ifdef VIRTUAL_SITES
-  n_vs = virtual_sites()->n_pressure_contribs();
+  n_vs = 1;
 #endif
 
   // Allocate memory for the data
@@ -228,7 +228,7 @@ void init_p_tensor(Observable_stat *stat) {
   auto const n_dipolar = 0;
 #endif
 #ifdef VIRTUAL_SITES
-  n_vs = virtual_sites()->n_pressure_contribs();
+  n_vs = 1;
 #endif
 
   obsstat_realloc_and_clear(stat, n_pre, bonded_ia_params.size(), n_non_bonded,

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -129,8 +129,7 @@ void pressure_calc(double *result, double *result_t, double *result_nb,
 
 #ifdef VIRTUAL_SITES
   {
-    auto const vs_stress =
-        virtual_sites()->pressure_and_stress_tensor_contribution();
+    auto const vs_stress = virtual_sites()->stress_tensor();
 
     *virials.virtual_sites += trace(vs_stress);
     boost::copy(flatten(vs_stress), p_tensor.virtual_sites);

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -29,6 +29,7 @@
 #include "npt.hpp"
 #include "pressure_inline.hpp"
 #include "virtual_sites.hpp"
+#include <boost/range/algorithm/copy.hpp>
 
 #include "short_range_loop.hpp"
 
@@ -127,8 +128,13 @@ void pressure_calc(double *result, double *result_t, double *result_nb,
   calc_long_range_virials(cell_structure.local_cells().particles());
 
 #ifdef VIRTUAL_SITES
-  virtual_sites()->pressure_and_stress_tensor_contribution(
-      virials.virtual_sites, p_tensor.virtual_sites);
+  {
+    auto const vs_stress =
+        virtual_sites()->pressure_and_stress_tensor_contribution();
+
+    *virials.virtual_sites += trace(vs_stress);
+    boost::copy(flatten(vs_stress), p_tensor.virtual_sites);
+  }
 #endif
 
   for (int n = 1; n < virials.data.n; n++)

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -73,17 +73,17 @@ inline void add_non_bonded_pair_virials(Particle const &p1, Particle const &p2,
   }
 
 #ifdef ELECTROSTATICS
-  /* real space Coulomb */
-  auto const p_coulomb = Coulomb::pair_pressure(p1, p2, d, dist);
+  {
+    /* real space Coulomb */
+    auto const p_coulomb = Coulomb::pair_pressure(p1, p2, d, dist);
 
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 3; j++) {
-      p_tensor.coulomb[i * 3 + j] += p_coulomb[i][j];
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
+        p_tensor.coulomb[i * 3 + j] += p_coulomb[i][j];
+      }
     }
-  }
 
-  for (int i = 0; i < 3; i++) {
-    virials.coulomb[0] += p_coulomb[i][i];
+    virials.coulomb[0] += trace(p_coulomb);
   }
 #endif /*ifdef ELECTROSTATICS */
 

--- a/src/core/virtual_sites.hpp
+++ b/src/core/virtual_sites.hpp
@@ -26,6 +26,8 @@
 
 #include "virtual_sites/VirtualSites.hpp"
 
+#include <memory>
+
 /** @brief get active virtual sites implementation */
 const std::shared_ptr<VirtualSites> &virtual_sites();
 

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -50,8 +50,7 @@ public:
   virtual void after_force_calc(){};
   virtual void after_lb_propagation(){};
   /** @brief Pressure contribution. */
-  virtual Utils::Matrix<double, 3, 3>
-  pressure_and_stress_tensor_contribution() const {
+  virtual Utils::Matrix<double, 3, 3> stress_tensor() const {
     return {};
   };
   /** @brief Enable/disable velocity calculations for vs. */

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -50,9 +50,7 @@ public:
   virtual void after_force_calc(){};
   virtual void after_lb_propagation(){};
   /** @brief Pressure contribution. */
-  virtual Utils::Matrix<double, 3, 3> stress_tensor() const {
-    return {};
-  };
+  virtual Utils::Matrix<double, 3, 3> stress_tensor() const { return {}; };
   /** @brief Enable/disable velocity calculations for vs. */
   void set_have_velocity(const bool &v) { m_have_velocity = v; };
   const bool &get_have_velocity() const { return m_have_velocity; };

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -38,12 +38,13 @@
 /** @brief Base class for virtual sites implementations */
 class VirtualSites {
 public:
-  VirtualSites() : m_have_velocity(true), m_have_quaternion(false){};
-  /** @brief Update positions and/or velocities of virtual sites.
-   *  Velocities are only updated if get_have_velocity() returns true.
-   *  @param recalc_positions  Skip the recalculation of positions if false.
+  VirtualSites() = default;
+  virtual ~VirtualSites() = default;
+
+  /**
+   * @brief Update positions and velocities of virtual sites.
    */
-  virtual void update(bool recalc_positions) const {}
+  virtual void update() const {}
   /** Back-transfer forces (and torques) to non-virtual particles. */
   virtual void back_transfer_forces_and_torques() const {}
   /** @brief Called after force calculation (and before rattle/shake) */
@@ -51,20 +52,14 @@ public:
   virtual void after_lb_propagation(){};
   /** @brief Pressure contribution. */
   virtual Utils::Matrix<double, 3, 3> stress_tensor() const { return {}; };
-  /** @brief Enable/disable velocity calculations for vs. */
-  void set_have_velocity(const bool &v) { m_have_velocity = v; };
-  const bool &get_have_velocity() const { return m_have_velocity; };
   /** @brief Enable/disable quaternion calculations for vs.*/
   void set_have_quaternion(const bool &have_quaternion) {
     m_have_quaternion = have_quaternion;
   };
   bool get_have_quaternion() const { return m_have_quaternion; };
 
-  virtual ~VirtualSites() = default;
-
 private:
-  bool m_have_velocity;
-  bool m_have_quaternion;
+  bool m_have_quaternion = false;
 };
 
 #endif

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -43,9 +43,9 @@ public:
    *  Velocities are only updated if get_have_velocity() returns true.
    *  @param recalc_positions  Skip the recalculation of positions if false.
    */
-  virtual void update(bool recalc_positions) const = 0;
+  virtual void update(bool recalc_positions) const {}
   /** Back-transfer forces (and torques) to non-virtual particles. */
-  virtual void back_transfer_forces_and_torques() const = 0;
+  virtual void back_transfer_forces_and_torques() const {}
   /** @brief Called after force calculation (and before rattle/shake) */
   virtual void after_force_calc(){};
   virtual void after_lb_propagation(){};

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -33,6 +33,8 @@
  */
 
 #ifdef VIRTUAL_SITES
+#include <utils/Vector.hpp>
+
 #include <memory>
 
 /** @brief Base class for virtual sites implementations */
@@ -50,9 +52,10 @@ public:
   virtual void after_force_calc(){};
   virtual void after_lb_propagation(){};
   /** @brief Pressure contribution. */
-  virtual void
-  pressure_and_stress_tensor_contribution(double *pressure,
-                                          double *stress_tensor) const {};
+  virtual Utils::Matrix<double, 3, 3>
+  pressure_and_stress_tensor_contribution() const {
+    return {};
+  };
   /** @brief Enable/disable velocity calculations for vs. */
   void set_have_velocity(const bool &v) { m_have_velocity = v; };
   const bool &get_have_velocity() const { return m_have_velocity; };

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -35,8 +35,6 @@
 #ifdef VIRTUAL_SITES
 #include <utils/Vector.hpp>
 
-#include <memory>
-
 /** @brief Base class for virtual sites implementations */
 class VirtualSites {
 public:

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -49,8 +49,6 @@ public:
   /** @brief Called after force calculation (and before rattle/shake) */
   virtual void after_force_calc(){};
   virtual void after_lb_propagation(){};
-  /** @brief Number of pressure contributions */
-  virtual int n_pressure_contribs() const { return 0; };
   /** @brief Pressure contribution. */
   virtual void
   pressure_and_stress_tensor_contribution(double *pressure,

--- a/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
+++ b/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
@@ -28,8 +28,6 @@
  * instantaneously transferred to the fluid
  */
 class VirtualSitesInertialessTracers : public VirtualSites {
-  void update(bool recalc_positions) const override{};
-  void back_transfer_forces_and_torques() const override{};
   void after_force_calc() override;
   void after_lb_propagation() override;
 };

--- a/src/core/virtual_sites/VirtualSitesOff.hpp
+++ b/src/core/virtual_sites/VirtualSitesOff.hpp
@@ -24,10 +24,7 @@
 #include "VirtualSites.hpp"
 
 /** @brief Do-nothing virtual-sites implementation */
-class VirtualSitesOff : public VirtualSites {
-  void update(bool) const override{};
-  void back_transfer_forces_and_torques() const override{};
-};
+class VirtualSitesOff : public VirtualSites {};
 
 #endif
 #endif

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -158,7 +158,7 @@ void VirtualSitesRelative::back_transfer_forces_and_torques() const {
 
 // Rigid body contribution to scalar pressure and stress tensor
 Utils::Matrix<double, 3, 3>
-VirtualSitesRelative::pressure_and_stress_tensor_contribution() const {
+VirtualSitesRelative::stress_tensor() const {
   Utils::Matrix<double, 3, 3> stress_tensor = {};
 
   for (auto &p : cell_structure.local_cells().particles()) {

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -19,6 +19,7 @@
 
 #include "VirtualSitesRelative.hpp"
 #include "forces_inline.hpp"
+#include <boost/range/numeric.hpp>
 #include <utils/math/quaternion.hpp>
 #include <utils/math/sqr.hpp>
 
@@ -160,16 +161,11 @@ void VirtualSitesRelative::back_transfer_forces_and_torques() const {
 // Rigid body contribution to scalar pressure and stress tensor
 Utils::Matrix<double, 3, 3>
 VirtualSitesRelative::pressure_and_stress_tensor_contribution() const {
-  // Division by 3 volume is somewhere else. (pressure.cpp after all pressure
-  // calculations) Iterate over all the particles in the local cells
-
   Utils::Matrix<double, 3, 3> stress_tensor = {};
 
   for (auto &p : cell_structure.local_cells().particles()) {
     if (!p.p.is_virtual)
       continue;
-
-    update_pos(p);
 
     // First obtain the real particle responsible for this virtual particle:
     const Particle *p_real =

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -40,9 +40,7 @@ void VirtualSitesRelative::update(bool recalc_positions) const {
         (get_have_velocity() ? (GHOSTTRANS_POSITION | GHOSTTRANS_MOMENTUM)
                              : GHOSTTRANS_NONE);
 
-    if (recalc_positions or get_have_velocity()) {
-      ghost_communicator(&cell_structure.exchange_ghosts_comm, data_parts);
-    }
+    ghost_communicator(&cell_structure.exchange_ghosts_comm, data_parts);
   }
   for (auto &p : cell_structure.local_cells().particles()) {
     if (!p.p.is_virtual)

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -157,8 +157,7 @@ void VirtualSitesRelative::back_transfer_forces_and_torques() const {
 }
 
 // Rigid body contribution to scalar pressure and stress tensor
-Utils::Matrix<double, 3, 3>
-VirtualSitesRelative::stress_tensor() const {
+Utils::Matrix<double, 3, 3> VirtualSitesRelative::stress_tensor() const {
   Utils::Matrix<double, 3, 3> stress_tensor = {};
 
   for (auto &p : cell_structure.local_cells().particles()) {

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -131,7 +131,7 @@ ParticleForce constraint_force(
  *
  * @param f Force on the virtual site.
  * @param p_ref Reference particle.
- * @param vs_real Parameters.
+ * @param vs_rel Parameters.
  * @return Constraint force.
  */
 auto constraint_stress(

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -67,6 +67,7 @@ void VirtualSitesRelative::update_virtual_particle_quaternion(
         "virtual_sites_relative.cpp - update_mol_pos_particle(): No real "
         "particle associated with virtual site.\n");
   }
+
   p.r.quat = multiply_quaternions(p_real->r.quat, p.p.vs_relative.quat);
 }
 

--- a/src/core/virtual_sites/VirtualSitesRelative.hpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.hpp
@@ -35,8 +35,6 @@ public:
   void update(bool recalc_positions) const override;
   /** @copydoc VirtualSites::back_transfer_forces_and_torques */
   void back_transfer_forces_and_torques() const override;
-  /** @copydoc VirtualSites::n_pressure_contribs */
-  int n_pressure_contribs() const override { return 1; };
   /** @copydoc VirtualSites::pressure_and_stress_tensor_contribution */
   void
   pressure_and_stress_tensor_contribution(double *pressure,

--- a/src/core/virtual_sites/VirtualSitesRelative.hpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.hpp
@@ -32,7 +32,7 @@ class VirtualSitesRelative : public VirtualSites {
 public:
   VirtualSitesRelative() = default;
   /** @copydoc VirtualSites::update */
-  void update(bool recalc_positions) const override;
+  void update() const override;
   /** @copydoc VirtualSites::back_transfer_forces_and_torques */
   void back_transfer_forces_and_torques() const override;
   /** @copydoc VirtualSites::stress_tensor */

--- a/src/core/virtual_sites/VirtualSitesRelative.hpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.hpp
@@ -37,20 +37,6 @@ public:
   void back_transfer_forces_and_torques() const override;
   /** @copydoc VirtualSites::stress_tensor */
   Utils::Matrix<double, 3, 3> stress_tensor() const override;
-
-private:
-  /** Update the position of the given virtual particle as defined by the real
-   *  particles in the same molecule
-   */
-  void update_pos(Particle &p) const;
-  /** Update the velocity of the given virtual particle as defined by the real
-   *  particles in the same molecule
-   */
-  void update_vel(Particle &p) const;
-  /** @brief Update the orientation of the virtual particles with respect
-   *  to the real particle.
-   */
-  void update_virtual_particle_quaternion(Particle &p) const;
 };
 
 #endif

--- a/src/core/virtual_sites/VirtualSitesRelative.hpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.hpp
@@ -35,9 +35,8 @@ public:
   void update(bool recalc_positions) const override;
   /** @copydoc VirtualSites::back_transfer_forces_and_torques */
   void back_transfer_forces_and_torques() const override;
-  /** @copydoc VirtualSites::pressure_and_stress_tensor_contribution */
-  Utils::Matrix<double, 3, 3>
-  pressure_and_stress_tensor_contribution() const override;
+  /** @copydoc VirtualSites::stress_tensor */
+  Utils::Matrix<double, 3, 3> stress_tensor() const override;
 
 private:
   /** Update the position of the given virtual particle as defined by the real

--- a/src/core/virtual_sites/VirtualSitesRelative.hpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.hpp
@@ -23,9 +23,9 @@
 #include "config.hpp"
 #ifdef VIRTUAL_SITES_RELATIVE
 
-#include "Particle.hpp"
-#include "communication.hpp"
-#include "virtual_sites.hpp"
+#include "VirtualSites.hpp"
+
+#include <utils/Vector.hpp>
 
 /** @brief Virtual sites implementation for rigid bodies */
 class VirtualSitesRelative : public VirtualSites {

--- a/src/core/virtual_sites/VirtualSitesRelative.hpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.hpp
@@ -36,9 +36,8 @@ public:
   /** @copydoc VirtualSites::back_transfer_forces_and_torques */
   void back_transfer_forces_and_torques() const override;
   /** @copydoc VirtualSites::pressure_and_stress_tensor_contribution */
-  void
-  pressure_and_stress_tensor_contribution(double *pressure,
-                                          double *stress_tensor) const override;
+  Utils::Matrix<double, 3, 3>
+  pressure_and_stress_tensor_contribution() const override;
 
 private:
   /** Update the position of the given virtual particle as defined by the real

--- a/src/python/espressomd/virtual_sites.py
+++ b/src/python/espressomd/virtual_sites.py
@@ -58,14 +58,5 @@ if has_features("VIRTUAL_SITES_RELATIVE"):
         """Virtual sites implementation placing virtual sites relative to other
         particles. See :ref:`Rigid arrangements of particles` for details.
 
-        Attributes can be set on the instance or passed to the constructor as
-        keyword arguments.
-
-        Attributes
-        ----------
-        have_velocity : :obj:`bool`
-            Determines whether the velocity of the virtual sites is calculated.
-            This carries a performance cost.
-
         """
         _so_name = "VirtualSites::VirtualSitesRelative"

--- a/src/script_interface/virtual_sites/VirtualSites.hpp
+++ b/src/script_interface/virtual_sites/VirtualSites.hpp
@@ -34,12 +34,7 @@ class VirtualSites : public AutoParameters<VirtualSites> {
 public:
   VirtualSites() {
     add_parameters(
-        {{"have_velocity",
-          [this](const Variant &v) {
-            virtual_sites()->set_have_velocity(get_value<bool>(v));
-          },
-          [this]() { return virtual_sites()->get_have_velocity(); }},
-         {"have_quaternion",
+        {{"have_quaternion",
           [this](const Variant &v) {
             virtual_sites()->set_have_quaternion(get_value<bool>(v));
           },

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -174,6 +174,23 @@ template <class T, size_t N> T trace(Matrix<T, N, N> const &m) {
   return tr;
 }
 
+/**
+ * @brief Flatten a matrix to a linear vector.
+ *
+ * @param m Input Matrix
+ * @return Flat vector with elements of @ref m.
+ */
+template <class T, size_t N, size_t M>
+Vector<T, N * M> flatten(Matrix<T, N, M> const &m) {
+  Vector<T, N * M> ret;
+
+  for (size_t i = 0; i < N; i++)
+    for (size_t j = 0; j < M; j++)
+      ret[i * M + j] = m[j][i];
+
+  return ret;
+}
+
 namespace detail {
 template <size_t N, typename T, typename U, typename Op>
 auto binary_op(Vector<T, N> const &a, Vector<U, N> const &b, Op op) {

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -155,6 +155,25 @@ using Vector3i = VectorXi<3>;
 
 template <class T, size_t N, size_t M> using Matrix = Vector<Vector<T, M>, N>;
 
+/**
+ * @brief Trace of a matrix.
+ *
+ * Returns the sum of the diagonal elements
+ * of a square matrix.
+ *
+ * @tparam T Arithmetic type
+ * @tparam N Matrix dimension
+ * @param m Input matrix
+ * @return Trace of matrix.
+ */
+template <class T, size_t N> T trace(Matrix<T, N, N> const &m) {
+  T tr = T{};
+  for (size_t i = 0; i < N; i++)
+    tr += m[i][i];
+
+  return tr;
+}
+
 namespace detail {
 template <size_t N, typename T, typename U, typename Op>
 auto binary_op(Vector<T, N> const &a, Vector<U, N> const &b, Op op) {

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -167,7 +167,7 @@ template <class T, size_t N, size_t M> using Matrix = Vector<Vector<T, M>, N>;
  * @return Trace of matrix.
  */
 template <class T, size_t N> T trace(Matrix<T, N, N> const &m) {
-  T tr = T{};
+  auto tr = T{};
   for (size_t i = 0; i < N; i++)
     tr += m[i][i];
 

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -178,7 +178,7 @@ template <class T, size_t N> T trace(Matrix<T, N, N> const &m) {
  * @brief Flatten a matrix to a linear vector.
  *
  * @param m Input Matrix
- * @return Flat vector with elements of @ref m.
+ * @return Flat vector with elements of the matrix.
  */
 template <class T, size_t N, size_t M>
 Vector<T, N * M> flatten(Matrix<T, N, M> const &m) {

--- a/src/utils/tests/Vector_test.cpp
+++ b/src/utils/tests/Vector_test.cpp
@@ -381,3 +381,11 @@ BOOST_AUTO_TEST_CASE(diag_matrix) {
     for (int j = 0; j < 3; j++)
       BOOST_CHECK_EQUAL(result[i][j], (i == j) ? v[i] : 0);
 }
+
+BOOST_AUTO_TEST_CASE(trace_) {
+  auto const A = Utils::Matrix<int, 3, 3>{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+  auto const result = trace(A);
+  auto const expected = A[0][0] + A[1][1] + A[2][2];
+
+  BOOST_CHECK_EQUAL(expected, result);
+}

--- a/src/utils/tests/Vector_test.cpp
+++ b/src/utils/tests/Vector_test.cpp
@@ -389,3 +389,11 @@ BOOST_AUTO_TEST_CASE(trace_) {
 
   BOOST_CHECK_EQUAL(expected, result);
 }
+
+BOOST_AUTO_TEST_CASE(flatten_) {
+  auto const A = Utils::Matrix<int, 2, 2>{{1, 2}, {3, 4}};
+  auto const result = flatten(A);
+  auto const expected = Utils::Vector<int, 4>{1, 3, 2, 4};
+
+  BOOST_CHECK(result == expected);
+}

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -160,8 +160,7 @@ if 'LB.OFF' in modes:
                          max_displacement=0.01)
 
 if espressomd.has_features(['VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE']):
-    system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative(
-        have_velocity=True, have_quaternion=True)
+    system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative(have_quaternion=True)
     system.part[1].vs_auto_relate_to(0)
 
 if espressomd.has_features(['LENNARD_JONES']) and 'LJ' in modes:

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -160,7 +160,8 @@ if 'LB.OFF' in modes:
                          max_displacement=0.01)
 
 if espressomd.has_features(['VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE']):
-    system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative(have_quaternion=True)
+    system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative(
+        have_quaternion=True)
     system.part[1].vs_auto_relate_to(0)
 
 if espressomd.has_features(['LENNARD_JONES']) and 'LJ' in modes:

--- a/testsuite/python/virtual_sites_relative.py
+++ b/testsuite/python/virtual_sites_relative.py
@@ -320,10 +320,12 @@ class VirtualSites(ut.TestCase):
         system.time_step = 0.01
         system.cell_system.skin = 0.1
         system.min_global_cut = 0.2
-        # Should not have one if vs are turned off
+        # Should not have a pressure
         system.virtual_sites = VirtualSitesOff()
-        self.assertNotIn("virtual_sites", system.analysis.pressure())
-        self.assertNotIn("virtual_sites", system.analysis.stress_tensor())
+        stress_vs = system.analysis.stress_tensor()["virtual_sites", 0]
+        p_vs = system.analysis.pressure()["virtual_sites", 0]
+        np.testing.assert_allclose(stress_vs, 0., atol=1e-10)
+        np.testing.assert_allclose(p_vs, 0., atol=1e-10)
 
         # vs relative contrib
         system.virtual_sites = VirtualSitesRelative()

--- a/testsuite/python/virtual_sites_relative.py
+++ b/testsuite/python/virtual_sites_relative.py
@@ -77,9 +77,8 @@ class VirtualSites(ut.TestCase):
         self.assertIsInstance(self.system.virtual_sites, VirtualSitesOff)
 
         # Switch implementation
-        self.system.virtual_sites = VirtualSitesRelative(have_velocity=False)
+        self.system.virtual_sites = VirtualSitesRelative()
         self.assertIsInstance(self.system.virtual_sites, VirtualSitesRelative)
-        self.assertFalse(self.system.virtual_sites.have_velocity)
 
     def test_vs_quat(self):
         self.system.part.clear()
@@ -128,7 +127,7 @@ class VirtualSites(ut.TestCase):
     def test_pos_vel_forces(self):
         system = self.system
         system.cell_system.skin = 0.3
-        system.virtual_sites = VirtualSitesRelative(have_velocity=True)
+        system.virtual_sites = VirtualSitesRelative()
         system.box_l = [10, 10, 10]
         system.part.clear()
         system.time_step = 0.004
@@ -203,21 +202,12 @@ class VirtualSites(ut.TestCase):
             # Check
             self.assertLessEqual(np.linalg.norm(t_exp - t), 1E-6)
 
-        # Check virtual sites without velocity
-        system.virtual_sites.have_velocity = False
-
-        # Velocity should not change
-        v2 = np.copy(system.part[2].v)
-        system.part[1].v = [17, -13.5, 2]
-        system.integrator.run(0, recalc_forces=True)
-        np.testing.assert_array_equal(v2, np.copy(system.part[2].v))
-
     def run_test_lj(self):
         """This fills the system with vs-based dumbells, adds a lj potential,
           integrates and verifies forces. This is to make sure that no pairs
           get lost or are outdated in the short range loop"""
         system = self.system
-        system.virtual_sites = VirtualSitesRelative(have_velocity=True)
+        system.virtual_sites = VirtualSitesRelative()
         # Parameters
         n = 90
         phi = 0.6

--- a/testsuite/python/virtual_sites_tracers_common.py
+++ b/testsuite/python/virtual_sites_tracers_common.py
@@ -64,7 +64,6 @@ class VirtualSitesTracersCommon:
         self.system.virtual_sites = VirtualSitesInertialessTracers()
         self.assertIsInstance(
             self.system.virtual_sites, VirtualSitesInertialessTracers)
-        self.assertTrue(self.system.virtual_sites.have_velocity)
 
     def test_advection(self):
         self.reset_lb(ext_force_density=[0.1, 0, 0])


### PR DESCRIPTION
This is some intermediate cleanup of virtual sites. Biggest change
is that the velocities are now always updated. This has actually very
little performance impact, and is less error prone. 

Description of changes:
 - Simplified interface of `VirtualSites`
 - Some cleanup of the pressure calc
 - Removed `VirtualSites::have_velocity()` mechanism
