### PR TITLE
Sort out CUDA builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,7 +186,7 @@ clang-sanitizer:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
 
 cuda11-maxset:
   <<: *global_job_definition
@@ -222,7 +222,7 @@ cuda10-maxset:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
 
 tutorials-samples-maxset:
   <<: *global_job_definition
@@ -237,7 +237,7 @@ tutorials-samples-maxset:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
 
 tutorials-samples-default:
   <<: *global_job_definition
@@ -252,7 +252,7 @@ tutorials-samples-default:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
   only:
     - schedules
 
@@ -269,7 +269,7 @@ tutorials-samples-empty:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
   only:
     - schedules
 
@@ -315,7 +315,7 @@ installation:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
   when: manual
 
 empty:
@@ -331,7 +331,7 @@ empty:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
 
 check_sphinx:
   <<: *global_job_definition
@@ -354,7 +354,7 @@ check_sphinx:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
 
 run_tutorials:
   <<: *global_job_definition
@@ -374,7 +374,7 @@ run_tutorials:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
   only:
     - schedules
 
@@ -425,7 +425,7 @@ check_with_odd_no_of_processors:
   tags:
     - docker
     - linux
-    - cuda
+    - cuda-kepler
 
 
 .deploy_base:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,7 +191,7 @@ clang-sanitizer:
 cuda11-maxset:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/cuda:e583d4b2eb8eedd10068957f952bd67008475ee5
+  image: docker.pkg.github.com/espressomd/docker/cuda:d372d95f6906c16abd9b47b994034a22981a9ff2
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -226,6 +226,11 @@ fi
 if [ "${run_checks}" = true ]; then
     start "TEST"
 
+    # fail if built with CUDA but no compatible GPU was found
+    if [ "${with_cuda}" = true ] && [ "${hide_gpu}" != true ]; then
+        ./pypresso -c "import espressomd;assert espressomd.gpu_available(), 'No GPU available'" || exit 1
+    fi
+
     # unit tests
     if [ "${make_check_unit_tests}" = true ]; then
         make -j${build_procs} check_unit_tests ${make_params} || exit 1

--- a/maintainer/CI/build_docker.sh
+++ b/maintainer/CI/build_docker.sh
@@ -24,6 +24,7 @@ with_fftw=${with_fftw}
 with_coverage=false
 with_cuda=true
 with_scafacos=true
+hide_gpu=true
 CC=gcc-8
 CXX=g++-8
 check_procs=${check_procs}


### PR DESCRIPTION
Description of changes:
- check that a GPU is available before running the testsuite in CUDA builds
- fix broken CUDA 11 image and restrict CUDA 10 jobs to Kepler runners
