### PR TITLE
Build system: fail when explicitly requested optional dependencies are not found

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ default:
      CC: 'gcc-9'
      CXX: 'g++-9'
   script:
-    - export with_cuda=false myconfig=default with_coverage=true
+    - export with_cuda=false myconfig=default with_coverage=true with_scafacos=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -90,7 +90,7 @@ maxset:
      CC: 'gcc-9'
      CXX: 'g++-9'
   script:
-    - export with_cuda=false myconfig=maxset with_coverage=true
+    - export with_cuda=false myconfig=maxset with_coverage=true with_scafacos=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -103,7 +103,7 @@ no_rotation:
      CC: 'gcc-9'
      CXX: 'g++-9'
   script:
-    - export with_cuda=false myconfig=no_rotation with_coverage=true
+    - export with_cuda=false myconfig=no_rotation with_coverage=true with_scafacos=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
@@ -187,7 +187,7 @@ clang-sanitizer:
      CC: 'clang-9'
      CXX: 'clang++-9'
   script:
-    - export myconfig=maxset with_cuda=true with_cuda_compiler=clang with_coverage=false
+    - export myconfig=maxset with_cuda=true with_cuda_compiler=clang with_coverage=false with_scafacos=true
     - export with_static_analysis=true test_timeout=900 with_asan=true with_ubsan=true
     - bash maintainer/CI/build_cmake.sh
   timeout: 2h
@@ -203,7 +203,7 @@ cuda10-maxset:
      CC: 'gcc-8'
      CXX: 'g++-8'
   script:
-    - export myconfig=maxset with_cuda=true with_coverage=false test_timeout=900 srcdir=${CI_PROJECT_DIR}
+    - export myconfig=maxset with_cuda=true with_coverage=false with_scafacos=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
     - bash maintainer/CI/build_cmake.sh
   artifacts:
     paths:
@@ -223,7 +223,7 @@ cuda9-maxset:
      CXX: 'g++-6'
      GCOV: 'gcov-6'
   script:
-    - export myconfig=maxset with_cuda=true with_coverage=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
+    - export myconfig=maxset with_cuda=true with_coverage=true with_scafacos=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
     - bash maintainer/CI/build_cmake.sh
   artifacts:
     paths:
@@ -242,7 +242,7 @@ tutorials-samples-maxset:
      CC: 'gcc-8'
      CXX: 'g++-8'
   script:
-    - export myconfig=maxset with_cuda=true with_coverage=false make_check_unit_tests=false make_check_python=false
+    - export myconfig=maxset with_cuda=true with_coverage=false with_scafacos=true make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=false test_timeout=1200
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -257,7 +257,7 @@ tutorials-samples-default:
      CC: 'gcc-8'
      CXX: 'g++-8'
   script:
-    - export myconfig=default with_cuda=true with_coverage=false make_check_unit_tests=false make_check_python=false
+    - export myconfig=default with_cuda=true with_coverage=false with_scafacos=true make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=false test_timeout=1200
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -274,7 +274,7 @@ tutorials-samples-empty:
      CC: 'gcc-8'
      CXX: 'g++-8'
   script:
-    - export myconfig=empty with_cuda=true with_coverage=false make_check_unit_tests=false make_check_python=false
+    - export myconfig=empty with_cuda=true with_coverage=false with_scafacos=true make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=false test_timeout=1200 with_scafacos=false
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -291,7 +291,7 @@ tutorials-samples-no-gpu:
      CC: 'gcc-8'
      CXX: 'g++-8'
   script:
-    - export myconfig=maxset with_cuda=true with_coverage=false make_check_unit_tests=false make_check_python=false
+    - export myconfig=maxset with_cuda=true with_coverage=false with_scafacos=true make_check_unit_tests=false make_check_python=false
     - export make_check_tutorials=true make_check_samples=true make_check_benchmarks=false test_timeout=1200 hide_gpu=true
     - bash maintainer/CI/build_cmake.sh
   tags:
@@ -307,7 +307,7 @@ installation:
      CC: 'gcc-8'
      CXX: 'g++-8'
   script:
-    - export myconfig=maxset with_cuda=true with_coverage=false make_check_unit_tests=false make_check_python=false
+    - export myconfig=maxset with_cuda=true with_coverage=false with_scafacos=true make_check_unit_tests=false make_check_python=false
     - export srcdir=${CI_PROJECT_DIR} build_type=Release
     - bash maintainer/CI/build_cmake.sh
     - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ include(GNUInstallDirs)
 project(ESPResSo)
 include(FindPythonModule)
 include(option_enum)
+include(option_if_available)
 if(POLICY CMP0074)
   # make find_package() use <PackageName>_ROOT variables
   cmake_policy(SET CMP0074 NEW)
@@ -69,11 +70,11 @@ set(CMAKE_FIND_FRAMEWORK LAST)
 # ##############################################################################
 
 option(WITH_PYTHON "Build with Python bindings" ON)
-option(WITH_GSL "Build with GSL support" ON)
+option_if_available(WITH_GSL "Build with GSL support" ON)
 option(WITH_CUDA "Build with GPU support" OFF)
-option(WITH_HDF5 "Build with HDF5 support" ON)
+option_if_available(WITH_HDF5 "Build with HDF5 support" ON)
 option(WITH_TESTS "Enable tests" ON)
