### PR TITLE
Conditionally define SKIP_MPICXX macros

### DIFF
--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -30,8 +30,12 @@
  */
 
 /* Prevent C++ bindings in MPI (there is a DataType called LB in there) */
+#ifndef OMPI_SKIP_MPICXX
 #define OMPI_SKIP_MPICXX
+#endif
+#ifndef MPICH_SKIP_MPICXX
 #define MPICH_SKIP_MPICXX
+#endif
 
 #include "config-features.hpp"
 


### PR DESCRIPTION
Compiling Espresso with HDF5 > v1.10.2 produces numerous warnings about redefinition of the two macros `MPICH_SKIP_MPICXX` and `OMPI_SKIP_MPICXX` set in src/config.hpp:33f.

Cause: Since HDF5 v1.10.2 they are set by HDF5 itself in a public header.
Fix: This PR conditionally defines these macros.
