### PR TITLE
Refactor CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
 status_pending:
   <<: *notification_job_definition
   stage: prepare
-  script: bash maintainer/gh_post_status.sh pending
+  script: sh maintainer/gh_post_status.sh pending
 
 style:
   <<: *global_job_definition
@@ -42,7 +42,7 @@ style:
   before_script:
     - git submodule deinit .
   script:
-    - maintainer/CI/fix_style.sh
+    - sh maintainer/CI/fix_style.sh
   tags:
     - docker
     - linux
@@ -572,19 +572,19 @@ deploy_tutorials:
 status_success:
   <<: *notification_job_definition
   stage: result
-  script: bash maintainer/gh_post_status.sh success
+  script: sh maintainer/gh_post_status.sh success
   when: on_success
 
 status_failure:
   <<: *notification_job_definition
   stage: result
-  script: bash maintainer/gh_post_status.sh failure
+  script: sh maintainer/gh_post_status.sh failure
   when: on_failure
 
 notify_success:
   <<: *notification_job_definition
   stage: result
-  script: bash maintainer/gh_close_issue.sh
+  script: sh maintainer/gh_close_issue.sh
   when: on_success
   only:
     - python
@@ -592,7 +592,7 @@ notify_success:
 notify_failure:
   <<: *notification_job_definition
   stage: result
-  script: bash maintainer/gh_create_issue.sh
+  script: sh maintainer/gh_create_issue.sh
   when: on_failure
   only:
     - python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         always_run: false
         files: '.*\.(py|pyx|pxd)'
         exclude: '\.pylintrc|.*.\.py\.in|^libs/'
-        args: ["--ignore=E266,E701,W291,W293", "--in-place", "--aggressive"]
+        args: ["--ignore=E266,E402,E701,W291,W293", "--in-place", "--aggressive"]
 
     -   id: cmake-format
         name: cmake-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         language: system
         always_run: false
         files: '.*\.(cpp|hpp|cu|cuh)'
+        exclude: '^libs/'
         args: ["-i", "-style=file"]
 
     -   id: autopep8
@@ -17,7 +18,7 @@ repos:
         language: system
         always_run: false
         files: '.*\.(py|pyx|pxd)'
-        exclude: '\.pylintrc|.*.\.py\.in'
+        exclude: '\.pylintrc|.*.\.py\.in|^libs/'
         args: ["--ignore=E266,E701,W291,W293", "--in-place", "--aggressive"]
 
     -   id: cmake-format
@@ -26,6 +27,7 @@ repos:
         language: system
         always_run: false
         files: 'CMakeLists.txt'
+        exclude: '^libs/h5xx/|^libs/Random123-1\.09/'
         args: ["-i"]
 
     -   id: ex-flags

--- a/doc/tutorials/convert.py
+++ b/doc/tutorials/convert.py
@@ -61,7 +61,7 @@ def add_cell_from_script(nb, filepath):
     if m and all(x.startswith('#') for x in m.group(0).strip().split('\n')):
         code = re.sub('^(#\n)+', '', code.replace(m.group(0), ''), re.M)
     # strip first component in relative paths
-    code = re.sub('(?<=[\'\"])\.\./', './', code)
+    code = re.sub(r'(?<=[\'\"])\.\./', './', code)
     # create new cells
     filename = os.path.relpath(os.path.realpath(filepath))
     if len(filename) > len(filepath):

--- a/maintainer/CI/doc_warnings.sh
+++ b/maintainer/CI/doc_warnings.sh
@@ -108,7 +108,7 @@ if [ "${?}" = "0" ]; then
 fi
 
 if [ "${CI}" != "" ]; then
-    "${srcdir}/maintainer/gh_post_docs_warnings.py" sphinx ${n_warnings} doc_warnings.log || exit 1
+    "${srcdir}/maintainer/gh_post_docs_warnings.py" sphinx "${n_warnings}" doc_warnings.log || exit 1
 fi
 
 if [ "${n_warnings}" = "0" ]; then

--- a/maintainer/CI/dox_warnings.sh
+++ b/maintainer/CI/dox_warnings.sh
@@ -34,7 +34,7 @@ for supported_version in 1.8.11 1.8.13 1.8.17; do
 done
 if [ "${dox_version_supported}" = false ]; then
     echo "Doxygen version ${dox_version} not fully supported" >&2
