### PR TITLE
Bump Python packages version requirements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: docker.pkg.github.com/espressomd/docker/ubuntu-20.04:1c6cfb03f7cedf008cf0d288fe460303627fc217
+image: docker.pkg.github.com/espressomd/docker/ubuntu-20.04:063f945eb434f6900402fd412f28a4486288c82b
 
 stages:
   - prepare

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -86,8 +86,8 @@ are required:
 
 .. code-block:: bash
 
-    sudo apt install python3-matplotlib python3-scipy ipython3 jupyter-notebook
-    pip3 install --user 'pint>=0.9' 'jupyter_contrib_nbextensions==0.5.1' \
+    sudo apt install python3-matplotlib python3-scipy python3-pint ipython3 jupyter-notebook
+    pip3 install --user 'jupyter_contrib_nbextensions==0.5.1' \
                         'sphinx>=1.6.7,!=2.1.0,!=3.0.0' 'sphinxcontrib-bibtex>=0.3.5'
     jupyter contrib nbextension install --user
     jupyter nbextension enable rubberband/main

--- a/doc/tutorials/constant_pH/constant_pH.ipynb
+++ b/doc/tutorials/constant_pH/constant_pH.ipynb
@@ -117,7 +117,10 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "import setuptools\n",
     "import pint  # module for working with units and dimensions\n",
+    "assert setuptools.version.pkg_resources.packaging.specifiers.SpecifierSet('>=0.10.1').contains(pint.__version__), \\\n",
+    "  f'pint version {pint.__version__} is too old: several numpy operations can cast away the unit'\n",
     "\n",
     "import espressomd\n",
     "espressomd.assert_features(['WCA', 'ELECTROSTATICS'])\n",

--- a/maintainer/benchmarks/CMakeLists.txt
+++ b/maintainer/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(ProcessorCount)
-processorcount(NP)
+ProcessorCount(NP)
 
 if(EXISTS ${MPIEXEC})
   # OpenMPI 3.0 and higher checks the number of processes against the number of

--- a/maintainer/format/autopep8.sh
+++ b/maintainer/format/autopep8.sh
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-AUTOPEP8_VER=1.3.4
-PYCODESTYLE_VER=2.3.1
+AUTOPEP8_VER=1.5
+PYCODESTYLE_VER=2.5.0
 
 python3 -m autopep8 --help 2>&1 > /dev/null
 if [ "$?" = "0" ]; then

--- a/maintainer/format/cmake-format.sh
+++ b/maintainer/format/cmake-format.sh
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-CMAKE_FORMAT_VER=0.6.9
+CMAKE_FORMAT_VER=0.6.11
 python3 -m cmake_format 2>&1 > /dev/null
 if [ "$?" = "0" ]; then
     CMAKE_FORMAT="python3 -m cmake_format"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ numpy>=1.14.0
 h5py>=2.7.1
 # optional scientific packages
 scipy>=0.19.0
-MDAnalysis>=0.18
-pint>=0.9
+MDAnalysis>=1.0.0
+pint>=0.10.1
 # optional packages for graphics and external devices
 matplotlib>=2.1.1
 vtk>=7.1.1
@@ -23,12 +23,12 @@ sphinxcontrib-bibtex>=0.3.5
 # jupyter dependencies
 jupyter_contrib_nbextensions==0.5.1
 # pep8 and its dependencies
-autopep8==1.3.4
-pycodestyle==2.3.1
+autopep8==1.5.0
+pycodestyle==2.5.0
 # pylint and its dependencies
-pylint>=2.2.2
-astroid>=2.1.0
+pylint>=2.4.4
+astroid>=2.3.3
 isort>=4.3.4
 setuptools>=39.0.1
 pre-commit>=2.2.0
-cmake-format==0.6.9
+cmake-format==0.6.11

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1577,7 +1577,7 @@ cdef class _ParticleSliceImpl:
         id_list = id_list[slice_]
 
         # Generate a mask which will remove ids of non-existing particles
-        mask = np.empty(len(id_list), dtype=np.bool)
+        mask = np.empty(len(id_list), dtype=type(True))
         mask[:] = True
         for i, id in enumerate(id_list):
             if not particle_exists(id):
@@ -1921,7 +1921,7 @@ Set quat and scalar dipole moment (dipm) instead.")
         if is_valid_type(idx, int):
             return particle_exists(idx)
         if isinstance(idx, (slice, tuple, list, np.ndarray)):
-            tf_array = np.zeros(len(idx), dtype=np.bool)
+            tf_array = np.zeros(len(idx), dtype=type(True))
             for i in range(len(idx)):
                 tf_array[i] = particle_exists(idx[i])
             return tf_array

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -274,7 +274,7 @@ def is_valid_type(value, t):
     if value is None:
         return False
     if t == int:
-        return isinstance(value, (int, np.integer, np.long))
+        return isinstance(value, (int, np.integer))
     elif t == float:
         if hasattr(np, 'float128'):
             return isinstance(

--- a/src/python/object_in_fluid/oif_classes.py
+++ b/src/python/object_in_fluid/oif_classes.py
@@ -1092,7 +1092,7 @@ class OifCell:
             i = 0
             for line in nodes_coord:  # extracts coordinates from the string line
                 line = line.split()
-                new_position = np.array(line).astype(np.float) + center
+                new_position = np.array(line).astype(float) + center
                 self.mesh.points[i].set_pos(new_position)
                 i += 1
 

--- a/testsuite/python/utils.py
+++ b/testsuite/python/utils.py
@@ -56,7 +56,7 @@ class espresso_utils(ut.TestCase):
         self.assertTrue(utils.is_valid_type(
             np.array([12], dtype=int)[0], int))
         self.assertTrue(utils.is_valid_type(
-            np.array([12], dtype=np.long)[0], int))
+            np.array([12], dtype=int)[0], int))
         self.assertTrue(utils.is_valid_type(
             np.array([1.], dtype=float)[0], float))
         self.assertTrue(utils.is_valid_type(


### PR DESCRIPTION
Description of changes:
- fix numpy 1.20 warnings about deprecated builtin types
- bump Python packages to the versions available in Ubuntu 20.04 (as per #3421)
- prevent running the constant pH tutorial with an unsupported `pint` version
