### PR TITLE
Core: Apply rotational thermostat only to particles with rotational DOF

### DIFF
--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -108,8 +108,9 @@ inline ParticleForce thermostat_force(Particle const &p) {
 
 #ifdef ROTATION
   return {friction_thermo_langevin(langevin, p),
-          convert_vector_body_to_space(
-              p, friction_thermo_langevin_rotation(langevin, p))};
+          p.p.rotation ? convert_vector_body_to_space(
+                             p, friction_thermo_langevin_rotation(langevin, p))
+                       : Utils::Vector3d{}};
 #else
   return friction_thermo_langevin(langevin, p);
 #endif


### PR DESCRIPTION
Fixes #3700 
(mostly). There are another 5% compared to 4.1.2, which I'm not going to investigate.

Description of changes:
In the initialization of particle forces, only apply rotational thermostat and the frame transform which it involves to particles that actually have rotational degrees enabled.

The actual thermostat code and the frame transform each accounted for approximately half of the performance loss.


Note: the frame transforms themselves can also be optimized, but that's a different story.

