### PR TITLE
WIP: test newer macOS CI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -383,7 +383,7 @@ osx:
     - export with_ccache=false myconfig=maxset with_cuda=false
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - mac
+    - mac-test
 
 ### Builds with different compilers
 


### PR DESCRIPTION
Do not merge. We will reuse the old runner tag once it is deemed stable.

@jngrad 