### PR TITLE
CMake GPU dependencies inversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,9 @@ endif()
 
 target_link_libraries(cxx_interface INTERFACE coverage_interface)
 
+# Give CMAKE_CXX_FLAGS higher precedence
+target_compile_options(cxx_interface INTERFACE ${CMAKE_CXX_FLAGS})
+
 #
 # Testing
 # ##############################################################################

--- a/cmake/FindCUDACompilerClang.cmake
+++ b/cmake/FindCUDACompilerClang.cmake
@@ -77,10 +77,8 @@ function(find_gpu_library)
   endif()
 endfunction(find_gpu_library)
 
-find_library(
-  CUDART_LIBRARY NAMES cudart PATHS ${CUDA_DIR}/lib64 ${CUDA_DIR}/lib
-                                    /usr/local/nvidia/lib
-                                    /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
+find_gpu_library(VARNAME CUDA_LIBRARY NAMES cuda REQUIRED)
+find_gpu_library(VARNAME CUDART_LIBRARY NAMES cudart REQUIRED)
 find_gpu_library(VARNAME CUFFT_LIBRARY NAMES cufft REQUIRED)
 
 function(add_gpu_library)

--- a/cmake/FindCUDACompilerClang.cmake
+++ b/cmake/FindCUDACompilerClang.cmake
@@ -65,6 +65,18 @@ if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.9)
   set(gpu_interface_flags "${gpu_interface_flags} --cuda-gpu-arch=sm_52")
 endif()
 
