### PR TITLE
Pitchfork layout: rename CMake targets

### DIFF
--- a/cmake/FindCUDACompilerNVCC.cmake
+++ b/cmake/FindCUDACompilerNVCC.cmake
@@ -78,7 +78,7 @@ function(add_gpu_library)
   set_property(TARGET ${GPU_TARGET_NAME} PROPERTY CUDA_SEPARABLE_COMPILATION ON)
   target_link_libraries(${GPU_TARGET_NAME} PRIVATE
     ${CUDA_LIBRARY} ${CUDART_LIBRARY} ${CUDA_CUFFT_LIBRARIES}
-    utils Boost::serialization Boost::mpi)
+    EspressoUtils Boost::serialization Boost::mpi)
 endfunction()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindCUDACompilerNVCC.cmake
+++ b/cmake/FindCUDACompilerNVCC.cmake
@@ -77,8 +77,7 @@ function(add_gpu_library)
   set(GPU_TARGET_NAME ${ARGV0})
   set_property(TARGET ${GPU_TARGET_NAME} PROPERTY CUDA_SEPARABLE_COMPILATION ON)
   target_link_libraries(${GPU_TARGET_NAME} PRIVATE
-    ${CUDA_LIBRARY} ${CUDART_LIBRARY} ${CUDA_CUFFT_LIBRARIES}
-    EspressoUtils Boost::serialization Boost::mpi)
+    ${CUDA_LIBRARY} ${CUDART_LIBRARY} ${CUDA_CUFFT_LIBRARIES})
 endfunction()
 
 include(FindPackageHandleStandardArgs)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(
   PRIVATE EspressoConfig EspressoShapes Profiler
           "$<$<BOOL:${FFTW3_FOUND}>:${FFTW3_LIBRARIES}>"
           $<$<BOOL:${SCAFACOS}>:Scafacos> cxx_interface
-  PUBLIC EspressoUtils MPI::MPI_CXX Random123 particle_observables
+  PUBLIC EspressoUtils MPI::MPI_CXX Random123 EspressoParticleObservables
          Boost::serialization Boost::mpi "$<$<BOOL:${H5MD}>:${HDF5_LIBRARIES}>"
          $<$<BOOL:${H5MD}>:Boost::filesystem> $<$<BOOL:${H5MD}>:h5xx>)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -75,7 +75,7 @@ install(TARGETS EspressoCore LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 target_link_libraries(
   EspressoCore
-  PRIVATE EspressoConfig shapes Profiler
+  PRIVATE EspressoConfig EspressoShapes Profiler
           "$<$<BOOL:${FFTW3_FOUND}>:${FFTW3_LIBRARIES}>"
           $<$<BOOL:${SCAFACOS}>:Scafacos> cxx_interface
   PUBLIC utils MPI::MPI_CXX Random123 particle_observables Boost::serialization

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -78,8 +78,8 @@ target_link_libraries(
   PRIVATE EspressoConfig EspressoShapes Profiler
           "$<$<BOOL:${FFTW3_FOUND}>:${FFTW3_LIBRARIES}>"
           $<$<BOOL:${SCAFACOS}>:Scafacos> cxx_interface
-  PUBLIC utils MPI::MPI_CXX Random123 particle_observables Boost::serialization
-         Boost::mpi "$<$<BOOL:${H5MD}>:${HDF5_LIBRARIES}>"
+  PUBLIC EspressoUtils MPI::MPI_CXX Random123 particle_observables
+         Boost::serialization Boost::mpi "$<$<BOOL:${H5MD}>:${HDF5_LIBRARIES}>"
          $<$<BOOL:${H5MD}>:Boost::filesystem> $<$<BOOL:${H5MD}>:h5xx>)
 
 target_include_directories(

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -28,8 +28,8 @@ unit_test(NAME RuntimeErrorCollector_test SRC RuntimeErrorCollector_test.cpp
 
 unit_test(NAME ScriptInterface_test SRC ScriptInterface_test.cpp DEPENDS
           ScriptInterface)
-unit_test(NAME MpiCallbacks_test SRC MpiCallbacks_test.cpp DEPENDS utils
-          Boost::mpi MPI::MPI_CXX NUM_PROC 2)
+unit_test(NAME MpiCallbacks_test SRC MpiCallbacks_test.cpp DEPENDS
+          EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME ParallelScriptInterface_test SRC
           ParallelScriptInterface_test.cpp DEPENDS ScriptInterface Boost::mpi
           MPI::MPI_CXX NUM_PROC 2)
@@ -39,23 +39,23 @@ unit_test(NAME AutoParameter_test SRC AutoParameter_test.cpp DEPENDS
           ScriptInterface)
 unit_test(NAME Variant_test SRC Variant_test.cpp DEPENDS ScriptInterface)
 unit_test(NAME ParticleIterator_test SRC ParticleIterator_test.cpp DEPENDS
-          utils)
-unit_test(NAME link_cell_test SRC link_cell_test.cpp DEPENDS utils)
-unit_test(NAME verlet_ia_test SRC verlet_ia_test.cpp DEPENDS utils)
-unit_test(NAME Particle_test SRC Particle_test.cpp DEPENDS utils
+          EspressoUtils)
+unit_test(NAME link_cell_test SRC link_cell_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME verlet_ia_test SRC verlet_ia_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME Particle_test SRC Particle_test.cpp DEPENDS EspressoUtils
           Boost::serialization)
 unit_test(NAME get_value SRC get_value_test.cpp DEPENDS ScriptInterface)
 unit_test(NAME field_coupling_couplings SRC field_coupling_couplings_test.cpp
-          DEPENDS utils)
+          DEPENDS EspressoUtils)
 unit_test(NAME field_coupling_fields SRC field_coupling_fields_test.cpp DEPENDS
-          utils)
+          EspressoUtils)
 unit_test(NAME field_coupling_force_field SRC
-          field_coupling_force_field_test.cpp DEPENDS utils)
+          field_coupling_force_field_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME periodic_fold_test SRC periodic_fold_test.cpp)
 unit_test(NAME None_test SRC None_test.cpp DEPENDS ScriptInterface)
 unit_test(NAME grid_test SRC grid_test.cpp DEPENDS EspressoCore)
 unit_test(NAME BoxGeometry_test SRC BoxGeometry_test.cpp DEPENDS EspressoCore)
 unit_test(NAME LocalBox_test SRC LocalBox_test.cpp DEPENDS EspressoCore)
 unit_test(NAME thermostats_test SRC thermostats_test.cpp DEPENDS EspressoCore)
-unit_test(NAME random_test SRC random_test.cpp DEPENDS utils Random123)
+unit_test(NAME random_test SRC random_test.cpp DEPENDS EspressoUtils Random123)
 unit_test(NAME BondList_test SRC BondList_test.cpp DEPENDS EspressoCore)

--- a/src/particle_observables/CMakeLists.txt
+++ b/src/particle_observables/CMakeLists.txt
@@ -1,10 +1,10 @@
-add_library(particle_observables INTERFACE)
+add_library(EspressoParticleObservables INTERFACE)
 target_include_directories(
-  particle_observables SYSTEM
+  EspressoParticleObservables SYSTEM
   INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>)
 
-install(TARGETS particle_observables
+install(TARGETS EspressoParticleObservables
         LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 if(WITH_TESTS)

--- a/src/particle_observables/tests/CMakeLists.txt
+++ b/src/particle_observables/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 include(unit_test)
 
-unit_test(NAME properties_test SRC properties.cpp DEPENDS particle_observables)
-unit_test(NAME algorithms_test SRC algorithms.cpp DEPENDS particle_observables)
+unit_test(NAME properties_test SRC properties.cpp DEPENDS
+          EspressoParticleObservables)
+unit_test(NAME algorithms_test SRC algorithms.cpp DEPENDS
+          EspressoParticleObservables)
 unit_test(NAME observables_test SRC observables.cpp DEPENDS
-          particle_observables)
+          EspressoParticleObservables)

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -18,7 +18,7 @@ install(TARGETS ScriptInterface
 
 target_link_libraries(
   ScriptInterface PRIVATE EspressoConfig EspressoCore
-  PUBLIC mpiio utils MPI::MPI_CXX EspressoShapes core_cluster_analysis
+  PUBLIC mpiio EspressoUtils MPI::MPI_CXX EspressoShapes core_cluster_analysis
   PRIVATE cxx_interface)
 
 target_include_directories(ScriptInterface PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -18,7 +18,7 @@ install(TARGETS ScriptInterface
 
 target_link_libraries(
   ScriptInterface PRIVATE EspressoConfig EspressoCore
-  PUBLIC mpiio utils MPI::MPI_CXX shapes core_cluster_analysis
+  PUBLIC mpiio utils MPI::MPI_CXX EspressoShapes core_cluster_analysis
   PRIVATE cxx_interface)
 
 target_include_directories(ScriptInterface PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/src/shapes/CMakeLists.txt
+++ b/src/shapes/CMakeLists.txt
@@ -3,13 +3,14 @@ set(SOURCE_FILES
     src/Rhomboid.cpp src/SimplePore.cpp src/Slitpore.cpp src/Sphere.cpp
     src/SpheroCylinder.cpp src/Torus.cpp src/Wall.cpp)
 
-add_library(shapes SHARED ${SOURCE_FILES})
-target_link_libraries(shapes PUBLIC utils PRIVATE Boost::boost cxx_interface)
+add_library(EspressoShapes SHARED ${SOURCE_FILES})
+target_link_libraries(EspressoShapes PUBLIC utils PRIVATE Boost::boost
+                                                          cxx_interface)
 target_include_directories(
-  shapes PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                $<INSTALL_INTERFACE:include>)
+  EspressoShapes PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                        $<INSTALL_INTERFACE:include>)
 
-install(TARGETS shapes LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
+install(TARGETS EspressoShapes LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 if(WITH_UNIT_TESTS)
   add_subdirectory(unit_tests)

--- a/src/shapes/CMakeLists.txt
+++ b/src/shapes/CMakeLists.txt
@@ -4,8 +4,8 @@ set(SOURCE_FILES
     src/SpheroCylinder.cpp src/Torus.cpp src/Wall.cpp)
 
 add_library(EspressoShapes SHARED ${SOURCE_FILES})
-target_link_libraries(EspressoShapes PUBLIC utils PRIVATE Boost::boost
-                                                          cxx_interface)
+target_link_libraries(EspressoShapes PUBLIC EspressoUtils PRIVATE Boost::boost
+                                                                  cxx_interface)
 target_include_directories(
   EspressoShapes PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                         $<INSTALL_INTERFACE:include>)

--- a/src/shapes/unit_tests/CMakeLists.txt
+++ b/src/shapes/unit_tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(unit_test)
-unit_test(NAME Wall_test SRC Wall_test.cpp DEPENDS shapes utils)
+unit_test(NAME Wall_test SRC Wall_test.cpp DEPENDS EspressoShapes utils)
 unit_test(NAME HollowConicalFrustum_test SRC HollowConicalFrustum_test.cpp
-          DEPENDS shapes utils)
-unit_test(NAME Union_test SRC Union_test.cpp DEPENDS shapes utils)
-unit_test(NAME Ellipsoid_test SRC Ellipsoid_test.cpp DEPENDS shapes utils)
+          DEPENDS EspressoShapes utils)
+unit_test(NAME Union_test SRC Union_test.cpp DEPENDS EspressoShapes utils)
+unit_test(NAME Ellipsoid_test SRC Ellipsoid_test.cpp DEPENDS EspressoShapes
+          utils)

--- a/src/shapes/unit_tests/CMakeLists.txt
+++ b/src/shapes/unit_tests/CMakeLists.txt
@@ -1,7 +1,8 @@
 include(unit_test)
-unit_test(NAME Wall_test SRC Wall_test.cpp DEPENDS EspressoShapes utils)
+unit_test(NAME Wall_test SRC Wall_test.cpp DEPENDS EspressoShapes EspressoUtils)
 unit_test(NAME HollowConicalFrustum_test SRC HollowConicalFrustum_test.cpp
-          DEPENDS EspressoShapes utils)
-unit_test(NAME Union_test SRC Union_test.cpp DEPENDS EspressoShapes utils)
+          DEPENDS EspressoShapes EspressoUtils)
+unit_test(NAME Union_test SRC Union_test.cpp DEPENDS EspressoShapes
+          EspressoUtils)
 unit_test(NAME Ellipsoid_test SRC Ellipsoid_test.cpp DEPENDS EspressoShapes
-          utils)
+          EspressoUtils)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,9 +1,10 @@
-add_library(utils INTERFACE)
+add_library(EspressoUtils INTERFACE)
 target_include_directories(
-  utils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                  $<INSTALL_INTERFACE:include> Boost::serialization Boost::mpi)
+  EspressoUtils
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include> Boost::serialization Boost::mpi)
 
-install(TARGETS utils LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
+install(TARGETS EspressoUtils LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 if(WITH_TESTS)
   add_subdirectory(tests)

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -1,64 +1,73 @@
 include(unit_test)
 
-unit_test(NAME abs_test SRC abs_test.cpp DEPENDS utils)
-unit_test(NAME Vector_test SRC Vector_test.cpp DEPENDS utils)
-unit_test(NAME Factory_test SRC Factory_test.cpp DEPENDS utils)
+unit_test(NAME abs_test SRC abs_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME Vector_test SRC Vector_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME Factory_test SRC Factory_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME NumeratedContainer_test SRC NumeratedContainer_test.cpp DEPENDS
-          utils)
-unit_test(NAME make_function_test SRC make_function_test.cpp DEPENDS utils)
-unit_test(NAME keys_test SRC keys_test.cpp DEPENDS utils)
-unit_test(NAME Cache_test SRC Cache_test.cpp DEPENDS utils)
-unit_test(NAME histogram SRC histogram.cpp DEPENDS utils)
-unit_test(NAME accumulator SRC accumulator.cpp DEPENDS utils)
-unit_test(NAME strcat_alloc SRC strcat_alloc_test.cpp DEPENDS utils)
-unit_test(NAME int_pow SRC int_pow_test.cpp DEPENDS utils)
-unit_test(NAME sgn SRC sgn_test.cpp DEPENDS utils)
-unit_test(NAME AS_erfc_part SRC AS_erfc_part_test.cpp DEPENDS utils)
-unit_test(NAME sinc SRC sinc_test.cpp DEPENDS utils)
-unit_test(NAME as_const SRC as_const_test.cpp DEPENDS utils)
-unit_test(NAME permute_ifield_test SRC permute_ifield_test.cpp DEPENDS utils)
-unit_test(NAME vec_rotate SRC vec_rotate_test.cpp DEPENDS utils)
-unit_test(NAME tensor_product SRC tensor_product_test.cpp DEPENDS utils)
+          EspressoUtils)
+unit_test(NAME make_function_test SRC make_function_test.cpp DEPENDS
+          EspressoUtils)
+unit_test(NAME keys_test SRC keys_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME Cache_test SRC Cache_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME histogram SRC histogram.cpp DEPENDS EspressoUtils)
+unit_test(NAME accumulator SRC accumulator.cpp DEPENDS EspressoUtils)
+unit_test(NAME strcat_alloc SRC strcat_alloc_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME int_pow SRC int_pow_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME sgn SRC sgn_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME AS_erfc_part SRC AS_erfc_part_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME sinc SRC sinc_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME as_const SRC as_const_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME permute_ifield_test SRC permute_ifield_test.cpp DEPENDS
+          EspressoUtils)
+unit_test(NAME vec_rotate SRC vec_rotate_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME tensor_product SRC tensor_product_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME interpolation_gradient SRC interpolation_gradient_test.cpp
-          DEPENDS utils)
-unit_test(NAME interpolation SRC interpolation_test.cpp DEPENDS utils)
-unit_test(NAME Span_test SRC Span_test.cpp DEPENDS utils)
+          DEPENDS EspressoUtils)
+unit_test(NAME interpolation SRC interpolation_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME Span_test SRC Span_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME matrix_vector_product SRC matrix_vector_product.cpp DEPENDS
-          utils)
-unit_test(NAME ravel_index SRC index_test.cpp DEPENDS utils)
-unit_test(NAME tuple_test SRC tuple_test.cpp DEPENDS utils)
-unit_test(NAME Array_test SRC Array_test.cpp DEPENDS Boost::serialization utils)
-unit_test(NAME contains_test SRC contains_test.cpp DEPENDS utils)
-unit_test(NAME Counter_test SRC Counter_test.cpp DEPENDS utils)
-unit_test(NAME RunningAverage_test SRC RunningAverage_test.cpp DEPENDS utils)
-unit_test(NAME for_each_pair_test SRC for_each_pair_test.cpp DEPENDS utils)
-unit_test(NAME raster_test SRC raster_test.cpp DEPENDS utils)
-unit_test(NAME make_lin_space_test SRC make_lin_space_test.cpp DEPENDS utils)
-unit_test(NAME sampling_test SRC sampling_test.cpp DEPENDS utils)
+          EspressoUtils)
+unit_test(NAME ravel_index SRC index_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME tuple_test SRC tuple_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME Array_test SRC Array_test.cpp DEPENDS Boost::serialization
+          EspressoUtils)
+unit_test(NAME contains_test SRC contains_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME Counter_test SRC Counter_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME RunningAverage_test SRC RunningAverage_test.cpp DEPENDS
+          EspressoUtils)
+unit_test(NAME for_each_pair_test SRC for_each_pair_test.cpp DEPENDS
+          EspressoUtils)
+unit_test(NAME raster_test SRC raster_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME make_lin_space_test SRC make_lin_space_test.cpp DEPENDS
+          EspressoUtils)
+unit_test(NAME sampling_test SRC sampling_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME coordinate_transformation_test SRC coordinate_transformation.cpp
-          DEPENDS utils)
-unit_test(NAME rotation_matrix_test SRC rotation_matrix_test.cpp DEPENDS utils)
-unit_test(NAME quaternion_test SRC quaternion_test.cpp DEPENDS utils)
-unit_test(NAME mask_test SRC mask_test.cpp DEPENDS utils)
-unit_test(NAME type_traits_test SRC type_traits_test.cpp DEPENDS utils)
-unit_test(NAME uniform_test SRC uniform_test.cpp DEPENDS utils)
-unit_test(NAME memcpy_archive_test SRC memcpy_archive_test.cpp DEPENDS utils)
+          DEPENDS EspressoUtils)
+unit_test(NAME rotation_matrix_test SRC rotation_matrix_test.cpp DEPENDS
+          EspressoUtils)
+unit_test(NAME quaternion_test SRC quaternion_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME mask_test SRC mask_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME type_traits_test SRC type_traits_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME uniform_test SRC uniform_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME memcpy_archive_test SRC memcpy_archive_test.cpp DEPENDS
+          EspressoUtils)
 unit_test(NAME triangle_functions_test SRC triangle_functions_test.cpp DEPENDS
-          utils)
-unit_test(NAME Bag_test SRC Bag_test.cpp DEPENDS utils Boost::serialization)
+          EspressoUtils)
+unit_test(NAME Bag_test SRC Bag_test.cpp DEPENDS EspressoUtils
+          Boost::serialization)
 unit_test(NAME integral_parameter_test SRC integral_parameter_test.cpp DEPENDS
-          utils)
-unit_test(NAME flatten_test SRC flatten_test.cpp DEPENDS utils)
+          EspressoUtils)
+unit_test(NAME flatten_test SRC flatten_test.cpp DEPENDS EspressoUtils)
 
