### PR TITLE
Improved error message for type error.

### DIFF
--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -1181,7 +1181,8 @@ void add_id_to_type_map(int part_id, int type) {
 
 int number_of_particles_with_type(int type) {
   if (particle_type_map.count(type) == 0)
-    throw std::runtime_error("The provided particle type " + std::to_string(type) +
+    throw std::runtime_error("The provided particle type " +
+                             std::to_string(type) +
                              " is currently not tracked by the system.");
   return static_cast<int>(particle_type_map.at(type).size());
 }

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -34,6 +34,7 @@
 #include "partCfg_global.hpp"
 #include "rotation.hpp"
 
+#include <string>
 #include <utils/Cache.hpp>
 #include <utils/constants.hpp>
 #include <utils/keys.hpp>
@@ -1180,8 +1181,8 @@ void add_id_to_type_map(int part_id, int type) {
 
 int number_of_particles_with_type(int type) {
   if (particle_type_map.count(type) == 0)
-    throw std::runtime_error("The provided particle type does not exist in "
-                             "the particle_type_map");
+    throw std::runtime_error("The provided particle type " + std::to_string(type) +
+                             " is currently not tracked by the system.");
   return static_cast<int>(particle_type_map.at(type).size());
 }
 

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -449,6 +449,12 @@ cdef class System:
         :obj:`int`
             The number of particles which have the given type.
 
+        Raises
+        ------
+        RuntimeError
+            If the particle ``type`` is not currently tracked by the system. 
+            To select which particle types are tracked, call :meth:`setup_type_map`.
+
         """
         check_type_or_throw_except(type, 1, int, "type must be 1 int")
         number = number_of_particles_with_type(type)


### PR DESCRIPTION
Fixes #3908

Description of changes:
- Changed the error message to include missing type.
- Appended docstring to include the error that is thrown.
