### PR TITLE
Update CI image tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,7 +114,7 @@ no_rotation:
 ubuntu:wo-dependencies:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/ubuntu-wo-dependencies:fc7628d32de0fce605976ba9edebe7eff186e618
+  image: docker.pkg.github.com/espressomd/docker/ubuntu-wo-dependencies:8a7d258889d87dcc9c96a200784b30b532d45b33
   script:
     - export myconfig=maxset with_cuda=false make_check_unit_tests=false make_check_python=false
     - bash maintainer/CI/build_cmake.sh
@@ -149,7 +149,7 @@ opensuse:15.2:
 centos:7:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/centos:446ff604bbfa63f30ddb462697fa0d0dc2630460
+  image: docker.pkg.github.com/espressomd/docker/centos:8a7d258889d87dcc9c96a200784b30b532d45b33
   script:
     - export with_cuda=false myconfig=maxset make_check_python=true with_stokesian_dynamics=true
     - bash maintainer/CI/build_cmake.sh
@@ -160,7 +160,7 @@ centos:7:
 fedora:32:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/fedora:fc7628d32de0fce605976ba9edebe7eff186e618
+  image: docker.pkg.github.com/espressomd/docker/fedora:8a7d258889d87dcc9c96a200784b30b532d45b33
   script:
     - export with_cuda=false myconfig=maxset make_check_python=false with_stokesian_dynamics=true
     - bash maintainer/CI/build_cmake.sh

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -31,6 +31,6 @@ make_check=${make_check}
 build_type=RelWithAssert
 myconfig=maxset
 EOF
-image="espressomd/docker-ubuntu-20.04:06b6216c7aa3555bcf28c90734dbb84e7285c96f"
+image="espressomd/docker-ubuntu-20.04:8a7d258889d87dcc9c96a200784b30b532d45b33"
 
 docker run -u espresso --env-file "${ENV_FILE}" -v "${PWD}:/travis" -it "${image}" /bin/bash -c "cp -r /travis .; cd travis && maintainer/CI/build_cmake.sh" || exit 1


### PR DESCRIPTION
Fixes failures in CI about images not being found in `docker.pkg.github.com/espressomd/docker`