### PR TITLE
Update espresso-ci scripts

### DIFF
--- a/maintainer/gh_post_docs_warnings.py
+++ b/maintainer/gh_post_docs_warnings.py
@@ -28,7 +28,8 @@ if not os.environ['CI_COMMIT_REF_NAME'].startswith('PR-'):
 
 PR = os.environ['CI_COMMIT_REF_NAME'][3:]
 URL = 'https://api.github.com/repos/espressomd/espresso/issues/' + \
-      PR + '/comments?access_token=' + os.environ['GITHUB_TOKEN']
+      PR + '/comments'
+HEADERS = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
 SIZELIMIT = 5000
 
 doc_type, has_warnings, filepath_warnings = sys.argv[-3:]
@@ -37,12 +38,11 @@ prefix = {'sphinx': 'doc', 'doxygen': 'dox'}[doc_type]
 TOKEN_ESPRESSO_CI = prefix + '_warnings.sh'
 
 # Delete all existing comments
-comments = requests.get(URL)
+comments = requests.get(URL, headers=HEADERS)
 for comment in comments.json():
     if comment['user']['login'] == 'espresso-ci' and \
             TOKEN_ESPRESSO_CI in comment['body']:
-        requests.delete(comment['url'] + '?access_token=' +
-                        os.environ['GITHUB_TOKEN'])
+        requests.delete(comment['url'], headers=HEADERS)
 
 # If documentation raised warnings, post a new comment
 if has_warnings:
@@ -75,4 +75,4 @@ if has_warnings:
         .format(doc_type, prefix))
     assert TOKEN_ESPRESSO_CI in comment
 
-    requests.post(URL, json={'body': comment})
+    requests.post(URL, headers=HEADERS, json={'body': comment})

--- a/maintainer/gh_post_docs_warnings.py
+++ b/maintainer/gh_post_docs_warnings.py
@@ -39,10 +39,12 @@ TOKEN_ESPRESSO_CI = prefix + '_warnings.sh'
 
 # Delete all existing comments
 comments = requests.get(URL, headers=HEADERS)
+comments.raise_for_status()
 for comment in comments.json():
     if comment['user']['login'] == 'espresso-ci' and \
             TOKEN_ESPRESSO_CI in comment['body']:
-        requests.delete(comment['url'], headers=HEADERS)
+        response = requests.delete(comment['url'], headers=HEADERS)
+        response.raise_for_status()
 
 # If documentation raised warnings, post a new comment
 if has_warnings:
@@ -75,4 +77,5 @@ if has_warnings:
         .format(doc_type, prefix))
     assert TOKEN_ESPRESSO_CI in comment
 
-    requests.post(URL, headers=HEADERS, json={'body': comment})
+    response = requests.post(URL, headers=HEADERS, json={'body': comment})
+    response.raise_for_status()

--- a/maintainer/gh_post_pylint.py
+++ b/maintainer/gh_post_pylint.py
@@ -36,10 +36,12 @@ n_warnings, filepath_warnings = sys.argv[-2:]
 
 # Delete older pylint messages
 comments = requests.get(URL, headers=HEADERS)
+comments.raise_for_status()
 for comment in comments.json():
     if comment['user']['login'] == 'espresso-ci' and \
             TOKEN_ESPRESSO_CI in comment['body']:
-        requests.delete(comment['url'], headers=HEADERS)
+        response = requests.delete(comment['url'], headers=HEADERS)
+        response.raise_for_status()
 
 # If pylint raised errors, post a new comment
 if n_warnings != '0':
@@ -68,4 +70,5 @@ if n_warnings != '0':
     )
     assert TOKEN_ESPRESSO_CI in comment
 
-    requests.post(URL, headers=HEADERS, json={'body': comment})
+    response = requests.post(URL, headers=HEADERS, json={'body': comment})
+    response.raise_for_status()

--- a/maintainer/gh_post_pylint.py
+++ b/maintainer/gh_post_pylint.py
@@ -27,19 +27,19 @@ if not os.environ['CI_COMMIT_REF_NAME'].startswith('PR-'):
 
 PR = os.environ['CI_COMMIT_REF_NAME'][3:]
 URL = 'https://api.github.com/repos/espressomd/espresso/issues/' + \
