### PR TITLE
Remove duplicated functions in DP3M code

### DIFF
--- a/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
@@ -25,6 +25,7 @@
 
 #include <utils/Vector.hpp>
 #include <utils/constants.hpp>
+#include <utils/index.hpp>
 #include <utils/math/int_pow.hpp>
 #include <utils/math/sinc.hpp>
 #include <utils/math/sqr.hpp>
@@ -32,6 +33,8 @@
 #include <boost/range/numeric.hpp>
 
 #include <cmath>
+
+#if defined(DP3M)
 
 /** Calculate the aliasing sums for the optimal influence function.
  *
@@ -77,7 +80,8 @@ double G_opt_dipolar(P3MParameters const &params, Utils::Vector3i const &shift,
       }
     }
   }
-  return numerator / (int_pow<S>(d_op.norm2()) * Utils::sqr(denominator));
+  return numerator / (int_pow<S>(static_cast<double>(d_op.norm2())) *
+                      Utils::sqr(denominator));
 }
 
 /**
@@ -213,4 +217,5 @@ double grid_influence_function_self_energy(P3MParameters const &params,
   return energy;
 }
 
+#endif
 #endif

--- a/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2010-2020 The ESPResSo project
+ * Copyright (C) 2002-2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ESPRESSO_DP3M_INFLUENCE_FUNCTION_HPP
+#define ESPRESSO_DP3M_INFLUENCE_FUNCTION_HPP
+
+#include "electrostatics_magnetostatics/p3m-common.hpp"
+
+#include <utils/Vector.hpp>
+#include <utils/constants.hpp>
+#include <utils/math/int_pow.hpp>
+#include <utils/math/sinc.hpp>
+#include <utils/math/sqr.hpp>
+
+#include <boost/range/numeric.hpp>
+
+#include <cmath>
+
+/** Calculate the aliasing sums for the optimal influence function.
+ *
+ *  Calculates the aliasing sums in the numerator and denominator of
+ *  the expression for the optimal influence function (see
+ *  @cite hockney88a : 8-22, p. 275).
+ *
+ *  \tparam S          order (2 for energy, 3 for forces)
+ *  \param shift       shift for a given n-vector
+ *  \param d_op        differential operator for a given n-vector
+ *  \return The result of the fraction.
+ */
+template <size_t S>
+double G_opt_dipolar(P3MParameters const &params, Utils::Vector3i const &shift,
+                     Utils::Vector3i const &d_op) {
+  using Utils::int_pow;
+  using Utils::sinc;
+  constexpr double limit = 30;
+
+  double numerator = 0.0;
+  double denominator = 0.0;
+
+  auto const f1 = 1.0 / static_cast<double>(params.mesh[0]);
+  auto const f2 = Utils::sqr(Utils::pi() / (params.alpha_L));
+
+  for (double mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
+    auto const nmx = shift[0] + params.mesh[0] * mx;
+    auto const sx = std::pow(sinc(f1 * nmx), 2.0 * params.cao);
+    for (double my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
+      auto const nmy = shift[1] + params.mesh[0] * my;
+      auto const sy = sx * std::pow(sinc(f1 * nmy), 2.0 * params.cao);
+      for (double mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
+        auto const nmz = shift[2] + params.mesh[0] * mz;
+        auto const sz = sy * std::pow(sinc(f1 * nmz), 2.0 * params.cao);
+        auto const nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
+        auto const exponent = f2 * nm2;
+        if (exponent < limit) {
+          auto const f3 = sz * std::exp(-exponent) / nm2;
+          auto const n_nm = d_op[0] * nmx + d_op[1] * nmy + d_op[2] * nmz;
+          numerator += f3 * int_pow<S>(n_nm);
+        }
+        denominator += sz;
+      }
+    }
+  }
+  return numerator / (int_pow<S>(d_op.norm2()) * Utils::sqr(denominator));
+}
+
+/**
+ * @brief Map influence function over a grid.
+ *
+ * This evaluates the optimal influence function @ref G_opt_dipolar
+ * over a regular grid of k vectors, and returns the values as a vector.
+ *
+ * @tparam S Order of the differential operator, e.g. 2 for energy, 3 for force
+ *
+ * @param params DP3M parameters
+ * @param n_start Lower left corner of the grid
+ * @param n_end Upper right corner of the grid.
+ * @param box_l Box size
+ * @return Values of the influence function at regular grid points.
+ */
+template <size_t S>
+std::vector<double> grid_influence_function(P3MParameters const &params,
+                                            Utils::Vector3i const &n_start,
+                                            Utils::Vector3i const &n_end,
+                                            Utils::Vector3d const &box_l) {
+
+  auto const size = n_end - n_start;
+
+  /* The influence function grid */
+  auto g =
+      std::vector<double>(boost::accumulate(size, 1, std::multiplies<>()), 0.);
+
+  /* Skip influence function calculation in tuning mode,
+     the results need not be correct for timing. */
+  if (params.tuning) {
+    return g;
+  }
+
+  double fak1 = Utils::int_pow<3>(params.mesh[0]) * 2.0 / Utils::sqr(box_l[0]);
+
+  auto const shifts =
+      detail::calc_meshift({params.mesh[0], params.mesh[1], params.mesh[2]});
+  auto const d_ops = detail::calc_meshift(
+      {params.mesh[0], params.mesh[1], params.mesh[2]}, true);
+
+  Utils::Vector3i n{};
+  for (n[0] = n_start[0]; n[0] < n_end[0]; n[0]++) {
+    for (n[1] = n_start[1]; n[1] < n_end[1]; n[1]++) {
+      for (n[2] = n_start[2]; n[2] < n_end[2]; n[2]++) {
+        auto const ind = Utils::get_linear_index(n - n_start, size,
+                                                 Utils::MemoryOrder::ROW_MAJOR);
+
+        if (((n[0] % (params.mesh[0] / 2) == 0) &&
+             (n[1] % (params.mesh[0] / 2) == 0) &&
+             (n[2] % (params.mesh[0] / 2) == 0))) {
+          g[ind] = 0.0;
+        } else {
+          auto const shift = Utils::Vector3i{shifts[0][n[0]], shifts[0][n[1]],
+                                             shifts[0][n[2]]};
+          auto const d_op =
+              Utils::Vector3i{d_ops[0][n[0]], d_ops[0][n[1]], d_ops[0][n[2]]};
+          auto const fak2 = G_opt_dipolar<S>(params, shift, d_op);
+          g[ind] = fak1 * fak2;
+        }
+      }
+    }
+  }
+  return g;
+}
+
+#endif

--- a/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
@@ -43,6 +43,7 @@
  *  @cite hockney88a : 8-22, p. 275).
  *
  *  \tparam S          order (2 for energy, 3 for forces)
+ *  \param params      DP3M parameters
  *  \param shift       shift for a given n-vector
  *  \param d_op        differential operator for a given n-vector
  *  \return The result of the fraction.
