### PR TITLE
core: p3m: reset r_cut when default value is provided in tuning

### DIFF
--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -192,6 +192,9 @@ void p3m_set_tune_params(double r_cut, const int mesh[3], int cao, double alpha,
   if (r_cut >= 0) {
     p3m.params.r_cut = r_cut;
     p3m.params.r_cut_iL = r_cut * (1. / box_geo.length()[0]);
+  } else if (r_cut == -1.0) {
+    p3m.params.r_cut = 0;
+    p3m.params.r_cut_iL = 0;
   }
 
   if (mesh[0] >= 0) {


### PR DESCRIPTION
This fixes the behavior of `p3m.tune()` if the `r_cut`-default value is provided (mentioned in #3889).