### PR TITLE
fix_style: try python3 -m pre_commit if pre-commit not found

### DIFF
--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -26,8 +26,13 @@ if ! git diff-index --quiet HEAD -- && [ "${1}" != "-f" ]; then
 fi
 
 if ! hash pre-commit 2>/dev/null; then
-    echo "pre-commit command not found."
-    exit 2
+    python3 -m pre_commit 2>&1 >/dev/null
+    if [ "$?" = "0" ]; then
+        alias pre-commit="python3 -m pre_commit"
+    else
+        echo "pre-commit command not found."
+        exit 2
+    fi
 fi
 
 pre-commit run --all-files


### PR DESCRIPTION
Same trick as in #3648. @biermanncarl reported being unable to use fix-style.sh because the pip binary directory is not in `$PATH` by default.