### PR TITLE
Refactor Observable_stat framework

### DIFF
--- a/src/core/AtomDecomposition.hpp
+++ b/src/core/AtomDecomposition.hpp
@@ -38,7 +38,7 @@
  * by just evenly distributing the particles over
  * all part-taking nodes. Pairs are found by just
  * considering all pairs independent of logical or
- * physical location, it has therefor quadratic time
+ * physical location, it has therefore quadratic time
  * complexity in the number of particles.
  *
  * For a more detailed discussion please see @cite plimpton1995a.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,7 @@ set(EspressoCore_SRC
     reaction_ensemble.cpp
     rotate_system.cpp
     rotation.cpp
+    Observable_stat.cpp
     RuntimeErrorCollector.cpp
     RuntimeError.cpp
     RuntimeErrorStream.cpp

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2010-2019 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Observable_stat.hpp"
+
+#include "bonded_interactions/bonded_interaction_data.hpp"
+#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
+
+/** Calculate the maximal number of non-bonded interaction pairs in the system.
+ */
+size_t max_non_bonded_pairs() {
+  return static_cast<size_t>(
+      (max_seen_particle_type * (max_seen_particle_type + 1)) / 2);
+}
+
+void Observable_stat::realloc_and_clear(size_t n_coulomb, size_t n_dipolar,
+                                        size_t n_vs, size_t c_size) {
+  // Number of doubles per interaction (pressure=1, stress tensor=9,...)
+  chunk_size = c_size;
+
+  auto const n_bonded = bonded_ia_params.size();
+  auto const n_non_bonded = max_non_bonded_pairs();
+
+  // Number of doubles to store pressure in
+  size_t const total = chunk_size * (1 + n_bonded + n_non_bonded + n_coulomb +
+                                     n_dipolar + n_vs + n_external_field);
+
+  // Allocate mem for the double list
+  data.resize(total);
+
+  // Number of chunks for different interaction types
+  this->n_coulomb = n_coulomb;
+  this->n_dipolar = n_dipolar;
+  this->n_virtual_sites = n_vs;
+  // Pointers to the start of different contributions
+  bonded = data.data() + chunk_size;
+  non_bonded = bonded + chunk_size * n_bonded;
+  coulomb = non_bonded + chunk_size * n_non_bonded;
+  dipolar = coulomb + chunk_size * n_coulomb;
+  virtual_sites = dipolar + chunk_size * n_dipolar;
+  external_fields = virtual_sites + chunk_size * n_vs;
+
+  // Set all observables to zero
+  for (int i = 0; i < total; i++)
+    data[i] = 0.0;
+
+  init_status = 0;
+}
+
+void Observable_stat_non_bonded::realloc_and_clear_non_bonded(size_t c_size) {
+  chunk_size_nb = c_size;
+  auto const n_non_bonded = max_non_bonded_pairs();
+  size_t const total = chunk_size_nb * 2 * n_non_bonded;
+
+  data_nb.resize(total);
+  non_bonded_intra = data_nb.data();
+  non_bonded_inter = non_bonded_intra + chunk_size_nb * n_non_bonded;
+
+  for (int i = 0; i < total; i++)
+    data_nb[i] = 0.0;
+}

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -24,6 +24,8 @@
 #include "config.hpp"
 
 #include "bonded_interactions/bonded_interaction_data.hpp"
+#include "electrostatics_magnetostatics/coulomb.hpp"
+#include "electrostatics_magnetostatics/dipole.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 
 #include <boost/mpi/communicator.hpp>
@@ -63,8 +65,10 @@ void realloc_and_clear_all_obs() {
 
 void Observable_stat::realloc_and_clear() {
   // number of chunks for different interaction types
-  auto const n_coulomb = (*m_get_n_coulomb)();
-  auto const n_dipolar = (*m_get_n_dipolar)();
+  auto const n_coulomb =
+      m_pressure_obs ? Coulomb::pressure_n() : Coulomb::energy_n();
+  auto const n_dipolar =
+      m_pressure_obs ? Dipole::pressure_n() : Dipole::energy_n();
   size_t n_vs = 0;
 #ifdef VIRTUAL_SITES
   n_vs = 1;

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -106,7 +106,6 @@ void Observable_stat_non_bonded::realloc_and_clear() {
   non_bonded_inter = Utils::Span<double>(non_bonded_intra.end(), span_size);
 }
 
-void Observable_stat_base::reduce(Observable_stat_base *output) const {
-  MPI_Reduce(data.data(), output ? output->data.data() : nullptr, data.size(),
-             MPI_DOUBLE, MPI_SUM, 0, comm_cart);
+void Observable_stat_base::reduce(double *out) const {
+  MPI_Reduce(data.data(), out, data.size(), MPI_DOUBLE, MPI_SUM, 0, comm_cart);
 }

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -24,6 +24,10 @@
 #include "bonded_interactions/bonded_interaction_data.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 
+#include <boost/mpi/communicator.hpp>
+
+extern boost::mpi::communicator comm_cart;
+
 /** Calculate the maximal number of non-bonded interaction pairs in the system.
  */
 size_t max_non_bonded_pairs() {
@@ -76,4 +80,14 @@ void Observable_stat_non_bonded::realloc_and_clear_non_bonded(size_t c_size) {
 
   for (int i = 0; i < total; i++)
     data_nb[i] = 0.0;
+}
+
+void Observable_stat::reduce(double *array) const {
+  MPI_Reduce(data.data(), array, data.size(), MPI_DOUBLE, MPI_SUM, 0,
+             comm_cart);
+}
+
+void Observable_stat_non_bonded::reduce(double *array) const {
+  MPI_Reduce(data_nb.data(), array, data_nb.size(), MPI_DOUBLE, MPI_SUM, 0,
+             comm_cart);
 }

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -21,6 +21,8 @@
 
 #include "Observable_stat.hpp"
 
+#include "config.hpp"
+
 #include "bonded_interactions/bonded_interaction_data.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -31,14 +31,14 @@ extern boost::mpi::communicator comm_cart;
 void Observable_stat::realloc_and_clear(size_t n_coulomb, size_t n_dipolar,
                                         size_t n_vs, size_t c_size) {
   // Number of doubles per interaction (pressure=1, stress tensor=9,...)
-  chunk_size = c_size;
+  m_chunk_size = c_size;
 
   auto const n_bonded = bonded_ia_params.size();
   auto const n_non_bonded = max_non_bonded_pairs();
 
   // Number of doubles to store pressure in
-  size_t const total = chunk_size * (1 + n_bonded + n_non_bonded + n_coulomb +
-                                     n_dipolar + n_vs + n_external_field);
+  size_t const total = m_chunk_size * (1 + n_bonded + n_non_bonded + n_coulomb +
+                                       n_dipolar + n_vs + n_external_field);
 
   // Allocate mem for the double list
   data.resize(total);
@@ -48,12 +48,12 @@ void Observable_stat::realloc_and_clear(size_t n_coulomb, size_t n_dipolar,
   this->n_dipolar = n_dipolar;
   this->n_virtual_sites = n_vs;
   // Pointers to the start of different contributions
-  bonded = data.data() + chunk_size;
-  non_bonded = bonded + chunk_size * n_bonded;
-  coulomb = non_bonded + chunk_size * n_non_bonded;
-  dipolar = coulomb + chunk_size * n_coulomb;
-  virtual_sites = dipolar + chunk_size * n_dipolar;
-  external_fields = virtual_sites + chunk_size * n_vs;
+  bonded = data.data() + m_chunk_size;
+  non_bonded = bonded + m_chunk_size * n_bonded;
+  coulomb = non_bonded + m_chunk_size * n_non_bonded;
+  dipolar = coulomb + m_chunk_size * n_coulomb;
+  virtual_sites = dipolar + m_chunk_size * n_dipolar;
+  external_fields = virtual_sites + m_chunk_size * n_vs;
 
   // Set all observables to zero
   for (int i = 0; i < total; i++)
@@ -63,13 +63,13 @@ void Observable_stat::realloc_and_clear(size_t n_coulomb, size_t n_dipolar,
 }
 
 void Observable_stat_non_bonded::realloc_and_clear(size_t c_size) {
-  chunk_size = c_size;
+  m_chunk_size = c_size;
   auto const n_non_bonded = max_non_bonded_pairs();
-  size_t const total = chunk_size * 2 * n_non_bonded;
+  size_t const total = m_chunk_size * 2 * n_non_bonded;
 
   data.resize(total);
   non_bonded_intra = data.data();
-  non_bonded_inter = non_bonded_intra + chunk_size * n_non_bonded;
+  non_bonded_inter = non_bonded_intra + m_chunk_size * n_non_bonded;
 
   for (int i = 0; i < total; i++)
     data[i] = 0.0;

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -59,7 +59,7 @@ void Observable_stat::realloc_and_clear(size_t n_coulomb, size_t n_dipolar,
   for (int i = 0; i < total; i++)
     data[i] = 0.0;
 
-  init_status = 0;
+  is_initialized = false;
 }
 
 void Observable_stat_non_bonded::realloc_and_clear(size_t c_size) {

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -82,12 +82,13 @@ void Observable_stat_non_bonded::realloc_and_clear_non_bonded(size_t c_size) {
     data_nb[i] = 0.0;
 }
 
-void Observable_stat::reduce(double *array) const {
-  MPI_Reduce(data.data(), array, data.size(), MPI_DOUBLE, MPI_SUM, 0,
-             comm_cart);
+void Observable_stat::reduce(Observable_stat *output) const {
+  MPI_Reduce(data.data(), output ? output->data.data() : nullptr, data.size(),
+             MPI_DOUBLE, MPI_SUM, 0, comm_cart);
 }
 
-void Observable_stat_non_bonded::reduce(double *array) const {
-  MPI_Reduce(data_nb.data(), array, data_nb.size(), MPI_DOUBLE, MPI_SUM, 0,
-             comm_cart);
+void Observable_stat_non_bonded::reduce(
+    Observable_stat_non_bonded *output) const {
+  MPI_Reduce(data_nb.data(), output ? output->data_nb.data() : nullptr,
+             data_nb.size(), MPI_DOUBLE, MPI_SUM, 0, comm_cart);
 }

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -89,10 +89,12 @@ struct Observable_stat : Observable_stat_base {
 
   /** Rescale values */
   void rescale(double volume, double time_step) {
-    for (size_t i = 0; i < chunk_size; ++i)
-      data[i] /= (volume * time_step * time_step);
-    for (size_t i = chunk_size; i < data.size(); ++i)
-      data[i] /= volume;
+    auto const factor1 = 1. / (volume * time_step * time_step);
+    auto const factor2 = 1. / volume;
+    for (auto it = data.begin(); it != data.begin() + chunk_size; ++it)
+      *it *= factor1;
+    for (auto it = data.begin() + chunk_size; it != data.end(); ++it)
+      *it *= factor2;
   }
 
   /** Get contribution from a bonded interaction */
@@ -120,8 +122,9 @@ public:
 
   /** Rescale values */
   void rescale(double volume) {
+    auto const factor = 1. / volume;
     for (auto &value : data)
-      value /= volume;
+      value *= factor;
   }
 
   /** Get contribution from a non-bonded intramolecular interaction */

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -84,7 +84,7 @@ struct Observable_stat {
   }
 
   /** Gather the contributions from all nodes */
-  void reduce(double *array) const;
+  void reduce(Observable_stat *output) const;
 };
 
 /** Structure used only in the pressure and stress tensor calculation to
@@ -134,7 +134,7 @@ struct Observable_stat_non_bonded {
   }
 
   /** Gather the contributions from all nodes */
-  void reduce(double *array) const;
+  void reduce(Observable_stat_non_bonded *output) const;
 };
 
 #endif // ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -56,6 +56,9 @@ struct Observable_stat {
 
   /** number of doubles per data item */
   size_t chunk_size;
+
+  void realloc_and_clear(size_t n_coulomb, size_t n_dipolar, size_t n_vs,
+                         size_t c_size);
 };
 
 /** Structure used only in the pressure and stress tensor calculation to
@@ -72,6 +75,8 @@ struct Observable_stat_non_bonded {
 
   /** number of doubles per data item */
   size_t chunk_size_nb;
+
+  void realloc_and_clear_non_bonded(size_t c_size);
 };
 
 #endif // ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -73,6 +73,14 @@ public:
     return acc;
   }
 
+  /** Rescale values */
+  void rescale(double volume) {
+    auto const factor = 1. / volume;
+    for (auto &e : data) {
+      e *= factor;
+    }
+  }
+
 protected:
   /** Get contribution from a non-bonded interaction */
   Utils::Span<double> non_bonded_contribution(double *base_pointer, int type1,
@@ -129,14 +137,6 @@ public:
   /** Resize the observable */
   void resize() final;
 
-  /** Rescale values */
-  void rescale(double volume) {
-    auto const factor = 1. / volume;
-    for (auto &e : data) {
-      e *= factor;
-    }
-  }
-
   /** Get contribution from a bonded interaction */
   Utils::Span<double> bonded_contribution(int bond_id) {
     return Utils::Span<double>(bonded.data() + m_chunk_size * bond_id,
@@ -167,13 +167,6 @@ public:
 
   /** Resize the observable */
   void resize() final;
-
-  /** Rescale values */
-  void rescale(double volume) {
-    auto const factor = 1. / volume;
-    for (auto &value : data)
-      value *= factor;
-  }
 
   /** Get contribution from a non-bonded intramolecular interaction */
   Utils::Span<double> non_bonded_intra_contribution(int type1,

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -130,13 +130,11 @@ public:
   void resize() final;
 
   /** Rescale values */
-  void rescale(double volume, double time_step) {
-    auto const factor1 = 1. / (volume * time_step * time_step);
-    auto const factor2 = 1. / volume;
-    for (auto it = data.begin(); it != data.begin() + m_chunk_size; ++it)
-      *it *= factor1;
-    for (auto it = data.begin() + m_chunk_size; it != data.end(); ++it)
-      *it *= factor2;
+  void rescale(double volume) {
+    auto const factor = 1. / volume;
+    for (auto &e : data) {
+      e *= factor;
+    }
   }
 
   /** Get contribution from a bonded interaction */

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -26,12 +26,6 @@ struct Observable_stat_base {
 public:
   /** Array for observables on each node. */
   std::vector<double> data;
-  /** Status flag for observable calculation. For 'analyze energy': 0
-   *  re-initialize observable struct, else everything is fine,
-   *  calculation can start. For 'analyze pressure' and 'analyze p_inst':
-   *  0 or !(1+v_comp) re-initialize, else all OK.
-   */
-  int init_status;
   /** Gather the contributions from all nodes */
   void reduce(Observable_stat_base *output) const;
 
@@ -61,6 +55,13 @@ protected:
 
 /** Structure used for pressure, stress tensor and energy calculations. */
 struct Observable_stat : Observable_stat_base {
+  /** Flag to signal if the observable is initialized */
+  bool is_initialized;
+  /** Flag to signal if the observable measures instantaneous pressure, i.e.
+   *  the pressure with velocity compensation (half a time step), instead of
+   *  the conventional pressure. Only relevant for NpT simulations.
+   */
+  bool v_comp;
   /** number of Coulomb interactions */
   size_t n_coulomb;
   /** number of dipolar interactions */

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -33,13 +33,13 @@ struct Observable_stat {
   std::vector<double> data;
 
   /** number of Coulomb interactions */
-  int n_coulomb;
+  size_t n_coulomb;
   /** number of dipolar interactions */
-  int n_dipolar;
+  size_t n_dipolar;
   /** Number of virtual sites relative (rigid body) contributions */
-  int n_virtual_sites;
+  size_t n_virtual_sites;
   /** Number of external field contributions */
-  const static int n_external_field = 1;
+  const static size_t n_external_field = 1;
 
   /** start of bonded interactions. Right after the special ones */
   double *bonded;
@@ -55,7 +55,7 @@ struct Observable_stat {
   double *external_fields;
 
   /** number of doubles per data item */
-  int chunk_size;
+  size_t chunk_size;
 };
 
 /** Structure used only in the pressure and stress tensor calculation to
@@ -71,7 +71,7 @@ struct Observable_stat_non_bonded {
   double *non_bonded_inter;
 
   /** number of doubles per data item */
-  int chunk_size_nb;
+  size_t chunk_size_nb;
 };
 
 #endif // ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -26,6 +26,11 @@
 #include <utility>
 #include <vector>
 
+/** Cache for system statistics.
+ *  Store unidimensional (energy, scalar pressure) and multi-dimensional
+ *  (stress tensors) properties of the system and provide accumulation and
+ *  reduction functionality.
+ */
 class Observable_stat_base {
 protected:
   /** Array for observables on each node. */
@@ -34,6 +39,8 @@ protected:
   size_t m_chunk_size;
 
 public:
+  /** @param chunk_size Dimensionality of the data
+   */
   explicit Observable_stat_base(size_t chunk_size) : m_chunk_size(chunk_size) {}
 
   /** Reinitialize the observable */
@@ -43,7 +50,7 @@ public:
   void reduce(Observable_stat_base *output) const;
 
   /** Accumulate values.
-   *  @param acc    Initial value for the accumulator
+   *  @param acc    Initial value for the accumulator.
    *  @param column Which column to sum up (only relevant for multi-dimensional
    *                observables).
    */
@@ -92,8 +99,8 @@ private:
   virtual void register_obs() = 0;
 };
 
-/** Structure used to cache the results of pressure, stress tensor and energy
- *  calculations.
+/** Structure used to cache the results of the scalar pressure, stress tensor
+ *  and energy calculations.
  */
 class Observable_stat : public Observable_stat_base {
 private:
@@ -127,7 +134,7 @@ public:
   Utils::Span<double> coulomb;
   /** Contribution(s) from dipolar interactions. */
   Utils::Span<double> dipolar;
-  /** Contribution(s) from virtual sites. */
+  /** Contribution(s) from virtual sites (accumulated). */
   Utils::Span<double> virtual_sites;
   /** Contribution from external fields (accumulated). */
   Utils::Span<double> external_fields;
@@ -206,7 +213,9 @@ private:
 
 /** Invalidate observables.
  *  This function is called whenever the system has changed in such a way
- *  that the cached energies are no longer accurate.
+ *  that the cached observables are no longer accurate or that the size of
+ *  the cache is no longer suitable (e.g. after addition of a new actor or
+ *  interaction).
  */
 void invalidate_obs();
 

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -42,22 +42,17 @@ public:
   /** Gather the contributions from all nodes */
   void reduce(Observable_stat_base *output) const;
 
-  /** Accumulate values */
-  double accumulate(double acc = 0.0, size_t from = 0) {
-    if (m_chunk_size == 1 and from == 0)
+  /** Accumulate values.
+   *  @param acc    Initial value for the accumulator
+   *  @param column Which column to sum up (only relevant for multi-dimensional
+   *                observables).
+   */
+  double accumulate(double acc = 0.0, size_t column = 0) {
+    assert(column < m_chunk_size);
+    if (m_chunk_size == 1)
       return boost::accumulate(data, acc);
 
-    for (auto it = data.begin() + from; it != data.end(); ++it)
-      acc += *it;
-    return acc;
-  }
-
-  /** Accumulate values along one axis */
-  double accumulate_along_dim(double acc = 0.0, size_t from = 0) {
-    if (m_chunk_size == 1 and from == 0 and m_chunk_size == 1)
-      return accumulate(acc);
-
-    for (auto it = data.begin() + from; it < data.end(); it += m_chunk_size)
+    for (auto it = data.begin() + column; it < data.end(); it += m_chunk_size)
       acc += *it;
     return acc;
   }

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -104,16 +104,13 @@ private:
  */
 class Observable_stat : public Observable_stat_base {
 private:
-  /** Callback for the Coulomb interaction */
-  size_t (*m_get_n_coulomb)();
-  /** Callback for the dipolar interaction */
-  size_t (*m_get_n_dipolar)();
+  /** Whether this observable is a pressure or energy observable */
+  bool m_pressure_obs;
 
 public:
-  explicit Observable_stat(size_t chunk_size, size_t (*get_n_coulomb)(),
-                           size_t (*get_n_dipolar)())
-      : Observable_stat_base(chunk_size), m_get_n_coulomb(get_n_coulomb),
-        m_get_n_dipolar(get_n_dipolar), is_initialized(false), v_comp(false) {
+  explicit Observable_stat(size_t chunk_size, bool pressure_obs = true)
+      : Observable_stat_base(chunk_size), m_pressure_obs(pressure_obs),
+        is_initialized(false), v_comp(false) {
     register_obs();
     realloc_and_clear();
   }

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -22,6 +22,7 @@
 #include <boost/range/numeric.hpp>
 
 #include <utils/Span.hpp>
+#include <utils/index.hpp>
 
 #include <algorithm>
 #include <utility>
@@ -90,7 +91,7 @@ protected:
       using std::swap;
       swap(type1, type2);
     }
-    int offset = ((2 * max_seen_particle_type - 1 - type1) * type1) / 2 + type2;
+    int offset = Utils::upper_triangular(type1, type2, max_seen_particle_type);
     return Utils::Span<double>(base_pointer + offset * m_chunk_size,
                                m_chunk_size);
   }

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -82,6 +82,9 @@ struct Observable_stat {
            chunk_size *
                (((2 * max_seen_particle_type - 1 - type1) * type1) / 2 + type2);
   }
+
+  /** Gather the contributions from all nodes */
+  void reduce(double *array) const;
 };
 
 /** Structure used only in the pressure and stress tensor calculation to
@@ -129,6 +132,9 @@ struct Observable_stat_non_bonded {
            chunk_size_nb *
                (((2 * max_seen_particle_type - 1 - type1) * type1) / 2 + type2);
   }
+
+  /** Gather the contributions from all nodes */
+  void reduce(double *array) const;
 };
 
 #endif // ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -59,6 +59,13 @@ struct Observable_stat {
 
   void realloc_and_clear(size_t n_coulomb, size_t n_dipolar, size_t n_vs,
                          size_t c_size);
+
+  void rescale(double volume, double time_step) {
+    for (size_t i = 0; i < chunk_size; ++i)
+      data[i] /= (volume * time_step * time_step);
+    for (size_t i = chunk_size; i < data.size(); ++i)
+      data[i] /= volume;
+  }
 };
 
 /** Structure used only in the pressure and stress tensor calculation to
@@ -77,6 +84,11 @@ struct Observable_stat_non_bonded {
   size_t chunk_size_nb;
 
   void realloc_and_clear_non_bonded(size_t c_size);
+
+  void rescale(double volume) {
+    for (auto &value : data_nb)
+      value /= volume;
+  }
 };
 
 #endif // ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -22,17 +22,45 @@
 #include <utility>
 #include <vector>
 
-struct Observable_stat {
+struct Observable_stat_base {
+public:
+  /** Array for observables on each node. */
+  std::vector<double> data;
   /** Status flag for observable calculation. For 'analyze energy': 0
    *  re-initialize observable struct, else everything is fine,
    *  calculation can start. For 'analyze pressure' and 'analyze p_inst':
    *  0 or !(1+v_comp) re-initialize, else all OK.
    */
   int init_status;
+  /** Gather the contributions from all nodes */
+  void reduce(Observable_stat_base *output) const;
 
-  /** Array for observables on each node. */
-  std::vector<double> data;
+protected:
+  /** number of doubles per data item */
+  size_t chunk_size;
+  /** Get contribution from a non-bonded interaction */
+  double *nonbonded_ia(double *base_pointer, int type1, int type2) const {
+    extern int max_seen_particle_type;
+    if (type1 > type2) {
+      using std::swap;
+      swap(type1, type2);
+    }
+    return base_pointer +
+           chunk_size *
+               (((2 * max_seen_particle_type - 1 - type1) * type1) / 2 + type2);
+  }
+  /** Calculate the maximal number of non-bonded interaction pairs in the
+   *  system.
+   */
+  size_t max_non_bonded_pairs() {
+    extern int max_seen_particle_type;
+    return static_cast<size_t>(
+        (max_seen_particle_type * (max_seen_particle_type + 1)) / 2);
+  }
+};
 
+/** Structure used for pressure, stress tensor and energy calculations. */
+struct Observable_stat : Observable_stat_base {
   /** number of Coulomb interactions */
   size_t n_coulomb;
   /** number of dipolar interactions */
@@ -55,12 +83,11 @@ struct Observable_stat {
   /** Start of observables for external fields */
   double *external_fields;
 
-  /** number of doubles per data item */
-  size_t chunk_size;
-
+  /** Reinitialize the observable */
   void realloc_and_clear(size_t n_coulomb, size_t n_dipolar, size_t n_vs,
                          size_t c_size);
 
+  /** Rescale values */
   void rescale(double volume, double time_step) {
     for (size_t i = 0; i < chunk_size; ++i)
       data[i] /= (volume * time_step * time_step);
@@ -72,69 +99,40 @@ struct Observable_stat {
   double *bonded_ia(int bond_id) { return bonded + (chunk_size * bond_id); }
 
   /** Get contribution from a non-bonded interaction */
-  double *nonbonded_ia(int type1, int type2) {
-    extern int max_seen_particle_type;
-    if (type1 > type2) {
-      using std::swap;
-      swap(type1, type2);
-    }
-    return non_bonded +
-           chunk_size *
-               (((2 * max_seen_particle_type - 1 - type1) * type1) / 2 + type2);
+  double *nonbonded_ia(int type1, int type2) const {
+    return Observable_stat_base::nonbonded_ia(non_bonded, type1, type2);
   }
-
-  /** Gather the contributions from all nodes */
-  void reduce(Observable_stat *output) const;
 };
 
 /** Structure used only in the pressure and stress tensor calculation to
  *  distinguish non-bonded intra- and inter- molecular contributions.
  */
-struct Observable_stat_non_bonded {
-  /** Array for observables on each node. */
-  std::vector<double> data_nb;
-
+struct Observable_stat_non_bonded : Observable_stat_base {
+private:
   /** start of observables for non-bonded intramolecular interactions. */
   double *non_bonded_intra;
   /** start of observables for non-bonded intermolecular interactions. */
   double *non_bonded_inter;
 
-  /** number of doubles per data item */
-  size_t chunk_size_nb;
+public:
+  /** Reinitialize the observable */
+  void realloc_and_clear(size_t c_size);
 
-  void realloc_and_clear_non_bonded(size_t c_size);
-
+  /** Rescale values */
   void rescale(double volume) {
-    for (auto &value : data_nb)
+    for (auto &value : data)
       value /= volume;
   }
 
   /** Get contribution from a non-bonded intramolecular interaction */
-  double *nonbonded_intra_ia(int type1, int type2) {
-    extern int max_seen_particle_type;
-    if (type1 > type2) {
-      using std::swap;
-      swap(type1, type2);
-    }
-    return non_bonded_intra +
-           chunk_size_nb *
-               (((2 * max_seen_particle_type - 1 - type1) * type1) / 2 + type2);
+  double *nonbonded_intra_ia(int type1, int type2) const {
+    return nonbonded_ia(non_bonded_intra, type1, type2);
   }
 
   /** Get contribution from a non-bonded intermolecular interaction */
-  double *nonbonded_inter_ia(int type1, int type2) {
-    extern int max_seen_particle_type;
-    if (type1 > type2) {
-      using std::swap;
-      swap(type1, type2);
-    }
-    return non_bonded_inter +
-           chunk_size_nb *
-               (((2 * max_seen_particle_type - 1 - type1) * type1) / 2 + type2);
+  double *nonbonded_inter_ia(int type1, int type2) const {
+    return nonbonded_ia(non_bonded_inter, type1, type2);
   }
-
-  /** Gather the contributions from all nodes */
-  void reduce(Observable_stat_non_bonded *output) const;
 };
 
 #endif // ESPRESSO_OBSERVABLE_STAT_HPP

--- a/src/core/actor/ActorList.hpp
+++ b/src/core/actor/ActorList.hpp
@@ -28,4 +28,4 @@ public:
   void remove(Actor *actor);
 };
 
-#endif /* ACTORLIST_HPP_ */
+#endif /* _ACTOR_ACTORLIST_HPP */

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -57,7 +57,6 @@
 #include "particle_data.hpp"
 #include "pressure.hpp"
 #include "rotation.hpp"
-#include "statistics.hpp"
 #include "virtual_sites.hpp"
 
 #include "electrostatics_magnetostatics/coulomb.hpp"

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -372,21 +372,27 @@ void mpi_gather_stats(GatherStats job, void *result, void *result_t,
   case GatherStats::energy:
     /* calculate and reduce (sum up) energies */
     mpi_call(mpi_gather_stats_slave, -1, job_slave);
-    energy_calc((double *)result, sim_time);
+    energy_calc(reinterpret_cast<Observable_stat *>(result), sim_time);
     break;
   case GatherStats::pressure:
     /* calculate and reduce (sum up) virials for 'analyze pressure' or
        'analyze stress_tensor' */
     mpi_call(mpi_gather_stats_slave, -1, job_slave);
-    pressure_calc((double *)result, (double *)result_t, (double *)result_nb,
-                  (double *)result_t_nb, 0);
+    pressure_calc(reinterpret_cast<Observable_stat *>(result),
+                  reinterpret_cast<Observable_stat *>(result_t),
+                  reinterpret_cast<Observable_stat_non_bonded *>(result_nb),
+                  reinterpret_cast<Observable_stat_non_bonded *>(result_t_nb),
+                  0);
     break;
   case GatherStats::pressure_v_comp:
     /* calculate and reduce (sum up) virials, revert velocities half a timestep
      * for 'analyze p_inst' */
     mpi_call(mpi_gather_stats_slave, -1, job_slave);
-    pressure_calc((double *)result, (double *)result_t, (double *)result_nb,
-                  (double *)result_t_nb, 1);
+    pressure_calc(reinterpret_cast<Observable_stat *>(result),
+                  reinterpret_cast<Observable_stat *>(result_t),
+                  reinterpret_cast<Observable_stat_non_bonded *>(result_nb),
+                  reinterpret_cast<Observable_stat_non_bonded *>(result_t_nb),
+                  1);
     break;
   case GatherStats::lb_fluid_momentum:
     mpi_call(mpi_gather_stats_slave, -1, job_slave);

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -228,23 +228,10 @@ void mpi_bcast_max_seen_particle_type(int s);
  *      \arg for \ref GatherStats::lb_boundary_forces, use
  *           \ref lb_collect_boundary_forces.
  *  \param[out] result where to store values gathered by
- *      \ref GatherStats::energy,
- *      \ref GatherStats::pressure,
- *      \ref GatherStats::pressure_v_comp,
  *      \ref GatherStats::lb_fluid_momentum,
  *      \ref GatherStats::lb_boundary_forces
- *  \param[out] result_t where to store values gathered by
- *      \ref GatherStats::pressure,
- *      \ref GatherStats::pressure_v_comp
- *  \param[out] result_nb where to store values gathered by
- *      \ref GatherStats::pressure,
- *      \ref GatherStats::pressure_v_comp
- *  \param[out] result_t_nb where to store values gathered by
- *      \ref GatherStats::pressure,
- *      \ref GatherStats::pressure_v_comp
  */
-void mpi_gather_stats(GatherStats job, void *result, void *result_t,
-                      void *result_nb, void *result_t_nb);
+void mpi_gather_stats(GatherStats job, double *result = nullptr);
 
 /** Send new \ref time_step and rescale the velocities accordingly. */
 void mpi_set_time_step(double time_step);

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -65,6 +65,14 @@ extern int this_node;
 extern int n_nodes;
 /** The communicator */
 extern boost::mpi::communicator comm_cart;
+/** Statistics to calculate */
+enum class GatherStats : int {
+  energy,
+  pressure,
+  pressure_v_comp,
+  lb_fluid_momentum,
+  lb_boundary_forces
+};
 
 /**
  * Default MPI tag used by callbacks.
@@ -208,47 +216,35 @@ void mpi_bcast_ia_params(int i, int j);
 void mpi_bcast_max_seen_particle_type(int s);
 
 /** Gather data for analysis.
- *  \todo update parameter descriptions
- *  \param job what to do:
- *      \arg \c 1 calculate and reduce (sum up) energies,
- *           using \ref energy_calc.
- *      \arg \c 2 calculate and reduce (sum up) pressure, stress tensor,
- *           using \ref pressure_calc.
- *      \arg \c 3 calculate and reduce (sum up) instantaneous pressure,
- *           using \ref pressure_calc.
- *      \arg \c 6 use \ref lb_calc_fluid_momentum
- *      \arg \c 8 use \ref lb_collect_boundary_forces
- *  \param result where to store the gathered value(s):
- *      \arg for \c job=1 unused (the results are stored in a global
- *           energy array of type \ref Observable_stat)
- *      \arg for \c job=2 unused (the results are stored in a global
- *           virials array of type \ref Observable_stat)
- *      \arg for \c job=3 unused (the results are stored in a global
- *           virials array of type \ref Observable_stat)
- *  \param result_t where to store the gathered value(s):
- *      \arg for \c job=1 unused (the results are stored in a global
- *           energy array of type \ref Observable_stat)
- *      \arg for \c job=2 unused (the results are stored in a global
- *           p_tensor tensor of type \ref Observable_stat)
- *      \arg for \c job=3 unused (the results are stored in a global
- *           p_tensor tensor of type \ref Observable_stat)
- *  \param result_nb where to store the gathered value(s):
- *      \arg for \c job=1 unused (the results are stored in a global
- *           energy array of type \ref Observable_stat_non_bonded)
- *      \arg for \c job=2 unused (the results are stored in a global
- *           virials_non_bonded array of type \ref Observable_stat_non_bonded)
- *      \arg for \c job=3 unused (the results are stored in a global
- *           virials_non_bonded array of type \ref Observable_stat_non_bonded)
- *  \param result_t_nb where to store the gathered value(s):
- *      \arg for \c job=1 unused (the results are stored in a global
- *           energy array of type \ref Observable_stat_non_bonded)
- *      \arg for \c job=2 unused (the results are stored in a global
- *           p_tensor_non_bonded tensor of type \ref Observable_stat_non_bonded)
- *      \arg for \c job=3 unused (the results are stored in a global
- *           p_tensor_non_bonded tensor of type \ref Observable_stat_non_bonded)
+ *  \param[in] job what to do:
+ *      \arg for \ref GatherStats::energy, calculate and reduce (sum up)
+ *           energies, using \ref energy_calc.
+ *      \arg for \ref GatherStats::pressure, calculate and reduce (sum up)
+ *           pressure, stress tensor, using \ref pressure_calc.
+ *      \arg for \ref GatherStats::pressure_v_comp, calculate and reduce
+ *           (sum up) instantaneous pressure, using \ref pressure_calc.
+ *      \arg for \ref GatherStats::lb_fluid_momentum, use
+ *           \ref lb_calc_fluid_momentum.
+ *      \arg for \ref GatherStats::lb_boundary_forces, use
+ *           \ref lb_collect_boundary_forces.
+ *  \param[out] result where to store values gathered by
+ *      \ref GatherStats::energy,
+ *      \ref GatherStats::pressure,
+ *      \ref GatherStats::pressure_v_comp,
+ *      \ref GatherStats::lb_fluid_momentum,
+ *      \ref GatherStats::lb_boundary_forces
+ *  \param[out] result_t where to store values gathered by
+ *      \ref GatherStats::pressure,
+ *      \ref GatherStats::pressure_v_comp
+ *  \param[out] result_nb where to store values gathered by
+ *      \ref GatherStats::pressure,
+ *      \ref GatherStats::pressure_v_comp
+ *  \param[out] result_t_nb where to store values gathered by
+ *      \ref GatherStats::pressure,
+ *      \ref GatherStats::pressure_v_comp
  */
-void mpi_gather_stats(int job, void *result, void *result_t, void *result_nb,
-                      void *result_t_nb);
+void mpi_gather_stats(GatherStats job, void *result, void *result_t,
+                      void *result_nb, void *result_t_nb);
 
 /** Send new \ref time_step and rescale the velocities accordingly. */
 void mpi_set_time_step(double time_step);

--- a/src/core/constraints/Constraint.hpp
+++ b/src/core/constraints/Constraint.hpp
@@ -19,6 +19,7 @@
 #ifndef CONSTRAINTS_CONSTRAINT_HPP
 #define CONSTRAINTS_CONSTRAINT_HPP
 
+#include "Observable_stat.hpp"
 #include "Particle.hpp"
 #include "energy.hpp"
 

--- a/src/core/constraints/Constraint.hpp
+++ b/src/core/constraints/Constraint.hpp
@@ -26,22 +26,18 @@ namespace Constraints {
 class Constraint {
 public:
   /**
-   * @brief Add energy contribution of this constraints to energy.
-   *
-   * Add constraint energy for particle to observable.
+   * @brief Add constraint energy for particle to the energy observable.
    *
    * @param[in] p The particle to add the energy for.
    * @param[in] folded_pos Folded position of the particle.
    * @param[in] t The time at which the energy should be calculated.
-   * @param[out] energy to add the energy to.
+   * @param[out] energy Energy observable to add this constraint's energy to.
    */
   virtual void add_energy(const Particle &p, const Utils::Vector3d &folded_pos,
                           double t, Observable_stat &energy) const = 0;
 
   /**
    * @brief Calculate the force of the constraint on a particle.
-   *
-   * Add constraint energy for particle to observable.
    *
    * @param[in] p The particle to calculate the force for.
    * @param[in] folded_pos Folded position of the particle.

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -136,6 +136,7 @@ void ShapeBasedConstraint::add_energy(const Particle &p,
     }
   }
   if (part_rep.p.type >= 0)
-    *energy.nonbonded_ia(p.p.type, part_rep.p.type) += nonbonded_en;
+    energy.non_bonded_contribution(p.p.type, part_rep.p.type)[0] +=
+        nonbonded_en;
 }
 } // namespace Constraints

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -136,6 +136,6 @@ void ShapeBasedConstraint::add_energy(const Particle &p,
     }
   }
   if (part_rep.p.type >= 0)
-    *obsstat_nonbonded(&energy, p.p.type, part_rep.p.type) += nonbonded_en;
+    *energy.nonbonded_ia(p.p.type, part_rep.p.type) += nonbonded_en;
 }
 } // namespace Constraints

--- a/src/core/constraints/ShapeBasedConstraint.hpp
+++ b/src/core/constraints/ShapeBasedConstraint.hpp
@@ -23,6 +23,7 @@
 
 #include "Constraint.hpp"
 #include "Particle.hpp"
+#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include <shapes/NoWhere.hpp>
 #include <shapes/Shape.hpp>
 

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -228,8 +228,6 @@ void copy_energy_from_GPU() {
   copy_CUDA_energy_to_energy(energy_host);
 }
 
-/** @name Generic copy functions from and to device */
-
 void _cuda_safe_mem(cudaError_t CU_err, const char *file, unsigned int line) {
   if (cudaSuccess != CU_err) {
     fprintf(stderr, "Cuda Memory error at %s:%u.\n", file, line);
@@ -254,5 +252,3 @@ void _cuda_safe_mem(cudaError_t CU_err, const char *file, unsigned int line) {
     }
   }
 }
-
-/*@}*/

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -22,6 +22,7 @@
 
 #include "debug.hpp"
 
+#include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 #include "cuda_init.hpp"
 #include "cuda_interface.hpp"
@@ -221,11 +222,19 @@ void clear_energy_on_GPU() {
 }
 
 void copy_energy_from_GPU() {
+  extern Observable_stat_wrapper obs_energy;
   if (!global_part_vars_host.communication_enabled)
     return;
   cuda_safe_mem(cudaMemcpy(&energy_host, energy_device, sizeof(CUDA_energy),
                            cudaMemcpyDeviceToHost));
-  copy_CUDA_energy_to_energy(energy_host);
+  if (!obs_energy.local.bonded.empty())
+    obs_energy.local.bonded[0] += energy_host.bonded;
+  if (!obs_energy.local.non_bonded.empty())
+    obs_energy.local.non_bonded[0] += energy_host.non_bonded;
+  if (!obs_energy.local.coulomb.empty())
+    obs_energy.local.coulomb[0] += energy_host.coulomb;
+  if (obs_energy.local.dipolar.size() >= 2)
+    obs_energy.local.dipolar[1] += energy_host.dipolar;
 }
 
 void _cuda_safe_mem(cudaError_t CU_err, const char *file, unsigned int line) {

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -23,7 +23,6 @@
 
 #include "communication.hpp"
 #include "config.hpp"
-#include "energy.hpp"
 #include "grid.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "serialization/CUDA_particle_data.hpp"
@@ -159,21 +158,6 @@ void cuda_mpi_send_forces(const ParticleRange &particles,
 
     add_forces_and_torques(particles, host_forces, host_torques);
   }
-}
-
-/** Takes a CUDA_energy struct and adds it to the core energy struct.
-This cannot be done from inside cuda_common_cuda.cu:copy_energy_from_GPU()
-because energy.hpp indirectly includes on mpi.h while .cu files may not depend
-on mpi.h. */
-void copy_CUDA_energy_to_energy(CUDA_energy energy_host) {
-  if (!obs_energy.local.bonded.empty())
-    obs_energy.local.bonded[0] += energy_host.bonded;
-  if (!obs_energy.local.non_bonded.empty())
-    obs_energy.local.non_bonded[0] += energy_host.non_bonded;
-  if (!obs_energy.local.coulomb.empty())
-    obs_energy.local.coulomb[0] += energy_host.coulomb;
-  if (obs_energy.local.dipolar.size() >= 2)
-    obs_energy.local.dipolar[1] += energy_host.dipolar;
 }
 
 void cuda_bcast_global_part_params() { mpi_bcast_cuda_global_part_vars(); }

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -166,11 +166,13 @@ This cannot be done from inside cuda_common_cuda.cu:copy_energy_from_GPU()
 because energy.hpp indirectly includes on mpi.h while .cu files may not depend
 on mpi.h. */
 void copy_CUDA_energy_to_energy(CUDA_energy energy_host) {
-  energy.bonded[0] += energy_host.bonded;
-  energy.non_bonded[0] += energy_host.non_bonded;
-  if (energy.n_coulomb >= 1)
+  if (!energy.bonded.empty())
+    energy.bonded[0] += energy_host.bonded;
+  if (!energy.non_bonded.empty())
+    energy.non_bonded[0] += energy_host.non_bonded;
+  if (!energy.coulomb.empty())
     energy.coulomb[0] += energy_host.coulomb;
-  if (energy.n_dipolar >= 2)
+  if (energy.dipolar.size() >= 2)
     energy.dipolar[1] += energy_host.dipolar;
 }
 

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -166,6 +166,7 @@ This cannot be done from inside cuda_common_cuda.cu:copy_energy_from_GPU()
 because energy.hpp indirectly includes on mpi.h while .cu files may not depend
 on mpi.h. */
 void copy_CUDA_energy_to_energy(CUDA_energy energy_host) {
+  extern Observable_stat energy;
   if (!energy.bonded.empty())
     energy.bonded[0] += energy_host.bonded;
   if (!energy.non_bonded.empty())

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -166,15 +166,14 @@ This cannot be done from inside cuda_common_cuda.cu:copy_energy_from_GPU()
 because energy.hpp indirectly includes on mpi.h while .cu files may not depend
 on mpi.h. */
 void copy_CUDA_energy_to_energy(CUDA_energy energy_host) {
-  extern Observable_stat energy;
-  if (!energy.bonded.empty())
-    energy.bonded[0] += energy_host.bonded;
-  if (!energy.non_bonded.empty())
-    energy.non_bonded[0] += energy_host.non_bonded;
-  if (!energy.coulomb.empty())
-    energy.coulomb[0] += energy_host.coulomb;
-  if (energy.dipolar.size() >= 2)
-    energy.dipolar[1] += energy_host.dipolar;
+  if (!obs_energy.local.bonded.empty())
+    obs_energy.local.bonded[0] += energy_host.bonded;
+  if (!obs_energy.local.non_bonded.empty())
+    obs_energy.local.non_bonded[0] += energy_host.non_bonded;
+  if (!obs_energy.local.coulomb.empty())
+    obs_energy.local.coulomb[0] += energy_host.coulomb;
+  if (obs_energy.local.dipolar.size() >= 2)
+    obs_energy.local.dipolar[1] += energy_host.dipolar;
 }
 
 void cuda_bcast_global_part_params() { mpi_bcast_cuda_global_part_vars(); }

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -108,7 +108,6 @@ typedef struct {
 
 void copy_forces_from_GPU(ParticleRange &particles);
 void copy_energy_from_GPU();
-void copy_CUDA_energy_to_energy(CUDA_energy energy_host);
 void clear_energy_on_GPU();
 
 CUDA_global_part_vars *gpu_get_global_particle_vars_pointer_host();

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -42,19 +42,6 @@
 Coulomb_parameters coulomb;
 
 namespace Coulomb {
-
-size_t pressure_n() {
-  switch (coulomb.method) {
-  case COULOMB_NONE:
-    return 0;
-  case COULOMB_P3M_GPU:
-  case COULOMB_P3M:
-    return 2;
-  default:
-    return 1;
-  }
-}
-
 void calc_pressure_long_range(Observable_stat &virials,
                               Observable_stat &p_tensor,
                               const ParticleRange &particles) {
@@ -361,21 +348,6 @@ void calc_energy_long_range(Observable_stat &energy,
 #endif
   default:
     break;
-  }
-}
-
-size_t energy_n() {
-  switch (coulomb.method) {
-  case COULOMB_NONE:
-    return 0;
-  case COULOMB_ELC_P3M:
-    return 3;
-  case COULOMB_P3M_GPU:
-  case COULOMB_P3M:
-  case COULOMB_SCAFACOS:
-    return 2;
-  default:
-    return 1;
   }
 }
 

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -75,7 +75,7 @@ void calc_pressure_long_range(Observable_stat &virials,
   case COULOMB_P3M: {
     p3m_charge_assign(particles);
     auto const p3m_stress = p3m_calc_kspace_stress();
-    std::copy_n(p3m_stress.data(), 9, p_tensor.coulomb + 9);
+    std::copy_n(p3m_stress.data(), 9, p_tensor.coulomb.begin() + 9);
     virials.coulomb[1] = p3m_stress[0] + p3m_stress[4] + p3m_stress[8];
 
     break;

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -46,17 +46,15 @@ Coulomb_parameters coulomb;
 
 namespace Coulomb {
 
-void pressure_n(int &n_coulomb) {
+size_t pressure_n() {
   switch (coulomb.method) {
   case COULOMB_NONE:
-    n_coulomb = 0;
-    break;
+    return 0;
   case COULOMB_P3M_GPU:
   case COULOMB_P3M:
-    n_coulomb = 2;
-    break;
+    return 2;
   default:
-    n_coulomb = 1;
+    return 1;
   }
 }
 
@@ -369,7 +367,7 @@ void calc_energy_long_range(Observable_stat &energy,
   }
 }
 
-int energy_n() {
+size_t energy_n() {
   switch (coulomb.method) {
   case COULOMB_NONE:
     return 0;

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -424,10 +424,7 @@ int elc_sanity_check() {
     return ES_ERROR;
   }
   case COULOMB_ELC_P3M:
-
   case COULOMB_P3M:
-    p3m.params.epsilon = P3M_EPSILON_METALLIC;
-    coulomb.method = COULOMB_ELC_P3M;
     return ES_OK;
   default:
     break;

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -19,9 +19,6 @@
 
 #include "electrostatics_magnetostatics/coulomb.hpp"
 
-// Real space cutoff
-double coulomb_cutoff;
-
 #ifdef ELECTROSTATICS
 #include "cells.hpp"
 #include "communication.hpp"

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -335,7 +335,7 @@ void calc_energy_long_range(Observable_stat &energy,
       energy.coulomb[1] +=
           0.5 * ELC_P3M_dielectric_layers_energy_self(particles);
 
-      //  assign both original and image charges now
+      // assign both original and image charges now
       ELC_p3m_charge_assign_both(particles);
       ELC_P3M_modify_p3m_sums_both(particles);
 
@@ -472,8 +472,6 @@ int set_prefactor(double prefactor) {
   return ES_OK;
 }
 
-/** @brief Deactivates the current Coulomb method
- */
 void deactivate_method() {
   coulomb.prefactor = 0;
 

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -67,7 +67,7 @@ struct Coulomb_parameters {
 extern Coulomb_parameters coulomb;
 
 namespace Coulomb {
-void pressure_n(int &n_coulomb);
+size_t pressure_n();
 void calc_pressure_long_range(Observable_stat &virials,
                               Observable_stat &p_tensor,
                               const ParticleRange &particles);
@@ -85,7 +85,7 @@ void calc_long_range_force(const ParticleRange &particles);
 
 void calc_energy_long_range(Observable_stat &energy,
                             const ParticleRange &particles);
-int energy_n();
+size_t energy_n();
 
 int iccp3m_sanity_check();
 

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -21,6 +21,8 @@
 
 #include "config.hpp"
 
+#include <cstddef>
+
 #ifdef ELECTROSTATICS
 #include "Observable_stat.hpp"
 

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -106,5 +106,10 @@ void deactivate_method();
  */
 void update_dependent_particles();
 } // namespace Coulomb
+#else  // ELECTROSTATICS
+namespace Coulomb {
+constexpr size_t pressure_n() { return 0; }
+constexpr size_t energy_n() { return 0; }
+} // namespace Coulomb
 #endif // ELECTROSTATICS
 #endif // ESPRESSO_COULOMB_HPP

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -58,7 +58,35 @@ struct Coulomb_parameters {
 extern Coulomb_parameters coulomb;
 
 namespace Coulomb {
-size_t pressure_n();
+/** Number of electrostatic contributions to the system pressure calculation. */
+inline size_t pressure_n() {
+  switch (coulomb.method) {
+  case COULOMB_NONE:
+    return 0;
+  case COULOMB_P3M_GPU:
+  case COULOMB_P3M:
+    return 2;
+  default:
+    return 1;
+  }
+}
+
+/** Number of electrostatic contributions to the system energy calculation. */
+inline size_t energy_n() {
+  switch (coulomb.method) {
+  case COULOMB_NONE:
+    return 0;
+  case COULOMB_ELC_P3M:
+    return 3;
+  case COULOMB_P3M_GPU:
+  case COULOMB_P3M:
+  case COULOMB_SCAFACOS:
+    return 2;
+  default:
+    return 1;
+  }
+}
+
 void calc_pressure_long_range(Observable_stat &virials,
                               Observable_stat &p_tensor,
                               const ParticleRange &particles);
@@ -76,7 +104,6 @@ void calc_long_range_force(const ParticleRange &particles);
 
 void calc_energy_long_range(Observable_stat &energy,
                             const ParticleRange &particles);
-size_t energy_n();
 
 int iccp3m_sanity_check();
 

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -27,15 +27,11 @@
 #include <ParticleRange.hpp>
 #include <utils/Vector.hpp>
 
-/** \name Type codes for the type of Coulomb interaction
-    Enumeration of implemented methods for the electrostatic
-    interaction.
-*/
-/************************************************************/
-/*@{*/
-
+/** Type codes for the type of %Coulomb interaction.
+ *  Enumeration of implemented methods for the electrostatic interaction.
+ */
 enum CoulombMethod {
-  COULOMB_NONE,      ///< %Coulomb interaction switched off (NONE)
+  COULOMB_NONE,      ///< %Coulomb interaction switched off
   COULOMB_DH,        ///< %Coulomb method is Debye-Hueckel
   COULOMB_P3M,       ///< %Coulomb method is P3M
   COULOMB_P3M_GPU,   ///< %Coulomb method is P3M with GPU-based long-range part
@@ -43,27 +39,22 @@ enum CoulombMethod {
   COULOMB_MMM1D,     ///< %Coulomb method is one-dimensional MMM
   COULOMB_RF,        ///< %Coulomb method is Reaction-Field
   COULOMB_MMM1D_GPU, ///< %Coulomb method is one-dimensional MMM running on GPU
-  COULOMB_SCAFACOS,  ///< %Coulomb method is scafacos
+  COULOMB_SCAFACOS,  ///< %Coulomb method is ScaFaCoS
 };
-/*@}*/
 
-/** \name Compounds for Coulomb interactions */
-/*@{*/
-
-/** field containing the interaction parameters for
- *  the Coulomb  interaction.  */
+/** Interaction parameters for the %Coulomb interaction. */
 struct Coulomb_parameters {
-  /** bjerrum length times temperature. */
+  /** Bjerrum length times temperature. */
   double prefactor = 0.;
 
   double field_induced = 0.;
   double field_applied = 0.;
 
-  /** Method to treat Coulomb interaction. */
+  /** Method to treat %Coulomb interaction. */
   CoulombMethod method = COULOMB_NONE;
 };
 
-/** Structure containing the Coulomb parameters. */
+/** Structure containing the %Coulomb parameters. */
 extern Coulomb_parameters coulomb;
 
 namespace Coulomb {
@@ -96,13 +87,11 @@ void bcast_coulomb_params();
 /** @brief Set the electrostatics prefactor */
 int set_prefactor(double prefactor);
 
-/** @brief Deactivates the current Coulomb method
-    This was part of coulomb_set_bjerrum()
-*/
+/** @brief Deactivates the current %Coulomb method. */
 void deactivate_method();
 
-/** @brief Update particles with properties depending on other particles
- *   e.g., charges of ICC particles
+/** @brief Update particles with properties depending on other particles,
+ *  namely ICC charges.
  */
 void update_dependent_particles();
 } // namespace Coulomb

--- a/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
@@ -102,10 +102,10 @@ pair_force(Particle const &p1, Particle const &p2, Utils::Vector3d const &d,
  * If supported by the method, this returns the virial
  * contribution to the pressure tensor for this pair.
  *
- * @param p1 Particle
- * @param p2 Particle
- * @param d  Distance
- * @param dist |d|
+ * @param p1 particle
+ * @param p2 particle
+ * @param d  distance vector
+ * @param dist distance norm
  * @return Contribution to the pressure tensor.
  */
 inline Utils::Vector<Utils::Vector3d, 3> pair_pressure(Particle const &p1,

--- a/src/core/electrostatics_magnetostatics/dipole.cpp
+++ b/src/core/electrostatics_magnetostatics/dipole.cpp
@@ -336,7 +336,7 @@ void set_method_local(DipolarInteraction method) {
   if ((dipole.method == DIPOLAR_BH_GPU) && (method != DIPOLAR_BH_GPU)) {
     deactivate_dipolar_barnes_hut();
   }
-#endif // BARNES_HUT
+#endif // DIPOLAR_ BARNES_HUT
   dipole.method = method;
 }
 

--- a/src/core/electrostatics_magnetostatics/dipole.cpp
+++ b/src/core/electrostatics_magnetostatics/dipole.cpp
@@ -48,7 +48,7 @@ Dipole_parameters dipole = {
 };
 
 namespace Dipole {
-int pressure_n() { return 0; }
+size_t pressure_n() { return 0; }
 
 void calc_pressure_long_range() {
   switch (dipole.method) {
@@ -260,11 +260,10 @@ void calc_energy_long_range(Observable_stat &energy,
   }
 }
 
-void energy_n(int &n_dipolar) {
+size_t energy_n() {
   switch (dipole.method) {
   case DIPOLAR_NONE:
-    n_dipolar = 1; // because there may be an external magnetic field
-    break;
+    return 1; // because there may be an external magnetic field
   case DIPOLAR_P3M:
   case DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA:
   case DIPOLAR_DS:
@@ -273,14 +272,14 @@ void energy_n(int &n_dipolar) {
   case DIPOLAR_BH_GPU:
 #endif
   case DIPOLAR_SCAFACOS:
-    n_dipolar = 2;
-    break;
+    return 2;
   case DIPOLAR_MDLC_P3M:
   case DIPOLAR_MDLC_DS:
-    n_dipolar = 3;
-    break;
+    return 3;
   default:
-    break;
+    runtimeErrorMsg()
+        << "energy calculation not implemented for dipolar method.";
+    return 0;
   }
 }
 

--- a/src/core/electrostatics_magnetostatics/dipole.cpp
+++ b/src/core/electrostatics_magnetostatics/dipole.cpp
@@ -19,9 +19,6 @@
 
 #include "electrostatics_magnetostatics/dipole.hpp"
 
-// Real space cutoff of long range methods
-double dipolar_cutoff;
-
 #ifdef DIPOLES
 
 #include "actor/DipolarBarnesHut.hpp"

--- a/src/core/electrostatics_magnetostatics/dipole.cpp
+++ b/src/core/electrostatics_magnetostatics/dipole.cpp
@@ -45,8 +45,6 @@ Dipole_parameters dipole = {
 };
 
 namespace Dipole {
-size_t pressure_n() { return 0; }
-
 void calc_pressure_long_range() {
   switch (dipole.method) {
   case DIPOLAR_NONE:
@@ -254,29 +252,6 @@ void calc_energy_long_range(Observable_stat &energy,
     runtimeErrorMsg()
         << "energy calculation not implemented for dipolar method.";
     break;
-  }
-}
-
-size_t energy_n() {
-  switch (dipole.method) {
-  case DIPOLAR_NONE:
-    return 1; // because there may be an external magnetic field
-  case DIPOLAR_P3M:
-  case DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA:
-  case DIPOLAR_DS:
-  case DIPOLAR_DS_GPU:
-#ifdef DIPOLAR_BARNES_HUT
-  case DIPOLAR_BH_GPU:
-#endif
-  case DIPOLAR_SCAFACOS:
-    return 2;
-  case DIPOLAR_MDLC_P3M:
-  case DIPOLAR_MDLC_DS:
-    return 3;
-  default:
-    runtimeErrorMsg()
-        << "energy calculation not implemented for dipolar method.";
-    return 0;
   }
 }
 

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -103,5 +103,10 @@ void set_method_local(DipolarInteraction method);
 
 } // namespace Dipole
 
+#else  // DIPOLES
+namespace Dipole {
+constexpr size_t pressure_n() { return 0; }
+constexpr size_t energy_n() { return 0; }
+} // namespace Dipole
 #endif // DIPOLES
 #endif // ESPRESSO_DIPOLE_HPP

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -21,6 +21,8 @@
 
 #include "config.hpp"
 
+#include <cstddef>
+
 #ifdef DIPOLES
 #include "Observable_stat.hpp"
 

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -21,8 +21,6 @@
 
 #include "config.hpp"
 
-extern double dipolar_cutoff;
-
 #ifdef DIPOLES
 #include "Observable_stat.hpp"
 

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -66,7 +66,31 @@ struct Dipole_parameters {
 extern Dipole_parameters dipole;
 
 namespace Dipole {
-size_t pressure_n();
+/** Number of electrostatic contributions to the system pressure calculation. */
+constexpr size_t pressure_n() { return 0; }
+
+/** Number of electrostatic contributions to the system energy calculation. */
+inline size_t energy_n() {
+  switch (dipole.method) {
+  case DIPOLAR_NONE:
+    return 1; // because there may be an external magnetic field
+  case DIPOLAR_P3M:
+  case DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA:
+  case DIPOLAR_DS:
+  case DIPOLAR_DS_GPU:
+#ifdef DIPOLAR_BARNES_HUT
+  case DIPOLAR_BH_GPU:
+#endif
+  case DIPOLAR_SCAFACOS:
+    return 2;
+  case DIPOLAR_MDLC_P3M:
+  case DIPOLAR_MDLC_DS:
+    return 3;
+  default:
+    return 0;
+  }
+}
+
 void calc_pressure_long_range();
 
 void nonbonded_sanity_check(int &state);
@@ -81,7 +105,6 @@ void calc_long_range_force(const ParticleRange &particles);
 
 void calc_energy_long_range(Observable_stat &energy,
                             const ParticleRange &particles);
-size_t energy_n();
 
 int set_mesh();
 void bcast_params(const boost::mpi::communicator &comm);

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -76,7 +76,7 @@ struct Dipole_parameters {
 extern Dipole_parameters dipole;
 
 namespace Dipole {
-int pressure_n();
+size_t pressure_n();
 void calc_pressure_long_range();
 
 void nonbonded_sanity_check(int &state);
@@ -91,7 +91,7 @@ void calc_long_range_force(const ParticleRange &particles);
 
 void calc_energy_long_range(Observable_stat &energy,
                             const ParticleRange &particles);
-void energy_n(int &n_dipolar);
+size_t energy_n();
 
 int set_mesh();
 void bcast_params(const boost::mpi::communicator &comm);

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -29,48 +29,40 @@
 #include <ParticleRange.hpp>
 #include <boost/mpi/communicator.hpp>
 
-/** \name Compounds for Dipole interactions */
-/*@{*/
-
-/** \name Type codes for the type of dipolar interaction
-  Enumeration of implemented methods for the magnetostatic
-  interaction.
+/** Type codes for the type of dipolar interaction.
+ *  Enumeration of implemented methods for the magnetostatic interaction.
  */
-/************************************************************/
-/*@{*/
 enum DipolarInteraction {
-  /** dipolar interaction switched off (NONE). */
+  /** Dipolar interaction switched off. */
   DIPOLAR_NONE = 0,
-  /** dipolar method is P3M. */
+  /** Dipolar method is P3M. */
   DIPOLAR_P3M,
   /** Dipolar method is P3M plus DLC. */
   DIPOLAR_MDLC_P3M,
-  /** Dipolar method is all with all and no replicas */
+  /** Dipolar method is all with all and no replicas. */
   DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA,
-  /** Dipolar method is magnetic dipolar direct sum */
+  /** Dipolar method is magnetic dipolar direct summation. */
   DIPOLAR_DS,
-  /** Dipolar method is direct sum plus DLC. */
+  /** Dipolar method is direct summation plus DLC. */
   DIPOLAR_MDLC_DS,
-  /** Direct summation on gpu */
+  /** Dipolar method is direct summation on GPU. */
   DIPOLAR_DS_GPU,
 #ifdef DIPOLAR_BARNES_HUT
-  /** Direct summation on gpu by Barnes-Hut algorithm */
+  /** Dipolar method is direct summation on GPU by Barnes-Hut algorithm. */
   DIPOLAR_BH_GPU,
 #endif
-  /** Scafacos library */
+  /** Dipolar method is ScaFaCoS. */
   DIPOLAR_SCAFACOS
 };
 
-/** field containing the interaction parameters for
- *  the Dipole interaction.  */
+/** Interaction parameters for the %dipole interaction. */
 struct Dipole_parameters {
   double prefactor;
 
   DipolarInteraction method;
 };
-/*@}*/
 
-/** Structure containing the Dipole parameters. */
+/** Structure containing the %dipole parameters. */
 extern Dipole_parameters dipole;
 
 namespace Dipole {
@@ -98,9 +90,7 @@ void bcast_params(const boost::mpi::communicator &comm);
 int set_Dprefactor(double prefactor);
 
 void set_method_local(DipolarInteraction method);
-
 } // namespace Dipole
-
 #else  // DIPOLES
 namespace Dipole {
 constexpr size_t pressure_n() { return 0; }

--- a/src/core/electrostatics_magnetostatics/dipole_inline.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole_inline.hpp
@@ -56,7 +56,6 @@ inline double pair_energy(Particle const &p1, Particle const &p2,
                           Utils::Vector3d const &d, double dist, double dist2) {
   double ret = 0;
   if (dipole.method != DIPOLAR_NONE) {
-    // ret=0;
     switch (dipole.method) {
 #ifdef DP3M
     case DIPOLAR_MDLC_P3M:

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -1229,6 +1229,9 @@ int ELC_set_params(double maxPWerror, double gap_size, double far_cut,
 
   Coulomb::elc_sanity_check();
 
+  p3m.params.epsilon = P3M_EPSILON_METALLIC;
+  coulomb.method = COULOMB_ELC_P3M;
+
   elc_params.far_cut = far_cut;
   if (far_cut != -1) {
     elc_params.far_cut2 = Utils::sqr(far_cut);

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -65,7 +65,7 @@ void init_forces_iccp3m(const ParticleRange &particles,
 void force_calc_iccp3m(const ParticleRange &particles,
                        const ParticleRange &ghost_particles);
 
-/** Variant of @ref add_non_bonded_pair_force where only Coulomb
+/** Variant of @ref add_non_bonded_pair_force where only %Coulomb
  *  contributions are calculated
  */
 inline void add_non_bonded_pair_force_iccp3m(Particle &p1, Particle &p2,
@@ -97,7 +97,7 @@ int iccp3m_iteration(const ParticleRange &particles,
 
   Coulomb::iccp3m_sanity_check();
 
-  if ((iccp3m_cfg.eout <= 0)) {
+  if (iccp3m_cfg.eout <= 0) {
     runtimeErrorMsg()
         << "ICCP3M: nonpositive dielectric constant is not allowed.";
   }
@@ -160,7 +160,7 @@ int iccp3m_iteration(const ParticleRange &particles,
         /* check if the charge now is more than 1e6, to determine if ICC still
          * leads to reasonable results */
         /* this is kind of an arbitrary measure but does a good job spotting
-         * divergence !*/
+         * divergence! */
         if (std::abs(p.p.q) > 1e6) {
           runtimeErrorMsg()
               << "too big charge assignment in iccp3m! q >1e6 , assigned "
@@ -199,7 +199,7 @@ void force_calc_iccp3m(const ParticleRange &particles,
 
   short_range_loop(Utils::NoOp{}, [](Particle &p1, Particle &p2,
                                      Distance const &d) {
-    /* calc non bonded interactions */
+    /* calc non-bonded interactions */
     add_non_bonded_pair_force_iccp3m(p1, p2, d.vec21, sqrt(d.dist2), d.dist2);
   });
 

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -45,10 +45,9 @@ Observable_stat total_energy{};
 /************************************************************/
 
 void init_energies(Observable_stat *stat) {
-  int n_pre, n_non_bonded, n_dipolar(0);
+  size_t n_pre(1), n_dipolar(0);
 
-  n_pre = 1;
-  n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
 
 #ifdef ELECTROSTATICS
   auto const n_coulomb = Coulomb::energy_n();
@@ -56,7 +55,7 @@ void init_energies(Observable_stat *stat) {
   int const n_coulomb = 0;
 #endif
 #ifdef DIPOLES
-  Dipole::energy_n(n_dipolar);
+  n_dipolar = Dipole::energy_n();
 #endif
 
   obsstat_realloc_and_clear(stat, n_pre, bonded_ia_params.size(), n_non_bonded,

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -38,15 +38,10 @@
 
 ActorList energyActors;
 
-namespace {
-auto cen = &Coulomb::energy_n;
-auto den = &Dipole::energy_n;
-} // namespace
-
 /** Energy from the current MPI rank */
-Observable_stat energy{1, ::cen, ::den};
+Observable_stat energy{1, false};
 /** Energy from the whole system */
-Observable_stat total_energy{1, ::cen, ::den};
+Observable_stat total_energy{1, false};
 
 /** Reduce the system energy from all MPI ranks. */
 void master_energy_calc() {

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -106,8 +106,7 @@ void energy_calc(double *result, const double time) {
 #endif
 
   /* gather data */
-  MPI_Reduce(energy.data.data(), result, energy.data.size(), MPI_DOUBLE,
-             MPI_SUM, 0, comm_cart);
+  energy.reduce(result);
 }
 
 /************************************************************/

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -53,7 +53,7 @@ void init_energies(Observable_stat *stat) {
   n_dipolar = Dipole::energy_n();
 #endif
 
-  stat->realloc_and_clear(n_coulomb, n_dipolar, 0, 1);
+  stat->realloc_and_clear(1, n_coulomb, n_dipolar, 0);
 }
 
 /************************************************************/
@@ -127,5 +127,5 @@ double calculate_current_potential_energy_of_system() {
     master_energy_calc();
   }
 
-  return total_energy.accumulate(-total_energy.first_field()[0]);
+  return total_energy.accumulate(-total_energy.kinetic[0]);
 }

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -55,7 +55,6 @@ void init_energies(Observable_stat *stat) {
 #endif
 
   stat->realloc_and_clear(n_coulomb, n_dipolar, 0, 1);
-  stat->init_status = 0;
 }
 
 /************************************************************/
@@ -63,8 +62,7 @@ void init_energies(Observable_stat *stat) {
 void master_energy_calc() {
   mpi_gather_stats(GatherStats::energy, reinterpret_cast<void *>(&total_energy),
                    nullptr, nullptr, nullptr);
-
-  total_energy.init_status = 1;
+  total_energy.is_initialized = true;
 }
 
 /************************************************************/
@@ -125,7 +123,7 @@ void calc_long_range_energies(const ParticleRange &particles) {
 
 double calculate_current_potential_energy_of_system() {
   // calculate potential energy
-  if (total_energy.init_status == 0) {
+  if (!total_energy.is_initialized) {
     init_energies(&total_energy);
     master_energy_calc();
   }

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -61,15 +61,15 @@ void init_energies(Observable_stat *stat) {
 /************************************************************/
 
 void master_energy_calc() {
-  mpi_gather_stats(GatherStats::energy, total_energy.data.data(), nullptr,
-                   nullptr, nullptr);
+  mpi_gather_stats(GatherStats::energy, reinterpret_cast<void *>(&total_energy),
+                   nullptr, nullptr, nullptr);
 
   total_energy.init_status = 1;
 }
 
 /************************************************************/
 
-void energy_calc(double *result, const double time) {
+void energy_calc(Observable_stat *result, const double time) {
   if (!interactions_sanity_checks())
     return;
 

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -61,7 +61,8 @@ void init_energies(Observable_stat *stat) {
 /************************************************************/
 
 void master_energy_calc() {
-  mpi_gather_stats(1, total_energy.data.data(), nullptr, nullptr, nullptr);
+  mpi_gather_stats(GatherStats::energy, total_energy.data.data(), nullptr,
+                   nullptr, nullptr);
 
   total_energy.init_status = 1;
 }

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "EspressoSystemInterface.hpp"
+#include "Observable_stat.hpp"
 #include "communication.hpp"
 #include "constraints.hpp"
 #include "cuda_interface.hpp"

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -45,21 +45,16 @@ Observable_stat total_energy{};
 /************************************************************/
 
 void init_energies(Observable_stat *stat) {
-  size_t n_pre(1), n_dipolar(0);
-
-  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  size_t n_coulomb(0), n_dipolar(0);
 
 #ifdef ELECTROSTATICS
-  auto const n_coulomb = Coulomb::energy_n();
-#else
-  int const n_coulomb = 0;
+  n_coulomb = Coulomb::energy_n();
 #endif
 #ifdef DIPOLES
   n_dipolar = Dipole::energy_n();
 #endif
 
-  obsstat_realloc_and_clear(stat, n_pre, bonded_ia_params.size(), n_non_bonded,
-                            n_coulomb, n_dipolar, 0, 1);
+  stat->realloc_and_clear(n_coulomb, n_dipolar, 0, 1);
   stat->init_status = 0;
 }
 

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -30,7 +30,6 @@
 #include "energy_inline.hpp"
 #include "event.hpp"
 #include "forces.hpp"
-#include <boost/range/numeric.hpp>
 
 #include "short_range_loop.hpp"
 
@@ -128,5 +127,5 @@ double calculate_current_potential_energy_of_system() {
     master_energy_calc();
   }
 
-  return boost::accumulate(total_energy.data, -total_energy.data[0]);
+  return total_energy.accumulate(-total_energy.first_field()[0]);
 }

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -38,7 +38,7 @@
 
 ActorList energyActors;
 
-/** Energy from the whole system */
+/** Energy of the system */
 Observable_stat_wrapper obs_energy{1, false};
 
 /** Reduce the system energy from all MPI ranks. */
@@ -51,7 +51,7 @@ void energy_calc(const double time) {
   if (!interactions_sanity_checks())
     return;
 
-  obs_energy.local.realloc_and_clear();
+  obs_energy.local.resize_and_clear();
 
 #ifdef CUDA
   clear_energy_on_GPU();
@@ -90,7 +90,7 @@ void energy_calc(const double time) {
 
 void update_energy() {
   if (!obs_energy.is_initialized) {
-    obs_energy.realloc_and_clear();
+    obs_energy.resize();
     master_energy_calc();
   }
 }

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -43,9 +43,12 @@ auto cen = &Coulomb::energy_n;
 auto den = &Dipole::energy_n;
 } // namespace
 
+/** Energy from the current MPI rank */
 Observable_stat energy{1, ::cen, ::den};
+/** Energy from the whole system */
 Observable_stat total_energy{1, ::cen, ::den};
 
+/** Reduce the system energy from all MPI ranks. */
 void master_energy_calc() {
   mpi_gather_stats(GatherStats::energy, reinterpret_cast<void *>(&total_energy),
                    nullptr, nullptr, nullptr);

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -54,7 +54,7 @@ void master_energy_calc();
 /** parallel energy calculation.
     @param result non-zero only on master node; will contain the cumulative over
    all nodes. */
-void energy_calc(double *result, double time);
+void energy_calc(Observable_stat *result, double time);
 
 /** Calculate long range energies (P3M, ...). */
 void calc_long_range_energies(const ParticleRange &particles);

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -31,36 +31,21 @@
 #include "ParticleRange.hpp"
 #include "actor/ActorList.hpp"
 
-/** \name Exported Variables */
-/************************************************************/
-/*@{*/
 ///
-extern Observable_stat total_energy;
+extern Observable_stat_wrapper obs_energy;
 
 extern ActorList energyActors;
-/*@}*/
 
-/** \name Exported Functions */
-/************************************************************/
-/*@{*/
+/** Recalculate energies (only if necessary). */
+void update_energy();
 
-/** allocate energy arrays and initialize with zero */
-void init_energies(Observable_stat *stat);
+/** Parallel energy calculation. */
+void energy_calc(double time);
 
-/** on the master node: calc energies only if necessary */
-void master_energy_calc();
-
-/** parallel energy calculation.
-    @param result non-zero only on master node; will contain the cumulative over
-   all nodes. */
-void energy_calc(Observable_stat *result, double time);
-
-/** Calculate long range energies (P3M, ...). */
+/** Calculate long-range energies (P3M, ...). */
 void calc_long_range_energies(const ParticleRange &particles);
 
 /** Calculate the total energy of the system. */
 double calculate_current_potential_energy_of_system();
-
-/*@}*/
 
 #endif

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -27,11 +27,8 @@
 #ifndef _ENERGY_H
 #define _ENERGY_H
 
-#include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 #include "actor/ActorList.hpp"
-
-extern Observable_stat_wrapper obs_energy;
 
 extern ActorList energyActors;
 

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -27,7 +27,7 @@
 #ifndef _ENERGY_H
 #define _ENERGY_H
 
-/* include the energy files */
+#include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 #include "actor/ActorList.hpp"
 #include "statistics.hpp"

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -31,7 +31,6 @@
 #include "ParticleRange.hpp"
 #include "actor/ActorList.hpp"
 
-///
 extern Observable_stat_wrapper obs_energy;
 
 extern ActorList energyActors;

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -30,13 +30,12 @@
 #include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 #include "actor/ActorList.hpp"
-#include "statistics.hpp"
 
 /** \name Exported Variables */
 /************************************************************/
 /*@{*/
 ///
-extern Observable_stat energy, total_energy;
+extern Observable_stat total_energy;
 
 extern ActorList energyActors;
 /*@}*/

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -58,7 +58,7 @@ void energy_calc(Observable_stat *result, double time);
 /** Calculate long range energies (P3M, ...). */
 void calc_long_range_energies(const ParticleRange &particles);
 
-/** Calculate the total energy */
+/** Calculate the total energy of the system. */
 double calculate_current_potential_energy_of_system();
 
 /*@}*/

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -27,6 +27,7 @@
 #include "config.hpp"
 #include <boost/range/algorithm/find_if.hpp>
 
+#include "Observable_stat.hpp"
 #include "bonded_interactions/angle_cosine.hpp"
 #include "bonded_interactions/angle_cossquare.hpp"
 #include "bonded_interactions/angle_harmonic.hpp"
@@ -69,6 +70,8 @@
 #ifdef DIPOLES
 #include "electrostatics_magnetostatics/dipole_inline.hpp"
 #endif
+
+extern Observable_stat_wrapper obs_energy;
 
 /** Calculate non-bonded energies between a pair of particles.
  *  @param p1         particle 1.

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -190,7 +190,7 @@ inline void add_non_bonded_pair_energy(Particle const &p1, Particle const &p2,
 #ifdef EXCLUSIONS
   if (do_nonbonded(p1, p2))
 #endif
-    *obsstat_nonbonded(&energy, p1.p.type, p2.p.type) +=
+    *energy.nonbonded_ia(p1.p.type, p2.p.type) +=
         calc_non_bonded_pair_energy(p1, p2, ia_params, d, dist);
 
 #ifdef ELECTROSTATICS
@@ -292,7 +292,7 @@ inline bool add_bonded_energy(Particle &p1, int bond_id,
   auto const result = calc_bonded_energy(iaparams, p1, partners);
 
   if (result) {
-    *obsstat_bonded(&energy, bond_id) += result.get();
+    *energy.bonded_ia(bond_id) += result.get();
 
     return false;
   }

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -176,7 +176,7 @@ inline double calc_non_bonded_pair_energy(Particle const &p1,
 }
 
 /** Add non-bonded and short-range Coulomb energies between a pair of particles
- *  to the @ref energy observable.
+ *  to the energy observable.
  *  @param p1        particle 1.
  *  @param p2        particle 2.
  *  @param d         vector between p1 and p2.
@@ -281,7 +281,7 @@ calc_bonded_energy(Bonded_ia_parameters const &iaparams, Particle const &p1,
   throw BondInvalidSizeError(n_partners);
 }
 
-/** Add bonded energies for one particle to the @ref energy observable.
+/** Add bonded energies for one particle to the energy observable.
  *  @param[in] p1   particle for which to calculate energies
  *  @param[in] bond_id Numeric id of the bond
  *  @param[in] partners Bond partners of particle.
@@ -303,7 +303,7 @@ inline bool add_bonded_energy(Particle &p1, int bond_id,
   return true;
 }
 
-/** Add kinetic energies for one particle to the @ref energy observable.
+/** Add kinetic energies for one particle to the energy observable.
  *  @param[in] p1   particle for which to calculate energies
  */
 inline void add_kinetic_energy(Particle const &p1) {
@@ -318,7 +318,7 @@ inline void add_kinetic_energy(Particle const &p1) {
 #ifdef ROTATION
   if (p1.p.rotation) {
     /* the rotational part is added to the total kinetic energy;
-       Here we use the rotational inertia  */
+     * Here we use the rotational inertia */
     energy.kinetic[0] += 0.5 * (Utils::sqr(p1.m.omega[0]) * p1.p.rinertia[0] +
                                 Utils::sqr(p1.m.omega[1]) * p1.p.rinertia[1] +
                                 Utils::sqr(p1.m.omega[2]) * p1.p.rinertia[2]);
@@ -326,8 +326,7 @@ inline void add_kinetic_energy(Particle const &p1) {
 #endif
 }
 
-/** Add kinetic and bonded energies for one particle to the @ref energy
- *  observable.
+/** Add kinetic and bonded energies for one particle to the energy observable.
  *  @param[in] p   particle for which to calculate energies
  */
 inline void add_single_particle_energy(Particle &p) {

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -63,13 +63,14 @@
 #endif
 #include "cells.hpp"
 #include "exclusions.hpp"
-#include "statistics.hpp"
 
 #include "energy.hpp"
 
 #ifdef DIPOLES
 #include "electrostatics_magnetostatics/dipole_inline.hpp"
 #endif
+
+extern Observable_stat energy;
 
 /** Calculate non-bonded energies between a pair of particles.
  *  @param p1         particle 1.

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -309,7 +309,7 @@ inline void add_kinetic_energy(Particle const &p1) {
 
   /* kinetic energy */
   if (not p1.p.is_virtual)
-    energy.data[0] += 0.5 * p1.p.mass * p1.m.v.norm2();
+    energy.first_field()[0] += 0.5 * p1.p.mass * p1.m.v.norm2();
 
     // Note that rotational degrees of virtual sites are integrated
     // and therefore can contribute to kinetic energy
@@ -317,9 +317,10 @@ inline void add_kinetic_energy(Particle const &p1) {
   if (p1.p.rotation) {
     /* the rotational part is added to the total kinetic energy;
        Here we use the rotational inertia  */
-    energy.data[0] += 0.5 * (Utils::sqr(p1.m.omega[0]) * p1.p.rinertia[0] +
-                             Utils::sqr(p1.m.omega[1]) * p1.p.rinertia[1] +
-                             Utils::sqr(p1.m.omega[2]) * p1.p.rinertia[2]);
+    energy.first_field()[0] +=
+        0.5 * (Utils::sqr(p1.m.omega[0]) * p1.p.rinertia[0] +
+               Utils::sqr(p1.m.omega[1]) * p1.p.rinertia[1] +
+               Utils::sqr(p1.m.omega[2]) * p1.p.rinertia[2]);
   }
 #endif
 }

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -70,8 +70,6 @@
 #include "electrostatics_magnetostatics/dipole_inline.hpp"
 #endif
 
-extern Observable_stat energy;
-
 /** Calculate non-bonded energies between a pair of particles.
  *  @param p1         particle 1.
  *  @param p2         particle 2.
@@ -191,18 +189,18 @@ inline void add_non_bonded_pair_energy(Particle const &p1, Particle const &p2,
 #ifdef EXCLUSIONS
   if (do_nonbonded(p1, p2))
 #endif
-    energy.non_bonded_contribution(p1.p.type, p2.p.type)[0] +=
+    obs_energy.local.non_bonded_contribution(p1.p.type, p2.p.type)[0] +=
         calc_non_bonded_pair_energy(p1, p2, ia_params, d, dist);
 
 #ifdef ELECTROSTATICS
-  if (!energy.coulomb.empty())
-    energy.coulomb[0] +=
+  if (!obs_energy.local.coulomb.empty())
+    obs_energy.local.coulomb[0] +=
         Coulomb::pair_energy(p1, p2, p1.p.q * p2.p.q, d, dist, dist2);
 #endif
 
 #ifdef DIPOLES
-  if (!energy.dipolar.empty())
-    energy.dipolar[0] += Dipole::pair_energy(p1, p2, d, dist, dist2);
+  if (!obs_energy.local.dipolar.empty())
+    obs_energy.local.dipolar[0] += Dipole::pair_energy(p1, p2, d, dist, dist2);
 #endif
 }
 
@@ -295,7 +293,7 @@ inline bool add_bonded_energy(Particle &p1, int bond_id,
   auto const result = calc_bonded_energy(iaparams, p1, partners);
 
   if (result) {
-    energy.bonded_contribution(bond_id)[0] += result.get();
+    obs_energy.local.bonded_contribution(bond_id)[0] += result.get();
 
     return false;
   }
@@ -311,7 +309,7 @@ inline void add_kinetic_energy(Particle const &p1) {
     return;
 
   /* kinetic energy */
-  energy.kinetic[0] += 0.5 * p1.p.mass * p1.m.v.norm2();
+  obs_energy.local.kinetic[0] += 0.5 * p1.p.mass * p1.m.v.norm2();
 
   // Note that rotational degrees of virtual sites are integrated
   // and therefore can contribute to kinetic energy
@@ -319,9 +317,10 @@ inline void add_kinetic_energy(Particle const &p1) {
   if (p1.p.rotation) {
     /* the rotational part is added to the total kinetic energy;
      * Here we use the rotational inertia */
-    energy.kinetic[0] += 0.5 * (Utils::sqr(p1.m.omega[0]) * p1.p.rinertia[0] +
-                                Utils::sqr(p1.m.omega[1]) * p1.p.rinertia[1] +
-                                Utils::sqr(p1.m.omega[2]) * p1.p.rinertia[2]);
+    obs_energy.local.kinetic[0] +=
+        0.5 * (Utils::sqr(p1.m.omega[0]) * p1.p.rinertia[0] +
+               Utils::sqr(p1.m.omega[1]) * p1.p.rinertia[1] +
+               Utils::sqr(p1.m.omega[2]) * p1.p.rinertia[2]);
   }
 #endif
 }

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -209,7 +209,7 @@ void on_particle_change() {
 }
 
 void on_coulomb_change() {
-  invalidate_obs();
+  realloc_and_clear_all_obs();
 
 #ifdef ELECTROSTATICS
   Coulomb::on_coulomb_change();
@@ -228,7 +228,7 @@ void on_coulomb_change() {
 }
 
 void on_short_range_ia_change() {
-  invalidate_obs();
+  realloc_and_clear_all_obs();
 
   cells_on_geometry_change(false);
 

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -25,6 +25,7 @@
  */
 #include "event.hpp"
 
+#include "Observable_stat.hpp"
 #include "Particle.hpp"
 #include "bonded_interactions/thermalized_bond.hpp"
 #include "cells.hpp"

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -42,7 +42,6 @@
 #include "npt.hpp"
 #include "partCfg_global.hpp"
 #include "particle_data.hpp"
-#include "statistics.hpp"
 #include "thermostat.hpp"
 #include "virtual_sites.hpp"
 
@@ -50,6 +49,7 @@
 
 #include "electrostatics_magnetostatics/coulomb.hpp"
 #include "electrostatics_magnetostatics/dipole.hpp"
+#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 
 #ifdef SCAFACOS
 #include "electrostatics_magnetostatics/scafacos.hpp"

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -209,7 +209,7 @@ void on_particle_change() {
 }
 
 void on_coulomb_change() {
-  realloc_and_clear_all_obs();
+  invalidate_obs();
 
 #ifdef ELECTROSTATICS
   Coulomb::on_coulomb_change();
@@ -228,7 +228,7 @@ void on_coulomb_change() {
 }
 
 void on_short_range_ia_change() {
-  realloc_and_clear_all_obs();
+  invalidate_obs();
 
   cells_on_geometry_change(false);
 

--- a/src/core/event.hpp
+++ b/src/core/event.hpp
@@ -107,8 +107,8 @@ unsigned global_ghost_flags();
 /** called every time the walls for the lb fluid are changed */
 void on_lbboundary_change();
 
-/** @brief Update particles with properties depending on other particles
- *   e.g., virtual sites, ICC charges
+/** @brief Update particles with properties depending on other particles,
+ *  namely virtual sites and ICC charges.
  */
 void update_dependent_particles();
 

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -271,8 +271,7 @@ Utils::Vector3d lbboundary_get_force(LBBoundary const *lbb) {
 #endif
   } else if (lattice_switch == ActiveLB::CPU) {
 #if defined(LB_BOUNDARIES)
-    mpi_gather_stats(GatherStats::lb_boundary_forces, forces.data(), nullptr,
-                     nullptr, nullptr);
+    mpi_gather_stats(GatherStats::lb_boundary_forces, forces.data());
 #endif
   }
   auto const container_index = std::distance(lbboundaries.begin(), it);

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -271,7 +271,8 @@ Utils::Vector3d lbboundary_get_force(LBBoundary const *lbb) {
 #endif
   } else if (lattice_switch == ActiveLB::CPU) {
 #if defined(LB_BOUNDARIES)
-    mpi_gather_stats(8, forces.data(), nullptr, nullptr, nullptr);
+    mpi_gather_stats(GatherStats::lb_boundary_forces, forces.data(), nullptr,
+                     nullptr, nullptr);
 #endif
   }
   auto const container_index = std::distance(lbboundaries.begin(), it);

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -1223,7 +1223,8 @@ Utils::Vector3d lb_lbfluid_calc_fluid_momentum() {
     lb_calc_fluid_momentum_GPU(fluid_momentum.data());
 #endif
   } else if (lattice_switch == ActiveLB::CPU) {
-    mpi_gather_stats(6, fluid_momentum.data(), nullptr, nullptr, nullptr);
+    mpi_gather_stats(GatherStats::lb_fluid_momentum, fluid_momentum.data(),
+                     nullptr, nullptr, nullptr);
   }
   return fluid_momentum;
 }

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -1223,8 +1223,7 @@ Utils::Vector3d lb_lbfluid_calc_fluid_momentum() {
     lb_calc_fluid_momentum_GPU(fluid_momentum.data());
 #endif
   } else if (lattice_switch == ActiveLB::CPU) {
-    mpi_gather_stats(GatherStats::lb_fluid_momentum, fluid_momentum.data(),
-                     nullptr, nullptr, nullptr);
+    mpi_gather_stats(GatherStats::lb_fluid_momentum, fluid_momentum.data());
   }
   return fluid_momentum;
 }

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -36,7 +36,6 @@
 #include "grid_based_algorithms/lbgpu.hpp"
 #include "integrate.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
-#include "statistics.hpp"
 
 #include <utils/constants.hpp>
 

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -35,7 +35,7 @@ static void backup_file(const std::string &from, const std::string &to) {
   if (this_node == 0) {
     /*
      * If the file itself *and* a backup file exists, something must
-     * have went wrong.
+     * have gone wrong.
      */
     boost::filesystem::path pfrom(from), pto(to);
     try {

--- a/src/core/observables/StressTensor.hpp
+++ b/src/core/observables/StressTensor.hpp
@@ -30,7 +30,7 @@ public:
   std::vector<size_t> shape() const override { return {3, 3}; }
   std::vector<double> operator()() const override {
     std::vector<double> res(n_values());
-    observable_compute_stress_tensor(true, res.data());
+    observable_compute_stress_tensor(res.data());
     return res;
   }
 };

--- a/src/core/observables/StressTensor.hpp
+++ b/src/core/observables/StressTensor.hpp
@@ -30,7 +30,7 @@ public:
   std::vector<size_t> shape() const override { return {3, 3}; }
   std::vector<double> operator()() const override {
     std::vector<double> res(n_values());
-    observable_compute_stress_tensor(1, res.data());
+    observable_compute_stress_tensor(true, res.data());
     return res;
   }
 };

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -164,7 +164,7 @@ double calculate_npt_p_vel_rescaled() {
   return acc / (nptiso.dimension * nptiso.volume);
 }
 
-void update_pressure(bool v_comp, bool observable_stress_tensor) {
+void update_pressure(bool v_comp) {
   if (obs_scalar_pressure.is_initialized &&
       obs_scalar_pressure.v_comp == v_comp)
     return;
@@ -178,12 +178,7 @@ void update_pressure(bool v_comp, bool observable_stress_tensor) {
       !(nptiso.invalidate_p_vel)) {
     if (!obs_scalar_pressure.is_initialized)
       master_pressure_calc(false);
-    auto const npt_p_vel_rescaled = calculate_npt_p_vel_rescaled();
-    if (observable_stress_tensor) {
-      obs_stress_tensor.local.kinetic[0] = npt_p_vel_rescaled;
-    } else {
-      obs_scalar_pressure.kinetic[0] = npt_p_vel_rescaled;
-    }
+    obs_scalar_pressure.kinetic[0] = calculate_npt_p_vel_rescaled();
     obs_scalar_pressure.v_comp = true;
   } else {
     master_pressure_calc(v_comp);
@@ -191,7 +186,7 @@ void update_pressure(bool v_comp, bool observable_stress_tensor) {
 }
 
 void observable_compute_stress_tensor(double *output) {
-  update_pressure(true, true);
+  update_pressure(true);
   for (size_t j = 0; j < 9; j++) {
     output[j] = obs_stress_tensor.accumulate(0, j);
   }

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -214,7 +214,7 @@ int observable_compute_stress_tensor(bool v_comp, double *A) {
   }
 
   for (int j = 0; j < 9; j++) {
-    A[j] = total_p_tensor.accumulate_along_dim(0, j);
+    A[j] = total_p_tensor.accumulate(0, j);
   }
   return 0;
 }

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -97,8 +97,9 @@ static void add_single_particle_virials(Particle &p) {
   cell_structure.execute_bond_handler(p, add_bonded_stress);
 }
 
-void pressure_calc(double *result, double *result_t, double *result_nb,
-                   double *result_t_nb, int v_comp) {
+void pressure_calc(Observable_stat *result, Observable_stat *result_t,
+                   Observable_stat_non_bonded *result_nb,
+                   Observable_stat_non_bonded *result_t_nb, int v_comp) {
   auto const volume = box_geo.volume();
 
   if (!interactions_sanity_checks())
@@ -221,9 +222,10 @@ void init_p_tensor_non_bonded(Observable_stat_non_bonded *stat_nb) {
 void master_pressure_calc(int v_comp) {
   mpi_gather_stats(v_comp ? GatherStats::pressure_v_comp
                           : GatherStats::pressure,
-                   total_pressure.data.data(), total_p_tensor.data.data(),
-                   total_pressure_non_bonded.data_nb.data(),
-                   total_p_tensor_non_bonded.data_nb.data());
+                   reinterpret_cast<void *>(&total_pressure),
+                   reinterpret_cast<void *>(&total_p_tensor),
+                   reinterpret_cast<void *>(&total_pressure_non_bonded),
+                   reinterpret_cast<void *>(&total_p_tensor_non_bonded));
 
   total_pressure.init_status = 1 + v_comp;
   total_p_tensor.init_status = 1 + v_comp;

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -22,6 +22,7 @@
  *  Implementation of pressure.hpp.
  */
 
+#include "Observable_stat.hpp"
 #include "cells.hpp"
 #include "communication.hpp"
 #include "event.hpp"

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -36,19 +36,14 @@
 #include "electrostatics_magnetostatics/coulomb.hpp"
 #include "electrostatics_magnetostatics/dipole.hpp"
 
-namespace {
-auto cpn = &Coulomb::pressure_n;
-auto dpn = &Dipole::pressure_n;
-} // namespace
-
 /** Scalar pressure from the current MPI rank */
-Observable_stat virials{1, ::cpn, ::dpn};
+Observable_stat virials{1};
 /** Scalar pressure from the whole system */
-Observable_stat total_pressure{1, ::cpn, ::dpn};
+Observable_stat total_pressure{1};
 /** Stress tensor from the current MPI rank */
-Observable_stat p_tensor{9, ::cpn, ::dpn};
+Observable_stat p_tensor{9};
 /** Stress tensor from the whole system */
-Observable_stat total_p_tensor{9, ::cpn, ::dpn};
+Observable_stat total_p_tensor{9};
 
 /** Contribution from the intra- and inter-molecular non-bonded interactions
  *  to the scalar pressure (from the current MPI rank) */

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -146,17 +146,10 @@ void pressure_calc(double *result, double *result_t, double *result_nb,
   p_tensor_non_bonded.rescale(volume);
 
   /* gather data */
-  MPI_Reduce(virials.data.data(), result, virials.data.size(), MPI_DOUBLE,
-             MPI_SUM, 0, comm_cart);
-  MPI_Reduce(p_tensor.data.data(), result_t, p_tensor.data.size(), MPI_DOUBLE,
-             MPI_SUM, 0, comm_cart);
-
-  MPI_Reduce(virials_non_bonded.data_nb.data(), result_nb,
-             virials_non_bonded.data_nb.size(), MPI_DOUBLE, MPI_SUM, 0,
-             comm_cart);
-  MPI_Reduce(p_tensor_non_bonded.data_nb.data(), result_t_nb,
-             p_tensor_non_bonded.data_nb.size(), MPI_DOUBLE, MPI_SUM, 0,
-             comm_cart);
+  virials.reduce(result);
+  p_tensor.reduce(result_t);
+  virials_non_bonded.reduce(result_nb);
+  p_tensor_non_bonded.reduce(result_t_nb);
 }
 
 /************************************************************/

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -219,14 +219,11 @@ void init_p_tensor_non_bonded(Observable_stat_non_bonded *stat_nb) {
 
 /************************************************************/
 void master_pressure_calc(int v_comp) {
-  if (v_comp)
-    mpi_gather_stats(3, total_pressure.data.data(), total_p_tensor.data.data(),
-                     total_pressure_non_bonded.data_nb.data(),
-                     total_p_tensor_non_bonded.data_nb.data());
-  else
-    mpi_gather_stats(2, total_pressure.data.data(), total_p_tensor.data.data(),
-                     total_pressure_non_bonded.data_nb.data(),
-                     total_p_tensor_non_bonded.data_nb.data());
+  mpi_gather_stats(v_comp ? GatherStats::pressure_v_comp
+                          : GatherStats::pressure,
+                   total_pressure.data.data(), total_p_tensor.data.data(),
+                   total_pressure_non_bonded.data_nb.data(),
+                   total_p_tensor_non_bonded.data_nb.data());
 
   total_pressure.init_status = 1 + v_comp;
   total_p_tensor.init_status = 1 + v_comp;

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -259,7 +259,7 @@ void update_pressure(bool v_comp) {
         !(nptiso.invalidate_p_vel)) {
       if (!total_pressure.is_initialized)
         master_pressure_calc(false);
-      total_pressure.data[0] = calculate_npt_p_vel_rescaled();
+      total_pressure.first_field()[0] = calculate_npt_p_vel_rescaled();
       total_pressure.v_comp = true;
     } else {
       master_pressure_calc(v_comp);
@@ -280,7 +280,7 @@ int observable_compute_stress_tensor(bool v_comp, double *A) {
         !(nptiso.invalidate_p_vel)) {
       if (!total_pressure.is_initialized)
         master_pressure_calc(false);
-      p_tensor.data[0] = calculate_npt_p_vel_rescaled();
+      p_tensor.first_field()[0] = calculate_npt_p_vel_rescaled();
       total_pressure.v_comp = true;
     } else {
       master_pressure_calc(v_comp);
@@ -288,10 +288,7 @@ int observable_compute_stress_tensor(bool v_comp, double *A) {
   }
 
   for (int j = 0; j < 9; j++) {
-    double value = total_p_tensor.data[j];
-    for (size_t i = 1; i < total_p_tensor.data.size() / 9; i++)
-      value += total_p_tensor.data[9 * i + j];
-    A[j] = value;
+    A[j] = total_p_tensor.accumulate_along_dim(0, j);
   }
   return 0;
 }

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -128,11 +128,11 @@ void pressure_calc(Observable_stat *result, Observable_stat *result_t,
   calc_long_range_virials(cell_structure.local_particles());
 
 #ifdef VIRTUAL_SITES
-  {
+  if (!virials.virtual_sites.empty()) {
     auto const vs_stress = virtual_sites()->stress_tensor();
 
-    *virials.virtual_sites += trace(vs_stress);
-    boost::copy(flatten(vs_stress), p_tensor.virtual_sites);
+    virials.virtual_sites[0] += trace(vs_stress);
+    boost::copy(flatten(vs_stress), p_tensor.virtual_sites.begin());
   }
 #endif
 
@@ -185,7 +185,7 @@ void init_virials(Observable_stat *stat) {
 #endif
 
   // Allocate memory for the data
-  stat->realloc_and_clear(n_coulomb, n_dipolar, n_vs, 1);
+  stat->realloc_and_clear(1, n_coulomb, n_dipolar, n_vs);
 }
 
 /************************************************************/
@@ -210,7 +210,7 @@ void init_p_tensor(Observable_stat *stat) {
   n_vs = 1;
 #endif
 
-  stat->realloc_and_clear(n_coulomb, n_dipolar, n_vs, 9);
+  stat->realloc_and_clear(9, n_coulomb, n_dipolar, n_vs);
 }
 
 /***************************/
@@ -259,7 +259,7 @@ void update_pressure(bool v_comp) {
         !(nptiso.invalidate_p_vel)) {
       if (!total_pressure.is_initialized)
         master_pressure_calc(false);
-      total_pressure.first_field()[0] = calculate_npt_p_vel_rescaled();
+      total_pressure.kinetic[0] = calculate_npt_p_vel_rescaled();
       total_pressure.v_comp = true;
     } else {
       master_pressure_calc(v_comp);
@@ -280,7 +280,7 @@ int observable_compute_stress_tensor(bool v_comp, double *A) {
         !(nptiso.invalidate_p_vel)) {
       if (!total_pressure.is_initialized)
         master_pressure_calc(false);
-      p_tensor.first_field()[0] = calculate_npt_p_vel_rescaled();
+      p_tensor.kinetic[0] = calculate_npt_p_vel_rescaled();
       total_pressure.v_comp = true;
     } else {
       master_pressure_calc(v_comp);

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -189,9 +189,7 @@ void calc_long_range_virials(const ParticleRange &particles) {
 void init_virials(Observable_stat *stat) {
   // Determine number of contribution for different interaction types
   // bonded, nonbonded, Coulomb, dipolar, rigid bodies
-  size_t n_pre(1), n_coulomb(0), n_dipolar(0), n_vs(0);
-
-  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  size_t n_coulomb(0), n_dipolar(0), n_vs(0);
 
 #ifdef ELECTROSTATICS
   n_coulomb = Coulomb::pressure_n();
@@ -204,16 +202,12 @@ void init_virials(Observable_stat *stat) {
 #endif
 
   // Allocate memory for the data
-  obsstat_realloc_and_clear(stat, n_pre, bonded_ia_params.size(), n_non_bonded,
-                            n_coulomb, n_dipolar, n_vs, 1);
-  stat->init_status = 0;
+  stat->realloc_and_clear(n_coulomb, n_dipolar, n_vs, 1);
 }
 
 /************************************************************/
 void init_virials_non_bonded(Observable_stat_non_bonded *stat_nb) {
-  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
-
-  obsstat_realloc_and_clear_non_bonded(stat_nb, n_non_bonded, 1);
+  stat_nb->realloc_and_clear_non_bonded(1);
 }
 
 /* Initialize the p_tensor */
@@ -221,32 +215,24 @@ void init_virials_non_bonded(Observable_stat_non_bonded *stat_nb) {
 void init_p_tensor(Observable_stat *stat) {
   // Determine number of contribution for different interaction types
   // bonded, nonbonded, Coulomb, dipolar, rigid bodies
-  size_t n_pre(1), n_coulomb(0), n_vs(0);
-
-  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  size_t n_coulomb(0), n_dipolar(0), n_vs(0);
 
 #ifdef ELECTROSTATICS
   n_coulomb = Coulomb::pressure_n();
 #endif
 #ifdef DIPOLES
-  auto const n_dipolar = Dipole::pressure_n();
-#else
-  auto const n_dipolar = 0;
+  n_dipolar = Dipole::pressure_n();
 #endif
 #ifdef VIRTUAL_SITES
   n_vs = 1;
 #endif
 
-  obsstat_realloc_and_clear(stat, n_pre, bonded_ia_params.size(), n_non_bonded,
-                            n_coulomb, n_dipolar, n_vs, 9);
-  stat->init_status = 0;
+  stat->realloc_and_clear(n_coulomb, n_dipolar, n_vs, 9);
 }
 
 /***************************/
 void init_p_tensor_non_bonded(Observable_stat_non_bonded *stat_nb) {
-  auto n_nonbonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
-
-  obsstat_realloc_and_clear_non_bonded(stat_nb, n_nonbonded, 9);
+  stat_nb->realloc_and_clear_non_bonded(9);
 }
 
 /************************************************************/

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -189,16 +189,15 @@ void calc_long_range_virials(const ParticleRange &particles) {
 void init_virials(Observable_stat *stat) {
   // Determine number of contribution for different interaction types
   // bonded, nonbonded, Coulomb, dipolar, rigid bodies
-  int n_pre, n_non_bonded, n_coulomb(0), n_dipolar(0), n_vs(0);
+  size_t n_pre(1), n_coulomb(0), n_dipolar(0), n_vs(0);
 
-  n_pre = 1;
-  n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
 
 #ifdef ELECTROSTATICS
-  Coulomb::pressure_n(n_coulomb);
+  n_coulomb = Coulomb::pressure_n();
 #endif
 #ifdef DIPOLES
-  Dipole::pressure_n();
+  n_dipolar = Dipole::pressure_n();
 #endif
 #ifdef VIRTUAL_SITES
   n_vs = 1;
@@ -212,9 +211,7 @@ void init_virials(Observable_stat *stat) {
 
 /************************************************************/
 void init_virials_non_bonded(Observable_stat_non_bonded *stat_nb) {
-  int n_non_bonded;
-
-  n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
 
   obsstat_realloc_and_clear_non_bonded(stat_nb, n_non_bonded, 1);
 }
@@ -224,13 +221,12 @@ void init_virials_non_bonded(Observable_stat_non_bonded *stat_nb) {
 void init_p_tensor(Observable_stat *stat) {
   // Determine number of contribution for different interaction types
   // bonded, nonbonded, Coulomb, dipolar, rigid bodies
-  int n_pre, n_non_bonded, n_coulomb(0), n_vs(0);
+  size_t n_pre(1), n_coulomb(0), n_vs(0);
 
-  n_pre = 1;
-  n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  auto n_non_bonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
 
 #ifdef ELECTROSTATICS
-  Coulomb::pressure_n(n_coulomb);
+  n_coulomb = Coulomb::pressure_n();
 #endif
 #ifdef DIPOLES
   auto const n_dipolar = Dipole::pressure_n();
@@ -248,8 +244,7 @@ void init_p_tensor(Observable_stat *stat) {
 
 /***************************/
 void init_p_tensor_non_bonded(Observable_stat_non_bonded *stat_nb) {
-  int n_nonbonded;
-  n_nonbonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
+  auto n_nonbonded = (max_seen_particle_type * (max_seen_particle_type + 1)) / 2;
 
   obsstat_realloc_and_clear_non_bonded(stat_nb, n_nonbonded, 9);
 }

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -190,7 +190,7 @@ void init_virials(Observable_stat *stat) {
 
 /************************************************************/
 void init_virials_non_bonded(Observable_stat_non_bonded *stat_nb) {
-  stat_nb->realloc_and_clear_non_bonded(1);
+  stat_nb->realloc_and_clear(1);
 }
 
 /* Initialize the p_tensor */
@@ -215,7 +215,7 @@ void init_p_tensor(Observable_stat *stat) {
 
 /***************************/
 void init_p_tensor_non_bonded(Observable_stat_non_bonded *stat_nb) {
-  stat_nb->realloc_and_clear_non_bonded(9);
+  stat_nb->realloc_and_clear(9);
 }
 
 /************************************************************/

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -41,16 +41,26 @@ auto cpn = &Coulomb::pressure_n;
 auto dpn = &Dipole::pressure_n;
 } // namespace
 
+/** Scalar pressure from the current MPI rank */
 Observable_stat virials{1, ::cpn, ::dpn};
+/** Scalar pressure from the whole system */
 Observable_stat total_pressure{1, ::cpn, ::dpn};
+/** Stress tensor from the current MPI rank */
 Observable_stat p_tensor{9, ::cpn, ::dpn};
+/** Stress tensor from the whole system */
 Observable_stat total_p_tensor{9, ::cpn, ::dpn};
 
-/* Observables used in the calculation of intra- and inter- molecular
- * non-bonded contributions to pressure and to stress tensor */
+/** Contribution from the intra- and inter-molecular non-bonded interactions
+ *  to the scalar pressure (from the current MPI rank) */
 Observable_stat_non_bonded virials_non_bonded{1};
+/** Contribution from the intra- and inter-molecular non-bonded interactions
+ *  to the scalar pressure (from the whole system) */
 Observable_stat_non_bonded total_pressure_non_bonded{1};
+/** Contribution from the intra- and inter-molecular non-bonded interactions
+ *  to the stress tensor (from the current MPI rank) */
 Observable_stat_non_bonded p_tensor_non_bonded{9};
+/** Contribution from the intra- and inter-molecular non-bonded interactions
+ *  to the stress tensor (from the whole system) */
 Observable_stat_non_bonded total_p_tensor_non_bonded{9};
 
 nptiso_struct nptiso = {0.0,
@@ -93,11 +103,8 @@ void pressure_calc(Observable_stat *result, Observable_stat *result_t,
     return;
 
   virials.realloc_and_clear();
-
   p_tensor.realloc_and_clear();
-
   virials_non_bonded.realloc_and_clear();
-
   p_tensor_non_bonded.realloc_and_clear();
 
   on_observable_calc();
@@ -140,7 +147,7 @@ void pressure_calc(Observable_stat *result, Observable_stat *result_t,
   p_tensor_non_bonded.reduce(result_t_nb);
 }
 
-/** on the master node: calc energies only if necessary
+/** Reduce the system scalar pressure and stress tensor from all MPI ranks.
  *  @param v_comp flag which enables compensation of the velocities required
  *                for deriving a pressure reflecting \ref nptiso_struct::p_inst
  *                (hence it only works with domain decomposition); naturally it

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -118,9 +118,9 @@ void pressure_calc(bool v_comp) {
 #endif
 
   /* rescale kinetic energy (=ideal contribution) */
-  obs_scalar_pressure.local.rescale(3.0 * volume, time_step);
+  obs_scalar_pressure.local.rescale(3.0 * volume);
 
-  obs_stress_tensor.local.rescale(volume, time_step);
+  obs_stress_tensor.local.rescale(volume);
 
   /* Intra- and Inter- part of nonbonded interaction */
   obs_scalar_pressure_non_bonded.local.rescale(3.0 * volume);

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -27,31 +27,24 @@
 
 #include "Observable_stat.hpp"
 
-extern Observable_stat total_pressure, total_p_tensor;
-extern Observable_stat_non_bonded total_pressure_non_bonded,
-    total_p_tensor_non_bonded;
+extern Observable_stat_wrapper obs_scalar_pressure;
+extern Observable_stat_wrapper obs_stress_tensor;
+extern Observable_stat_non_bonded_wrapper obs_scalar_pressure_non_bonded;
+extern Observable_stat_non_bonded_wrapper obs_stress_tensor_non_bonded;
 
-/** Calculates the pressure in the system from a virial expansion.
- *  @param[out] result Calculated scalar pressure
- *  @param[out] result_t Calculated stress tensor
- *  @param[out] result_nb Calculated intra- and inter-molecular nonbonded
- *                        contributions to the scalar pressure
- *  @param[out] result_t_nb Calculated intra- and inter-molecular nonbonded
- *                          contributions to the stress tensor
+/** Parallel pressure calculation from a virial expansion.
  *  @param[in] v_comp flag which enables compensation of the velocities
  *                    required for deriving a pressure reflecting
  *                    \ref nptiso_struct::p_inst (hence it only works with
  *                    domain decomposition); naturally it therefore doesn't
  *                    make sense to use it without NpT.
  */
-void pressure_calc(Observable_stat *result, Observable_stat *result_t,
-                   Observable_stat_non_bonded *result_nb,
-                   Observable_stat_non_bonded *result_t_nb, bool v_comp);
+void pressure_calc(bool v_comp);
 
 /** Function to calculate stress tensor for the observables */
 int observable_compute_stress_tensor(bool v_comp, double *A);
 
-/** Recalculate the virials, pressure and stress tensors */
+/** Recalculate the virials, pressure and stress tensors (only if necessary). */
 void update_pressure(bool v_comp);
 
 #endif

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -45,8 +45,7 @@ void observable_compute_stress_tensor(double *output);
  *                    \ref nptiso_struct::p_inst (hence it only works with
  *                    domain decomposition); naturally it therefore doesn't
  *                    make sense to use it without NpT.
- *  @param[in] observable_stress_tensor flag for internal use
  */
-void update_pressure(bool v_comp, bool observable_stress_tensor = false);
+void update_pressure(bool v_comp);
 
 #endif

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -37,15 +37,6 @@ extern Observable_stat_non_bonded virials_non_bonded, total_pressure_non_bonded,
     p_tensor_non_bonded, total_p_tensor_non_bonded;
 /*@}*/
 
-/** \name Exported Functions */
-/************************************************************/
-/*@{*/
-void init_virials(Observable_stat *stat);
-void init_virials_non_bonded(Observable_stat_non_bonded *stat_nb);
-void init_p_tensor_non_bonded(Observable_stat_non_bonded *stat_nb);
-void init_p_tensor(Observable_stat *stat);
-void master_pressure_calc(int v_comp);
-
 /** Calculates the pressure in the system from a virial expansion.
  *  @param[out] result Calculated scalar pressure
  *  @param[out] result_t Calculated stress tensor
@@ -66,7 +57,5 @@ void pressure_calc(double *result, double *result_t, double *result_nb,
 int observable_compute_stress_tensor(int v_comp, double *A);
 
 void update_pressure(int v_comp);
-
-/*@}*/
 
 #endif

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -25,13 +25,6 @@
 #ifndef CORE_PRESSURE_HPP
 #define CORE_PRESSURE_HPP
 
-#include "Observable_stat.hpp"
-
-extern Observable_stat_wrapper obs_scalar_pressure;
-extern Observable_stat_wrapper obs_stress_tensor;
-extern Observable_stat_non_bonded_wrapper obs_scalar_pressure_non_bonded;
-extern Observable_stat_non_bonded_wrapper obs_stress_tensor_non_bonded;
-
 /** Parallel pressure calculation from a virial expansion.
  *  @param[in] v_comp flag which enables compensation of the velocities
  *                    required for deriving a pressure reflecting

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -27,15 +27,9 @@
 
 #include "Observable_stat.hpp"
 
-/** \name Exported Variables */
-/************************************************************/
-/*@{*/
-///
 extern Observable_stat total_pressure, total_p_tensor;
-///
 extern Observable_stat_non_bonded total_pressure_non_bonded,
     total_p_tensor_non_bonded;
-/*@}*/
 
 /** Calculates the pressure in the system from a virial expansion.
  *  @param[out] result Calculated scalar pressure
@@ -44,7 +38,7 @@ extern Observable_stat_non_bonded total_pressure_non_bonded,
  *                        contributions to the scalar pressure
  *  @param[out] result_t_nb Calculated intra- and inter-molecular nonbonded
  *                          contributions to the stress tensor
- *  @param[in] v_comp flag which enables (1) compensation of the velocities
+ *  @param[in] v_comp flag which enables compensation of the velocities
  *                    required for deriving a pressure reflecting
  *                    \ref nptiso_struct::p_inst (hence it only works with
  *                    domain decomposition); naturally it therefore doesn't

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -41,10 +41,19 @@ extern Observable_stat_non_bonded_wrapper obs_stress_tensor_non_bonded;
  */
 void pressure_calc(bool v_comp);
 
-/** Function to calculate stress tensor for the observables */
-int observable_compute_stress_tensor(bool v_comp, double *A);
+/** Helper function for @ref Observables::StressTensor.
+ *  @param[out] output Destination array.
+ */
+void observable_compute_stress_tensor(double *output);
 
-/** Recalculate the virials, pressure and stress tensors (only if necessary). */
-void update_pressure(bool v_comp);
+/** Recalculate the virials, pressure and stress tensors (only if necessary).
+ *  @param[in] v_comp flag which enables compensation of the velocities
+ *                    required for deriving a pressure reflecting
+ *                    \ref nptiso_struct::p_inst (hence it only works with
+ *                    domain decomposition); naturally it therefore doesn't
+ *                    make sense to use it without NpT.
+ *  @param[in] observable_stress_tensor flag for internal use
+ */
+void update_pressure(bool v_comp, bool observable_stress_tensor = false);
 
 #endif

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -53,11 +53,12 @@ extern Observable_stat_non_bonded virials_non_bonded, total_pressure_non_bonded,
  */
 void pressure_calc(Observable_stat *result, Observable_stat *result_t,
                    Observable_stat_non_bonded *result_nb,
-                   Observable_stat_non_bonded *result_t_nb, int v_comp);
+                   Observable_stat_non_bonded *result_t_nb, bool v_comp);
 
 /** Function to calculate stress tensor for the observables */
-int observable_compute_stress_tensor(int v_comp, double *A);
+int observable_compute_stress_tensor(bool v_comp, double *A);
 
-void update_pressure(int v_comp);
+/** Recalculate the virials, pressure and stress tensors */
+void update_pressure(bool v_comp);
 
 #endif

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -25,6 +25,7 @@
 #ifndef CORE_PRESSURE_HPP
 #define CORE_PRESSURE_HPP
 
+#include "Observable_stat.hpp"
 #include "statistics.hpp"
 
 /** \name Exported Variables */

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -51,8 +51,9 @@ extern Observable_stat_non_bonded virials_non_bonded, total_pressure_non_bonded,
  *                    domain decomposition); naturally it therefore doesn't
  *                    make sense to use it without NpT.
  */
-void pressure_calc(double *result, double *result_t, double *result_nb,
-                   double *result_t_nb, int v_comp);
+void pressure_calc(Observable_stat *result, Observable_stat *result_t,
+                   Observable_stat_non_bonded *result_nb,
+                   Observable_stat_non_bonded *result_t_nb, int v_comp);
 
 /** Function to calculate stress tensor for the observables */
 int observable_compute_stress_tensor(int v_comp, double *A);

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -26,16 +26,15 @@
 #define CORE_PRESSURE_HPP
 
 #include "Observable_stat.hpp"
-#include "statistics.hpp"
 
 /** \name Exported Variables */
 /************************************************************/
 /*@{*/
 ///
-extern Observable_stat virials, total_pressure, p_tensor, total_p_tensor;
+extern Observable_stat total_pressure, total_p_tensor;
 ///
-extern Observable_stat_non_bonded virials_non_bonded, total_pressure_non_bonded,
-    p_tensor_non_bonded, total_p_tensor_non_bonded;
+extern Observable_stat_non_bonded total_pressure_non_bonded,
+    total_p_tensor_non_bonded;
 /*@}*/
 
 /** Calculates the pressure in the system from a virial expansion.

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -189,17 +189,20 @@ inline void add_kinetic_virials(Particle const &p1, bool v_comp) {
   if (not p1.p.is_virtual) {
     /* kinetic energy */
     if (v_comp) {
-      virials.data[0] += ((p1.m.v * time_step) -
-                          (p1.f.f * (0.5 * Utils::sqr(time_step) / p1.p.mass)))
-                             .norm2() *
-                         p1.p.mass;
+      virials.first_field()[0] +=
+          ((p1.m.v * time_step) -
+           (p1.f.f * (0.5 * Utils::sqr(time_step) / p1.p.mass)))
+              .norm2() *
+          p1.p.mass;
     } else {
-      virials.data[0] += Utils::sqr(time_step) * p1.m.v.norm2() * p1.p.mass;
+      virials.first_field()[0] +=
+          Utils::sqr(time_step) * p1.m.v.norm2() * p1.p.mass;
     }
 
+    auto first_field = p_tensor.first_field();
     for (int k = 0; k < 3; k++)
       for (int l = 0; l < 3; l++)
-        p_tensor.data[k * 3 + l] +=
+        first_field[k * 3 + l] +=
             (p1.m.v[k] * time_step) * (p1.m.v[l] * time_step) * p1.p.mass;
   }
 }

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -202,19 +202,15 @@ inline void add_kinetic_virials(Particle const &p1, bool v_comp) {
   /* kinetic energy */
   if (v_comp) {
     obs_scalar_pressure.local.kinetic[0] +=
-        ((p1.m.v * time_step) -
-         (p1.f.f * (0.5 * Utils::sqr(time_step) / p1.p.mass)))
-            .norm2() *
-        p1.p.mass;
+        (p1.m.v - (p1.f.f * (0.5 * time_step / p1.p.mass))).norm2() * p1.p.mass;
   } else {
-    obs_scalar_pressure.local.kinetic[0] +=
-        Utils::sqr(time_step) * p1.m.v.norm2() * p1.p.mass;
+    obs_scalar_pressure.local.kinetic[0] += p1.m.v.norm2() * p1.p.mass;
   }
 
   for (int k = 0; k < 3; k++)
     for (int l = 0; l < 3; l++)
       obs_stress_tensor.local.kinetic[k * 3 + l] +=
-          (p1.m.v[k] * time_step) * (p1.m.v[l] * time_step) * p1.p.mass;
+          (p1.m.v[k]) * (p1.m.v[l]) * p1.p.mass;
 }
 
 #endif

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -33,6 +33,9 @@
 
 #include <utils/math/tensor_product.hpp>
 
+extern Observable_stat virials, p_tensor;
+extern Observable_stat_non_bonded virials_non_bonded, p_tensor_non_bonded;
+
 /** Calculate non bonded energies between a pair of particles.
  *  @param p1        pointer to particle 1.
  *  @param p2        pointer to particle 2.

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -25,6 +25,7 @@
 #ifndef CORE_PRESSURE_INLINE_HPP
 #define CORE_PRESSURE_INLINE_HPP
 
+#include "Observable_stat.hpp"
 #include "exclusions.hpp"
 #include "forces_inline.hpp"
 #include "integrate.hpp"
@@ -32,6 +33,11 @@
 #include "pressure.hpp"
 
 #include <utils/math/tensor_product.hpp>
+
+extern Observable_stat_wrapper obs_scalar_pressure;
+extern Observable_stat_wrapper obs_stress_tensor;
+extern Observable_stat_non_bonded_wrapper obs_scalar_pressure_non_bonded;
+extern Observable_stat_non_bonded_wrapper obs_stress_tensor_non_bonded;
 
 /** Calculate non bonded energies between a pair of particles.
  *  @param p1        pointer to particle 1.

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -46,32 +46,30 @@ inline void add_non_bonded_pair_virials(Particle const &p1, Particle const &p2,
 #endif
   {
     auto const force = calc_non_bonded_pair_force(p1, p2, d, dist);
-    *obsstat_nonbonded(&virials, p1.p.type, p2.p.type) += d * force;
+    *virials.nonbonded_ia(p1.p.type, p2.p.type) += d * force;
 
     /* stress tensor part */
     for (int k = 0; k < 3; k++)
       for (int l = 0; l < 3; l++)
-        obsstat_nonbonded(&p_tensor, p1.p.type, p2.p.type)[k * 3 + l] +=
+        p_tensor.nonbonded_ia(p1.p.type, p2.p.type)[k * 3 + l] +=
             force[k] * d[l];
 
     auto const p1molid = p1.p.mol_id;
     auto const p2molid = p2.p.mol_id;
     if (p1molid == p2molid) {
-      *obsstat_nonbonded_intra(&virials_non_bonded, p1.p.type, p2.p.type) +=
-          d * force;
+      *virials_non_bonded.nonbonded_intra_ia(p1.p.type, p2.p.type) += d * force;
 
       for (int k = 0; k < 3; k++)
         for (int l = 0; l < 3; l++)
-          obsstat_nonbonded_intra(&p_tensor_non_bonded, p1.p.type,
-                                  p2.p.type)[k * 3 + l] += force[k] * d[l];
+          p_tensor_non_bonded.nonbonded_intra_ia(
+              p1.p.type, p2.p.type)[k * 3 + l] += force[k] * d[l];
     } else {
-      *obsstat_nonbonded_inter(&virials_non_bonded, p1.p.type, p2.p.type) +=
-          d * force;
+      *virials_non_bonded.nonbonded_inter_ia(p1.p.type, p2.p.type) += d * force;
 
       for (int k = 0; k < 3; k++)
         for (int l = 0; l < 3; l++)
-          obsstat_nonbonded_inter(&p_tensor_non_bonded, p1.p.type,
-                                  p2.p.type)[k * 3 + l] += force[k] * d[l];
+          p_tensor_non_bonded.nonbonded_inter_ia(
+              p1.p.type, p2.p.type)[k * 3 + l] += force[k] * d[l];
     }
   }
 
@@ -167,12 +165,12 @@ inline bool add_bonded_stress(Particle &p1, int bond_id,
   if (result) {
     auto const &stress = result.get();
 
-    *obsstat_bonded(&virials, bond_id) += trace(stress);
+    *virials.bonded_ia(bond_id) += trace(stress);
 
     /* stress tensor part */
     for (int k = 0; k < 3; k++)
       for (int l = 0; l < 3; l++)
-        obsstat_bonded(&p_tensor, bond_id)[k * 3 + l] += stress[k][l];
+        p_tensor.bonded_ia(bond_id)[k * 3 + l] += stress[k][l];
 
     return false;
   }

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -181,11 +181,11 @@ inline bool add_bonded_stress(Particle &p1, int bond_id,
 /** Calculate kinetic pressure (aka energy) for one particle.
  *  @param p1 particle for which to calculate pressure
  *  @param v_comp flag which enables compensation of the velocities required
- *                for deriving a pressure reflecting \ref
- * nptiso_struct::p_inst (hence it only works with domain decomposition);
- * naturally it therefore doesn't make sense to use it without NpT.
+ *     for deriving a pressure reflecting \ref nptiso_struct::p_inst
+ *     (hence it only works with domain decomposition); naturally it
+ *     therefore doesn't make sense to use it without NpT.
  */
-inline void add_kinetic_virials(Particle const &p1, int v_comp) {
+inline void add_kinetic_virials(Particle const &p1, bool v_comp) {
   if (not p1.p.is_virtual) {
     /* kinetic energy */
     if (v_comp) {

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -25,6 +25,7 @@
 #include "grid.hpp"
 #include "integrate.hpp"
 #include "partCfg_global.hpp"
+#include "statistics.hpp"
 
 #include <utils/constants.hpp>
 #include <utils/index.hpp>

--- a/src/core/short_range_loop.hpp
+++ b/src/core/short_range_loop.hpp
@@ -22,7 +22,6 @@
 #include "algorithm/for_each_pair.hpp"
 #include "cells.hpp"
 #include "grid.hpp"
-#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 
 #include <boost/iterator/indirect_iterator.hpp>
 #include <profiler/profiler.hpp>

--- a/src/core/short_range_loop.hpp
+++ b/src/core/short_range_loop.hpp
@@ -56,9 +56,9 @@ struct EuclidianDistance {
 };
 
 /**
- * @brief Decided which distance function to use depending on the
-          cell system, and call the pair code.
-*/
+ * @brief Decide which distance function to use depending on the
+ * cell system, and call the pair code.
+ */
 template <typename CellIterator, typename ParticleKernel, typename PairKernel,
           typename VerletCriterion>
 void decide_distance(CellIterator first, CellIterator last,
@@ -83,8 +83,7 @@ void decide_distance(CellIterator first, CellIterator last,
 }
 
 /**
- * @brief Functor that returns true for
- *        any arguments.
+ * @brief Functor that returns true for any argument.
  */
 struct True {
   template <class... T> bool operator()(T...) const { return true; }

--- a/src/core/short_range_loop.hpp
+++ b/src/core/short_range_loop.hpp
@@ -22,6 +22,7 @@
 #include "algorithm/for_each_pair.hpp"
 #include "cells.hpp"
 #include "grid.hpp"
+#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 
 #include <boost/iterator/indirect_iterator.hpp>
 #include <profiler/profiler.hpp>

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -512,13 +512,3 @@ void analyze_append(PartCfg &partCfg) {
   }
   configs.emplace_back(config);
 }
-
-/****************************************************************************************
- *                                 Observables handling
- ****************************************************************************************/
-
-void invalidate_obs() {
-  total_energy.is_initialized = false;
-  total_pressure.is_initialized = false;
-  total_p_tensor.is_initialized = false;
-}

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -27,14 +27,12 @@
 #include "statistics.hpp"
 
 #include "Particle.hpp"
-#include "bonded_interactions/bonded_interaction_data.hpp"
 #include "communication.hpp"
 #include "energy.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
 #include "grid_based_algorithms/lb_interface.hpp"
 #include "integrate.hpp"
-#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "npt.hpp"
 #include "partCfg_global.hpp"
 #include "pressure.hpp"
@@ -517,52 +515,6 @@ void analyze_append(PartCfg &partCfg) {
 /****************************************************************************************
  *                                 Observables handling
  ****************************************************************************************/
-
-void obsstat_realloc_and_clear(Observable_stat *stat, size_t n_pre, size_t n_bonded,
-                               size_t n_non_bonded, size_t n_coulomb, size_t n_dipolar,
-                               size_t n_vs, size_t c_size) {
-
-  // Number of doubles to store pressure in
-  size_t const total =
-      c_size *
-      (n_pre + bonded_ia_params.size() + n_non_bonded +
-       n_coulomb + n_dipolar + n_vs + Observable_stat::n_external_field);
-
-  // Allocate mem for the double list
-  stat->data.resize(total);
-
-  // Number of doubles per interaction (pressure=1, stress tensor=9,...)
-  stat->chunk_size = c_size;
-
-  // Number of chunks for different interaction types
-  stat->n_coulomb = n_coulomb;
-  stat->n_dipolar = n_dipolar;
-  stat->n_virtual_sites = n_vs;
-  // Pointers to the start of different contributions
-  stat->bonded = stat->data.data() + c_size * n_pre;
-  stat->non_bonded = stat->bonded + c_size * bonded_ia_params.size();
-  stat->coulomb = stat->non_bonded + c_size * n_non_bonded;
-  stat->dipolar = stat->coulomb + c_size * n_coulomb;
-  stat->virtual_sites = stat->dipolar + c_size * n_dipolar;
-  stat->external_fields = stat->virtual_sites + c_size * n_vs;
-
-  // Set all observables to zero
-  for (int i = 0; i < total; i++)
-    stat->data[i] = 0.0;
-}
-
-void obsstat_realloc_and_clear_non_bonded(Observable_stat_non_bonded *stat_nb,
-                                          size_t n_nonbonded, size_t c_size) {
-  size_t const total = c_size * 2 * n_nonbonded;
-
-  stat_nb->data_nb.resize(total);
-  stat_nb->chunk_size_nb = c_size;
-  stat_nb->non_bonded_intra = stat_nb->data_nb.data();
-  stat_nb->non_bonded_inter = stat_nb->non_bonded_intra + c_size * n_nonbonded;
-
-  for (int i = 0; i < total; i++)
-    stat_nb->data_nb[i] = 0.0;
-}
 
 void invalidate_obs() {
   total_energy.init_status = 0;

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -43,6 +43,7 @@
 #include <utils/Vector.hpp>
 #include <utils/constants.hpp>
 #include <utils/contains.hpp>
+#include <utils/math/sqr.hpp>
 
 #include <cstdlib>
 #include <limits>

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -518,7 +518,7 @@ void analyze_append(PartCfg &partCfg) {
  ****************************************************************************************/
 
 void invalidate_obs() {
-  total_energy.init_status = 0;
-  total_pressure.init_status = 0;
-  total_p_tensor.init_status = 0;
+  total_energy.is_initialized = false;
+  total_pressure.is_initialized = false;
+  total_p_tensor.is_initialized = false;
 }

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -26,6 +26,7 @@
 
 #include "statistics.hpp"
 
+#include "Observable_stat.hpp"
 #include "Particle.hpp"
 #include "communication.hpp"
 #include "energy.hpp"

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -521,30 +521,3 @@ void invalidate_obs() {
   total_pressure.init_status = 0;
   total_p_tensor.init_status = 0;
 }
-
-void update_pressure(int v_comp) {
-  Utils::Vector3d p_vel;
-  /* if desired (v_comp==1) replace ideal component with instantaneous one */
-  if (total_pressure.init_status != 1 + v_comp) {
-    init_virials(&total_pressure);
-    init_p_tensor(&total_p_tensor);
-
-    init_virials_non_bonded(&total_pressure_non_bonded);
-    init_p_tensor_non_bonded(&total_p_tensor_non_bonded);
-
-    if (v_comp && (integ_switch == INTEG_METHOD_NPT_ISO) &&
-        !(nptiso.invalidate_p_vel)) {
-      if (total_pressure.init_status == 0)
-        master_pressure_calc(0);
-      total_pressure.data[0] = 0.0;
-      MPI_Reduce(nptiso.p_vel.data(), p_vel.data(), 3, MPI_DOUBLE, MPI_SUM, 0,
-                 MPI_COMM_WORLD);
-      for (int i = 0; i < 3; i++)
-        if (nptiso.geometry & nptiso.nptgeom_dir[i])
-          total_pressure.data[0] += p_vel[i];
-      total_pressure.data[0] /= (nptiso.dimension * nptiso.volume);
-      total_pressure.init_status = 1 + v_comp;
-    } else
-      master_pressure_calc(v_comp);
-  }
-}

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -518,14 +518,14 @@ void analyze_append(PartCfg &partCfg) {
  *                                 Observables handling
  ****************************************************************************************/
 
-void obsstat_realloc_and_clear(Observable_stat *stat, int n_pre, int n_bonded,
-                               int n_non_bonded, int n_coulomb, int n_dipolar,
-                               int n_vs, int c_size) {
+void obsstat_realloc_and_clear(Observable_stat *stat, size_t n_pre, size_t n_bonded,
+                               size_t n_non_bonded, size_t n_coulomb, size_t n_dipolar,
+                               size_t n_vs, size_t c_size) {
 
   // Number of doubles to store pressure in
-  const int total =
+  size_t const total =
       c_size *
-      (n_pre + static_cast<int>(bonded_ia_params.size()) + n_non_bonded +
+      (n_pre + bonded_ia_params.size() + n_non_bonded +
        n_coulomb + n_dipolar + n_vs + Observable_stat::n_external_field);
 
   // Allocate mem for the double list
@@ -552,8 +552,8 @@ void obsstat_realloc_and_clear(Observable_stat *stat, int n_pre, int n_bonded,
 }
 
 void obsstat_realloc_and_clear_non_bonded(Observable_stat_non_bonded *stat_nb,
-                                          int n_nonbonded, int c_size) {
-  auto const total = c_size * (n_nonbonded + n_nonbonded);
+                                          size_t n_nonbonded, size_t c_size) {
+  size_t const total = c_size * 2 * n_nonbonded;
 
   stat_nb->data_nb.resize(total);
   stat_nb->chunk_size_nb = c_size;

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -26,20 +26,14 @@
 
 #include "statistics.hpp"
 
-#include "Observable_stat.hpp"
 #include "Particle.hpp"
+#include "cells.hpp"
 #include "communication.hpp"
-#include "energy.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
 #include "grid_based_algorithms/lb_interface.hpp"
-#include "integrate.hpp"
-#include "npt.hpp"
 #include "partCfg_global.hpp"
-#include "pressure.hpp"
-#include "short_range_loop.hpp"
 
-#include <utils/NoOp.hpp>
 #include <utils/Vector.hpp>
 #include <utils/constants.hpp>
 #include <utils/contains.hpp>

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -26,7 +26,6 @@
  *  Implementation in statistics.cpp.
  */
 
-#include "Observable_stat.hpp"
 #include "PartCfg.hpp"
 #include "Particle.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -28,7 +28,6 @@
 
 #include "PartCfg.hpp"
 #include "Particle.hpp"
-#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 
 #include <map>
 #include <string>

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -206,6 +206,4 @@ void momentofinertiamatrix(PartCfg &partCfg, int type, double *MofImatrix);
 Utils::Vector3d calc_linear_momentum(int include_particles,
                                      int include_lbfluid);
 
-void invalidate_obs();
-
 #endif

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -207,47 +207,6 @@ void momentofinertiamatrix(PartCfg &partCfg, int type, double *MofImatrix);
 Utils::Vector3d calc_linear_momentum(int include_particles,
                                      int include_lbfluid);
 
-inline double *obsstat_bonded(Observable_stat *stat, int j) {
-  return stat->bonded + stat->chunk_size * j;
-}
-
-inline double *obsstat_nonbonded(Observable_stat *stat, int p1, int p2) {
-  if (p1 > p2) {
-    int tmp = p2;
-    p2 = p1;
-    p1 = tmp;
-  }
-  return stat->non_bonded +
-         stat->chunk_size *
-             (((2 * max_seen_particle_type - 1 - p1) * p1) / 2 + p2);
-}
-
-inline double *obsstat_nonbonded_intra(Observable_stat_non_bonded *stat, int p1,
-                                       int p2) {
-  /*  return stat->non_bonded_intra + stat->chunk_size*1; */
-  if (p1 > p2) {
-    int tmp = p2;
-    p2 = p1;
-    p1 = tmp;
-  }
-  return stat->non_bonded_intra +
-         stat->chunk_size_nb *
-             (((2 * max_seen_particle_type - 1 - p1) * p1) / 2 + p2);
-}
-
-inline double *obsstat_nonbonded_inter(Observable_stat_non_bonded *stat, int p1,
-                                       int p2) {
-  /*  return stat->non_bonded_inter + stat->chunk_size*1; */
-  if (p1 > p2) {
-    int tmp = p2;
-    p2 = p1;
-    p1 = tmp;
-  }
-  return stat->non_bonded_inter +
-         stat->chunk_size_nb *
-             (((2 * max_seen_particle_type - 1 - p1) * p1) / 2 + p2);
-}
-
 void invalidate_obs();
 
 #endif

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -257,12 +257,12 @@ void invalidate_obs();
 /** Docs missing
  * \todo Docs missing
  */
-void obsstat_realloc_and_clear(Observable_stat *stat, int n_pre, int n_bonded,
-                               int n_non_bonded, int n_coulomb, int n_dipolar,
-                               int n_vs, int chunk_size);
+void obsstat_realloc_and_clear(Observable_stat *stat, size_t n_pre, size_t n_bonded,
+                               size_t n_non_bonded, size_t n_coulomb, size_t n_dipolar,
+                               size_t n_vs, size_t c_size);
 
 void obsstat_realloc_and_clear_non_bonded(Observable_stat_non_bonded *stat_nb,
-                                          int n_nonbonded, int chunk_size_nb);
+                                          size_t n_nonbonded, size_t chunk_size_nb);
 
 /*@}*/
 

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -46,10 +46,6 @@ int get_n_configs();
 int get_n_part_conf();
 /*@}*/
 
-/** \name Exported Functions */
-/************************************************************/
-/*@{*/
-
 /** Calculate the minimal distance of two particles with types in set1 resp.
  *  set2.
  *  @param set1 types of particles
@@ -253,17 +249,5 @@ inline double *obsstat_nonbonded_inter(Observable_stat_non_bonded *stat, int p1,
 }
 
 void invalidate_obs();
-
-/** Docs missing
- * \todo Docs missing
- */
-void obsstat_realloc_and_clear(Observable_stat *stat, size_t n_pre, size_t n_bonded,
-                               size_t n_non_bonded, size_t n_coulomb, size_t n_dipolar,
-                               size_t n_vs, size_t c_size);
-
-void obsstat_realloc_and_clear_non_bonded(Observable_stat_non_bonded *stat_nb,
-                                          size_t n_nonbonded, size_t chunk_size_nb);
-
-/*@}*/
 
 #endif

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -29,8 +29,8 @@
 #include "event.hpp"
 #include "grid.hpp"
 #include "integrate.hpp"
+#include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "particle_data.hpp"
-#include "statistics.hpp"
 
 #include <utils/constants.hpp>
 #include <utils/math/quaternion.hpp>

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -22,6 +22,7 @@
 #include "virtual_sites.hpp"
 
 #ifdef VIRTUAL_SITES
+#include "Observable_stat.hpp"
 #include "communication.hpp"
 #include "config.hpp"
 #include "errorhandling.hpp"

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -58,8 +58,8 @@ calculate_vs_relate_to_params(Particle const &p_current,
   // get the distance between the particles
   Utils::Vector3d d = get_mi_vector(p_current.r.p, p_relate_to.r.p, box_geo);
 
-  // Check, if the distance between virtual and non-virtual particles is larger
-  // htan minimum global cutoff If so, warn user
+  // Check if the distance between virtual and non-virtual particles is larger
+  // than minimum global cutoff. If so, warn user.
   auto const dist = d.norm();
   if (dist > min_global_cut && n_nodes > 1) {
     runtimeErrorMsg()

--- a/src/core/virtual_sites.hpp
+++ b/src/core/virtual_sites.hpp
@@ -28,7 +28,7 @@
 
 #include <memory>
 
-/** @brief get active virtual sites implementation */
+/** @brief Get active virtual sites implementation */
 const std::shared_ptr<VirtualSites> &virtual_sites();
 
 /** @brief Set active virtual sites implementation */

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -23,12 +23,12 @@
 
 /** \file
  *  This file contains routine to handle virtual sites
- *  Virtual sites are like particles, but they will be not integrated.
+ *  Virtual sites are like particles, but they will not be integrated.
  *  Step performed for virtual sites:
  *  - update virtual sites
  *  - calculate forces
  *  - distribute forces
- *  - move no-virtual particles
+ *  - move non-virtual particles
  *  - update virtual sites
  */
 

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -44,6 +44,7 @@ cdef extern from "particle_data.hpp":
 
 cdef extern from "Observable_stat.hpp":
     ctypedef struct Observable_stat:
+        void realloc_and_clear()
         cbool is_initialized
         cbool v_comp
         Span[double] kinetic
@@ -63,6 +64,7 @@ cdef extern from "Observable_stat.hpp":
         Span[double] non_bonded_contribution(int type1, int type2)
 
     ctypedef struct Observable_stat_non_bonded:
+        void realloc_and_clear()
         Span[double] non_bonded_intra_contribution(int type1, int type2)
         Span[double] non_bonded_inter_contribution(int type1, int type2)
 
@@ -111,7 +113,6 @@ cdef extern from "energy.hpp":
     cdef Observable_stat total_energy
     cdef Observable_stat_non_bonded total_energy_non_bonded
     cdef void master_energy_calc()
-    cdef void init_energies(Observable_stat * stat)
     double calculate_current_potential_energy_of_system()
 
 cdef extern from "dpd.hpp":

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -43,8 +43,7 @@ cdef extern from "particle_data.hpp":
     int max_seen_particle_type
 
 cdef extern from "Observable_stat.hpp":
-    ctypedef struct Observable_stat:
-        void realloc_and_clear()
+    cdef cppclass Observable_stat_wrapper:
         cbool is_initialized
         cbool v_comp
         Span[double] kinetic
@@ -60,8 +59,7 @@ cdef extern from "Observable_stat.hpp":
         Span[double] bonded_contribution(int bond_id)
         Span[double] non_bonded_contribution(int type1, int type2)
 
-    ctypedef struct Observable_stat_non_bonded:
-        void realloc_and_clear()
+    cdef cppclass Observable_stat_non_bonded_wrapper:
         Span[double] non_bonded_intra_contribution(int type1, int type2)
         Span[double] non_bonded_inter_contribution(int type1, int type2)
 
@@ -100,16 +98,16 @@ cdef extern from "statistics_chain.hpp":
     array2 calc_rh(int, int, int)
 
 cdef extern from "pressure.hpp":
-    cdef Observable_stat total_pressure
-    cdef Observable_stat_non_bonded total_pressure_non_bonded
-    cdef Observable_stat total_p_tensor
-    cdef Observable_stat_non_bonded total_p_tensor_non_bonded
+    cdef Observable_stat_wrapper obs_scalar_pressure
+    cdef Observable_stat_non_bonded_wrapper obs_scalar_pressure_non_bonded
+    cdef Observable_stat_wrapper obs_stress_tensor
+    cdef Observable_stat_non_bonded_wrapper obs_stress_tensor_non_bonded
     cdef void update_pressure(cbool)
 
 cdef extern from "energy.hpp":
-    cdef Observable_stat total_energy
-    cdef Observable_stat_non_bonded total_energy_non_bonded
-    cdef void master_energy_calc()
+    cdef Observable_stat_wrapper obs_energy
+    # cdef Observable_stat_non_bonded_wrapper obs_energy_non_bonded
+    cdef void update_energy()
     double calculate_current_potential_energy_of_system()
 
 cdef extern from "dpd.hpp":

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -21,6 +21,7 @@
 
 from .utils cimport Vector3i, Vector3d, Vector9d
 from libcpp.vector cimport vector  # import std::vector as vector
+from libcpp cimport bool as cbool
 
 cdef extern from "<array>" namespace "std" nogil:
     cdef cppclass array4 "std::array<double, 4>":
@@ -43,7 +44,8 @@ cdef extern from "particle_data.hpp":
 
 cdef extern from "Observable_stat.hpp":
     ctypedef struct Observable_stat:
-        int init_status
+        cbool is_initialized
+        cbool v_comp
         vector[double] data
         size_t n_coulomb
         size_t n_dipolar
@@ -101,7 +103,7 @@ cdef extern from "pressure.hpp":
     cdef Observable_stat_non_bonded total_pressure_non_bonded
     cdef Observable_stat total_p_tensor
     cdef Observable_stat_non_bonded total_p_tensor_non_bonded
-    cdef void update_pressure(int)
+    cdef void update_pressure(cbool)
 
 cdef extern from "energy.hpp":
     cdef Observable_stat total_energy

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -58,18 +58,17 @@ cdef extern from "statistics.hpp":
         double * dipolar
         double * virtual_sites
         double * external_fields
+        double * bonded_ia(int bond_id)
+        double * nonbonded_ia(int type1, int type2)
 
     ctypedef struct Observable_stat_non_bonded:
-        pass
+        double * nonbonded_intra_ia(int type1, int type2)
+        double * nonbonded_inter_ia(int type1, int type2)
 
     cdef vector[double] calc_structurefactor(PartCfg & , const vector[int] & p_types, int order)
     cdef vector[vector[double]] modify_stucturefactor(int order, double * sf)
     cdef double mindist(PartCfg & , const vector[int] & set1, const vector[int] & set2)
     cdef vector[int] nbhood(PartCfg & , const Vector3d & pos, double r_catch, const Vector3i & planedims)
-    cdef double * obsstat_bonded(Observable_stat * stat, int j)
-    cdef double * obsstat_nonbonded(Observable_stat * stat, int i, int j)
-    cdef double * obsstat_nonbonded_inter(Observable_stat_non_bonded * stat, int i, int j)
-    cdef double * obsstat_nonbonded_intra(Observable_stat_non_bonded * stat, int i, int j)
     cdef vector[double] calc_linear_momentum(int include_particles, int include_lbfluid)
     cdef vector[double] centerofmass(PartCfg & , int part_type)
 

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -19,7 +19,7 @@
 
 # For C-extern Analysis
 
-from .utils cimport Vector3i, Vector3d, Vector9d
+from .utils cimport Vector3i, Vector3d, Vector9d, Span
 from libcpp.vector cimport vector  # import std::vector as vector
 from libcpp cimport bool as cbool
 
@@ -46,7 +46,13 @@ cdef extern from "Observable_stat.hpp":
     ctypedef struct Observable_stat:
         cbool is_initialized
         cbool v_comp
-        vector[double] data
+        Span[double] first_field()
+        double accumulate(...)
+        double accumulate2 "accumulate"(double acc, size_t from_)
+        double accumulate1 "accumulate"(double acc)
+        double accumulate_along_dim(...)
+        double accumulate_along_dim2 "accumulate_along_dim"(double acc, size_t from_)
+        double accumulate_along_dim1 "accumulate_along_dim"(double acc)
         size_t n_coulomb
         size_t n_dipolar
         size_t n_non_bonded

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -46,29 +46,25 @@ cdef extern from "Observable_stat.hpp":
     ctypedef struct Observable_stat:
         cbool is_initialized
         cbool v_comp
-        Span[double] first_field()
+        Span[double] kinetic
+        Span[double] bonded
+        Span[double] non_bonded
+        Span[double] coulomb
+        Span[double] dipolar
+        Span[double] virtual_sites
+        Span[double] external_fields
         double accumulate(...)
         double accumulate2 "accumulate"(double acc, size_t from_)
         double accumulate1 "accumulate"(double acc)
         double accumulate_along_dim(...)
         double accumulate_along_dim2 "accumulate_along_dim"(double acc, size_t from_)
         double accumulate_along_dim1 "accumulate_along_dim"(double acc)
-        size_t n_coulomb
-        size_t n_dipolar
-        size_t n_non_bonded
-        size_t n_virtual_sites
-        double * bonded
-        double * non_bonded
-        double * coulomb
-        double * dipolar
-        double * virtual_sites
-        double * external_fields
-        double * bonded_ia(int bond_id)
-        double * nonbonded_ia(int type1, int type2)
+        Span[double] bonded_contribution(int bond_id)
+        Span[double] non_bonded_contribution(int type1, int type2)
 
     ctypedef struct Observable_stat_non_bonded:
-        double * nonbonded_intra_ia(int type1, int type2)
-        double * nonbonded_inter_ia(int type1, int type2)
+        Span[double] non_bonded_intra_contribution(int type1, int type2)
+        Span[double] non_bonded_inter_contribution(int type1, int type2)
 
 cdef extern from "statistics.hpp":
     int get_n_part_conf()

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -97,16 +97,20 @@ cdef extern from "statistics_chain.hpp":
     array4 calc_rg(int, int, int) except +
     array2 calc_rh(int, int, int)
 
-cdef extern from "pressure.hpp":
+cdef extern from "pressure_inline.hpp":
     cdef Observable_stat_wrapper obs_scalar_pressure
     cdef Observable_stat_non_bonded_wrapper obs_scalar_pressure_non_bonded
     cdef Observable_stat_wrapper obs_stress_tensor
     cdef Observable_stat_non_bonded_wrapper obs_stress_tensor_non_bonded
+
+cdef extern from "pressure.hpp":
     cdef void update_pressure(cbool)
 
-cdef extern from "energy.hpp":
+cdef extern from "energy_inline.hpp":
     cdef Observable_stat_wrapper obs_energy
     # cdef Observable_stat_non_bonded_wrapper obs_energy_non_bonded
+
+cdef extern from "energy.hpp":
     cdef void update_energy()
     double calculate_current_potential_energy_of_system()
 

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -108,7 +108,6 @@ cdef extern from "pressure.hpp":
 
 cdef extern from "energy_inline.hpp":
     cdef Observable_stat_wrapper obs_energy
-    # cdef Observable_stat_non_bonded_wrapper obs_energy_non_bonded
 
 cdef extern from "energy.hpp":
     cdef void update_energy()

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -48,10 +48,10 @@ cdef extern from "statistics.hpp":
     ctypedef struct Observable_stat:
         int init_status
         vector[double] data
-        int n_coulomb
-        int n_dipolar
-        int n_non_bonded
-        int n_virtual_sites
+        size_t n_coulomb
+        size_t n_dipolar
+        size_t n_non_bonded
+        size_t n_virtual_sites
         double * bonded
         double * non_bonded
         double * coulomb

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -55,11 +55,8 @@ cdef extern from "Observable_stat.hpp":
         Span[double] virtual_sites
         Span[double] external_fields
         double accumulate(...)
-        double accumulate2 "accumulate"(double acc, size_t from_)
+        double accumulate2 "accumulate"(double acc, size_t column)
         double accumulate1 "accumulate"(double acc)
-        double accumulate_along_dim(...)
-        double accumulate_along_dim2 "accumulate_along_dim"(double acc, size_t from_)
-        double accumulate_along_dim1 "accumulate_along_dim"(double acc)
         Span[double] bonded_contribution(int bond_id)
         Span[double] non_bonded_contribution(int type1, int type2)
 

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -41,10 +41,7 @@ cdef extern from "partCfg_global.hpp":
 cdef extern from "particle_data.hpp":
     int max_seen_particle_type
 
-cdef extern from "statistics.hpp":
-    int get_n_part_conf()
-    int get_n_configs()
-
+cdef extern from "Observable_stat.hpp":
     ctypedef struct Observable_stat:
         int init_status
         vector[double] data
@@ -64,6 +61,10 @@ cdef extern from "statistics.hpp":
     ctypedef struct Observable_stat_non_bonded:
         double * nonbonded_intra_ia(int type1, int type2)
         double * nonbonded_inter_ia(int type1, int type2)
+
+cdef extern from "statistics.hpp":
+    int get_n_part_conf()
+    int get_n_configs()
 
     cdef vector[double] calc_structurefactor(PartCfg & , const vector[int] & p_types, int order)
     cdef vector[vector[double]] modify_stucturefactor(int order, double * sf)

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -244,12 +244,13 @@ class Analysis:
         total_bonded = 0
         for i in range(bonded_ia_params.size()):
             if bonded_ia_params[i].type != BONDED_IA_NONE:
-                p["bonded", i] = analyze.obsstat_bonded( & analyze.total_pressure, i)[0]
-                total_bonded += analyze.obsstat_bonded( & analyze.total_pressure, i)[0]
+                p["bonded", i] = analyze.total_pressure.bonded_ia(i)[0]
+                total_bonded += analyze.total_pressure.bonded_ia(i)[0]
         p["bonded"] = total_bonded
 
         # Non-Bonded interactions, total as well as intra and inter molecular
         cdef int j
+        cdef double val
         cdef double total_intra
         cdef double total_inter
         cdef double total_non_bonded
@@ -259,13 +260,17 @@ class Analysis:
 
         for i in range(analyze.max_seen_particle_type):
             for j in range(i, analyze.max_seen_particle_type):
-                #      if checkIfParticlesInteract(i, j):
-                p["non_bonded", i, j] = analyze.obsstat_nonbonded( & analyze.total_pressure, i, j)[0]
-                total_non_bonded += analyze.obsstat_nonbonded( & analyze.total_pressure, i, j)[0]
-                total_intra += analyze.obsstat_nonbonded_intra( & analyze.total_pressure_non_bonded, i, j)[0]
-                p["non_bonded_intra", i, j] = analyze.obsstat_nonbonded_intra( & analyze.total_pressure_non_bonded, i, j)[0]
-                p["non_bonded_inter", i, j] = analyze.obsstat_nonbonded_inter( & analyze.total_pressure_non_bonded, i, j)[0]
-                total_inter += analyze.obsstat_nonbonded_inter( & analyze.total_pressure_non_bonded, i, j)[0]
+                val = analyze.total_pressure.nonbonded_ia(i, j)[0]
+                p["non_bonded", i, j] = val
+                total_non_bonded += val
+                val = analyze.total_pressure_non_bonded.nonbonded_intra_ia(i, j)[
+                    0]
+                total_intra += val
+                p["non_bonded_intra", i, j] = val
+                val = analyze.total_pressure_non_bonded.nonbonded_inter_ia(i, j)[
+                    0]
+                total_inter += val
+                p["non_bonded_inter", i, j] = val
         p["non_bonded_intra"] = total_intra
         p["non_bonded_inter"] = total_inter
         p["non_bonded"] = total_non_bonded
@@ -359,7 +364,7 @@ class Analysis:
         for i in range(bonded_ia_params.size()):
             if bonded_ia_params[i].type != BONDED_IA_NONE:
                 p["bonded", i] = np.reshape(create_nparray_from_double_array(
-                    analyze.obsstat_bonded( & analyze.total_p_tensor, i), 9),
+                    analyze.total_p_tensor.bonded_ia(i), 9),
                     (3, 3))
                 total_bonded += p["bonded", i]
         p["bonded"] = total_bonded
@@ -374,20 +379,18 @@ class Analysis:
             for j in range(i, analyze.max_seen_particle_type):
                 #      if checkIfParticlesInteract(i, j):
                 p["non_bonded", i, j] = np.reshape(
-                    create_nparray_from_double_array(analyze.obsstat_nonbonded(
-                        & analyze.total_p_tensor, i, j), 9), (3, 3))
+                    create_nparray_from_double_array(
+                        analyze.total_p_tensor.nonbonded_ia(i, j), 9), (3, 3))
                 total_non_bonded += p["non_bonded", i, j]
 
                 p["non_bonded_intra", i, j] = np.reshape(
                     create_nparray_from_double_array(
-                        analyze.obsstat_nonbonded_intra(
-                            & analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
+                        analyze.total_p_tensor_non_bonded.nonbonded_intra_ia(i, j), 9), (3, 3))
                 total_non_bonded_intra += p["non_bonded_intra", i, j]
 
                 p["non_bonded_inter", i, j] = np.reshape(
                     create_nparray_from_double_array(
-                        analyze.obsstat_nonbonded_inter(
-                            & analyze.total_p_tensor_non_bonded, i, j), 9), (3, 3))
+                        analyze.total_p_tensor_non_bonded.nonbonded_inter_ia(i, j), 9), (3, 3))
                 total_non_bonded_inter += p["non_bonded_inter", i, j]
 
         p["non_bonded_intra"] = total_non_bonded_intra
@@ -487,12 +490,13 @@ class Analysis:
         total_bonded = 0
         for i in range(bonded_ia_params.size()):
             if bonded_ia_params[i].type != BONDED_IA_NONE:
-                e["bonded", i] = analyze.obsstat_bonded( & analyze.total_energy, i)[0]
-                total_bonded += analyze.obsstat_bonded( & analyze.total_energy, i)[0]
+                e["bonded", i] = analyze.total_energy.bonded_ia(i)[0]
+                total_bonded += analyze.total_energy.bonded_ia(i)[0]
         e["bonded"] = total_bonded
 
         # Non-Bonded interactions, total as well as intra and inter molecular
         cdef int j
+        cdef double val
         cdef double total_intra
         cdef double total_inter
         cdef double total_non_bonded
@@ -501,15 +505,16 @@ class Analysis:
         total_non_bonded = 0.
 
         for i in range(analyze.max_seen_particle_type):
-            for j in range(analyze.max_seen_particle_type):
-                #      if checkIfParticlesInteract(i, j):
-                e["non_bonded", i, j] = analyze.obsstat_nonbonded( & analyze.total_energy, i, j)[0]
-                if i <= j:
-                    total_non_bonded += analyze.obsstat_nonbonded( & analyze.total_energy, i, j)[0]
-        #       total_intra +=analyze.obsstat_nonbonded_intra(&analyze.total_energy_non_bonded, i, j)[0]
-        #       e["non_bonded_intra",i,j] =analyze.obsstat_nonbonded_intra(&analyze.total_energy_non_bonded, i, j)[0]
-        #       e["nonBondedInter",i,j] =analyze.obsstat_nonbonded_inter(&analyze.total_energy_non_bonded, i, j)[0]
-        #       total_inter+= analyze.obsstat_nonbonded_inter(&analyze.total_energy_non_bonded, i, j)[0]
+            for j in range(i, analyze.max_seen_particle_type):
+                val = analyze.total_energy.nonbonded_ia(i, j)[0]
+                e["non_bonded", i, j] = val
+                total_non_bonded += val
+        #       val = analyze.total_energy_non_bonded.nonbonded_intra_ia(i, j)[0]
+        #       e["non_bonded_intra",i,j] = val
+        #       total_intra += val
+        #       val = analyze.total_energy_non_bonded.nonbonded_inter_ia(i, j)[0]
+        #       e["nonBondedInter",i,j] = val
+        #       total_inter += val
         # e["nonBondedIntra"]=total_intra
         # e["nonBondedInter"]=total_inter
         e["non_bonded"] = total_non_bonded

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -295,7 +295,7 @@ class Analysis:
             for i in range(analyze.total_pressure.n_virtual_sites):
                 p_vs += analyze.total_pressure.virtual_sites[i]
                 p["virtual_sites", i] = analyze.total_pressure.virtual_sites[
-                    0]
+                    i]
             if analyze.total_pressure.n_virtual_sites:
                 p["virtual_sites"] = p_vs
 

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -215,15 +215,14 @@ class Analysis:
             * ``"virtual_sites"``: Stress contribution due to virtual sites
 
         """
-        v_comp = int(v_comp)
-
-        check_type_or_throw_except(v_comp, 1, int, "v_comp must be a boolean")
+        check_type_or_throw_except(v_comp, 1, bool, "v_comp must be a boolean")
 
         # Dict to store the results
         p = OrderedDict()
 
         # Update in ESPResSo core if necessary
-        if analyze.total_pressure.init_status != 1 + v_comp:
+        if not (
+                analyze.total_pressure.is_initialized and analyze.total_pressure.v_comp == v_comp):
             analyze.update_pressure(v_comp)
 
         # Individual components of the pressure
@@ -332,15 +331,14 @@ class Analysis:
             * ``"virtual_sites"``: Stress tensor contribution for virtual sites
 
         """
-        v_comp = int(v_comp)
-
-        check_type_or_throw_except(v_comp, 1, int, "v_comp must be a boolean")
+        check_type_or_throw_except(v_comp, 1, bool, "v_comp must be a boolean")
 
         # Dict to store the results
         p = OrderedDict()
 
         # Update in ESPResSo core if necessary
-        if analyze.total_p_tensor.init_status != 1 + v_comp:
+        if not (
+                analyze.total_p_tensor.is_initialized and analyze.total_p_tensor.v_comp == v_comp):
             analyze.update_pressure(v_comp)
 
         # Individual components of the pressure
@@ -467,7 +465,7 @@ class Analysis:
 
         e = OrderedDict()
 
-        if analyze.total_energy.init_status == 0:
+        if not analyze.total_energy.is_initialized:
             analyze.init_energies( & analyze.total_energy)
             analyze.master_energy_calc()
             handle_errors("calc_long_range_energies failed")

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -226,12 +226,12 @@ class Analysis:
                 analyze.obs_scalar_pressure.is_initialized and analyze.obs_scalar_pressure.v_comp == v_comp):
             analyze.update_pressure(v_comp)
 
-        # Individual components of the pressure
-
         # Total pressure
         p["total"] = analyze.obs_scalar_pressure.accumulate()
 
-        # kinetic
+        # Individual components of the pressure
+
+        # Kinetic
         p["kinetic"] = analyze.obs_scalar_pressure.kinetic[0]
 
         # Bonded
@@ -340,8 +340,6 @@ class Analysis:
                 analyze.obs_stress_tensor.is_initialized and analyze.obs_stress_tensor.v_comp == v_comp):
             analyze.update_pressure(v_comp)
 
-        # Individual components of the pressure
-
         # Total pressure
         cdef int i
         total = np.zeros(9)
@@ -350,7 +348,9 @@ class Analysis:
 
         p["total"] = total.reshape((3, 3))
 
-        # kinetic
+        # Individual components of the pressure
+
+        # Kinetic
         p["kinetic"] = create_nparray_from_double_span(
             analyze.obs_stress_tensor.kinetic).reshape((3, 3))
 
@@ -456,15 +456,12 @@ class Analysis:
         >>> print(energy["external_fields"])
 
         """
-        #  assert len(self._system.part), "no particles in the system"
 
         e = OrderedDict()
 
         if not analyze.obs_energy.is_initialized:
             analyze.update_energy()
             handle_errors("calc_long_range_energies failed")
-
-        # Individual components of the pressure
 
         # Total energy
         cdef int i
@@ -473,6 +470,8 @@ class Analysis:
 
         e["total"] = total
         e["external_fields"] = analyze.obs_energy.external_fields[0]
+
+        # Individual components of the energy
 
         # Kinetic energy
         e["kinetic"] = analyze.obs_energy.kinetic[0]
@@ -488,13 +487,9 @@ class Analysis:
                 total_bonded += val
         e["bonded"] = total_bonded
 
-        # Non-Bonded interactions, total as well as intra and inter molecular
+        # Total non-bonded interactions
         cdef int j
-        # cdef double total_intra
-        # cdef double total_inter
         cdef double total_non_bonded
-        # total_inter = 0
-        # total_intra = 0
         total_non_bonded = 0.
 
         for i in range(analyze.max_seen_particle_type):
@@ -502,14 +497,6 @@ class Analysis:
                 val = analyze.obs_energy.non_bonded_contribution(i, j)[0]
                 e["non_bonded", i, j] = val
                 total_non_bonded += val
-        #       val = analyze.obs_energy_non_bonded.non_bonded_intra_contribution(i, j)[0]
-        #       e["non_bonded_intra",i,j] = val
-        #       total_intra += val
-        #       val = analyze.obs_energy_non_bonded.non_bonded_inter_contribution(i, j)[0]
-        #       e["nonBondedInter",i,j] = val
-        #       total_inter += val
-        # e["nonBondedIntra"] = total_intra
-        # e["nonBondedInter"] = total_inter
         e["non_bonded"] = total_non_bonded
 
         # Electrostatics

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -345,7 +345,7 @@ class Analysis:
         cdef int i
         total = np.zeros(9)
         for i in range(9):
-            total[i] = analyze.total_p_tensor.accumulate_along_dim(0.0, i)
+            total[i] = analyze.total_p_tensor.accumulate(0.0, i)
 
         p["total"] = total.reshape((3, 3))
 

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -460,7 +460,7 @@ class Analysis:
         e = OrderedDict()
 
         if not analyze.total_energy.is_initialized:
-            analyze.init_energies( & analyze.total_energy)
+            analyze.total_energy.realloc_and_clear()
             analyze.master_energy_calc()
             handle_errors("calc_long_range_energies failed")
 

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -38,6 +38,7 @@ cdef extern from "utils/Span.hpp" namespace "Utils":
     Span[const T] make_const_span[T](T * , size_t)
 
 cdef np.ndarray create_nparray_from_double_array(double * x, int n)
+cdef np.ndarray create_nparray_from_double_span(Span[double] x)
 cpdef check_type_or_throw_except(x, n, t, msg)
 cdef check_range_or_except(D, x, v_min, incl_min, v_max, incl_max)
 

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -54,11 +54,11 @@ cpdef check_type_or_throw_except(x, n, t, msg):
 
 cdef np.ndarray create_nparray_from_double_array(double * x, int len_x):
     """
-    Returns a numpy array from double array
+    Returns a numpy array from double array.
 
     Parameters
     ----------
-    x : double* which is to be converted
+    x : C-style array of type double which is to be converted
     len_x: len of array
 
     """
@@ -66,6 +66,17 @@ cdef np.ndarray create_nparray_from_double_array(double * x, int len_x):
     for i in range(len_x):
         numpyArray[i] = x[i]
     return numpyArray
+
+cdef np.ndarray create_nparray_from_double_span(Span[double] x):
+    """
+    Returns a numpy array from double span.
+
+    Parameters
+    ----------
+    x : Span of type double which is to be converted
+
+    """
+    return create_nparray_from_double_array(x.data(), x.size())
 
 cdef check_range_or_except(D, name, v_min, incl_min, v_max, incl_max):
     """

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -86,8 +86,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["kinetic"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 3., delta=1e-7)
-        self.assertAlmostEqual(
-            energy["non_bonded", 0, 1], energy["non_bonded", 1, 0], delta=1e-7)
+        self.assertAlmostEqual(energy["non_bonded", 0, 1], 1., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded", 0, 0]
                                + energy["non_bonded", 0, 1]
                                + energy["non_bonded", 1, 1], energy["total"], delta=1e-7)


### PR DESCRIPTION
Description of changes:
- convert `Observable_stat` structs to self-contained classes
   - remove manual memory management when resizing `Observable_stat` objects
   - replace hazardous raw pointers by `Utils::Span`
   - hide observable implementation details
      - accumulation of the flat array and MPI reduction are done by the class
      - finding the contribution of specific bonded/non-bonded IAs is done by the class
- dependency inversions
   - replace manually-curated `Observable_stat` list in `invalidate_obs()` by a self-updating callback list
   - decouple observables from the pressure/energy/coulomb/dipolar frameworks
   - remove most `statistics.hpp` includes (it's now only visible to 9 source files)
- analysis `energy()` now returns the lower triangle of the non-bonded IAs, to be consistent with `pressure()` and `stress_tensor()`
- improve Doxygen documentation of the pressure/energy/coulomb/dipolar frameworks