### PR TITLE
Core: Fix LB profile observable

### DIFF
--- a/src/core/observables/LBProfileObservable.hpp
+++ b/src/core/observables/LBProfileObservable.hpp
@@ -57,19 +57,19 @@ public:
     sampling_positions.clear();
     if (sampling_delta_x == 0 or sampling_delta_y == 0 or sampling_delta_z == 0)
       throw std::runtime_error("Parameter delta_x/y/z must not be zero!");
-    const auto n_samples_x = static_cast<size_t>(std::rint(
-        (box_geo.length()[0] - sampling_offset_x) / sampling_delta_x));
-    const auto n_samples_y = static_cast<size_t>(std::rint(
-        (box_geo.length()[1] - sampling_offset_y) / sampling_delta_y));
-    const auto n_samples_z = static_cast<size_t>(std::rint(
-        (box_geo.length()[2] - sampling_offset_z) / sampling_delta_z));
+    const auto n_samples_x =
+        static_cast<size_t>(std::rint((max_x - min_x) / sampling_delta_x));
+    const auto n_samples_y =
+        static_cast<size_t>(std::rint((max_y - min_y) / sampling_delta_y));
+    const auto n_samples_z =
+        static_cast<size_t>(std::rint((max_z - min_z) / sampling_delta_z));
     for (size_t x = 0; x < n_samples_x; ++x) {
       for (size_t y = 0; y < n_samples_y; ++y) {
         for (size_t z = 0; z < n_samples_z; ++z) {
-          sampling_positions.push_back(
-              Utils::Vector3d{{sampling_offset_x + x * sampling_delta_x,
-                               sampling_offset_y + y * sampling_delta_y,
-                               sampling_offset_z + z * sampling_delta_z}});
+          sampling_positions.push_back(Utils::Vector3d{
+              {min_x + sampling_offset_x + x * sampling_delta_x,
+               min_y + sampling_offset_y + y * sampling_delta_y,
+               min_z + sampling_offset_z + z * sampling_delta_z}});
         }
       }
     }

--- a/testsuite/python/observable_profileLB.py
+++ b/testsuite/python/observable_profileLB.py
@@ -28,11 +28,11 @@ Tests for the LB fluid profile observables.
 
 """
 
-BOX_L_X = 12.0
-BOX_L_Y = 12.0
-BOX_L_Z = 12.0
 TIME_STEP = 0.1
-AGRID = 0.5
+AGRID = 0.7
+BOX_L_X = 17.0 * AGRID
+BOX_L_Y = 17.0 * AGRID
+BOX_L_Z = 17.0 * AGRID
 VISC = .7
 DENS = 1.7
 LB_PARAMS = {'agrid': AGRID,
@@ -62,7 +62,7 @@ LB_VELOCITY_PROFILE_PARAMS = {
 
 class ObservableProfileLBCommon:
     lbf = None
-    system = espressomd.System(box_l=[12.0, 12.0, 12.0])
+    system = espressomd.System(box_l=[BOX_L_X, BOX_L_Y, BOX_L_Z])
     system.time_step = TIME_STEP
     system.cell_system.skin = 0.4 * AGRID
 


### PR DESCRIPTION
Fixes #3603 


* respect min- and max_x,y,z rather than using 0 and box_size
* remove off-by-one error for the number of sampling positions for certain choices of box size and sampling_delta or offset

This is probably the least invasive way to fix the issue.
LB and particle profile observables are consistent, when using the same min- and max_x,y,z and a sampling_offset of agrid/2.
Alternatively, the sampling_delta parameter could be removed, but then, min_x would have to be set to agrid/2 and max_x to box_l +agrid/2. That's probably more confusing.

