### PR TITLE
Fix OpenGL visualization of Slitpore

### DIFF
--- a/doc/sphinx/constraints.rst
+++ b/doc/sphinx/constraints.rst
@@ -311,12 +311,9 @@ Two parallel infinite planes, connected by a cylindrical orifice. The cylinder
 is connected to the planes by torus segments with an adjustable radius.
 
 Length and radius of the cylindrical pore can be set via the corresponding parameters
-(``length`` and ``radius``). The parameter ``center`` defines the central point of the pore.
+``length`` and ``radius``. The parameter ``center`` defines the central point of the pore.
 The orientation of the pore is given by the vector ``axis``, which points along the cylinder's symmetry axis.
-The pore openings are smoothed with torus segments, the radius of which can be set using the parameter ``smoothing_radius``.
-In the OpenGL visualizer, these torus segments are rendered as a half-torus instead of a quarter-torus.
-You can safely ignore this visual artifact, in the force/energy calculation, only a quarter-torus is used.
-
+The pore openings are smoothed with radius ``smoothing_radius``.
 
 .. figure:: figures/shape-simplepore.png
    :alt: Example constraint with a ``SimplePore`` shape.
@@ -331,6 +328,10 @@ Pictured is an example constraint with a ``SimplePore`` shape created with ::
                       smoothing_radius=2,
                       center=[25, 25, 25])
     system.constraints.add(shape=pore, particle_type=0, penetrable=True)
+
+Note: in the OpenGL visualizer, if the OpenGL Extrusion library is not available,
+the smooth pore openings will be rendered using a sliced torus. You can safely
+ignore this visual artifact, it has no impact on the force/energy calculation.
 
 
 Stomatocyte
@@ -466,6 +467,9 @@ are described in the shape's class :class:`espressomd.shapes.HollowConicalFrustu
    :alt: Schematic for the conical frustum shape showing geometrical parameters
    :align: center
    :height: 6.00000cm
+
+Note: in the OpenGL visualizer, if the OpenGL Extrusion library is not available,
+the shape surface will be rendered with dots.
 
 
 Union

