### PR TITLE
P3M: reordered sanity checks in initialization

### DIFF
--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -80,6 +80,10 @@ static bool p3m_sanity_checks_system(const Utils::Vector3i &grid);
  */
 static bool p3m_sanity_checks_boxl();
 
+/** Checks that necessary parameters are set
+ */
+static bool p3m_sanity_checks_parameters();
+
 /** Calculate the optimal influence function of @cite hockney88a.
  *  (optimised for force calculations)
  *
@@ -156,7 +160,7 @@ void p3m_init() {
     return;
   }
 
-  if (p3m_sanity_checks()) {
+  if (p3m_sanity_checks_parameters()) {
     return;
   }
 
@@ -165,6 +169,10 @@ void p3m_init() {
   /* initializes the (inverse) mesh constant p3m.params.a (p3m.params.ai) and
    * the cutoff for charge assignment p3m.params.cao_cut */
   p3m_init_a_ai_cao_cut();
+
+  if (p3m_sanity_checks()) {
+    return;
+  }
 
   p3m_calc_local_ca_mesh(p3m.local_mesh, p3m.params, local_geo, skin);
 
@@ -1290,14 +1298,8 @@ bool p3m_sanity_checks_system(const Utils::Vector3i &grid) {
   return ret;
 }
 
-bool p3m_sanity_checks() {
-  bool ret = false;
-
-  if (p3m_sanity_checks_system(node_grid))
-    ret = true;
-
-  if (p3m_sanity_checks_boxl())
-    ret = true;
+bool p3m_sanity_checks_parameters() {
+  bool ret{false};
 
   if (p3m.params.mesh[0] == 0) {
     runtimeErrorMsg() << "P3M_init: mesh size is not yet set";
@@ -1311,6 +1313,20 @@ bool p3m_sanity_checks() {
     runtimeErrorMsg() << "P3M_init: alpha must be >0";
     ret = true;
   }
+  return ret;
+}
+
+bool p3m_sanity_checks() {
+  bool ret = false;
+
+  if (p3m_sanity_checks_system(node_grid))
+    ret = true;
+
+  if (p3m_sanity_checks_boxl())
+    ret = true;
+
+  if (p3m_sanity_checks_parameters())
+    ret = true;
 
   return ret;
 }


### PR DESCRIPTION
Fixes #3920 

Description of changes:
- introduced `p3m_sanity_checks_parameters`
- reordered sanity checks in `p3m_init` to update `cao_cut` before it gets checked