### PR TITLE
CMake: use python -m sphinx instead of sphinx-build et al.

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -22,24 +22,7 @@
 # limitations under the License.
 #=============================================================================
 
-# Use the Cython executable that lives next to the Python executable
-# if it is a local installation.
-if( PYTHONINTERP_FOUND )
-  get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
-  find_program( CYTHON_EXECUTABLE
-    NAMES cython cython.bat cython3
-    HINTS ${_python_path}
-    )
-else()
-  find_program( CYTHON_EXECUTABLE
-    NAMES cython cython.bat cython3
-    )
-endif()
-
-# Check version
-if(NOT CYTHON_EXECUTABLE)
-  set(CYTHON_EXECUTABLE ${PYTHON_EXECUTABLE} -m cython)
-endif()
+set(CYTHON_EXECUTABLE ${PYTHON_EXECUTABLE} -m cython)
 execute_process(COMMAND ${CYTHON_EXECUTABLE} -V
                 ERROR_VARIABLE CYTHON_OUTPUT RESULT_VARIABLE CYTHON_STATUS OUTPUT_QUIET)
 if(CYTHON_STATUS EQUAL 0)

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,25 +1,13 @@
 include(FindPackageHandleStandardArgs)
 
-find_program(
-  SPHINX_EXECUTABLE
-  NAMES sphinx-build
-        sphinx-build-${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
-  HINTS $ENV{SPHINX_DIR} PATHS /opt/local/ /usr/local/
-                               $ENV{HOME}/Library/Python/2.7/ PATH_SUFFIXES bin
-  DOC "Sphinx documentation generator.")
+set(SPHINX_EXECUTABLE ${PYTHON_EXECUTABLE} -m sphinx)
+set(SPHINX_API_DOC_EXE ${PYTHON_EXECUTABLE} -m sphinx.apidoc)
 
-find_program(
-  SPHINX_API_DOC_EXE
-  NAMES sphinx-apidoc
-        sphinx-apidoc-${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} HINTS
-  PATH_SUFFIXES bin PATHS /opt/local/ /usr/local/ $ENV{HOME}/Library/Python/2.7/
-  DOC "Sphinx api-doc executable.")
+execute_process(
+  COMMAND ${SPHINX_EXECUTABLE} --version OUTPUT_VARIABLE QUERY_VERSION_OUT
+  ERROR_VARIABLE QUERY_VERSION_ERR RESULT_VARIABLE QUERY_VERSION_RESULT)
 
-if(Sphinx_FIND_VERSION)
-  execute_process(
-    COMMAND "${SPHINX_EXECUTABLE}" --version OUTPUT_VARIABLE QUERY_VERSION_OUT
-    ERROR_VARIABLE QUERY_VERSION_ERR RESULT_VARIABLE QUERY_VERSION_RESULT)
-
+if(NOT QUERY_VERSION_RESULT)
   # Sphinx switched at some point from returning ther version on stdout to
   # printing it at stderr. Since we do not know ther version yet, we use stdout
   # if it matches a version regex, or stderr otherwise.
@@ -29,16 +17,14 @@ if(Sphinx_FIND_VERSION)
     set(QUERY_VERSION "${QUERY_VERSION_ERR}")
   endif()
 
-  if(NOT QUERY_VERSION_RESULT)
-    string(REGEX MATCH "[0-9.]+" SPHINX_VERSION "${QUERY_VERSION}")
-  endif()
+  string(REGEX MATCH "[0-9.]+" SPHINX_VERSION "${QUERY_VERSION}")
+endif()
 
-  set(SPHINX_VERSION_COMPATIBLE TRUE)
-  # Blacklist broken version
-  if("${SPHINX_VERSION}" VERSION_EQUAL "2.1.0")
-    message(WARNING "Sphinx version 2.1.0 is not compatible.")
-    set(SPHINX_VERSION_COMPATIBLE FALSE)
-  endif()
+set(SPHINX_VERSION_COMPATIBLE TRUE)
+# Blacklist broken version
+if("${SPHINX_VERSION}" VERSION_EQUAL "2.1.0")
+  message(WARNING "Sphinx version 2.1.0 is not compatible.")
+  set(SPHINX_VERSION_COMPATIBLE FALSE)
 endif()
 
 find_package_handle_standard_args(
@@ -46,3 +32,4 @@ find_package_handle_standard_args(
   SPHINX_VERSION_COMPATIBLE VERSION_VAR SPHINX_VERSION)
 
 mark_as_advanced(SPHINX_EXECUTABLE)
+mark_as_advanced(SPHINX_API_DOC_EXE)

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,7 +1,6 @@
 include(FindPackageHandleStandardArgs)
 
 set(SPHINX_EXECUTABLE ${PYTHON_EXECUTABLE} -m sphinx)
-set(SPHINX_API_DOC_EXE ${PYTHON_EXECUTABLE} -m sphinx.apidoc)
 
 execute_process(
   COMMAND ${SPHINX_EXECUTABLE} --version OUTPUT_VARIABLE QUERY_VERSION_OUT
@@ -18,6 +17,12 @@ if(NOT QUERY_VERSION_RESULT)
   endif()
 
   string(REGEX MATCH "[0-9]+\.[0-9.]+" SPHINX_VERSION "${QUERY_VERSION}")
+
+  if("${SPHINX_VERSION}" VERSION_LESS "1.7")
+    set(SPHINX_API_DOC_EXE ${PYTHON_EXECUTABLE} -m sphinx.apidoc)
+  else()
+    set(SPHINX_API_DOC_EXE ${PYTHON_EXECUTABLE} -m sphinx.ext.apidoc)
+  endif()
 endif()
 
 set(SPHINX_VERSION_COMPATIBLE TRUE)

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -11,13 +11,13 @@ if(NOT QUERY_VERSION_RESULT)
   # Sphinx switched at some point from returning ther version on stdout to
   # printing it at stderr. Since we do not know ther version yet, we use stdout
   # if it matches a version regex, or stderr otherwise.
-  if(QUERY_VERSION_OUT MATCHES "[0-9.]+")
+  if(QUERY_VERSION_OUT MATCHES "[0-9]+\.[0-9.]+")
     set(QUERY_VERSION "${QUERY_VERSION_OUT}")
   else()
     set(QUERY_VERSION "${QUERY_VERSION_ERR}")
   endif()
 
-  string(REGEX MATCH "[0-9.]+" SPHINX_VERSION "${QUERY_VERSION}")
+  string(REGEX MATCH "[0-9]+\.[0-9.]+" SPHINX_VERSION "${QUERY_VERSION}")
 endif()
 
 set(SPHINX_VERSION_COMPATIBLE TRUE)

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -22,8 +22,8 @@ endif()
 
 set(SPHINX_VERSION_COMPATIBLE TRUE)
 # Blacklist broken version
-if("${SPHINX_VERSION}" VERSION_EQUAL "2.1.0")
-  message(WARNING "Sphinx version 2.1.0 is not compatible.")
+if("${SPHINX_VERSION}" VERSION_EQUAL "2.1.0" OR "${SPHINX_VERSION}" VERSION_EQUAL "3.0.0")
+  message(WARNING "Sphinx version ${SPHINX_VERSION} is not compatible.")
   set(SPHINX_VERSION_COMPATIBLE FALSE)
 endif()
 


### PR DESCRIPTION
This helps in situations where the python3 version of `sphinx-build` is not in $PATH, but the python2 version is.

Also apply the same trick to Cython, where we already used it as a fallback.

Problem reported by @biermanncarl and discussed with @KaiSzuttor.