### PR TITLE
All_compare test: Expect "true" on single process

### DIFF
--- a/src/utils/tests/all_compare_test.cpp
+++ b/src/utils/tests/all_compare_test.cpp
@@ -37,7 +37,8 @@ BOOST_AUTO_TEST_CASE(true_) {
 BOOST_AUTO_TEST_CASE(false_) {
   mpi::communicator world;
 
-  BOOST_CHECK(not all_compare(world, (world.rank() > 0) ? 42 : 41));
+  BOOST_CHECK(all_compare(world, (world.rank() > 0) ? 42 : 41) ==
+              (world.size() <= 1));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The all_compare test checks if all_compare correctly returns false if supplied with different values. This, however, only holds true if the test is called with more than one processes.

