### PR TITLE
script_interface: Avoid uncatched exception in destructor of ScriptIn…

### DIFF
--- a/src/script_interface/ParallelScriptInterface.cpp
+++ b/src/script_interface/ParallelScriptInterface.cpp
@@ -59,7 +59,16 @@ ParallelScriptInterface::ParallelScriptInterface(std::string const &name)
 
 ParallelScriptInterface::~ParallelScriptInterface() {
   /* Delete the instances on the other nodes */
-  call(CallbackAction::DELETE);
+  try {
+    call(CallbackAction::DELETE);
+  } catch (...) {
+    /* We have to do MPI calls in the destructor, which
+       can cause exceptions. To avoid sanitizer warnings
+       about this, and to clarify we directly explicitly
+       call terminate, which would happen anyway.
+    */
+    std::terminate();
+  }
 }
 
 bool ParallelScriptInterface::operator==(ParallelScriptInterface const &rhs) {


### PR DESCRIPTION
…terface::ParallelScriptInterface.

The destructor of this class does mpi calls which can throw (which isn't allowed in destructors), this
can not be avoided. So we catch potential exceptions and just terminate to be explicit and avoid a
warning from the linter.