@@ -58,7 +59,7 @@ double G_opt_dipolar(P3MParameters const &params, Utils::Vector3i const &shift,
   double denominator = 0.0;
 
   auto const f1 = 1.0 / static_cast<double>(params.mesh[0]);
-  auto const f2 = Utils::sqr(Utils::pi() / (params.alpha_L));
+  auto const f2 = Utils::sqr(Utils::pi() / params.alpha_L);
 
   for (double mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
     auto const nmx = shift[0] + params.mesh[0] * mx;
@@ -116,7 +117,8 @@ std::vector<double> grid_influence_function(P3MParameters const &params,
     return g;
   }
 
-  double fak1 = Utils::int_pow<3>(params.mesh[0]) * 2.0 / Utils::sqr(box_l[0]);
+  double fak1 = Utils::int_pow<3>(static_cast<double>(params.mesh[0])) * 2.0 /
+                Utils::sqr(box_l[0]);
 
   auto const shifts =
       detail::calc_meshift({params.mesh[0], params.mesh[1], params.mesh[2]});

--- a/src/core/electrostatics_magnetostatics/fft.cpp
+++ b/src/core/electrostatics_magnetostatics/fft.cpp
@@ -71,6 +71,7 @@ namespace {
  *  \param[out] node_list2  Linear node index list for grid2.
  *  \param[out] pos         Positions of the nodes in grid2
  *  \param[out] my_pos      Position of comm.rank() in grid2.
+ *  \param[in]  comm        MPI communicator.
  *  \return Size of the communication group.
  */
 boost::optional<std::vector<int>>

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -58,6 +58,17 @@ enum P3M_TUNE_ERROR {
   P3M_TUNE_ACCURACY_TOO_LARGE = 32
 };
 
+namespace detail {
+/** @brief Index helpers for direct and reciprocal space.
+ *  After the FFT the data is in order YZX, which
+ *  means that Y is the slowest changing index.
+ */
+namespace FFT_indexing {
+enum FFT_REAL_VECTOR : int { RX = 0, RY = 1, RZ = 2 };
+enum FFT_WAVE_VECTOR : int { KY = 0, KZ = 1, KX = 2 };
+} // namespace FFT_indexing
+} // namespace detail
+
 /** This value indicates metallic boundary conditions. */
 #define P3M_EPSILON_METALLIC 0.0
 

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -61,9 +61,6 @@ enum P3M_TUNE_ERROR {
 /** This value indicates metallic boundary conditions. */
 #define P3M_EPSILON_METALLIC 0.0
 
-/** Default for boundary conditions in magnetic calculations. */
-#define P3M_EPSILON_MAGNETIC 0.0
-
 /** precision limit for the r_cut zero */
 #define P3M_RCUT_PREC 1e-3
 /** granularity of the time measurement */

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -198,12 +198,11 @@ namespace detail {
  */
 std::array<std::vector<int>, 3> inline calc_meshift(
     std::array<int, 3> const &mesh_size, bool zero_out_midpoint = false) {
-  std::array<std::vector<int>, 3> ret;
+  std::array<std::vector<int>, 3> ret{};
 
   for (size_t i = 0; i < 3; i++) {
-    ret[i].resize(mesh_size[i]);
+    ret[i] = std::vector<int>(mesh_size[i]);
 
-    ret[i][0] = 0;
     for (int j = 1; j <= mesh_size[i] / 2; j++) {
       ret[i][j] = j;
       ret[i][mesh_size[i] - j] = -j;

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -34,6 +34,9 @@
  */
 #include "config.hpp"
 
+#include <array>
+#include <vector>
+
 #if defined(P3M) || defined(DP3M)
 
 #include "LocalBox.hpp"
@@ -187,5 +190,33 @@ void p3m_calc_lm_ld_pos(p3m_local_mesh &local_mesh,
                         const P3MParameters &params);
 
 #endif /* P3M || DP3M */
+
+namespace detail {
+/** Calculate a mesh shift sequence.
+ *  For each mesh size @f$ n @f$ in @c mesh_size, create a sequence of integer
+ *  values @f$ \left( 0, \ldots, \lfloor n/2 \rfloor, -\lfloor n/2 \rfloor,
+ *  \ldots, -1\right) @f$ if @c zero_out_midpoint is false, otherwise
+ *  @f$ \left( 0, \ldots, \lfloor n/2 - 1 \rfloor, 0, -\lfloor n/2 \rfloor,
+ *  \ldots, -1\right) @f$.
+ */
+std::array<std::vector<int>, 3> inline calc_meshift(
+    std::array<int, 3> const &mesh_size, bool zero_out_midpoint = false) {
+  std::array<std::vector<int>, 3> ret;
+
+  for (size_t i = 0; i < 3; i++) {
+    ret[i].resize(mesh_size[i]);
+
+    ret[i][0] = 0;
+    for (int j = 1; j <= mesh_size[i] / 2; j++) {
+      ret[i][j] = j;
+      ret[i][mesh_size[i] - j] = -j;
+    }
+    if (zero_out_midpoint)
+      ret[i][mesh_size[i] / 2] = 0;
+  }
+
+  return ret;
+}
+} // namespace detail
 
 #endif /* _P3M_COMMON_H */

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -189,7 +189,7 @@ void p3m_calc_lm_ld_pos(p3m_local_mesh &local_mesh,
 #endif /* P3M || DP3M */
 
 namespace detail {
-/** Calculate a mesh shift sequence.
+/** Calculate indices that shift @ref P3MParameters::mesh "mesh" by `mesh/2`.
  *  For each mesh size @f$ n @f$ in @c mesh_size, create a sequence of integer
  *  values @f$ \left( 0, \ldots, \lfloor n/2 \rfloor, -\lfloor n/2 \rfloor,
  *  \ldots, -1\right) @f$ if @c zero_out_midpoint is false, otherwise

--- a/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
@@ -41,13 +41,6 @@ struct p3m_data_struct_base {
   /** number of permutations in k_space */
   int ks_pnum;
 
-  /** Calculate indices that shift @ref P3MParameters::mesh "mesh" by `mesh/2`.
-   */
-  std::array<std::vector<int>, 3> calc_meshift() {
-    return detail::calc_meshift(
-        {params.mesh[0], params.mesh[1], params.mesh[2]}, false);
-  }
-
   /** Calculate the Fourier transformed differential operator.
    *  Remark: This is done on the level of n-vectors and not k-vectors,
    *  i.e. the prefactor @f$ 2i\pi/L @f$ is missing!

--- a/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2010-2020 The ESPResSo project
+ * Copyright (C) 2002-2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef P3M_DATA_STRUCT_HPP
+#define P3M_DATA_STRUCT_HPP
+
+#include "config.hpp"
+
+#ifdef P3M
+
+#include "p3m-common.hpp"
+
+struct p3m_data_struct_base {
+  P3MParameters params;
+
+  /** Spatial differential operator in k-space. We use an i*k differentiation.
+   */
+  std::array<std::vector<double>, 3> d_op;
+  /** Force optimised influence function (k-space) */
+  std::vector<double> g_force;
+  /** Energy optimised influence function (k-space) */
+  std::vector<double> g_energy;
+
+  /** number of permutations in k_space */
+  int ks_pnum;
+};
+
+#endif
+#endif

--- a/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
@@ -32,7 +32,7 @@ struct p3m_data_struct_base {
 
   /** Spatial differential operator in k-space. We use an i*k differentiation.
    */
-  std::array<std::vector<double>, 3> d_op;
+  std::array<std::vector<int>, 3> d_op;
   /** Force optimised influence function (k-space) */
   std::vector<double> g_force;
   /** Energy optimised influence function (k-space) */
@@ -40,6 +40,15 @@ struct p3m_data_struct_base {
 
   /** number of permutations in k_space */
   int ks_pnum;
+
+  /** Calculate the Fourier transformed differential operator.
+   *  Remark: This is done on the level of n-vectors and not k-vectors,
+   *  i.e. the prefactor @f$ 2i\pi/L @f$ is missing!
+   */
+  void calc_differential_operator() {
+    d_op = detail::calc_meshift(
+        {params.mesh[0], params.mesh[1], params.mesh[2]}, true);
+  }
 };
 
 #endif

--- a/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
@@ -41,6 +41,13 @@ struct p3m_data_struct_base {
   /** number of permutations in k_space */
   int ks_pnum;
 
+  /** Calculate indices that shift @ref P3MParameters::mesh "mesh" by `mesh/2`.
+   */
+  std::array<std::vector<int>, 3> calc_meshift() {
+    return detail::calc_meshift(
+        {params.mesh[0], params.mesh[1], params.mesh[2]}, false);
+  }
+
   /** Calculate the Fourier transformed differential operator.
    *  Remark: This is done on the level of n-vectors and not k-vectors,
    *  i.e. the prefactor @f$ 2i\pi/L @f$ is missing!

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -264,21 +264,19 @@ double dp3m_average_dipolar_self_energy(double box_l, int mesh) {
 double
 dp3m_perform_aliasing_sums_dipolar_self_energy(Utils::Vector3i const &shift) {
   double u_sum = 0.0;
-  /* lots of temporary variables... */
-  double f1, sx, sy, sz, mx, my, mz, nmx, nmy, nmz;
-  int limit = P3M_BRILLOUIN + 5;
+  constexpr int limit = P3M_BRILLOUIN + 5;
 
-  f1 = 1.0 / (double)dp3m.params.mesh[0];
+  auto const f1 = 1.0 / static_cast<double>(dp3m.params.mesh[0]);
 
-  for (mx = -limit; mx <= limit; mx++) {
-    nmx = shift[0] + dp3m.params.mesh[0] * mx;
-    sx = pow(sinc(f1 * nmx), 2.0 * dp3m.params.cao);
-    for (my = -limit; my <= limit; my++) {
-      nmy = shift[1] + dp3m.params.mesh[0] * my;
-      sy = sx * pow(sinc(f1 * nmy), 2.0 * dp3m.params.cao);
-      for (mz = -limit; mz <= limit; mz++) {
-        nmz = shift[2] + dp3m.params.mesh[0] * mz;
-        sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
+  for (double mx = -limit; mx <= limit; mx++) {
+    auto const nmx = shift[0] + dp3m.params.mesh[0] * mx;
+    auto const sx = pow(sinc(f1 * nmx), 2.0 * dp3m.params.cao);
+    for (double my = -limit; my <= limit; my++) {
+      auto const nmy = shift[1] + dp3m.params.mesh[0] * my;
+      auto const sy = sx * pow(sinc(f1 * nmy), 2.0 * dp3m.params.cao);
+      for (double mz = -limit; mz <= limit; mz++) {
+        auto const nmz = shift[2] + dp3m.params.mesh[0] * mz;
+        auto const sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
         u_sum += sz;
       }
     }
@@ -830,41 +828,36 @@ void dp3m_calc_influence_function_force() {
 
 double dp3m_perform_aliasing_sums_force(Utils::Vector3i const &shift,
                                         Utils::Vector3i const &d_op) {
-  /* lots of temporary variables... */
-  double sx, sy, sz, f1, f2, f3, mx, my, mz, nmx, nmy, nmz, nm2, expo;
-  double limit = 30;
-  double n_nm;
-  double n_nm3;
+  constexpr double limit = 30;
 
   double numerator = 0.0;
   double denominator = 0.0;
 
-  f1 = 1.0 / (double)dp3m.params.mesh[0];
-  f2 = Utils::sqr(Utils::pi() / (dp3m.params.alpha_L));
+  auto const f1 = 1.0 / static_cast<double>(dp3m.params.mesh[0]);
+  auto const f2 = Utils::sqr(Utils::pi() / (dp3m.params.alpha_L));
 
-  for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
-    nmx = shift[0] + dp3m.params.mesh[0] * mx;
-    sx = pow(sinc(f1 * nmx), 2.0 * dp3m.params.cao);
-    for (my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
-      nmy = shift[1] + dp3m.params.mesh[0] * my;
-      sy = sx * pow(sinc(f1 * nmy), 2.0 * dp3m.params.cao);
-      for (mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
-        nmz = shift[2] + dp3m.params.mesh[0] * mz;
-        sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
-
-        nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
-        expo = f2 * nm2;
-        f3 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
-
-        n_nm = d_op[0] * nmx + d_op[1] * nmy + d_op[2] * nmz;
-        n_nm3 = Utils::int_pow<3>(n_nm);
-
-        numerator += f3 * n_nm3;
+  for (double mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
+    auto const nmx = shift[0] + dp3m.params.mesh[0] * mx;
+    auto const sx = pow(sinc(f1 * nmx), 2.0 * dp3m.params.cao);
+    for (double my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
+      auto const nmy = shift[1] + dp3m.params.mesh[0] * my;
+      auto const sy = sx * pow(sinc(f1 * nmy), 2.0 * dp3m.params.cao);
+      for (double mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
+        auto const nmz = shift[2] + dp3m.params.mesh[0] * mz;
+        auto const sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
+        auto const nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
+        auto const exponent = f2 * nm2;
+        if (exponent < limit) {
+          auto const f3 = sz * exp(-exponent) / nm2;
+          auto const n_nm = d_op[0] * nmx + d_op[1] * nmy + d_op[2] * nmz;
+          numerator += f3 * Utils::int_pow<3>(n_nm);
+        }
         denominator += sz;
       }
     }
   }
-  return numerator / (pow(d_op.norm2(), 3) * Utils::sqr(denominator));
+  return numerator /
+         (Utils::int_pow<3>(d_op.norm2()) * Utils::sqr(denominator));
 }
 
 /*****************************************************************************/
@@ -907,40 +900,35 @@ void dp3m_calc_influence_function_energy() {
 
 double dp3m_perform_aliasing_sums_energy(Utils::Vector3i const &shift,
                                          Utils::Vector3i const &d_op) {
-  /* lots of temporary variables... */
-  double sx, sy, sz, f1, f2, f3, mx, my, mz, nmx, nmy, nmz, nm2, expo;
-  double limit = 30;
-  double n_nm;
-  double n_nm2;
+  constexpr double limit = 30;
 
   double numerator = 0.0;
   double denominator = 0.0;
 
-  f1 = 1.0 / (double)dp3m.params.mesh[0];
-  f2 = Utils::sqr(Utils::pi() / (dp3m.params.alpha_L));
+  auto const f1 = 1.0 / static_cast<double>(dp3m.params.mesh[0]);
+  auto const f2 = Utils::sqr(Utils::pi() / dp3m.params.alpha_L);
 
-  for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
-    nmx = shift[0] + dp3m.params.mesh[0] * mx;
-    sx = pow(sinc(f1 * nmx), 2.0 * dp3m.params.cao);
-    for (my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
-      nmy = shift[1] + dp3m.params.mesh[0] * my;
-      sy = sx * pow(sinc(f1 * nmy), 2.0 * dp3m.params.cao);
-      for (mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
-        nmz = shift[2] + dp3m.params.mesh[0] * mz;
-        sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
-
-        nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
-        expo = f2 * nm2;
-        f3 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
-
-        n_nm = d_op[0] * nmx + d_op[1] * nmy + d_op[2] * nmz;
-        n_nm2 = n_nm * n_nm;
-        numerator += f3 * n_nm2;
+  for (double mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
+    auto const nmx = shift[0] + dp3m.params.mesh[0] * mx;
+    auto const sx = pow(sinc(f1 * nmx), 2.0 * dp3m.params.cao);
+    for (double my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
+      auto const nmy = shift[1] + dp3m.params.mesh[0] * my;
+      auto const sy = sx * pow(sinc(f1 * nmy), 2.0 * dp3m.params.cao);
+      for (double mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
+        auto const nmz = shift[2] + dp3m.params.mesh[0] * mz;
+        auto const sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
+        auto const nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
+        auto const exponent = f2 * nm2;
+        if (exponent < limit) {
+          auto const f3 = sz * exp(-exponent) / nm2;
+          auto const n_nm = d_op[0] * nmx + d_op[1] * nmy + d_op[2] * nmz;
+          numerator += f3 * Utils::sqr(n_nm);
+        }
         denominator += sz;
       }
     }
   }
-  return numerator / (pow(d_op.norm2(), 2) * Utils::sqr(denominator));
+  return numerator / (Utils::sqr(d_op.norm2()) * Utils::sqr(denominator));
 }
 
 /*****************************************************************************/

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -112,9 +112,6 @@ static double calc_surface_term(bool force_flag, bool energy_flag,
 /************************************************************/
 /*@{*/
 
-// These 3 functions are to tune the P3M code in the case of dipolar
-// interactions
-
 double P3M_DIPOLAR_real_space_error(double box_size, double prefac,
                                     double r_cut_iL, int n_c_part,
                                     double sum_q2, double alpha_L);
@@ -221,7 +218,7 @@ void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
                           double accuracy, int n_interpol) {
   if (r_cut >= 0) {
     dp3m.params.r_cut = r_cut;
-    dp3m.params.r_cut_iL = r_cut * (1. / box_geo.length()[0]);
+    dp3m.params.r_cut_iL = r_cut / box_geo.length()[0];
   }
 
   if (mesh >= 0)
@@ -256,7 +253,7 @@ int dp3m_set_params(double r_cut, int mesh, int cao, double alpha,
     return -3;
 
   dp3m.params.r_cut = r_cut;
-  dp3m.params.r_cut_iL = r_cut * (1. / box_geo.length()[0]);
+  dp3m.params.r_cut_iL = r_cut / box_geo.length()[0];
   dp3m.params.mesh[2] = dp3m.params.mesh[1] = dp3m.params.mesh[0] = mesh;
   dp3m.params.cao = cao;
 
@@ -386,8 +383,7 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
   double tmp0, tmp1;
 
   auto const dipole_prefac =
-      dipole.prefactor /
-      (double)(dp3m.params.mesh[0] * dp3m.params.mesh[1] * dp3m.params.mesh[2]);
+      dipole.prefactor / Utils::int_pow<3>(dp3m.params.mesh[0]);
 
   if (dp3m.sum_mu2 > 0) {
     /* Gather information for FFT grid inside the nodes domain (inner local
@@ -454,7 +450,7 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
         k_space_energy_dip -=
             dipole.prefactor *
             (dp3m.sum_mu2 * 2 *
-             pow(dp3m.params.alpha_L * (1. / box_geo.length()[0]), 3) *
+             pow(dp3m.params.alpha_L / box_geo.length()[0], 3) *
              Utils::sqrt_pi_i() / 3.0);
 
         auto const volume = box_geo.volume();
@@ -850,15 +846,13 @@ static double dp3m_mcr_time(int mesh, int cao, double r_cut_iL,
 static double dp3m_mc_time(char **log, int mesh, int cao, double r_cut_iL_min,
                            double r_cut_iL_max, double *_r_cut_iL,
                            double *_alpha_L, double *_accuracy) {
-  double int_time;
   double r_cut_iL;
-  double rs_err, ks_err, mesh_size, k_cut;
-  int i, n_cells;
+  double rs_err, ks_err;
   char b[3 * ES_INTEGER_SPACE + 3 * ES_DOUBLE_SPACE + 128];
 
   /* initial checks. */
-  mesh_size = box_geo.length()[0] / (double)mesh;
-  k_cut = mesh_size * cao / 2.0;
+  auto const mesh_size = box_geo.length()[0] / static_cast<double>(mesh);
+  auto const k_cut = mesh_size * cao / 2.0;
 
   auto const min_box_l = *boost::min_element(box_geo.length());
   auto const min_local_box_l = *boost::min_element(local_geo.length());
@@ -912,7 +906,7 @@ static double dp3m_mc_time(char **log, int mesh, int cao, double r_cut_iL_min,
     runtimeErrorMsg() << "dipolar P3M: tuning when dlc needs to be fixed";
   }
 
-  int_time = dp3m_mcr_time(mesh, cao, r_cut_iL, *_alpha_L);
+  double const int_time = dp3m_mcr_time(mesh, cao, r_cut_iL, *_alpha_L);
   if (int_time == -P3M_TUNE_FAIL) {
     *log = strcat_alloc(*log, "tuning failed, test integration not possible\n");
     return int_time;
@@ -925,8 +919,8 @@ static double dp3m_mc_time(char **log, int mesh, int cao, double r_cut_iL_min,
   }
 
   /* print result */
-  sprintf(b, "%-4d %-3d %.5e %.5e %.5e %.3e %.3e %-8d\n", mesh, cao, r_cut_iL,
-          *_alpha_L, *_accuracy, rs_err, ks_err, (int)int_time);
+  sprintf(b, "%-4d %-3d %.5e %.5e %.5e %.3e %.3e %-8.0f\n", mesh, cao, r_cut_iL,
+          *_alpha_L, *_accuracy, rs_err, ks_err, int_time);
   *log = strcat_alloc(*log, b);
   return int_time;
 }
@@ -1152,8 +1146,8 @@ int dp3m_adaptive_tune(char **logger) {
 
     r_cut_iL_min = 0;
     r_cut_iL_max = std::min(min_local_box_l, min_box_l / 2) - skin;
-    r_cut_iL_min *= (1. / box_geo.length()[0]);
-    r_cut_iL_max *= (1. / box_geo.length()[0]);
+    r_cut_iL_min *= 1. / box_geo.length()[0];
+    r_cut_iL_max *= 1. / box_geo.length()[0];
   } else {
     r_cut_iL_min = r_cut_iL_max = dp3m.params.r_cut_iL;
 
@@ -1229,12 +1223,8 @@ int dp3m_adaptive_tune(char **logger) {
 }
 
 void dp3m_count_magnetic_particles() {
-  double node_sums[2], tot_sums[2];
-
-  for (int i = 0; i < 2; i++) {
-    node_sums[i] = 0.0;
-    tot_sums[i] = 0.0;
-  }
+  double node_sums[2] = {0, 0};
+  double tot_sums[2] = {0, 0};
 
   for (auto const &p : cell_structure.local_particles()) {
     if (p.p.dipm != 0.0) {
@@ -1254,18 +1244,19 @@ REGISTER_CALLBACK(dp3m_count_magnetic_particles)
 static double dp3m_k_space_error(double box_size, double prefac, int mesh,
                                  int cao, int n_c_part, double sum_q2,
                                  double alpha_L) {
-  int nx, ny, nz;
-  double he_q = 0.0, mesh_i = 1. / mesh, alpha_L_i = 1. / alpha_L;
-  double alias1, alias2, n2, cs;
+  double he_q = 0.0;
+  auto const mesh_i = 1. / mesh;
+  auto const alpha_L_i = 1. / alpha_L;
 
-  for (nx = -mesh / 2; nx < mesh / 2; nx++)
-    for (ny = -mesh / 2; ny < mesh / 2; ny++)
-      for (nz = -mesh / 2; nz < mesh / 2; nz++)
+  for (int nx = -mesh / 2; nx < mesh / 2; nx++)
+    for (int ny = -mesh / 2; ny < mesh / 2; ny++)
+      for (int nz = -mesh / 2; nz < mesh / 2; nz++)
         if ((nx != 0) || (ny != 0) || (nz != 0)) {
-          n2 = Utils::sqr(nx) + Utils::sqr(ny) + Utils::sqr(nz);
-          cs = p3m_analytic_cotangent_sum(nx, mesh_i, cao) *
-               p3m_analytic_cotangent_sum(ny, mesh_i, cao) *
-               p3m_analytic_cotangent_sum(nz, mesh_i, cao);
+          auto const n2 = Utils::sqr(nx) + Utils::sqr(ny) + Utils::sqr(nz);
+          auto const cs = p3m_analytic_cotangent_sum(nx, mesh_i, cao) *
+                          p3m_analytic_cotangent_sum(ny, mesh_i, cao) *
+                          p3m_analytic_cotangent_sum(nz, mesh_i, cao);
+          double alias1, alias2;
           dp3m_tune_aliasing_sums(nx, ny, nz, mesh, mesh_i, cao, alpha_L_i,
                                   &alias1, &alias2);
           double d = alias1 - Utils::sqr(alias2 / cs) / Utils::int_pow<3>(n2);
@@ -1275,8 +1266,8 @@ static double dp3m_k_space_error(double box_size, double prefac, int mesh,
             he_q += d;
         }
 
-  return 8. * Utils::pi() * Utils::pi() / 3. * sum_q2 *
-         sqrt(he_q / (double)n_c_part) / Utils::int_pow<4>(box_size);
+  return 8. * Utils::sqr(Utils::pi()) / 3. * sum_q2 * sqrt(he_q / n_c_part) /
+         Utils::int_pow<4>(box_size);
 }
 
 /** Tuning dipolar-P3M */
@@ -1284,28 +1275,26 @@ void dp3m_tune_aliasing_sums(int nx, int ny, int nz, int mesh, double mesh_i,
                              int cao, double alpha_L_i, double *alias1,
                              double *alias2) {
   using Utils::sinc;
-  int mx, my, mz;
-  double nmx, nmy, nmz;
-  double fnmx, fnmy, fnmz;
 
-  double ex, ex2, nm2, U2, factor1;
-
-  factor1 = Utils::sqr(Utils::pi() * alpha_L_i);
+  auto const factor1 = Utils::sqr(Utils::pi() * alpha_L_i);
 
   *alias1 = *alias2 = 0.0;
-  for (mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
-    fnmx = mesh_i * (nmx = nx + mx * mesh);
-    for (my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
-      fnmy = mesh_i * (nmy = ny + my * mesh);
-      for (mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
-        fnmz = mesh_i * (nmz = nz + mz * mesh);
+  for (int mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
+    auto const nmx = nx + mx * mesh;
+    auto const fnmx = mesh_i * nmx;
+    for (int my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
+      auto const nmy = ny + my * mesh;
+      auto const fnmy = mesh_i * nmy;
+      for (int mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
+        auto const nmz = nz + mz * mesh;
+        auto const fnmz = mesh_i * nmz;
 
-        nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
-        ex2 = Utils::sqr(ex = exp(-factor1 * nm2));
+        auto const nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
+        auto const ex = std::exp(-factor1 * nm2);
 
-        U2 = pow(sinc(fnmx) * sinc(fnmy) * sinc(fnmz), 2.0 * cao);
+        auto const U2 = pow(sinc(fnmx) * sinc(fnmy) * sinc(fnmz), 2.0 * cao);
 
-        *alias1 += ex2 * nm2;
+        *alias1 += Utils::sqr(ex) * nm2;
         *alias2 += U2 * ex * pow((nx * nmx + ny * nmy + nz * nmz), 3.) / nm2;
       }
     }
@@ -1355,10 +1344,10 @@ double P3M_DIPOLAR_real_space_error(double box_size, double prefac,
 double dp3m_rtbisection(double box_size, double prefac, double r_cut_iL,
                         int n_c_part, double sum_q2, double x1, double x2,
                         double xacc, double tuned_accuracy) {
-  int j;
-  double dx, f, fmid, xmid, rtb, constant, JJ_RTBIS_MAX = 40;
+  constexpr int JJ_RTBIS_MAX = 40;
+  double dx, f, fmid, rtb;
 
-  constant = tuned_accuracy / sqrt(2.);
+  auto const constant = tuned_accuracy / sqrt(2.);
 
   f = P3M_DIPOLAR_real_space_error(box_size, prefac, r_cut_iL, n_c_part, sum_q2,
                                    x1) -
@@ -1371,12 +1360,12 @@ double dp3m_rtbisection(double box_size, double prefac, double r_cut_iL,
         << "Root must be bracketed for bisection in dp3m_rtbisection";
     return -DP3M_RTBISECTION_ERROR;
   }
-  rtb = f < 0.0 ? (dx = x2 - x1, x1)
-                : (dx = x1 - x2,
-                   x2); // Orient the search dx, and set rtb to x1 or x2 ...
-  for (j = 1; j <= JJ_RTBIS_MAX; j++) {
+  // Orient the search dx, and set rtb to x1 or x2 ...
+  rtb = f < 0.0 ? (dx = x2 - x1, x1) : (dx = x1 - x2, x2);
+  for (int j = 1; j <= JJ_RTBIS_MAX; j++) {
+    auto const xmid = rtb + (dx *= 0.5);
     fmid = P3M_DIPOLAR_real_space_error(box_size, prefac, r_cut_iL, n_c_part,
-                                        sum_q2, xmid = rtb + (dx *= 0.5)) -
+                                        sum_q2, xmid) -
            constant;
     if (fmid <= 0.0)
       rtb = xmid;
@@ -1390,8 +1379,7 @@ double dp3m_rtbisection(double box_size, double prefac, double r_cut_iL,
 /************************************************************/
 
 void dp3m_init_a_ai_cao_cut() {
-  int i;
-  for (i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     dp3m.params.ai[i] = (double)dp3m.params.mesh[i] / box_geo.length()[i];
     dp3m.params.a[i] = 1.0 / dp3m.params.ai[i];
     dp3m.params.cao_cut[i] = 0.5 * dp3m.params.a[i] * dp3m.params.cao;
@@ -1401,9 +1389,8 @@ void dp3m_init_a_ai_cao_cut() {
 /*****************************************************************************/
 
 bool dp3m_sanity_checks_boxl() {
-  int i;
   bool ret = false;
-  for (i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     /* check k-space cutoff */
     if (dp3m.params.cao_cut[i] >= 0.5 * box_geo.length()[i]) {
       runtimeErrorMsg() << "dipolar P3M_init: k-space cutoff "
@@ -1480,7 +1467,7 @@ void dp3m_scaleby_box_l() {
   }
 
   dp3m.params.r_cut = dp3m.params.r_cut_iL * box_geo.length()[0];
-  dp3m.params.alpha = dp3m.params.alpha_L * (1. / box_geo.length()[0]);
+  dp3m.params.alpha = dp3m.params.alpha_L / box_geo.length()[0];
   dp3m_init_a_ai_cao_cut();
   p3m_calc_lm_ld_pos(dp3m.local_mesh, dp3m.params);
   dp3m_sanity_checks_boxl();
@@ -1491,14 +1478,13 @@ void dp3m_scaleby_box_l() {
 
 /** Calculate the dipolar-P3M energy correction */
 void dp3m_compute_constants_energy_dipolar() {
-  double Eself, Ukp3m;
 
   if (dp3m.energy_correction != 0.0)
     return;
 
-  Ukp3m = dp3m_average_dipolar_self_energy() * box_geo.volume();
+  auto const Ukp3m = dp3m_average_dipolar_self_energy() * box_geo.volume();
 
-  Eself = -(2 * pow(dp3m.params.alpha_L, 3) * Utils::sqrt_pi_i() / 3.0);
+  auto const Eself = -2 * pow(dp3m.params.alpha_L, 3) * Utils::sqrt_pi_i() / 3;
 
   dp3m.energy_correction =
       -dp3m.sum_mu2 * (Ukp3m + Eself + 2. * Utils::pi() / 3.);

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -172,36 +172,39 @@ void dp3m_init() {
     // dipolar prefactor is zero: magnetostatics switched off
     dp3m.params.r_cut = 0.0;
     dp3m.params.r_cut_iL = 0.0;
-  } else {
-    if (dp3m_sanity_checks(node_grid))
-      return;
-
-    dp3m.params.cao3 = Utils::int_pow<3>(dp3m.params.cao);
-
-    /* initializes the (inverse) mesh constant dp3m.params.a (dp3m.params.ai)
-     * and the cutoff for charge assignment dp3m.params.cao_cut */
-    dp3m_init_a_ai_cao_cut();
-
-    p3m_calc_local_ca_mesh(dp3m.local_mesh, dp3m.params, local_geo, skin);
-
-    dp3m.sm.resize(comm_cart, dp3m.local_mesh);
-    int ca_mesh_size = fft_init(dp3m.local_mesh.dim, dp3m.local_mesh.margin,
-                                dp3m.params.mesh, dp3m.params.mesh_off,
-                                dp3m.ks_pnum, dp3m.fft, node_grid, comm_cart);
-    dp3m.rs_mesh.resize(ca_mesh_size);
-    dp3m.ks_mesh.resize(ca_mesh_size);
-
-    for (auto &val : dp3m.rs_mesh_dip) {
-      val.resize(ca_mesh_size);
-    }
-
-    dp3m.calc_differential_operator();
-
-    /* fix box length dependent constants */
-    dp3m_scaleby_box_l();
-
-    dp3m_count_magnetic_particles();
+    return;
   }
+
+  if (dp3m_sanity_checks(node_grid)) {
+    return;
+  }
+
+  dp3m.params.cao3 = Utils::int_pow<3>(dp3m.params.cao);
+
+  /* initializes the (inverse) mesh constant dp3m.params.a (dp3m.params.ai)
+   * and the cutoff for charge assignment dp3m.params.cao_cut */
+  dp3m_init_a_ai_cao_cut();
+
+  p3m_calc_local_ca_mesh(dp3m.local_mesh, dp3m.params, local_geo, skin);
+
+  dp3m.sm.resize(comm_cart, dp3m.local_mesh);
+
+  int ca_mesh_size = fft_init(dp3m.local_mesh.dim, dp3m.local_mesh.margin,
+                              dp3m.params.mesh, dp3m.params.mesh_off,
+                              dp3m.ks_pnum, dp3m.fft, node_grid, comm_cart);
+  dp3m.rs_mesh.resize(ca_mesh_size);
+  dp3m.ks_mesh.resize(ca_mesh_size);
+
+  for (auto &val : dp3m.rs_mesh_dip) {
+    val.resize(ca_mesh_size);
+  }
+
+  dp3m.calc_differential_operator();
+
+  /* fix box length dependent constants */
+  dp3m_scaleby_box_l();
+
+  dp3m_count_magnetic_particles();
 }
 
 /******************

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -1259,7 +1259,8 @@ static double dp3m_k_space_error(double box_size, double prefac, int mesh,
           double alias1, alias2;
           dp3m_tune_aliasing_sums(nx, ny, nz, mesh, mesh_i, cao, alpha_L_i,
                                   &alias1, &alias2);
-          double d = alias1 - Utils::sqr(alias2 / cs) / Utils::int_pow<3>(n2);
+          double d = alias1 - Utils::sqr(alias2 / cs) /
+                                  Utils::int_pow<3>(static_cast<double>(n2));
           /* at high precisions, d can become negative due to extinction;
              also, don't take values that have no significant digits left*/
           if (d > 0 && (fabs(d / alias1) > ROUND_ERROR_PREC))

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -33,6 +33,7 @@
  */
 
 #include "electrostatics_magnetostatics/p3m-dipolar.hpp"
+#include "electrostatics_magnetostatics/dp3m_influence_function.hpp"
 
 #ifdef DP3M
 
@@ -98,52 +99,6 @@ static void dp3m_calc_influence_function_energy();
  *  the error.
  */
 static void dp3m_compute_constants_energy_dipolar();
-
-/** Calculate the aliasing sums for the optimal influence function.
- *
- *  Calculates the aliasing sums in the numerator and denominator of
- *  the expression for the optimal influence function (see
- *  @cite hockney88a : 8-22, p. 275).
- *
- *  \tparam S          order (2 for energy, 3 for forces)
- *  \param shift       shift for a given n-vector
- *  \param d_op        differential operator for a given n-vector
- *  \return The result of the fraction.
- */
-template <size_t S>
-double dp3m_perform_aliasing_sums(Utils::Vector3i const &shift,
-                                  Utils::Vector3i const &d_op) {
-  using Utils::int_pow;
-  constexpr double limit = 30;
-
-  double numerator = 0.0;
-  double denominator = 0.0;
-
-  auto const f1 = 1.0 / static_cast<double>(dp3m.params.mesh[0]);
-  auto const f2 = Utils::sqr(Utils::pi() / (dp3m.params.alpha_L));
-
-  for (double mx = -P3M_BRILLOUIN; mx <= P3M_BRILLOUIN; mx++) {
-    auto const nmx = shift[0] + dp3m.params.mesh[0] * mx;
-    auto const sx = pow(sinc(f1 * nmx), 2.0 * dp3m.params.cao);
-    for (double my = -P3M_BRILLOUIN; my <= P3M_BRILLOUIN; my++) {
-      auto const nmy = shift[1] + dp3m.params.mesh[0] * my;
-      auto const sy = sx * pow(sinc(f1 * nmy), 2.0 * dp3m.params.cao);
-      for (double mz = -P3M_BRILLOUIN; mz <= P3M_BRILLOUIN; mz++) {
-        auto const nmz = shift[2] + dp3m.params.mesh[0] * mz;
-        auto const sz = sy * pow(sinc(f1 * nmz), 2.0 * dp3m.params.cao);
-        auto const nm2 = Utils::sqr(nmx) + Utils::sqr(nmy) + Utils::sqr(nmz);
-        auto const exponent = f2 * nm2;
-        if (exponent < limit) {
-          auto const f3 = sz * exp(-exponent) / nm2;
-          auto const n_nm = d_op[0] * nmx + d_op[1] * nmy + d_op[2] * nmz;
-          numerator += f3 * int_pow<S>(n_nm);
-        }
-        denominator += sz;
-      }
-    }
-  }
-  return numerator / (int_pow<S>(d_op.norm2()) * Utils::sqr(denominator));
-}
 
 static double dp3m_k_space_error(double box_size, double prefac, int mesh,
                                  int cao, int n_c_part, double sum_q2,
@@ -822,73 +777,19 @@ double calc_surface_term(bool force_flag, bool energy_flag,
 /*****************************************************************************/
 
 void dp3m_calc_influence_function_force() {
-  auto const n_start = Utils::Vector3i{dp3m.fft.plan[3].start};
-  auto const n_size = Utils::Vector3i{dp3m.fft.plan[3].new_mesh};
-  auto const n_end = n_start + n_size;
+  auto const start = Utils::Vector3i{dp3m.fft.plan[3].start};
+  auto const size = Utils::Vector3i{dp3m.fft.plan[3].new_mesh};
 
-  dp3m.g_force.resize(n_size[0] * n_size[1] * n_size[2]);
-  double fak1 = Utils::int_pow<3>(dp3m.params.mesh[0]) * 2.0 /
-                Utils::int_pow<2>(box_geo.length()[0]);
-
-  auto const shifts = dp3m.calc_meshift();
-
-  Utils::Vector3i n{};
-  for (n[0] = n_start[0]; n[0] < n_end[0]; n[0]++)
-    for (n[1] = n_start[1]; n[1] < n_end[1]; n[1]++)
-      for (n[2] = n_start[2]; n[2] < n_end[2]; n[2]++) {
-        auto const ind = Utils::get_linear_index(n - n_start, n_size,
-                                                 Utils::MemoryOrder::ROW_MAJOR);
-
-        if (((n[0] == 0) && (n[1] == 0) && (n[2] == 0)) ||
-            ((n[0] % (dp3m.params.mesh[0] / 2) == 0) &&
-             (n[1] % (dp3m.params.mesh[0] / 2) == 0) &&
-             (n[2] % (dp3m.params.mesh[0] / 2) == 0))) {
-          dp3m.g_force[ind] = 0.0;
-        } else {
-          auto const shift = Utils::Vector3i{shifts[0][n[0]], shifts[0][n[1]],
-                                             shifts[0][n[2]]};
-          auto const d_op = Utils::Vector3i{
-              dp3m.d_op[0][n[0]], dp3m.d_op[0][n[1]], dp3m.d_op[0][n[2]]};
-          auto const fak2 = dp3m_perform_aliasing_sums<3>(shift, d_op);
-          dp3m.g_force[ind] = fak1 * fak2;
-        }
-      }
+  dp3m.g_force = grid_influence_function<3>(dp3m.params, start, start + size,
+                                            box_geo.length());
 }
 
-/*****************************************************************************/
-
 void dp3m_calc_influence_function_energy() {
-  auto const n_start = Utils::Vector3i{dp3m.fft.plan[3].start};
-  auto const n_size = Utils::Vector3i{dp3m.fft.plan[3].new_mesh};
-  auto const n_end = n_start + n_size;
+  auto const start = Utils::Vector3i{dp3m.fft.plan[3].start};
+  auto const size = Utils::Vector3i{dp3m.fft.plan[3].new_mesh};
 
-  dp3m.g_energy.resize(n_size[0] * n_size[1] * n_size[2]);
-  double fak1 = Utils::int_pow<3>(dp3m.params.mesh[0]) * 2.0 /
-                Utils::int_pow<2>(box_geo.length()[0]);
-
-  auto const shifts = dp3m.calc_meshift();
-
-  Utils::Vector3i n{};
-  for (n[0] = n_start[0]; n[0] < n_end[0]; n[0]++)
-    for (n[1] = n_start[1]; n[1] < n_end[1]; n[1]++)
-      for (n[2] = n_start[2]; n[2] < n_end[2]; n[2]++) {
-        auto const ind = Utils::get_linear_index(n - n_start, n_size,
-                                                 Utils::MemoryOrder::ROW_MAJOR);
-
-        if (((n[0] == 0) && (n[1] == 0) && (n[2] == 0)) ||
-            ((n[0] % (dp3m.params.mesh[0] / 2) == 0) &&
-             (n[1] % (dp3m.params.mesh[0] / 2) == 0) &&
-             (n[2] % (dp3m.params.mesh[0] / 2) == 0))) {
-          dp3m.g_energy[ind] = 0.0;
-        } else {
-          auto const shift = Utils::Vector3i{shifts[0][n[0]], shifts[0][n[1]],
-                                             shifts[0][n[2]]};
-          auto const d_op = Utils::Vector3i{
-              dp3m.d_op[0][n[0]], dp3m.d_op[0][n[1]], dp3m.d_op[0][n[2]]};
-          auto const fak2 = dp3m_perform_aliasing_sums<2>(shift, d_op);
-          dp3m.g_energy[ind] = fak1 * fak2;
-        }
-      }
+  dp3m.g_energy = grid_influence_function<2>(dp3m.params, start, start + size,
+                                             box_geo.length());
 }
 
 /*****************************************************************************/

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -259,8 +259,8 @@ double dp3m_average_dipolar_self_energy(double box_l, int mesh) {
           double const U2 = dp3m_perform_aliasing_sums_dipolar_self_energy(n);
           node_phi +=
               dp3m.g_energy[ind] * U2 *
-              (Utils::sqr(dp3m.d_op[n[0]]) + Utils::sqr(dp3m.d_op[n[1]]) +
-               Utils::sqr(dp3m.d_op[n[2]]));
+              (Utils::sqr(dp3m.d_op[0][n[0]]) + Utils::sqr(dp3m.d_op[0][n[1]]) +
+               Utils::sqr(dp3m.d_op[0][n[2]]));
         }
       }
     }
@@ -506,18 +506,20 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
           for (j[2] = 0; j[2] < dp3m.fft.plan[3].new_mesh[2]; j[2]++) {
             node_k_space_energy_dip +=
                 dp3m.g_energy[i] *
-                (Utils::sqr(dp3m.rs_mesh_dip[0][ind] *
-                                dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] +
-                            dp3m.rs_mesh_dip[1][ind] *
-                                dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] +
-                            dp3m.rs_mesh_dip[2][ind] *
-                                dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]]) +
-                 Utils::sqr(dp3m.rs_mesh_dip[0][ind + 1] *
-                                dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] +
-                            dp3m.rs_mesh_dip[1][ind + 1] *
-                                dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] +
-                            dp3m.rs_mesh_dip[2][ind + 1] *
-                                dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]]));
+                (Utils::sqr(
+                     dp3m.rs_mesh_dip[0][ind] *
+                         dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] +
+                     dp3m.rs_mesh_dip[1][ind] *
+                         dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] +
+                     dp3m.rs_mesh_dip[2][ind] *
+                         dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]]) +
+                 Utils::sqr(
+                     dp3m.rs_mesh_dip[0][ind + 1] *
+                         dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] +
+                     dp3m.rs_mesh_dip[1][ind + 1] *
+                         dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] +
+                     dp3m.rs_mesh_dip[2][ind + 1] *
+                         dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]]));
             ind += 2;
             i++;
           }
@@ -565,18 +567,18 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
             // tmp0 = Re(mu)*k,   tmp1 = Im(mu)*k
 
             tmp0 = dp3m.rs_mesh_dip[0][ind] *
-                       dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] +
+                       dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] +
                    dp3m.rs_mesh_dip[1][ind] *
-                       dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] +
+                       dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] +
                    dp3m.rs_mesh_dip[2][ind] *
-                       dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]];
+                       dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]];
 
             tmp1 = dp3m.rs_mesh_dip[0][ind + 1] *
-                       dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] +
+                       dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] +
                    dp3m.rs_mesh_dip[1][ind + 1] *
-                       dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] +
+                       dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] +
                    dp3m.rs_mesh_dip[2][ind + 1] *
-                       dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]];
+                       dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]];
 
             /* the optimal influence function is the same for torques
                and energy */
@@ -596,11 +598,13 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
         for (j[0] = 0; j[0] < dp3m.fft.plan[3].new_mesh[0]; j[0]++) {
           for (j[1] = 0; j[1] < dp3m.fft.plan[3].new_mesh[1]; j[1]++) {
             for (j[2] = 0; j[2] < dp3m.fft.plan[3].new_mesh[2]; j[2]++) {
-              dp3m.rs_mesh[ind] = dp3m.d_op[j[d] + dp3m.fft.plan[3].start[d]] *
-                                  dp3m.ks_mesh[ind];
+              dp3m.rs_mesh[ind] =
+                  dp3m.d_op[0][j[d] + dp3m.fft.plan[3].start[d]] *
+                  dp3m.ks_mesh[ind];
               ind++;
-              dp3m.rs_mesh[ind] = dp3m.d_op[j[d] + dp3m.fft.plan[3].start[d]] *
-                                  dp3m.ks_mesh[ind];
+              dp3m.rs_mesh[ind] =
+                  dp3m.d_op[0][j[d] + dp3m.fft.plan[3].start[d]] *
+                  dp3m.ks_mesh[ind];
               ind++;
             }
           }
@@ -637,17 +641,17 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
                j[2]++) { // j[2]=n_x
             // tmp0 = Im(mu)*k,   tmp1 = -Re(mu)*k
             tmp0 = dp3m.rs_mesh_dip[0][ind + 1] *
-                       dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] +
+                       dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] +
                    dp3m.rs_mesh_dip[1][ind + 1] *
-                       dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] +
+                       dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] +
                    dp3m.rs_mesh_dip[2][ind + 1] *
-                       dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]];
+                       dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]];
             tmp1 = dp3m.rs_mesh_dip[0][ind] *
-                       dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] +
+                       dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] +
                    dp3m.rs_mesh_dip[1][ind] *
-                       dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] +
+                       dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] +
                    dp3m.rs_mesh_dip[2][ind] *
-                       dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]];
+                       dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]];
             dp3m.ks_mesh[ind] = tmp0 * dp3m.g_force[i];
             dp3m.ks_mesh[ind + 1] = -tmp1 * dp3m.g_force[i];
             ind += 2;
