### PR TITLE
Reduce code duplication in thermostat tests

### DIFF
--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -236,6 +236,9 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/ek_common.py
           ${CMAKE_CURRENT_BINARY_DIR}
   COMMAND
+    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/thermostats_common.py
+    ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND
     ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/ek_eof_one_species_base.py
     ${CMAKE_CURRENT_BINARY_DIR})

--- a/testsuite/python/brownian_dynamics.py
+++ b/testsuite/python/brownian_dynamics.py
@@ -239,10 +239,7 @@ class BrownianDynamics(ut.TestCase):
         np.testing.assert_almost_equal(np.copy(virtual.v), [1, 0, 0])
         np.testing.assert_almost_equal(np.copy(physical.v), [0, 0, 0])
 
-        system.part.clear()
-        virtual = system.part.add(pos=[0, 0, 0], virtual=True, v=[1, 0, 0])
-        physical = system.part.add(pos=[0, 0, 0], virtual=False, v=[1, 0, 0])
-
+        virtual.pos = physical.pos = [0, 0, 0]
         system.thermostat.set_brownian(
             kT=0, gamma=1, gamma_rotation=1., act_on_virtual=True, seed=41)
         system.integrator.run(1)

--- a/testsuite/python/brownian_dynamics.py
+++ b/testsuite/python/brownian_dynamics.py
@@ -34,9 +34,14 @@ class BrownianDynamics(ut.TestCase):
     system.periodicity = [0, 0, 0]
     system.integrator.set_brownian_dynamics()
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         np.random.seed(42)
+
+    def tearDown(self):
+        self.system.time_step = 1e-12
+        self.system.cell_system.skin = 0.0
+        self.system.part.clear()
+        self.system.auto_update_accumulators.clear()
 
     def check_velocity_distribution(self, vel, minmax, n_bins, error_tol, kT):
         """check the recorded particle distributions in velocity against a
@@ -70,7 +75,6 @@ class BrownianDynamics(ut.TestCase):
         """
         N = 200
         system = self.system
-        system.part.clear()
         system.time_step = 1.6
 
         # Place particles
@@ -122,7 +126,6 @@ class BrownianDynamics(ut.TestCase):
         """
         N = 400
         system = self.system
-        system.part.clear()
         system.time_step = 1.9
         system.part.add(pos=np.random.random((N, 3)))
         if espressomd.has_features("ROTATION"):
@@ -192,7 +195,6 @@ class BrownianDynamics(ut.TestCase):
         dt = 0.5
 
         system = self.system
-        system.part.clear()
         p = system.part.add(pos=(0, 0, 0), id=0)
         system.time_step = dt
         system.thermostat.set_brownian(kT=kT, gamma=gamma, seed=41)
@@ -225,7 +227,6 @@ class BrownianDynamics(ut.TestCase):
     def test_07__virtual(self):
         system = self.system
         system.time_step = 0.01
-        system.part.clear()
 
         virtual = system.part.add(pos=[0, 0, 0], virtual=True, v=[1, 0, 0])
         physical = system.part.add(pos=[0, 0, 0], virtual=False, v=[1, 0, 0])
@@ -253,7 +254,6 @@ class BrownianDynamics(ut.TestCase):
         """Checks that the Brownian noise is uncorrelated"""
 
         system = self.system
-        system.part.clear()
         system.time_step = 0.01
         system.cell_system.skin = 0.1
         system.part.add(id=(0, 1), pos=np.zeros((2, 3)))
@@ -270,7 +270,6 @@ class BrownianDynamics(ut.TestCase):
         system.thermostat.set_brownian(kT=kT, gamma=2.1, seed=17)
         steps = int(1e4)
         system.integrator.run(steps)
-        system.auto_update_accumulators.clear()
 
         # test translational noise correlation
         vel = np.array(vel_series.time_series())

--- a/testsuite/python/brownian_dynamics.py
+++ b/testsuite/python/brownian_dynamics.py
@@ -20,12 +20,12 @@ import unittest as ut
 import unittest_decorators as utx
 import espressomd
 import numpy as np
-from espressomd.accumulators import Correlator, TimeSeries
-from espressomd.observables import ParticleVelocities, ParticleBodyAngularVelocities, ParticlePositions
-from tests_common import single_component_maxwell
+from espressomd.accumulators import Correlator
+from espressomd.observables import ParticlePositions
+from thermostats_common import ThermostatsCommon
 
 
-class BrownianDynamics(ut.TestCase):
+class ThermalizedBond(ut.TestCase, ThermostatsCommon):
 
     """Tests velocity distributions and diffusion for Brownian Dynamics"""
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])
@@ -43,26 +43,6 @@ class BrownianDynamics(ut.TestCase):
         self.system.part.clear()
         self.system.auto_update_accumulators.clear()
 
-    def check_velocity_distribution(self, vel, minmax, n_bins, error_tol, kT):
-        """check the recorded particle distributions in velocity against a
-           histogram with n_bins bins. Drop velocities outside minmax. Check
-           individual histogram bins up to an accuracy of error_tol against the
-           analytical result for kT."""
-        for i in range(3):
-            hist = np.histogram(
-                vel[:, i], range=(-minmax, minmax), bins=n_bins, density=False)
-            data = hist[0] / float(vel.shape[0])
-            bins = hist[1]
-            for j in range(n_bins):
-                found = data[j]
-                expected = single_component_maxwell(bins[j], bins[j + 1], kT)
-                self.assertLessEqual(abs(found - expected), error_tol)
-
-    def test_00_verify_single_component_maxwell(self):
-        """Verifies the normalization of the analytical expression."""
-        self.assertLessEqual(
-            abs(single_component_maxwell(-10, 10, 4.) - 1.), 1E-4)
-
     def check_vel_dist_global_temp(self, recalc_forces, loops):
         """Test velocity distribution for global temperature parameters.
 
