### PR TITLE
Improve performance of particle updates

### DIFF
--- a/src/core/CellStructure.cpp
+++ b/src/core/CellStructure.cpp
@@ -52,8 +52,7 @@ void CellStructure::remove_particle(int id) {
 Particle *CellStructure::add_local_particle(Particle &&p) {
   auto const sort_cell = particle_to_cell(p);
   if (sort_cell) {
-    sort_cell->push_back(std::move(p));
-    update_particle_index(sort_cell);
+    append_indexed_particle(sort_cell, std::move(p));
 
     return &sort_cell->back();
   }
@@ -71,8 +70,7 @@ Particle *CellStructure::add_particle(Particle &&p) {
    * needed, otherwise a local resort if sufficient. */
   set_resort_particles(sort_cell ? Cells::RESORT_LOCAL : Cells::RESORT_GLOBAL);
 
-  cell->push_back(std::move(p));
-  update_particle_index(cell);
+  append_indexed_particle(cell, std::move(p));
 
   return &cell->back();
 }

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -102,6 +102,18 @@ public:
   /**
    * @brief Update local particle index.
    *
+   * Update the entry for a particle in the local particle
+   * index.
+   *
+   * @param p Pointer to the particle.
+   **/
+  void update_particle_index(Particle &p) {
+    update_particle_index(p.identity(), std::addressof(p));
+  }
+
+  /**
+   * @brief Update local particle index.
+   *
    * @param pl List of particles whose index entries should be updated.
    */
   void update_particle_index(ParticleList &pl) {
@@ -119,6 +131,28 @@ public:
     assert(pl), update_particle_index(*pl);
   }
 
+private:
+  /**
+   * @brief Append a particle to a list and update this
+   *        particle index accordingly.
+   * @param pl List to add the particle to.
+   * @param p Particle to add.
+   */
+  void append_indexed_particle(ParticleList *pl, Particle &&p) {
+    auto const old_data = pl->data();
+    pl->push_back(std::move(p));
+
+    /* If the list storage moved due to reallocation,
+     * we have to update the index for all particles,
+     * otherwise just for the particle that we added. */
+    if (old_data != pl->data())
+      update_particle_index(pl);
+    else {
+      update_particle_index(pl->back());
+    }
+  }
+
+public:
   /**
    * @brief Get a local particle by id.
    *

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -450,7 +450,7 @@ void build_particle_node() {
  *  @brief Get the mpi rank which owns the particle with id.
  */
 int get_particle_node(int id) {
-  if ((id < 0) or (id > get_maximal_particle_id()))
+  if (id < 0)
     throw std::runtime_error("Invalid particle id!");
 
   if (particle_node.empty())


### PR DESCRIPTION
Fixes maybe #3594.

Description of changes:
- Remove an expensive check from `get_particle_node`
- Reduce number of particle index update when adding particles
