### PR TITLE
Fix LB node interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,7 @@ target_compile_options(
             $<$<BOOL:${WARNINGS_ARE_ERRORS}>:-Werror>
             # add extra warnings
             $<$<CXX_COMPILER_ID:Clang>:-Wextern-initializer>
+            $<$<CXX_COMPILER_ID:Clang>:-Wrange-loop-analysis>
             # disable warnings from -Wextra
             -Wno-sign-compare
             -Wno-unused-function

--- a/src/core/cluster_analysis/ClusterStructure.cpp
+++ b/src/core/cluster_analysis/ClusterStructure.cpp
@@ -54,7 +54,7 @@ void ClusterStructure::run_for_all_pairs() {
 void ClusterStructure::run_for_bonded_particles() {
   clear();
   for (const auto &p : partCfg()) {
-    for (auto const &bond : p.bonds()) {
+    for (auto const bond : p.bonds()) {
       if (bond.partner_ids().size() == 1) {
         add_pair(p, get_particle_data(bond.partner_ids()[0]));
       }

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -964,7 +964,7 @@ void auto_exclusions(int distance) {
   /* determine initial connectivity */
   for (auto const &part1 : partCfg()) {
     auto const p1 = part1.p.identity;
-    for (auto const &bond : part1.bonds()) {
+    for (auto const bond : part1.bonds()) {
       if ((bond.partner_ids().size() == 1) and (bond.partner_ids()[0] != p1)) {
         auto const p2 = bond.partner_ids()[0];
         add_partner(partners[p1], p1, p2, 1);

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -85,9 +85,8 @@ cdef class HydrodynamicInteraction(Actor):
         if isinstance(key, (tuple, list, np.ndarray)):
             if len(key) == 3:
                 return LBFluidRoutines(np.array(key))
-        else:
-            raise Exception(
-                f"{key} is not a valid key. Should be a point on the nodegrid e.g. lbf[0,0,0].")
+        raise Exception(
+            f"{key} is not a valid key. Should be a point on the nodegrid e.g. lbf[0,0,0].")
 
     # validate the given parameters on actor initialization
     ####################################################

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -423,14 +423,13 @@ cdef class LBFluidRoutines:
 
         def __set__(self, value):
             cdef Vector3d c_velocity
-            if all(is_valid_type(v, float) for v in value) and len(value) == 3:
-                c_velocity[0] = value[0]
-                c_velocity[1] = value[1]
-                c_velocity[2] = value[2]
-                python_lbnode_set_velocity(self.node, c_velocity)
-            else:
-                raise ValueError(
-                    "Velocity has to be of shape 3 and type float.")
+            utils.check_type_or_throw_except(
+                value, 3, float, "velocity has to be 3 floats")
+            c_velocity[0] = value[0]
+            c_velocity[1] = value[1]
+            c_velocity[2] = value[2]
+            python_lbnode_set_velocity(self.node, c_velocity)
+
     property density:
         def __get__(self):
             return python_lbnode_get_density(self.node)

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -82,11 +82,9 @@ cdef class HydrodynamicInteraction(Actor):
         return _construct, (self.__class__, self._params), None
 
     def __getitem__(self, key):
-        if isinstance(key, (tuple, list, np.ndarray)):
-            if len(key) == 3:
-                return LBFluidRoutines(np.array(key))
-        raise Exception(
-            f"{key} is not a valid key. Should be a point on the nodegrid e.g. lbf[0,0,0].")
+        utils.check_type_or_throw_except(
+            key, 3, int, "The index of an lb fluid node consists of three integers, e.g. lbf[0,0,0]")
+        return LBFluidRoutines(key)
 
     # validate the given parameters on actor initialization
     ####################################################

--- a/src/utils/tests/memcpy_archive_test.cpp
+++ b/src/utils/tests/memcpy_archive_test.cpp
@@ -21,6 +21,15 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
+/* This <boost/serialization/version.hpp> include guards against an issue
+ * in boost::serialization from boost 1.74.0 that leads to compiler error
+ * "explicit specialization of undeclared template struct 'version'" when
+ * including <boost/serialization/optional.hpp>. More details in tickets:
+ * https://github.com/boostorg/serialization/issues/210
+ * https://github.com/boostorg/serialization/issues/217
+ */
+#include <boost/serialization/version.hpp>
+
 #include <utils/serialization/memcpy_archive.hpp>
 
 #include <utils/Vector.hpp>

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -185,6 +185,8 @@ class TestLB:
             np.copy(self.lbf[0, 0, 0].velocity), [1, 2, 3], atol=1E-10)
         with self.assertRaises(Exception):
             self.lbf[0, 0, 0].velocity = [1, 2]
+        with self.assertRaises(Exception):
+            self.lbf[0, 1].velocity = [1, 2, 3]
 
     def test_raise_if_not_active(self):
         lbf = self.lb_class(visc=1.0, dens=1.0, agrid=1.0, tau=0.1)

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -180,6 +180,11 @@ class TestLB:
         self.assertEqual(self.lbf.seed, 57)
         self.lbf.tau = 0.2
         self.assertAlmostEqual(self.lbf.tau, 0.2)
+        self.lbf[0, 0, 0].velocity = [1, 2, 3]
+        np.testing.assert_allclose(
+            np.copy(self.lbf[0, 0, 0].velocity), [1, 2, 3], atol=1E-10)
+        with self.assertRaises(Exception):
+            self.lbf[0, 0, 0].velocity = [1, 2]
 
     def test_raise_if_not_active(self):
         lbf = self.lb_class(visc=1.0, dens=1.0, agrid=1.0, tau=0.1)


### PR DESCRIPTION
Description of changes:
- incorrect LB node grid indices (e.g. `lbf[0,0].velocity`) are now caught
- incorrect LB node grid indices type (e.g. `lbf[0,0,0.1]`) now produce the correct error message
- it is now legal to write `lbf[0,0,0].velocity = np.array([0,0,0])`
- add patch for regression in boost 1.74