-    if [ ! -z "${CI}" ]; then
+    if [ -n "${CI}" ]; then
         exit 1
     fi
     echo "Proceeding anyway"
@@ -89,7 +89,7 @@ rm -f dox_warnings_summary.log
 
 # print summary
 cat dox_warnings_summary.log
-n_warnings=$(cat dox_warnings_summary.log | wc -l)
+n_warnings=$(wc -l < dox_warnings_summary.log)
 
 if [ "${CI}" != "" ]; then
     "${srcdir}/maintainer/gh_post_docs_warnings.py" doxygen "${n_warnings}" dox_warnings_summary.log || exit 2

--- a/maintainer/CI/fix_style.sh
+++ b/maintainer/CI/fix_style.sh
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 1
 
 if ! git diff-index --quiet HEAD -- && [ "${1}" != "-f" ]; then
     echo "Warning, your working tree is not clean. Please commit your changes."
@@ -36,7 +36,7 @@ if [ -f "pylint.log" ]; then
     pylint_errors=$(grep -Pc '^[a-z]+/.+?.py:[0-9]+:[0-9]+: [CRWEF][0-9]+:' "pylint.log")
 fi
 
-if [ "${CI}" != "" ]; then
+if [ -n "${CI}" ]; then
     git --no-pager diff > style.patch
     maintainer/gh_post_style_patch.py || exit 1
     maintainer/gh_post_pylint.py "${pylint_errors}" pylint.log || exit 1

--- a/maintainer/add_missing_headers.sh
+++ b/maintainer/add_missing_headers.sh
@@ -19,7 +19,7 @@
 
 # Add copyright header to C++, CUDA, Doxygen, Python and shell files.
 
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 1
 
 # Get files without headers
 all_files=$(maintainer/files_with_header.sh)

--- a/maintainer/benchmarks/suite.sh
+++ b/maintainer/benchmarks/suite.sh
@@ -49,7 +49,7 @@ mkdir "${build_dir}"
 cd "${build_dir}"
 
 # check for unstaged changes
-if [ ! -z "$(git status --porcelain -- ${directories})" ]; then
+if [ -n "$(git status --porcelain -- ${directories})" ]; then
   echo "fatal: you have unstaged changes, please commit or stash them:"
   git diff-index --name-only HEAD -- ${directories}
   exit 1

--- a/maintainer/find_potentially_missing_authors.sh
+++ b/maintainer/find_potentially_missing_authors.sh
@@ -21,7 +21,7 @@
 # based on git commits. The output has to be checked manually, because
 # users have committed under different spellings and abbreviations.
 
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 1
 
 git shortlog -s |
   cut -f 2 |

--- a/maintainer/gh_post.py
+++ b/maintainer/gh_post.py
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2018-2020 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import requests
+
+if not os.environ.get('CI_COMMIT_REF_NAME', '').startswith('PR-'):
+    raise RuntimeError("Not a pull request.")
+
+PR = os.environ['CI_COMMIT_REF_NAME'][3:]
+API = 'https://api.github.com'
+URL = f'{API}/repos/espressomd/espresso/issues/{PR}/comments'
+HEADERS = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
+CI_JOB_URL = os.environ['CI_JOB_URL']
+LOGIN = 'espresso-ci'
+
+
+def delete_comments_by_token(token):
+    """
+    Delete posts made by the espresso-ci bot containing the string in ``token``.
+    """
+    comments = requests.get(URL, headers=HEADERS)
+    comments.raise_for_status()
+    for comment in comments.json():
+        if comment['user']['login'] == LOGIN and token in comment['body']:
+            print(f"deleting {comment['url']}")
+            response = requests.delete(comment['url'], headers=HEADERS)
+            response.raise_for_status()
+
+
+def post_message(message):
+    """
+    Post a message using the espresso-ci bot.
+    """
+    response = requests.post(URL, headers=HEADERS, json={'body': message})
+    response.raise_for_status()

--- a/maintainer/gh_post_docs_warnings.py
+++ b/maintainer/gh_post_docs_warnings.py
@@ -18,33 +18,24 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import re
 import os
-import sys
-import requests
 