@@ -76,41 +56,17 @@ class BrownianDynamics(ut.TestCase):
         N = 200
         system = self.system
         system.time_step = 1.6
-
-        # Place particles
-        system.part.add(pos=np.random.random((N, 3)))
-
-        # Enable rotation if compiled in
-        if espressomd.has_features("ROTATION"):
-            system.part[:].rotation = [1, 1, 1]
-
         kT = 1.1
         gamma = 3.5
         system.thermostat.set_brownian(kT=kT, gamma=gamma, seed=41)
-
-        # Warmup
-        system.integrator.run(20)
-
-        # Sampling
-        v_stored = np.zeros((N * loops, 3))
-        omega_stored = np.zeros((N * loops, 3))
-        for i in range(loops):
-            system.integrator.run(1, recalc_forces=recalc_forces)
-            v_stored[i * N:(i + 1) * N, :] = system.part[:].v
-            if espressomd.has_features("ROTATION"):
-                omega_stored[i * N:(i + 1) * N, :] = system.part[:].omega_body
-
         v_minmax = 5
         bins = 4
         error_tol = 0.01
-        self.check_velocity_distribution(
-            v_stored, v_minmax, bins, error_tol, kT)
-        if espressomd.has_features("ROTATION"):
-            self.check_velocity_distribution(
-                omega_stored, v_minmax, bins, error_tol, kT)
+        self.check_global(
+            N, kT, loops, v_minmax, bins, error_tol, recalc_forces)
 
     def test_vel_dist_global_temp(self):
-        """Test velocity distribution for global temperature."""
+        """Test velocity distribution for global Brownian parameters."""
         self.check_vel_dist_global_temp(False, loops=200)
 
     def test_vel_dist_global_temp_initial_forces(self):
@@ -120,63 +76,24 @@ class BrownianDynamics(ut.TestCase):
         self.check_vel_dist_global_temp(True, loops=170)
 
     @utx.skipIfMissingFeatures("BROWNIAN_PER_PARTICLE")
