### PR TITLE
Added check if particles are not in ELC gap region

### DIFF
--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -255,8 +255,8 @@ Usage notes:
     z-direction not to contain particles. The size in z-direction of this slab
     is controlled by the ``gap_size`` parameter. The user has to ensure that
     no particles enter this region by means of constraints or by fixing the
-    particles' z-coordinate. When there is no empty slab of the specified size,
-    the method will silently produce wrong results.
+    particles' z-coordinate. When particles enter the slab of the specified
+    size, an error will be thrown.
 
 *ELC* is an |es| actor and is used with::
 

--- a/doc/sphinx/magnetostatics.rst
+++ b/doc/sphinx/magnetostatics.rst
@@ -96,8 +96,8 @@ Usage notes:
     z-direction not to contain particles. The size in z-direction of this slab
     is controlled by the ``gap_size`` parameter. The user has to ensure that
     no particles enter this region by means of constraints or by fixing the
-    particles' z-coordinate. When there is no empty slab of the specified size,
-    the method will silently produce wrong results.
+    particles' z-coordinate. When particles enter the slab of the specified
+    size, an error will be thrown.
 
   * The method can be tuned using the ``accuracy`` parameter. In contrast to
     the electrostatic method, it refers to the energy. Furthermore, it is

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -223,16 +223,17 @@ void distribute(int size) {
   MPI_Allreduce(send_buf, gblcblk, size, MPI_DOUBLE, MPI_SUM, comm_cart);
 }
 
