### PR TITLE
Make vtk dependency optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - run: |
        brew install boost boost-mpi fftw
        brew install hdf5-mpi
-       pip3 install numpy cython vtk h5py scipy
+       pip3 install numpy cython h5py scipy
     - run: |
         export myconfig=maxset with_cuda=false test_timeout=600
         bash maintainer/CI/build_cmake.sh

--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -40,10 +40,13 @@ import threading
 
 
 # workaround for https://github.com/enthought/mayavi/issues/3
-import vtk
-output = vtk.vtkFileOutputWindow()
-output.SetFileName("/dev/null")
-vtk.vtkOutputWindow().SetInstance(output)
+try:
+    import vtk
+    output = vtk.vtkFileOutputWindow()
+    output.SetFileName("/dev/null")
+    vtk.vtkOutputWindow().SetInstance(output)
+except ImportError:
+    print("Note: Log message suppression requires the `vtk` Python module to be present")
 
 cdef class mayaviLive:
     """


### PR DESCRIPTION
* Make vtk import in Mayavi visualizer optional. It is only used for log message suppression
* Remove vtk installation from mac build jobs