### PR TITLE
Disable dlopen trick on OpenMPI >= 3.0.0

### DIFF
--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -165,7 +165,7 @@ void openmpi_fix_vader() {
  */
 void openmpi_global_namespace() {
   if (OMPI_MAJOR_VERSION >= 3)
-      return;
+    return;
 #ifdef RTLD_NOLOAD
   const int mode = RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD;
 #else

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -164,6 +164,8 @@ void openmpi_fix_vader() {
  * about some weird two-level symbol namespace thing.
  */
 void openmpi_global_namespace() {
+  if (OMPI_MAJOR_VERSION >= 3)
+      return;
 #ifdef RTLD_NOLOAD
   const int mode = RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD;
 #else


### PR DESCRIPTION
It is not needed anymore since https://github.com/open-mpi/ompi/issues/3705. Related: #3812, where we document this trick.