### PR TITLE
script_interface: Fixed build with c++17

### DIFF
--- a/src/script_interface/accumulators/Correlator.hpp
+++ b/src/script_interface/accumulators/Correlator.hpp
@@ -42,7 +42,6 @@ class Correlator : public AccumulatorBase {
 
 public:
   Correlator() {
-    using Utils::as_const;
     /* Only args can be changed after construction. */
     add_parameters(
         {{"tau_lin", m_correlator, &CoreCorr::tau_lin},
@@ -53,8 +52,8 @@ public:
          {"args", m_correlator, &CoreCorr::set_correlation_args,
           &CoreCorr::correlation_args},
          {"dim_corr", m_correlator, &CoreCorr::dim_corr},
-         {"obs1", as_const(m_obs1)},
-         {"obs2", as_const(m_obs2)},
+         {"obs1", Utils::as_const(m_obs1)},
+         {"obs2", Utils::as_const(m_obs2)},
          {"n_result", m_correlator, &CoreCorr::n_result}});
   }
 


### PR DESCRIPTION
C++17 introduces `std::as_const` which made some calls to `Utils::as_const` ambiguous, this fixes this by qualifying the function.