@@ -666,23 +670,23 @@ double dp3m_calc_kspace_forces(bool force_flag, bool energy_flag,
                j[1]++) { // j[1]=n_z
             for (j[2] = 0; j[2] < dp3m.fft.plan[3].new_mesh[2];
                  j[2]++) { // j[2]=n_x
-              tmp0 = dp3m.d_op[j[d] + dp3m.fft.plan[3].start[d]] *
+              tmp0 = dp3m.d_op[0][j[d] + dp3m.fft.plan[3].start[d]] *
                      dp3m.ks_mesh[ind];
               dp3m.rs_mesh_dip[0][ind] =
-                  dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] * tmp0;
+                  dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] * tmp0;
               dp3m.rs_mesh_dip[1][ind] =
-                  dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] * tmp0;
+                  dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] * tmp0;
               dp3m.rs_mesh_dip[2][ind] =
-                  dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]] * tmp0;
+                  dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]] * tmp0;
               ind++;
-              tmp0 = dp3m.d_op[j[d] + dp3m.fft.plan[3].start[d]] *
+              tmp0 = dp3m.d_op[0][j[d] + dp3m.fft.plan[3].start[d]] *
                      dp3m.ks_mesh[ind];
               dp3m.rs_mesh_dip[0][ind] =
-                  dp3m.d_op[j[2] + dp3m.fft.plan[3].start[2]] * tmp0;
+                  dp3m.d_op[0][j[2] + dp3m.fft.plan[3].start[2]] * tmp0;
               dp3m.rs_mesh_dip[1][ind] =
