### PR TITLE
Removed dependence of cells on head node code

### DIFF
--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -37,7 +37,6 @@
 #include "integrate.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "nsquare.hpp"
-#include "particle_data.hpp"
 
 #include <utils/NoOp.hpp>
 #include <utils/mpi/gather_buffer.hpp>
@@ -203,14 +202,9 @@ void cells_re_init(int new_cs, double range) {
   topology_init(new_cs, range);
   cell_structure.min_range = range;
 
-  clear_particle_node();
-
   for (auto &p : Cells::particles(Utils::make_span(old_local_cells))) {
     cell_structure.add_particle(std::move(p));
   }
-
-  /* to enforce initialization of the ghost cells */
-  cell_structure.set_resort_particles(Cells::RESORT_GLOBAL);
 
   on_cell_structure_change();
 }
@@ -287,7 +281,6 @@ ParticleList sort_and_fold_parts(const CellStructure &cs,
 void cells_resort_particles(int global_flag) {
   invalidate_ghosts();
 
-  clear_particle_node();
   n_verlet_updates++;
 
   static std::vector<Cell *> modified_cells;

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -666,6 +666,8 @@ std::vector<int> mpi_resort_particles(int global_flag) {
   mpi_call(mpi_resort_particles_slave, global_flag, 0);
   cells_resort_particles(global_flag);
 
+  clear_particle_node();
+
   std::vector<int> n_parts;
   boost::mpi::gather(comm_cart, cells_get_n_particles(), n_parts, 0);
 

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -129,8 +129,6 @@ void on_integration_start() {
   npt_ensemble_init(box_geo);
 #endif
 
-  /* Update particle and observable information for routines in statistics.cpp
-   */
   invalidate_obs();
   partCfg().invalidate();
   invalidate_fetch_cache();
@@ -184,6 +182,8 @@ void on_observable_calc() {
     ek_integrate_electrostatics();
   }
 #endif
+
+  clear_particle_node();
 }
 
 void on_particle_charge_change() {
@@ -274,7 +274,6 @@ void on_boxl_change() {
 }
 
 void on_cell_structure_change() {
-
 /* Now give methods a chance to react to the change in cell
    structure. Most ES methods need to reinitialize, as they depend
    on skin, node grid and so on. Only for a change in box length we

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -44,10 +44,7 @@ Utils::Vector3i node_grid{};
 
 /************************************************************/
 
-void init_node_grid() {
-  grid_changed_n_nodes();
-  cells_on_geometry_change(CELL_FLAG_GRIDCHANGED);
-}
+void init_node_grid() { grid_changed_n_nodes(); }
 
 int map_position_node_array(const Utils::Vector3d &pos) {
   auto const f_pos = folded_position(pos, box_geo);


### PR DESCRIPTION
Sorry for the many PRs, but I think this is easier to understand than one big one.

Changes:
- Moved particle node management out of parallel code
- Removed duplicate cell system initialization in startup