### PR TITLE
Simplify CI and bump version requirements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,7 +127,7 @@ ubuntu:wo-dependencies:
 debian:10:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/debian:d496478230db4e5c286680e3bdc1621af1fccffc
+  image: docker.pkg.github.com/espressomd/docker/debian:d372d95f6906c16abd9b47b994034a22981a9ff2
   script:
     - export with_cuda=false myconfig=maxset make_check_python=false with_stokesian_dynamics=true
     - bash maintainer/CI/build_cmake.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,16 +195,15 @@ cuda11-maxset:
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'
+     GCOV: 'gcov-9'
   script:
-    - export myconfig=maxset with_cuda=true with_coverage=false test_timeout=900 srcdir=${CI_PROJECT_DIR}
+    - export myconfig=maxset with_cuda=true with_coverage=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
     - export with_scafacos=true with_stokesian_dynamics=true
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux
     - cuda
-  only:
-    - schedules
 
 cuda10-maxset:
   <<: *global_job_definition
@@ -220,23 +219,6 @@ cuda10-maxset:
     paths:
     - build/
     expire_in: 1 week
-  tags:
-    - docker
-    - linux
-    - cuda
-
-cuda9-maxset:
-  <<: *global_job_definition
-  stage: build
-  image: docker.pkg.github.com/espressomd/docker/ubuntu-18.04:8a7d258889d87dcc9c96a200784b30b532d45b33
-  variables:
-     CC: 'gcc-6'
-     CXX: 'g++-6'
-     GCOV: 'gcov-6'
-  script:
-    - export myconfig=maxset with_cuda=true with_coverage=true test_timeout=900 srcdir=${CI_PROJECT_DIR}
-    - export with_scafacos=true with_stokesian_dynamics=true
-    - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
     - linux

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,17 +146,6 @@ opensuse:15.2:
     - docker
     - linux
 
-centos:7:
-  <<: *global_job_definition
-  stage: build
-  image: docker.pkg.github.com/espressomd/docker/centos:446ff604bbfa63f30ddb462697fa0d0dc2630460
-  script:
-    - export with_cuda=false myconfig=maxset make_check_python=true with_stokesian_dynamics=true
-    - bash maintainer/CI/build_cmake.sh
-  tags:
-    - docker
-    - linux
-
 fedora:32:
   <<: *global_job_definition
   stage: build

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,8 +1,9 @@
 extraction:
   cpp:
-    after_prepare: "pip3 install numpy cython"
+    after_prepare: "pip3 install --user numpy cython 'cmake==3.17'"
     configure:
       command:
+      - export PATH="${HOME}/.local/bin:${PATH}"
       - "mkdir build"
       - "cd build && cmake .."
     index:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.16)
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 if(POLICY CMP0076)
   # make target_sources() convert relative paths to absolute

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ endif(WITH_CUDA)
 find_package(PythonInterp 3.6 REQUIRED)
 
 if(WITH_PYTHON)
-  find_package(Cython 0.26 REQUIRED)
+  find_package(Cython 0.29 REQUIRED)
   find_package(PythonHeaders REQUIRED)
   find_package(NumPy REQUIRED)
   find_program(IPYTHON_EXECUTABLE NAMES jupyter ipython3 ipython)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ endforeach(func_name __PRETTY_FUNCTION__ __FUNCTION__)
 # CUDA compiler
 if(WITH_CUDA)
   set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
-  set(MINIMAL_CUDA_VERSION 9.0)
+  set(MINIMAL_CUDA_VERSION 10.0)
   option_enum(varname "WITH_CUDA_COMPILER" help_text "CUDA compiler"
               default_value "nvcc" possible_values "nvcc;clang")
   if(WITH_CUDA_COMPILER STREQUAL "nvcc")
@@ -157,8 +157,7 @@ if(WITH_CUDA)
         FATAL_ERROR
           "Cannot enable code coverage with Clang as the CUDA compiler")
     endif()
-    set(MINIMAL_CUDA_VERSION 8.0)
-    find_package(CUDACompilerClang 6.0 REQUIRED)
+    find_package(CUDACompilerClang 9.0 REQUIRED)
   else()
     message(FATAL_ERROR "Unknown CUDA compiler '${WITH_CUDA_COMPILER}'")
   endif()

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -129,7 +129,6 @@ Installing requirements on other Linux distributions
 Please refer to the following Dockerfiles to find the minimum set of packages
 required to compile |es| on other Linux distributions:
 
-* `CentOS <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-centos>`_
 * `Fedora <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-fedora>`_
 * `Debian <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-debian>`_
 * `OpenSUSE <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-opensuse>`_

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -93,13 +93,6 @@ are required:
     jupyter nbextension enable rubberband/main
     jupyter nbextension enable exercise2/main
 
-To compile |es| on Ubuntu 18.04 LTS, you will need to install a more recent
-version of CMake with:
-
-.. code-block:: bash
-
-    pip3 install --user cmake
-
 Nvidia GPU acceleration
 """""""""""""""""""""""
 
@@ -110,16 +103,11 @@ CUDA SDK to make use of GPU computation:
 
     sudo apt install nvidia-cuda-toolkit
 
-On Ubuntu, the default GCC compiler is too recent for nvcc, which will generate
-compiler errors. You can either install an older version of GCC and select it
-with environment variables ``CC`` and ``CXX`` when building |es|, or edit the
-system header files as shown in the following example for Ubuntu 18.04:
-
-.. code-block:: bash
-
-    sudo sed -i 's/__GNUC__ > 6/__GNUC__ > 7/g' /usr/include/crt/host_config.h
-    sudo sed -i 's/than 6/than 7/g' /usr/include/crt/host_config.h
-
+On Ubuntu 20.04, the default GCC compiler is too recent for nvcc, which will
+generate compiler errors. You can either install an older version of GCC and
+select it with environment variables ``CC`` and ``CXX`` when building |es|,
+or edit the system header files as shown in the following
+`patch for Ubuntu 20.04 <https://github.com/espressomd/espresso/issues/3654#issuecomment-612165048>`_.
 
 .. _Installing requirements on other Linux distributions:
 


### PR DESCRIPTION
Partial fix for #3093

Description of changes:
- drop support for CUDA 8 and 9
- remove CI jobs for CentOS and Ubuntu 18.04
- bump CMake and Cython version requirements