-    def test_05_brownian_per_particle(self):
-        """Test Brownian dynamics with particle specific kT and gamma. Covers all combinations of
-           particle specific gamma and temp set or not set.
+    def test_vel_dist_per_particle(self):
+        """Test Brownian dynamics with particle-specific kT and gamma. Covers
+           all combinations of particle-specific gamma and temp set or not set.
         """
         N = 400
         system = self.system
         system.time_step = 1.9
-        system.part.add(pos=np.random.random((N, 3)))
-        if espressomd.has_features("ROTATION"):
-            system.part[:].rotation = [1, 1, 1]
-
         kT = 0.9
         gamma = 3.2
         gamma2 = 4.3
         kT2 = 1.5
         system.thermostat.set_brownian(kT=kT, gamma=gamma, seed=41)
-        # Set different kT on 2nd half of particles
-        system.part[int(N / 2):].temp = kT2
-        # Set different gamma on half of the particles (overlap over both kTs)
-        if espressomd.has_features("PARTICLE_ANISOTROPY"):
-            system.part[int(N / 4):int(3 * N / 4)].gamma = 3 * [gamma2]
-        else:
-            system.part[int(N / 4):int(3 * N / 4)].gamma = gamma2
-
-        system.integrator.run(50)
         loops = 200
-
-        v_kT = np.zeros((int(N / 2) * loops, 3))
-        v_kT2 = np.zeros((int(N / 2 * loops), 3))
-
-        if espressomd.has_features("ROTATION"):
-            omega_kT = np.zeros((int(N / 2) * loops, 3))
-            omega_kT2 = np.zeros((int(N / 2 * loops), 3))
-
-        for i in range(loops):
-            system.integrator.run(1)
-            v_kT[int(i * N / 2):int((i + 1) * N / 2),
-                 :] = system.part[:int(N / 2)].v
-            v_kT2[int(i * N / 2):int((i + 1) * N / 2),
-                  :] = system.part[int(N / 2):].v
-
-            if espressomd.has_features("ROTATION"):
-                omega_kT[int(i * N / 2):int((i + 1) * N / 2), :] = \
-                    system.part[:int(N / 2)].omega_body
-                omega_kT2[int(i * N / 2):int((i + 1) * N / 2), :] = \
-                    system.part[int(N / 2):].omega_body
         v_minmax = 5
         bins = 4
         error_tol = 0.012
-        self.check_velocity_distribution(v_kT, v_minmax, bins, error_tol, kT)
-        self.check_velocity_distribution(v_kT2, v_minmax, bins, error_tol, kT2)
-
-        if espressomd.has_features("ROTATION"):
-            self.check_velocity_distribution(
-                omega_kT, v_minmax, bins, error_tol, kT)
-            self.check_velocity_distribution(
-                omega_kT2, v_minmax, bins, error_tol, kT2)
+        self.check_per_particle(
+            N, kT, kT2, gamma2, loops, v_minmax, bins, error_tol)
 
     def setup_diff_mass_rinertia(self, p):
         if espressomd.has_features("MASS"):
@@ -253,50 +170,12 @@ class BrownianDynamics(ut.TestCase):
         system = self.system
         system.time_step = 0.01
         system.cell_system.skin = 0.1
-        system.part.add(id=(0, 1), pos=np.zeros((2, 3)))
-        vel_obs = ParticleVelocities(ids=system.part[:].id)
-        vel_series = TimeSeries(obs=vel_obs)
-        system.auto_update_accumulators.add(vel_series)
-        if espressomd.has_features("ROTATION"):
-            system.part[:].rotation = (1, 1, 1)
-            omega_obs = ParticleBodyAngularVelocities(ids=system.part[:].id)
-            omega_series = TimeSeries(obs=omega_obs)
-            system.auto_update_accumulators.add(omega_series)
-
         kT = 3.2
         system.thermostat.set_brownian(kT=kT, gamma=2.1, seed=17)
+        system.part.add(id=(0, 1), pos=np.zeros((2, 3)))
         steps = int(1e4)
-        system.integrator.run(steps)
-
-        # test translational noise correlation
-        vel = np.array(vel_series.time_series())
-        for ind in range(2):
-            for i in range(3):
-                for j in range(i, 3):
-                    corrcoef = np.dot(
-                        vel[:, ind, i], vel[:, ind, j]) / steps / kT
-                    if i == j:
-                        self.assertAlmostEqual(corrcoef, 1.0, delta=0.04)
-                    else:
-                        self.assertLessEqual(np.abs(corrcoef), 0.04)
-
-        # test rotational noise correlation
-        if espressomd.has_features("ROTATION"):
-            omega = np.array(omega_series.time_series())
-            for ind in range(2):
-                for i in range(3):
-                    for j in range(3):
-                        corrcoef = np.dot(
-                            omega[:, ind, i], omega[:, ind, j]) / steps / kT
-                        if i == j:
-                            self.assertAlmostEqual(corrcoef, 1.0, delta=0.04)
-                        else:
-                            self.assertLessEqual(np.abs(corrcoef), 0.04)
-                        # translational and angular velocities should be
-                        # independent
-                        corrcoef = np.dot(
-                            vel[:, ind, i], omega[:, ind, j]) / steps / kT
-                        self.assertLessEqual(np.abs(corrcoef), 0.04)
+        error_delta = 0.04
+        self.check_noise_correlation(kT, steps, error_delta)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -29,8 +29,7 @@ from tests_common import single_component_maxwell
 @utx.skipIfMissingFeatures("DPD")
 class DPDThermostat(ut.TestCase):
 
-    """Tests the velocity distribution created by the dpd thermostat against
-       the single component Maxwell distribution."""
+    """Tests the velocity distribution created by the DPD thermostat."""
 
     s = espressomd.System(box_l=3 * [10.0])
     s.time_step = 0.01

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -23,11 +23,11 @@ from itertools import product
 
 import espressomd
 from espressomd.observables import DPDStress
-from tests_common import single_component_maxwell
+from thermostats_common import ThermostatsCommon
 
 
 @utx.skipIfMissingFeatures("DPD")
-class DPDThermostat(ut.TestCase):
+class DPDThermostat(ut.TestCase, ThermostatsCommon):
 
     """Tests the velocity distribution created by the DPD thermostat."""
 
@@ -42,26 +42,6 @@ class DPDThermostat(ut.TestCase):
         s = self.s
         s.part.clear()
         s.thermostat.turn_off()
-
-    def check_velocity_distribution(self, vel, minmax, n_bins, error_tol, kT):
-        """check the recorded particle distributions in velocity against a
-           histogram with n_bins bins. Drop velocities outside minmax. Check
-           individual histogram bins up to an accuracy of error_tol against
-           the analytical result for kT."""
-        for i in range(3):
-            hist = np.histogram(
-                vel[:, i], range=(-minmax, minmax), bins=n_bins, density=False)
-            data = hist[0] / float(vel.shape[0])
-            bins = hist[1]
-            for j in range(n_bins):
-                found = data[j]
-                expected = single_component_maxwell(bins[j], bins[j + 1], kT)
-                self.assertAlmostEqual(found, expected, delta=error_tol)
-
-    def test_aa_verify_single_component_maxwell(self):
-        """Verifies the normalization of the analytical expression."""
-        self.assertAlmostEqual(
-            single_component_maxwell(-10, 10, 4.), 1., delta=1E-4)
 
     def check_total_zero(self):
         v_total = np.sum(self.s.part[:].v, axis=0)

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -62,15 +62,15 @@ class DPDThermostat(ut.TestCase, ThermostatsCommon):
             trans_weight_function=0, trans_gamma=gamma, trans_r_cut=1.5)
         s.integrator.run(100)
         loops = 100
-        v_stored = np.zeros((N * loops, 3))
+        v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             s.integrator.run(10)
-            v_stored[i * N:(i + 1) * N, :] = s.part[:].v
+            v_stored[i] = s.part[:].v
         v_minmax = 5
         bins = 5
         error_tol = 0.01
         self.check_velocity_distribution(
-            v_stored, v_minmax, bins, error_tol, kT)
+            v_stored.reshape((-1, 3)), v_minmax, bins, error_tol, kT)
 
         if not with_langevin:
             self.check_total_zero()
@@ -103,15 +103,15 @@ class DPDThermostat(ut.TestCase, ThermostatsCommon):
             trans_weight_function=0, trans_gamma=gamma, trans_r_cut=1.5)
         s.integrator.run(100)
         loops = 250
-        v_stored = np.zeros((N * loops, 3))
+        v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             s.integrator.run(10)
-            v_stored[i * N:(i + 1) * N, :] = s.part[:].v
+            v_stored[i] = s.part[:].v
         v_minmax = 5
         bins = 5
         error_tol = 0.01
         self.check_velocity_distribution(
-            v_stored, v_minmax, bins, error_tol, kT)
+            v_stored.reshape((-1, 3)), v_minmax, bins, error_tol, kT)
         self.check_total_zero()
 
     def test_disable(self):
@@ -150,15 +150,15 @@ class DPDThermostat(ut.TestCase, ThermostatsCommon):
         s.integrator.run(250)
 
         loops = 250
-        v_stored = np.zeros((N * loops, 3))
+        v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             s.integrator.run(10)
-            v_stored[i * N:(i + 1) * N, :] = s.part[:].v
+            v_stored[i] = s.part[:].v
         v_minmax = 5
         bins = 5
         error_tol = 0.012
         self.check_velocity_distribution(
-            v_stored, v_minmax, bins, error_tol, kT)
+            v_stored.reshape((-1, 3)), v_minmax, bins, error_tol, kT)
 
     def test_const_weight_function(self):
         s = self.s

--- a/testsuite/python/langevin_thermostat.py
+++ b/testsuite/python/langevin_thermostat.py
@@ -35,9 +35,14 @@ class LangevinThermostat(ut.TestCase):
     system.cell_system.skin = 0
     system.periodicity = [0, 0, 0]
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         np.random.seed(42)
+
+    def tearDown(self):
+        self.system.time_step = 1e-12
+        self.system.cell_system.skin = 0.0
+        self.system.part.clear()
+        self.system.auto_update_accumulators.clear()
 
     def check_velocity_distribution(self, vel, minmax, n_bins, error_tol, kT):
         """check the recorded particle distributions in velocity against a
