### PR TITLE
Fix CMake compiler flags logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,9 +456,6 @@ endif()
 
 target_link_libraries(cxx_interface INTERFACE coverage_interface)
 
-# Give CMAKE_CXX_FLAGS higher precedence
-target_compile_options(cxx_interface INTERFACE ${CMAKE_CXX_FLAGS})
-
 #
 # Testing
 # ##############################################################################


### PR DESCRIPTION
Remove non-standard CMake logic that appends a whitespace-separated list of compiler flags as a string at the end of a list, making it incompatible with automated build systems like RPM Build (Fedora) and OSC (OpenSUSE).