-if not os.environ['CI_COMMIT_REF_NAME'].startswith('PR-'):
+if not os.environ.get('CI_COMMIT_REF_NAME', '').startswith('PR-'):
+    print("Not a pull request. Exiting now.")
     exit(0)
 
-PR = os.environ['CI_COMMIT_REF_NAME'][3:]
-URL = 'https://api.github.com/repos/espressomd/espresso/issues/' + \
-      PR + '/comments'
-HEADERS = {'Authorization': 'token ' + os.environ['GITHUB_TOKEN']}
-SIZELIMIT = 5000
+import re
+import sys
+import gh_post
 
 doc_type, has_warnings, filepath_warnings = sys.argv[-3:]
 has_warnings = has_warnings != '0'
 prefix = {'sphinx': 'doc', 'doxygen': 'dox'}[doc_type]
 TOKEN_ESPRESSO_CI = prefix + '_warnings.sh'
+SIZELIMIT = 5000
 
-# Delete all existing comments
-comments = requests.get(URL, headers=HEADERS)
-comments.raise_for_status()
-for comment in comments.json():
-    if comment['user']['login'] == 'espresso-ci' and \
-            TOKEN_ESPRESSO_CI in comment['body']:
-        response = requests.delete(comment['url'], headers=HEADERS)
-        response.raise_for_status()
+# Delete obsolete posts
+gh_post.delete_comments_by_token(TOKEN_ESPRESSO_CI)
 
 # If documentation raised warnings, post a new comment
 if has_warnings:
@@ -66,16 +57,13 @@ if has_warnings:
             comment += line + '\n'
         comment = comment.rstrip() + '\n' + backticks + '\n'
         comment += (
-            '\nThis list was truncated, check the [container logfile]'
-            '({}) for the complete list.\n'.format(os.environ['CI_JOB_URL']))
+            f'\nThis list was truncated, check the [container logfile]'
+            f'({gh_post.CI_JOB_URL}) for the complete list.\n')
     else:
         comment += warnings.rstrip() + '\n' + backticks + '\n'
     comment += (
-        '\nYou can generate these warnings with `make -t; make {}; '
-        '../maintainer/CI/{}_warnings.sh` using the maxset config. This is '
-        'the same command that I have executed to generate the log above.'
-        .format(doc_type, prefix))
+        f'\nYou can generate these warnings with `make -t; make {doc_type}; '
+        f'../maintainer/CI/{prefix}_warnings.sh` using the maxset config. This '
+        f'is the same command that I have executed to generate the log above.')
     assert TOKEN_ESPRESSO_CI in comment
-
-    response = requests.post(URL, headers=HEADERS, json={'body': comment})
-    response.raise_for_status()
+    gh_post.post_message(comment)

--- a/maintainer/gh_post_status.sh
+++ b/maintainer/gh_post_status.sh
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[ "${#}" -eq 1 ] || exit -1
+[ "${#}" -eq 1 ] || exit 1
 
 GIT_COMMIT=$(git rev-parse HEAD)
 URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}"

--- a/maintainer/update_header.sh
+++ b/maintainer/update_header.sh
@@ -30,7 +30,7 @@
 # To review the diff:
 # $> git diff --word-diff-regex=. -U0 | grep -Po 'Copyright.+' | sort | uniq
 
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 1
 
 files=$(maintainer/files_with_header.sh)
 num_files=$(echo ${files} | wc -w)

--- a/samples/gibbs_ensemble_socket.py
+++ b/samples/gibbs_ensemble_socket.py
@@ -299,7 +299,6 @@ def check_exchange_particle(boxes, inner_potential, rand_box):
     return True
 
 
-
 # init socket
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -71,9 +71,9 @@ void clear_particle_node();
 /**
  * @brief Get particle data.
  *
- *   @param part the identity of the particle to fetch
- *   @return Pointer to copy of particle if it exists,
- *           nullptr otherwise;
+ *  @param part the identity of the particle to fetch
+ *  @return Pointer to copy of particle if it exists,
+ *          nullptr otherwise;
  */
 const Particle &get_particle_data(int part);
 

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -207,7 +207,7 @@ def setup_and_add_drude_exclusion_bonds(system, verbose=False):
     # All Drude types need...
     for td in drude_type_list:
 
