### PR TITLE
Refactor P3M/DP3M exception mechanism

### DIFF
--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -183,8 +183,13 @@ void on_coulomb_change() {
 #ifdef P3M
 #ifdef CUDA
   case COULOMB_P3M_GPU:
-    if (this_node == 0)
-      p3m_gpu_init(p3m.params.cao, p3m.params.mesh, p3m.params.alpha);
+    if (this_node == 0) {
+      try {
+        p3m_gpu_init(p3m.params.cao, p3m.params.mesh, p3m.params.alpha);
+      } catch (std::runtime_error const &err) {
+        runtimeErrorMsg() << err.what();
+      }
+    }
     break;
 #endif
   case COULOMB_ELC_P3M:

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -971,8 +971,10 @@ int ELC_tune(double error) {
     lz = elc_params.h + elc_params.space_layer;
   }
 
-  if (h < 0)
+  if (h < 0) {
+    runtimeErrorMsg() << "gap size too large";
     return ES_ERROR;
+  }
 
   elc_params.far_cut = min_inv_boxl;
 
@@ -991,8 +993,10 @@ int ELC_tune(double error) {
 
     elc_params.far_cut += min_inv_boxl;
   } while (err > error && elc_params.far_cut < MAXIMAL_FAR_CUT);
-  if (elc_params.far_cut >= MAXIMAL_FAR_CUT)
+  if (elc_params.far_cut >= MAXIMAL_FAR_CUT) {
+    runtimeErrorMsg() << "maxPWerror too small";
     return ES_ERROR;
+  }
   elc_params.far_cut -= min_inv_boxl;
   elc_params.far_cut2 = Utils::sqr(elc_params.far_cut);
 
@@ -1074,7 +1078,7 @@ void ELC_init() {
 
   if (elc_params.far_calculated && (elc_params.dielectric_contrast_on)) {
     if (ELC_tune(elc_params.maxPWerror) == ES_ERROR) {
-      runtimeErrorMsg() << "ELC auto-retuning failed, gap size too small";
+      runtimeErrorMsg() << "ELC auto-retuning failed";
     }
   }
   if (elc_params.dielectric_contrast_on) {
@@ -1130,7 +1134,7 @@ int ELC_set_params(double maxPWerror, double gap_size, double far_cut,
 
   ELC_setup_constants();
 
-  Coulomb::elc_sanity_check();
+  int error_code = Coulomb::elc_sanity_check();
 
   p3m.params.epsilon = P3M_EPSILON_METALLIC;
   coulomb.method = COULOMB_ELC_P3M;
@@ -1142,12 +1146,12 @@ int ELC_set_params(double maxPWerror, double gap_size, double far_cut,
   } else {
     elc_params.far_calculated = true;
     if (ELC_tune(elc_params.maxPWerror) == ES_ERROR) {
-      runtimeErrorMsg() << "ELC tuning failed, gap size too small";
+      error_code = ES_ERROR;
     }
   }
   mpi_bcast_coulomb_params();
 
-  return ES_OK;
+  return error_code;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -70,6 +70,7 @@
 #include <array>
 #include <cstdio>
 #include <functional>
+#include <stdexcept>
 #include <vector>
 
 /************************************************
@@ -243,64 +244,62 @@ void dp3m_set_tune_params(double r_cut, int mesh, int cao, double accuracy) {
 
 /*****************************************************************************/
 
-int dp3m_set_params(double r_cut, int mesh, int cao, double alpha,
-                    double accuracy) {
-  if (dipole.method != DIPOLAR_P3M && dipole.method != DIPOLAR_MDLC_P3M)
-    Dipole::set_method_local(DIPOLAR_P3M);
-
+void dp3m_set_params(double r_cut, int mesh, int cao, double alpha,
+                     double accuracy) {
   if (r_cut < 0)
-    return -1;
+    throw std::runtime_error("DipolarP3M: invalid r_cut");
 
   if (mesh < 0)
-    return -2;
+    throw std::runtime_error("DipolarP3M: invalid mesh size");
 
-  if (cao < 1 || cao > 7 || cao > mesh)
-    return -3;
+  if (cao < 1 || cao > 7)
+    throw std::runtime_error("DipolarP3M: invalid cao");
+
+  if (cao > mesh)
+    throw std::runtime_error("DipolarP3M: cao larger than mesh size");
+
+  if (alpha <= 0.0 && alpha != -1.0)
+    throw std::runtime_error("DipolarP3M: invalid alpha");
+
+  if (accuracy <= 0.0 && accuracy != -1.0)
+    throw std::runtime_error("DipolarP3M: invalid accuracy");
+
+  if (dipole.method != DIPOLAR_P3M && dipole.method != DIPOLAR_MDLC_P3M)
+    Dipole::set_method_local(DIPOLAR_P3M);
 
   dp3m.params.r_cut = r_cut;
   dp3m.params.r_cut_iL = r_cut / box_geo.length()[0];
   dp3m.params.mesh[2] = dp3m.params.mesh[1] = dp3m.params.mesh[0] = mesh;
   dp3m.params.cao = cao;
-
-  if (alpha > 0) {
-    dp3m.params.alpha = alpha;
-    dp3m.params.alpha_L = alpha * box_geo.length()[0];
-  } else if (alpha != -1.0)
-    return -4;
-
-  if (accuracy >= 0)
-    dp3m.params.accuracy = accuracy;
-  else if (accuracy != -1.0)
-    return -5;
+  dp3m.params.alpha = alpha;
+  dp3m.params.alpha_L = alpha * box_geo.length()[0];
+  dp3m.params.accuracy = accuracy;
 
   mpi_bcast_coulomb_params();
-
-  return 0;
 }
 
-int dp3m_set_mesh_offset(double x, double y, double z) {
+void dp3m_set_mesh_offset(double x, double y, double z) {
+  if (x == -1.0 && y == -1.0 && z == -1.0)
+    return;
+
   if (x < 0.0 || x > 1.0 || y < 0.0 || y > 1.0 || z < 0.0 || z > 1.0)
-    return ES_ERROR;
+    throw std::runtime_error("DipolarP3M: invalid mesh offset");
 
   dp3m.params.mesh_off[0] = x;
   dp3m.params.mesh_off[1] = y;
   dp3m.params.mesh_off[2] = z;
 
   mpi_bcast_coulomb_params();
-
-  return ES_OK;
 }
 
 /** We left the handling of the epsilon, due to portability reasons in
  *  the future for the electrical dipoles, or if people want to do
  *  electrical dipoles alone using the magnetic code. Currently unused.
  */
-int dp3m_set_eps(double eps) {
+void dp3m_set_eps(double eps) {
   dp3m.params.epsilon = eps;
 
   mpi_bcast_coulomb_params();
-
-  return ES_OK;
 }
 
 namespace {

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -225,8 +225,7 @@ void dp3m_init() {
  * functions related to the parsing & tuning of the dipolar parameters
  ******************/
 
-void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
-                          double accuracy) {
+void dp3m_set_tune_params(double r_cut, int mesh, int cao, double accuracy) {
   if (r_cut >= 0) {
     dp3m.params.r_cut = r_cut;
     dp3m.params.r_cut_iL = r_cut / box_geo.length()[0];
@@ -237,11 +236,6 @@ void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
 
   if (cao >= 0)
     dp3m.params.cao = cao;
-
-  if (alpha >= 0) {
-    dp3m.params.alpha = alpha;
-    dp3m.params.alpha_L = alpha * box_geo.length()[0];
-  }
 
   if (accuracy >= 0)
     dp3m.params.accuracy = accuracy;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -90,8 +90,7 @@ struct dp3m_data_struct : public p3m_data_struct_base {
 extern dp3m_data_struct dp3m;
 
 /** @copydoc p3m_set_tune_params */
-void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha,
-                          double accuracy);
+void dp3m_set_tune_params(double r_cut, int mesh, int cao, double accuracy);
 
 /** @copydoc p3m_set_params */
 int dp3m_set_params(double r_cut, int mesh, int cao, double alpha,

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -60,11 +60,11 @@ struct dp3m_data_struct : public p3m_data_struct_base {
 
   /** local mesh. */
   p3m_local_mesh local_mesh;
-  /** real space mesh (local) for CA/FFT.*/
+  /** real space mesh (local) for CA/FFT. */
   fft_vector<double> rs_mesh;
-  /** real space mesh (local) for CA/FFT of the dipolar field.*/
+  /** real space mesh (local) for CA/FFT of the dipolar field. */
   std::array<fft_vector<double>, 3> rs_mesh_dip;
-  /** k-space mesh (local) for k-space calculation and FFT.*/
+  /** k-space mesh (local) for k-space calculation and FFT. */
   std::vector<double> ks_mesh;
 
   /** number of dipolar particles (only on master node). */
@@ -72,7 +72,7 @@ struct dp3m_data_struct : public p3m_data_struct_base {
   /** Sum of square of magnetic dipoles (only on master node). */
   double sum_mu2;
 
-  /** position shift for calc. of first assignment mesh point. */
+  /** position shift for calculation of first assignment mesh point. */
   double pos_shift;
 
   p3m_interpolation_cache inter_weights;
@@ -80,7 +80,7 @@ struct dp3m_data_struct : public p3m_data_struct_base {
   /** send/recv mesh sizes */
   p3m_send_mesh sm;
 
-  /* Stores the value of the energy correction due to MS effects */
+  /** value of the energy correction due to MS effects */
   double energy_correction;
 
   fft_data_struct fft;
@@ -115,8 +115,6 @@ void dp3m_scaleby_box_l();
 bool dp3m_sanity_checks(const Utils::Vector3i &grid);
 
 /** Assign the physical dipoles using the tabulated assignment function.
- *  If Dstore_ca_frac is true, then the charge fractions are buffered in
- *  Dcur_ca_fmp and Dcur_ca_frac.
  */
 void dp3m_dipole_assign(const ParticleRange &particles);
 

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -93,14 +93,14 @@ extern dp3m_data_struct dp3m;
 void dp3m_set_tune_params(double r_cut, int mesh, int cao, double accuracy);
 
 /** @copydoc p3m_set_params */
-int dp3m_set_params(double r_cut, int mesh, int cao, double alpha,
-                    double accuracy);
+void dp3m_set_params(double r_cut, int mesh, int cao, double alpha,
+                     double accuracy);
 
 /** @copydoc p3m_set_mesh_offset */
-int dp3m_set_mesh_offset(double x, double y, double z);
+void dp3m_set_mesh_offset(double x, double y, double z);
 
 /** @copydoc p3m_set_eps */
-int dp3m_set_eps(double eps);
+void dp3m_set_eps(double eps);
 
 /** Initialize all structures, parameters and arrays needed for the
  *  P3M algorithm for dipole-dipole interactions.

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -205,7 +205,7 @@ void p3m_init() {
   p3m_count_charged_particles();
 }
 
-void p3m_set_tune_params(double r_cut, const int mesh[3], int cao, double alpha,
+void p3m_set_tune_params(double r_cut, const int mesh[3], int cao,
                          double accuracy) {
   if (r_cut >= 0) {
     p3m.params.r_cut = r_cut;
@@ -223,11 +223,6 @@ void p3m_set_tune_params(double r_cut, const int mesh[3], int cao, double alpha,
 
   if (cao >= 0)
     p3m.params.cao = cao;
-
-  if (alpha >= 0) {
-    p3m.params.alpha = alpha;
-    p3m.params.alpha_L = alpha * box_geo.length()[0];
-  }
 
   if (accuracy >= 0)
     p3m.params.accuracy = accuracy;

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -66,6 +66,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <functional>
+#include <stdexcept>
 
 using Utils::sinc;
 
@@ -228,20 +229,29 @@ void p3m_set_tune_params(double r_cut, const int mesh[3], int cao,
     p3m.params.accuracy = accuracy;
 }
 
-int p3m_set_params(double r_cut, const int *mesh, int cao, double alpha,
-                   double accuracy) {
+void p3m_set_params(double r_cut, const int *mesh, int cao, double alpha,
+                    double accuracy) {
+  if (r_cut < 0)
+    throw std::runtime_error("P3M: invalid r_cut");
+
+  if (mesh[0] < 0 || mesh[1] < 0 || mesh[2] < 0)
+    throw std::runtime_error("P3M: invalid mesh size");
+
+  if (cao < 1 || cao > 7)
+    throw std::runtime_error("P3M: invalid cao");
+
+  if (cao > mesh[0] || cao > mesh[1] || cao > mesh[2])
+    throw std::runtime_error("P3M: cao larger than mesh size");
+
+  if (alpha <= 0.0 && alpha != -1.0)
+    throw std::runtime_error("P3M: invalid alpha");
+
+  if (accuracy <= 0.0 && accuracy != -1.0)
+    throw std::runtime_error("P3M: invalid accuracy");
+
   if (coulomb.method != COULOMB_P3M && coulomb.method != COULOMB_ELC_P3M &&
       coulomb.method != COULOMB_P3M_GPU)
     coulomb.method = COULOMB_P3M;
-
-  if (r_cut < 0)
-    return -1;
-
-  if ((mesh[0] < 0) || (mesh[1] < 0) || (mesh[2] < 0))
-    return -2;
-
-  if (cao < 1 || cao > 7 || cao > mesh[0] || cao > mesh[1] || cao > mesh[2])
-    return -3;
 
   p3m.params.r_cut = r_cut;
   p3m.params.r_cut_iL = r_cut * (1. / box_geo.length()[0]);
@@ -249,42 +259,31 @@ int p3m_set_params(double r_cut, const int *mesh, int cao, double alpha,
   p3m.params.mesh[1] = mesh[1];
   p3m.params.mesh[0] = mesh[0];
   p3m.params.cao = cao;
-
-  if (alpha > 0) {
-    p3m.params.alpha = alpha;
-    p3m.params.alpha_L = alpha * box_geo.length()[0];
-  } else if (alpha != -1.0)
-    return -4;
-
-  if (accuracy >= 0)
-    p3m.params.accuracy = accuracy;
-  else if (accuracy != -1.0)
-    return -5;
+  p3m.params.alpha = alpha;
+  p3m.params.alpha_L = alpha * box_geo.length()[0];
+  p3m.params.accuracy = accuracy;
 
   mpi_bcast_coulomb_params();
-
-  return 0;
 }
 
-int p3m_set_mesh_offset(double x, double y, double z) {
+void p3m_set_mesh_offset(double x, double y, double z) {
+  if (x == -1.0 && y == -1.0 && z == -1.0)
+    return;
+
   if (x < 0.0 || x > 1.0 || y < 0.0 || y > 1.0 || z < 0.0 || z > 1.0)
-    return ES_ERROR;
+    throw std::runtime_error("P3M: invalid mesh offset");
 
   p3m.params.mesh_off[0] = x;
   p3m.params.mesh_off[1] = y;
   p3m.params.mesh_off[2] = z;
 
   mpi_bcast_coulomb_params();
-
-  return ES_OK;
 }
 
-int p3m_set_eps(double eps) {
+void p3m_set_eps(double eps) {
   p3m.params.epsilon = eps;
 
   mpi_bcast_coulomb_params();
-
-  return ES_OK;
 }
 
 namespace {

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -61,9 +61,9 @@ struct p3m_data_struct : public p3m_data_struct_base {
 
   /** local mesh. */
   p3m_local_mesh local_mesh;
-  /** real space mesh (local) for CA/FFT.*/
+  /** real space mesh (local) for CA/FFT. */
   fft_vector<double> rs_mesh;
-  /** mesh (local) for the electric field.*/
+  /** mesh (local) for the electric field. */
   std::array<fft_vector<double>, 3> E_mesh;
 
   /** number of charged particles (only on master node). */

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -197,10 +197,9 @@ inline void p3m_add_pair_force(double q1q2, Utils::Vector3d const &d,
  *  @param[in]  r_cut        @copybrief P3MParameters::r_cut
  *  @param[in]  mesh         @copybrief P3MParameters::mesh
  *  @param[in]  cao          @copybrief P3MParameters::cao
- *  @param[in]  alpha        @copybrief P3MParameters::alpha
  *  @param[in]  accuracy     @copybrief P3MParameters::accuracy
  */
-void p3m_set_tune_params(double r_cut, const int mesh[3], int cao, double alpha,
+void p3m_set_tune_params(double r_cut, const int mesh[3], int cao,
                          double accuracy);
 
 /** Set custom parameters

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -209,23 +209,22 @@ void p3m_set_tune_params(double r_cut, const int mesh[3], int cao,
  *  @param[in]  cao          @copybrief P3MParameters::cao
  *  @param[in]  alpha        @copybrief P3MParameters::alpha
  *  @param[in]  accuracy     @copybrief P3MParameters::accuracy
- *  @return Custom error code
  */
-int p3m_set_params(double r_cut, const int *mesh, int cao, double alpha,
-                   double accuracy);
+void p3m_set_params(double r_cut, const int *mesh, int cao, double alpha,
+                    double accuracy);
 
 /** Set mesh offset
  *
  *  @param[in]  x , y , z  Components of @ref P3MParameters::mesh_off
  *                         "mesh_off"
  */
-int p3m_set_mesh_offset(double x, double y, double z);
+void p3m_set_mesh_offset(double x, double y, double z);
 
 /** Set @ref P3MParameters::epsilon "epsilon" parameter
  *
  *  @param[in]  eps          @copybrief P3MParameters::epsilon
  */
-int p3m_set_eps(double eps);
+void p3m_set_eps(double eps);
 
 /** Calculate real space contribution of Coulomb pair energy. */
 inline double p3m_pair_energy(double chgfac, double dist) {

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_cuda.cu
@@ -68,6 +68,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 
 #if defined(OMPI_MPI_H) || defined(_MPI_H)
 #error CU-file includes mpi.h! This should not happen!
@@ -559,6 +560,9 @@ void assign_forces(const CUDA_particle_data *const pdata, const P3MGpuData p,
  * is (cuFFT convention) Nx x Ny x [ Nz /2 + 1 ].
  */
 void p3m_gpu_init(int cao, const int mesh[3], double alpha) {
+  if (mesh[0] == -1 && mesh[1] == -1 && mesh[2] == -1)
+    throw std::runtime_error("P3M: invalid mesh size");
+
   espressoSystemInterface.requestParticleStructGpu();
 
   bool reinit_if = false, mesh_changed = false;

--- a/src/core/immersed_boundary/ibm_tribend.cpp
+++ b/src/core/immersed_boundary/ibm_tribend.cpp
@@ -28,6 +28,7 @@
 #include <utils/Vector.hpp>
 #include <utils/constants.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <tuple>
 
@@ -55,9 +56,7 @@ IBM_Tribend_CalcForce(Particle const &p1, Particle const &p2,
   n2 /= Aj;
 
   // Get the prefactor for the force term
-  auto sc = n1 * n2;
-  if (sc > 1.0)
-    sc = 1.0;
+  auto const sc = std::min(1.0, n1 * n2);
 
   // Get theta as angle between normals
   auto theta = acos(sc);
@@ -126,9 +125,7 @@ int IBM_Tribend_SetParams(const int bond_type, const int ind1, const int ind2,
     auto const n2 = n2l / n2l.norm();
 
     // calculate theta0 by taking the acos of the scalar n1*n2
-    auto sc = n1 * n2;
-    if (sc > 1.0)
-      sc = 1.0;
+    auto const sc = std::min(1.0, n1 * n2);
 
     theta0 = acos(sc);
 

--- a/src/python/espressomd/actors.pyx
+++ b/src/python/espressomd/actors.pyx
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 include "myconfig.pxi"
 from .highlander import ThereCanOnlyBeOne
-from .utils cimport handle_errors
+from .utils import handle_errors
 
 cdef class Actor:
 

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -30,9 +30,9 @@ from .globals import Globals
 
 from collections import OrderedDict
 from .system import System
-from .utils import array_locked, is_valid_type
+from .utils import array_locked, is_valid_type, handle_errors
 from .utils cimport Vector3i, Vector3d, Vector9d
-from .utils cimport handle_errors, check_type_or_throw_except
+from .utils cimport check_type_or_throw_except
 from .utils cimport create_nparray_from_double_array
 from .particle_data cimport get_n_part
 

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -25,7 +25,8 @@ from .globals cimport verlet_reuse, skin
 from .globals cimport mpi_bcast_parameter
 from libcpp.vector cimport vector
 from .cellsystem cimport cell_structure
-from .utils cimport handle_errors, Vector3i, check_type_or_throw_except
+from .utils import handle_errors
+from .utils cimport Vector3i, check_type_or_throw_except
 
 
 cdef class CellSystem:

--- a/src/python/espressomd/collision_detection.pyx
+++ b/src/python/espressomd/collision_detection.pyx
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from .script_interface import ScriptInterfaceHelper, script_interface_register
 from .utils import to_str
-from .utils cimport handle_errors
+from .utils import handle_errors
 from .interactions import BondedInteraction, BondedInteractions
 
 

--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -26,7 +26,7 @@ from . import utils
 import tempfile
 import shutil
 from .utils import is_valid_type
-from .utils cimport Vector3i, Vector6d, handle_errors
+from .utils cimport Vector3i, Vector6d
 import numpy as np
 
 IF ELECTROKINETICS:

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -123,8 +123,7 @@ IF ELECTROSTATICS and P3M:
 
         def _set_params_in_es_core(self):
             if coulomb.method == COULOMB_P3M_GPU:
-                raise Exception(
-                    "ELC tuning failed, ELC is not set up to work with the GPU P3M")
+                raise Exception("ELC is not set up to work with the GPU P3M")
 
             if self._params["const_pot"]:
                 self._params["delta_mid_top"] = -1
@@ -139,8 +138,7 @@ IF ELECTROSTATICS and P3M:
                 self._params["delta_mid_bot"],
                 self._params["const_pot"],
                     self._params["pot_diff"]):
-                handle_errors(
-                    "ELC tuning failed, ELC is not set up to work with the GPU P3M")
+                handle_errors("ELC tuning failed")
 
         def _activate_method(self):
             check_neutrality(self._params)

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -22,7 +22,8 @@ include "myconfig.pxi"
 from . cimport actors
 from . import actors
 import numpy as np
-from .utils cimport handle_errors, check_type_or_throw_except, check_range_or_except
+from .utils import handle_errors
+from .utils cimport check_type_or_throw_except, check_range_or_except
 
 IF ELECTROSTATICS and P3M:
     from espressomd.electrostatics import check_neutrality

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -68,10 +68,10 @@ IF ELECTROSTATICS:
         from p3m_common cimport P3MParameters
 
         cdef extern from "electrostatics_magnetostatics/p3m.hpp":
-            int p3m_set_params(double r_cut, int * mesh, int cao, double alpha, double accuracy)
+            void p3m_set_params(double r_cut, int * mesh, int cao, double alpha, double accuracy) except +
             void p3m_set_tune_params(double r_cut, int mesh[3], int cao, double accuracy)
-            int p3m_set_mesh_offset(double x, double y, double z)
-            int p3m_set_eps(double eps)
+            void p3m_set_mesh_offset(double x, double y, double z) except +
+            void p3m_set_eps(double eps)
             int p3m_adaptive_tune(bool verbose)
 
             ctypedef struct p3m_data_struct:
@@ -82,7 +82,7 @@ IF ELECTROSTATICS:
 
         IF CUDA:
             cdef extern from "electrostatics_magnetostatics/p3m_gpu.hpp":
-                void p3m_gpu_init(int cao, int * mesh, double alpha)
+                void p3m_gpu_init(int cao, int * mesh, double alpha) except +
 
             cdef inline python_p3m_gpu_init(params):
                 cdef int cao
@@ -99,56 +99,6 @@ IF ELECTROSTATICS:
                 alpha = params["alpha"]
                 p3m_gpu_init(cao, mesh, alpha)
                 handle_errors("python_p3m_gpu_init")
-
-        cdef inline python_p3m_set_mesh_offset(mesh_off):
-            cdef double mesh_offset[3]
-            mesh_offset[0] = mesh_off[0]
-            mesh_offset[1] = mesh_off[1]
-            mesh_offset[2] = mesh_off[2]
-            return p3m_set_mesh_offset(
-                mesh_offset[0], mesh_offset[1], mesh_offset[2])
-
-        cdef inline python_p3m_adaptive_tune(bool verbose):
-            cdef int response = p3m_adaptive_tune(verbose)
-            if response:
-                handle_errors("python_p3m_adaptive_tune")
-
-        cdef inline python_p3m_set_params(p_r_cut, p_mesh, p_cao, p_alpha, p_accuracy):
-            cdef int mesh[3]
-            cdef double r_cut
-            cdef int cao
-            cdef double alpha
-            cdef double accuracy
-            r_cut = p_r_cut
-            cao = p_cao
-            alpha = p_alpha
-            accuracy = p_accuracy
-            if is_valid_type(p_mesh, int):
-                mesh[0] = p_mesh
-                mesh[1] = p_mesh
-                mesh[2] = p_mesh
-            else:
-                mesh = p_mesh
-
-            return p3m_set_params(r_cut, mesh, cao, alpha, accuracy)
-
-        cdef inline python_p3m_set_tune_params(p_r_cut, p_mesh, p_cao, p_accuracy):
-            cdef int mesh[3]
-            cdef double r_cut
-            cdef int cao
-            cdef double accuracy
-            r_cut = p_r_cut
-            cao = p_cao
-            accuracy = p_accuracy
-
-            if is_valid_type(p_mesh, int):
-                mesh[0] = p_mesh
-                mesh[1] = p_mesh
-                mesh[2] = p_mesh
-            else:
-                mesh = p_mesh
-
-            p3m_set_tune_params(r_cut, mesh, cao, accuracy)
 
     cdef extern from "electrostatics_magnetostatics/debye_hueckel.hpp":
         ctypedef struct Debye_hueckel_params:

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -18,8 +18,7 @@
 #
 
 include "myconfig.pxi"
-from .utils import is_valid_type, to_str, handle_errors
-from .utils cimport handle_errors
+from .utils import is_valid_type, to_str
 from libcpp cimport bool
 
 cdef extern from "SystemInterface.hpp":

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -69,7 +69,7 @@ IF ELECTROSTATICS:
 
         cdef extern from "electrostatics_magnetostatics/p3m.hpp":
             int p3m_set_params(double r_cut, int * mesh, int cao, double alpha, double accuracy)
-            void p3m_set_tune_params(double r_cut, int mesh[3], int cao, double alpha, double accuracy)
+            void p3m_set_tune_params(double r_cut, int mesh[3], int cao, double accuracy)
             int p3m_set_mesh_offset(double x, double y, double z)
             int p3m_set_eps(double eps)
             int p3m_adaptive_tune(bool verbose)
@@ -132,15 +132,13 @@ IF ELECTROSTATICS:
 
             return p3m_set_params(r_cut, mesh, cao, alpha, accuracy)
 
-        cdef inline python_p3m_set_tune_params(p_r_cut, p_mesh, p_cao, p_alpha, p_accuracy):
+        cdef inline python_p3m_set_tune_params(p_r_cut, p_mesh, p_cao, p_accuracy):
             cdef int mesh[3]
             cdef double r_cut
             cdef int cao
-            cdef double alpha
             cdef double accuracy
             r_cut = p_r_cut
             cao = p_cao
-            alpha = p_alpha
             accuracy = p_accuracy
 
             if is_valid_type(p_mesh, int):
@@ -150,7 +148,7 @@ IF ELECTROSTATICS:
             else:
                 mesh = p_mesh
 
-            p3m_set_tune_params(r_cut, mesh, cao, alpha, accuracy)
+            p3m_set_tune_params(r_cut, mesh, cao, accuracy)
 
     cdef extern from "electrostatics_magnetostatics/debye_hueckel.hpp":
         ctypedef struct Debye_hueckel_params:

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -84,22 +84,6 @@ IF ELECTROSTATICS:
             cdef extern from "electrostatics_magnetostatics/p3m_gpu.hpp":
                 void p3m_gpu_init(int cao, int * mesh, double alpha) except +
 
-            cdef inline python_p3m_gpu_init(params):
-                cdef int cao
-                cdef int mesh[3]
-                cdef double alpha
-                cao = params["cao"]
-                # Mesh can be specified as single int, but here, an array is
-                # needed
-                if not hasattr(params["mesh"], "__getitem__"):
-                    for i in range(3):
-                        mesh[i] = params["mesh"]
-                else:
-                    mesh = params["mesh"]
-                alpha = params["alpha"]
-                p3m_gpu_init(cao, mesh, alpha)
-                handle_errors("python_p3m_gpu_init")
-
     cdef extern from "electrostatics_magnetostatics/debye_hueckel.hpp":
         ctypedef struct Debye_hueckel_params:
             double r_cut
@@ -133,15 +117,6 @@ IF ELECTROSTATICS:
         void MMM1D_set_params(double switch_rad, double maxPWerror)
         int MMM1D_init()
         int mmm1d_tune(bool verbose)
-
-    cdef inline pyMMM1D_tune(bool verbose):
-        cdef int resp
-        resp = MMM1D_init()
-        if resp:
-            handle_errors("pyMMM1D_tune")
-        resp = mmm1d_tune(verbose)
-        if resp:
-            handle_errors("pyMMM1D_tune")
 
 IF ELECTROSTATICS and MMM1D_GPU:
 

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -236,10 +236,6 @@ IF P3M == 1:
             if not (self._params["prefactor"] > 0.0):
                 raise ValueError("prefactor should be a positive float")
 
-            if not (self._params["r_cut"] >= 0
-                    or self._params["r_cut"] == default_params["r_cut"]):
-                raise ValueError("P3M r_cut has to be >=0")
-
             if is_valid_type(self._params["mesh"], int):
                 if self._params["mesh"] % 2 != 0 and self._params["mesh"] != -1:
                     raise ValueError(
@@ -253,13 +249,6 @@ IF P3M == 1:
                     raise ValueError(
                         "P3M requires an even number of mesh points in all directions")
 
-            if not (self._params["cao"] >= -1 and self._params["cao"] <= 7):
-                raise ValueError(
-                    "P3M cao has to be an integer between -1 and 7")
-
-            if self._params["tune"] and not (self._params["accuracy"] >= 0):
-                raise ValueError("P3M accuracy has to be positive")
-
             if self._params["epsilon"] == "metallic":
                 self._params["epsilon"] = 0.0
 
@@ -270,10 +259,6 @@ IF P3M == 1:
             if self._params["mesh_off"] != default_params["mesh_off"]:
                 check_type_or_throw_except(self._params["mesh_off"], 3, float,
                                            "mesh_off should be a (3,) array_like of values between 0.0 and 1.0")
-
-            if not (self._params["alpha"] == default_params["alpha"]
-                    or self._params["alpha"] > 0):
-                raise ValueError("alpha should be positive")
 
         def valid_keys(self):
             return ["mesh", "cao", "accuracy", "epsilon", "alpha", "r_cut",
@@ -303,18 +288,28 @@ IF P3M == 1:
             return params
 
         def _set_params_in_es_core(self):
-            # Sets lb, bcast, resets vars to zero if lb=0
+            cdef int mesh[3]
+            if is_valid_type(self._params["mesh"], int):
+                for i in range(3):
+                    mesh[i] = self._params["mesh"]
+            else:
+                check_type_or_throw_except(
+                    self._params["mesh"], 3, int, "mesh size must be 3 ints")
+                for i in range(3):
+                    mesh[i] = self._params["mesh"][i]
+
             set_prefactor(self._params["prefactor"])
-            # Sets cdef vars and calls p3m_set_params() in core
-            python_p3m_set_params(self._params["r_cut"],
-                                  self._params["mesh"], self._params["cao"],
-                                  self._params["alpha"], self._params["accuracy"])
-            # p3m_set_params()  -> set r_cuts, mesh, cao, validates sanity, bcasts
-            # Careful: bcast calls on_coulomb_change(), which calls p3m_init(),
-            #         which resets r_cut if lb is zero. OK.
+            # Sets p3m parameters
+            # p3m_set_params() -> set parameters and bcasts
+            # Careful: calls on_coulomb_change(), which calls p3m_init(),
+            #          which resets r_cut if prefactor=0
+            p3m_set_params(self._params["r_cut"], mesh, self._params["cao"],
+                           self._params["alpha"], self._params["accuracy"])
             # Sets eps, bcast
             p3m_set_eps(self._params["epsilon"])
-            python_p3m_set_mesh_offset(self._params["mesh_off"])
+            p3m_set_mesh_offset(self._params["mesh_off"][0],
+                                self._params["mesh_off"][1],
+                                self._params["mesh_off"][2])
 
         def tune(self, **tune_params_subset):
             # update the three necessary parameters if not provided by the user
@@ -326,13 +321,23 @@ IF P3M == 1:
             super().tune(**tune_params_subset)
 
         def _tune(self):
+            cdef int mesh[3]
+            if is_valid_type(self._params["mesh"], int):
+                for i in range(3):
+                    mesh[i] = self._params["mesh"]
+            else:
+                check_type_or_throw_except(
+                    self._params["mesh"], 3, int, "mesh size must be 3 ints")
+                for i in range(3):
+                    mesh[i] = self._params["mesh"][i]
+
             set_prefactor(self._params["prefactor"])
             p3m_set_eps(self._params["epsilon"])
-            python_p3m_set_tune_params(self._params["r_cut"],
-                                       self._params["mesh"],
-                                       self._params["cao"],
-                                       self._params["accuracy"])
-            python_p3m_adaptive_tune(self._params["verbose"])
+            p3m_set_tune_params(self._params["r_cut"], mesh,
+                                self._params["cao"], self._params["accuracy"])
+            tuning_error = p3m_adaptive_tune(self._params["verbose"])
+            if tuning_error:
+                handle_errors("P3M: tuning failed")
             self._params.update(self._get_params_from_es_core())
 
         def _activate_method(self):
@@ -384,10 +389,6 @@ IF P3M == 1:
             def validate_params(self):
                 default_params = self.default_params()
 
-                if not (self._params["r_cut"] >= 0
-                        or self._params["r_cut"] == default_params["r_cut"]):
-                    raise ValueError("P3M r_cut has to be >=0")
-
                 if is_valid_type(self._params["mesh"], int):
                     if self._params["mesh"] % 2 != 0 and self._params["mesh"] != -1:
                         raise ValueError(
@@ -400,14 +401,6 @@ IF P3M == 1:
                        (self._params["mesh"][2] % 2 != 0 and self._params["mesh"][2] != -1):
                         raise ValueError(
                             "P3M requires an even number of mesh points in all directions")
-
-                if not (self._params["cao"] >= -1
-                        and self._params["cao"] <= 7):
-                    raise ValueError(
-                        "P3M cao has to be an integer between -1 and 7")
-
-                if not (self._params["accuracy"] >= 0):
-                    raise ValueError("P3M accuracy has to be positive")
 
                 if self._params["epsilon"] == "metallic":
                     self._params["epsilon"] = 0.0
@@ -458,13 +451,24 @@ IF P3M == 1:
                 super().tune(**tune_params_subset)
 
             def _tune(self):
+                cdef int mesh[3]
+                if is_valid_type(self._params["mesh"], int):
+                    for i in range(3):
+                        mesh[i] = self._params["mesh"]
+                else:
+                    check_type_or_throw_except(
+                        self._params["mesh"], 3, int, "mesh size must be 3 ints")
+                    for i in range(3):
+                        mesh[i] = self._params["mesh"][i]
+
                 set_prefactor(self._params["prefactor"])
                 p3m_set_eps(self._params["epsilon"])
-                python_p3m_set_tune_params(self._params["r_cut"],
-                                           self._params["mesh"],
-                                           self._params["cao"],
-                                           self._params["accuracy"])
-                python_p3m_adaptive_tune(self._params["verbose"])
+                p3m_set_tune_params(self._params["r_cut"], mesh,
+                                    self._params["cao"],
+                                    self._params["accuracy"])
+                tuning_error = p3m_adaptive_tune(self._params["verbose"])
+                if tuning_error:
+                    handle_errors("P3M: tuning failed")
                 self._params.update(self._get_params_from_es_core())
 
             def _activate_method(self):
@@ -477,14 +481,23 @@ IF P3M == 1:
                 self._set_params_in_es_core()
 
             def _set_params_in_es_core(self):
+                cdef int mesh[3]
+                if is_valid_type(self._params["mesh"], int):
+                    for i in range(3):
+                        mesh[i] = self._params["mesh"]
+                else:
+                    check_type_or_throw_except(
+                        self._params["mesh"], 3, int, "mesh size must be 3 ints")
+                    for i in range(3):
+                        mesh[i] = self._params["mesh"][i]
+
                 set_prefactor(self._params["prefactor"])
-                python_p3m_set_params(self._params["r_cut"],
-                                      self._params["mesh"],
-                                      self._params["cao"],
-                                      self._params["alpha"],
-                                      self._params["accuracy"])
+                p3m_set_params(self._params["r_cut"], mesh, self._params["cao"],
+                               self._params["alpha"], self._params["accuracy"])
                 p3m_set_eps(self._params["epsilon"])
-                python_p3m_set_mesh_offset(self._params["mesh_off"])
+                p3m_set_mesh_offset(self._params["mesh_off"][0],
+                                    self._params["mesh_off"][1],
+                                    self._params["mesh_off"][2])
                 handle_errors("p3m gpu init")
 
 IF ELECTROSTATICS:

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -277,7 +277,8 @@ IF P3M == 1:
 
         def valid_keys(self):
             return ["mesh", "cao", "accuracy", "epsilon", "alpha", "r_cut",
-                    "prefactor", "tune", "check_neutrality", "verbose"]
+                    "prefactor", "tune", "check_neutrality", "verbose",
+                    "mesh_off"]
 
         def required_keys(self):
             return ["prefactor", "accuracy"]
@@ -422,7 +423,8 @@ IF P3M == 1:
 
             def valid_keys(self):
                 return ["mesh", "cao", "accuracy", "epsilon", "alpha", "r_cut",
-                        "prefactor", "tune", "check_neutrality", "verbose"]
+                        "prefactor", "tune", "check_neutrality", "verbose",
+                        "mesh_off"]
 
             def required_keys(self):
                 return ["prefactor", "accuracy"]

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -331,7 +331,6 @@ IF P3M == 1:
             python_p3m_set_tune_params(self._params["r_cut"],
                                        self._params["mesh"],
                                        self._params["cao"],
-                                       -1.0,
                                        self._params["accuracy"])
             python_p3m_adaptive_tune(self._params["verbose"])
             self._params.update(self._get_params_from_es_core())
@@ -464,7 +463,6 @@ IF P3M == 1:
                 python_p3m_set_tune_params(self._params["r_cut"],
                                            self._params["mesh"],
                                            self._params["cao"],
-                                           -1.0,
                                            self._params["accuracy"])
                 python_p3m_adaptive_tune(self._params["verbose"])
                 self._params.update(self._get_params_from_es_core())

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -24,8 +24,7 @@ import numpy as np
 IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
     from . cimport scafacos
-from .utils cimport handle_errors
-from .utils import is_valid_type, check_type_or_throw_except, to_str
+from .utils import is_valid_type, check_type_or_throw_except, to_str, handle_errors
 from . cimport checks
 from .analyze cimport partCfg, PartCfg
 from .particle_data cimport particle

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -340,6 +340,7 @@ IF P3M == 1:
             if self._params["tune"]:
                 self._tune()
             self._set_params_in_es_core()
+            handle_errors("P3M: initialization failed")
 
     IF CUDA:
         cdef class P3MGPU(ElectrostaticInteraction):
@@ -484,7 +485,7 @@ IF P3M == 1:
                 p3m_set_mesh_offset(self._params["mesh_off"][0],
                                     self._params["mesh_off"][1],
                                     self._params["mesh_off"][2])
-                handle_errors("p3m gpu init")
+                handle_errors("P3M: initialization failed")
 
 IF ELECTROSTATICS:
     cdef class MMM1D(ElectrostaticInteraction):

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -192,6 +192,15 @@ IF ELECTROSTATICS:
 
 
 IF P3M == 1:
+    cdef _check_and_copy_mesh_size(int mesh[3], pmesh):
+        if is_valid_type(pmesh, int):
+            pmesh = 3 * [pmesh]
+        else:
+            check_type_or_throw_except(
+                pmesh, 3, int, "mesh size must be 3 ints")
+        for i in range(3):
+            mesh[i] = pmesh[i]
+
     cdef class P3M(ElectrostaticInteraction):
         """
         P3M electrostatics solver.
@@ -289,14 +298,7 @@ IF P3M == 1:
 
         def _set_params_in_es_core(self):
             cdef int mesh[3]
-            if is_valid_type(self._params["mesh"], int):
-                for i in range(3):
-                    mesh[i] = self._params["mesh"]
-            else:
-                check_type_or_throw_except(
-                    self._params["mesh"], 3, int, "mesh size must be 3 ints")
-                for i in range(3):
-                    mesh[i] = self._params["mesh"][i]
+            _check_and_copy_mesh_size(mesh, self._params["mesh"])
 
             set_prefactor(self._params["prefactor"])
             # Sets p3m parameters
@@ -322,14 +324,7 @@ IF P3M == 1:
 
         def _tune(self):
             cdef int mesh[3]
-            if is_valid_type(self._params["mesh"], int):
-                for i in range(3):
-                    mesh[i] = self._params["mesh"]
-            else:
-                check_type_or_throw_except(
-                    self._params["mesh"], 3, int, "mesh size must be 3 ints")
-                for i in range(3):
-                    mesh[i] = self._params["mesh"][i]
+            _check_and_copy_mesh_size(mesh, self._params["mesh"])
 
             set_prefactor(self._params["prefactor"])
             p3m_set_eps(self._params["epsilon"])
@@ -452,14 +447,7 @@ IF P3M == 1:
 
             def _tune(self):
                 cdef int mesh[3]
-                if is_valid_type(self._params["mesh"], int):
-                    for i in range(3):
-                        mesh[i] = self._params["mesh"]
-                else:
-                    check_type_or_throw_except(
-                        self._params["mesh"], 3, int, "mesh size must be 3 ints")
-                    for i in range(3):
-                        mesh[i] = self._params["mesh"][i]
+                _check_and_copy_mesh_size(mesh, self._params["mesh"])
 
                 set_prefactor(self._params["prefactor"])
                 p3m_set_eps(self._params["epsilon"])
@@ -482,14 +470,7 @@ IF P3M == 1:
 
             def _set_params_in_es_core(self):
                 cdef int mesh[3]
-                if is_valid_type(self._params["mesh"], int):
-                    for i in range(3):
-                        mesh[i] = self._params["mesh"]
-                else:
-                    check_type_or_throw_except(
-                        self._params["mesh"], 3, int, "mesh size must be 3 ints")
-                    for i in range(3):
-                        mesh[i] = self._params["mesh"][i]
+                _check_and_copy_mesh_size(mesh, self._params["mesh"])
 
                 set_prefactor(self._params["prefactor"])
                 p3m_set_params(self._params["r_cut"], mesh, self._params["cao"],

--- a/src/python/espressomd/globals.pyx
+++ b/src/python/espressomd/globals.pyx
@@ -24,8 +24,8 @@ from .globals cimport sim_time
 from .globals cimport timing_samples
 from .globals cimport forcecap_set
 from .globals cimport forcecap_get
-from .utils import array_locked
-from .utils cimport Vector3d, make_array_locked, handle_errors
+from .utils import array_locked, handle_errors
+from .utils cimport Vector3d, make_array_locked
 
 cdef class Globals:
     property box_l:

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -18,8 +18,8 @@
 #
 from cpython.exc cimport PyErr_CheckSignals, PyErr_SetInterrupt
 include "myconfig.pxi"
-from .utils cimport handle_errors, check_type_or_throw_except
-from .utils import to_char_pointer
+from .utils cimport check_type_or_throw_except
+from .utils import to_char_pointer, handle_errors
 from . cimport integrate
 
 cdef class IntegratorHandle:

--- a/src/python/espressomd/magnetostatic_extensions.pyx
+++ b/src/python/espressomd/magnetostatic_extensions.pyx
@@ -20,7 +20,8 @@
 from . cimport utils
 include "myconfig.pxi"
 from .actors import Actor
-from .utils cimport handle_errors, check_range_or_except, check_type_or_throw_except
+from .utils import handle_errors
+from .utils cimport check_range_or_except, check_type_or_throw_except
 
 IF DIPOLES and DP3M:
     class MagnetostaticExtension(Actor):

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -63,19 +63,14 @@ IF DP3M == 1:
     from p3m_common cimport P3MParameters
 
     cdef extern from "electrostatics_magnetostatics/p3m-dipolar.hpp":
-        int dp3m_set_params(double r_cut, int mesh, int cao, double alpha, double accuracy)
+        void dp3m_set_params(double r_cut, int mesh, int cao, double alpha, double accuracy) except +
         void dp3m_set_tune_params(double r_cut, int mesh, int cao, double accuracy)
-        int dp3m_set_mesh_offset(double x, double y, double z)
-        int dp3m_set_eps(double eps)
+        void dp3m_set_mesh_offset(double x, double y, double z) except +
+        void dp3m_set_eps(double eps)
         int dp3m_adaptive_tune(bool verbose)
-        int dp3m_deactivate()
+        void dp3m_deactivate()
 
         ctypedef struct dp3m_data_struct:
             P3MParameters params
 
         cdef extern dp3m_data_struct dp3m
-
-    cdef inline python_dp3m_adaptive_tune(bool verbose):
-        cdef int response = dp3m_adaptive_tune(verbose)
-        if response:
-            handle_errors("python_dp3m_adaptive_tune")

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from libcpp cimport bool
-from .utils cimport handle_errors
 
 include "myconfig.pxi"
 

--- a/src/python/espressomd/magnetostatics.pxd
+++ b/src/python/espressomd/magnetostatics.pxd
@@ -64,7 +64,7 @@ IF DP3M == 1:
 
     cdef extern from "electrostatics_magnetostatics/p3m-dipolar.hpp":
         int dp3m_set_params(double r_cut, int mesh, int cao, double alpha, double accuracy)
-        void dp3m_set_tune_params(double r_cut, int mesh, int cao, double alpha, double accuracy)
+        void dp3m_set_tune_params(double r_cut, int mesh, int cao, double accuracy)
         int dp3m_set_mesh_offset(double x, double y, double z)
         int dp3m_set_eps(double eps)
         int dp3m_adaptive_tune(bool verbose)

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -23,7 +23,7 @@ IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
     from . cimport scafacos
 
-from .utils cimport handle_errors
+from .utils import handle_errors
 from .utils import is_valid_type, check_type_or_throw_except, to_str
 
 IF DIPOLES == 1:

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -96,10 +96,6 @@ IF DP3M == 1:
             super().validate_params()
             default_params = self.default_params()
 
-            if not (self._params["r_cut"] >= 0
-                    or self._params["r_cut"] == default_params["r_cut"]):
-                raise ValueError("P3M r_cut has to be >=0")
-
             if is_valid_type(self._params["mesh"], int):
                 pass
             else:
@@ -109,13 +105,6 @@ IF DP3M == 1:
                    (self._params["mesh"][0] != self._params["mesh"][2]):
                     raise ValueError(
                         "DipolarP3M requires a cubic box")
-
-            if not (self._params["cao"] >= -1 and self._params["cao"] <= 7):
-                raise ValueError(
-                    "P3M cao has to be an integer between -1 and 7")
-
-            if not (self._params["accuracy"] > 0):
-                raise ValueError("P3M accuracy has to be positive")
 
             if self._params["epsilon"] == "metallic":
                 self._params["epsilon"] = 0.0
@@ -154,20 +143,32 @@ IF DP3M == 1:
             return params
 
         def _set_params_in_es_core(self):
+            if hasattr(self._params["mesh"], "__getitem__"):
+                mesh = self._params["mesh"][0]
+            else:
+                mesh = self._params["mesh"]
+
             self.set_magnetostatics_prefactor()
             dp3m_set_eps(self._params["epsilon"])
-            self.python_dp3m_set_mesh_offset(self._params["mesh_off"])
-            self.python_dp3m_set_params(
-                self._params["r_cut"], self._params["mesh"],
-                self._params["cao"], self._params["alpha"], self._params["accuracy"])
+            dp3m_set_mesh_offset(self._params["mesh_off"][0],
+                                 self._params["mesh_off"][1],
+                                 self._params["mesh_off"][2])
+            dp3m_set_params(self._params["r_cut"], mesh, self._params["cao"],
+                            self._params["alpha"], self._params["accuracy"])
 
         def _tune(self):
+            if hasattr(self._params["mesh"], "__getitem__"):
+                mesh = self._params["mesh"][0]
+            else:
+                mesh = self._params["mesh"]
+
             self.set_magnetostatics_prefactor()
             dp3m_set_eps(self._params["epsilon"])
-            self.python_dp3m_set_tune_params(
-                self._params["r_cut"], self._params["mesh"],
-                self._params["cao"], self._params["accuracy"])
-            python_dp3m_adaptive_tune(self._params["verbose"])
+            dp3m_set_tune_params(self._params["r_cut"], mesh,
+                                 self._params["cao"], self._params["accuracy"])
+            tuning_error = dp3m_adaptive_tune(self._params["verbose"])
+            if tuning_error:
+                handle_errors("DipolarP3M: tuning failed")
             self._params.update(self._get_params_from_es_core())
 
         def _activate_method(self):
@@ -180,46 +181,6 @@ IF DP3M == 1:
         def _deactivate_method(self):
             dp3m_deactivate()
             super()._deactivate_method()
-
-        def python_dp3m_set_mesh_offset(self, mesh_off):
-            cdef double mesh_offset[3]
-            mesh_offset[0] = mesh_off[0]
-            mesh_offset[1] = mesh_off[1]
-            mesh_offset[2] = mesh_off[2]
-            return dp3m_set_mesh_offset(
-                mesh_offset[0], mesh_offset[1], mesh_offset[2])
-
-        def python_dp3m_set_params(self, p_r_cut, p_mesh, p_cao, p_alpha,
-                                   p_accuracy):
-            cdef int mesh
-            cdef double r_cut
-            cdef int cao
-            cdef double alpha
-            cdef double accuracy
-            r_cut = p_r_cut
-            cao = p_cao
-            alpha = p_alpha
-            accuracy = p_accuracy
-            if hasattr(p_mesh, "__getitem__"):
-                mesh = p_mesh[0]
-            else:
-                mesh = p_mesh
-            dp3m_set_params(r_cut, mesh, cao, alpha, accuracy)
-
-        def python_dp3m_set_tune_params(self, p_r_cut, p_mesh, p_cao,
-                                        p_accuracy):
-            cdef int mesh
-            cdef double r_cut
-            cdef int cao
-            cdef double accuracy
-            r_cut = p_r_cut
-            cao = p_cao
-            accuracy = p_accuracy
-            if hasattr(p_mesh, "__getitem__"):
-                mesh = p_mesh[0]
-            else:
-                mesh = p_mesh
-            dp3m_set_tune_params(r_cut, mesh, cao, accuracy)
 
 IF DIPOLES == 1:
     cdef class DipolarDirectSumCpu(MagnetostaticInteraction):

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -166,7 +166,7 @@ IF DP3M == 1:
             dp3m_set_eps(self._params["epsilon"])
             self.python_dp3m_set_tune_params(
                 self._params["r_cut"], self._params["mesh"],
-                self._params["cao"], -1., self._params["accuracy"])
+                self._params["cao"], self._params["accuracy"])
             python_dp3m_adaptive_tune(self._params["verbose"])
             self._params.update(self._get_params_from_es_core())
 
@@ -206,22 +206,20 @@ IF DP3M == 1:
                 mesh = p_mesh
             dp3m_set_params(r_cut, mesh, cao, alpha, accuracy)
 
-        def python_dp3m_set_tune_params(self, p_r_cut, p_mesh, p_cao, p_alpha,
+        def python_dp3m_set_tune_params(self, p_r_cut, p_mesh, p_cao,
                                         p_accuracy):
             cdef int mesh
             cdef double r_cut
             cdef int cao
-            cdef double alpha
             cdef double accuracy
             r_cut = p_r_cut
             cao = p_cao
-            alpha = p_alpha
             accuracy = p_accuracy
             if hasattr(p_mesh, "__getitem__"):
                 mesh = p_mesh[0]
             else:
                 mesh = p_mesh
-            dp3m_set_tune_params(r_cut, mesh, cao, alpha, accuracy)
+            dp3m_set_tune_params(r_cut, mesh, cao, accuracy)
 
 IF DIPOLES == 1:
     cdef class DipolarDirectSumCpu(MagnetostaticInteraction):

--- a/src/python/espressomd/scafacos.pyx
+++ b/src/python/espressomd/scafacos.pyx
@@ -21,8 +21,7 @@ from .actors cimport Actor
 from libcpp.string cimport string  # import std::string
 from . cimport electrostatics
 from . cimport magnetostatics
-from .utils import to_char_pointer, to_str
-from .utils cimport handle_errors
+from .utils import to_char_pointer, to_str, handle_errors
 
 
 include "myconfig.pxi"

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -15,8 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
-from .utils import to_char_pointer, to_str
-from .utils cimport Vector3d, make_array_locked, handle_errors
+from .utils import to_char_pointer, to_str, handle_errors
+from .utils cimport Vector3d, make_array_locked
 
 from libcpp.memory cimport make_shared
 

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -46,8 +46,8 @@ from .globals import Globals
 from .globals cimport FIELD_MAX_OIF_OBJECTS
 from .globals cimport integ_switch, max_oif_objects
 from .globals cimport maximal_cutoff_bonded, maximal_cutoff_nonbonded, mpi_bcast_parameter
-from .utils cimport handle_errors, check_type_or_throw_except
-from .utils import is_valid_type
+from .utils cimport check_type_or_throw_except
+from .utils import is_valid_type, handle_errors
 IF VIRTUAL_SITES:
     from .virtual_sites import ActiveVirtualSitesHandle, VirtualSitesOff
 

--- a/testsuite/python/p3m_fft.py
+++ b/testsuite/python/p3m_fft.py
@@ -113,7 +113,7 @@ class FFT_test(ut.TestCase):
         unsorted_node_grid = self.system.cell_system.node_grid[::-1]
         self.system.cell_system.node_grid = unsorted_node_grid
         solver = espressomd.electrostatics.P3M(prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_p3m_adaptive_tune: ERROR: P3M_init: node grid must be sorted, largest first'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: P3M_init: node grid must be sorted, largest first'):
             self.system.actors.add(solver)
 
     @utx.skipIfMissingFeatures("DP3M")
@@ -126,7 +126,7 @@ class FFT_test(ut.TestCase):
         self.system.cell_system.node_grid = unsorted_node_grid
         solver = espressomd.magnetostatics.DipolarP3M(
             prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_dp3m_adaptive_tune: ERROR: dipolar P3M_init: node grid must be sorted, largest first'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: dipolar P3M_init: node grid must be sorted, largest first'):
             self.system.actors.add(solver)
 
 

--- a/testsuite/python/p3m_tuning_exceptions.py
+++ b/testsuite/python/p3m_tuning_exceptions.py
@@ -49,7 +49,7 @@ class P3M_tuning_test(ut.TestCase):
         self.add_charged_particles()
 
         solver = espressomd.electrostatics.P3MGPU(prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_p3m_adaptive_tune: ERROR: time_step not set'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: time_step not set'):
             self.system.actors.add(solver)
 
     @utx.skipIfMissingFeatures("P3M")
@@ -59,7 +59,7 @@ class P3M_tuning_test(ut.TestCase):
         self.add_charged_particles()
 
         solver = espressomd.electrostatics.P3M(prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_p3m_adaptive_tune: ERROR: time_step not set'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: time_step not set'):
             self.system.actors.add(solver)
 
     @utx.skipIfMissingFeatures("DP3M")
@@ -70,7 +70,7 @@ class P3M_tuning_test(ut.TestCase):
 
         solver = espressomd.magnetostatics.DipolarP3M(
             prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_dp3m_adaptive_tune: ERROR: time_step not set'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: time_step not set'):
             self.system.actors.add(solver)
 
     ##############################################
@@ -85,7 +85,7 @@ class P3M_tuning_test(ut.TestCase):
         self.system.time_step = 0.01
 
         solver = espressomd.electrostatics.P3MGPU(prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_p3m_adaptive_tune: ERROR: no charged particles in the system'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: no charged particles in the system'):
             self.system.actors.add(solver)
 
     @utx.skipIfMissingFeatures("P3M")
@@ -95,7 +95,7 @@ class P3M_tuning_test(ut.TestCase):
         self.system.time_step = 0.01
 
         solver = espressomd.electrostatics.P3M(prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_p3m_adaptive_tune: ERROR: no charged particles in the system'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: no charged particles in the system'):
             self.system.actors.add(solver)
 
     @utx.skipIfMissingFeatures("DP3M")
@@ -106,7 +106,7 @@ class P3M_tuning_test(ut.TestCase):
 
         solver = espressomd.magnetostatics.DipolarP3M(
             prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_dp3m_adaptive_tune: ERROR: no dipolar particles in the system'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: no dipolar particles in the system'):
             self.system.actors.add(solver)
 
     #######################################
@@ -124,7 +124,7 @@ class P3M_tuning_test(ut.TestCase):
 
         solver = espressomd.electrostatics.P3MGPU(
             prefactor=2, accuracy=1e-2, epsilon=1)
-        with self.assertRaisesRegex(Exception, 'python_p3m_adaptive_tune: ERROR: non-metallic epsilon requires cubic box'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: non-metallic epsilon requires cubic box'):
             self.system.actors.add(solver)
 
     @utx.skipIfMissingFeatures("P3M")
@@ -137,7 +137,7 @@ class P3M_tuning_test(ut.TestCase):
 
         solver = espressomd.electrostatics.P3M(
             prefactor=2, accuracy=1e-2, epsilon=1)
-        with self.assertRaisesRegex(Exception, 'python_p3m_adaptive_tune: ERROR: non-metallic epsilon requires cubic box'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: non-metallic epsilon requires cubic box'):
             self.system.actors.add(solver)
 
     @utx.skipIfMissingFeatures("DP3M")
@@ -150,8 +150,67 @@ class P3M_tuning_test(ut.TestCase):
 
         solver = espressomd.magnetostatics.DipolarP3M(
             prefactor=2, accuracy=1e-2)
-        with self.assertRaisesRegex(Exception, 'python_dp3m_adaptive_tune: ERROR: dipolar P3M requires a cubic box'):
+        with self.assertRaisesRegex(Exception, 'P3M: tuning failed: ERROR: dipolar P3M requires a cubic box'):
             self.system.actors.add(solver)
+
+    ##########################################
+    # block of tests with invalid parameters #
+    ##########################################
+
+    def check_invalid_params(self, solver_class, **custom_params):
+        valid_params = {
+            'prefactor': 2, 'accuracy': .01, 'tune': False, 'cao': 1,
+            'r_cut': 3.73e-01, 'alpha': 3.81e+00, 'mesh': (8, 8, 8),
+            'mesh_off': [-1, -1, -1]}
+        valid_params.update(custom_params)
+
+        invalid_params = [
+            ('cao', 0, 'P3M: invalid cao'),
+            ('cao', 8, 'P3M: invalid cao'),
+            ('r_cut', -2.0, 'P3M: invalid r_cut'),
+            ('alpha', -2.0, 'P3M: invalid alpha'),
+            ('accuracy', -2.0, 'P3M: invalid accuracy'),
+            ('mesh', (-1, -1, -1), 'P3M: invalid mesh size'),
+            ('mesh', (0, 0, 0), 'P3M: cao larger than mesh size'),
+            ('mesh_off', (-2, 1, 1), 'P3M: invalid mesh offset'),
+        ]
+
+        for key, invalid_value, err_msg in invalid_params:
+            params = valid_params.copy()
+            params[key] = invalid_value
+            solver = solver_class(**params)
+            with self.assertRaisesRegex(RuntimeError, err_msg):
+                self.system.actors.add(solver)
+            self.system.actors.clear()
+
+    @utx.skipIfMissingFeatures("P3M")
+    def test_04_invalid_params_p3m_cpu(self):
+        import espressomd.electrostatics
+
+        self.system.time_step = 0.01
+        self.add_charged_particles()
+
+        self.check_invalid_params(espressomd.electrostatics.P3M)
+
+    @utx.skipIfMissingGPU()
+    @utx.skipIfMissingFeatures("P3M")
+    def test_04_invalid_params_p3m_gpu(self):
+        import espressomd.electrostatics
+
+        self.system.time_step = 0.01
+        self.add_charged_particles()
+
+        self.check_invalid_params(espressomd.electrostatics.P3MGPU,
+                                  mesh=3 * [28], alpha=0.3548, r_cut=4.4434)
+
+    @utx.skipIfMissingFeatures("DP3M")
+    def test_04_invalid_params_dp3m_cpu(self):
+        import espressomd.magnetostatics
+
+        self.system.time_step = 0.01
+        self.add_magnetic_particles()
+
+        self.check_invalid_params(espressomd.magnetostatics.DipolarP3M)
 
     ###########################################################
     # block of tests where tuning should not throw exceptions #
@@ -179,12 +238,20 @@ class P3M_tuning_test(ut.TestCase):
         self.system.time_step = 0.01
         self.add_charged_particles()
 
-        solver = espressomd.electrostatics.P3M(prefactor=2, accuracy=1e-2,
-                                               epsilon='metallic')
-        try:
-            self.system.actors.add(solver)
-        except Exception as err:
-            self.fail('tuning raised Exception("' + str(err) + '")')
+        solver = espressomd.electrostatics.P3M(prefactor=2, accuracy=0.1)
+        valid_params = {
+            'mesh_off': solver.default_params()['mesh_off'],  # sentinel
+            'cao': 2, 'r_cut': 3.18, 'mesh': 8}
+
+        # tuning with cao or r_cut or mesh constrained, or without constraints
+        for key, value in valid_params.items():
+            solver = espressomd.electrostatics.P3M(
+                prefactor=2, accuracy=1e-2, epsilon=0.0, **{key: value})
+            try:
+                self.system.actors.add(solver)
+            except Exception as err:
+                self.fail('tuning raised Exception("' + str(err) + '")')
+            self.system.actors.clear()
 
     @utx.skipIfMissingFeatures("DP3M")
     def test_09_no_errors_dp3m_cpu(self):
@@ -194,11 +261,20 @@ class P3M_tuning_test(ut.TestCase):
         self.add_magnetic_particles()
 
         solver = espressomd.magnetostatics.DipolarP3M(
-            prefactor=2, accuracy=1e-2)
-        try:
-            self.system.actors.add(solver)
-        except Exception as err:
-            self.fail('tuning raised Exception("' + str(err) + '")')
+            prefactor=2, accuracy=0.1)
+        valid_params = {
+            'mesh_off': solver.default_params()['mesh_off'],  # sentinel
+            'cao': 1, 'r_cut': 3.28125, 'mesh': 5}
+
+        # tuning with cao or r_cut or mesh constrained, or without constraints
+        for key, value in valid_params.items():
+            solver = espressomd.magnetostatics.DipolarP3M(
+                prefactor=2, accuracy=1e-2, **{key: value})
+            try:
+                self.system.actors.add(solver)
+            except Exception as err:
+                self.fail('tuning raised Exception("' + str(err) + '")')
+            self.system.actors.clear()
 
     @utx.skipIfMissingFeatures("P3M")
     def test_09_no_errors_p3m_cpu_rescale_mesh(self):


### PR DESCRIPTION
Fixes #4117

Description of changes:
- raise `RuntimeError` when a P3M/DP3M actor is instantiated with incorrect parameters, instead of silently ignoring the error code from the core and leaving the core struct in an undefined state (e.g. an incorrect `alpha` would cause the core setter to return early with an unhandled error code, leaving `alpha` and `accuracy` uninitialized in the core)
- move error messages in the P3M/DP3M setters from Cython to the core and fix misleading ELC error messages
- remove the possibility to constrain `alpha` during tuning (had no effect: `alpha` is derived from the other parameters)
- restore the python interface of the P3M mesh offset parameter
- remove ~120 lines of duplicated Cython code