@@ -63,7 +68,6 @@ class LangevinThermostat(ut.TestCase):
         """Test for RNG seed consistency."""
         system = self.system
         system.time_step = 0.01
-        system.part.clear()
         system.part.add(pos=[0, 0, 0])
 
         kT = 1.1
@@ -136,7 +140,6 @@ class LangevinThermostat(ut.TestCase):
         v0 = np.array((5., 5., 5.))
 
         system.time_step = 0.0005
-        system.part.clear()
         system.part.add(pos=(0, 0, 0), v=v0)
         if espressomd.has_features("MASS"):
             system.part[0].mass = 3
@@ -174,7 +177,6 @@ class LangevinThermostat(ut.TestCase):
         o0 = np.array((5., 5., 5.))
 
         system.time_step = 0.0001
-        system.part.clear()
         system.part.add(pos=(0, 0, 0), omega_body=o0, rotation=(1, 1, 1))
         if espressomd.has_features("ROTATIONAL_INERTIA"):
             system.part[0].rinertia = [2, 2, 2]
@@ -213,7 +215,6 @@ class LangevinThermostat(ut.TestCase):
         """
         N = 200
         system = self.system
-        system.part.clear()
         system.time_step = 0.06
 
         # Place particles
@@ -265,7 +266,6 @@ class LangevinThermostat(ut.TestCase):
         """
         N = 400
         system = self.system