-                  dp3m.d_op[j[0] + dp3m.fft.plan[3].start[0]] * tmp0;
+                  dp3m.d_op[0][j[0] + dp3m.fft.plan[3].start[0]] * tmp0;
               dp3m.rs_mesh_dip[2][ind] =
-                  dp3m.d_op[j[1] + dp3m.fft.plan[3].start[1]] * tmp0;
+                  dp3m.d_op[0][j[1] + dp3m.fft.plan[3].start[1]] * tmp0;
               ind++;
             }
           }
@@ -814,12 +818,12 @@ void dp3m_calc_differential_operator() {
   double dmesh;
 
   dmesh = (double)dp3m.params.mesh[0];
-  dp3m.d_op.resize(dp3m.params.mesh[0]);
+  dp3m.d_op[0].resize(dp3m.params.mesh[0]);
 
   for (i = 0; i < dp3m.params.mesh[0]; i++)
-    dp3m.d_op[i] = (double)i - std::round((double)i / dmesh) * dmesh;
+    dp3m.d_op[0][i] = (double)i - std::round((double)i / dmesh) * dmesh;
 
-  dp3m.d_op[dp3m.params.mesh[0] / 2] = 0;
+  dp3m.d_op[0][dp3m.params.mesh[0] / 2] = 0;
 }
 
 /*****************************************************************************/