-      PR + '/comments?access_token=' + os.environ['GITHUB_TOKEN']
+      PR + '/comments'
+HEADERS = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
 SIZELIMIT = 5000
 TOKEN_ESPRESSO_CI = 'Pylint summary'
 
 n_warnings, filepath_warnings = sys.argv[-2:]
 
 # Delete older pylint messages
-comments = requests.get(URL)
+comments = requests.get(URL, headers=HEADERS)
 for comment in comments.json():
     if comment['user']['login'] == 'espresso-ci' and \
             TOKEN_ESPRESSO_CI in comment['body']:
-        requests.delete(comment['url'] + '?access_token=' +
-                        os.environ['GITHUB_TOKEN'])
+        requests.delete(comment['url'], headers=HEADERS)
 
 # If pylint raised errors, post a new comment
 if n_warnings != '0':
@@ -68,4 +68,4 @@ if n_warnings != '0':
     )
     assert TOKEN_ESPRESSO_CI in comment
 
-    requests.post(URL, json={'body': comment})
+    requests.post(URL, headers=HEADERS, json={'body': comment})

--- a/maintainer/gh_post_status.sh
+++ b/maintainer/gh_post_status.sh
@@ -21,7 +21,8 @@
 GIT_COMMIT=$(git rev-parse HEAD)
 URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}"
 STATUS="${1}"
-curl "https://api.github.com/repos/espressomd/espresso/statuses/${GIT_COMMIT}?access_token=${GITHUB_TOKEN}" \
+curl "https://api.github.com/repos/espressomd/espresso/statuses/${GIT_COMMIT}" \
+     -H "Authorization: token ${GITHUB_TOKEN}" \
      -H "Content-Type: application/json" \
      -X POST \
      -d "{\"state\": \"${STATUS}\", \"context\": \"ICP GitLab CI\", \"target_url\": \"${URL}\"}"

--- a/maintainer/gh_post_style_patch.py
+++ b/maintainer/gh_post_style_patch.py
@@ -33,10 +33,12 @@ TOKEN_ESPRESSO_CI = 'style.patch'
 
 # Delete all existing comments
 comments = requests.get(URL, headers=HEADERS)
+comments.raise_for_status()
 for comment in comments.json():
     if comment['user']['login'] == 'espresso-ci' and \
             TOKEN_ESPRESSO_CI in comment['body']:
-        requests.delete(comment['url'], headers=HEADERS)
+        response = requests.delete(comment['url'], headers=HEADERS)
+        response.raise_for_status()
 
 MESSAGE = '''Your pull request does not meet our code formatting \
 rules. {header}, please do one of the following:
@@ -74,4 +76,6 @@ if subprocess.call(["git", "diff-index", "--quiet", "HEAD", "--"]) != 0:
 
     if patch:
         assert TOKEN_ESPRESSO_CI in message
-        requests.post(URL, headers=HEADERS, json={'body': message})
+        response = requests.post(URL, headers=HEADERS,
+                                 json={'body': message})
+        response.raise_for_status()

--- a/maintainer/gh_post_style_patch.py
+++ b/maintainer/gh_post_style_patch.py
@@ -26,17 +26,17 @@ if not os.environ['CI_COMMIT_REF_NAME'].startswith('PR-'):
 
 PR = os.environ['CI_COMMIT_REF_NAME'][3:]
 URL = 'https://api.github.com/repos/espressomd/espresso/issues/' + \
-      PR + '/comments?access_token=' + os.environ['GITHUB_TOKEN']
+      PR + '/comments'
+HEADERS = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
 SIZELIMIT = 10000
 TOKEN_ESPRESSO_CI = 'style.patch'
 
 # Delete all existing comments
-comments = requests.get(URL)
+comments = requests.get(URL, headers=HEADERS)
 for comment in comments.json():
     if comment['user']['login'] == 'espresso-ci' and \
             TOKEN_ESPRESSO_CI in comment['body']:
-        requests.delete(comment['url'] + '?access_token=' +
-                        os.environ['GITHUB_TOKEN'])
+        requests.delete(comment['url'], headers=HEADERS)
 
 MESSAGE = '''Your pull request does not meet our code formatting \
 rules. {header}, please do one of the following:
