### PR TITLE
Create installation FAQ

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -767,10 +767,9 @@ targets are available:
 
 A number of options are available when calling ``make``. The most
 interesting option is probably ``-j num_jobs``, which can be used for
-parallel compilation on computers that have more than one CPU or core.
-*num_jobs* specifies the maximal number of jobs that will be run.
-Setting *num_jobs* to the number of available processors speeds up the
-compilation process significantly.
+parallel compilation. ``num_jobs`` specifies the maximal number of
+concurrent jobs that will be run. Setting ``num_jobs`` to the number
+of available processors speeds up the compilation process significantly.
 
 .. _Running es:
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -929,6 +929,16 @@ use one tool at a time.
 | ``--cuda-memcheck`` | ``cuda-memcheck python <args>``              |
 +---------------------+----------------------------------------------+
 
+.. _Troubleshooting:
+
+Troubleshooting
+---------------
+
+If you encounter issues when building |es| or running it for the first time,
+please have a look at the `Installation FAQ <https://github.com/espressomd/espresso/wiki/Installation-FAQ>`_
+on the wiki. If you still didn't find an answer, see :ref:`Community support`.
+
+____
 
 .. [1]
    http://espressomd.org

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -289,7 +289,8 @@ Tutorials
 There are a number of tutorials that introduce the use of |es| for different
 physical systems. You can also find the tutorials and related scripts in the
 directory :file:`/doc/tutorials` or `online on GitHub <https://github.com/espressomd/espresso/blob/python/doc/tutorials/>`_.
-Currently, the following tutorials are available:
+
+The following tutorials are available:
 
 * :file:`lennard_jones`: Modelling of a single-component and a two-component Lennard-Jones liquid.
 * :file:`visualization`: Using the online visualizers of |es|.
@@ -308,6 +309,8 @@ Sample scripts
 
 Several scripts that can serve as usage examples can be found in the directory :file:`/samples`,
 or in the `git repository <https://github.com/espressomd/espresso/blob/python/samples/>`_.
+
+The following samples are available:
 
 .. include:: samples.rst
 
@@ -435,9 +438,7 @@ report so to the developers using the instructions in :ref:`Contributing`.
 +--------------------------------+------------------------+------------------+------------+
 | Quaternion Integrator          | Core                   | Good             | Yes        |
 +--------------------------------+------------------------+------------------+------------+
-| Stokesian Dynamics on CPU      | Single                 | None             | Yes        |
-+--------------------------------+------------------------+------------------+------------+
-| Stokesian Dynamics on GPU      | Experimental           | None             | No         |
+| Stokesian Dynamics             | Single                 | None             | Yes        |
 +--------------------------------+------------------------+------------------+------------+
 |                                **Interactions**                                         |
 +--------------------------------+------------------------+------------------+------------+

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -289,6 +289,7 @@ Tutorials
 There are a number of tutorials that introduce the use of |es| for different
 physical systems. You can also find the tutorials and related scripts in the
 directory :file:`/doc/tutorials` or `online on GitHub <https://github.com/espressomd/espresso/blob/python/doc/tutorials/>`_.
+They are executed with the ``ipypresso`` script.
 
 The following tutorials are available:
 
@@ -309,6 +310,7 @@ Sample scripts
 
 Several scripts that can serve as usage examples can be found in the directory :file:`/samples`,
 or in the `git repository <https://github.com/espressomd/espresso/blob/python/samples/>`_.
+They are executed with the ``pypresso`` script.
 
 The following samples are available:
 


### PR DESCRIPTION
Fixes #3947

Link to the wiki: [Installation FAQ](https://github.com/espressomd/espresso/wiki/Installation-FAQ).