@@ -857,11 +861,11 @@ void dp3m_calc_influence_function_force() {
           double nominator[1] = {0.0};
           double denominator = dp3m_perform_aliasing_sums_force(n, nominator);
           double fak2 = nominator[0];
-          fak2 /=
-              pow(Utils::sqr(dp3m.d_op[n[0]]) + Utils::sqr(dp3m.d_op[n[1]]) +
-                      Utils::sqr(dp3m.d_op[n[2]]),
-                  3) *
-              Utils::sqr(denominator);
+          fak2 /= pow(Utils::sqr(dp3m.d_op[0][n[0]]) +
+                          Utils::sqr(dp3m.d_op[0][n[1]]) +
+                          Utils::sqr(dp3m.d_op[0][n[2]]),
+                      3) *
+                  Utils::sqr(denominator);
           dp3m.g_force[ind] = fak1 * fak2;
         }
       }
@@ -896,8 +900,8 @@ double dp3m_perform_aliasing_sums_force(const int n[3], double nominator[1]) {
         expo = f2 * nm2;
         f3 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
 
-        n_nm = dp3m.d_op[n[0]] * nmx + dp3m.d_op[n[1]] * nmy +
-               dp3m.d_op[n[2]] * nmz;
+        n_nm = dp3m.d_op[0][n[0]] * nmx + dp3m.d_op[0][n[1]] * nmy +
+               dp3m.d_op[0][n[2]] * nmz;
         n_nm3 = Utils::int_pow<3>(n_nm);
 
         nominator[0] += f3 * n_nm3;
@@ -943,11 +947,11 @@ void dp3m_calc_influence_function_energy() {
           double nominator[1] = {0.0};
           double denominator = dp3m_perform_aliasing_sums_energy(n, nominator);
           double fak2 = nominator[0];
-          fak2 /=
-              pow(Utils::sqr(dp3m.d_op[n[0]]) + Utils::sqr(dp3m.d_op[n[1]]) +
-                      Utils::sqr(dp3m.d_op[n[2]]),
-                  2) *
-              Utils::sqr(denominator);
+          fak2 /= pow(Utils::sqr(dp3m.d_op[0][n[0]]) +
+                          Utils::sqr(dp3m.d_op[0][n[1]]) +
+                          Utils::sqr(dp3m.d_op[0][n[2]]),
+                      2) *
+                  Utils::sqr(denominator);
           dp3m.g_energy[ind] = fak1 * fak2;
         }
       }
