### PR TITLE
Skip bond calculation loop if not needed.

### DIFF
--- a/src/core/AtomDecomposition.cpp
+++ b/src/core/AtomDecomposition.cpp
@@ -147,6 +147,8 @@ AtomDecomposition::AtomDecomposition(const boost::mpi::communicator &comm,
   mark_cells();
 }
 
-Utils::Vector3d AtomDecomposition::max_range() const {
+Utils::Vector3d AtomDecomposition::max_cutoff() const {
   return Utils::Vector3d::broadcast(std::numeric_limits<double>::infinity());
 }
+
+Utils::Vector3d AtomDecomposition::max_range() const { return max_cutoff(); }

--- a/src/core/AtomDecomposition.hpp
+++ b/src/core/AtomDecomposition.hpp
@@ -92,7 +92,9 @@ public:
     return id_to_cell(p.identity());
   }
 
+  Utils::Vector3d max_cutoff() const override;
   Utils::Vector3d max_range() const override;
+
   /* Return true if minimum image convention is
    * needed for distance calculation. */
   boost::optional<BoxGeometry> minimum_image_distance() const override {

--- a/src/core/CellStructure.cpp
+++ b/src/core/CellStructure.cpp
@@ -179,6 +179,10 @@ ParticleRange CellStructure::ghost_particles() {
   return Cells::particles(decomposition().ghost_cells());
 }
 
+Utils::Vector3d CellStructure::max_cutoff() const {
+  return decomposition().max_cutoff();
+}
+
 Utils::Vector3d CellStructure::max_range() const {
   return decomposition().max_range();
 }

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -240,6 +240,9 @@ public:
 public:
   int decomposition_type() const { return m_type; }
 
+  /** Maximal cutoff supported by current cell system. */
+  Utils::Vector3d max_cutoff() const;
+
   /** Maximal pair range supported by current cell system. */
   Utils::Vector3d max_range() const;
 

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -449,12 +449,11 @@ private:
       std::unique_ptr<ParticleDecomposition> &&decomposition) {
     clear_particle_index();
 
-    auto local_parts = local_particles();
-    std::vector<Particle> particles(local_parts.begin(), local_parts.end());
+    /* Swap in new cell system */
+    std::swap(m_decomposition, decomposition);
 
-    m_decomposition = std::move(decomposition);
-
-    for (auto &p : particles) {
+    /* Add particles to new system */
+    for (auto &p : Cells::particles(decomposition->local_cells())) {
       add_particle(std::move(p));
     }
   }

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -127,12 +127,11 @@ private:
   /** One of @ref Cells::Resort, announces the level of resort needed.
    */
   unsigned m_resort_particles = Cells::RESORT_NONE;
+  bool m_rebuild_verlet_list = true;
+  std::vector<std::pair<Particle *, Particle *>> m_verlet_list;
 
 public:
   bool use_verlet_list = true;
-
-  bool m_rebuild_verlet_list = true;
-  std::vector<std::pair<Particle *, Particle *>> m_verlet_list;
 
   /**
    * @brief Update local particle index.
@@ -519,7 +518,7 @@ private:
    * @param verlet_criterion Filter for verlet lists.
    */
   template <class PairKernel, class VerletCriterion>
-  void verlet_list_loop(PairKernel &&pair_kernel,
+  void verlet_list_loop(PairKernel pair_kernel,
                         const VerletCriterion &verlet_criterion) {
     /* In this case the verlet list update is attached to
      * the pair kernel, and the verlet list is rebuilt as
@@ -527,8 +526,7 @@ private:
     if (m_rebuild_verlet_list) {
       m_verlet_list.clear();
 
-      link_cell([&pair_kernel, &verlet_criterion,
-                 this](Particle &p1, Particle &p2, Distance const &d) {
+      link_cell([&](Particle &p1, Particle &p2, Distance const &d) {
         if (verlet_criterion(p1, p2, d)) {
           m_verlet_list.emplace_back(&p1, &p2);
           pair_kernel(p1, p2, d);
@@ -569,10 +567,10 @@ public:
    * @param verlet_criterion Filter for verlet lists.
    */
   template <class PairKernel, class VerletCriterion>
-  void non_bonded_loop(PairKernel &&pair_kernel,
+  void non_bonded_loop(PairKernel pair_kernel,
                        const VerletCriterion &verlet_criterion) {
     if (use_verlet_list) {
-      verlet_list_loop(std::forward<PairKernel>(pair_kernel), verlet_criterion);
+      verlet_list_loop(pair_kernel, verlet_criterion);
     } else {
       /* No verlet lists, just run the kernel with pairs from the cells. */
       link_cell(pair_kernel);

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -331,6 +331,7 @@ public:
     return assert(m_decomposition), *m_decomposition;
   }
 
+private:
   ParticleDecomposition &decomposition() {
     return assert(m_decomposition), *m_decomposition;
   }

--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -262,13 +262,15 @@ void DomainDecomposition::fill_comm_cell_lists(ParticleList **part_lists,
         *part_lists++ = &(cells.at(i).particles());
       }
 }
-Utils::Vector3d DomainDecomposition::max_range() const {
+Utils::Vector3d DomainDecomposition::max_cutoff() const {
   auto dir_max_range = [this](int i) {
     return std::min(0.5 * m_box.length()[i], m_local_box.length()[i]);
   };
 
   return {dir_max_range(0), dir_max_range(1), dir_max_range(2)};
 }
+
+Utils::Vector3d DomainDecomposition::max_range() const { return cell_size; }
 int DomainDecomposition::calc_processor_min_num_cells() const {
   /* the minimal number of cells can be lower if there are at least two nodes
      serving a direction,

--- a/src/core/DomainDecomposition.hpp
+++ b/src/core/DomainDecomposition.hpp
@@ -112,6 +112,7 @@ public:
   }
 
   void resort(bool global, std::vector<ParticleChange> &diff) override;
+  Utils::Vector3d max_cutoff() const override;
   Utils::Vector3d max_range() const override;
 
   boost::optional<BoxGeometry> minimum_image_distance() const override {

--- a/src/core/ParticleDecomposition.hpp
+++ b/src/core/ParticleDecomposition.hpp
@@ -115,7 +115,13 @@ public:
   /**
    * @brief Maximum supported cutoff.
    */
+  virtual Utils::Vector3d max_cutoff() const = 0;
+
+  /**
+   * @brief Range in which calculations are performed.
+   */
   virtual Utils::Vector3d max_range() const = 0;
+
   /**
    * @brief Return the box geometry needed for distance calculation
    *        if minimum image convention should be used needed for

--- a/src/core/bonded_interactions/bonded_interaction_data.cpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.cpp
@@ -31,7 +31,7 @@ std::vector<Bonded_ia_parameters> bonded_ia_params;
 auto cutoff(int type, Bond_parameters const &bp) {
   switch (type) {
   case BONDED_IA_NONE:
-    return -1.;
+    return BONDED_INACTIVE_CUTOFF;
   case BONDED_IA_FENE:
     return bp.fene.cutoff();
   case BONDED_IA_HARMONIC:
@@ -79,7 +79,7 @@ auto cutoff(int type, Bond_parameters const &bp) {
 
 double maximal_cutoff_bonded() {
   auto const max_cut_bonded =
-      boost::accumulate(bonded_ia_params, -1.,
+      boost::accumulate(bonded_ia_params, BONDED_INACTIVE_CUTOFF,
                         [](auto max_cut, Bonded_ia_parameters const &bond) {
                           return std::max(max_cut, cutoff(bond.type, bond.p));
                         });

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -90,6 +90,10 @@ enum TabulatedBondedInteraction {
   TAB_BOND_DIHEDRAL = 3 /**< Flag for @ref BONDED_IA_TABULATED_DIHEDRAL */
 };
 
+/* Special cutoff value for an disabled bond. Bonds
+ * that have this cutoff are not visitied during bond evaluation. */
+static constexpr double BONDED_INACTIVE_CUTOFF = -1.;
+
 /** Parameters for FENE bond Potential. */
 struct Fene_bond_parameters {
   /** spring constant */
@@ -354,7 +358,7 @@ struct IBM_Tribend_Parameters {
 };
 
 struct VirtualBond_Parameters {
-  double cutoff() const { return -1.; }
+  double cutoff() const { return BONDED_INACTIVE_CUTOFF; }
 };
 
 /** Union in which to store the parameters of an individual bonded interaction

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -121,7 +121,7 @@ struct Oif_global_forces_bond_parameters {
   /** Volume coefficient */
   double kv;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for OIF local forces
@@ -148,7 +148,7 @@ struct Oif_local_forces_bond_parameters {
   /** Viscous coefficient of the triangle vertices */
   double kvisc;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for harmonic bond Potential */
@@ -206,7 +206,7 @@ struct Bonded_coulomb_bond_parameters {
   /** %Coulomb prefactor */
   double prefactor;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for %Coulomb bond short-range Potential */
@@ -214,7 +214,7 @@ struct Bonded_coulomb_sr_bond_parameters {
   /** charge factor */
   double q1q2;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for three-body angular potential (harmonic). */
@@ -224,7 +224,7 @@ struct Angle_harmonic_bond_parameters {
   /** equilibrium angle (default is 180 degrees) */
   double phi0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for three-body angular potential (cosine). */
@@ -238,7 +238,7 @@ struct Angle_cosine_bond_parameters {
   /** sine of @p phi0 (internal parameter) */
   double sin_phi0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for three-body angular potential (cossquare). */
@@ -250,7 +250,7 @@ struct Angle_cossquare_bond_parameters {
   /** cosine of @p phi0 (internal parameter) */
   double cos_phi0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for four-body angular potential (dihedral-angle potentials). */
@@ -259,7 +259,7 @@ struct Dihedral_bond_parameters {
   double bend;
   double phase;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for n-body tabulated potential (n=2,3,4). */
@@ -272,7 +272,7 @@ struct Tabulated_bond_parameters {
     case TAB_BOND_LENGTH:
       return assert(pot), pot->cutoff();
     default:
-      return -1.;
+      return 0.;
     };
   }
 };
@@ -339,7 +339,7 @@ struct IBM_VolCons_Parameters {
   /** Spring constant for volume force */
   double kappaV;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for IBM tribend */
@@ -350,7 +350,7 @@ struct IBM_Tribend_Parameters {
   /** Reference angle */
   double theta0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 struct VirtualBond_Parameters {

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -42,6 +42,7 @@
 #include <utils/mpi/gather_buffer.hpp>
 
 #include <algorithm>
+#include <boost/range/algorithm/min_element.hpp>
 #include <functional>
 #include <stdexcept>
 #include <vector>
@@ -112,18 +113,13 @@ REGISTER_CALLBACK(get_pairs_of_types_local)
 namespace detail {
 void search_distance_sanity_check(double const distance) {
   /** get_pairs_filtered() finds pairs via the non_bonded_loop. The maximum
-   *finding range is therefore limited by the cell size if domain decomposition
-   *is used
+   *finding range is therefore limited by the decomposition that is used
    **/
-  if (cell_structure.decomposition_type() == CELL_STRUCTURE_DOMDEC) {
-    auto cell_size = get_domain_decomposition()->cell_size;
-    auto min_cell_side_length =
-        *std::min_element(cell_size.begin(), cell_size.end());
-    if (distance > min_cell_side_length) {
-      runtimeErrorMsg() << "pair search distance " << distance
-                        << " bigger than smallest cell side length "
-                        << min_cell_side_length << ".\n";
-    }
+  auto range = *boost::min_element(cell_structure.max_range());
+  if (distance > range) {
+    runtimeErrorMsg() << "pair search distance " << distance
+                      << " bigger than the decomposition range " << range
+                      << ".\n";
   }
 }
 } // namespace detail

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -25,8 +25,10 @@
  *  Implementation of cells.hpp.
  */
 #include "cells.hpp"
+
 #include "Particle.hpp"
 #include "communication.hpp"
+#include "errorhandling.hpp"
 #include "event.hpp"
 #include "grid.hpp"
 #include "integrate.hpp"
@@ -48,23 +50,24 @@
 CellStructure cell_structure;
 
 /**
- * @brief Get pairs closer than distance from the cells.
+ * @brief Get pairs of particles that are closer than a distance and fulfill a
+ * filter criterion.
  *
- * This is mostly for testing purposes and uses link_cell
- * to get pairs out of the cellsystem by a simple distance
- * criterion.
+ * It uses link_cell to get pairs out of the cellsystem
+ * by a simple distance criterion and
  *
  * Pairs are sorted so that first.id < second.id
  */
-std::vector<std::pair<int, int>> get_pairs(double distance) {
+template <class Filter>
+std::vector<std::pair<int, int>> get_pairs_filtered(double const distance,
+                                                    Filter filter) {
   std::vector<std::pair<int, int>> ret;
+  on_observable_calc();
   auto const cutoff2 = distance * distance;
-
-  cells_update_ghosts(Cells::DATA_PART_POSITION | Cells::DATA_PART_PROPERTIES);
-
-  auto pair_kernel = [&ret, &cutoff2](Particle const &p1, Particle const &p2,
-                                      Distance const &d) {
-    if (d.dist2 < cutoff2)
+  auto pair_kernel = [&ret, &cutoff2, &filter](Particle const &p1,
+                                               Particle const &p2,
+                                               Distance const &d) {
+    if (d.dist2 < cutoff2 and filter(p1) and filter(p2))
       ret.emplace_back(p1.p.identity, p2.p.identity);
   };
 
@@ -79,29 +82,66 @@ std::vector<std::pair<int, int>> get_pairs(double distance) {
   return ret;
 }
 
-void mpi_get_pairs_local(int, int) {
-  on_observable_calc();
+std::vector<std::pair<int, int>> get_pairs(double const distance) {
+  return get_pairs_filtered(distance, [](Particle const &p) { return true; });
+}
 
-  double distance;
-  boost::mpi::broadcast(comm_cart, distance, 0);
+std::vector<std::pair<int, int>>
+get_pairs_of_types(double const distance, std::vector<int> const &types) {
+  return get_pairs_filtered(distance, [types](Particle const &p) {
+    return std::any_of(types.begin(), types.end(),
+                       [p](int const type) { return p.p.type == type; });
+  });
+}
 
+void get_pairs_local(double const distance) {
   auto local_pairs = get_pairs(distance);
-
   Utils::Mpi::gather_buffer(local_pairs, comm_cart);
 }
 
-REGISTER_CALLBACK(mpi_get_pairs_local)
+REGISTER_CALLBACK(get_pairs_local)
 
-std::vector<std::pair<int, int>> mpi_get_pairs(double distance) {
-  mpi_call(mpi_get_pairs_local, 0, 0);
-  on_observable_calc();
+void get_pairs_of_types_local(double const distance,
+                              std::vector<int> const &types) {
+  auto local_pairs = get_pairs_of_types(distance, types);
+  Utils::Mpi::gather_buffer(local_pairs, comm_cart);
+}
 
-  boost::mpi::broadcast(comm_cart, distance, 0);
+REGISTER_CALLBACK(get_pairs_of_types_local)
 
+namespace detail {
+void search_distance_sanity_check(double const distance) {
+  /** get_pairs_filtered() finds pairs via the non_bonded_loop. The maximum
+   *finding range is therefore limited by the cell size if domain decomposition
+   *is used
+   **/
+  if (cell_structure.decomposition_type() == CELL_STRUCTURE_DOMDEC) {
+    auto cell_size = get_domain_decomposition()->cell_size;
+    auto min_cell_side_length =
+        *std::min_element(cell_size.begin(), cell_size.end());
+    if (distance > min_cell_side_length) {
+      runtimeErrorMsg() << "pair search distance " << distance
+                        << " bigger than smallest cell side length "
+                        << min_cell_side_length << ".\n";
+    }
+  }
+}
+} // namespace detail
+
+std::vector<std::pair<int, int>> mpi_get_pairs(double const distance) {
+  detail::search_distance_sanity_check(distance);
+  mpi_call(get_pairs_local, distance);
   auto pairs = get_pairs(distance);
-
   Utils::Mpi::gather_buffer(pairs, comm_cart);
+  return pairs;
+}
 
+std::vector<std::pair<int, int>>
+mpi_get_pairs_of_types(double const distance, std::vector<int> const &types) {
+  detail::search_distance_sanity_check(distance);
+  mpi_call(get_pairs_of_types_local, distance, types);
+  auto pairs = get_pairs_of_types(distance, types);
+  Utils::Mpi::gather_buffer(pairs, comm_cart);
   return pairs;
 }
 

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -88,6 +88,14 @@ void cells_update_ghosts(unsigned data_parts);
  */
 std::vector<std::pair<int, int>> mpi_get_pairs(double distance);
 
+/**
+ * @brief Get pairs closer than @p distance if both their types are in @p types
+ *
+ * Pairs are sorted so that first.id < second.id
+ */
+std::vector<std::pair<int, int>>
+mpi_get_pairs_of_types(double distance, std::vector<int> const &types);
+
 /** Check if a particle resorting is required. */
 void check_resort_particles();
 

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -83,7 +83,7 @@ void energy_calc(const double time) {
         add_non_bonded_pair_energy(p1, p2, d.vec21, sqrt(d.dist2), d.dist2,
                                    obs_energy);
       },
-      maximal_cutoff());
+      maximal_cutoff(), maximal_cutoff_bonded());
 
   calc_long_range_energies(cell_structure.local_particles());
 

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -129,7 +129,7 @@ void force_calc(CellStructure &cell_structure, double time_step) {
           detect_collision(p1, p2, d.dist2);
 #endif
       },
-      maximal_cutoff(),
+      maximal_cutoff(), maximal_cutoff_bonded(),
       VerletCriterion{skin, interaction_range(), coulomb_cutoff, dipole_cutoff,
                       collision_detection_cutoff()});
 

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -362,7 +362,7 @@ int python_integrate(int n_steps, bool recalc_forces, bool reuse_forces_par) {
     /* maximal skin that can be used without resorting is the maximal
      * range of the cell system minus what is needed for interactions. */
     skin = std::min(0.4 * max_cut,
-                    *boost::min_element(cell_structure.max_range()) - max_cut);
+                    *boost::min_element(cell_structure.max_cutoff()) - max_cut);
     mpi_bcast_parameter(FIELD_SKIN);
   }
 

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -119,7 +119,7 @@ void pressure_calc() {
         add_non_bonded_pair_virials(p1, p2, d.vec21, sqrt(d.dist2),
                                     obs_pressure);
       },
-      maximal_cutoff());
+      maximal_cutoff(), maximal_cutoff_bonded());
 
   calc_long_range_virials(cell_structure.local_particles());
 

--- a/src/core/short_range_loop.hpp
+++ b/src/core/short_range_loop.hpp
@@ -38,7 +38,7 @@ struct True {
 template <class BondKernel, class PairKernel,
           class VerletCriterion = detail::True>
 void short_range_loop(BondKernel bond_kernel, PairKernel pair_kernel,
-                      double distance_cutoff = 1.,
+                      double distance_cutoff,
                       const VerletCriterion &verlet_criterion = {}) {
   ESPRESSO_PROFILER_CXX_MARK_FUNCTION;
 

--- a/src/core/short_range_loop.hpp
+++ b/src/core/short_range_loop.hpp
@@ -38,14 +38,17 @@ struct True {
 template <class BondKernel, class PairKernel,
           class VerletCriterion = detail::True>
 void short_range_loop(BondKernel bond_kernel, PairKernel pair_kernel,
-                      double distance_cutoff,
+                      double pair_cutoff, double bond_cutoff,
                       const VerletCriterion &verlet_criterion = {}) {
   ESPRESSO_PROFILER_CXX_MARK_FUNCTION;
 
   assert(cell_structure.get_resort_particles() == Cells::RESORT_NONE);
 
-  cell_structure.bond_loop(bond_kernel);
-  if (distance_cutoff > 0.)
+  if (bond_cutoff >= 0.) {
+    cell_structure.bond_loop(bond_kernel);
+  }
+
+  if (pair_cutoff >= 0.)
     cell_structure.non_bonded_loop(pair_kernel, verlet_criterion);
 }
 #endif

--- a/src/core/tuning.cpp
+++ b/src/core/tuning.cpp
@@ -105,7 +105,7 @@ void tune_skin(double min_skin, double max_skin, double tol, int int_steps,
    * the maximal range that can be supported by the cell system, but
    * never larger than half the box size. */
   double const max_permissible_skin = std::min(
-      *boost::min_element(cell_structure.max_range()) - maximal_cutoff(),
+      *boost::min_element(cell_structure.max_cutoff()) - maximal_cutoff(),
       0.5 * *boost::max_element(box_geo.length()));
 
   if (adjust_max_skin and max_skin > max_permissible_skin)

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -37,7 +37,8 @@ cdef extern from "cells.hpp":
 
     const DomainDecomposition * get_domain_decomposition()
 
-    vector[pair[int, int]] mpi_get_pairs(double distance)
+    vector[pair[int, int]] mpi_get_pairs(double distance) except +
+    vector[pair[int, int]] mpi_get_pairs_of_types(double distance, vector[int] types) except +
     vector[int] mpi_resort_particles(int global_flag)
     void mpi_bcast_cell_structure(int cs)
     void mpi_set_use_verlet_lists(bool use_verlet_lists)

--- a/testsuite/python/pairs.py
+++ b/testsuite/python/pairs.py
@@ -15,40 +15,47 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest as ut
-import unittest_decorators as utx
 import espressomd
 
 
-@utx.skipIfMissingFeatures(["LENNARD_JONES"])
 class PairTest(ut.TestCase):
+    """
+    Tests the particle pair finder of the cell system.
+    It checks that particles are found if their distance is below the threshold, 
+    no matter the type of cell system, periodicity and the image box they are in.
+    Also tests that the ``types`` argument works as expected and an exception is raised
+    when the distance threshold is larger than the cell size.
+    """
+
     s = espressomd.System(box_l=[1.0, 1.0, 1.0])
 
     def setUp(self):
-        self.s.time_step = 0.1
-        self.s.thermostat.turn_off()
-
-        self.s.part.clear()
+        self.s.time_step = 0.1     
         self.s.box_l = 3 * [10.]
         self.s.cell_system.skin = 0.3
 
         # Force an appropriate cell grid
-        self.s.non_bonded_inter[0, 0].lennard_jones.set_params(
-            epsilon=0.0, sigma=1.0, cutoff=1.5, shift=0.0)
+        self.s.min_global_cut = 1.6
 
         vel = [1., 2., 3.]
 
-        self.s.part.add(id=0, pos=[5., 4.5, 5.], v=vel)
-        self.s.part.add(id=1, pos=[5., 5.5, 5.], v=vel)
-        self.s.part.add(id=2, pos=[9.5, 5., 5.], v=vel)
-        self.s.part.add(id=3, pos=[0.5, 5., 5.], v=vel)
-        self.s.part.add(id=4, pos=[5., 5., 9.5], v=vel)
-        self.s.part.add(id=5, pos=[5., 5., 0.5], v=vel)
-        self.s.part.add(id=6, pos=[5., 9.5, 5.], v=vel)
-        self.s.part.add(id=7, pos=[5., 0.5, 5.], v=vel)
-        self.s.part.add(id=8, pos=[5., 9.5, 9.5], v=vel)
-        self.s.part.add(id=9, pos=[5., 0.5, 0.5], v=vel)
-        self.s.part.add(id=10, pos=[1., 1., 1.], v=vel)
-        self.s.part.add(id=11, pos=[9., 9., 9.], v=vel)
+        self.s.part.add(id=0, pos=[5., 4.5, 5.], v=vel, type=0)
+        self.s.part.add(id=1, pos=[5., 5.5, 5.], v=vel, type=1)
+        self.s.part.add(id=2, pos=[9.5, 5., 5.], v=vel, type=2)
+        self.s.part.add(id=3, pos=[0.5, 5., 5.], v=vel, type=3)
+        self.s.part.add(id=4, pos=[5., 5., 9.5], v=vel, type=4)
+        self.s.part.add(id=5, pos=[5., 5., 0.5], v=vel, type=5)
+        self.s.part.add(id=6, pos=[5., 9.5, 5.], v=vel, type=6)
+        self.s.part.add(id=7, pos=[5., 0.5, 5.], v=vel, type=7)
+        self.s.part.add(id=8, pos=[5., 9.5, 9.5], v=vel, type=8)
+        self.s.part.add(id=9, pos=[5., 0.5, 0.5], v=vel, type=9)
+        self.s.part.add(id=10, pos=[1., 1., 1.], v=vel, type=10)
+        self.s.part.add(id=11, pos=[9., 9., 9.], v=vel, type=11)
+
+        self.types_to_get_pairs = [0, 1, 4, 5, 6]
+
+    def tearDown(self):
+        self.s.part.clear()
 
     def expected_pairs(self, periodicity):
         if all(periodicity == (1, 1, 1)):
@@ -56,50 +63,53 @@ class PairTest(ut.TestCase):
         elif all(periodicity == (1, 1, 0)):
             return [(0, 1), (2, 3), (6, 7)]
 
-    def check(self):
-        pairs = self.s.cell_system.get_pairs_(1.5)
-        epairs = self.expected_pairs(self.s.periodicity)
-        print(pairs)
+    def expected_pairs_with_types(self, periodicity):
+        if all(periodicity == (1, 1, 1)):
+            return [(0, 1), (4, 5)]
+        elif all(periodicity == (1, 1, 0)):
+            return [(0, 1)]
 
-        self.assertEqual(len(pairs), len(epairs))
-        for p in pairs:
-            self.assertIn(p, epairs)
+    def check_pairs(self):
+        pairs = self.s.cell_system.get_pairs(1.5)
+        epairs = self.expected_pairs(self.s.periodicity)
+        self.assertSetEqual(set(pairs), set(epairs))
+
+        pairs_by_type = self.s.cell_system.get_pairs(
+            1.5, types=self.types_to_get_pairs)
+        epairs_by_type = self.expected_pairs_with_types(self.s.periodicity)
+        self.assertSetEqual(set(pairs_by_type), set(epairs_by_type))
+
+    def check_exception(self):
+        with self.assertRaises(Exception):
+            self.s.cell_system.get_pairs(3.)
+
+    def run_and_check(self, n_steps=100):
+        self.s.integrator.run(0)
+        self.check_pairs()
+        self.s.integrator.run(n_steps)
+        self.check_pairs()
 
     def test_nsquare(self):
         self.s.cell_system.set_n_square()
         self.s.periodicity = [1, 1, 1]
-
-        self.s.integrator.run(0)
-        self.check()
-        self.s.integrator.run(100)
-        self.check()
+        self.run_and_check()
 
     def test_nsquare_partial_z(self):
         self.s.cell_system.set_n_square()
         self.s.periodicity = [1, 1, 0]
-
-        self.s.integrator.run(0)
-        self.check()
-        self.s.integrator.run(100)
-        self.check()
+        self.run_and_check()
 
     def test_dd(self):
         self.s.cell_system.set_domain_decomposition()
         self.s.periodicity = [1, 1, 1]
-
-        self.s.integrator.run(0)
-        self.check()
-        self.s.integrator.run(100)
-        self.check()
+        self.run_and_check()
+        self.check_exception()
 
     def test_dd_partial_z(self):
         self.s.cell_system.set_domain_decomposition()
         self.s.periodicity = [1, 1, 0]
-
-        self.s.integrator.run(0)
-        self.check()
-        self.s.integrator.run(100)
-        self.check()
+        self.run_and_check()
+        self.check_exception()
 
 
 if __name__ == "__main__":

--- a/testsuite/python/random_pairs.py
+++ b/testsuite/python/random_pairs.py
@@ -58,7 +58,7 @@ class RandomPairTest(ut.TestCase):
 
     def pairs_n2(self, dist):
         # Go through list of all possible pairs for full periodicity
-        # and skip those that ar not within the desired distance
+        # and skip those that are not within the desired distance
         # for the current periodicity
 
         pairs = []
@@ -73,7 +73,7 @@ class RandomPairTest(ut.TestCase):
             self.assertEqual(e, 1)
 
     def check_pairs(self, n2_pairs):
-        cs_pairs = self.system.cell_system.get_pairs_(1.5)
+        cs_pairs = self.system.cell_system.get_pairs(1.5)
         self.check_duplicates(cs_pairs)
         self.assertGreater(len(cs_pairs), 0)
         self.assertEqual(n2_pairs ^ set(cs_pairs), set())


### PR DESCRIPTION
Follow up on #4025.

If there are not bonds to evaluate, the bond evaluation can be skipped.

Description of changes:
- short_range_loop: Execute bond loop only when needed.
- core: Replace magic number by named constant 