--- a/doc/sphinx/constraints.rst
+++ b/doc/sphinx/constraints.rst
@@ -336,6 +336,10 @@ ignore this visual artifact, it has no impact on the force/energy calculation.
 Stomatocyte
 """""""""""
 
+.. note::
+
+    Requires ``EXPERIMENTAL_FEATURES``.
+
 :class:`espressomd.shapes.Stomatocyte`
 
 A stomatocyte-shaped boundary surface.
@@ -343,13 +347,19 @@ This command should be used with care.
 The position can be any point in the simulation box and is set via the (3,) array_like parameter ``center``.
 The orientation of the (cylindrically symmetric) stomatocyte is given by an ``axis`` (a (3,) array_like of :obj:`float`),
 which points in the direction of the symmetry axis and does not need to be normalized.
-The parameters: ``outer_radius``, ``inner_radius``, and ``layer_width``, specify the shape of the stomatocyte.
-Here inappropriate choices of these parameters can yield undesired results.
+Parameters ``outer_radius``, ``inner_radius``, and ``layer_width`` specify the
+shape of the stomatocyte. Here inappropriate choices of parameters can yield
+undesired results, such as discontinuous shapes or NaN values. Always use
+values greater than 1 for ``inner_radius`` to avoid NaN values.
 The width ``layer_width`` is used as a scaling parameter.
 That is, a stomatocyte given by ``outer_radius:inner_radius:layer_width`` = 7:3:1
 is half the size of the stomatocyte given by 7:3:2.
-Not all choices of the parameters give reasonable values for the shape of the stomatocyte,
+
+Not all choices of parameters give reasonable values for the shape of the stomatocyte,
 but the combination 7:3:1 is a good point to start from when trying to modify the shape.
+If you observe jumps in forces for particles inside the stomatocyte cavity,
+your parameters are most likely wrong, in which case the OpenGL visualizer
+will typically fail to draw dots inside the stomatocyte cavity.
 
 
 .. figure:: figures/shape-stomatocyte1.png

--- a/doc/sphinx/constraints.rst
+++ b/doc/sphinx/constraints.rst
@@ -194,7 +194,7 @@ vector so that the product of ``dist`` and ``normal`` is a point on the surface.
 Therefore negative distances are quite common!
 
 .. figure:: figures/shape-wall.png
-   :alt: Example constraint with a ``Wall`` shape.
+   :alt: Visualization of a constraint with a ``Wall`` shape.
    :align: center
    :height: 6.00000cm
 
@@ -220,7 +220,7 @@ and ``+1`` for outward.
 .. _shape-sphere:
 
 .. figure:: figures/shape-sphere.png
-   :alt: Example constraint with a ``Sphere`` shape.
+   :alt: Visualization of a constraint with a Sphere shape.
    :align: center
    :height: 6.00000cm
 
@@ -243,7 +243,7 @@ The distance to the surface is determined iteratively via Newton's method.
 .. _shape-ellipsoid:
 
 .. figure:: figures/shape-ellipsoid.png
-   :alt: Example constraint with an ``Ellipsoid`` shape.
+   :alt: Visualization of a constraint with an Ellipsoid shape.
    :align: center
    :height: 6.00000cm
 
@@ -263,9 +263,8 @@ The ``axis`` parameter is a vector along the cylinder axis, which is normalized 
 The direction ``direction`` determines the force direction, ``-1`` for inward and ``+1`` for outward.
 
 
-
 .. figure:: figures/shape-cylinder.png
-   :alt: Example constraint with a ``Cylinder`` shape.
+   :alt: Visualization of a constraint with a Cylinder shape.
    :align: center
    :height: 6.00000cm
 
@@ -316,7 +315,7 @@ The orientation of the pore is given by the vector ``axis``, which points along 
 The pore openings are smoothed with radius ``smoothing_radius``.
 
 .. figure:: figures/shape-simplepore.png
-   :alt: Example constraint with a ``SimplePore`` shape.
+   :alt: Visualization of a constraint with a SimplePore shape.
    :align: center
    :height: 6.00000cm
 
@@ -354,12 +353,12 @@ but the combination 7:3:1 is a good point to start from when trying to modify th
 
 
 .. figure:: figures/shape-stomatocyte1.png
-   :alt: Example constraint with a ``Stomatocyte`` shape.
+   :alt: Visualization of a constraint with a Stomatocyte shape.
    :align: center
    :height: 6.00000cm
 
 .. figure:: figures/shape-stomatocyte2.png
-   :alt: Close-up of the internal ``Stomatocyte`` structure.
+   :alt: Close-up view of the internal Stomatocyte structure.
    :align: center
    :height: 6.00000cm
 
@@ -389,7 +388,7 @@ The region is described as a pore (lower vertical part of the "T"-shape) and a c
 .. _figure-slitpore:
 
 .. figure:: figures/slitpore.png
-   :alt: Schematic for the slitpore shape showing geometrical parameters
+   :alt: Schematic for the Slitpore shape with labeled geometrical parameters.
    :align: center
    :height: 6.00000cm
 
@@ -404,7 +403,7 @@ The meaning of the geometrical parameters can be inferred from the schematic in 
 
 
 .. figure:: figures/shape-slitpore.png
-   :alt: Example constraint with a ``Slitpore`` shape.
+   :alt: Visualization of a constraint with a Slitpore shape.
    :align: center
    :height: 6.00000cm
 
@@ -436,7 +435,7 @@ The direction ``direction`` determines the force direction, ``-1`` for inward an
 
 
 .. figure:: figures/shape-spherocylinder.png
-   :alt: Example constraint with a ``SpheroCylinder`` shape.
+   :alt: Visualization of a constraint with a SpheroCylinder shape.
    :align: center
    :height: 6.00000cm
 
@@ -459,12 +458,12 @@ A hollow cone with round corners. The specific parameters
 are described in the shape's class :class:`espressomd.shapes.HollowConicalFrustum`.
 
 .. figure:: figures/shape-conical_frustum.png
-   :alt: Conical frustum shape schematic.
+   :alt: Visualization of a constraint with a HollowConicalFrustum shape.
    :align: center
    :height: 6.00000cm
 
 .. figure:: figures/conical_frustum.png
-   :alt: Schematic for the conical frustum shape showing geometrical parameters
+   :alt: Schematic for the HollowConicalFrustum shape with labeled geometrical parameters.
    :align: center
    :height: 6.00000cm
 

--- a/src/python/espressomd/visualization_opengl.py
+++ b/src/python/espressomd/visualization_opengl.py
@@ -2151,7 +2151,7 @@ class Slitpore(Shape):
                 [0.5 * (self.max_box_l + self.pore_width) - self.lower_smoothing_radius,
                  0., self.pore_mouth - self.pore_length],
                 [0.5 * (self.max_box_l + self.pore_width) - self.lower_smoothing_radius,
-                 self.max_self.box_l, self.pore_mouth - self.pore_length],
+                 self.max_box_l, self.pore_mouth - self.pore_length],
                 [0.5 * (self.max_box_l - self.pore_width) + self.lower_smoothing_radius, self.max_box_l, self.pore_mouth - self.pore_length]]
             draw_plane(wall_0, self.color, self.material)
 


### PR DESCRIPTION
Description of changes:
- fix regression from the recent OpenGL visualizer cleanup PR (`Slitpore` crashes the visualizer when `lower_smoothing_radius < pore_width / 2`)
- document known visualization artifacts that depend on the OpenGL libraries available
- document known issues with `Stomatocyte`
