### PR TITLE
config: Removed feature UMBRELLA

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -429,8 +429,6 @@ section :ref:`Isotropic non-bonded interactions`):
 
 -  ``HAT`` Enable the Hat potential.
 
--  ``UMBRELLA`` Enable the umbrella potential (experimental).
-
 Some of the short-range interactions have additional features:
 
 -  ``LJGEN_SOFTCORE`` This modifies the generic Lennard-Jones potential

--- a/src/config/features.def
+++ b/src/config/features.def
@@ -82,7 +82,6 @@ MORSE
 BUCKINGHAM
 SOFT_SPHERE
 HAT
-UMBRELLA                        requires EXPERIMENTAL_FEATURES
 GAY_BERNE                       implies ROTATION
 THOLE                           requires ELECTROSTATICS
 

--- a/src/core/bonded_interactions/umbrella.cpp
+++ b/src/core/bonded_interactions/umbrella.cpp
@@ -25,8 +25,6 @@
 
 #include "config.hpp"
 
-#ifdef UMBRELLA
-
 #include "umbrella.hpp"
 
 #include "interactions.hpp"
@@ -50,5 +48,3 @@ int umbrella_set_params(int bond_type, double k, int dir, double r) {
 
   return ES_OK;
 }
-
-#endif /* ifdef UMBRELLA */

--- a/src/core/bonded_interactions/umbrella.hpp
+++ b/src/core/bonded_interactions/umbrella.hpp
@@ -31,12 +31,11 @@
 
 #include "config.hpp"
 
-#ifdef UMBRELLA
-
 #include "bonded_interactions/bonded_interaction_data.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 
 #include <utils/Vector.hpp>
+#include <utils/math/sqr.hpp>
 
 #include <boost/optional.hpp>
 
@@ -79,5 +78,4 @@ umbrella_pair_energy(Bonded_ia_parameters const &ia_params,
          Utils::sqr(distn - ia_params.p.umbrella.r);
 }
 
-#endif /* ifdef UMBRELLA */
 #endif

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -242,10 +242,8 @@ calc_bonded_energy(Bonded_ia_parameters const &iaparams, Particle const &p1,
 #endif
     case BONDED_IA_TABULATED_DISTANCE:
       return tab_bond_energy(iaparams, dx);
-#ifdef UMBRELLA
     case BONDED_IA_UMBRELLA:
       return umbrella_pair_energy(iaparams, dx);
-#endif
     case BONDED_IA_VIRTUAL_BOND:
       return boost::optional<double>(0);
     default:

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -334,10 +334,8 @@ calc_bond_pair_force(Particle const &p1, Particle const &p2,
 #endif
   case BONDED_IA_TABULATED_DISTANCE:
     return tab_bond_force(iaparams, dx);
-#ifdef UMBRELLA
   case BONDED_IA_UMBRELLA:
     return umbrella_pair_force(iaparams, dx);
-#endif
   case BONDED_IA_VIRTUAL_BOND:
   case BONDED_IA_RIGID_BOND:
     return Utils::Vector3d{};


### PR DESCRIPTION
`UMBRELLA` used to enable umbrella sampling which does not exist anymore,
now it only controls a bonded interaction type which does not have an performance
impact so this is no longer needed. Also building with `UMBRELLA` was broken.

Description of changes:
- Fixed build with `UMBRELLA`
- Removed `UMBRELLA` as a compile-time feature

