### PR TITLE
Save particle state in a dict (Issue #3916)

### DIFF
--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -222,6 +222,7 @@ python_test(FILE p3m_tuning_exceptions.py MAX_NUM_PROC 1 LABELS gpu)
 python_test(FILE integrator_exceptions.py MAX_NUM_PROC 1)
 python_test(FILE utils.py MAX_NUM_PROC 1)
 python_test(FILE npt_thermostat.py MAX_NUM_PROC 4)
+python_test(FILE particle_to_dict.py MAX_NUM_PROC 1)
 
 add_custom_target(
   python_test_data

--- a/testsuite/python/particle_to_dict.py
+++ b/testsuite/python/particle_to_dict.py
@@ -1,0 +1,19 @@
+import unittest as ut
+import unittest_decorators as utx
+import numpy as np
+import espressomd
+
+class ParticleDictionaryTest(ut.TestCase):
+    box_l = 30.
+    system = espressomd.System(box_l = 3 * [box_l])
+
+    def test(self):
+        p = self.system.part.add(pos = np.random.uniform(size = (10,3)) * self.box_l)
+        pp = str(p)
+        pdict = p.to_dict()
+        p.remove()
+        self.system.part.add(pdict)
+        self.assertEqual(str(self.system.part.select()), pp)
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
#3916 

Add functions:
ParticleHandle.to_dict()
ParticleSlice.to_dict()

Description of changes:
Returns the particles attributes as a dictionary, such that it can be used to save the particle data and recover it by using
        
p = system.part.add(...)
particle_dict = p.to_dict()
system.part.add(particle_dict)

Codes are mainly written by @RiccardoFrenner 