-option(WITH_SCAFACOS "Build with Scafacos support" OFF)
+option_if_available(WITH_SCAFACOS "Build with ScaFaCoS support" OFF)
 option(WITH_BENCHMARKS "Enable benchmarks" OFF)
 option(WITH_VALGRIND_INSTRUMENTATION
        "Build with valgrind instrumentation markers" OFF)
@@ -186,17 +187,34 @@ endif()
 
 # We need the parallel hdf5 version!
 if(WITH_HDF5)
+  # The FindHDF5 function will fall back to the serial version if no parallel
+  # version was found, and print to the CMake log that HDF5 was found. There is
+  # no QUIET argument to override that message. This can be confusing to people
+  # who are not familiar with the way hdf5 is distributed in Linux package
+  # repositories (libhdf5-dev is the serial version).
   set(HDF5_PREFER_PARALLEL 1)
   find_package(HDF5 "1.8" COMPONENTS C)
-  if(HDF5_IS_PARALLEL)
-    set(H5MD 1)
-    include(FindPythonModule)
-    find_python_module(h5py)
-    add_feature_info(HDF5 ON "parallel")
-  else()
-    unset(H5MD)
-    unset(HDF5_FOUND)
-  endif(HDF5_IS_PARALLEL)
+  if(HDF5_FOUND)
+    if(HDF5_IS_PARALLEL)
+      set(H5MD 1)
+      include(FindPythonModule)
+      find_python_module(h5py)
+      add_feature_info(HDF5 ON "parallel")
+    else()
+      unset(H5MD)
+      set(HDF5_FOUND FALSE)
+      if(NOT WITH_HDF5_IS_DEFAULT_VALUE)
+        message(
+          FATAL_ERROR
+            "Optional dependency HDF5 explicitly requested, but parallel version not found."
+        )
+      endif()
+    endif(HDF5_IS_PARALLEL)
+  elseif(NOT WITH_HDF5_IS_DEFAULT_VALUE)
+    message(
+      FATAL_ERROR
+        "Optional dependency HDF5 explicitly requested, but not found.")
+  endif(HDF5_FOUND)
 endif(WITH_HDF5)
 
 # Check for the h5xx submodule and try to check it out if not found or update it
@@ -220,6 +238,10 @@ if(WITH_SCAFACOS)
   pkg_check_modules(SCAFACOS scafacos)
   if(SCAFACOS_FOUND)
     set(SCAFACOS 1)
+  elseif(NOT WITH_SCAFACOS_IS_DEFAULT_VALUE)
+    message(
+      FATAL_ERROR
+        "Optional dependency ScaFaCoS explicitly requested, but not found.")
   endif(SCAFACOS_FOUND)
 endif(WITH_SCAFACOS)
 
@@ -227,6 +249,10 @@ if(WITH_GSL)
   find_package(GSL)
   if(GSL_FOUND)
     set(GSL 1)
+  elseif(NOT WITH_GSL_IS_DEFAULT_VALUE)
+    message(
+      FATAL_ERROR "Optional dependency GSL explicitly requested, but not found."
+    )
   endif(GSL_FOUND)
 endif(WITH_GSL)
 

--- a/cmake/option_if_available.cmake
+++ b/cmake/option_if_available.cmake
@@ -1,0 +1,39 @@
+# Copyright (C) 2020 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Like `option()`, but create an extra boolean variable to store whether the
+# option was set to its default value or to a user-provided value. With this
+# command, the project can be installed with optional dependencies without
+# the need to provide a list of CMake flags. Unavailable dependencies will be
+# silently ignored. However, if the user specifically requested an optional
+# dependency by passing the corresponding CMake flag, the build system has
+# the possibility to throw an error if the dependency is unavailable.
+#
+# Note that when calling CMake again without clearing the build folder,
+# variables from the previous CMake call are loaded in memory. For example,
+# if the user passed a value to an `option_if_available()` the first time but
+# not the second time, the variable will still be flagged as a user-provided
+# value in the second CMake call.
+macro(option_if_available varname help_text default_value)
+  if("${${varname}}" STREQUAL "")
+    set(${varname}_IS_DEFAULT_VALUE TRUE)
+  else()
+    set(${varname}_IS_DEFAULT_VALUE FALSE)
+  endif()
+  option(${varname} ${help_text} ${default_value})
+endmacro()

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -96,7 +96,7 @@ set_default_value with_cuda false
 set_default_value with_cuda_compiler "nvcc"
 set_default_value build_type "RelWithAssert"
 set_default_value with_ccache false
-set_default_value with_scafacos true
+set_default_value with_scafacos false
 set_default_value test_timeout 300
 set_default_value hide_gpu false
 

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -23,6 +23,7 @@ cmake_params=${cmake_params}
 with_fftw=${with_fftw}
 with_coverage=false
 with_cuda=true
+with_scafacos=true
 CC=gcc-8
 CXX=g++-8
 check_procs=${check_procs}


### PR DESCRIPTION
Follow-up to #3656

Provide meaningful error messages when optional dependencies (HDF5, GSL, ScaFaCoS) are specifically requested by the user with `-DWITH_FEATURE=ON` but not found on the system.