### PR TITLE
Remove deprecated CUDA compat library

### DIFF
--- a/cmake/FindCUDACompilerNVCC.cmake
+++ b/cmake/FindCUDACompilerNVCC.cmake
@@ -63,7 +63,6 @@ function(find_gpu_library)
   cmake_parse_arguments(LIBRARY "REQUIRED" "NAMES;VARNAME" "" ${ARGN})
   list(APPEND LIBRARY_PATHS
        ${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/lib
-       ${CUDA_TOOLKIT_ROOT_DIR}/compat
        /usr/local/nvidia/lib /usr/lib/x86_64-linux-gnu)
   if(LIBRARY_REQUIRED)
     find_library(${LIBRARY_VARNAME} NAMES ${LIBRARY_NAMES} PATHS ${LIBRARY_PATHS} NO_DEFAULT_PATH REQUIRED)


### PR DESCRIPTION
Fixes #4087, fixes #4089

The CUDA `compat` library was introduced in CUDA 10.0 for backwards compatibility with older CUDA versions ([CUDA 10.0 release notes](https://docs.nvidia.com/cuda/archive/10.0/cuda-toolkit-release-notes/#cuda-general-new-features)). This library was deprecated in CUDA 11.0 and became incompatible with NVIDIA driver 450.102.04. It was removed from CUDA 11.0 but is still present in the official Docker image [`nvidia/cuda:11.0-devel-ubuntu20.04`](https://hub.docker.com/layers/nvidia/cuda/11.0-devel-ubuntu20.04/images/sha256-bd7a97c99c7a2bcc183ea07e6b193727de3d180b8c8d118575c6a7968d30c80c?context=explore), which can cause the linker to resolve symbols in `cuda.h` from a deprecated version of `libcuda.so` instead of the most recent one.

Such a binary fails to call standard cuda functions like `cudaGetDeviceCount()`, returning an error code that when passed to `cudaGetErrorString(error_code)` generates the error message "system has unsupported display driver / cuda driver combination", because the `compat` code is designed for driver 450.80.02.