-        #...exclusions with core
+        # ...exclusions with core
         qd = drude_dict[td]["q"]  # Drude charge
         qc = drude_dict[td]["qc"]  # Core charge
         subtr_sr_bond = interactions.BondedCoulombSRBond(
@@ -255,9 +255,9 @@ def setup_intramol_exclusion_bonds(system, mol_drude_types, mol_core_types,
     for td in mol_drude_types:
         drude_dict[td]["subtr_sr_bonds_intramol"] = {}
 
-        #... sr exclusion bond with other partial core charges...
+        # ... sr exclusion bond with other partial core charges...
         for tc, qp in zip(mol_core_types, mol_core_partial_charges):
-            #...excluding the Drude core partner
+            # ...excluding the Drude core partner
             if drude_dict[td]["core_type"] != tc:
                 qd = drude_dict[td]["q"]  # Drude charge
                 subtr_sr_bond = interactions.BondedCoulombSRBond(

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -306,7 +306,7 @@ IF TABULATED:
                                  vector[double] force)
 IF ROTATION:
     cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
-        #* Parameters for the harmonic dumbbell bond potential */
+        # Parameters for the harmonic dumbbell bond potential
         cdef struct Harmonic_dumbbell_bond_parameters:
             double k1
             double k2
@@ -320,14 +320,14 @@ ELSE:
         double r_cut
 
 cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
-    #* Parameters for n-body tabulated potential (n=2,3,4). */
+    # Parameters for n-body tabulated potential (n=2,3,4).
     cdef struct Tabulated_bond_parameters:
         int type
         TabulatedPotential * pot
 
 IF ELECTROSTATICS:
     cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
-        #* Parameters for Bonded Coulomb p3m sr */
+        # Parameters for Bonded Coulomb p3m sr
         cdef struct Bonded_coulomb_sr_bond_parameters:
             double q1q2
 ELSE:
@@ -342,14 +342,14 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
         double drmax2
         double drmax2i
 
-    #* Parameters for oif_global_forces */
+    # Parameters for oif_global_forces
     cdef struct Oif_global_forces_bond_parameters:
         double A0_g
         double ka_g
         double V0
         double kv
 
-    #* Parameters for oif_local_forces */
+    # Parameters for oif_local_forces
     cdef struct Oif_local_forces_bond_parameters:
         double r0
         double ks
@@ -361,13 +361,13 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
         double kal
         double kvisc
 
-    #* Parameters for harmonic bond Potential */
+    # Parameters for harmonic bond Potential
     cdef struct Harmonic_bond_parameters:
         double k
         double r
         double r_cut
 
-    #* Parameters for thermalized  bond */
+    # Parameters for thermalized  bond
     cdef struct Thermalized_bond_parameters:
         double temp_com
         double gamma_com
@@ -375,35 +375,35 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
         double gamma_distance
         double r_cut
 
-    #* Parameters for Bonded Coulomb */
+    # Parameters for Bonded Coulomb
     cdef struct Bonded_coulomb_bond_parameters:
         double prefactor
 
-    #* Parameters for three body angular potential (bond_angle_harmonic).
+    # Parameters for three body angular potential (bond_angle_harmonic).
     cdef struct Angle_harmonic_bond_parameters:
         double bend
         double phi0
 
-    #* Parameters for three body angular potential (bond_angle_cosine).
+    # Parameters for three body angular potential (bond_angle_cosine).
     cdef struct Angle_cosine_bond_parameters:
         double bend
         double phi0
         double cos_phi0
         double sin_phi0
 
-    #* Parameters for three body angular potential (bond_angle_cossquare).
+    # Parameters for three body angular potential (bond_angle_cossquare).
     cdef struct Angle_cossquare_bond_parameters:
         double bend
         double phi0
         double cos_phi0
 
-    #* Parameters for four body angular potential (dihedral-angle potentials). */
+    # Parameters for four body angular potential (dihedral-angle potentials).
     cdef struct Dihedral_bond_parameters:
         double mult
         double bend
         double phase
 
-    #* Parameters for n-body overlapped potential (n=2,3,4). */
+    # Parameters for n-body overlapped potential (n=2,3,4).
     cdef struct Overlap_bond_parameters:
         char * filename
         int    type
@@ -413,30 +413,32 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
         double * para_b
         double * para_c
 
-    #* Parameters for one-directional harmonic potential */
+    # Parameters for one-directional harmonic potential
     cdef struct Umbrella_bond_parameters:
         double k
         int    dir
         double r
 
-    #* Parameters for subt-LJ potential */
+    # Parameters for subt-LJ potential
     cdef struct Subt_lj_bond_parameters:
         double k
         double r
         double r2
 
-    #* Parameters for the rigid_bond/SHAKE/RATTLE ALGORITHM */
+    # Parameters for the rigid_bond/SHAKE/RATTLE ALGORITHM
     cdef struct Rigid_bond_parameters:
-        #*Length of rigid bond/Constrained Bond*/
+        # Length of rigid bond/Constrained Bond
         # double d
-        #*Square of the length of Constrained Bond*/
+        # Square of the length of Constrained Bond
         double d2
-        #*Positional Tolerance/Accuracy value for termination of RATTLE/SHAKE iterations during position corrections*/
+        # Positional Tolerance/Accuracy value for termination of RATTLE/SHAKE
+        # iterations during position corrections
         double p_tol
-        #*Velocity Tolerance/Accuracy for termination of RATTLE/SHAKE iterations during velocity corrections */
+        # Velocity Tolerance/Accuracy for termination of RATTLE/SHAKE
+        # iterations during velocity corrections
         double v_tol
 
-    #* Parameters for IBM Triel */
+    # Parameters for IBM Triel
     cdef cppclass tElasticLaw:
         pass
 
@@ -455,24 +457,25 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
         double k1
         double k2
 
-    #* Parameters for IBM Tribend */
+    # Parameters for IBM Tribend
     cdef struct IBM_Tribend_Parameters:
         double kb
         double theta0
 
-    #* Parameters for IBM VolCons */
+    # Parameters for IBM VolCons
     cdef struct IBM_VolCons_Parameters:
         int softID
         double kappaV
         double volRef
 
-    #* Parameters for Quartic */
+    # Parameters for Quartic
     cdef struct Quartic_bond_parameters:
         double k0, k1
         double r
         double r_cut
 
-    #* Union in which to store the parameters of an individual bonded interaction */
+    # Union in which to store the parameters of an individual bonded
+    # interaction
     cdef union Bond_parameters:
         Fene_bond_parameters fene
         Oif_global_forces_bond_parameters oif_global_forces
@@ -496,7 +499,7 @@ cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
     cdef struct Bonded_ia_parameters:
         int type
         int num
-        #* union to store the different bonded interaction parameters. */
+        # union to store the different bonded interaction parameters.
         Bond_parameters p
 
     vector[Bonded_ia_parameters] bonded_ia_params

--- a/testsuite/scripts/importlib_wrapper.py
+++ b/testsuite/scripts/importlib_wrapper.py
@@ -440,14 +440,14 @@ def protect_ipython_magics(code):
     formatted comment. This is necessary whenever the code must be parsed
     through ``ast``, because magic commands are not valid Python statements.
     """
-    return re.sub("^(%+)(?=[a-z])", "#_IPYTHON_MAGIC_\g<1>", code, flags=re.M)
+    return re.sub("^(%+)(?=[a-z])", r"#_IPYTHON_MAGIC_\g<1>", code, flags=re.M)
 
 
 def deprotect_ipython_magics(code):
     """
     Reverse the action of :func:`protect_ipython_magics`.
     """
-    return re.sub("^#_IPYTHON_MAGIC_(%+)(?=[a-z])", "\g<1>", code, flags=re.M)
+    return re.sub("^#_IPYTHON_MAGIC_(%+)(?=[a-z])", r"\g<1>", code, flags=re.M)
 
 
 class GetMatplotlibPyplot(ast.NodeVisitor):


### PR DESCRIPTION
Description of changes:
- the bot was unable to delete obsolete posts since the pre-commit tool was introduced, this is now fixed
- properly handle `KeyError` when running `maintainer/gh_post_*.py` scripts outside a CI environment
- exclude PEP8 rule E402 and skip formatting of library code when running `pre-commit`
- run CI shell scripts using Dash instead of Bash when possible