+function(find_gpu_library)
+  cmake_parse_arguments(LIBRARY "REQUIRED" "NAMES;VARNAME" "" ${ARGN})
+  list(APPEND LIBRARY_PATHS
+       ${CUDA_DIR}/lib64 ${CUDA_DIR}/lib
+       /usr/local/nvidia/lib /usr/lib/x86_64-linux-gnu)
+  if(LIBRARY_REQUIRED)
+    find_library(${LIBRARY_VARNAME} NAMES ${LIBRARY_NAMES} PATHS ${LIBRARY_PATHS} NO_DEFAULT_PATH REQUIRED)
+  else()
+    find_library(${LIBRARY_VARNAME} NAMES ${LIBRARY_NAMES} PATHS ${LIBRARY_PATHS} NO_DEFAULT_PATH)
+  endif()
+endfunction(find_gpu_library)
+
 find_library(
   CUDART_LIBRARY NAMES cudart PATHS ${CUDA_DIR}/lib64 ${CUDA_DIR}/lib
                                     /usr/local/nvidia/lib

--- a/cmake/FindCUDACompilerClang.cmake
+++ b/cmake/FindCUDACompilerClang.cmake
@@ -81,10 +81,7 @@ find_library(
   CUDART_LIBRARY NAMES cudart PATHS ${CUDA_DIR}/lib64 ${CUDA_DIR}/lib
                                     /usr/local/nvidia/lib
                                     /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
-find_library(
-  CUFFT_LIBRARY NAMES cufft PATHS ${CUDA_DIR}/lib64 ${CUDA_DIR}/lib
-                                  /usr/local/nvidia/lib
-                                  /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
+find_gpu_library(VARNAME CUFFT_LIBRARY NAMES cufft REQUIRED)
 
 function(add_gpu_library)
   set(options STATIC SHARED MODULE EXCLUDE_FROM_ALL)

--- a/cmake/FindCUDACompilerHIP.cmake
+++ b/cmake/FindCUDACompilerHIP.cmake
@@ -51,6 +51,16 @@ list(APPEND HIP_HIPCC_FLAGS_RELWITHDEBINFO -O2 -g -DNDEBUG)
 list(APPEND HIP_HIPCC_FLAGS_COVERAGE -O3 -g)
 list(APPEND HIP_HIPCC_FLAGS_RELWITHASSERT -O3 -g)
 
+function(find_gpu_library)
+  cmake_parse_arguments(LIBRARY "REQUIRED" "NAMES;VARNAME" "" ${ARGN})
+  list(APPEND LIBRARY_PATHS ${ROCM_HOME}/lib)
+  if(LIBRARY_REQUIRED)
+    find_library(${LIBRARY_VARNAME} NAMES ${LIBRARY_NAMES} PATHS ${LIBRARY_PATHS} NO_DEFAULT_PATH REQUIRED)
+  else()
+    find_library(${LIBRARY_VARNAME} NAMES ${LIBRARY_NAMES} PATHS ${LIBRARY_PATHS} NO_DEFAULT_PATH)
+  endif()
+endfunction(find_gpu_library)
+
 find_library(ROCFFT_LIB name "rocfft" PATHS ${ROCM_HOME}/lib)
 
 function(add_gpu_library)

--- a/cmake/FindCUDACompilerHIP.cmake
+++ b/cmake/FindCUDACompilerHIP.cmake
@@ -61,7 +61,7 @@ function(find_gpu_library)
   endif()
 endfunction(find_gpu_library)
 
-find_library(ROCFFT_LIB name "rocfft" PATHS ${ROCM_HOME}/lib)
+find_gpu_library(VARNAME ROCFFT_LIB NAMES rocfft REQUIRED)
 
 function(add_gpu_library)
   hip_add_library(${ARGV})

--- a/cmake/FindCUDACompilerNVCC.cmake
+++ b/cmake/FindCUDACompilerNVCC.cmake
@@ -68,13 +68,17 @@ function(find_gpu_library)
   endif()
 endfunction(find_gpu_library)
 
+find_gpu_library(VARNAME CUDA_LIBRARY NAMES cuda REQUIRED)
+find_gpu_library(VARNAME CUDART_LIBRARY NAMES cudart REQUIRED)
 find_gpu_library(VARNAME CUDA_CUFFT_LIBRARIES NAMES cufft REQUIRED)
 
 function(add_gpu_library)
   cuda_add_library(${ARGV})
   set(GPU_TARGET_NAME ${ARGV0})
   set_property(TARGET ${GPU_TARGET_NAME} PROPERTY CUDA_SEPARABLE_COMPILATION ON)
-  target_link_libraries(${GPU_TARGET_NAME} PRIVATE ${CUDA_CUFFT_LIBRARIES} utils Boost::serialization Boost::mpi)
+  target_link_libraries(${GPU_TARGET_NAME} PRIVATE
+    ${CUDA_LIBRARY} ${CUDART_LIBRARY} ${CUDA_CUFFT_LIBRARIES}
+    utils Boost::serialization Boost::mpi)
 endfunction()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindCUDACompilerNVCC.cmake
+++ b/cmake/FindCUDACompilerNVCC.cmake
@@ -56,6 +56,18 @@ list(APPEND CUDA_NVCC_FLAGS
        $<$<BOOL:${WARNINGS_ARE_ERRORS}>:-Xcompiler=-Werror;-Xptxas=-Werror>
        $<$<BOOL:${CMAKE_OSX_SYSROOT}>:-Xcompiler=-isysroot;-Xcompiler=${CMAKE_OSX_SYSROOT}>)
 
+function(find_gpu_library)
+  cmake_parse_arguments(LIBRARY "REQUIRED" "NAMES;VARNAME" "" ${ARGN})
+  list(APPEND LIBRARY_PATHS
+       ${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/lib
+       /usr/local/nvidia/lib /usr/lib/x86_64-linux-gnu)
+  if(LIBRARY_REQUIRED)
+    find_library(${LIBRARY_VARNAME} NAMES ${LIBRARY_NAMES} PATHS ${LIBRARY_PATHS} NO_DEFAULT_PATH REQUIRED)
+  else()
+    find_library(${LIBRARY_VARNAME} NAMES ${LIBRARY_NAMES} PATHS ${LIBRARY_PATHS} NO_DEFAULT_PATH)
+  endif()
+endfunction(find_gpu_library)
+
 function(add_gpu_library)
   cuda_add_library(${ARGV})
   set(GPU_TARGET_NAME ${ARGV0})

--- a/cmake/FindCUDACompilerNVCC.cmake
+++ b/cmake/FindCUDACompilerNVCC.cmake
@@ -68,6 +68,8 @@ function(find_gpu_library)
   endif()
 endfunction(find_gpu_library)
 
+find_gpu_library(VARNAME CUDA_CUFFT_LIBRARIES NAMES cufft REQUIRED)
+
 function(add_gpu_library)
   cuda_add_library(${ARGV})
   set(GPU_TARGET_NAME ${ARGV0})

--- a/cmake/option_if_available.cmake
+++ b/cmake/option_if_available.cmake
@@ -30,10 +30,12 @@
 # not the second time, the variable will still be flagged as a user-provided
 # value in the second CMake call.
 macro(option_if_available varname help_text default_value)
-  if("${${varname}}" STREQUAL "")
-    set(${varname}_IS_DEFAULT_VALUE TRUE)
-  else()
-    set(${varname}_IS_DEFAULT_VALUE FALSE)
+  if(NOT DEFINED ${varname}_IS_DEFAULT_VALUE)
+    if("${${varname}}" STREQUAL "")
+      set(${varname}_IS_DEFAULT_VALUE TRUE CACHE INTERNAL "does ${varname} contain the default value?")
+    else()
+      set(${varname}_IS_DEFAULT_VALUE FALSE CACHE INTERNAL "does ${varname} contain the default value?")
+    endif()
   endif()
   option(${varname} ${help_text} ${default_value})
 endmacro()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -85,8 +85,8 @@ target_link_libraries(
 target_include_directories(
   EspressoCore
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-         "$<$<BOOL:${H5MD}>:${CMAKE_CURRRENT_SOURCE_DIR}/io/writer>" SYSTEM
-  PUBLIC "$<$<BOOL:${H5MD}>:${HDF5_INCLUDE_DIRS}>" SYSTEM
+         "$<$<BOOL:${H5MD}>:${CMAKE_CURRRENT_SOURCE_DIR}/io/writer>"
+  PUBLIC "$<$<BOOL:${H5MD}>:${HDF5_INCLUDE_DIRS}>"
   PRIVATE "$<$<BOOL:${FFTW3_FOUND}>:${FFTW3_INCLUDE_DIR}>")
 
 target_compile_definitions(EspressoCore PUBLIC $<$<BOOL:${H5MD}>:H5XX_USE_MPI>)

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -25,7 +25,7 @@
 #include <utils/Vector.hpp>
 
 /** @brief LB implementation currently active. */
-enum class ActiveLB { NONE, CPU, GPU };
+enum class ActiveLB : int { NONE, CPU, GPU };
 
 /** @brief Switch determining the type of lattice dynamics. */
 extern ActiveLB lattice_switch;

--- a/src/core/integrators/brownian_inline.hpp
+++ b/src/core/integrators/brownian_inline.hpp
@@ -411,14 +411,14 @@ inline Utils::Vector4d bd_random_walk_rot(BrownianThermostat const &brownian,
         sigma_pos = BrownianThermostat::sigma(p.p.T, p.p.gamma_rot);
       } else {
         // just an indication of the infinity
-        sigma_pos = Utils::Vector3d{};
+        sigma_pos = {};
       }
     } else if (temperature > 0.) {
       // Default temperature but particle-specific gamma
       sigma_pos = BrownianThermostat::sigma(temperature, p.p.gamma_rot);
     } else {
       // just an indication of the infinity
-      sigma_pos = Utils::Vector3d{};
+      sigma_pos = {};
     }
   } // particle-specific gamma
   else {
@@ -428,7 +428,7 @@ inline Utils::Vector4d bd_random_walk_rot(BrownianThermostat const &brownian,
         sigma_pos = BrownianThermostat::sigma(p.p.T, brownian.gamma_rotation);
       } else {
         // just an indication of the infinity
-        sigma_pos = Utils::Vector3d{};
+        sigma_pos = {};
       }
     } else {
       // Default values for both


### PR DESCRIPTION
Create a `find_gpu_library()` helper function to delegate GPU library inclusion in parts of the CMake tree that need them. This avoids updating `FindCUDACompiler*.cmake` files whenever a new GPU dependency is required.

Description of changes:
- fix a bug in `option_if_available()` that failed CI in the Intel build
- fix variable `CUDA_LIBRARY` (was an empty string on Clang)
- mark essential CUDA libraries as `REQUIRED`
- remove an incorrect include `-Isrc/core/SYSTEM`
- fix a compiler error in builds without feature `ROTATION`
- give `CMAKE_CXX_FLAGS` higher precedence
