### PR TITLE
Move to newer GPU runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ clang-sanitizer:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
 
 cuda11-maxset:
   <<: *global_job_definition
@@ -271,7 +271,7 @@ cuda10-maxset:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
 
 tutorials-samples-maxset:
   <<: *global_job_definition
@@ -295,7 +295,7 @@ tutorials-samples-maxset:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
 
 tutorials-samples-default:
   <<: *global_job_definition
@@ -318,7 +318,7 @@ tutorials-samples-default:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
   only:
     - schedules
 
@@ -344,7 +344,7 @@ tutorials-samples-empty:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
   only:
     - schedules
 
@@ -405,7 +405,7 @@ installation:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
   when: manual
 
 empty:
@@ -425,7 +425,7 @@ empty:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
 
 check_sphinx:
   <<: *global_job_definition
@@ -448,7 +448,7 @@ check_sphinx:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
 
 run_tutorials:
   <<: *global_job_definition
@@ -468,7 +468,7 @@ run_tutorials:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
   only:
     - schedules
 
@@ -519,7 +519,7 @@ check_with_odd_no_of_processors:
   tags:
     - docker
     - linux
-    - cuda-kepler
+    - cuda
 
 
 .deploy_base:


### PR DESCRIPTION
Kepler GPU runners are being phased out in favor of Turing GPU runners in our CI infrastructure.