### PR TITLE
Fix steepest descent interface

### DIFF
--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -21,6 +21,7 @@ from libcpp cimport bool
 from libcpp.vector cimport vector
 from .particle_data import ParticleHandle
 from .particle_data cimport *
+from .integrate import SteepestDescent
 from .interactions import NonBondedInteractions
 from .interactions cimport BONDED_IA_DIHEDRAL, BONDED_IA_TABULATED_DIHEDRAL
 from .interactions cimport IA_parameters, get_ia_param, bonded_ia_params
@@ -282,6 +283,9 @@ cdef class mayaviLive:
         a secondary thread.
 
         """
+        if isinstance(self.system.integrator.get_state(), SteepestDescent):
+            raise RuntimeError(
+                "Cannot run visualizer with Steepest Descent integrator")
         assert isinstance(threading.current_thread(), threading._MainThread)
         self.gui.start_event_loop()
 
@@ -291,6 +295,9 @@ cdef class mayaviLive:
     def run(self, integ_steps=1):
         """Convenience method with a simple integration thread.
         """
+        if isinstance(self.system.integrator.get_state(), SteepestDescent):
+            raise RuntimeError(
+                "Cannot run visualizer with Steepest Descent integrator")
 
         def main():
             while True:

--- a/src/python/espressomd/visualization_opengl.py
+++ b/src/python/espressomd/visualization_opengl.py
@@ -30,6 +30,7 @@ from matplotlib.pyplot import imsave
 
 import espressomd
 from .particle_data import ParticleHandle
+from .integrate import SteepestDescent
 
 
 class openGLLive():
@@ -591,6 +592,9 @@ class openGLLive():
         """Convenience method with a simple integration thread.
 
         """
+        if isinstance(self.system.integrator.get_state(), SteepestDescent):
+            raise RuntimeError(
+                "Cannot run visualizer with Steepest Descent integrator")
 
         def main():
             while True:
@@ -616,6 +620,9 @@ class openGLLive():
         """The blocking start method.
 
         """
+        if isinstance(self.system.integrator.get_state(), SteepestDescent):
+            raise RuntimeError(
+                "Cannot run visualizer with Steepest Descent integrator")
         self._init_opengl()
         self._init_espresso_visualization()
         self._init_controls()


### PR DESCRIPTION
Description of changes:
- prevent visualizers from running when steepest descent is active by raising an exception (otherwise the visualizer freezes)
- additionally, only in 4.1.3: fix incorrect assertions in the steepest descent interface (0f5a3e84aa)
