### PR TITLE
Removed remaining globals from ghosts

### DIFF
--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -142,10 +142,8 @@ static void topology_release(int cs) {
     topology_release(cell_structure.type);
     break;
   case CELL_STRUCTURE_DOMDEC:
-    dd_topology_release();
     break;
   case CELL_STRUCTURE_NSQUARE:
-    nsq_topology_release();
     break;
   default:
     fprintf(stderr,
@@ -216,7 +214,6 @@ static void invalidate_ghosts() {
 void cells_re_init(int new_cs, double range) {
   invalidate_ghosts();
 
-  topology_release(cell_structure.type);
   /* MOVE old local_cell list to temporary buffer */
   std::vector<Cell *> old_local_cells;
   std::swap(old_local_cells, cell_structure.m_local_cells);

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -133,27 +133,6 @@ std::vector<std::pair<int, int>> mpi_get_pairs(double distance) {
 /************************************************************/
 /*@{*/
 
-/** Choose the topology release function of a certain cell system. */
-static void topology_release(int cs) {
-  switch (cs) {
-  case CELL_STRUCTURE_NONEYET:
-    break;
-  case CELL_STRUCTURE_CURRENT:
-    topology_release(cell_structure.type);
-    break;
-  case CELL_STRUCTURE_DOMDEC:
-    break;
-  case CELL_STRUCTURE_NSQUARE:
-    break;
-  default:
-    fprintf(stderr,
-            "INTERNAL ERROR: attempting to sort the particles in an "
-            "unknown way (%d)\n",
-            cs);
-    errexit();
-  }
-}
-
 /** Choose the topology init function of a certain cell system. */
 void topology_init(int cs, double range) {
   /** broadcast the flag for using Verlet list */

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -605,16 +605,6 @@ void dd_topology_init(const Utils::Vector3i &grid, double range) {
   dd_init_cell_interactions(grid);
 }
 
-/************************************************************/
-void dd_topology_release() {
-  /* free ghost cell pointer list */
-
-  cell_structure.m_ghost_cells.resize(0);
-  /* free ghost communicators */
-  free_comm(&cell_structure.exchange_ghosts_comm);
-  free_comm(&cell_structure.collect_ghost_force_comm);
-}
-
 namespace {
 
 /**

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -203,7 +203,8 @@ void dd_mark_cells() {
  *  \param lc          lower left corner of the subgrid.
  *  \param hc          high up corner of the subgrid.
  */
-int dd_fill_comm_cell_lists(Cell **part_lists, Utils::Vector3i const &lc,
+int dd_fill_comm_cell_lists(ParticleList **part_lists,
+                            Utils::Vector3i const &lc,
                             Utils::Vector3i const &hc) {
   /* sanity check */
   for (int i = 0; i < 3; i++) {
@@ -224,7 +225,7 @@ int dd_fill_comm_cell_lists(Cell **part_lists, Utils::Vector3i const &lc,
                              {dd.ghost_cell_grid[0], dd.ghost_cell_grid[1],
                               dd.ghost_cell_grid[2]});
 
-        part_lists[c] = &cells[i];
+        part_lists[c] = &(cells[i].particles());
         c++;
       }
   return c;

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -135,16 +135,6 @@ void dd_on_geometry_change(int flags, const Utils::Vector3i &grid,
  */
 void dd_topology_init(const Utils::Vector3i &grid, double range);
 
-/** Called when the current cell structure is invalidated because for
- *  example the box length has changed. This procedure may NOT destroy
- *  the old inner and ghost cells, but it should free all other
- *  organizational data. Note that parameters like the box length or
- *  the node_grid may already have changed. Therefore organizational
- *  data has to be stored independently from variables that may be
- *  changed from outside.
- */
-void dd_topology_release();
-
 /** Just resort the particles. Used during integration. The particles
  *  are stored in the cell structure.
  *

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -83,13 +83,6 @@ private:
   std::vector<char> bondbuf; //< Buffer for bond lists
 };
 
-void prepare_comm(GhostCommunicator *gcr, int num) {
-  assert(gcr);
-  gcr->comm.resize(num);
-  for (auto &ghost_comm : gcr->comm)
-    ghost_comm.shift.fill(0.0);
-}
-
 void free_comm(GhostCommunicator *gcr) {
   // Invalidate the elements in all "part_lists" of all GhostCommunications.
   for (auto &ghost_comm : gcr->comm)

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -83,12 +83,6 @@ private:
   std::vector<char> bondbuf; //< Buffer for bond lists
 };
 
-void free_comm(GhostCommunicator *gcr) {
-  // Invalidate the elements in all "part_lists" of all GhostCommunications.
-  for (auto &ghost_comm : gcr->comm)
-    ghost_comm.part_lists.clear();
-}
-
 static size_t calc_transmit_size(unsigned data_parts) {
   size_t size = {};
   if (data_parts & GHOSTTRANS_PROPRTS) {

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -103,8 +103,7 @@
  *  systems, therefore have a look at @ref dd_topology_init or
  *  @ref nsq_topology_init for further details.
  */
-#include "Cell.hpp"
-#include <mpi.h>
+#include "ParticleList.hpp"
 
 /** \name Transfer types, for \ref GhostCommunicator::type */
 /************************************************************/
@@ -156,7 +155,7 @@ struct GhostCommunication {
   int node;
 
   /** Pointer array to particle lists to communicate. */
-  std::vector<Cell *> part_lists = {};
+  std::vector<ParticleList *> part_lists = {};
 
   /** Position shift for ghost particles. The shift is done on the sender side.
    */

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -162,8 +162,10 @@ struct GhostCommunication {
   Utils::Vector3d shift = {};
 };
 
-/** Properties for a ghost communication. A ghost communication is defined */
+/** Properties for a ghost communication. */
 struct GhostCommunicator {
+  explicit GhostCommunicator(int size = 0) : comm(static_cast<size_t>(size)) {}
+
   /** List of ghost communications. */
   std::vector<GhostCommunication> comm;
 };

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -167,8 +167,8 @@ struct GhostCommunication {
 /** Properties for a ghost communication. */
 struct GhostCommunicator {
   GhostCommunicator() = default;
-  GhostCommunicator(boost::mpi::communicator const &comm, size_t size)
-      : mpi_comm(comm), communications(size) {}
+  GhostCommunicator(boost::mpi::communicator comm, size_t size)
+      : mpi_comm(std::move(comm)), communications(size) {}
 
   /** Attached mpi communicator */
   boost::mpi::communicator mpi_comm;

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -176,9 +176,6 @@ struct GhostCommunicator {
 /************************************************************/
 /*@{*/
 
-/** Initialize a communicator. */
-void prepare_comm(GhostCommunicator *gcr, int num);
-
 /** Free a communicator. */
 void free_comm(GhostCommunicator *gcr);
 

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -176,9 +176,6 @@ struct GhostCommunicator {
 /************************************************************/
 /*@{*/
 
-/** Free a communicator. */
-void free_comm(GhostCommunicator *gcr);
-
 /**
  * @brief Do a ghost communication with caller specified data parts.
  */

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -105,6 +105,8 @@
  */
 #include "ParticleList.hpp"
 
+#include <boost/mpi/communicator.hpp>
+
 /** \name Transfer types, for \ref GhostCommunicator::type */
 /************************************************************/
 /*@{*/
@@ -164,10 +166,15 @@ struct GhostCommunication {
 
 /** Properties for a ghost communication. */
 struct GhostCommunicator {
-  explicit GhostCommunicator(int size = 0) : comm(static_cast<size_t>(size)) {}
+  GhostCommunicator() = default;
+  GhostCommunicator(boost::mpi::communicator const &comm, size_t size)
+      : mpi_comm(comm), communications(size) {}
+
+  /** Attached mpi communicator */
+  boost::mpi::communicator mpi_comm;
 
   /** List of ghost communications. */
-  std::vector<GhostCommunication> comm;
+  std::vector<GhostCommunication> communications;
 };
 
 /*@}*/

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -37,12 +37,6 @@ static Cell *nsq_id_to_cell(int id) {
   return ((id % n_nodes) == this_node) ? local : nullptr;
 }
 
-void nsq_topology_release() {
-  /* free ghost cell pointer list */
-  free_comm(&cell_structure.exchange_ghosts_comm);
-  free_comm(&cell_structure.collect_ghost_force_comm);
-}
-
 static GhostCommunicator nsq_prepare_comm() {
   /* no need for comm for only 1 node */
   if (n_nodes == 1) {

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -40,15 +40,15 @@ static Cell *nsq_id_to_cell(int id) {
 static GhostCommunicator nsq_prepare_comm() {
   /* no need for comm for only 1 node */
   if (n_nodes == 1) {
-    return GhostCommunicator{0};
+    return GhostCommunicator{comm_cart, 0};
   }
 
-  auto comm = GhostCommunicator{n_nodes};
+  auto comm = GhostCommunicator{comm_cart, static_cast<size_t>(n_nodes)};
   /* every node has its dedicated comm step */
   for (int n = 0; n < n_nodes; n++) {
-    comm.comm[n].part_lists.resize(1);
-    comm.comm[n].part_lists[0] = &(cells[n].particles());
-    comm.comm[n].node = n;
+    comm.communications[n].part_lists.resize(1);
+    comm.communications[n].part_lists[0] = &(cells[n].particles());
+    comm.communications[n].node = n;
   }
 
   return comm;
@@ -113,16 +113,18 @@ void nsq_topology_init() {
       /* use the prefetched send buffers. Node 0 transmits first and never
        * prefetches. */
       if (this_node == 0 || this_node != n) {
-        cell_structure.exchange_ghosts_comm.comm[n].type = GHOST_BCST;
+        cell_structure.exchange_ghosts_comm.communications[n].type = GHOST_BCST;
       } else {
-        cell_structure.exchange_ghosts_comm.comm[n].type =
+        cell_structure.exchange_ghosts_comm.communications[n].type =
             GHOST_BCST | GHOST_PREFETCH;
       }
-      cell_structure.collect_ghost_force_comm.comm[n].type = GHOST_RDCE;
+      cell_structure.collect_ghost_force_comm.communications[n].type =
+          GHOST_RDCE;
     }
     /* first round: all nodes except the first one prefetch their send data */
     if (this_node != 0) {
-      cell_structure.exchange_ghosts_comm.comm[0].type |= GHOST_PREFETCH;
+      cell_structure.exchange_ghosts_comm.communications[0].type |=
+          GHOST_PREFETCH;
     }
   }
 }

--- a/src/core/nsquare.cpp
+++ b/src/core/nsquare.cpp
@@ -55,7 +55,7 @@ static void nsq_prepare_comm(GhostCommunicator *comm) {
   /* every node has its dedicated comm step */
   for (n = 0; n < n_nodes; n++) {
     comm->comm[n].part_lists.resize(1);
-    comm->comm[n].part_lists[0] = &cells[n];
+    comm->comm[n].part_lists[0] = &(cells[n].particles());
     comm->comm[n].node = n;
   }
 }

--- a/src/core/nsquare.hpp
+++ b/src/core/nsquare.hpp
@@ -51,9 +51,6 @@
 
 #include "cells.hpp"
 
-/** always returns the one local cell */
-void nsq_topology_release();
-
 /** setup the nsquare topology */
 void nsq_topology_init();
 


### PR DESCRIPTION
Description of changes:
- Removed dependence of the ghost comm on global state
- Made ghosts operate on `ParticlelList` instead of `Cell`, which is all they need to know.
- Removed some left-over management functions that are no longer needed because cells/ghost communications are proper types now.