-        system.part.clear()
         system.time_step = 0.06
         system.part.add(pos=np.random.random((N, 3)))
         if espressomd.has_features("ROTATION"):
@@ -330,7 +330,6 @@ class LangevinThermostat(ut.TestCase):
     def test_06__diffusion(self):
         """This tests rotational and translational diffusion coeff via Green-Kubo"""
         system = self.system
-        system.part.clear()
 
         kT = 1.37
         dt = 0.1
@@ -493,7 +492,6 @@ class LangevinThermostat(ut.TestCase):
     def test_07__virtual(self):
         system = self.system
         system.time_step = 0.01
-        system.part.clear()
 
         virtual = system.part.add(pos=[0, 0, 0], virtual=True, v=[1, 0, 0])
         physical = system.part.add(pos=[0, 0, 0], virtual=False, v=[1, 0, 0])
@@ -517,7 +515,6 @@ class LangevinThermostat(ut.TestCase):
         """Checks that the Langevin noise is uncorrelated"""
 
         system = self.system
-        system.part.clear()
         system.time_step = 0.01
         system.cell_system.skin = 0.1
         system.part.add(id=(1, 2), pos=np.zeros((2, 3)))

--- a/testsuite/python/langevin_thermostat.py
+++ b/testsuite/python/langevin_thermostat.py
@@ -27,13 +27,12 @@ from tests_common import single_component_maxwell
 
 class LangevinThermostat(ut.TestCase):
 
-    """Tests the velocity distribution created by the Langevin thermostat
-       against the single component Maxwell distribution."""
-
+    """Tests velocity distributions and diffusion for Langevin Dynamics"""
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])
     system.cell_system.set_domain_decomposition(use_verlet_lists=True)
     system.cell_system.skin = 0
     system.periodicity = [0, 0, 0]
+    system.integrator.set_vv()
 
     def setUp(self):
         np.random.seed(42)

--- a/testsuite/python/lb_thermostat.py
+++ b/testsuite/python/lb_thermostat.py
@@ -61,15 +61,15 @@ class LBThermostatCommon(ThermostatsCommon):
         self.system.integrator.run(20)
         N = len(self.system.part)
         loops = 250
