### PR TITLE
Observables and correlators/accumulators maintainance

### DIFF
--- a/src/core/accumulators/Correlator.cpp
+++ b/src/core/accumulators/Correlator.cpp
@@ -65,7 +65,7 @@ std::vector<double> compress_discard2(std::vector<double> const &A1,
 
 std::vector<double> scalar_product(std::vector<double> const &A,
                                    std::vector<double> const &B,
-                                   Utils::Vector3d) {
+                                   Utils::Vector3d const &) {
   if (A.size() != B.size()) {
     throw std::runtime_error(
         "Error in scalar product: The vector sizes do not match");
@@ -77,7 +77,7 @@ std::vector<double> scalar_product(std::vector<double> const &A,
 
 std::vector<double> componentwise_product(std::vector<double> const &A,
                                           std::vector<double> const &B,
-                                          Utils::Vector3d) {
+                                          Utils::Vector3d const &) {
   std::vector<double> C(A.size());
   if (A.size() != B.size()) {
     throw std::runtime_error(
@@ -91,7 +91,7 @@ std::vector<double> componentwise_product(std::vector<double> const &A,
 
 std::vector<double> tensor_product(std::vector<double> const &A,
                                    std::vector<double> const &B,
-                                   Utils::Vector3d) {
+                                   Utils::Vector3d const &) {
   std::vector<double> C(A.size() * B.size());
   auto C_it = C.begin();
 
@@ -107,7 +107,7 @@ std::vector<double> tensor_product(std::vector<double> const &A,
 
 std::vector<double> square_distance_componentwise(std::vector<double> const &A,
                                                   std::vector<double> const &B,
-                                                  Utils::Vector3d) {
+                                                  Utils::Vector3d const &) {
   if (A.size() != B.size()) {
     throw std::runtime_error(
         "Error in square distance componentwise: The vector sizes do not "
@@ -127,7 +127,7 @@ std::vector<double> square_distance_componentwise(std::vector<double> const &A,
 // sets w
 std::vector<double> fcs_acf(std::vector<double> const &A,
                             std::vector<double> const &B,
-                            Utils::Vector3d wsquare) {
+                            Utils::Vector3d const &wsquare) {
   if (A.size() != B.size()) {
     throw std::runtime_error(
         "Error in fcs acf: The vector sizes do not match.");

--- a/src/core/accumulators/Correlator.cpp
+++ b/src/core/accumulators/Correlator.cpp
@@ -95,9 +95,9 @@ std::vector<double> tensor_product(std::vector<double> const &A,
   std::vector<double> C(A.size() * B.size());
   auto C_it = C.begin();
 
-  for (auto A_it = A.begin(); A_it != A.begin(); ++A_it) {
-    for (double B_it : B) {
-      *(C_it++) = *A_it * B_it;
+  for (double a : A) {
+    for (double b : B) {
+      *(C_it++) = a * b;
     }
   }
   assert(C_it == C.end());

--- a/src/core/accumulators/Correlator.hpp
+++ b/src/core/accumulators/Correlator.hpp
@@ -259,9 +259,9 @@ private:
   unsigned int dim_A; ///< dimensionality of A
   unsigned int dim_B; ///< dimensionality of B
 
-  using correlation_operation_type =
-      std::vector<double> (*)(std::vector<double> const &,
-                              std::vector<double> const &, Utils::Vector3d);
+  using correlation_operation_type = std::vector<double> (*)(
+      std::vector<double> const &, std::vector<double> const &,
+      Utils::Vector3d const &);
 
   correlation_operation_type corr_operation;
 

--- a/testsuite/python/correlation.py
+++ b/testsuite/python/correlation.py
@@ -89,6 +89,10 @@ class CorrelatorTest(ut.TestCase):
 
         corr = acc.result()
 
+        # Check pickling
+        acc_unpickeled = pickle.loads(pickle.dumps(acc))
+        np.testing.assert_array_equal(corr, acc_unpickeled.result())
+
         tau = self.calc_tau(s.time_step, acc.tau_lin, corr.shape[0])
         np.testing.assert_array_almost_equal(corr[:, 0], tau)
         for i in range(corr.shape[0]):
@@ -109,6 +113,10 @@ class CorrelatorTest(ut.TestCase):
         s.integrator.run(20000)
 
         corr = acc.result()
+
+        # Check pickling
+        acc_unpickeled = pickle.loads(pickle.dumps(acc))
+        np.testing.assert_array_equal(corr, acc_unpickeled.result())
 
         tau = self.calc_tau(s.time_step, acc.tau_lin, corr.shape[0])
         np.testing.assert_array_almost_equal(corr[:, 0], tau)
@@ -139,6 +147,23 @@ class CorrelatorTest(ut.TestCase):
         np.testing.assert_array_almost_equal(corr[:, 0], tau)
         for i in range(corr.shape[0]):
             np.testing.assert_array_almost_equal(corr[i, 2:], np.sum(v**2))
+
+    def test_correlator_interface(self):
+        # test setters and getters
+        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        acc = espressomd.accumulators.Correlator(
+            obs1=obs, tau_lin=10, tau_max=12.0, delta_N=1,
+            corr_operation="scalar_product")
+        # check tau_lin
+        self.assertEqual(acc.tau_lin, 10)
+        # check tau_max
+        self.assertEqual(acc.tau_max, 12.)
+        # check delta_N
+        self.assertEqual(acc.delta_N, 1)
+        acc.delta_N = 2
+        self.assertEqual(acc.delta_N, 2)
+        # check corr_operation
+        self.assertEqual(acc.corr_operation, "scalar_product")
 
 
 if __name__ == "__main__":

--- a/testsuite/python/correlation.py
+++ b/testsuite/python/correlation.py
@@ -34,9 +34,20 @@ class CorrelatorTest(ut.TestCase):
     def tearDown(self):
         self.system.part.clear()
 
-    def test(self):
+    def calc_tau(self, time_step, tau_lin, length):
+        tau = []
+        for i in range(tau_lin):
+            tau.append(i)
+        factor = 1
+        while len(tau) < length:
+            p = tau[-1] + factor * 1
+            for i in range(0, tau_lin, 2):
+                tau.append(p + factor * i)
+            factor *= 2
+        return time_step * np.array(tau[:length])
+
+    def test_square_distance_componentwise(self):
         s = self.system
-        s.thermostat.turn_off()
         s.part.add(id=0, pos=(0, 0, 0), v=(1, 2, 3))
 
         obs = espressomd.observables.ParticlePositions(ids=(0,))
@@ -54,11 +65,80 @@ class CorrelatorTest(ut.TestCase):
         acc_unpickeled = pickle.loads(pickle.dumps(acc))
         np.testing.assert_array_equal(corr, acc_unpickeled.result())
 
+        tau = self.calc_tau(s.time_step, acc.tau_lin, corr.shape[0])
+        np.testing.assert_array_almost_equal(corr[:, 0], tau)
         for i in range(corr.shape[0]):
             t = corr[i, 0]
             self.assertAlmostEqual(corr[i, 2], t * t, places=3)
             self.assertAlmostEqual(corr[i, 3], 4 * t * t, places=3)
             self.assertAlmostEqual(corr[i, 4], 9 * t * t, places=3)
+
+    def test_tensor_product(self):
+        s = self.system
+        v = np.array([1, 2, 3])
+        s.part.add(id=0, pos=(0, 0, 0), v=v)
+
+        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        acc = espressomd.accumulators.Correlator(
+            obs1=obs, tau_lin=10, tau_max=10.0, delta_N=1,
+            corr_operation="tensor_product")
+
+        s.integrator.run(1000)
+        s.auto_update_accumulators.add(acc)
+        s.integrator.run(20000)
+
+        corr = acc.result()
+
+        tau = self.calc_tau(s.time_step, acc.tau_lin, corr.shape[0])
+        np.testing.assert_array_almost_equal(corr[:, 0], tau)
+        for i in range(corr.shape[0]):
+            np.testing.assert_array_almost_equal(corr[i, 2:], np.kron(v, v))
+
+    def test_componentwise_product(self):
+        s = self.system
+        v = np.array([1, 2, 3])
+        s.part.add(id=0, pos=(0, 0, 0), v=v)
+
+        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        acc = espressomd.accumulators.Correlator(
+            obs1=obs, tau_lin=10, tau_max=10.0, delta_N=1,
+            corr_operation="componentwise_product")
+
+        s.integrator.run(1000)
+        s.auto_update_accumulators.add(acc)
+        s.integrator.run(20000)
+
+        corr = acc.result()
+
+        tau = self.calc_tau(s.time_step, acc.tau_lin, corr.shape[0])
+        np.testing.assert_array_almost_equal(corr[:, 0], tau)
+        for i in range(corr.shape[0]):
+            np.testing.assert_array_almost_equal(corr[i, 2:], v**2)
+
+    def test_scalar_product(self):
+        s = self.system
+        v = np.array([1, 2, 3])
+        s.part.add(id=0, pos=(0, 0, 0), v=v)
+
+        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        acc = espressomd.accumulators.Correlator(
+            obs1=obs, tau_lin=10, tau_max=10.0, delta_N=1,
+            corr_operation="scalar_product")
+
+        s.integrator.run(1000)
+        s.auto_update_accumulators.add(acc)
+        s.integrator.run(20000)
+
+        corr = acc.result()
+
+        # Check pickling
+        acc_unpickeled = pickle.loads(pickle.dumps(acc))
+        np.testing.assert_array_equal(corr, acc_unpickeled.result())
+
+        tau = self.calc_tau(s.time_step, acc.tau_lin, corr.shape[0])
+        np.testing.assert_array_almost_equal(corr[:, 0], tau)
+        for i in range(corr.shape[0]):
+            np.testing.assert_array_almost_equal(corr[i, 2:], np.sum(v**2))
 
 
 if __name__ == "__main__":

--- a/testsuite/python/correlation.py
+++ b/testsuite/python/correlation.py
@@ -27,31 +27,32 @@ import espressomd.accumulators
 
 class CorrelatorTest(ut.TestCase):
     # Handle for espresso system
-    system = espressomd.System(box_l=[1.0, 1.0, 1.0])
+    system = espressomd.System(box_l=[10, 10, 10])
+    system.cell_system.skin = 0.4
+    system.time_step = 0.01
+
+    def tearDown(self):
+        self.system.part.clear()
 
     def test(self):
         s = self.system
-        s.box_l = [10, 10, 10]
-        s.cell_system.skin = 0.4
-        # s.periodicity=0,0,0
-        s.time_step = 0.01
         s.thermostat.turn_off()
         s.part.add(id=0, pos=(0, 0, 0), v=(1, 2, 3))
 
-        O = espressomd.observables.ParticlePositions(ids=(0,))
-        C2 = espressomd.accumulators.Correlator(
-            obs1=O, tau_lin=10, tau_max=10.0, delta_N=1,
+        obs = espressomd.observables.ParticlePositions(ids=(0,))
+        acc = espressomd.accumulators.Correlator(
+            obs1=obs, tau_lin=10, tau_max=10.0, delta_N=1,
             corr_operation="square_distance_componentwise")
 
         s.integrator.run(1000)
-        s.auto_update_accumulators.add(C2)
+        s.auto_update_accumulators.add(acc)
         s.integrator.run(20000)
 
-        corr = C2.result()
+        corr = acc.result()
 
         # Check pickling
-        C_unpickeled = pickle.loads(pickle.dumps(C2))
-        np.testing.assert_array_equal(corr, C_unpickeled.result())
+        acc_unpickeled = pickle.loads(pickle.dumps(acc))
+        np.testing.assert_array_equal(corr, acc_unpickeled.result())
 
         for i in range(corr.shape[0]):
             t = corr[i, 0]

--- a/testsuite/python/observable_cylindrical.py
+++ b/testsuite/python/observable_cylindrical.py
@@ -211,6 +211,69 @@ class TestCylindricalObservable(ut.TestCase):
         self.flux_density_profile_test()
         self.density_profile_test()
 
+    def test_cylindrical_pid_profile_interface(self):
+        # test setters and getters
+        params = self.params.copy()
+        params['n_r_bins'] = 4
+        params['n_phi_bins'] = 6
+        params['n_z_bins'] = 8
+        params['ids'] = [0, 1]
+        params['axis'] = [0.0, 1.0, 0.0]
+        self.system.part.add(id=0, pos=[0, 0, 0], type=0)
+        self.system.part.add(id=1, pos=[0, 0, 0], type=1)
+        observable = espressomd.observables.CylindricalDensityProfile(**params)
+        # check pids
+        self.assertEqual(observable.ids, params['ids'])
+        new_pids = [params['ids'][0]]
+        observable.ids = new_pids
+        self.assertEqual(observable.ids, new_pids)
+        # check bins
+        self.assertEqual(observable.n_r_bins, params['n_r_bins'])
+        self.assertEqual(observable.n_phi_bins, params['n_phi_bins'])
+        self.assertEqual(observable.n_z_bins, params['n_z_bins'])
+        obs_data = observable.calculate()
+        np.testing.assert_array_equal(obs_data.shape, [4, 6, 8])
+        observable.n_r_bins = 1
+        observable.n_phi_bins = 2
+        observable.n_z_bins = 3
+        self.assertEqual(observable.n_r_bins, 1)
+        self.assertEqual(observable.n_phi_bins, 2)
+        self.assertEqual(observable.n_z_bins, 3)
+        obs_data = observable.calculate()
+        np.testing.assert_array_equal(obs_data.shape, [1, 2, 3])
+        # check edges lower corner
+        self.assertEqual(observable.min_r, params['min_r'])
+        self.assertEqual(observable.min_phi, params['min_phi'])
+        self.assertEqual(observable.min_z, params['min_z'])
+        observable.min_r = 4
+        observable.min_phi = 5
+        observable.min_z = 6
+        self.assertEqual(observable.min_r, 4)
+        self.assertEqual(observable.min_phi, 5)
+        self.assertEqual(observable.min_z, 6)
+        obs_bin_edges = observable.bin_edges()
+        np.testing.assert_array_equal(obs_bin_edges[0, 0, 0], [4, 5, 6])
+        # check edges upper corner
+        self.assertEqual(observable.max_r, params['max_r'])
+        self.assertEqual(observable.max_phi, params['max_phi'])
+        self.assertEqual(observable.max_z, params['max_z'])
+        observable.max_r = 7
+        observable.max_phi = 8
+        observable.max_z = 9
+        self.assertEqual(observable.max_r, 7)
+        self.assertEqual(observable.max_phi, 8)
+        self.assertEqual(observable.max_z, 9)
+        obs_bin_edges = observable.bin_edges()
+        np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
+        # check center
+        np.testing.assert_array_equal(observable.center, params['center'])
+        observable.center = [3, 2, 1]
+        np.testing.assert_array_equal(observable.center, [3, 2, 1])
+        # check axis
+        np.testing.assert_array_equal(observable.axis, params['axis'])
+        observable.axis = [6, 5, 4]
+        np.testing.assert_array_equal(observable.axis, [6, 5, 4])
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/observable_cylindrical.py
+++ b/testsuite/python/observable_cylindrical.py
@@ -266,13 +266,14 @@ class TestCylindricalObservable(ut.TestCase):
         obs_bin_edges = observable.bin_edges()
         np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
         # check center
-        np.testing.assert_array_equal(observable.center, params['center'])
+        np.testing.assert_array_equal(
+            np.copy(observable.center), params['center'])
         observable.center = [3, 2, 1]
-        np.testing.assert_array_equal(observable.center, [3, 2, 1])
+        np.testing.assert_array_equal(np.copy(observable.center), [3, 2, 1])
         # check axis
-        np.testing.assert_array_equal(observable.axis, params['axis'])
+        np.testing.assert_array_equal(np.copy(observable.axis), params['axis'])
         observable.axis = [6, 5, 4]
-        np.testing.assert_array_equal(observable.axis, [6, 5, 4])
+        np.testing.assert_array_equal(np.copy(observable.axis), [6, 5, 4])
 
 
 if __name__ == "__main__":

--- a/testsuite/python/observable_cylindrical.py
+++ b/testsuite/python/observable_cylindrical.py
@@ -46,6 +46,9 @@ class TestCylindricalObservable(ut.TestCase):
         'max_z': 5.0,
     }
 
+    def tearDown(self):
+        self.system.part.clear()
+
     def swap_axis(self, arr, axis):
         if axis == 'x':
             arr = np.dot(

--- a/testsuite/python/observable_cylindricalLB.py
+++ b/testsuite/python/observable_cylindricalLB.py
@@ -61,6 +61,9 @@ class CylindricalLBObservableCommon:
         'max_z': 5.0,
     }
 
+    def tearDown(self):
+        self.system.part.clear()
+
     def swap_axis(self, arr, axis):
         if axis == 'x':
             arr = np.dot(tests_common.rotation_matrix(

--- a/testsuite/python/observable_cylindricalLB.py
+++ b/testsuite/python/observable_cylindricalLB.py
@@ -267,13 +267,14 @@ class CylindricalLBObservableCommon:
         obs_bin_edges = observable.bin_edges()
         np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
         # check center
-        np.testing.assert_array_equal(observable.center, params['center'])
+        np.testing.assert_array_equal(
+            np.copy(observable.center), params['center'])
         observable.center = [3, 2, 1]
-        np.testing.assert_array_equal(observable.center, [3, 2, 1])
+        np.testing.assert_array_equal(np.copy(observable.center), [3, 2, 1])
         # check axis
-        np.testing.assert_array_equal(observable.axis, params['axis'])
+        np.testing.assert_array_equal(np.copy(observable.axis), params['axis'])
         observable.axis = [6, 5, 4]
-        np.testing.assert_array_equal(observable.axis, [6, 5, 4])
+        np.testing.assert_array_equal(np.copy(observable.axis), [6, 5, 4])
         # check sampling_density
         self.assertEqual(observable.sampling_density, 2)
         observable.sampling_density = 3

--- a/testsuite/python/observable_cylindricalLB.py
+++ b/testsuite/python/observable_cylindricalLB.py
@@ -217,6 +217,68 @@ class CylindricalLBObservableCommon:
         self.params['axis'] = 'z'
         self.perform_tests()
 
+    def test_cylindrical_lb_profile_interface(self):
+        # test setters and getters
+        params = self.params.copy()
+        params['n_r_bins'] = 4
+        params['n_phi_bins'] = 6
+        params['n_z_bins'] = 8
+        params['axis'] = [0.0, 1.0, 0.0]
+        params['sampling_density'] = 2
+        del params['ids']
+        observable = espressomd.observables.CylindricalLBVelocityProfile(
+            **params)
+        # check bins
+        self.assertEqual(observable.n_r_bins, params['n_r_bins'])
+        self.assertEqual(observable.n_phi_bins, params['n_phi_bins'])
+        self.assertEqual(observable.n_z_bins, params['n_z_bins'])
+        obs_data = observable.calculate()
+        np.testing.assert_array_equal(obs_data.shape, [4, 6, 8, 3])
+        observable.n_r_bins = 1
+        observable.n_phi_bins = 2
+        observable.n_z_bins = 3
+        self.assertEqual(observable.n_r_bins, 1)
+        self.assertEqual(observable.n_phi_bins, 2)
+        self.assertEqual(observable.n_z_bins, 3)
+        obs_data = observable.calculate()
+        np.testing.assert_array_equal(obs_data.shape, [1, 2, 3, 3])
+        # check edges lower corner
+        self.assertEqual(observable.min_r, params['min_r'])
+        self.assertEqual(observable.min_phi, params['min_phi'])
+        self.assertEqual(observable.min_z, params['min_z'])
+        observable.min_r = 4
+        observable.min_phi = 5
+        observable.min_z = 6
+        self.assertEqual(observable.min_r, 4)
+        self.assertEqual(observable.min_phi, 5)
+        self.assertEqual(observable.min_z, 6)
+        obs_bin_edges = observable.bin_edges()
+        np.testing.assert_array_equal(obs_bin_edges[0, 0, 0], [4, 5, 6])
+        # check edges upper corner
+        self.assertEqual(observable.max_r, params['max_r'])
+        self.assertEqual(observable.max_phi, params['max_phi'])
+        self.assertEqual(observable.max_z, params['max_z'])
+        observable.max_r = 7
+        observable.max_phi = 8
+        observable.max_z = 9
+        self.assertEqual(observable.max_r, 7)
+        self.assertEqual(observable.max_phi, 8)
+        self.assertEqual(observable.max_z, 9)
+        obs_bin_edges = observable.bin_edges()
+        np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
+        # check center
+        np.testing.assert_array_equal(observable.center, params['center'])
+        observable.center = [3, 2, 1]
+        np.testing.assert_array_equal(observable.center, [3, 2, 1])
+        # check axis
+        np.testing.assert_array_equal(observable.axis, params['axis'])
+        observable.axis = [6, 5, 4]
+        np.testing.assert_array_equal(observable.axis, [6, 5, 4])
+        # check sampling_density
+        self.assertEqual(observable.sampling_density, 2)
+        observable.sampling_density = 3
+        self.assertEqual(observable.sampling_density, 3)
+
 
 class CylindricalLBObservableCPU(ut.TestCase, CylindricalLBObservableCommon):
 

--- a/testsuite/python/observable_profileLB.py
+++ b/testsuite/python/observable_profileLB.py
@@ -119,6 +119,73 @@ class ObservableProfileLBCommon:
         with self.assertRaises(RuntimeError):
             obs.calculate()
 
+    def test_lb_profile_interface(self):
+        # test setters and getters
+        params = LB_VELOCITY_PROFILE_PARAMS.copy()
+        params['n_x_bins'] = 4
+        params['n_y_bins'] = 6
+        params['n_z_bins'] = 8
+        obs = espressomd.observables.LBVelocityProfile(**params)
+        # check flag
+        self.assertFalse(obs.allow_empty_bins)
+        obs.allow_empty_bins = True
+        self.assertTrue(obs.allow_empty_bins)
+        # check bins
+        self.assertEqual(obs.n_x_bins, 4)
+        self.assertEqual(obs.n_y_bins, 6)
+        self.assertEqual(obs.n_z_bins, 8)
+        obs_data = obs.calculate()
+        np.testing.assert_array_equal(obs_data.shape, [4, 6, 8, 3])
+        obs.n_x_bins = 1
+        obs.n_y_bins = 2
+        obs.n_z_bins = 3
+        obs_data = obs.calculate()
+        np.testing.assert_array_equal(obs_data.shape, [1, 2, 3, 3])
+        # check edges lower corner
+        self.assertEqual(obs.min_x, params['min_x'])
+        self.assertEqual(obs.min_y, params['min_y'])
+        self.assertEqual(obs.min_z, params['min_z'])
+        obs.min_x = 4
+        obs.min_y = 5
+        obs.min_z = 6
+        self.assertEqual(obs.min_x, 4)
+        self.assertEqual(obs.min_y, 5)
+        self.assertEqual(obs.min_z, 6)
+        obs_bin_edges = obs.bin_edges()
+        np.testing.assert_array_equal(obs_bin_edges[0, 0, 0], [4, 5, 6])
+        # check edges upper corner
+        self.assertEqual(obs.max_x, params['max_x'])
+        self.assertEqual(obs.max_y, params['max_y'])
+        self.assertEqual(obs.max_z, params['max_z'])
+        obs.max_x = 7
+        obs.max_y = 8
+        obs.max_z = 9
+        self.assertEqual(obs.max_x, 7)
+        self.assertEqual(obs.max_y, 8)
+        self.assertEqual(obs.max_z, 9)
+        obs_bin_edges = obs.bin_edges()
+        np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
+        # check delta
+        self.assertEqual(obs.sampling_delta_x, params['sampling_delta_x'])
+        self.assertEqual(obs.sampling_delta_y, params['sampling_delta_y'])
+        self.assertEqual(obs.sampling_delta_z, params['sampling_delta_z'])
+        obs.sampling_delta_x = 10
+        obs.sampling_delta_y = 11
+        obs.sampling_delta_z = 12
+        self.assertEqual(obs.sampling_delta_x, 10)
+        self.assertEqual(obs.sampling_delta_y, 11)
+        self.assertEqual(obs.sampling_delta_z, 12)
+        # check delta
+        self.assertEqual(obs.sampling_offset_x, params['sampling_offset_x'])
+        self.assertEqual(obs.sampling_offset_y, params['sampling_offset_y'])
+        self.assertEqual(obs.sampling_offset_z, params['sampling_offset_z'])
+        obs.sampling_offset_x = 13
+        obs.sampling_offset_y = 14
+        obs.sampling_offset_z = 15
+        self.assertEqual(obs.sampling_offset_x, 13)
+        self.assertEqual(obs.sampling_offset_y, 14)
+        self.assertEqual(obs.sampling_offset_z, 15)
+
 
 class LBCPU(ut.TestCase, ObservableProfileLBCommon):
 

--- a/testsuite/python/observables.py
+++ b/testsuite/python/observables.py
@@ -123,6 +123,12 @@ class Observables(ut.TestCase):
                 " and particle property " +
                 pprop_name, decimal=11)
 
+            # Test setters and getters
+            self.assertEqual(observable.ids, id_list)
+            new_pids = [id_list[0]]
+            observable.ids = new_pids
+            self.assertEqual(observable.ids, new_pids)
+
         return func
 
     test_pos = generate_test_for_pid_observable(

--- a/testsuite/python/polymer_linear.py
+++ b/testsuite/python/polymer_linear.py
@@ -198,6 +198,18 @@ class LinearPolymerPositions(ut.TestCase):
                 respect_constraints=True, seed=self.seed)
         self.system.constraints.remove(wall_constraint)
 
+    def test_failure(self):
+        """
+        Check the runtime error message.
+
+        """
+        with self.assertRaisesRegex(Exception, 'Failed to create polymer positions.'):
+            polymer.linear_polymer_positions(
+                n_polymers=1, beads_per_chain=10,
+                start_positions=np.array([[0, 0, 0]]),
+                bond_length=self.box_l / 2, min_distance=self.box_l / 2.1,
+                bond_angle=np.pi, max_tries=2, seed=self.seed)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/rdf.py
+++ b/testsuite/python/rdf.py
@@ -104,6 +104,41 @@ class RdfTest(ut.TestCase):
 
         np.testing.assert_allclose(rdf10, rdf01)
 
+    def test_rdf_interface(self):
+        # test setters and getters
+        s = self.s
+        s.part.add(id=0, pos=[0, 0, 0], type=0)
+        s.part.add(id=1, pos=[0, 0, 0], type=1)
+        observable = espressomd.observables.RDF(ids1=s.part[:].id[0::2],
+                                                ids2=s.part[:].id[1::2],
+                                                min_r=1, max_r=2, n_r_bins=3)
+        # check pids
+        self.assertEqual(observable.ids1, s.part[:].id[0::2])
+        self.assertEqual(observable.ids2, s.part[:].id[1::2])
+        new_pids1 = [s.part[:].id[0]]
+        new_pids2 = [s.part[:].id[1]]
+        observable.ids1 = new_pids1
+        observable.ids2 = new_pids2
+        self.assertEqual(observable.ids1, new_pids1)
+        self.assertEqual(observable.ids2, new_pids2)
+        # check bins
+        self.assertEqual(observable.n_r_bins, 3)
+        observable.n_r_bins = 2
+        self.assertEqual(observable.n_r_bins, 2)
+        obs_data = observable.calculate()
+        np.testing.assert_array_equal(obs_data.shape, [2])
+        # check edges lower corner
+        self.assertEqual(observable.min_r, 1)
+        observable.min_r = 0
+        self.assertEqual(observable.min_r, 0)
+        # check edges upper corner
+        self.assertEqual(observable.max_r, 2)
+        observable.max_r = 4
+        self.assertEqual(observable.max_r, 4)
+        # check bin centers
+        obs_bin_centers = observable.bin_centers()
+        np.testing.assert_array_equal(obs_bin_centers, [1, 3])
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/rdf.py
+++ b/testsuite/python/rdf.py
@@ -28,6 +28,8 @@ class RdfTest(ut.TestCase):
 
     def setUp(self):
         self.s.box_l = 3 * [10]
+
+    def tearDown(self):
         self.s.part.clear()
 
     def bin_volumes(self, midpoints):

--- a/testsuite/python/rotation_per_particle.py
+++ b/testsuite/python/rotation_per_particle.py
@@ -133,11 +133,13 @@ class Rotation(ut.TestCase):
         # place particle in cell with MPI rank 0
         p = s.part.add(pos=0.01 * self.s.box_l, rotation=(1, 1, 1))
         p.rotate((1, 0, 0), -np.pi / 2)
-        np.testing.assert_array_almost_equal(p.director, [0, 1, 0], decimal=10)
+        np.testing.assert_array_almost_equal(
+            np.copy(p.director), [0, 1, 0], decimal=10)
         # place particle in cell with MPI rank N-1
         p = s.part.add(pos=0.99 * self.s.box_l, rotation=(1, 1, 1))
         p.rotate((1, 0, 0), -np.pi / 2)
-        np.testing.assert_array_almost_equal(p.director, [0, 1, 0], decimal=10)
+        np.testing.assert_array_almost_equal(
+            np.copy(p.director), [0, 1, 0], decimal=10)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/rotation_per_particle.py
+++ b/testsuite/python/rotation_per_particle.py
@@ -127,6 +127,18 @@ class Rotation(ut.TestCase):
         np.testing.assert_allclose(
             p.convert_vector_space_to_body(v_r), v, atol=1E-10)
 
+    def test_rotation_mpi_communication(self):
+        s = self.s
+        s.part.clear()
+        # place particle in cell with MPI rank 0
+        p = s.part.add(pos=0.01 * self.s.box_l, rotation=(1, 1, 1))
+        p.rotate((1, 0, 0), -np.pi / 2)
+        np.testing.assert_array_almost_equal(p.director, [0, 1, 0], decimal=10)
+        # place particle in cell with MPI rank N-1
+        p = s.part.add(pos=0.99 * self.s.box_l, rotation=(1, 1, 1))
+        p.rotate((1, 0, 0), -np.pi / 2)
+        np.testing.assert_array_almost_equal(p.director, [0, 1, 0], decimal=10)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/rotation_per_particle.py
+++ b/testsuite/python/rotation_per_particle.py
@@ -33,9 +33,9 @@ class Rotation(ut.TestCase):
            thermalized"""
         s = self.s
         s.thermostat.set_langevin(gamma=1, kT=1, seed=42)
-        for x in 0, 1:
-            for y in 0, 1:
-                for z in 0, 1:
+        for x in (0, 1):
+            for y in (0, 1):
+                for z in (0, 1):
                     s.part.clear()
                     s.part.add(id=0, pos=(0, 0, 0), rotation=(x, y, z),
                                quat=(1, 0, 0, 0), omega_body=(0, 0, 0),
@@ -61,7 +61,7 @@ class Rotation(ut.TestCase):
         s.part.clear()
         s.part.add(id=0, pos=(0.9, 0.9, 0.9), ext_torque=(1, 1, 1))
         s.thermostat.turn_off()
-        for dir in 0, 1, 2:
+        for dir in (0, 1, 2):
             # Reset orientation
             s.part[0].quat = [1, 0, 0, 0]
 

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -110,12 +110,16 @@ if espressomd.has_features('P3M') and 'P3M.CPU' in modes:
 
 obs = espressomd.observables.ParticlePositions(ids=[0, 1])
 acc = espressomd.accumulators.MeanVarianceCalculator(obs=obs)
+acc_time_series = espressomd.accumulators.TimeSeries(obs=obs)
 acc.update()
+acc_time_series.update()
 system.part[0].pos = [1.0, 2.0, 3.0]
 acc.update()
+acc_time_series.update()
 
 
 system.auto_update_accumulators.add(acc)
+system.auto_update_accumulators.add(acc_time_series)
 
 # constraints
 system.constraints.add(shape=Sphere(center=system.box_l / 2, radius=0.1),
@@ -187,6 +191,7 @@ if 'THERM.LB' not in modes:
     system.part[1].add_bond((thermalized_bond, 0))
 checkpoint.register("system")
 checkpoint.register("acc")
+checkpoint.register("acc_time_series")
 # calculate forces
 system.integrator.run(0)
 particle_force0 = np.copy(system.part[0].f)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -277,6 +277,13 @@ class CheckpointTest(ut.TestCase):
             system.auto_update_accumulators[0].get_variance(),
             np.array([[0., 0.5, 2.], [0., 0., 0.]]))
 
+    def test_time_series(self):
+        expected = [[[1, 1, 1], [1, 1, 2]], [[1, 2, 3], [1, 1, 2]]]
+        np.testing.assert_array_equal(acc_time_series.time_series(), expected)
+        np.testing.assert_array_equal(
+            system.auto_update_accumulators[1].time_series(),
+            expected)
+
     @utx.skipIfMissingFeatures('P3M')
     @ut.skipIf('P3M.CPU' not in modes,
                "Skipping test due to missing combination.")

--- a/testsuite/python/time_series.py
+++ b/testsuite/python/time_series.py
@@ -23,6 +23,8 @@ Testmodule for the time series accumulator.
 """
 import unittest as ut
 import numpy as np
+import pickle
+
 import espressomd
 import espressomd.observables
 import espressomd.accumulators
@@ -52,6 +54,11 @@ class TimeSeriesTest(ut.TestCase):
             acc.update()
 
         time_series = acc.time_series()
+
+        # Check pickling
+        acc_unpickeled = pickle.loads(pickle.dumps(acc))
+        np.testing.assert_array_equal(
+            time_series, acc_unpickeled.time_series())
 
         for result, expected in zip(time_series, positions):
             np.testing.assert_array_equal(result, expected)

--- a/testsuite/python/time_series.py
+++ b/testsuite/python/time_series.py
@@ -18,24 +18,19 @@
 #
 
 """
-Testmodule for the observable recorder.
+Testmodule for the time series accumulator.
 
 """
 import unittest as ut
 import numpy as np
 import espressomd
-from espressomd.observables import ParticlePositions
-from espressomd.accumulators import TimeSeries
+import espressomd.observables
+import espressomd.accumulators
 
 N_PART = 100
 
 
 class TimeSeriesTest(ut.TestCase):
-
-    """
-    Test class for the observable time series.
-
-    """
 
     def test_time_series(self):
         """Check that accumulator results are the same as the respective numpy result.
@@ -45,8 +40,8 @@ class TimeSeriesTest(ut.TestCase):
         system = espressomd.System(box_l=3 * [1.])
         system.part.add(pos=np.random.random((N_PART, 3)))
 
-        obs = ParticlePositions(ids=system.part[:].id)
-        time_series = TimeSeries(obs=obs)
+        obs = espressomd.observables.ParticlePositions(ids=system.part[:].id)
+        acc = espressomd.accumulators.TimeSeries(obs=obs)
 
         positions = []
         for _ in range(10):
@@ -54,14 +49,15 @@ class TimeSeriesTest(ut.TestCase):
             positions.append(pos)
 
             system.part[:].pos = pos
-            time_series.update()
+            acc.update()
 
-        for result, expected in zip(time_series.time_series(), positions):
-            np.testing.assert_array_equal(
-                result, expected)
+        time_series = acc.time_series()
 
-        time_series.clear()
-        self.assertEqual(len(time_series.time_series()), 0)
+        for result, expected in zip(time_series, positions):
+            np.testing.assert_array_equal(result, expected)
+
+        acc.clear()
+        self.assertEqual(len(acc.time_series()), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Description of changes:
- fix broken tensor_product correlator (only returned zeros in 4.1)
- add more correlators and accumulators test cases
- test script interface getters/setters for observables, correlators and accumulators
- make code coverage more reproducible