-unit_test(NAME gather_buffer_test SRC gather_buffer_test.cpp DEPENDS utils
-          Boost::mpi MPI::MPI_CXX NUM_PROC 4)
-unit_test(NAME scatter_buffer_test SRC scatter_buffer_test.cpp DEPENDS utils
-          Boost::mpi MPI::MPI_CXX NUM_PROC 4)
-unit_test(NAME all_compare_test SRC all_compare_test.cpp DEPENDS utils
+unit_test(NAME gather_buffer_test SRC gather_buffer_test.cpp DEPENDS
+          EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
+unit_test(NAME scatter_buffer_test SRC scatter_buffer_test.cpp DEPENDS
+          EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
+unit_test(NAME all_compare_test SRC all_compare_test.cpp DEPENDS EspressoUtils
           Boost::mpi MPI::MPI_CXX NUM_PROC 3)
-unit_test(NAME gatherv_test SRC gatherv_test.cpp DEPENDS utils Boost::mpi
-          MPI::MPI_CXX)
-unit_test(NAME all_gatherv_test SRC all_gatherv_test.cpp DEPENDS utils
+unit_test(NAME gatherv_test SRC gatherv_test.cpp DEPENDS EspressoUtils
           Boost::mpi MPI::MPI_CXX)
-unit_test(NAME sendrecv_test SRC sendrecv_test.cpp DEPENDS utils Boost::mpi
-          MPI::MPI_CXX utils NUM_PROC 3)
+unit_test(NAME all_gatherv_test SRC all_gatherv_test.cpp DEPENDS EspressoUtils
+          Boost::mpi MPI::MPI_CXX)
+unit_test(NAME sendrecv_test SRC sendrecv_test.cpp DEPENDS EspressoUtils
+          Boost::mpi MPI::MPI_CXX EspressoUtils NUM_PROC 3)


### PR DESCRIPTION
Fixes #3624

Adding the `Espresso` prefix to targets in `/src` with "common" names will help against collisions, e.g. `EspressoShapes`, `EspressoUtils`, `EspressoParticleObservables`. This is also coherent with the naming of other targets in that directory, e.g. `EspressoCore`, `EspressoConfig`.