### PR TITLE
Remove Observable_stat external linkage

### DIFF
--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -28,7 +28,7 @@
 Observable_stat::Observable_stat(size_t chunk_size) : m_chunk_size(chunk_size) {
   // number of chunks for different interaction types
   auto constexpr n_coulomb = 2;
-  auto constexpr n_dipolar = 3;
+  auto constexpr n_dipolar = 2;
 #ifdef VIRTUAL_SITES
   auto constexpr n_vs = 1;
 #else

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -27,7 +27,7 @@
 
 Observable_stat::Observable_stat(size_t chunk_size) : m_chunk_size(chunk_size) {
   // number of chunks for different interaction types
-  auto constexpr n_coulomb = 3;
+  auto constexpr n_coulomb = 2;
   auto constexpr n_dipolar = 3;
 #ifdef VIRTUAL_SITES
   auto constexpr n_vs = 1;

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -29,7 +29,7 @@
 #include <utility>
 #include <vector>
 
-/** Observable for the scalar pressure, pressure tensor and energy. */
+/** Observable for the pressure and energy. */
 class Observable_stat {
   /** Array for observables on each node. */
   std::vector<double> m_data;

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -68,7 +68,7 @@ public:
    *  @param column Which column to sum up (only relevant for multi-dimensional
    *                observables).
    */
-  double accumulate(double acc = 0.0, size_t column = 0) {
+  double accumulate(double acc = 0.0, size_t column = 0) const {
     assert(column < m_chunk_size);
     if (m_chunk_size == 1)
       return boost::accumulate(m_data, acc);

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -126,25 +126,20 @@
  *        result = fene_pair_force(iaparams, dx);
  *        break;
  *      @endcode
- *    - in function @ref add_bonded_force(): add the new interaction to the
- *      switch statement if it is not a pairwise bond. For the harmonic angle,
- *      the code looks like this:
+ *    - in functions called by @ref add_bonded_force(): add the new interaction
+ *      to the switch statements if it is not a pairwise bond. For the harmonic
+ *      angle, the code looks like this:
  *      @code{.cpp}
  *      case BONDED_IA_ANGLE_HARMONIC:
- *        std::tie(force1, force2, force3) =
- *          angle_harmonic_force(p1->r.p, p2->r.p, p3->r.p, iaparams);
- *        break;
+ *        return angle_harmonic_force(p1.r.p, p2.r.p, p3.r.p, iaparams);
  *      @endcode
  *  * In energy_inline.hpp:
  *    - include the header file of the new interaction
- *    - in function @ref add_bonded_energy(): add the new interaction to the
+ *    - in function @ref calc_bonded_energy(): add the new interaction to the
  *      switch statement. For the FENE bond, e.g., the code looks like this:
  *      @code{.cpp}
- *      boost::optional<double> retval;
- *      // ...
  *      case BONDED_IA_FENE:
- *        retval = fene_pair_energy(iaparams, dx);
- *        break;
+ *        return fene_pair_energy(iaparams, dx);
  *      @endcode
  *  * Pressure tensor and virial calculation: if your bonded
  *    interaction is not a pair bond or modifies the particles involved,

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -113,7 +113,8 @@ ParticleForce ShapeBasedConstraint::force(Particle const &p,
 
 void ShapeBasedConstraint::add_energy(const Particle &p,
                                       const Utils::Vector3d &folded_pos,
-                                      double t, Observable_stat &energy) const {
+                                      double t,
+                                      Observable_stat &obs_energy) const {
   double dist;
   double nonbonded_en = 0.0;
 

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -22,7 +22,6 @@
 
 #include "debug.hpp"
 
-#include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 #include "cuda_init.hpp"
 #include "cuda_interface.hpp"
@@ -221,15 +220,12 @@ void clear_energy_on_GPU() {
   cuda_safe_mem(cudaMemset(energy_device, 0, sizeof(CUDA_energy)));
 }
 
-void copy_energy_from_GPU(Observable_stat &obs_energy) {
+CUDA_energy copy_energy_from_GPU() {
   if (!global_part_vars_host.communication_enabled)
-    return;
+    return {};
   cuda_safe_mem(cudaMemcpy(&energy_host, energy_device, sizeof(CUDA_energy),
                            cudaMemcpyDeviceToHost));
-  if (!obs_energy.coulomb.empty())
-    obs_energy.coulomb[1] += energy_host.coulomb;
-  if (obs_energy.dipolar.size() >= 2)
-    obs_energy.dipolar[1] += energy_host.dipolar;
+  return energy_host;
 }
 
 void _cuda_safe_mem(cudaError_t CU_err, const char *file, unsigned int line) {

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -221,8 +221,7 @@ void clear_energy_on_GPU() {
   cuda_safe_mem(cudaMemset(energy_device, 0, sizeof(CUDA_energy)));
 }
 
-void copy_energy_from_GPU() {
-  extern Observable_stat obs_energy;
+void copy_energy_from_GPU(Observable_stat &obs_energy) {
   if (!global_part_vars_host.communication_enabled)
     return;
   cuda_safe_mem(cudaMemcpy(&energy_host, energy_device, sizeof(CUDA_energy),

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -227,7 +227,7 @@ void copy_energy_from_GPU(Observable_stat &obs_energy) {
   cuda_safe_mem(cudaMemcpy(&energy_host, energy_device, sizeof(CUDA_energy),
                            cudaMemcpyDeviceToHost));
   if (!obs_energy.coulomb.empty())
-    obs_energy.coulomb[0] += energy_host.coulomb;
+    obs_energy.coulomb[1] += energy_host.coulomb;
   if (obs_energy.dipolar.size() >= 2)
     obs_energy.dipolar[1] += energy_host.dipolar;
 }

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -24,7 +24,6 @@
 #ifdef CUDA
 
 #include "CudaHostAllocator.hpp"
-#include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 
 #include <utils/Span.hpp>
@@ -108,7 +107,7 @@ typedef struct {
 } CUDA_global_part_vars;
 
 void copy_forces_from_GPU(ParticleRange &particles);
-void copy_energy_from_GPU(Observable_stat &obs_energy);
+CUDA_energy copy_energy_from_GPU();
 void clear_energy_on_GPU();
 
 CUDA_global_part_vars *gpu_get_global_particle_vars_pointer_host();

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -24,6 +24,7 @@
 #ifdef CUDA
 
 #include "CudaHostAllocator.hpp"
+#include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 
 #include <utils/Span.hpp>
@@ -107,7 +108,7 @@ typedef struct {
 } CUDA_global_part_vars;
 
 void copy_forces_from_GPU(ParticleRange &particles);
-void copy_energy_from_GPU();
+void copy_energy_from_GPU(Observable_stat &obs_energy);
 void clear_energy_on_GPU();
 
 CUDA_global_part_vars *gpu_get_global_particle_vars_pointer_host();

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -42,8 +42,7 @@
 Coulomb_parameters coulomb;
 
 namespace Coulomb {
-void calc_pressure_long_range(Observable_stat &virials,
-                              Observable_stat &p_tensor,
+void calc_pressure_long_range(Observable_stat &p_tensor,
                               const ParticleRange &particles) {
   switch (coulomb.method) {
 #ifdef P3M
@@ -60,7 +59,6 @@ void calc_pressure_long_range(Observable_stat &virials,
     p3m_charge_assign(particles);
     auto const p3m_p_tensor = p3m_calc_kspace_pressure_tensor();
     std::copy_n(p3m_p_tensor.data(), 9, p_tensor.coulomb.begin() + 9);
-    virials.coulomb[1] = p3m_p_tensor[0] + p3m_p_tensor[4] + p3m_p_tensor[8];
 
     break;
   }

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -42,8 +42,7 @@
 Coulomb_parameters coulomb;
 
 namespace Coulomb {
-void calc_pressure_long_range(Observable_stat &p_tensor,
-                              const ParticleRange &particles) {
+Utils::Vector9d calc_pressure_long_range(const ParticleRange &particles) {
   switch (coulomb.method) {
 #ifdef P3M
   case COULOMB_ELC_P3M:
@@ -57,10 +56,7 @@ void calc_pressure_long_range(Observable_stat &p_tensor,
     break;
   case COULOMB_P3M: {
     p3m_charge_assign(particles);
-    auto const p3m_p_tensor = p3m_calc_kspace_pressure_tensor();
-    std::copy_n(p3m_p_tensor.data(), 9, p_tensor.coulomb.begin() + 9);
-
-    break;
+    return p3m_calc_kspace_pressure_tensor();
   }
 #endif
   case COULOMB_MMM1D:
@@ -72,6 +68,7 @@ void calc_pressure_long_range(Observable_stat &p_tensor,
   default:
     break;
   }
+  return {};
 }
 
 void sanity_checks(int &state) {

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -335,7 +335,7 @@ void calc_energy_long_range(Observable_stat &energy,
       // restore modified sums
       ELC_P3M_restore_p3m_sums(particles);
     }
-    energy.coulomb[2] = ELC_energy(particles);
+    energy.coulomb[1] += ELC_energy(particles);
     break;
 #endif
 #ifdef SCAFACOS

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -24,7 +24,6 @@
 #include <cstddef>
 
 #ifdef ELECTROSTATICS
-#include "Observable_stat.hpp"
 
 #include <ParticleRange.hpp>
 #include <utils/Vector.hpp>
@@ -60,8 +59,7 @@ struct Coulomb_parameters {
 extern Coulomb_parameters coulomb;
 
 namespace Coulomb {
-void calc_pressure_long_range(Observable_stat &p_tensor,
-                              const ParticleRange &particles);
+Utils::Vector9d calc_pressure_long_range(const ParticleRange &particles);
 
 void sanity_checks(int &state);
 double cutoff(const Utils::Vector3d &box_l);

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -60,8 +60,7 @@ struct Coulomb_parameters {
 extern Coulomb_parameters coulomb;
 
 namespace Coulomb {
-void calc_pressure_long_range(Observable_stat &virials,
-                              Observable_stat &p_tensor,
+void calc_pressure_long_range(Observable_stat &p_tensor,
                               const ParticleRange &particles);
 
 void sanity_checks(int &state);

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -74,8 +74,7 @@ void init();
 
 void calc_long_range_force(const ParticleRange &particles);
 
-void calc_energy_long_range(Observable_stat &energy,
-                            const ParticleRange &particles);
+double calc_energy_long_range(const ParticleRange &particles);
 
 int iccp3m_sanity_check();
 

--- a/src/core/electrostatics_magnetostatics/dipole.cpp
+++ b/src/core/electrostatics_magnetostatics/dipole.cpp
@@ -205,33 +205,31 @@ void calc_long_range_force(const ParticleRange &particles) {
   }
 }
 
-void calc_energy_long_range(Observable_stat &energy,
-                            const ParticleRange &particles) {
+double calc_energy_long_range(const ParticleRange &particles) {
+  double energy = 0.;
   switch (dipole.method) {
 #ifdef DP3M
   case DIPOLAR_P3M:
     dp3m_dipole_assign(particles);
-    energy.dipolar[1] = dp3m_calc_kspace_forces(false, true, particles);
+    energy = dp3m_calc_kspace_forces(false, true, particles);
     break;
   case DIPOLAR_MDLC_P3M:
     dp3m_dipole_assign(particles);
-    energy.dipolar[1] = dp3m_calc_kspace_forces(false, true, particles);
-    energy.dipolar[1] += add_mdlc_energy_corrections(particles);
+    energy = dp3m_calc_kspace_forces(false, true, particles);
+    energy += add_mdlc_energy_corrections(particles);
     break;
 #endif
   case DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA:
-    energy.dipolar[1] = dawaanr_calculations(false, true, particles);
+    energy = dawaanr_calculations(false, true, particles);
     break;
 #ifdef DP3M
   case DIPOLAR_MDLC_DS:
-    energy.dipolar[1] =
-        magnetic_dipolar_direct_sum_calculations(false, true, particles);
-    energy.dipolar[1] += add_mdlc_energy_corrections(particles);
+    energy = magnetic_dipolar_direct_sum_calculations(false, true, particles);
+    energy += add_mdlc_energy_corrections(particles);
     break;
 #endif
   case DIPOLAR_DS:
-    energy.dipolar[1] =
-        magnetic_dipolar_direct_sum_calculations(false, true, particles);
+    energy = magnetic_dipolar_direct_sum_calculations(false, true, particles);
     break;
   case DIPOLAR_DS_GPU: // NOLINT(bugprone-branch-clone)
     // do nothing: it's an actor
@@ -244,7 +242,7 @@ void calc_energy_long_range(Observable_stat &energy,
 #ifdef SCAFACOS_DIPOLES
   case DIPOLAR_SCAFACOS:
     assert(Scafacos::dipolar());
-    energy.dipolar[1] = Scafacos::long_range_energy();
+    energy = Scafacos::long_range_energy();
 #endif
   case DIPOLAR_NONE:
     break;
@@ -253,6 +251,7 @@ void calc_energy_long_range(Observable_stat &energy,
         << "energy calculation not implemented for dipolar method.";
     break;
   }
+  return energy;
 }
 
 int set_mesh() {

--- a/src/core/electrostatics_magnetostatics/dipole.cpp
+++ b/src/core/electrostatics_magnetostatics/dipole.cpp
@@ -216,7 +216,7 @@ void calc_energy_long_range(Observable_stat &energy,
   case DIPOLAR_MDLC_P3M:
     dp3m_dipole_assign(particles);
     energy.dipolar[1] = dp3m_calc_kspace_forces(false, true, particles);
-    energy.dipolar[2] = add_mdlc_energy_corrections(particles);
+    energy.dipolar[1] += add_mdlc_energy_corrections(particles);
     break;
 #endif
   case DIPOLAR_ALL_WITH_ALL_AND_NO_REPLICA:
@@ -226,7 +226,7 @@ void calc_energy_long_range(Observable_stat &energy,
   case DIPOLAR_MDLC_DS:
     energy.dipolar[1] =
         magnetic_dipolar_direct_sum_calculations(false, true, particles);
-    energy.dipolar[2] = add_mdlc_energy_corrections(particles);
+    energy.dipolar[1] += add_mdlc_energy_corrections(particles);
     break;
 #endif
   case DIPOLAR_DS:

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -24,8 +24,6 @@
 #include <cstddef>
 
 #ifdef DIPOLES
-#include "Observable_stat.hpp"
-
 #include <utils/Vector.hpp>
 
 #include <ParticleRange.hpp>

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -80,8 +80,7 @@ void init();
 
 void calc_long_range_force(const ParticleRange &particles);
 
-void calc_energy_long_range(Observable_stat &energy,
-                            const ParticleRange &particles);
+double calc_energy_long_range(const ParticleRange &particles);
 
 int set_mesh();
 void bcast_params(const boost::mpi::communicator &comm);

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -43,6 +43,8 @@ ActorList energyActors;
 /** Energy of the system */
 Observable_stat obs_energy{1};
 
+Observable_stat const &get_obs_energy() { return obs_energy; }
+
 /** Reduce the system energy from all MPI ranks. */
 void master_energy_calc() { mpi_gather_stats(GatherStats::energy); }
 
@@ -65,13 +67,14 @@ void energy_calc(const double time) {
   on_observable_calc();
 
   for (auto const &p : cell_structure.local_particles()) {
-    add_kinetic_energy(p);
+    add_kinetic_energy(p, obs_energy);
   }
 
   short_range_loop(
-      [](Particle &p) { add_single_particle_energy(p); },
+      [](Particle &p) { add_bonded_energy(p, obs_energy); },
       [](Particle const &p1, Particle const &p2, Distance const &d) {
-        add_non_bonded_pair_energy(p1, p2, d.vec21, sqrt(d.dist2), d.dist2);
+        add_non_bonded_pair_energy(p1, p2, d.vec21, sqrt(d.dist2), d.dist2,
+                                   obs_energy);
       });
 
   calc_long_range_energies(cell_structure.local_particles());
@@ -80,7 +83,7 @@ void energy_calc(const double time) {
   Constraints::constraints.add_energy(local_parts, time, obs_energy);
 
 #ifdef CUDA
-  copy_energy_from_GPU();
+  copy_energy_from_GPU(obs_energy);
 #endif
 
   /* gather data */

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -27,16 +27,20 @@
 #ifndef _ENERGY_H
 #define _ENERGY_H
 
+#include "Observable_stat.hpp"
 #include "ParticleRange.hpp"
 #include "actor/ActorList.hpp"
 
 extern ActorList energyActors;
 
-/** Calculate energies. */
-void update_energy();
-
 /** Parallel energy calculation. */
 void energy_calc(double time);
+
+/** Run @ref energy_calc in parallel. */
+void update_energy();
+
+/** Return the energy observable. */
+Observable_stat const &get_obs_energy();
 
 /** Calculate long-range energies (P3M, ...). */
 void calc_long_range_energies(const ParticleRange &particles);

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -279,17 +279,15 @@ calc_bonded_energy(Bonded_ia_parameters const &iaparams, Particle const &p1,
   throw BondInvalidSizeError(n_partners);
 }
 
-/** Add kinetic energies for one particle to the energy observable.
+/** Calculate kinetic energies for one particle.
  *  @param[in] p1   particle for which to calculate energies
- *  @param[out]    obs_energy   energy observable
  */
-inline void add_kinetic_energy(Particle const &p1,
-                               Observable_stat &obs_energy) {
+inline double calc_kinetic_energy(Particle const &p1) {
   if (p1.p.is_virtual)
-    return;
+    return 0.0;
 
   /* kinetic energy */
-  obs_energy.kinetic[0] += 0.5 * p1.p.mass * p1.m.v.norm2();
+  auto res = 0.5 * p1.p.mass * p1.m.v.norm2();
 
   // Note that rotational degrees of virtual sites are integrated
   // and therefore can contribute to kinetic energy
@@ -297,10 +295,10 @@ inline void add_kinetic_energy(Particle const &p1,
   if (p1.p.rotation) {
     /* the rotational part is added to the total kinetic energy;
      * Here we use the rotational inertia */
-    obs_energy.kinetic[0] +=
-        0.5 * (hadamard_product(p1.m.omega, p1.m.omega) * p1.p.rinertia);
+    res += 0.5 * (hadamard_product(p1.m.omega, p1.m.omega) * p1.p.rinertia);
   }
 #endif
+  return res;
 }
 
 /** Add bonded energies for one particle to the energy observable.

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -37,8 +37,6 @@
 #include "electrostatics_magnetostatics/coulomb.hpp"
 #include "electrostatics_magnetostatics/dipole.hpp"
 
-/** Scalar pressure of the system */
-Observable_stat obs_scalar_pressure{1};
 /** Pressure tensor of the system */
 Observable_stat obs_pressure_tensor{9};
 
@@ -55,17 +53,6 @@ nptiso_struct nptiso = {0.0,
                         0,
                         false,
                         0};
-
-/** Calculate the scalar pressure from the pressure tensor. */
-Observable_stat get_scalar_pressure(Observable_stat const &pressure_tensor) {
-  Observable_stat scalar_pressure{1};
-  auto it_scalar = scalar_pressure.data_().begin();
-  auto it_tensor = pressure_tensor.data_().begin();
-  auto it_tensor_end = pressure_tensor.data_().end();
-  for (; it_tensor < it_tensor_end; it_tensor += 9)
-    *(it_scalar++) += (it_tensor[0] + it_tensor[4] + it_tensor[8]) / 3.;
-  return scalar_pressure;
-}
 
 /** Calculate long-range virials (P3M, ...). */
 void calc_long_range_virials(const ParticleRange &particles) {
@@ -120,7 +107,6 @@ void pressure_calc() {
   if (obs_pressure_tensor_res) {
     std::swap(obs_pressure_tensor, *obs_pressure_tensor_res);
   }
-  obs_scalar_pressure = get_scalar_pressure(obs_pressure_tensor);
 }
 
 void update_pressure() { mpi_gather_stats(GatherStats::pressure); }

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -60,7 +60,8 @@ Observable_stat const &get_obs_pressure() { return obs_pressure; }
 void calc_long_range_virials(const ParticleRange &particles) {
 #ifdef ELECTROSTATICS
   /* calculate k-space part of electrostatic interaction. */
-  Coulomb::calc_pressure_long_range(obs_pressure, particles);
+  auto const coulomb_pressure = Coulomb::calc_pressure_long_range(particles);
+  boost::copy(coulomb_pressure, obs_pressure.coulomb.begin() + 9);
 #endif
 #ifdef DIPOLES
   /* calculate k-space part of magnetostatic interaction. */

--- a/src/core/pressure.hpp
+++ b/src/core/pressure.hpp
@@ -25,16 +25,20 @@
 #ifndef CORE_PRESSURE_HPP
 #define CORE_PRESSURE_HPP
 
+#include "Observable_stat.hpp"
+
 #include <utils/Vector.hpp>
 
-/** Parallel pressure calculation from a virial expansion.
- */
+/** Parallel pressure calculation from a virial expansion. */
 void pressure_calc();
+
+/** Run @ref pressure_calc in parallel. */
+void update_pressure();
+
+/** Return the pressure observable. */
+Observable_stat const &get_obs_pressure();
 
 /** Helper function for @ref Observables::PressureTensor. */
 Utils::Vector9d observable_compute_pressure_tensor();
-
-/** Calculate the scalar pressure and pressure tensor. */
-void update_pressure();
 
 #endif

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -32,7 +32,7 @@
 
 #include <utils/math/tensor_product.hpp>
 
-extern Observable_stat obs_pressure_tensor;
+extern Observable_stat obs_pressure;
 
 /** Calculate non bonded energies between a pair of particles.
  *  @param p1        pointer to particle 1.
@@ -51,18 +51,17 @@ inline void add_non_bonded_pair_virials(Particle const &p1, Particle const &p2,
 
     auto const type1 = p1.p.mol_id;
     auto const type2 = p2.p.mol_id;
-    obs_pressure_tensor.add_non_bonded_contribution(type1, type2,
-                                                    flatten(stress));
+    obs_pressure.add_non_bonded_contribution(type1, type2, flatten(stress));
   }
 
 #ifdef ELECTROSTATICS
-  if (!obs_pressure_tensor.coulomb.empty()) {
+  if (!obs_pressure.coulomb.empty()) {
     /* real space Coulomb */
     auto const p_coulomb = Coulomb::pair_pressure(p1, p2, d, dist);
 
     for (int i = 0; i < 3; i++) {
       for (int j = 0; j < 3; j++) {
-        obs_pressure_tensor.coulomb[i * 3 + j] += p_coulomb[i][j];
+        obs_pressure.coulomb[i * 3 + j] += p_coulomb[i][j];
       }
     }
   }
@@ -148,8 +147,7 @@ inline bool add_bonded_pressure_tensor(Particle &p1, int bond_id,
     /* pressure tensor part */
     for (int k = 0; k < 3; k++)
       for (int l = 0; l < 3; l++)
-        obs_pressure_tensor.bonded_contribution(bond_id)[k * 3 + l] +=
-            tensor[k][l];
+        obs_pressure.bonded_contribution(bond_id)[k * 3 + l] += tensor[k][l];
 
     return false;
   }
@@ -167,8 +165,7 @@ inline void add_kinetic_virials(Particle const &p1) {
   /* kinetic pressure */
   for (int k = 0; k < 3; k++)
     for (int l = 0; l < 3; l++)
-      obs_pressure_tensor.kinetic[k * 3 + l] +=
-          (p1.m.v[k]) * (p1.m.v[l]) * p1.p.mass;
+      obs_pressure.kinetic[k * 3 + l] += p1.m.v[k] * p1.m.v[l] * p1.p.mass;
 }
 
 #endif

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -52,14 +52,12 @@ inline void add_non_bonded_pair_virials(Particle const &p1, Particle const &p2,
 
     auto const type1 = p1.p.mol_id;
     auto const type2 = p2.p.mol_id;
-    obs_scalar_pressure.add_non_bonded_contribution(type1, type2,
-                                                    trace(stress));
     obs_pressure_tensor.add_non_bonded_contribution(type1, type2,
                                                     flatten(stress));
   }
 
 #ifdef ELECTROSTATICS
-  if (!obs_scalar_pressure.coulomb.empty()) {
+  if (!obs_pressure_tensor.coulomb.empty()) {
     /* real space Coulomb */
     auto const p_coulomb = Coulomb::pair_pressure(p1, p2, d, dist);
 
@@ -68,8 +66,6 @@ inline void add_non_bonded_pair_virials(Particle const &p1, Particle const &p2,
         obs_pressure_tensor.coulomb[i * 3 + j] += p_coulomb[i][j];
       }
     }
-
-    obs_scalar_pressure.coulomb[0] += trace(p_coulomb);
   }
 #endif /*ifdef ELECTROSTATICS */
 
@@ -150,8 +146,6 @@ inline bool add_bonded_pressure_tensor(Particle &p1, int bond_id,
   if (result) {
     auto const &tensor = result.get();
 
-    obs_scalar_pressure.bonded_contribution(bond_id)[0] += trace(tensor);
-
     /* pressure tensor part */
     for (int k = 0; k < 3; k++)
       for (int l = 0; l < 3; l++)
@@ -171,9 +165,7 @@ inline void add_kinetic_virials(Particle const &p1) {
   if (p1.p.is_virtual)
     return;
 
-  /* kinetic energy */
-  obs_scalar_pressure.kinetic[0] += p1.m.v.norm2() * p1.p.mass;
-
+  /* kinetic pressure */
   for (int k = 0; k < 3; k++)
     for (int l = 0; l < 3; l++)
       obs_pressure_tensor.kinetic[k * 3 + l] +=

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -32,7 +32,6 @@
 
 #include <utils/math/tensor_product.hpp>
 
-extern Observable_stat obs_scalar_pressure;
 extern Observable_stat obs_pressure_tensor;
 
 /** Calculate non bonded energies between a pair of particles.

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -58,6 +58,7 @@ cdef extern from "Observable_stat.hpp":
         Span[double] bonded_contribution(int bond_id)
         Span[double] non_bonded_intra_contribution(int type1, int type2)
         Span[double] non_bonded_inter_contribution(int type1, int type2)
+        size_t chunk_size()
 
 cdef extern from "statistics.hpp":
     cdef vector[double] calc_structurefactor(PartCfg & , const vector[int] & p_types, int order)

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -20,6 +20,7 @@
 # For C-extern Analysis
 
 cimport numpy as np
+import numpy as np
 from .utils cimport Vector3i, Vector3d, Vector9d, Span
 from .utils cimport create_nparray_from_double_span
 from libcpp.vector cimport vector  # import std::vector as vector
@@ -81,7 +82,6 @@ cdef extern from "statistics_chain.hpp":
     array2 calc_rh(int, int, int)
 
 cdef extern from "pressure_inline.hpp":
-    cdef Observable_stat obs_scalar_pressure
     cdef Observable_stat obs_pressure_tensor
 
 cdef extern from "pressure.hpp":
@@ -97,25 +97,52 @@ cdef extern from "energy.hpp":
 cdef extern from "dpd.hpp":
     Vector9d dpd_stress()
 
-cdef inline get_obs_contribs(Span[double] contributions, int size):
+cdef inline get_obs_contribs(Span[double] contributions, int size,
+                             cbool calc_scalar_pressure):
     """
     Convert an Observable_stat range of contributions into a correctly
     shaped numpy array.
+
+    Parameters
+    ----------
+    contributions : (N,) array_like of :obj:`float`
+        Flattened array of energy/pressure contributions from an observable.
+    size : :obj:`int`, \{1, 9\}
+        Dimensionality of the data.
+    calc_scalar_pressure : :obj:`bool`
+        Whether to calculate a scalar pressure (only relevant when
+        ``contributions`` is a pressure tensor).
+
     """
     cdef np.ndarray value
     value = create_nparray_from_double_span(contributions)
     if size == 9:
-        return value.reshape((-1, 3, 3))
+        if calc_scalar_pressure:
+            return np.einsum('...ii', value.reshape((-1, 3, 3))) / 3
+        else:
+            return value.reshape((-1, 3, 3))
     else:
         return value
 
-cdef inline get_obs_contrib(Span[double] contribution, int size):
+cdef inline get_obs_contrib(Span[double] contribution, int size,
+                            cbool calc_scalar_pressure):
     """
     Convert an Observable_stat contribution into a correctly
     shaped numpy array. If the size is 1, decay to a float.
+
+    Parameters
+    ----------
+    contributions : (N,) array_like of :obj:`float`
+        Flattened array of energy/pressure contributions from an observable.
+    size : :obj:`int`, \{1, 9\}
+        Dimensionality of the data.
+    calc_scalar_pressure : :obj:`bool`
+        Whether to calculate a scalar pressure (only relevant when
+        ``contributions`` is a pressure tensor).
+
     """
     cdef np.ndarray value
-    value = get_obs_contribs(contribution, size)
+    value = get_obs_contribs(contribution, size, calc_scalar_pressure)
     if value.shape[0] == 1:
         return value[0]
     return value

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -81,17 +81,13 @@ cdef extern from "statistics_chain.hpp":
     array4 calc_rg(int, int, int) except +
     array2 calc_rh(int, int, int)
 
-cdef extern from "pressure_inline.hpp":
-    cdef Observable_stat obs_pressure
-
 cdef extern from "pressure.hpp":
     cdef void update_pressure()
-
-cdef extern from "energy_inline.hpp":
-    cdef Observable_stat obs_energy
+    cdef const Observable_stat & get_obs_pressure()
 
 cdef extern from "energy.hpp":
     cdef void update_energy()
+    cdef const Observable_stat & get_obs_energy()
     double calculate_current_potential_energy_of_system()
 
 cdef extern from "dpd.hpp":

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -19,7 +19,9 @@
 
 # For C-extern Analysis
 
+cimport numpy as np
 from .utils cimport Vector3i, Vector3d, Vector9d, Span
+from .utils cimport create_nparray_from_double_span
 from libcpp.vector cimport vector  # import std::vector as vector
 from libcpp cimport bool as cbool
 
@@ -94,3 +96,26 @@ cdef extern from "energy.hpp":
 
 cdef extern from "dpd.hpp":
     Vector9d dpd_stress()
+
+cdef inline get_obs_contribs(Span[double] contributions, int size):
+    """
+    Convert an Observable_stat range of contributions into a correctly
+    shaped numpy array.
+    """
+    cdef np.ndarray value
+    value = create_nparray_from_double_span(contributions)
+    if size == 9:
+        return value.reshape((-1, 3, 3))
+    else:
+        return value
+
+cdef inline get_obs_contrib(Span[double] contribution, int size):
+    """
+    Convert an Observable_stat contribution into a correctly
+    shaped numpy array. If the size is 1, decay to a float.
+    """
+    cdef np.ndarray value
+    value = get_obs_contribs(contribution, size)
+    if value.shape[0] == 1:
+        return value[0]
+    return value

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -82,7 +82,7 @@ cdef extern from "statistics_chain.hpp":
     array2 calc_rh(int, int, int)
 
 cdef extern from "pressure_inline.hpp":
-    cdef Observable_stat obs_pressure_tensor
+    cdef Observable_stat obs_pressure
 
 cdef extern from "pressure.hpp":
     cdef void update_pressure()

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -64,7 +64,7 @@ cdef _Observable_stat_to_dict(Observable_stat obs, int size,
         * ``"nonbonded_intra", <type_i>, <type_j>``: nonbonded contribution between short ranged forces between type i and j and with the same mol_id
         * ``"nonbonded_inter", <type_i>, <type_j>``: nonbonded contribution between short ranged forces between type i and j and different mol_ids
         * ``"coulomb"``: Coulomb contribution, how it is calculated depends on the method
-        * ``"coulomb", <i>``: Coulomb contribution from particle pairs (``i=0``), electrostatics solvers (``i=1``) and their corrections (``i=2``)
+        * ``"coulomb", <i>``: Coulomb contribution from particle pairs (``i=0``), electrostatics solvers (``i=1``)
         * ``"dipolar"``: dipolar contribution, how it is calculated depends on the method
         * ``"dipolar", <i>``: dipolar contribution from particle pairs and magnetic field constraints (``i=0``), magnetostatics solvers (``i=1``) and their corrections (``i=2``)
         * ``"virtual_sites"``: virtual sites contribution
@@ -323,7 +323,7 @@ class Analysis:
             * ``"coulomb"``: Coulomb pressure, how it is calculated depends on the method. It is equivalent to 1/3 of the trace of the Coulomb pressure tensor.
               For how the pressure tensor is calculated, see :ref:`Pressure Tensor`. The averaged value in an isotropic NVT simulation is equivalent to the average of
               :math:`E^{coulomb}/(3V)`, see :cite:`brown95a`.
-            * ``"coulomb", <i>``: Coulomb pressure from particle pairs (``i=0``), electrostatics solvers (``i=1``) and their corrections (``i=2``)
+            * ``"coulomb", <i>``: Coulomb pressure from particle pairs (``i=0``), electrostatics solvers (``i=1``)
             * ``"dipolar"``: not implemented
             * ``"virtual_sites"``: Pressure contribution from virtual sites
 
@@ -357,7 +357,7 @@ class Analysis:
             * ``"nonbonded_intra", <type_i>, <type_j>``: nonbonded pressure tensor between short ranged forces between type i and j and with the same mol_id
             * ``"nonbonded_inter", <type_i>, <type_j>``: nonbonded pressure tensor between short ranged forces between type i and j and different mol_ids
             * ``"coulomb"``: Maxwell pressure tensor, how it is calculated depends on the method
-            * ``"coulomb", <i>``: Maxwell pressure tensor from particle pairs (``i=0``), electrostatics solvers (``i=1``) and their corrections (``i=2``)
+            * ``"coulomb", <i>``: Maxwell pressure tensor from particle pairs (``i=0``), electrostatics solvers (``i=1``)
             * ``"dipolar"``: not implemented
             * ``"virtual_sites"``: pressure tensor contribution from virtual sites
 
@@ -398,7 +398,7 @@ class Analysis:
             * ``"nonbonded_intra", <type_i>, <type_j>``: nonbonded energy between short ranged forces between type i and j and with the same mol_id
             * ``"nonbonded_inter", <type_i>, <type_j>``: nonbonded energy between short ranged forces between type i and j and different mol_ids
             * ``"coulomb"``: Coulomb energy, how it is calculated depends on the method
-            * ``"coulomb", <i>``: Coulomb energy from particle pairs (``i=0``), electrostatics solvers (``i=1``) and their corrections (``i=2``)
+            * ``"coulomb", <i>``: Coulomb energy from particle pairs (``i=0``), electrostatics solvers (``i=1``)
             * ``"dipolar"``: dipolar energy
             * ``"dipolar", <i>``: dipolar energy from particle pairs and magnetic field constraints (``i=0``), magnetostatics solvers (``i=1``) and their corrections (``i=2``)
 

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -332,7 +332,7 @@ class Analysis:
         # Update in ESPResSo core
         analyze.update_pressure()
 
-        return _Observable_stat_to_dict(analyze.obs_pressure_tensor, 9, True)
+        return _Observable_stat_to_dict(analyze.obs_pressure, 9, True)
 
     def pressure_tensor(self):
         """Calculate the instantaneous pressure_tensor (in parallel). This is
@@ -366,7 +366,7 @@ class Analysis:
         # Update in ESPResSo core
         analyze.update_pressure()
 
-        return _Observable_stat_to_dict(analyze.obs_pressure_tensor, 9, False)
+        return _Observable_stat_to_dict(analyze.obs_pressure, 9, False)
 
     IF DPD == 1:
         def dpd_stress(self):

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -332,7 +332,7 @@ class Analysis:
         # Update in ESPResSo core
         analyze.update_pressure()
 
-        return _Observable_stat_to_dict(analyze.obs_pressure, 9, True)
+        return _Observable_stat_to_dict(analyze.get_obs_pressure(), 9, True)
 
     def pressure_tensor(self):
         """Calculate the instantaneous pressure_tensor (in parallel). This is
@@ -366,7 +366,7 @@ class Analysis:
         # Update in ESPResSo core
         analyze.update_pressure()
 
-        return _Observable_stat_to_dict(analyze.obs_pressure, 9, False)
+        return _Observable_stat_to_dict(analyze.get_obs_pressure(), 9, False)
 
     IF DPD == 1:
         def dpd_stress(self):
@@ -417,7 +417,7 @@ class Analysis:
         analyze.update_energy()
         handle_errors("calc_long_range_energies failed")
 
-        return _Observable_stat_to_dict(analyze.obs_energy, 1, False)
+        return _Observable_stat_to_dict(analyze.get_obs_energy(), 1, False)
 
     def calc_re(self, chain_start=None, number_of_chains=None,
                 chain_length=None):

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -66,7 +66,7 @@ cdef _Observable_stat_to_dict(Observable_stat obs, int size,
         * ``"coulomb"``: Coulomb contribution, how it is calculated depends on the method
         * ``"coulomb", <i>``: Coulomb contribution from particle pairs (``i=0``), electrostatics solvers (``i=1``)
         * ``"dipolar"``: dipolar contribution, how it is calculated depends on the method
-        * ``"dipolar", <i>``: dipolar contribution from particle pairs and magnetic field constraints (``i=0``), magnetostatics solvers (``i=1``) and their corrections (``i=2``)
+        * ``"dipolar", <i>``: dipolar contribution from particle pairs and magnetic field constraints (``i=0``), magnetostatics solvers (``i=1``)
         * ``"virtual_sites"``: virtual sites contribution
         * ``"virtual_sites", <i>``: contribution from virtual site i
 
@@ -400,7 +400,7 @@ class Analysis:
             * ``"coulomb"``: Coulomb energy, how it is calculated depends on the method
             * ``"coulomb", <i>``: Coulomb energy from particle pairs (``i=0``), electrostatics solvers (``i=1``)
             * ``"dipolar"``: dipolar energy
-            * ``"dipolar", <i>``: dipolar energy from particle pairs and magnetic field constraints (``i=0``), magnetostatics solvers (``i=1``) and their corrections (``i=2``)
+            * ``"dipolar", <i>``: dipolar energy from particle pairs and magnetic field constraints (``i=0``), magnetostatics solvers (``i=1``)
 
 
         Examples

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -36,16 +36,13 @@ from .utils cimport create_nparray_from_double_array
 from .particle_data cimport get_n_part
 
 
-cdef _Observable_stat_to_dict(Observable_stat obs, int size,
-                              cbool calc_sp):
+cdef _Observable_stat_to_dict(Observable_stat obs, cbool calc_sp):
     """Transform an Observable_stat struct to a python dict.
 
     Parameters
     ----------
     obs :
         Core observable.
-    size : :obj:`int`, \{1, 9\}
-        Dimensionality of the data.
     calc_sp : :obj:`bool`
         Whether to calculate a scalar pressure (only relevant when
         ``obs`` is a pressure tensor observable).
@@ -71,6 +68,8 @@ cdef _Observable_stat_to_dict(Observable_stat obs, int size,
         * ``"virtual_sites", <i>``: contribution from virtual site i
 
     """
+
+    size = obs.chunk_size()
 
     def set_initial():
         if size == 9 and not calc_sp:
@@ -332,7 +331,7 @@ class Analysis:
         # Update in ESPResSo core
         analyze.update_pressure()
 
-        return _Observable_stat_to_dict(analyze.get_obs_pressure(), 9, True)
+        return _Observable_stat_to_dict(analyze.get_obs_pressure(), True)
 
     def pressure_tensor(self):
         """Calculate the instantaneous pressure_tensor (in parallel). This is
@@ -366,7 +365,7 @@ class Analysis:
         # Update in ESPResSo core
         analyze.update_pressure()
 
-        return _Observable_stat_to_dict(analyze.get_obs_pressure(), 9, False)
+        return _Observable_stat_to_dict(analyze.get_obs_pressure(), False)
 
     IF DPD == 1:
         def dpd_stress(self):
@@ -417,7 +416,7 @@ class Analysis:
         analyze.update_energy()
         handle_errors("calc_long_range_energies failed")
 
-        return _Observable_stat_to_dict(analyze.get_obs_energy(), 1, False)
+        return _Observable_stat_to_dict(analyze.get_obs_energy(), False)
 
     def calc_re(self, chain_start=None, number_of_chains=None,
                 chain_length=None):


### PR DESCRIPTION
Description of changes:
- re-use code in the cython interface to extract data from `Observable_stat` objects
- remove `obs_scalar_pressure` global variable
   - write-only variable in the core -> can be calculated from `obs_pressure_tensor` in cython
   - simplify pressure kernels
   - less MPI communication
- rename `obs_pressure_tensor` to `obs_pressure` for consistency with `obs_energy`
- remove external linkage for  `obs_pressure` and `obs_energy`
   - these globals are no longer visible outside of their translation unit
   - use a const reference getter for the script interface
   - partial fix for #2628
- narrow includes of `Observable_stat.hpp`
- add ELC/DLC energy corrections to the P3M/DP3M/DDS solver energy slots
   - the `analyze.energy()`, `analyze.pressure()`, `analyze.pressure_tensor()` functions now only reports 2 slots for Coulomb and dipolar contributions: particles contribution and electrostatics/magnetostatics solver contribution