### PR TITLE
Add pylint configuration to pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,12 @@ repos:
         always_run: false
         exclude: '.*\.(sh|py|sh\.in|cmakein)|.git'
         types: [file, executable]
+
+    -   id: pylint
+        name: pylint
+        entry: sh maintainer/lint/pylint.sh
+        language: system
+        always_run: false
+        files: '.*\.py'
+        args: ["--score=no", "--reports=no", "--output-format=text"]
+        log_file: pylint.log

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -15,7 +15,6 @@
 # serve to show the default.
 
 import sys
-import os
 import sphinx
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
Fixes #3952

Description of changes:
- add pylint check to pre-commit configuration
- pylint can now be run exclusively on files belonging to the repository by running ```pre-commit run pylint``` or automatically on changed files if the pre-commit hook is installed (the preferred way)