-        v_stored = np.zeros((N * loops, 3))
+        v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             self.system.integrator.run(3)
-            v_stored[i * N:(i + 1) * N, :] = self.system.part[:].v
+            v_stored[i] = self.system.part[:].v
         minmax = 5
         n_bins = 7
         error_tol = 0.01
         self.check_velocity_distribution(
-            v_stored, minmax, n_bins, error_tol, KT)
+            v_stored.reshape((-1, 3)), minmax, n_bins, error_tol, KT)
 
 
 class LBCPUThermostat(ut.TestCase, LBThermostatCommon):

--- a/testsuite/python/lb_thermostat.py
+++ b/testsuite/python/lb_thermostat.py
@@ -19,7 +19,7 @@ import unittest_decorators as utx
 import numpy as np
 
 import espressomd.lb
-from tests_common import single_component_maxwell
+from thermostats_common import ThermostatsCommon
 
 """
 Check the lattice-Boltzmann thermostat with respect to the particle velocity
@@ -41,7 +41,7 @@ LB_PARAMS = {'agrid': AGRID,
              'seed': 123}
 
 
-class LBThermostatCommon:
+class LBThermostatCommon(ThermostatsCommon):
 
     """Base class of the test that holds the test logic."""
     lbf = None
@@ -68,15 +68,8 @@ class LBThermostatCommon:
         minmax = 5
         n_bins = 7
         error_tol = 0.01
-        for i in range(3):
-            hist = np.histogram(v_stored[:, i], range=(-minmax, minmax),
-                                bins=n_bins, density=False)
-            data = hist[0] / float(v_stored.shape[0])
-            bins = hist[1]
-            for j in range(n_bins):
-                found = data[j]
-                expected = single_component_maxwell(bins[j], bins[j + 1], KT)
-                self.assertAlmostEqual(found, expected, delta=error_tol)
+        self.check_velocity_distribution(
+            v_stored, minmax, n_bins, error_tol, KT)
 
 
 class LBCPUThermostat(ut.TestCase, LBThermostatCommon):

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -645,12 +645,6 @@ class DynamicDict(dict):
         return eval(value, self) if isinstance(value, str) else value
 
 
-def single_component_maxwell(x1, x2, kT):
-    """Integrate the probability density from x1 to x2 using the trapezoidal rule"""
-    x = np.linspace(x1, x2, 1000)
-    return np.trapz(np.exp(-x**2 / (2. * kT)), x) / np.sqrt(2. * np.pi * kT)
-
-
 def count_fluid_nodes(lbf):
     """Counts the non-boundary nodes in the passed lb fluid instance."""
 

--- a/testsuite/python/thermalized_bond.py
+++ b/testsuite/python/thermalized_bond.py
@@ -21,11 +21,11 @@ import unittest as ut
 import unittest_decorators as utx
 
 import espressomd
-from tests_common import single_component_maxwell
+from thermostats_common import ThermostatsCommon
 
 
 @utx.skipIfMissingFeatures(["MASS"])
-class ThermalizedBond(ut.TestCase):
+class ThermalizedBond(ut.TestCase, ThermostatsCommon):
 
     """Tests the two velocity distributions for COM and distance created by the
        thermalized bond independently against the single component Maxwell
@@ -39,23 +39,6 @@ class ThermalizedBond(ut.TestCase):
     @classmethod
     def setUpClass(cls):
         np.random.seed(42)
-
-    def check_velocity_distribution(self, vel, minmax, n_bins, error_tol, kT):
-        """check the recorded particle distributions in velocity against a
-           histogram with n_bins bins. Drop velocities outside minmax. Check
-           individual histogram bins up to an accuracy of error_tol against the
-           analytical result for kT."""
-
-        for i in range(3):
-            hist = np.histogram(
-                vel[:, i], range=(-minmax, minmax), bins=n_bins, density=False)
-            data = hist[0] / float(vel.shape[0])
-            bins = hist[1]
-
-            for j in range(n_bins):
-                found = data[j]
-                expected = single_component_maxwell(bins[j], bins[j + 1], kT)
-                self.assertAlmostEqual(found, expected, delta=error_tol)
 
     def test_com_langevin(self):
         """Test for COM thermalization."""


### PR DESCRIPTION
Fixes #3975

Description of changes:
- factor out code duplication between Brownian/Langevin/DPD/LB thermostat tests
- improve tests readability with particle observables, or reshaped numpy arrays
