### PR TITLE
Make h5md a private target source

### DIFF
--- a/src/core/io/writer/CMakeLists.txt
+++ b/src/core/io/writer/CMakeLists.txt
@@ -1,3 +1,3 @@
 target_sources(
   EspressoCore
-  PUBLIC "$<$<BOOL:${H5MD}>:${CMAKE_CURRENT_SOURCE_DIR}/h5md_core.cpp>")
+  PRIVATE "$<$<BOOL:${H5MD}>:${CMAKE_CURRENT_SOURCE_DIR}/h5md_core.cpp>")


### PR DESCRIPTION
Fixes the build system, that recompiled the `h5md_core.cpp.o` object file 46 times at every rebuild.