@@ -74,4 +74,4 @@ if subprocess.call(["git", "diff-index", "--quiet", "HEAD", "--"]) != 0:
 
     if patch:
         assert TOKEN_ESPRESSO_CI in message
-        requests.post(URL, json={'body': message})
+        requests.post(URL, headers=HEADERS, json={'body': message})

--- a/maintainer/gh_post_style_patch.py
+++ b/maintainer/gh_post_style_patch.py
@@ -38,29 +38,40 @@ for comment in comments.json():
         requests.delete(comment['url'] + '?access_token=' +
                         os.environ['GITHUB_TOKEN'])
 
+MESSAGE = '''Your pull request does not meet our code formatting \
+rules. {header}, please do one of the following:
+
+- You can download a patch with my suggested changes
+  [here]({url}/artifacts/raw/style.patch), inspect it and make
+  changes manually.
+- You can directly apply it to your repository by running
+  `curl {url}/artifacts/raw/style.patch | git apply -`.
+- You can run `maintainer/CI/fix_style.sh` to automatically fix your coding
+  style. This is the same command that I have executed to generate the patch
+  above, but it requires certain tools to be installed on your computer.
+
+You can run `gitlab-runner exec docker style` afterwards to check if your \
+changes worked out properly.
+
+Please note that there are often multiple ways to correctly format code. \
+As I am just a robot, I sometimes fail to identify the most aesthetically \
+pleasing way. So please look over my suggested changes and adapt them \
+where the style does not make sense.\
+'''
+
 # If the working directory is not clean, post a new comment
 if subprocess.call(["git", "diff-index", "--quiet", "HEAD", "--"]) != 0:
-    comment = 'Your pull request does not meet our code formatting rules. '
     patch = subprocess.check_output(['git', '--no-pager', 'diff'])
     if len(patch) <= SIZELIMIT:
-        comment += 'Specifically, I suggest you make the following changes:\n'
-        comment += '```diff\n'
+        comment = 'Specifically, I suggest you make the following changes:'
+        comment += '\n```diff\n'
         comment += patch.decode('utf-8').replace('`', r'\`').strip()
         comment += '\n```\n'
-        comment += 'To apply these changes, please do one of the following:\n'
+        comment += 'To apply these changes'
     else:
-        comment += 'To fix this, please do one of the following:\n'
-    comment += '- You can download a patch with my suggested changes '
-    comment += '[here](' + os.environ['CI_JOB_URL'] + \
-               '/artifacts/raw/style.patch), '
-    comment += 'inspect it and make changes manually.\n'
-    comment += '- You can directly apply it to your repository by running '
-    comment += '`curl ' + os.environ['CI_JOB_URL'] + \
-               '/artifacts/raw/style.patch | git apply -`.\n'
-    comment += '- You can run `maintainer/CI/fix_style.sh` to automatically fix your coding style. This is the same command that I have executed to generate the patch above, but it requires certain tools to be installed on your computer.\n\n'
-    comment += 'You can run `gitlab-runner exec docker style` afterwards to check if your changes worked out properly.\n\n'
-    comment += 'Please note that there are often multiple ways to correctly format code. As I am just a robot, I sometimes fail to identify the most aesthetically pleasing way. So please look over my suggested changes and adapt them where the style does not make sense.'
+        comment = 'To fix this'
+    message = MESSAGE.format(header=comment, url=os.environ['CI_JOB_URL'])
 
     if patch:
-        assert TOKEN_ESPRESSO_CI in comment
-        requests.post(URL, json={'body': comment})
+        assert TOKEN_ESPRESSO_CI in message
+        requests.post(URL, json={'body': message})


### PR DESCRIPTION

Description of changes:
- use the new GET syntax for the GitHub API (fixes #3612)
- print a clear error message and exit Python with a non-zero return value when the GitHub API returns an HTTP error code (partial fix for #2832)