-/** checks if a particle is in the forbidden gap region
+/** Checks if a particle is in the forbidden gap region
  */
 inline void check_gap(const Particle &p) {
-  if ((p.p.q != 0) && ((p.r.p[2] > elc_params.h) || (p.r.p[2] < 0))) {
+  if (p.p.q != 0) {
     if (p.r.p[2] < 0)
       runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
                         << "region by " << (p.r.p[2]);
-    else
+    else if (p.r.p[2] > elc_params.h) {
       runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
                         << "region by " << (p.r.p[2] - elc_params.h);
+    }
   }
 }
 

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -247,6 +247,16 @@ static void add_dipole_force(const ParticleRange &particles) {
   gblcblk[2] = 0; // sum q_i
 
   for (auto const &p : local_particles) {
+    /* check if charged particles are in valid region */
+    if ((p.p.q != 0) && ((p.r.p[2] > elc_params.h) || (p.r.p[2] < 0))) {
+      if (p.r.p[2] < 0)
+        runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
+                          << "region by " << (p.r.p[2]);
+      else
+        runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
+                          << "region by " << (p.r.p[2] - elc_params.h);
+    }
+
     gblcblk[0] += p.p.q * (p.r.p[2] - shift);
     gblcblk[1] += p.p.q * p.r.p[2];
     gblcblk[2] += p.p.q;

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -223,9 +223,9 @@ void distribute(int size) {
   MPI_Allreduce(send_buf, gblcblk, size, MPI_DOUBLE, MPI_SUM, comm_cart);
 }
 
-/** Checks if a particle is in the forbidden gap region
+/** Checks if a charged particle is in the forbidden gap region
  */
-inline void check_gap(const Particle &p) {
+inline void check_gap_elc(const Particle &p) {
   if (p.p.q != 0) {
     if (p.r.p[2] < 0)
       runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
@@ -261,7 +261,7 @@ static void add_dipole_force(const ParticleRange &particles) {
   gblcblk[2] = 0; // sum q_i
 
   for (auto const &p : local_particles) {
-    check_gap(p);
+    check_gap_elc(p);
 
     gblcblk[0] += p.p.q * (p.r.p[2] - shift);
     gblcblk[1] += p.p.q * p.r.p[2];
@@ -327,7 +327,7 @@ static double dipole_energy(const ParticleRange &particles) {
   gblcblk[6] = 0; // sum q_i z_i           primary box
 
   for (auto &p : particles) {
-    check_gap(p);
+    check_gap_elc(p);
 
     gblcblk[0] += p.p.q;
     gblcblk[2] += p.p.q * (p.r.p[2] - shift);

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -223,6 +223,19 @@ void distribute(int size) {
   MPI_Allreduce(send_buf, gblcblk, size, MPI_DOUBLE, MPI_SUM, comm_cart);
 }
 
+/** checks if a particle is in the forbidden gap region
+ */
+inline void check_gap(const Particle &p) {
+  if ((p.p.q != 0) && ((p.r.p[2] > elc_params.h) || (p.r.p[2] < 0))) {
+    if (p.r.p[2] < 0)
+      runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
+                        << "region by " << (p.r.p[2]);
+    else
+      runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
+                        << "region by " << (p.r.p[2] - elc_params.h);
+  }
+}
+
 /*****************************************************************/
 /* dipole terms */
 /*****************************************************************/
@@ -247,15 +260,7 @@ static void add_dipole_force(const ParticleRange &particles) {
   gblcblk[2] = 0; // sum q_i
 
   for (auto const &p : local_particles) {
-    /* check if charged particles are in valid region */
-    if ((p.p.q != 0) && ((p.r.p[2] > elc_params.h) || (p.r.p[2] < 0))) {
-      if (p.r.p[2] < 0)
-        runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
-                          << "region by " << (p.r.p[2]);
-      else
-        runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
-                          << "region by " << (p.r.p[2] - elc_params.h);
-    }
+    check_gap(p);
 
     gblcblk[0] += p.p.q * (p.r.p[2] - shift);
     gblcblk[1] += p.p.q * p.r.p[2];
@@ -321,6 +326,8 @@ static double dipole_energy(const ParticleRange &particles) {
   gblcblk[6] = 0; // sum q_i z_i           primary box
 
   for (auto &p : particles) {
+    check_gap(p);
+
     gblcblk[0] += p.p.q;
     gblcblk[2] += p.p.q * (p.r.p[2] - shift);
     gblcblk[4] += p.p.q * (Utils::sqr(p.r.p[2] - shift));

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -42,15 +42,15 @@
 
 DLC_struct dlc_params = {1e100, 0, 0, 0, 0};
 
-/** Checks if a charged particle is in the forbidden gap region
+/** Checks if a magnetic particle is in the forbidden gap region
  */
 inline void check_gap_mdlc(const Particle &p) {
   if (p.p.dipm != 0) {
     if (p.r.p[2] < 0)
-      runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
+      runtimeErrorMsg() << "Particle " << p.p.identity << " entered MDLC gap "
                         << "region by " << (p.r.p[2]);
     else if (p.r.p[2] > dlc_params.h) {
-      runtimeErrorMsg() << "Particle " << p.p.identity << " entered ELC gap "
+      runtimeErrorMsg() << "Particle " << p.p.identity << " entered MDLC gap "
                         << "region by " << (p.r.p[2] - dlc_params.h);
     }
   }
@@ -389,7 +389,7 @@ double add_mdlc_energy_corrections(const ParticleRange &particles) {
   // Check if particles aren't in the forbidden gap region
   // This loop is needed, because there is no other guaranteed
   // single pass over all particles in this function.
-  for (auto const p : particles) {
+  for (auto const &p : particles) {
     check_gap_mdlc(p);
   }
 

--- a/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
+++ b/src/core/electrostatics_magnetostatics/mdlc_correction.cpp
@@ -389,7 +389,7 @@ double add_mdlc_energy_corrections(const ParticleRange &particles) {
   // Check if particles aren't in the forbidden gap region
   // This loop is needed, because there is no other guaranteed
   // single pass over all particles in this function.
-  for (auto const p: particles) {
+  for (auto const p : particles) {
     check_gap_mdlc(p);
   }
 

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -62,7 +62,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         s.box_l = 3 * [box_l]
         ref_E_path = abspath("data/mdlc_reference_data_energy.dat")
         ref_E = float(np.genfromtxt(ref_E_path))
-        gap_size = 0.3 * s.box_l[2]
+        gap_size = 2.0
 
         # Particles
         data = np.genfromtxt(

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -89,7 +89,10 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
 
         # Check if error is thrown when particles enter the MDLC gap
         # positive direction
-        s.part[0].pos = [s.box_l[0] / 2, s.box_l[1] / 2, s.box_l[2] - gap_size / 2]
+        s.part[0].pos = [
+            s.box_l[0] / 2,
+            s.box_l[1] / 2,
+            s.box_l[2] - gap_size / 2]
         with self.assertRaises(Exception):
             self.system.analysis.energy()
         with self.assertRaises(Exception):

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -62,6 +62,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         s.box_l = 3 * [box_l]
         ref_E_path = abspath("data/mdlc_reference_data_energy.dat")
         ref_E = float(np.genfromtxt(ref_E_path))
+        gap_size = 0.3 * s.box_l[2]
 
         # Particles
         data = np.genfromtxt(
@@ -70,7 +71,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         s.part[:].rotation = (1, 1, 1)
 
         p3m = magnetostatics.DipolarP3M(prefactor=1, mesh=32, accuracy=1E-4)
-        dlc = magnetostatic_extensions.DLC(maxPWerror=1E-5, gap_size=2.)
+        dlc = magnetostatic_extensions.DLC(maxPWerror=1E-5, gap_size=gap_size)
         s.actors.add(p3m)
         s.actors.add(dlc)
         s.integrator.run(0)
@@ -85,6 +86,20 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         self.assertLessEqual(abs(err_e), tol_e, "Energy difference too large")
         self.assertLessEqual(abs(err_t), tol_t, "Torque difference too large")
         self.assertLessEqual(abs(err_f), tol_f, "Force difference too large")
+
+        # Check if error is thrown when particles enter the MDLC gap
+        # positive direction
+        s.part[0].pos = [s.box_l[0] / 2, s.box_l[1] / 2, s.box_l[2] - gap_size / 2]
+        with self.assertRaises(Exception):
+            self.system.analysis.energy()
+        with self.assertRaises(Exception):
+            self.integrator.run(2)
+        # negative direction
+        s.part[0].pos = [s.box_l[0] / 2, s.box_l[1] / 2, -gap_size / 2]
+        with self.assertRaises(Exception):
+            self.system.analysis.energy()
+        with self.assertRaises(Exception):
+            self.integrator.run(2)
 
     def test_p3m(self):
         s = self.system

--- a/testsuite/python/elc.py
+++ b/testsuite/python/elc.py
@@ -85,5 +85,6 @@ class ElcTest(ut.TestCase):
         with self.assertRaises(Exception):
             self.integrator.run(2)
 
+
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/elc.py
+++ b/testsuite/python/elc.py
@@ -73,13 +73,13 @@ class ElcTest(ut.TestCase):
 
         # Check if error is thrown when particles enter the ELC gap
         # positive direction
-        p1.pos = [BOX_L[0]/2, BOX_L[1]/2, BOX_L[2]-GAP[2]/2]
+        p1.pos = [BOX_L[0] / 2, BOX_L[1] / 2, BOX_L[2] - GAP[2] / 2]
         with self.assertRaises(Exception):
             self.system.analysis.energy()
         with self.assertRaises(Exception):
             self.integrator.run(2)
         # negative direction
-        p1.pos = [BOX_L[0]/2, BOX_L[1]/2, -GAP[2]/2]
+        p1.pos = [BOX_L[0] / 2, BOX_L[1] / 2, -GAP[2] / 2]
         with self.assertRaises(Exception):
             self.system.analysis.energy()
         with self.assertRaises(Exception):

--- a/testsuite/python/elc.py
+++ b/testsuite/python/elc.py
@@ -71,6 +71,12 @@ class ElcTest(ut.TestCase):
         self.assertAlmostEqual(E_expected, p1.f[2] / p1.q)
         self.assertAlmostEqual(E_expected, p2.f[2] / p2.q)
 
+        # Check if error is thrown when particles enter the ELC gap
+        p1.pos = [BOX_L[0]/2, BOX_L[1]/2, BOX_L[2]-GAP[2]/2]
+        with self.assertRaises(Exception):
+            self.system.analysis.energy()
+        with self.assertRaises(Exception):
+            self.integrator.run(2)
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/elc.py
+++ b/testsuite/python/elc.py
@@ -72,7 +72,14 @@ class ElcTest(ut.TestCase):
         self.assertAlmostEqual(E_expected, p2.f[2] / p2.q)
 
         # Check if error is thrown when particles enter the ELC gap
+        # positive direction
         p1.pos = [BOX_L[0]/2, BOX_L[1]/2, BOX_L[2]-GAP[2]/2]
+        with self.assertRaises(Exception):
+            self.system.analysis.energy()
+        with self.assertRaises(Exception):
+            self.integrator.run(2)
+        # negative direction
+        p1.pos = [BOX_L[0]/2, BOX_L[1]/2, -GAP[2]/2]
         with self.assertRaises(Exception):
             self.system.analysis.energy()
         with self.assertRaises(Exception):


### PR DESCRIPTION
Fixes Issue #4009

Description of changes:
- add a check in both positive and negative direction with error message
