### PR TITLE
cmake: turn ctest  in cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,9 @@ if(WITH_TESTS)
   if(WITH_PYTHON)
     add_subdirectory(testsuite)
   endif(WITH_PYTHON)
-  set(CTEST_ARGS "" CACHE STRING "Extra arguments to give to ctest calls (separated by semicolons)")
+  set(CTEST_ARGS ""
+      CACHE STRING
+            "Extra arguments to give to ctest calls (separated by semicolons)")
 endif(WITH_TESTS)
 
 if(WITH_BENCHMARKS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if(WITH_TESTS)
   if(WITH_PYTHON)
     add_subdirectory(testsuite)
   endif(WITH_PYTHON)
-  set(CTEST_ARGS "" CACHE STRING "Extra arguments to give to ctest calls")
+  set(CTEST_ARGS "" CACHE STRING "Extra arguments to give to ctest calls (separated by semicolons)")
 endif(WITH_TESTS)
 
 if(WITH_BENCHMARKS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,7 @@ if(WITH_TESTS)
   if(WITH_PYTHON)
     add_subdirectory(testsuite)
   endif(WITH_PYTHON)
+  set(CTEST_ARGS "" CACHE STRING "Extra arguments to give to ctest calls")
 endif(WITH_TESTS)
 
 if(WITH_BENCHMARKS)

--- a/maintainer/benchmarks/CMakeLists.txt
+++ b/maintainer/benchmarks/CMakeLists.txt
@@ -114,6 +114,6 @@ python_benchmark(
 
 add_custom_target(
   benchmark_python COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                           $(ARGS) --output-on-failure)
+                           ${CTEST_ARGS} --output-on-failure)
 
 add_dependencies(benchmark benchmark_python)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Target for the unit tests
 add_custom_target(
   check_unit_tests COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                           $(ARGS) --output-on-failure)
+                           ${CTEST_ARGS} --output-on-failure)
 
 if(WITH_TESTS)
   # Run unit tests on check

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -246,8 +246,9 @@ add_custom_target(
           parallel_odd ${CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_parallel_odd pypresso python_test_data)
 add_custom_target(
-  check_python_gpu COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                           -j${TEST_NP} -L gpu ${CTEST_ARGS} --output-on-failure)
+  check_python_gpu
+  COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -j${TEST_NP} -L gpu
+          ${CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_gpu pypresso python_test_data)
 
 add_custom_target(

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -243,21 +243,21 @@ add_custom_target(
 add_custom_target(
   check_python_parallel_odd
   COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -j${TEST_NP} -L
-          parallel_odd $(ARGS) --output-on-failure)
+          parallel_odd ${CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_parallel_odd pypresso python_test_data)
 add_custom_target(
   check_python_gpu COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                           -j${TEST_NP} -L gpu $(ARGS) --output-on-failure)
+                           -j${TEST_NP} -L gpu ${CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_gpu pypresso python_test_data)
 
 add_custom_target(
   check_python_skip_long
   COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT} -j${TEST_NP} -LE
-          long $(ARGS) --output-on-failure)
+          long ${CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_skip_long pypresso python_test_data)
 
 add_custom_target(
   check_python COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                       -j${TEST_NP} $(ARGS) --output-on-failure)
+                       -j${TEST_NP} ${CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python pypresso python_test_data)
 add_dependencies(check check_python)

--- a/testsuite/scripts/benchmarks/CMakeLists.txt
+++ b/testsuite/scripts/benchmarks/CMakeLists.txt
@@ -26,6 +26,6 @@ benchmark_test(FILE test_p3m.py)
 
 add_custom_target(
   check_benchmarks COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                           -j${TEST_NP} $(ARGS) --output-on-failure)
+                           -j${TEST_NP} ${CTEST_ARGS} --output-on-failure)
 
 add_dependencies(check_benchmarks pypresso local_benchmarks)

--- a/testsuite/scripts/samples/CMakeLists.txt
+++ b/testsuite/scripts/samples/CMakeLists.txt
@@ -87,6 +87,6 @@ sample_test(FILE test_immersed_boundary.py)
 
 add_custom_target(
   check_samples COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                        -j${TEST_NP} $(ARGS) --output-on-failure)
+                        -j${TEST_NP} ${CTEST_ARGS} --output-on-failure)
 
 add_dependencies(check_samples pypresso local_samples)

--- a/testsuite/scripts/tutorials/CMakeLists.txt
+++ b/testsuite/scripts/tutorials/CMakeLists.txt
@@ -52,6 +52,6 @@ tutorial_test(FILE test_12-constant_pH.py)
 
 add_custom_target(
   check_tutorials COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${TEST_TIMEOUT}
-                          -j${TEST_NP} $(ARGS) --output-on-failure)
+                          -j${TEST_NP} ${CTEST_ARGS} --output-on-failure)
 
 add_dependencies(check_tutorials pypresso local_tutorials)


### PR DESCRIPTION
Fixes #3861

Description of changes:
- remove Makefile variable expansion commands from custom targets to improve compatibility with other build systems like `ninja`
