### PR TITLE
Skip bond calculation loop if not needed

### DIFF
--- a/src/core/bonded_interactions/bonded_interaction_data.cpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.cpp
@@ -31,7 +31,7 @@ std::vector<Bonded_ia_parameters> bonded_ia_params;
 auto cutoff(int type, Bond_parameters const &bp) {
   switch (type) {
   case BONDED_IA_NONE:
-    return -1.;
+    return BONDED_INACTIVE_CUTOFF;
   case BONDED_IA_FENE:
     return bp.fene.cutoff();
   case BONDED_IA_HARMONIC:
@@ -79,7 +79,7 @@ auto cutoff(int type, Bond_parameters const &bp) {
 
 double maximal_cutoff_bonded() {
   auto const max_cut_bonded =
-      boost::accumulate(bonded_ia_params, -1.,
+      boost::accumulate(bonded_ia_params, BONDED_INACTIVE_CUTOFF,
                         [](auto max_cut, Bonded_ia_parameters const &bond) {
                           return std::max(max_cut, cutoff(bond.type, bond.p));
                         });

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -90,6 +90,11 @@ enum TabulatedBondedInteraction {
   TAB_BOND_DIHEDRAL = 3 /**< Flag for @ref BONDED_IA_TABULATED_DIHEDRAL */
 };
 
+/* Special cutoff value for a disabled bond.
+ * Bonds that have this cutoff are not visited during bond evaluation.
+ */
+static constexpr double BONDED_INACTIVE_CUTOFF = -1.;
+
 /** Parameters for FENE bond Potential. */
 struct Fene_bond_parameters {
   /** spring constant */
@@ -354,7 +359,7 @@ struct IBM_Tribend_Parameters {
 };
 
 struct VirtualBond_Parameters {
-  double cutoff() const { return -1.; }
+  double cutoff() const { return BONDED_INACTIVE_CUTOFF; }
 };
 
 /** Union in which to store the parameters of an individual bonded interaction

--- a/src/core/bonded_interactions/bonded_interaction_data.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_data.hpp
@@ -121,7 +121,7 @@ struct Oif_global_forces_bond_parameters {
   /** Volume coefficient */
   double kv;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for OIF local forces
@@ -148,7 +148,7 @@ struct Oif_local_forces_bond_parameters {
   /** Viscous coefficient of the triangle vertices */
   double kvisc;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for harmonic bond Potential */
@@ -206,7 +206,7 @@ struct Bonded_coulomb_bond_parameters {
   /** %Coulomb prefactor */
   double prefactor;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for %Coulomb bond short-range Potential */
@@ -214,7 +214,7 @@ struct Bonded_coulomb_sr_bond_parameters {
   /** charge factor */
   double q1q2;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for three-body angular potential (harmonic). */
@@ -224,7 +224,7 @@ struct Angle_harmonic_bond_parameters {
   /** equilibrium angle (default is 180 degrees) */
   double phi0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for three-body angular potential (cosine). */
@@ -238,7 +238,7 @@ struct Angle_cosine_bond_parameters {
   /** sine of @p phi0 (internal parameter) */
   double sin_phi0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for three-body angular potential (cossquare). */
@@ -250,7 +250,7 @@ struct Angle_cossquare_bond_parameters {
   /** cosine of @p phi0 (internal parameter) */
   double cos_phi0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for four-body angular potential (dihedral-angle potentials). */
@@ -259,7 +259,7 @@ struct Dihedral_bond_parameters {
   double bend;
   double phase;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for n-body tabulated potential (n=2,3,4). */
@@ -272,7 +272,7 @@ struct Tabulated_bond_parameters {
     case TAB_BOND_LENGTH:
       return assert(pot), pot->cutoff();
     default:
-      return -1.;
+      return 0.;
     };
   }
 };
@@ -339,7 +339,7 @@ struct IBM_VolCons_Parameters {
   /** Spring constant for volume force */
   double kappaV;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 /** Parameters for IBM tribend */
@@ -350,7 +350,7 @@ struct IBM_Tribend_Parameters {
   /** Reference angle */
   double theta0;
 
-  double cutoff() const { return -1.; }
+  double cutoff() const { return 0.; }
 };
 
 struct VirtualBond_Parameters {

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -83,7 +83,7 @@ void energy_calc(const double time) {
         add_non_bonded_pair_energy(p1, p2, d.vec21, sqrt(d.dist2), d.dist2,
                                    obs_energy);
       },
-      maximal_cutoff());
+      maximal_cutoff(), maximal_cutoff_bonded());
 
   calc_long_range_energies(cell_structure.local_particles());
 

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -130,7 +130,7 @@ void force_calc(CellStructure &cell_structure, double time_step) {
           detect_collision(p1, p2, d.dist2);
 #endif
       },
-      maximal_cutoff(),
+      maximal_cutoff(), maximal_cutoff_bonded(),
       VerletCriterion{skin, interaction_range(), coulomb_cutoff, dipole_cutoff,
                       collision_detection_cutoff()});
 

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -104,7 +104,7 @@ void pressure_calc() {
         add_non_bonded_pair_virials(p1, p2, d.vec21, sqrt(d.dist2),
                                     obs_pressure);
       },
-      maximal_cutoff());
+      maximal_cutoff(), maximal_cutoff_bonded());
 
   calc_long_range_virials(cell_structure.local_particles());
 

--- a/src/core/short_range_loop.hpp
+++ b/src/core/short_range_loop.hpp
@@ -38,14 +38,17 @@ struct True {
 template <class BondKernel, class PairKernel,
           class VerletCriterion = detail::True>
 void short_range_loop(BondKernel bond_kernel, PairKernel pair_kernel,
-                      double distance_cutoff,
+                      double pair_cutoff, double bond_cutoff,
                       const VerletCriterion &verlet_criterion = {}) {
   ESPRESSO_PROFILER_CXX_MARK_FUNCTION;
 
   assert(cell_structure.get_resort_particles() == Cells::RESORT_NONE);
 
-  cell_structure.bond_loop(bond_kernel);
-  if (distance_cutoff > 0.)
+  if (bond_cutoff >= 0.) {
+    cell_structure.bond_loop(bond_kernel);
+  }
+
+  if (pair_cutoff >= 0.)
     cell_structure.non_bonded_loop(pair_kernel, verlet_criterion);
 }
 #endif


### PR DESCRIPTION
Rebase of #4030 on top of `python`
Partial fix for #3680

Description of changes:
- separate bonded IA cutoff from non-bonded IA cutoff
- skip bond loop independently from non-bonded loop