### PR TITLE
Remove compensation flag for kinetic pressure contribution

### DIFF
--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -184,16 +184,10 @@ class Observable_stat_wrapper : public Observable_stat {
 public:
   /** Observed statistic for the current MPI rank. */
   Observable_stat local;
-  /** Flag to signal if the observable measures instantaneous pressure, i.e.
-   *  the pressure with velocity compensation (half a time step), instead of
-   *  the conventional pressure. Only relevant for NpT simulations.
-   */
-  bool v_comp;
 
   explicit Observable_stat_wrapper(size_t chunk_size, bool pressure_obs = true)
       : Observable_stat{chunk_size, pressure_obs}, local{chunk_size,
-                                                         pressure_obs},
-        v_comp(false) {}
+                                                         pressure_obs} {}
 
   /** Gather the contributions from all MPI ranks. */
   void reduce() { local.reduce(data.data()); }

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -372,7 +372,6 @@ void mpi_gather_stats(GatherStats job, double *result) {
     energy_calc(sim_time);
     break;
   case GatherStats::pressure:
-  case GatherStats::pressure_v_comp:
     mpi_call(mpi_gather_stats_slave, -1, job_slave);
     pressure_calc();
     break;
@@ -402,7 +401,6 @@ void mpi_gather_stats_slave(int, int job_slave) {
     energy_calc(sim_time);
     break;
   case GatherStats::pressure:
-  case GatherStats::pressure_v_comp:
     pressure_calc();
     break;
   case GatherStats::lb_fluid_momentum:

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -374,7 +374,7 @@ void mpi_gather_stats(GatherStats job, double *result) {
   case GatherStats::pressure:
   case GatherStats::pressure_v_comp:
     mpi_call(mpi_gather_stats_slave, -1, job_slave);
-    pressure_calc(job == GatherStats::pressure_v_comp);
+    pressure_calc();
     break;
   case GatherStats::lb_fluid_momentum:
     mpi_call(mpi_gather_stats_slave, -1, job_slave);
@@ -403,7 +403,7 @@ void mpi_gather_stats_slave(int, int job_slave) {
     break;
   case GatherStats::pressure:
   case GatherStats::pressure_v_comp:
-    pressure_calc(job == GatherStats::pressure_v_comp);
+    pressure_calc();
     break;
   case GatherStats::lb_fluid_momentum:
     lb_calc_fluid_momentum(nullptr, lbpar, lbfields, lblattice);

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -69,7 +69,6 @@ extern boost::mpi::communicator comm_cart;
 enum class GatherStats : int {
   energy,
   pressure,
-  pressure_v_comp,
   lb_fluid_momentum,
   lb_boundary_forces
 };
@@ -221,8 +220,6 @@ void mpi_bcast_max_seen_particle_type(int s);
  *           energies, using \ref energy_calc.
  *      \arg for \ref GatherStats::pressure, calculate and reduce (sum up)
  *           pressure, using \ref pressure_calc.
- *      \arg for \ref GatherStats::pressure_v_comp, calculate and reduce
- *           (sum up) instantaneous pressure, using \ref pressure_calc.
  *      \arg for \ref GatherStats::lb_fluid_momentum, use
  *           \ref lb_calc_fluid_momentum.
  *      \arg for \ref GatherStats::lb_boundary_forces, use

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -324,13 +324,6 @@ void on_parameter_change(int field) {
   case FIELD_NPTISO_PISTON:
     reinit_thermo = true;
     break;
-#ifdef NPT
-  case FIELD_INTEG_SWITCH:
-    if (integ_switch != INTEG_METHOD_NPT_ISO)
-      nptiso.invalidate_p_vel = true;
-    break;
-#endif
-    break;
   case FIELD_FORCE_CAP:
     /* If the force cap changed, forces are invalid */
     recalc_forces = true;

--- a/src/core/npt.cpp
+++ b/src/core/npt.cpp
@@ -24,7 +24,6 @@
 
 #ifdef NPT
 void synchronize_npt_state(int n_steps) {
-  nptiso.invalidate_p_vel = false;
   MPI_Bcast(&nptiso.p_inst, 1, MPI_DOUBLE, 0, comm_cart);
   MPI_Bcast(&nptiso.p_diff, 1, MPI_DOUBLE, 0, comm_cart);
   MPI_Bcast(&nptiso.volume, 1, MPI_DOUBLE, 0, comm_cart);

--- a/src/core/npt.hpp
+++ b/src/core/npt.hpp
@@ -49,10 +49,6 @@ typedef struct {
   Utils::Vector3d p_vir;
   /** ideal gas components of \ref p_inst, derived from the velocities */
   Utils::Vector3d p_vel;
-  /** flag which indicates if \ref p_vel may (false) or may not (true) be used
-   *  in offline pressure calculations such as 'analyze p_inst'
-   */
-  bool invalidate_p_vel;
   /** geometry information for the NpT integrator. Holds the vector
    *  \< dir, dir, dir \> where a positive value for dir indicates that
    *  box movement is allowed in that direction. To check whether a

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -58,7 +58,6 @@ nptiso_struct nptiso = {0.0,
                         0.0,
                         {0.0, 0.0, 0.0},
                         {0.0, 0.0, 0.0},
-                        true,
                         0,
                         {NPTGEOM_XDIR, NPTGEOM_YDIR, NPTGEOM_ZDIR},
                         0,
@@ -148,34 +147,13 @@ void master_pressure_calc(bool v_comp) {
   obs_pressure_tensor.v_comp = v_comp;
 }
 
-/** Calculate the sum of the ideal gas components of the instantaneous
- *  pressure, rescaled by the box dimensions.
- */
-double calculate_npt_p_vel_rescaled() {
-  Utils::Vector3d p_vel;
-  MPI_Reduce(nptiso.p_vel.data(), p_vel.data(), 3, MPI_DOUBLE, MPI_SUM, 0,
-             MPI_COMM_WORLD);
-  double acc = 0.0;
-  for (int i = 0; i < 3; i++)
-    if (nptiso.geometry & nptiso.nptgeom_dir[i])
-      acc += p_vel[i];
-  return acc / (nptiso.dimension * nptiso.volume);
-}
-
 void update_pressure(bool v_comp) {
   obs_scalar_pressure.resize();
   obs_scalar_pressure_non_bonded.resize();
   obs_pressure_tensor.resize();
   obs_pressure_tensor_non_bonded.resize();
 
-  if (v_comp && (integ_switch == INTEG_METHOD_NPT_ISO) &&
-      !(nptiso.invalidate_p_vel)) {
-    master_pressure_calc(false);
-    obs_scalar_pressure.kinetic[0] = calculate_npt_p_vel_rescaled();
-    obs_scalar_pressure.v_comp = true;
-  } else {
-    master_pressure_calc(v_comp);
-  }
+  master_pressure_calc(v_comp);
 }
 
 Utils::Vector9d observable_compute_pressure_tensor() {

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -28,24 +28,13 @@
 #include <utils/Vector.hpp>
 
 /** Parallel pressure calculation from a virial expansion.
- *  @param[in] v_comp flag which enables compensation of the velocities
- *                    required for deriving a pressure reflecting
- *                    \ref nptiso_struct::p_inst (hence it only works with
- *                    domain decomposition); naturally it therefore doesn't
- *                    make sense to use it without NpT.
  */
-void pressure_calc(bool v_comp);
+void pressure_calc();
 
 /** Helper function for @ref Observables::PressureTensor. */
 Utils::Vector9d observable_compute_pressure_tensor();
 
-/** Calculate the scalar pressure and pressure tensor.
- *  @param[in] v_comp flag which enables compensation of the velocities
- *                    required for deriving a pressure reflecting
- *                    \ref nptiso_struct::p_inst (hence it only works with
- *                    domain decomposition); naturally it therefore doesn't
- *                    make sense to use it without NpT.
- */
-void update_pressure(bool v_comp);
+/** Calculate the scalar pressure and pressure tensor. */
+void update_pressure();
 
 #endif

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -44,7 +44,6 @@ cdef extern from "particle_data.hpp":
 
 cdef extern from "Observable_stat.hpp":
     cdef cppclass Observable_stat_wrapper:
-        cbool v_comp
         Span[double] kinetic
         Span[double] bonded
         Span[double] non_bonded

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -91,7 +91,7 @@ cdef extern from "pressure_inline.hpp":
     cdef Observable_stat_non_bonded_wrapper obs_pressure_tensor_non_bonded
 
 cdef extern from "pressure.hpp":
-    cdef void update_pressure(cbool)
+    cdef void update_pressure()
 
 cdef extern from "energy_inline.hpp":
     cdef Observable_stat_wrapper obs_energy

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -177,7 +177,7 @@ class Analysis:
 
         return analyze.nbhood(analyze.partCfg(), c_pos, r_catch, planedims)
 
-    def pressure(self, v_comp=False):
+    def pressure(self):
         """Calculate the instantaneous pressure (in parallel). This is only
         sensible in an isotropic system which is homogeneous (on average)! Do
         not use this in an anisotropic or inhomogeneous system. In order to
@@ -204,13 +204,12 @@ class Analysis:
             * ``"virtual_sites"``: Pressure contribution due to virtual sites
 
         """
-        check_type_or_throw_except(v_comp, 1, bool, "v_comp must be a boolean")
 
         # Dict to store the results
         p = OrderedDict()
 
         # Update in ESPResSo core
-        analyze.update_pressure(v_comp)
+        analyze.update_pressure()
 
         # Total pressure
         p["total"] = analyze.obs_scalar_pressure.accumulate()
@@ -289,7 +288,7 @@ class Analysis:
 
         return p
 
-    def pressure_tensor(self, v_comp=False):
+    def pressure_tensor(self):
         """Calculate the instantaneous pressure_tensor (in parallel). This is
         sensible in an anisotropic system. Still it assumes that the system is
         homogeneous since the volume averaged pressure_tensor is used. Do not use
@@ -317,13 +316,12 @@ class Analysis:
             * ``"virtual_sites"``: pressure tensor contribution for virtual sites
 
         """
-        check_type_or_throw_except(v_comp, 1, bool, "v_comp must be a boolean")
 
         # Dict to store the results
         p = OrderedDict()
 
         # Update in ESPResSo core
-        analyze.update_pressure(v_comp)
+        analyze.update_pressure()
 
         # Total pressure
         cdef int i


### PR DESCRIPTION
Description of changes:
- Fixed kinetic pressure compensation in pressure observable
- Do not depend on NpT instantanuous pressure in pressure observable calc
- Removed no unneeded `v_comp` flag for compensated kinetic pressure
