### PR TITLE
Bump Boost version requirement to 1.66

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,12 +339,7 @@ if(WITH_TESTS)
   list(APPEND BOOST_COMPONENTS unit_test_framework)
 endif()
 
-set(BOOST_MINIMUM_VERSION "1.65.0")
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND CUDA_FOUND
-   AND CUDA_VERSION VERSION_GREATER_EQUAL "9.0")
-  set(BOOST_MINIMUM_VERSION "1.66.0")
-endif()
+set(BOOST_MINIMUM_VERSION "1.66.0")
 
 # old Boost.MPI versions contain a use-after-free bug that seems to only cause
 # crashes on 32-bit architectures

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -36,8 +36,8 @@ function(PYTHON_TEST)
   set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${TEST_NUM_PROC}
                                                DEPENDS "${TEST_DEPENDS}")
 
-  if("gpu" IN_LIST TEST_LABELS)
-    set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL ON)
+  if("gpu" IN_LIST TEST_LABELS AND WITH_CUDA)
+    set_tests_properties(${TEST_NAME} PROPERTIES RESOURCE_LOCK GPU)
   endif()
 
   if(${TEST_MAX_NUM_PROC} LESS 2)

--- a/testsuite/scripts/CMakeLists.txt
+++ b/testsuite/scripts/CMakeLists.txt
@@ -23,7 +23,7 @@ macro(PYTHON_SCRIPTS_TEST)
   set_tests_properties(${TEST_NAME} PROPERTIES FIXTURES_REQUIRED
                                                IMPORTLIB_WRAPPER)
   set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}")
-  if("gpu" IN_LIST TEST_LABELS)
+  if("gpu" IN_LIST TEST_LABELS AND WITH_CUDA)
     set_tests_properties(${TEST_NAME} PROPERTIES RESOURCE_LOCK GPU)
   endif()
 endmacro(PYTHON_SCRIPTS_TEST)


### PR DESCRIPTION
Fixes #3807, fixes #3093

Description of changes:
- increase Boost version to avoid singleton bug from 1.65.1
- improve parallelism of GPU integration tests