### PR TITLE
Removed communication and geometry globals from domain decomposition

### DIFF
--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -69,4 +69,23 @@ public:
   double volume() const { return m_length[0] * m_length[1] * m_length[2]; }
 };
 
+template <typename T> T get_mi_coord(T a, T b, T box_length, bool periodic) {
+  auto const dx = a - b;
+
+  if (periodic && (std::fabs(dx) > (0.5 * box_length))) {
+    return dx - std::round(dx * (1. / box_length)) * box_length;
+  }
+
+  return dx;
+}
+
+template <typename T>
+Utils::Vector<T, 3> get_mi_vector(const Utils::Vector<T, 3> &a,
+                                  const Utils::Vector<T, 3> &b,
+                                  const BoxGeometry &box) {
+  return {get_mi_coord(a[0], b[0], box.length()[0], box.periodic(0)),
+          get_mi_coord(a[1], b[1], box.length()[1], box.periodic(1)),
+          get_mi_coord(a[2], b[2], box.length()[2], box.periodic(2))};
+}
+
 #endif // CORE_BOX_GEOMETRY_HPP

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -146,7 +146,7 @@ void topology_init(int cs, double range) {
     topology_init(cell_structure.type, range);
     break;
   case CELL_STRUCTURE_DOMDEC:
-    dd_topology_init(node_grid, range, comm_cart);
+    dd_topology_init(comm_cart, range, box_geo, local_geo);
     break;
   case CELL_STRUCTURE_NSQUARE:
     nsq_topology_init();
@@ -298,7 +298,7 @@ void cells_resort_particles(int global_flag) {
     nsq_exchange_particles(global_flag, &displaced_parts, modified_cells);
     break;
   case CELL_STRUCTURE_DOMDEC:
-    dd_exchange_and_sort_particles(global_flag, &displaced_parts, node_grid,
+    dd_exchange_and_sort_particles(global_flag, &displaced_parts,
                                    modified_cells);
     break;
   }
@@ -343,7 +343,7 @@ void cells_on_geometry_change(bool fast) {
 
   switch (cell_structure.type) {
   case CELL_STRUCTURE_DOMDEC:
-    dd_on_geometry_change(fast, node_grid, range);
+    dd_on_geometry_change(fast, range, box_geo, local_geo);
     break;
   case CELL_STRUCTURE_NSQUARE:
     break;

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -338,9 +338,7 @@ void cells_resort_particles(int global_flag) {
 /*************************************************/
 
 void cells_on_geometry_change(int flags) {
-  /* Consider skin only if there are actually interactions */
-  auto const max_cut = maximal_cutoff();
-  auto const range = (max_cut > 0.) ? max_cut + skin : INACTIVE_CUTOFF;
+  auto const range = interaction_range();
   cell_structure.min_range = range;
 
   switch (cell_structure.type) {

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -146,7 +146,7 @@ void topology_init(int cs, double range) {
     topology_init(cell_structure.type, range);
     break;
   case CELL_STRUCTURE_DOMDEC:
-    dd_topology_init(node_grid, range);
+    dd_topology_init(node_grid, range, comm_cart);
     break;
   case CELL_STRUCTURE_NSQUARE:
     nsq_topology_init();

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -337,13 +337,13 @@ void cells_resort_particles(int global_flag) {
 
 /*************************************************/
 
-void cells_on_geometry_change(int flags) {
+void cells_on_geometry_change(bool fast) {
   auto const range = interaction_range();
   cell_structure.min_range = range;
 
   switch (cell_structure.type) {
   case CELL_STRUCTURE_DOMDEC:
-    dd_on_geometry_change(flags, node_grid, range);
+    dd_on_geometry_change(fast, node_grid, range);
     break;
   case CELL_STRUCTURE_NSQUARE:
     break;

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -58,16 +58,6 @@ enum {
 
 /*@}*/
 
-/** \name Flags for cells_on_geometry_change */
-/*@{*/
-
-/** Flag for cells_on_geometry_change: the processor grid has changed. */
-#define CELL_FLAG_GRIDCHANGED 1
-/** Flag for cells_on_geometry_change: skip shrinking of cells. */
-#define CELL_FLAG_FAST 2
-
-/*@}*/
-
 /************************************************************/
 /** \name Exported Variables */
 /************************************************************/
@@ -108,19 +98,14 @@ void cells_resort_particles(int global_flag);
  *  It calculates the maximal interaction range, and as said reinitializes
  *  the cells structure if something significant has changed.
  *
- *  If bit @ref CELL_FLAG_FAST is set, the routine should try to save time.
+ *  If the fast flag is set, the routine should try to save time.
  *  Currently this means that if the maximal range decreased, it does
  *  not reorganize the particles. This is used in the NpT algorithm to
  *  avoid frequent reorganization of particles.
  *
- *  If bit @ref CELL_FLAG_GRIDCHANGED is set, it means the nodes' topology
- *  has changed, i. e. the grid or periodicity. In this case a full
- *  reorganization is due.
- *
- *  @param flags a bitmask of @ref CELL_FLAG_GRIDCHANGED,
- *               and/or @ref CELL_FLAG_FAST, see above.
+ *  @param fast If true, do not try to optimize the cell size.
  */
-void cells_on_geometry_change(int flags);
+void cells_on_geometry_change(bool fast);
 
 /** Update ghost information. If needed,
  *  the particles are also resorted.

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -262,12 +262,10 @@ GhostCommunicator dd_prepare_comm(const Utils::Vector3i &grid) {
   for (dir = 0; dir < 3; dir++) {
     for (lr = 0; lr < 2; lr++) {
       /* No communication for border of non periodic direction */
-      if (box_geo.periodic(dir) || (local_geo.boundary()[2 * dir + lr] == 0)) {
-        if (grid[dir] == 1)
-          num++;
-        else
-          num += 2;
-      }
+      if (grid[dir] == 1)
+        num++;
+      else
+        num += 2;
     }
   }
 
@@ -293,64 +291,55 @@ GhostCommunicator dd_prepare_comm(const Utils::Vector3i &grid) {
     for (lr = 0; lr < 2; lr++) {
       if (grid[dir] == 1) {
         /* just copy cells on a single node */
-        if (box_geo.periodic(dir) ||
-            (local_geo.boundary()[2 * dir + lr] == 0)) {
-          comm.communications[cnt].type = GHOST_LOCL;
-          comm.communications[cnt].node = this_node;
+        comm.communications[cnt].type = GHOST_LOCL;
+        comm.communications[cnt].node = this_node;
 
-          /* Buffer has to contain Send and Recv cells -> factor 2 */
-          comm.communications[cnt].part_lists.resize(2 * n_comm_cells[dir]);
-          /* prepare folding of ghost positions */
-          comm.communications[cnt].shift = shift(box_geo, local_geo, dir, lr);
+        /* Buffer has to contain Send and Recv cells -> factor 2 */
+        comm.communications[cnt].part_lists.resize(2 * n_comm_cells[dir]);
+        /* prepare folding of ghost positions */
+        comm.communications[cnt].shift = shift(box_geo, local_geo, dir, lr);
 
-          /* fill send comm cells */
-          lc[dir] = hc[dir] = 1 + lr * (dd.cell_grid[dir] - 1);
+        /* fill send comm cells */
+        lc[dir] = hc[dir] = 1 + lr * (dd.cell_grid[dir] - 1);
 
-          dd_fill_comm_cell_lists(comm.communications[cnt].part_lists.data(),
-                                  lc, hc);
+        dd_fill_comm_cell_lists(comm.communications[cnt].part_lists.data(), lc,
+                                hc);
 
-          /* fill recv comm cells */
-          lc[dir] = hc[dir] = 0 + (1 - lr) * (dd.cell_grid[dir] + 1);
+        /* fill recv comm cells */
+        lc[dir] = hc[dir] = 0 + (1 - lr) * (dd.cell_grid[dir] + 1);
 
-          /* place receive cells after send cells */
-          dd_fill_comm_cell_lists(
-              &comm.communications[cnt].part_lists[n_comm_cells[dir]], lc, hc);
+        /* place receive cells after send cells */
+        dd_fill_comm_cell_lists(
+            &comm.communications[cnt].part_lists[n_comm_cells[dir]], lc, hc);
 
-          cnt++;
-        }
+        cnt++;
       } else {
         /* i: send/recv loop */
         for (i = 0; i < 2; i++) {
-          if (box_geo.periodic(dir) ||
-              (local_geo.boundary()[2 * dir + lr] == 0))
-            if ((node_pos[dir] + i) % 2 == 0) {
-              comm.communications[cnt].type = GHOST_SEND;
-              comm.communications[cnt].node = node_neighbors[2 * dir + lr];
-              comm.communications[cnt].part_lists.resize(n_comm_cells[dir]);
-              /* prepare folding of ghost positions */
-              comm.communications[cnt].shift =
-                  shift(box_geo, local_geo, dir, lr);
+          if ((node_pos[dir] + i) % 2 == 0) {
+            comm.communications[cnt].type = GHOST_SEND;
+            comm.communications[cnt].node = node_neighbors[2 * dir + lr];
+            comm.communications[cnt].part_lists.resize(n_comm_cells[dir]);
+            /* prepare folding of ghost positions */
+            comm.communications[cnt].shift = shift(box_geo, local_geo, dir, lr);
 
-              lc[dir] = hc[dir] = 1 + lr * (dd.cell_grid[dir] - 1);
+            lc[dir] = hc[dir] = 1 + lr * (dd.cell_grid[dir] - 1);
 
-              dd_fill_comm_cell_lists(
-                  comm.communications[cnt].part_lists.data(), lc, hc);
-              cnt++;
-            }
-          if (box_geo.periodic(dir) ||
-              (local_geo.boundary()[2 * dir + (1 - lr)] == 0))
-            if ((node_pos[dir] + (1 - i)) % 2 == 0) {
-              comm.communications[cnt].type = GHOST_RECV;
-              comm.communications[cnt].node =
-                  node_neighbors[2 * dir + (1 - lr)];
-              comm.communications[cnt].part_lists.resize(n_comm_cells[dir]);
+            dd_fill_comm_cell_lists(comm.communications[cnt].part_lists.data(),
+                                    lc, hc);
+            cnt++;
+          }
+          if ((node_pos[dir] + (1 - i)) % 2 == 0) {
+            comm.communications[cnt].type = GHOST_RECV;
+            comm.communications[cnt].node = node_neighbors[2 * dir + (1 - lr)];
+            comm.communications[cnt].part_lists.resize(n_comm_cells[dir]);
 
-              lc[dir] = hc[dir] = (1 - lr) * (dd.cell_grid[dir] + 1);
+            lc[dir] = hc[dir] = (1 - lr) * (dd.cell_grid[dir] + 1);
 
-              dd_fill_comm_cell_lists(
-                  comm.communications[cnt].part_lists.data(), lc, hc);
-              cnt++;
-            }
+            dd_fill_comm_cell_lists(comm.communications[cnt].part_lists.data(),
+                                    lc, hc);
+            cnt++;
+          }
         }
       }
       done[dir] = 1;
@@ -407,34 +396,27 @@ void dd_update_communicators_w_boxl(const Utils::Vector3i &grid) {
     /* lr loop: left right */
     for (int lr = 0; lr < 2; lr++) {
       if (grid[dir] == 1) {
-        if (box_geo.periodic(dir) ||
-            (local_geo.boundary()[2 * dir + lr] == 0)) {
-          /* prepare folding of ghost positions */
-          if (local_geo.boundary()[2 * dir + lr] != 0) {
-            cell_structure.exchange_ghosts_comm.communications[cnt].shift =
-                shift(box_geo, local_geo, dir, lr);
-          }
-          cnt++;
+        /* prepare folding of ghost positions */
+        if (local_geo.boundary()[2 * dir + lr] != 0) {
+          cell_structure.exchange_ghosts_comm.communications[cnt].shift =
+              shift(box_geo, local_geo, dir, lr);
         }
+        cnt++;
       } else {
         auto const node_pos = calc_node_pos(comm_cart);
         /* i: send/recv loop */
         for (int i = 0; i < 2; i++) {
-          if (box_geo.periodic(dir) ||
-              (local_geo.boundary()[2 * dir + lr] == 0))
-            if ((node_pos[dir] + i) % 2 == 0) {
-              /* prepare folding of ghost positions */
-              if (local_geo.boundary()[2 * dir + lr] != 0) {
-                cell_structure.exchange_ghosts_comm.communications[cnt].shift =
-                    shift(box_geo, local_geo, dir, lr);
-              }
-              cnt++;
+          if ((node_pos[dir] + i) % 2 == 0) {
+            /* prepare folding of ghost positions */
+            if (local_geo.boundary()[2 * dir + lr] != 0) {
+              cell_structure.exchange_ghosts_comm.communications[cnt].shift =
+                  shift(box_geo, local_geo, dir, lr);
             }
-          if (box_geo.periodic(dir) ||
-              (local_geo.boundary()[2 * dir + (1 - lr)] == 0))
-            if ((node_pos[dir] + (1 - i)) % 2 == 0) {
-              cnt++;
-            }
+            cnt++;
+          }
+          if ((node_pos[dir] + (1 - i)) % 2 == 0) {
+            cnt++;
+          }
         }
       }
     }

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -523,23 +523,13 @@ Cell *dd_save_position_to_cell(const Utils::Vector3d &pos) {
 /* Public Functions */
 /************************************************************/
 
-void dd_on_geometry_change(int flags, const Utils::Vector3i &grid,
-                           const double range) {
+void dd_on_geometry_change(bool fast, const Utils::Vector3i &grid,
+                           double range) {
   /* check that the CPU domains are still sufficiently large. */
   for (int i = 0; i < 3; i++)
     if (local_geo.length()[i] < range) {
       runtimeErrorMsg() << "box_l in direction " << i << " is too small";
     }
-
-  /* A full resorting is necessary if the grid has changed. We simply
-   * don't have anything fast for this case. Probably also not necessary. */
-  if (flags & CELL_FLAG_GRIDCHANGED) {
-    /* Reset min num cells to default */
-    min_num_cells = calc_processor_min_num_cells(grid);
-
-    cells_re_init(CELL_STRUCTURE_CURRENT, range);
-    return;
-  }
 
   /* otherwise, re-set our geometrical dimensions which have changed
      (in addition to the general ones that \ref grid_changed_box_l
@@ -561,7 +551,7 @@ void dd_on_geometry_change(int flags, const Utils::Vector3i &grid,
 
   /* If we are not in a hurry, check if we can maybe optimize the cell
      system by using smaller cells. */
-  if (!(flags & CELL_FLAG_FAST) && range > 0) {
+  if (not fast) {
     int i;
     for (i = 0; i < 3; i++) {
       auto poss_size = (int)floor(local_geo.length()[i] / range);

--- a/src/core/domain_decomposition.cpp
+++ b/src/core/domain_decomposition.cpp
@@ -24,8 +24,8 @@
  */
 
 #include "domain_decomposition.hpp"
-
 #include "errorhandling.hpp"
+#include "ghosts.hpp"
 
 #include <utils/index.hpp>
 #include <utils/mpi/sendrecv.hpp>

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -60,6 +60,8 @@
 #include "Cell.hpp"
 #include "ghosts.hpp"
 
+#include <boost/mpi/communicator.hpp>
+
 /** Structure containing the information about the cell grid used for domain
  *  decomposition.
  */
@@ -81,6 +83,8 @@ struct DomainDecomposition {
   /** inverse cell size = \see DomainDecomposition::cell_size ^ -1. */
   double inv_cell_size[3];
   bool fully_connected[3];
+
+  boost::mpi::communicator comm;
 };
 
 /************************************************************/
@@ -134,7 +138,8 @@ void dd_on_geometry_change(bool fast, const Utils::Vector3i &grid,
  *  @param grid  Number of nodes in each spatial dimension.
  *  @param range Desired interaction range
  */
-void dd_topology_init(const Utils::Vector3i &grid, double range);
+void dd_topology_init(const Utils::Vector3i &grid, double range,
+                      const boost::mpi::communicator &comm);
 
 /** Just resort the particles. Used during integration. The particles
  *  are stored in the cell structure.

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -60,7 +60,6 @@
 #include "BoxGeometry.hpp"
 #include "Cell.hpp"
 #include "LocalBox.hpp"
-#include "ghosts.hpp"
 
 #include <boost/mpi/communicator.hpp>
 

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -57,7 +57,9 @@
  *  Implementation in domain_decomposition.cpp.
  */
 
+#include "BoxGeometry.hpp"
 #include "Cell.hpp"
+#include "LocalBox.hpp"
 #include "ghosts.hpp"
 
 #include <boost/mpi/communicator.hpp>
@@ -85,6 +87,8 @@ struct DomainDecomposition {
   bool fully_connected[3];
 
   boost::mpi::communicator comm;
+  BoxGeometry box_geo;
+  LocalBox<double> local_geo;
 };
 
 /************************************************************/
@@ -119,14 +123,12 @@ extern int min_num_cells;
 /** adjust the domain decomposition to a change in the geometry.
  *  Tries to speed up things if possible.
  *
- *  @param fast  A combination of \ref CELL_FLAG_FAST and \ref
- *                CELL_FLAG_GRIDCHANGED, see documentation of \ref
- *                cells_on_geometry_change.
- *  @param grid   Number of nodes in each spatial dimension.
+ *  @param fast If true do not optimize the cell size but
+ *              return asap.
  *  @param range Desired interaction range
  */
-void dd_on_geometry_change(bool fast, const Utils::Vector3i &grid,
-                           double range);
+void dd_on_geometry_change(bool fast, double range, const BoxGeometry &box_geo,
+                           const LocalBox<double> &local_geo);
 
 /** Initialize the topology. The argument is a list of cell pointers,
  *  containing particles that have to be sorted into new cells. The
@@ -135,11 +137,12 @@ void dd_on_geometry_change(bool fast, const Utils::Vector3i &grid,
  *  structure has to be reinitialized. This also includes setting up
  *  the cell_structure array.
  *
- *  @param grid  Number of nodes in each spatial dimension.
+ *  @param comm MPI communicator to use for the cell system.
  *  @param range Desired interaction range
  */
-void dd_topology_init(const Utils::Vector3i &grid, double range,
-                      const boost::mpi::communicator &comm);
+void dd_topology_init(const boost::mpi::communicator &comm, double range,
+                      const BoxGeometry &box_geo,
+                      const LocalBox<double> &local_geo);
 
 /** Just resort the particles. Used during integration. The particles
  *  are stored in the cell structure.
@@ -149,31 +152,12 @@ void dd_topology_init(const Utils::Vector3i &grid, double range,
  *      Molecular dynamics, or any other integration scheme using only local
  *      particle moves)
  *  @param pl     List of particles
- *  @param grid   Number of nodes in each spatial dimension
  */
 void dd_exchange_and_sort_particles(int global, ParticleList *pl,
-                                    const Utils::Vector3i &grid,
                                     std::vector<Cell *> &modified_cells);
 
 /** calculate physical (processor) minimal number of cells */
 int calc_processor_min_num_cells(const Utils::Vector3i &grid);
-
-/** Fill a communication cell pointer list. Fill the cell pointers of
- *  all cells which are inside a rectangular subgrid of the 3D cell
- *  grid (\ref DomainDecomposition::ghost_cell_grid) starting from the
- *  lower left corner lc up to the high top corner hc. The cell
- *  pointer list part_lists must already be large enough.
- *  \param part_lists  List of cell pointers to store the result.
- *  \param lc          lower left corner of the subgrid.
- *  \param hc          high up corner of the subgrid.
- */
-int dd_fill_comm_cell_lists(Cell **part_lists, Utils::Vector3i const &lc,
-                            Utils::Vector3i const &hc);
-
-/** Of every two communication rounds, set the first receivers to prefetch and
- *  poststore
- */
-void dd_assign_prefetches(GhostCommunicator *comm);
 
 /*@}*/
 

--- a/src/core/domain_decomposition.hpp
+++ b/src/core/domain_decomposition.hpp
@@ -115,13 +115,13 @@ extern int min_num_cells;
 /** adjust the domain decomposition to a change in the geometry.
  *  Tries to speed up things if possible.
  *
- *  @param flags  A combination of \ref CELL_FLAG_FAST and \ref
+ *  @param fast  A combination of \ref CELL_FLAG_FAST and \ref
  *                CELL_FLAG_GRIDCHANGED, see documentation of \ref
  *                cells_on_geometry_change.
  *  @param grid   Number of nodes in each spatial dimension.
  *  @param range Desired interaction range
  */
-void dd_on_geometry_change(int flags, const Utils::Vector3i &grid,
+void dd_on_geometry_change(bool fast, const Utils::Vector3i &grid,
                            double range);
 
 /** Initialize the topology. The argument is a list of cell pointers,

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -230,7 +230,7 @@ void on_coulomb_change() {
 void on_short_range_ia_change() {
   invalidate_obs();
 
-  cells_on_geometry_change(0);
+  cells_on_geometry_change(false);
 
   recalc_forces = true;
 }
@@ -256,7 +256,7 @@ void on_boxl_change() {
   grid_changed_box_l(box_geo);
   /* Electrostatics cutoffs mostly depend on the system size,
      therefore recalculate them. */
-  cells_on_geometry_change(0);
+  cells_on_geometry_change(false);
 
 /* Now give methods a chance to react to the change in box length */
 #ifdef ELECTROSTATICS
@@ -305,7 +305,7 @@ void on_parameter_change(int field) {
     break;
   case FIELD_MIN_GLOBAL_CUT:
   case FIELD_SKIN:
-    cells_on_geometry_change(0);
+    cells_on_geometry_change(false);
     break;
   case FIELD_PERIODIC:
 #ifdef SCAFACOS
@@ -321,7 +321,7 @@ void on_parameter_change(int field) {
 #endif
 
 #endif
-    cells_on_geometry_change(0);
+    cells_on_geometry_change(false);
     break;
   case FIELD_NODEGRID:
     grid_changed_n_nodes();

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -325,8 +325,7 @@ void on_parameter_change(int field) {
     break;
   case FIELD_NODEGRID:
     grid_changed_n_nodes();
-    cells_on_geometry_change(CELL_FLAG_GRIDCHANGED);
-    break;
+    cells_re_init(CELL_STRUCTURE_CURRENT, cell_structure.min_range);
   case FIELD_MINNUMCELLS:
   case FIELD_MAXNUMCELLS:
     cells_re_init(CELL_STRUCTURE_CURRENT, cell_structure.min_range);

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -303,10 +303,6 @@ void on_parameter_change(int field) {
   case FIELD_BOXL:
     on_boxl_change();
     break;
-  case FIELD_MIN_GLOBAL_CUT:
-  case FIELD_SKIN:
-    cells_on_geometry_change(false);
-    break;
   case FIELD_PERIODIC:
 #ifdef SCAFACOS
 #ifdef ELECTROSTATICS
@@ -319,13 +315,13 @@ void on_parameter_change(int field) {
       Scafacos::update_system_params();
     }
 #endif
-
 #endif
+  case FIELD_MIN_GLOBAL_CUT:
+  case FIELD_SKIN:
     cells_on_geometry_change(false);
     break;
   case FIELD_NODEGRID:
     grid_changed_n_nodes();
-    cells_re_init(CELL_STRUCTURE_CURRENT, cell_structure.min_range);
   case FIELD_MINNUMCELLS:
   case FIELD_MAXNUMCELLS:
     cells_re_init(CELL_STRUCTURE_CURRENT, cell_structure.min_range);

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -321,7 +321,7 @@ void on_parameter_change(int field) {
 #endif
 
 #endif
-    cells_on_geometry_change(CELL_FLAG_GRIDCHANGED);
+    cells_on_geometry_change(0);
     break;
   case FIELD_NODEGRID:
     grid_changed_n_nodes();

--- a/src/core/grid.hpp
+++ b/src/core/grid.hpp
@@ -92,25 +92,6 @@ void grid_changed_box_l(const BoxGeometry &box);
  * the particles accordingly */
 void rescale_boxl(int dir, double d_new);
 
-template <typename T> T get_mi_coord(T a, T b, T box_length, bool periodic) {
-  auto const dx = a - b;
-
-  if (periodic && (std::fabs(dx) > (0.5 * box_length))) {
-    return dx - std::round(dx * (1. / box_length)) * box_length;
-  }
-
-  return dx;
-}
-
-template <typename T>
-Utils::Vector<T, 3> get_mi_vector(const Utils::Vector<T, 3> &a,
-                                  const Utils::Vector<T, 3> &b,
-                                  const BoxGeometry &box) {
-  return {get_mi_coord(a[0], b[0], box.length()[0], box.periodic(0)),
-          get_mi_coord(a[1], b[1], box.length()[1], box.periodic(1)),
-          get_mi_coord(a[2], b[2], box.length()[2], box.periodic(2))};
-}
-
 /** fold a coordinate to primary simulation box.
     \param pos         the position...
     \param image_box   and the box

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -488,3 +488,9 @@ int integrate_set_npt_isotropic(double ext_pressure, double piston,
   return ES_OK;
 }
 #endif
+
+double interaction_range() {
+  /* Consider skin only if there are actually interactions */
+  auto const max_cut = maximal_cutoff();
+  return (max_cut > 0.) ? max_cut + skin : INACTIVE_CUTOFF;
+}

--- a/src/core/integrate.hpp
+++ b/src/core/integrate.hpp
@@ -59,6 +59,8 @@ extern double verlet_reuse;
 /** Communicate signal handling to the Python interpreter */
 extern bool set_py_interrupt;
 
+double interaction_range();
+
 /** check sanity of integrator params */
 void integrator_sanity_checks();
 

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -149,7 +149,7 @@ void velocity_verlet_npt_propagate_pos(const ParticleRange &particles) {
 
   /* fast box length update */
   grid_changed_box_l(box_geo);
-  cells_on_geometry_change(CELL_FLAG_FAST);
+  cells_on_geometry_change(true);
 }
 
 void velocity_verlet_npt_propagate_vel(const ParticleRange &particles) {

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -28,7 +28,6 @@ cdef extern from "communication.hpp":
     vector[int] mpi_resort_particles(int global_flag)
 
 cdef extern from "cells.hpp":
-    int CELL_STRUCTURE_CURRENT
     int CELL_STRUCTURE_DOMDEC
     int CELL_STRUCTURE_NSQUARE
 

--- a/src/utils/include/utils/mpi/cart_comm.hpp
+++ b/src/utils/include/utils/mpi/cart_comm.hpp
@@ -125,7 +125,7 @@ cart_neighbors(const boost::mpi::communicator &comm) {
 /**
  * @brief Information about a cartesian communicator.
  *
- * Memebers coorespond to the output arguments of
+ * Members correspond to the output arguments of
  * MPI_Cart_get.
  *
  * @tparam dim Number of dimensions.
@@ -139,6 +139,7 @@ template <size_t dim> struct CartInfo {
 /**
  * @brief Wrapper around MPI_Cart_get.
  *
+ * @tparam dim Number of dimensions.
  * @param comm Communicator with cartesian topology.
  *
  * @return Struct with information about the communicator.

--- a/src/utils/include/utils/mpi/cart_comm.hpp
+++ b/src/utils/include/utils/mpi/cart_comm.hpp
@@ -131,7 +131,9 @@ cart_neighbors(const boost::mpi::communicator &comm) {
  * @tparam dim Number of dimensions.
  */
 template <size_t dim> struct CartInfo {
-  Utils::Vector<int, dim> dims, periods, coords;
+  Utils::Vector<int, dim> dims;
+  Utils::Vector<int, dim> periods;
+  Utils::Vector<int, dim> coords;
 };
 
 /**

--- a/src/utils/include/utils/mpi/cart_comm.hpp
+++ b/src/utils/include/utils/mpi/cart_comm.hpp
@@ -121,6 +121,36 @@ cart_neighbors(const boost::mpi::communicator &comm) {
 
   return ret;
 }
+
+/**
+ * @brief Information about a cartesian communicator.
+ *
+ * Memebers coorespond to the output arguments of
+ * MPI_Cart_get.
+ *
+ * @tparam dim Number of dimensions.
+ */
+template <size_t dim> struct CartInfo {
+  Utils::Vector<int, dim> dims, periods, coords;
+};
+
+/**
+ * @brief Wrapper around MPI_Cart_get.
+ *
+ * @param comm Communicator with cartesian topology.
+ *
+ * @return Struct with information about the communicator.
+ */
+template <size_t dim>
+CartInfo<dim> cart_get(const boost::mpi::communicator &comm) {
+  CartInfo<dim> ret{};
+
+  BOOST_MPI_CHECK_RESULT(MPI_Cart_get, (comm, dim, ret.dims.data(),
+                                        ret.periods.data(), ret.coords.data()));
+
+  return ret;
+}
+
 } // namespace Mpi
 } // namespace Utils
 


### PR DESCRIPTION
If I wouldn't know better I'd say that this code was specifically crafted to be hard to refactor.

Description of changes:
- Removed geometry globals from dd
- Removed communication globals from dd
- Modified dd so that the periodicity does not change the communication pattern
- Treat periodicity change as geometry change
- Moved `get_mi_*` stuff to `BoxGeometry`
