### PR TITLE
Fix CMake warning, update macOS installation instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,5 @@ jobs:
        brew install hdf5-mpi
        pip3 install numpy cython vtk h5py scipy
     - run: |
-        export myconfig=maxset with_cuda=false
+        export myconfig=maxset with_cuda=false test_timeout=600
         bash maintainer/CI/build_cmake.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ endif()
 # CMake modules/macros are in a subdirectory to keep this file cleaner
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+# C++ standard
+enable_language(CXX)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 include(FeatureSummary)
 include(GNUInstallDirs)
 project(ESPResSo)
@@ -40,12 +46,6 @@ if(POLICY CMP0074)
   # make find_package() use <PackageName>_ROOT variables
   cmake_policy(SET CMP0074 NEW)
 endif()
-
-# C++ standard
-enable_language(CXX)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(PROJECT_VERSION "4.2-dev")
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -184,16 +184,26 @@ using the following commands:
     sudo rm -r ~/anaconda[23]
     sudo rm -r /Library/Python
 
-If you want to install MacPorts, download the installer package
-appropriate for your Mac OS X version from
-https://www.macports.org/install.php and install it.
-
-If you want to install Homebrew, use the following commands.
+Install the command line tools (gcc, git, make, etc.) with either:
 
 .. code-block:: bash
 
     sudo xcode-select --install
+
+or:
+
+.. code-block:: bash
+
     sudo xcodebuild -license accept
+
+If you want to install MacPorts, download the installer package
+appropriate for your Mac OS X version from
+https://www.macports.org/install.php and install it.
+
+If you want to install Homebrew, use the following command:
+
+.. code-block:: bash
+
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 Installing packages using MacPorts
@@ -203,8 +213,6 @@ Run the following commands:
 
 .. code-block:: bash
 
-    sudo xcode-select --install
-    sudo xcodebuild -license accept
     sudo port selfupdate
     sudo port install cmake python37 py37-cython py37-numpy \
       openmpi-default fftw-3 +openmpi boost +openmpi +python37 \
@@ -217,6 +225,8 @@ Run the following commands:
 
 Installing packages using Homebrew
 """"""""""""""""""""""""""""""""""
+
+Run the following commands:
 
 .. code-block:: bash
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -184,27 +184,13 @@ using the following commands:
     sudo rm -r ~/anaconda[23]
     sudo rm -r /Library/Python
 
-Install the command line tools (gcc, git, make, etc.) with either:
-
-.. code-block:: bash
-
-    sudo xcode-select --install
-
-or:
-
-.. code-block:: bash
-
-    sudo xcodebuild -license accept
-
 If you want to install MacPorts, download the installer package
 appropriate for your Mac OS X version from
-https://www.macports.org/install.php and install it.
+https://www.macports.org/install.php and follow their
+installation instructions.
 
-If you want to install Homebrew, use the following command:
-
-.. code-block:: bash
-
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+If you want to install Homebrew, follow the installation
+instructions at https://docs.brew.sh/Installation.
 
 Installing packages using MacPorts
 """"""""""""""""""""""""""""""""""


### PR DESCRIPTION
Description of changes:
- fix `GNUInstallDirs`-related warning generated in CMake 3.18
- update macOS installation instructions for command line tools
- increase timeout on macOS runner from GitHub Workflows