@@ -982,8 +986,8 @@ double dp3m_perform_aliasing_sums_energy(const int n[3], double nominator[1]) {
         expo = f2 * nm2;
         f3 = (expo < limit) ? sz * exp(-expo) / nm2 : 0.0;
 
-        n_nm = dp3m.d_op[n[0]] * nmx + dp3m.d_op[n[1]] * nmy +
-               dp3m.d_op[n[2]] * nmz;
+        n_nm = dp3m.d_op[0][n[0]] * nmx + dp3m.d_op[0][n[1]] * nmy +
+               dp3m.d_op[0][n[2]] * nmz;
         n_nm2 = n_nm * n_nm;
         nominator[0] += f3 * n_nm2;
         denominator += sz;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -211,7 +211,7 @@ void dp3m_init() {
  ******************/
 
 void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
-                          double accuracy, int n_interpol) {
+                          double accuracy) {
   if (r_cut >= 0) {
     dp3m.params.r_cut = r_cut;
     dp3m.params.r_cut_iL = r_cut / box_geo.length()[0];

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -89,12 +89,6 @@ static bool dp3m_sanity_checks_boxl();
 /** Shift the mesh points by mesh/2 */
 static void dp3m_calc_meshift();
 
-/** Calculate the Fourier transformed differential operator.
- *  Remark: This is done on the level of n-vectors and not k-vectors,
- *          i.e. the prefactor i*2*PI/L is missing!
- */
-static void dp3m_calc_differential_operator();
-
 /** Calculate the influence function optimized for the dipolar forces. */
 static void dp3m_calc_influence_function_force();
 
@@ -222,7 +216,7 @@ void dp3m_init() {
 
     /* k-space part: */
 
-    dp3m_calc_differential_operator();
+    dp3m.calc_differential_operator();
 
     dp3m_calc_influence_function_force();
     dp3m_calc_influence_function_energy();
@@ -809,21 +803,6 @@ void dp3m_calc_meshift() {
   dp3m.meshift.resize(dp3m.params.mesh[0]);
   for (i = 0; i < dp3m.params.mesh[0]; i++)
     dp3m.meshift[i] = i - std::round(i / dmesh) * dmesh;
-}
-
-/*****************************************************************************/
-
-void dp3m_calc_differential_operator() {
-  int i;
-  double dmesh;
-
-  dmesh = (double)dp3m.params.mesh[0];
-  dp3m.d_op[0].resize(dp3m.params.mesh[0]);
-
-  for (i = 0; i < dp3m.params.mesh[0]; i++)
-    dp3m.d_op[0][i] = (double)i - std::round((double)i / dmesh) * dmesh;
-
-  dp3m.d_op[0][dp3m.params.mesh[0] / 2] = 0;
 }
 
 /*****************************************************************************/

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -185,10 +185,6 @@ void dp3m_init() {
     p3m_calc_local_ca_mesh(dp3m.local_mesh, dp3m.params, local_geo, skin);
 
     dp3m.sm.resize(comm_cart, dp3m.local_mesh);
-
-    /* fix box length dependent constants */
-    dp3m_scaleby_box_l();
-
     int ca_mesh_size = fft_init(dp3m.local_mesh.dim, dp3m.local_mesh.margin,
                                 dp3m.params.mesh, dp3m.params.mesh_off,
                                 dp3m.ks_pnum, dp3m.fft, node_grid, comm_cart);
@@ -199,12 +195,10 @@ void dp3m_init() {
       val.resize(ca_mesh_size);
     }
 
-    /* k-space part: */
-
     dp3m.calc_differential_operator();
 
-    dp3m_calc_influence_function_force();
-    dp3m_calc_influence_function_energy();
+    /* fix box length dependent constants */
+    dp3m_scaleby_box_l();
 
     dp3m_count_magnetic_particles();
   }
@@ -814,7 +808,6 @@ static double dp3m_mcr_time(int mesh, int cao, double r_cut_iL,
   dp3m.params.mesh[0] = dp3m.params.mesh[1] = dp3m.params.mesh[2] = mesh;
   dp3m.params.cao = cao;
   dp3m.params.alpha_L = alpha_L;
-  dp3m_scaleby_box_l();
   /* initialize p3m structures */
   mpi_bcast_coulomb_params();
   /* perform force calculation test */
@@ -1210,7 +1203,6 @@ int dp3m_adaptive_tune(char **logger) {
   dp3m.params.cao = cao;
   dp3m.params.alpha_L = alpha_L;
   dp3m.params.accuracy = accuracy;
-  dp3m_scaleby_box_l();
   /* broadcast tuned p3m parameters */
   mpi_bcast_coulomb_params();
   /* Tell the user about the outcome */

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -148,8 +148,6 @@ double dp3m_average_dipolar_self_energy() {
 /************************************************************/
 
 dp3m_data_struct::dp3m_data_struct() {
-  params.epsilon = P3M_EPSILON_MAGNETIC;
-
   /* local_mesh is uninitialized */
   /* sm is uninitialized */
   sum_dip_part = 0;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -112,9 +112,8 @@ static double calc_surface_term(bool force_flag, bool energy_flag,
 /************************************************************/
 /*@{*/
 
-double P3M_DIPOLAR_real_space_error(double box_size, double prefac,
-                                    double r_cut_iL, int n_c_part,
-                                    double sum_q2, double alpha_L);
+double dp3m_real_space_error(double box_size, double prefac, double r_cut_iL,
+                             int n_c_part, double sum_q2, double alpha_L);
 static void dp3m_tune_aliasing_sums(int nx, int ny, int nz, int mesh,
                                     double mesh_i, int cao, double alpha_L_i,
                                     double *alias1, double *alias2);
@@ -752,9 +751,9 @@ double dp3m_get_accuracy(int mesh, int cao, double r_cut_iL, double *_alpha_L,
 
   // Alpha cannot be zero in the dipolar case because real_space formula breaks
   // down
-  rs_err = P3M_DIPOLAR_real_space_error(box_geo.length()[0], dipole.prefactor,
-                                        r_cut_iL, dp3m.sum_dip_part,
-                                        dp3m.sum_mu2, 0.001);
+  rs_err =
+      dp3m_real_space_error(box_geo.length()[0], dipole.prefactor, r_cut_iL,
+                            dp3m.sum_dip_part, dp3m.sum_mu2, 0.001);
 
   if (Utils::sqrt_2() * rs_err > dp3m.params.accuracy) {
     /* assume rs_err = ks_err -> rs_err = accuracy/sqrt(2.0) -> alpha_L */
@@ -778,9 +777,9 @@ double dp3m_get_accuracy(int mesh, int cao, double r_cut_iL, double *_alpha_L,
   *_alpha_L = alpha_L;
   /* calculate real space and k-space error for this alpha_L */
 
-  rs_err = P3M_DIPOLAR_real_space_error(box_geo.length()[0], dipole.prefactor,
-                                        r_cut_iL, dp3m.sum_dip_part,
-                                        dp3m.sum_mu2, alpha_L);
+  rs_err =
+      dp3m_real_space_error(box_geo.length()[0], dipole.prefactor, r_cut_iL,
+                            dp3m.sum_dip_part, dp3m.sum_mu2, alpha_L);
   ks_err = dp3m_k_space_error(box_geo.length()[0], dipole.prefactor, mesh, cao,
                               dp3m.sum_dip_part, dp3m.sum_mu2, alpha_L);
 
@@ -1303,9 +1302,8 @@ void dp3m_tune_aliasing_sums(int nx, int ny, int nz, int mesh, double mesh_i,
  *  Please note that in this more refined approach we don't use
  *  eq. (37), but eq. (33) which maintains all the powers in alpha.
  */
-double P3M_DIPOLAR_real_space_error(double box_size, double prefac,
-                                    double r_cut_iL, int n_c_part,
-                                    double sum_q2, double alpha_L) {
+double dp3m_real_space_error(double box_size, double prefac, double r_cut_iL,
+                             int n_c_part, double sum_q2, double alpha_L) {
   double d_error_f, d_cc, d_dc, d_rcut2, d_con;
   double d_a2, d_c, d_RCUT;
 
@@ -1341,28 +1339,28 @@ double dp3m_rtbisection(double box_size, double prefac, double r_cut_iL,
                         int n_c_part, double sum_q2, double x1, double x2,
                         double xacc, double tuned_accuracy) {
   constexpr int JJ_RTBIS_MAX = 40;
-  double dx, f, fmid, rtb;
 
-  auto const constant = tuned_accuracy / sqrt(2.);
+  auto const constant = tuned_accuracy / Utils::sqrt_2();
 
-  f = P3M_DIPOLAR_real_space_error(box_size, prefac, r_cut_iL, n_c_part, sum_q2,
-                                   x1) -
+  auto const f1 =
+      dp3m_real_space_error(box_size, prefac, r_cut_iL, n_c_part, sum_q2, x1) -
       constant;
-  fmid = P3M_DIPOLAR_real_space_error(box_size, prefac, r_cut_iL, n_c_part,
-                                      sum_q2, x2) -
-         constant;
-  if (f * fmid >= 0.0) {
+  auto const f2 =
+      dp3m_real_space_error(box_size, prefac, r_cut_iL, n_c_part, sum_q2, x2) -
+      constant;
+  if (f1 * f2 >= 0.0) {
     runtimeErrorMsg()
         << "Root must be bracketed for bisection in dp3m_rtbisection";
     return -DP3M_RTBISECTION_ERROR;
   }
   // Orient the search dx, and set rtb to x1 or x2 ...
-  rtb = f < 0.0 ? (dx = x2 - x1, x1) : (dx = x1 - x2, x2);
+  double dx;
+  double rtb = f1 < 0.0 ? (dx = x2 - x1, x1) : (dx = x1 - x2, x2);
   for (int j = 1; j <= JJ_RTBIS_MAX; j++) {
     auto const xmid = rtb + (dx *= 0.5);
-    fmid = P3M_DIPOLAR_real_space_error(box_size, prefac, r_cut_iL, n_c_part,
-                                        sum_q2, xmid) -
-           constant;
+    auto const fmid = dp3m_real_space_error(box_size, prefac, r_cut_iL,
+                                            n_c_part, sum_q2, xmid) -
+                      constant;
     if (fmid <= 0.0)
       rtb = xmid;
     if (fabs(dx) < xacc || fmid == 0.0)

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -67,8 +67,6 @@ struct dp3m_data_struct : public p3m_data_struct_base {
 
   /** position shift for calc. of first assignment mesh point. */
   double pos_shift;
-  /** help variable for calculation of aliasing sums */
-  std::vector<double> meshift;
 
   p3m_interpolation_cache inter_weights;
 

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -82,10 +82,6 @@ struct dp3m_data_struct : public p3m_data_struct_base {
 /** dipolar P3M parameters. */
 extern dp3m_data_struct dp3m;
 
-/** \name Exported Functions */
-/************************************************************/
-/*@{*/
-
 /** @copydoc p3m_set_tune_params */
 void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
                           double accuracy, int n_interpol);
@@ -290,8 +286,6 @@ inline double dp3m_pair_energy(Particle const &p1, Particle const &p2,
   }
   return 0.0;
 }
-
-/*@}*/
 
 #endif /* DP3M */
 #endif /* _P3M_DIPOLES_H */

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -84,7 +84,7 @@ extern dp3m_data_struct dp3m;
 
 /** @copydoc p3m_set_tune_params */
 void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
-                          double accuracy, int n_interpol);
+                          double accuracy);
 
 /** @copydoc p3m_set_params */
 int dp3m_set_params(double r_cut, int mesh, int cao, double alpha,

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -40,6 +40,7 @@
 #include "electrostatics_magnetostatics/dipole.hpp"
 #include "fft.hpp"
 #include "p3m-common.hpp"
+#include "p3m-data_struct.hpp"
 #include "p3m_interpolation.hpp"
 #include "p3m_send_mesh.hpp"
 
@@ -47,10 +48,8 @@
 #include <utils/constants.hpp>
 #include <utils/math/AS_erfc_part.hpp>
 
-struct dp3m_data_struct {
+struct dp3m_data_struct : public p3m_data_struct_base {
   dp3m_data_struct();
-
-  P3MParameters params;
 
   /** local mesh. */
   p3m_local_mesh local_mesh;
@@ -71,18 +70,7 @@ struct dp3m_data_struct {
   /** help variable for calculation of aliasing sums */
   std::vector<double> meshift;
 
-  /** Spatial differential operator in k-space. We use an i*k differentiation.
-   */
-  std::vector<double> d_op;
-  /** Force optimised influence function (k-space) */
-  std::vector<double> g_force;
-  /** Energy optimised influence function (k-space) */
-  std::vector<double> g_energy;
-
   p3m_interpolation_cache inter_weights;
-
-  /** number of permutations in k_space */
-  int ks_pnum;
 
   /** send/recv mesh sizes */
   p3m_send_mesh sm;

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -61,21 +61,6 @@ using Utils::strcat_alloc;
 
 p3m_data_struct p3m;
 
-/** @name Index helpers for direct and reciprocal space
- *  After the FFT the data is in order YZX, which
- *  means that Y is the slowest changing index.
- *  The defines are here to not get confused and
- *  be able to easily change the order.
- */
-/*@{*/
-#define RX 0
-#define RY 1
-#define RZ 2
-#define KY 0
-#define KZ 1
-#define KX 2
-/*@}*/
-
 /** \name Private Functions */
 /*@{*/
 
@@ -412,6 +397,8 @@ double dipole_correction_energy(Utils::Vector3d const &box_dipole) {
  *  eq. (2.8) is not present here since M is the empty set in our simulations.
  */
 Utils::Vector9d p3m_calc_kspace_pressure_tensor() {
+  using namespace detail::FFT_indexing;
+
   Utils::Vector9d node_k_space_pressure_tensor{};
 
   if (p3m.sum_q2 > 0) {

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -150,6 +150,8 @@ static void p3m_tune_aliasing_sums(int nx, int ny, int nz, const int mesh[3],
                                    double alpha_L_i, double *alias1,
                                    double *alias2);
 
+/*@}*/
+
 p3m_data_struct::p3m_data_struct() {
   /* local_mesh is uninitialized */
   /* sm is uninitialized */
@@ -173,7 +175,7 @@ void p3m_init() {
     return;
   }
 
-  p3m.params.cao3 = p3m.params.cao * p3m.params.cao * p3m.params.cao;
+  p3m.params.cao3 = Utils::int_pow<3>(p3m.params.cao);
 
   /* initializes the (inverse) mesh constant p3m.params.a (p3m.params.ai) and
    * the cutoff for charge assignment p3m.params.cao_cut */
@@ -192,7 +194,6 @@ void p3m_init() {
     e.resize(ca_mesh_size);
   }
 
-  /* k-space part: */
   p3m.calc_differential_operator();
 
   /* fix box length dependent constants */
@@ -225,8 +226,6 @@ void p3m_set_tune_params(double r_cut, const int mesh[3], int cao, double alpha,
   if (accuracy >= 0)
     p3m.params.accuracy = accuracy;
 }
-
-/*@}*/
 
 int p3m_set_params(double r_cut, const int *mesh, int cao, double alpha,
                    double accuracy) {

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -166,36 +166,39 @@ void p3m_init() {
     // prefactor is zero: electrostatics switched off
     p3m.params.r_cut = 0.0;
     p3m.params.r_cut_iL = 0.0;
-  } else {
-    if (p3m_sanity_checks()) {
-      return;
-    }
-    p3m.params.cao3 = p3m.params.cao * p3m.params.cao * p3m.params.cao;
-
-    /* initializes the (inverse) mesh constant p3m.params.a (p3m.params.ai) and
-     * the cutoff for charge assignment p3m.params.cao_cut */
-    p3m_init_a_ai_cao_cut();
-
-    p3m_calc_local_ca_mesh(p3m.local_mesh, p3m.params, local_geo, skin);
-
-    p3m.sm.resize(comm_cart, p3m.local_mesh);
-
-    int ca_mesh_size = fft_init(p3m.local_mesh.dim, p3m.local_mesh.margin,
-                                p3m.params.mesh, p3m.params.mesh_off,
-                                p3m.ks_pnum, p3m.fft, node_grid, comm_cart);
-    p3m.rs_mesh.resize(ca_mesh_size);
-    for (auto &e : p3m.E_mesh) {
-      e.resize(ca_mesh_size);
-    }
-
-    /* k-space part: */
-    p3m.calc_differential_operator();
-
-    /* fix box length dependent constants */
-    p3m_scaleby_box_l();
-
-    p3m_count_charged_particles();
+    return;
   }
+
+  if (p3m_sanity_checks()) {
+    return;
+  }
+
+  p3m.params.cao3 = p3m.params.cao * p3m.params.cao * p3m.params.cao;
+
+  /* initializes the (inverse) mesh constant p3m.params.a (p3m.params.ai) and
+   * the cutoff for charge assignment p3m.params.cao_cut */
+  p3m_init_a_ai_cao_cut();
+
+  p3m_calc_local_ca_mesh(p3m.local_mesh, p3m.params, local_geo, skin);
+
+  p3m.sm.resize(comm_cart, p3m.local_mesh);
+
+  int ca_mesh_size =
+      fft_init(p3m.local_mesh.dim, p3m.local_mesh.margin, p3m.params.mesh,
+               p3m.params.mesh_off, p3m.ks_pnum, p3m.fft, node_grid, comm_cart);
+  p3m.rs_mesh.resize(ca_mesh_size);
+
+  for (auto &e : p3m.E_mesh) {
+    e.resize(ca_mesh_size);
+  }
+
+  /* k-space part: */
+  p3m.calc_differential_operator();
+
+  /* fix box length dependent constants */
+  p3m_scaleby_box_l();
+
+  p3m_count_charged_particles();
 }
 
 void p3m_set_tune_params(double r_cut, const int mesh[3], int cao, double alpha,

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -95,12 +95,6 @@ static bool p3m_sanity_checks_system(const Utils::Vector3i &grid);
  */
 static bool p3m_sanity_checks_boxl();
 
-/** Calculate the Fourier transformed differential operator.
- *  Remark: This is done on the level of n-vectors and not k-vectors,
- *          i.e. the prefactor i*2*PI/L is missing!
- */
-static void p3m_calc_differential_operator();
-
 /** Calculate the optimal influence function of @cite hockney88a.
  *  (optimised for force calculations)
  *
@@ -195,7 +189,7 @@ void p3m_init() {
     }
 
     /* k-space part: */
-    p3m_calc_differential_operator();
+    p3m.calc_differential_operator();
 
     /* fix box length dependent constants */
     p3m_scaleby_box_l();
@@ -573,19 +567,6 @@ double p3m_calc_kspace_forces(bool force_flag, bool energy_flag,
   } /* if (energy_flag) */
 
   return 0.0;
-}
-
-void p3m_calc_differential_operator() {
-  for (int i = 0; i < 3; i++) {
-    p3m.d_op[i].resize(p3m.params.mesh[i]);
-    p3m.d_op[i][0] = 0;
-    p3m.d_op[i][p3m.params.mesh[i] / 2] = 0.0;
-
-    for (int j = 1; j < p3m.params.mesh[i] / 2; j++) {
-      p3m.d_op[i][j] = j;
-      p3m.d_op[i][p3m.params.mesh[i] - j] = -j;
-    }
-  }
 }
 
 void p3m_calc_influence_function_force() {

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -39,6 +39,7 @@
 
 #include "fft.hpp"
 #include "p3m-common.hpp"
+#include "p3m-data_struct.hpp"
 #include "p3m_interpolation.hpp"
 #include "p3m_send_mesh.hpp"
 
@@ -50,10 +51,8 @@
  * data types
  ************************************************/
 
-struct p3m_data_struct {
+struct p3m_data_struct : public p3m_data_struct_base {
   p3m_data_struct();
-
-  P3MParameters params;
 
   /** local mesh. */
   p3m_local_mesh local_mesh;
@@ -69,18 +68,7 @@ struct p3m_data_struct {
   /** square of sum of charges (only on master node). */
   double square_sum_q;
 
-  /** Spatial differential operator in k-space. We use an i*k differentiation.
-   */
-  std::array<std::vector<double>, 3> d_op;
-  /** Force optimised influence function (k-space) */
-  std::vector<double> g_force;
-  /** Energy optimised influence function (k-space) */
-  std::vector<double> g_energy;
-
   p3m_interpolation_cache inter_weights;
-
-  /** number of permutations in k_space */
-  int ks_pnum;
 
   /** send/recv mesh sizes */
   p3m_send_mesh sm;

--- a/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
@@ -34,23 +34,6 @@
 namespace detail {
 enum : int { RX = 0, RY = 1, RZ = 2 };
 
-std::array<std::vector<int>, 3> inline calc_meshift(
-    std::array<int, 3> const &mesh_size) {
-  std::array<std::vector<int>, 3> ret;
-
-  for (size_t i = 0; i < 3; i++) {
-    ret[i].resize(mesh_size[i]);
-
-    ret[i][0] = 0;
-    for (int j = 1; j <= mesh_size[i] / 2; j++) {
-      ret[i][j] = j;
-      ret[i][mesh_size[i] - j] = -j;
-    }
-  }
-
-  return ret;
-}
-
 template <typename T> T g_ewald(T alpha, T k2) {
   auto constexpr limit = T{30};
   auto const exponent = Utils::sqr(1. / (2. * alpha)) * k2;

--- a/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
@@ -47,9 +47,11 @@ std::pair<double, double> aliasing_sums_ik(size_t cao, double alpha,
                                            const Utils::Vector3d &k,
                                            const Utils::Vector3d &h) {
   using Utils::int_pow;
-  using Utils::pi;
   using Utils::sinc;
   using Utils::Vector3d;
+
+  constexpr double two_pi = 2 * Utils::pi();
+  constexpr double two_pi_i = 1 / two_pi;
 
   double numerator = 0.0;
   double denominator = 0.0;
@@ -58,10 +60,10 @@ std::pair<double, double> aliasing_sums_ik(size_t cao, double alpha,
     for (int my = -m; my <= m; my++) {
       for (int mz = -m; mz <= m; mz++) {
         auto const km =
-            k + 2 * pi() * Vector3d{mx / h[RX], my / h[RY], mz / h[RZ]};
-        auto const U2 = std::pow(sinc(0.5 * km[RX] * h[RX] / pi()) *
-                                     sinc(0.5 * km[RY] * h[RY] / pi()) *
-                                     sinc(0.5 * km[RZ] * h[RZ] / pi()),
+            k + two_pi * Vector3d{mx / h[RX], my / h[RY], mz / h[RZ]};
+        auto const U2 = std::pow(sinc(km[RX] * h[RX] * two_pi_i) *
+                                     sinc(km[RY] * h[RY] * two_pi_i) *
+                                     sinc(km[RZ] * h[RZ] * two_pi_i),
                                  2 * cao);
 
         numerator += U2 * g_ewald(alpha, km.norm2()) * int_pow<S>(k * km);

--- a/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
@@ -33,8 +33,6 @@
 #include <cmath>
 
 namespace detail {
-enum : int { RX = 0, RY = 1, RZ = 2 };
-
 template <typename T> T g_ewald(T alpha, T k2) {
   auto constexpr limit = T{30};
   auto const exponent = Utils::sqr(1. / (2. * alpha)) * k2;
@@ -46,6 +44,7 @@ template <size_t S, size_t m>
 std::pair<double, double> aliasing_sums_ik(size_t cao, double alpha,
                                            const Utils::Vector3d &k,
                                            const Utils::Vector3d &h) {
+  using namespace detail::FFT_indexing;
   using Utils::int_pow;
   using Utils::sinc;
   using Utils::Vector3d;
@@ -127,8 +126,7 @@ std::vector<double> grid_influence_function(const P3MParameters &params,
                                             const Utils::Vector3i &n_start,
                                             const Utils::Vector3i &n_end,
                                             const Utils::Vector3d &box_l) {
-  enum : int { RX = 0, RY = 1, RZ = 2 };
-  enum : int { KY = 0, KZ = 1, KX = 2 };
+  using namespace detail::FFT_indexing;
 
   auto const shifts =
       detail::calc_meshift({params.mesh[0], params.mesh[1], params.mesh[2]});

--- a/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
@@ -23,6 +23,7 @@
 
 #include <utils/Vector.hpp>
 #include <utils/constants.hpp>
+#include <utils/index.hpp>
 #include <utils/math/int_pow.hpp>
 #include <utils/math/sinc.hpp>
 #include <utils/math/sqr.hpp>

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -29,6 +29,7 @@ unit_test(NAME MpiCallbacks_test SRC MpiCallbacks_test.cpp DEPENDS
           EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME ParticleIterator_test SRC ParticleIterator_test.cpp DEPENDS
           EspressoUtils)
+unit_test(NAME p3m_test SRC p3m_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME link_cell_test SRC link_cell_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME verlet_ia_test SRC verlet_ia_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME Particle_test SRC Particle_test.cpp DEPENDS EspressoUtils

--- a/src/core/unit_tests/p3m_test.cpp
+++ b/src/core/unit_tests/p3m_test.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2010-2020 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE p3m test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include "electrostatics_magnetostatics/p3m-common.hpp"
+
+BOOST_AUTO_TEST_CASE(calc_meshift_false) {
+  std::array<std::vector<int>, 3> const ref = {
+      std::vector<int>{0}, std::vector<int>{0, 1, -2, -1},
+      std::vector<int>{0, 1, 2, 3, -3, -2, -1}};
+
+  auto const val = detail::calc_meshift({1, 4, 7}, false);
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < ref[i].size(); ++j) {
+      BOOST_CHECK_EQUAL(val[i][j], ref[i][j]);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(calc_meshift_true) {
+  std::array<std::vector<int>, 3> const ref = {
+      std::vector<int>{0}, std::vector<int>{0, 1, 0, -1},
+      std::vector<int>{0, 1, 2, 0, -3, -2, -1}};
+
+  auto const val = detail::calc_meshift({1, 4, 7}, true);
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < ref[i].size(); ++j) {
+      BOOST_CHECK_EQUAL(val[i][j], ref[i][j]);
+    }
+  }
+}

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -60,7 +60,7 @@ IF DP3M == 1:
 
     cdef extern from "electrostatics_magnetostatics/p3m-dipolar.hpp":
         int dp3m_set_params(double r_cut, int mesh, int cao, double alpha, double accuracy)
-        void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha, double accuracy, int n_interpol)
+        void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha, double accuracy)
         int dp3m_set_mesh_offset(double x, double y, double z)
         int dp3m_set_eps(double eps)
         int dp3m_adaptive_tune(char ** log)

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -233,7 +233,10 @@ IF DP3M == 1:
             alpha = p_alpha
             accuracy = p_accuracy
             n_interpol = p_n_interpol
-            mesh = p_mesh
+            if hasattr(p_mesh, "__getitem__"):
+                mesh = p_mesh[0]
+            else:
+                mesh = p_mesh
             dp3m_set_tune_params(r_cut, mesh, cao, alpha, accuracy, n_interpol)
 
 IF DIPOLES == 1:

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -125,25 +125,20 @@ IF DP3M == 1:
                 self._params["epsilon"], 1, float,
                 "epsilon should be a double or 'metallic'")
 
-            if not (self._params["inter"] == default_params["inter"]
-                    or self._params["inter"] > 0):
-                raise ValueError("inter should be a positive integer")
-
             if self._params["mesh_off"] != default_params["mesh_off"]:
                 check_type_or_throw_except(self._params["mesh_off"], 3, float,
                                            "mesh_off should be a (3,) array_like of values between 0.0 and 1.0")
 
         def valid_keys(self):
             return ["prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off",
-                    "cao", "inter", "accuracy", "epsilon", "cao_cut", "a", "ai",
-                    "alpha", "r_cut", "inter2", "cao3", "additional_mesh", "tune"]
+                    "cao", "accuracy", "epsilon", "cao_cut", "a", "ai",
+                    "alpha", "r_cut", "cao3", "additional_mesh", "tune"]
 
         def required_keys(self):
             return ["accuracy", ]
 
         def default_params(self):
             return {"cao": -1,
-                    "inter": -1,
                     "r_cut": -1,
                     "accuracy": -1,
                     "mesh": -1,
@@ -171,7 +166,7 @@ IF DP3M == 1:
             dp3m_set_eps(self._params["epsilon"])
             self.python_dp3m_set_tune_params(
                 self._params["r_cut"], self._params["mesh"],
-                self._params["cao"], -1., self._params["accuracy"], self._params["inter"])
+                self._params["cao"], -1., self._params["accuracy"])
             resp, log = self.python_dp3m_adaptive_tune()
             handle_errors("dipolar P3M tuning failed")
             print(to_str(log))
@@ -221,23 +216,21 @@ IF DP3M == 1:
             dp3m_set_params(r_cut, mesh, cao, alpha, accuracy)
 
         def python_dp3m_set_tune_params(self, p_r_cut, p_mesh, p_cao, p_alpha,
-                                        p_accuracy, p_n_interpol):
+                                        p_accuracy):
             cdef int mesh
             cdef double r_cut
             cdef int cao
             cdef double alpha
             cdef double accuracy
-            cdef int n_interpol
             r_cut = p_r_cut
             cao = p_cao
             alpha = p_alpha
             accuracy = p_accuracy
-            n_interpol = p_n_interpol
             if hasattr(p_mesh, "__getitem__"):
                 mesh = p_mesh[0]
             else:
                 mesh = p_mesh
-            dp3m_set_tune_params(r_cut, mesh, cao, alpha, accuracy, n_interpol)
+            dp3m_set_tune_params(r_cut, mesh, cao, alpha, accuracy)
 
 IF DIPOLES == 1:
     cdef class DipolarDirectSumCpu(MagnetostaticInteraction):

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -102,17 +102,14 @@ IF DP3M == 1:
                 raise ValueError("P3M r_cut has to be >=0")
 
             if is_valid_type(self._params["mesh"], int):
-                if self._params["mesh"] % 2 != 0 and self._params["mesh"] != -1:
-                    raise ValueError(
-                        "P3M requires an even number of mesh points in all directions")
+                pass
             else:
                 check_type_or_throw_except(self._params["mesh"], 3, int,
-                                           "P3M mesh has to be an integer or integer list of length 3")
-                if (self._params["mesh"][0] % 2 != 0 and self._params["mesh"][0] != -1) or \
-                   (self._params["mesh"][1] % 2 != 0 and self._params["mesh"][1] != -1) or \
-                   (self._params["mesh"][2] % 2 != 0 and self._params["mesh"][2] != -1):
+                                           "DipolarP3M mesh has to be an integer or integer list of length 3")
+                if (self._params["mesh"][0] != self._params["mesh"][1]) or \
+                   (self._params["mesh"][0] != self._params["mesh"][2]):
                     raise ValueError(
-                        "P3M requires an even number of mesh points in all directions")
+                        "DipolarP3M requires a cubic box")
 
             if not (self._params["cao"] >= -1 and self._params["cao"] <= 7):
                 raise ValueError(

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -48,10 +48,6 @@ class CoulombCloudWall(ut.TestCase):
         self.S.time_step = 0.01
         self.S.cell_system.skin = 0.4
 
-        #  Clear actors that might be left from prev tests
-        if self.S.actors:
-            del self.S.actors[0]
-        self.S.part.clear()
         data = np.genfromtxt(tests_common.abspath(
             "data/coulomb_cloud_wall_system.data"))
 
@@ -64,6 +60,10 @@ class CoulombCloudWall(ut.TestCase):
             f = particle[5:]
             self.S.part.add(id=int(id), pos=pos, q=q)
             self.forces[id] = f
+
+    def tearDown(self):
+        self.S.part.clear()
+        self.S.actors.clear()
 
     def compare(self, method_name, energy=True, prefactor=None):
         # Compare forces and energy now in the system to stored ones

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -45,10 +45,6 @@ class CoulombCloudWall(ut.TestCase):
         self.S.time_step = 0.01
         self.S.cell_system.skin = 0.4
 
-        #  Clear actors that might be left from prev tests
-        if self.S.actors:
-            del self.S.actors[0]
-        self.S.part.clear()
         data = np.genfromtxt(
             abspath("data/coulomb_cloud_wall_duplicated_system.data"))
 
@@ -61,6 +57,10 @@ class CoulombCloudWall(ut.TestCase):
             f = particle[5:]
             self.S.part.add(id=int(id), pos=pos, q=q)
             self.forces[id] = f
+
+    def tearDown(self):
+        self.S.part.clear()
+        self.S.actors.clear()
 
     def compare(self, method_name, energy=True):
         # Compare forces and energy now in the system to stored ones

--- a/testsuite/python/coulomb_mixed_periodicity.py
+++ b/testsuite/python/coulomb_mixed_periodicity.py
@@ -44,11 +44,8 @@ class CoulombMixedPeriodicity(ut.TestCase):
         self.S.box_l = (10, 10, 10)
         self.S.time_step = 0.01
         self.S.cell_system.skin = 0.
-        while self.S.actors:
-            del self.S.actors[0]
+        self.S.actors.clear()
 
-        #  Clear actors that might be left from prev tests
-        self.S.part.clear()
         data = np.genfromtxt(tests_common.abspath(
             "data/coulomb_mixed_periodicity_system.data"))
 
@@ -61,6 +58,9 @@ class CoulombMixedPeriodicity(ut.TestCase):
             f = particle[5:]
             self.S.part.add(id=int(id), pos=pos, q=q)
             self.forces[id] = f
+
+    def tearDown(self):
+        self.S.part.clear()
 
     def compare(self, method_name, energy=True):
         # Compare forces and energy now in the system to stored ones

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -38,15 +38,18 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
        2d: as long as this test AND the scafacos_dipolar_1d_2d test passes, we are safe.
        3d: as long as the independently written p3m and p2nfft agree, we are safe.
     """
-    s = espressomd.System(box_l=[1.0, 1.0, 1.0])
-    s.time_step = 0.01
-    s.cell_system.skin = .4
-    s.periodicity = [1, 1, 1]
-    s.thermostat.turn_off()
+    system = espressomd.System(box_l=[1.0, 1.0, 1.0])
+    system.time_step = 0.01
+    system.cell_system.skin = .4
+    system.periodicity = [1, 1, 1]
+    system.thermostat.turn_off()
+
+    def tearDown(self):
+        self.system.part.clear()
+        self.system.actors.clear()
 
     def test_mdlc(self):
-        s = self.s
-        s.part.clear()
+        s = self.system
         rho = 0.3
 
         # This is only for box size calculation. The actual particle number is
@@ -91,13 +94,11 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         self.assertLessEqual(abs(err_t), tol_t, "Torque difference too large")
         self.assertLessEqual(abs(err_f), tol_f, "Force difference too large")
 
-        s.part.clear()
         del s.actors[0]
         del s.actors[0]
 
     def test_p3m(self):
-        s = self.s
-        s.part.clear()
+        s = self.system
         rho = 0.09
 
         # This is only for box size calculation. The actual particle number is
@@ -139,13 +140,9 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         self.assertLessEqual(abs(err_t), tol_t, "Torque difference too large")
         self.assertLessEqual(abs(err_f), tol_f, "Force difference too large")
 
-        s.part.clear()
-        del s.actors[0]
-
     @utx.skipIfMissingFeatures("SCAFACOS_DIPOLES")
     def test_scafacos_dipoles(self):
-        s = self.s
-        s.part.clear()
+        s = self.system
         rho = 0.09
 
         # This is only for box size calculation. The actual particle number is
@@ -197,9 +194,6 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         self.assertLessEqual(abs(err_e), tol_e, "Energy difference too large")
         self.assertLessEqual(abs(err_t), tol_t, "Torque difference too large")
         self.assertLessEqual(abs(err_f), tol_f, "Force difference too large")
-
-        s.part.clear()
-        del s.actors[0]
 
 
 if __name__ == "__main__":

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -33,11 +33,12 @@ class ElectrostaticInteractionsTests(ut.TestCase):
         self.system.box_l = [20, 20, 20]
         self.system.time_step = 0.01
 
-        if not self.system.part.exists(0):
-            self.system.part.add(id=0, pos=(1.0, 2.0, 2.0), q=1)
-        if not self.system.part.exists(1):
-            self.system.part.add(
-                id=1, pos=(3.0, 2.0, 2.0), q=-1)
+        self.system.part.add(id=0, pos=(1.0, 2.0, 2.0), q=1)
+        self.system.part.add(id=1, pos=(3.0, 2.0, 2.0), q=-1)
+
+    def tearDown(self):
+        self.system.part.clear()
+        self.system.actors.clear()
 
     def calc_dh_potential(self, r, df_params):
         kT = 1.0
@@ -100,7 +101,6 @@ class ElectrostaticInteractionsTests(ut.TestCase):
                                    [p3m_force, 0, 0], atol=1E-4)
         np.testing.assert_allclose(np.copy(self.system.part[1].f),
                                    [-p3m_force, 0, 0], atol=1E-5)
-        self.system.actors.remove(p3m)
 
     @utx.skipIfMissingFeatures(["P3M"])
     def test_p3m_non_metallic(self):
@@ -156,7 +156,6 @@ class ElectrostaticInteractionsTests(ut.TestCase):
 
         np.testing.assert_allclose(u_dh_core, u_dh, atol=1e-7)
         np.testing.assert_allclose(f_dh_core, -f_dh, atol=1e-2)
-        self.system.actors.remove(dh)
 
     def test_rf(self):
         """Tests the ReactionField coulomb interaction by comparing the
@@ -198,7 +197,6 @@ class ElectrostaticInteractionsTests(ut.TestCase):
 
         np.testing.assert_allclose(u_rf_core, u_rf, atol=1e-7)
         np.testing.assert_allclose(f_rf_core, -f_rf, atol=1e-2)
-        self.system.actors.remove(rf)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -110,10 +110,8 @@ class ElectrostaticInteractionsTests(ut.TestCase):
         self.system.part[1].pos = [3.0, 2.0, 2.0]
         for epsilon_power in range(-4, 5):
             epsilon = 10**epsilon_power
-            # reference value for energy only calculated for prefactor = 1,
-            # the formula is not an exact fit for small epsilon values
-            p3m_energy = -4 * np.pi / box_vol * 8 / (2 + 1 / epsilon) - 0.5
-            p3m_energy *= prefactor / 1.01053
+            p3m_energy = np.pi / box_vol * 16 / (1 + 2 * epsilon) - 0.501
+            p3m_energy *= prefactor
             p3m = espressomd.electrostatics.P3M(prefactor=prefactor,
                                                 accuracy=9.910945054074526e-08,
                                                 mesh=[22, 22, 22],

--- a/testsuite/python/magnetostaticInteractions.py
+++ b/testsuite/python/magnetostaticInteractions.py
@@ -17,6 +17,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import unittest as ut
+import unittest_decorators as utx
+import numpy as np
+
 import espressomd
 from espressomd import magnetostatics
 from tests_common import generate_test_for_class
@@ -33,6 +36,7 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
 
     def tearDown(self):
         self.system.part.clear()
+        self.system.actors.clear()
 
     if espressomd.has_features(["DP3M"]):
         test_DP3M = generate_test_for_class(
@@ -48,6 +52,67 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
             test_DdsRCpu = generate_test_for_class(
                 system, magnetostatics.DipolarDirectSumWithReplicaCpu,
                 dict(prefactor=3.4, n_replica=2))
+
+    @utx.skipIfMissingFeatures(["DP3M"])
+    def test_dp3m(self):
+        self.system.time_step = 0.01
+        prefactor = 1.1
+        self.system.part[0].pos = [1.0, 2.0, 2.0]
+        self.system.part[1].pos = [3.0, 2.0, 2.0]
+        dp3m_energy = 1.6733349639532644
+        dp3m_force = np.array([-3.54175042, -4.6761059, 9.96632774])
+        dp3m = espressomd.magnetostatics.DipolarP3M(
+            prefactor=prefactor,
+            accuracy=9.995178689932661e-07,
+            mesh=[49, 49, 49],
+            mesh_off=[0.5, 0.5, 0.5],
+            cao=7,
+            r_cut=4.739799499511719,
+            alpha=0.9056147262573242,
+            alpha_L=9.056147262573242,
+            r_cut_iL=0.4739799499511719,
+            cao_cut=3 * [0.7142857142857142],
+            a=3 * [0.2040816326530612],
+            additional_mesh=[0., 0., 0.],
+            tune=False)
+        self.system.actors.add(dp3m)
+        self.assertAlmostEqual(self.system.analysis.energy()['dipolar'],
+                               dp3m_energy, places=5)
+        # need to update forces
+        self.system.integrator.run(0)
+        np.testing.assert_allclose(np.copy(self.system.part[0].f),
+                                   dp3m_force, atol=1E-5)
+        np.testing.assert_allclose(np.copy(self.system.part[1].f),
+                                   -dp3m_force, atol=1E-5)
+
+    @utx.skipIfMissingFeatures(["DP3M"])
+    def test_dp3m_non_metallic(self):
+        self.system.time_step = 0.01
+        prefactor = 1.1
+        self.system.part[0].pos = [1.0, 2.0, 2.0]
+        self.system.part[1].pos = [3.0, 2.0, 2.0]
+        for epsilon_power in range(-4, 5):
+            epsilon = 10**epsilon_power
+            dp3m_energy = 1.66706 / (1 + 2 * epsilon) + 1.673333
+            dp3m = espressomd.magnetostatics.DipolarP3M(
+                prefactor=prefactor,
+                accuracy=9.995178689932661e-07,
+                mesh=[49, 49, 49],
+                mesh_off=[0.5, 0.5, 0.5],
+                cao=7,
+                epsilon=epsilon,
+                r_cut=4.739799499511719,
+                alpha=0.9056147262573242,
+                alpha_L=9.056147262573242,
+                r_cut_iL=0.4739799499511719,
+                cao_cut=3 * [0.7142857142857142],
+                a=3 * [0.2040816326530612],
+                additional_mesh=[0., 0., 0.],
+                tune=False)
+            self.system.actors.add(dp3m)
+            self.assertAlmostEqual(self.system.analysis.energy()['dipolar'],
+                                   dp3m_energy, places=3)
+            self.system.actors.remove(dp3m)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/magnetostaticInteractions.py
+++ b/testsuite/python/magnetostaticInteractions.py
@@ -41,9 +41,8 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
     if espressomd.has_features(["DP3M"]):
         test_DP3M = generate_test_for_class(
             system, magnetostatics.DipolarP3M,
-            dict(prefactor=1.0, epsilon=0.0, inter=1000,
-                 mesh_off=[0.5, 0.5, 0.5], r_cut=2.4, mesh=[8, 8, 8],
-                 cao=1, alpha=12, accuracy=0.01, tune=False))
+            dict(prefactor=1., epsilon=0., mesh_off=[0.5, 0.5, 0.5], r_cut=2.4,
+                 cao=1, mesh=[8, 8, 8], alpha=12, accuracy=0.01, tune=False))
 
     if espressomd.has_features(["DIPOLAR_DIRECT_SUM"]):
         test_DdsCpu = generate_test_for_class(

--- a/testsuite/python/magnetostaticInteractions.py
+++ b/testsuite/python/magnetostaticInteractions.py
@@ -28,10 +28,11 @@ class MagnetostaticsInteractionsTests(ut.TestCase):
 
     def setUp(self):
         self.system.box_l = [10, 10, 10]
-        if not self.system.part.exists(0):
-            self.system.part.add(id=0, pos=(0.1, 0.1, 0.1), dip=(1.3, 2.1, -6))
-        if not self.system.part.exists(1):
-            self.system.part.add(id=1, pos=(0, 0, 0), dip=(7.3, 6.1, -4))
+        self.system.part.add(id=0, pos=(0.1, 0.1, 0.1), dip=(1.3, 2.1, -6))
+        self.system.part.add(id=1, pos=(0, 0, 0), dip=(7.3, 6.1, -4))
+
+    def tearDown(self):
+        self.system.part.clear()
 
     if espressomd.has_features(["DP3M"]):
         test_DP3M = generate_test_for_class(

--- a/testsuite/python/p3m_tuning_exceptions.py
+++ b/testsuite/python/p3m_tuning_exceptions.py
@@ -194,7 +194,7 @@ class P3M_tuning_test(ut.TestCase):
         self.add_magnetic_particles()
 
         solver = espressomd.magnetostatics.DipolarP3M(
-            prefactor=2, accuracy=1e-2)
+            prefactor=2, accuracy=1e-2, mesh=49)
         try:
             self.system.actors.add(solver)
         except Exception as err:

--- a/testsuite/python/p3m_tuning_exceptions.py
+++ b/testsuite/python/p3m_tuning_exceptions.py
@@ -194,7 +194,7 @@ class P3M_tuning_test(ut.TestCase):
         self.add_magnetic_particles()
 
         solver = espressomd.magnetostatics.DipolarP3M(
-            prefactor=2, accuracy=1e-2, mesh=49)
+            prefactor=2, accuracy=1e-2)
         try:
             self.system.actors.add(solver)
         except Exception as err:


### PR DESCRIPTION
Part of the effort to reduce divergences between P3M and DP3M code. Follow-up to #3841.

Description of changes:
- group common members of the P3M and DP3M code in a base struct
- replace the 4 duplicated versions of `calc_meshift()` by a single one that works for all edge cases (unit tested)
- create an analogue of the P3M `G_opt<S,m>()` function for DP3M to reduce code duplication
- fix `heap-buffer-overflow` bug caused by a mesh size synchronization issue between P3M and FFT data structs
- fix `DipolarP3M` actor: remove unused `inter` and `inter2` parameters, fix range check on `mesh` that caused checkpointing to fail
- add a python test for the non-metallic case of DP3M
- fix unittest classes for P3M/DP3M tests (the list of actors must be cleared during teardown to avoid side-effects)
- modernize variable declarations (C++ Core Guidelines [ES.22](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-init), [ES.25](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-const), [ES.49](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-casts-named), [F.20](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f20-for-out-output-values-prefer-return-values-to-output-parameters))
