### PR TITLE
Script interface maintenance

### DIFF
--- a/src/core/RuntimeErrorStream.cpp
+++ b/src/core/RuntimeErrorStream.cpp
@@ -22,8 +22,7 @@
 #include <utility>
 
 namespace ErrorHandling {
-/** ostringstream is not copyable, but it is fine here to copy just the content.
- */
+// ostringstream is not copyable, but it is fine here to copy just the content.
 RuntimeErrorStream::RuntimeErrorStream(const RuntimeErrorStream &rhs)
     : m_ec(rhs.m_ec), m_line(rhs.m_line), m_file(rhs.m_file),
       m_function(rhs.m_function) {

--- a/src/python/espressomd/actors.pyx
+++ b/src/python/espressomd/actors.pyx
@@ -79,7 +79,7 @@ cdef class Actor:
         if inter in Actor.active_list:
             if not Actor.active_list[inter]:
                 raise Exception(
-                    "Class not registered in Actor.active_list " + self.__class__.__bases__[0])
+                    "Class not registered in Actor.active_list: " + self.__class__.__bases__[0].__name__)
             Actor.active_list[inter] = False
 
     def is_valid(self):

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -342,9 +342,9 @@ class ForceField(_Interpolated):
         Spacing of the grid points.
     default_scale : :obj:`float`
         Scaling factor for particles that have no individual scaling factor.
-    particle_scales : array_like of (:obj:`int`, :obj:`float`)
-        A list of tuples of ids and scaling factors. For
-        particles in the list the interaction is scaled with
+    particle_scales : :obj:`dict`(:obj:`int`, :obj:`float`)
+        A dictionary mapping particle ids to scaling factors.
+        For these particles, the interaction is scaled with
         their individual scaling factor. Other particles are
         scaled with the default scaling factor.
 
@@ -374,9 +374,9 @@ class PotentialField(_Interpolated):
         Spacing of the grid points.
     default_scale : :obj:`float`
         Scaling factor for particles that have no individual scaling factor.
-    particle_scales : array_like (:obj:`int`, :obj:`float`)
-        A list of tuples of ids and scaling factors. For
-        particles in the list the interaction is scaled with
+    particle_scales : :obj:`dict`(:obj:`int`, :obj:`float`)
+        A dictionary mapping particle ids to scaling factors.
+        For these particles, the interaction is scaled with
         their individual scaling factor. Other particles are
         scaled with the default scaling factor.
 

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -342,7 +342,7 @@ class ForceField(_Interpolated):
         Spacing of the grid points.
     default_scale : :obj:`float`
         Scaling factor for particles that have no individual scaling factor.
-    particle_scales : :obj:`dict`(:obj:`int`, :obj:`float`)
+    particle_scales : :obj:`dict`
         A dictionary mapping particle ids to scaling factors.
         For these particles, the interaction is scaled with
         their individual scaling factor. Other particles are
@@ -374,7 +374,7 @@ class PotentialField(_Interpolated):
         Spacing of the grid points.
     default_scale : :obj:`float`
         Scaling factor for particles that have no individual scaling factor.
-    particle_scales : :obj:`dict`(:obj:`int`, :obj:`float`)
+    particle_scales : :obj:`dict`
         A dictionary mapping particle ids to scaling factors.
         For these particles, the interaction is scaled with
         their individual scaling factor. Other particles are

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -345,7 +345,8 @@ class ForceField(_Interpolated):
     particle_scales : array_like of (:obj:`int`, :obj:`float`)
         A list of tuples of ids and scaling factors. For
         particles in the list the interaction is scaled with
-        their individual scaling factor before it is applied.
+        their individual scaling factor. Other particles are
+        scaled with the default scaling factor.
 
     """
 
@@ -376,7 +377,8 @@ class PotentialField(_Interpolated):
     particle_scales : array_like (:obj:`int`, :obj:`float`)
         A list of tuples of ids and scaling factors. For
         particles in the list the interaction is scaled with
-        their individual scaling factor before it is applied.
+        their individual scaling factor. Other particles are
+        scaled with the default scaling factor.
 
     """
 

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -195,6 +195,8 @@ cdef Variant python_object_to_variant(value):
     if isinstance(value, PScriptInterface):
         oref = value.get_sip()
         return make_variant(oref.sip)
+    elif isinstance(value, dict):
+        raise TypeError("No conversion from type dict to Variant")
     elif hasattr(value, '__iter__') and not(type(value) == str):
         for e in value:
             vec.push_back(python_object_to_variant(e))
@@ -208,7 +210,8 @@ cdef Variant python_object_to_variant(value):
     elif np.issubdtype(np.dtype(type(value)), np.floating):
         return make_variant[double](value)
     else:
-        raise TypeError("Unknown type for conversion to Variant")
+        raise TypeError(
+            f"No conversion from type {type(value).__name__} to Variant")
 
 cdef variant_to_python_object(const Variant & value) except +:
     """Convert C++ Variant objects to Python objects."""

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -184,6 +184,7 @@ cdef Variant python_object_to_variant(value):
     """Convert Python objects to C++ Variant objects."""
 
     cdef vector[Variant] vec
+    cdef unordered_map[int, Variant] vmap
     cdef PObjectRef oref
 
     if value is None:
@@ -196,7 +197,12 @@ cdef Variant python_object_to_variant(value):
         oref = value.get_sip()
         return make_variant(oref.sip)
     elif isinstance(value, dict):
-        raise TypeError("No conversion from type dict to Variant")
+        for k, v in value.items():
+            if not isinstance(k, int):
+                raise TypeError(
+                    f"No conversion from type dict_item([({type(k).__name__}, {type(v).__name__})]) to Variant[std::unordered_map<int, Variant>]")
+            vmap[k] = python_object_to_variant(v)
+        return make_variant[unordered_map[int, Variant]](vmap)
     elif hasattr(value, '__iter__') and not(type(value) == str):
         for e in value:
             vec.push_back(python_object_to_variant(e))
@@ -217,6 +223,7 @@ cdef variant_to_python_object(const Variant & value) except +:
     """Convert C++ Variant objects to Python objects."""
 
     cdef vector[Variant] vec
+    cdef unordered_map[int, Variant] vmap
     cdef shared_ptr[ObjectHandle] ptr
     if is_none(value):
         return None
@@ -264,6 +271,14 @@ cdef variant_to_python_object(const Variant & value) except +:
 
         for i in vec:
             res.append(variant_to_python_object(i))
+
+        return res
+    if is_type[unordered_map[int, Variant]](value):
+        vmap = get_value[unordered_map[int, Variant]](value)
+        res = {}
+
+        for kv in vmap:
+            res[kv.first] = variant_to_python_object(kv.second)
 
         return res
 

--- a/src/python/espressomd/visualization_opengl.py
+++ b/src/python/espressomd/visualization_opengl.py
@@ -1931,6 +1931,7 @@ class Cylinder(Shape):
         self.axis = np.array(self.shape.get_parameter('axis'))
         self.length = self.shape.get_parameter('length')
         self.radius = self.shape.get_parameter('radius')
+        self.open = self.shape.get_parameter('open')
         self.cap_center_1 = self.center - self.axis / \
             np.linalg.norm(self.axis) * 0.5 * self.length
         self.cap_center_2 = self.center + self.axis / \
@@ -1939,7 +1940,7 @@ class Cylinder(Shape):
     def draw(self):
         draw_cylinder(self.cap_center_1, self.cap_center_2,
                       self.radius, self.color, self.material,
-                      self.quality, draw_caps=True)
+                      self.quality, draw_caps=not self.open)
 
 
 class Ellipsoid(Shape):

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -28,6 +28,7 @@
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/string.hpp>
+#include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/variant.hpp>
 #include <boost/serialization/vector.hpp>
 
@@ -52,7 +53,8 @@ constexpr const None none{};
 using Variant = boost::make_recursive_variant<
     None, bool, int, size_t, double, std::string, std::vector<int>,
     std::vector<double>, ObjectRef, std::vector<boost::recursive_variant_>,
-    Utils::Vector2d, Utils::Vector3d, Utils::Vector4d>::type;
+    Utils::Vector2d, Utils::Vector3d, Utils::Vector4d,
+    std::unordered_map<int, boost::recursive_variant_>>::type;
 
 using VariantMap = std::unordered_map<std::string, Variant>;
 

--- a/src/script_interface/constraints/couplings.hpp
+++ b/src/script_interface/constraints/couplings.hpp
@@ -72,15 +72,8 @@ template <> struct coupling_parameters_impl<Scaled> {
                 AutoParameter::read_only,
                 [this_]() { return this_().default_scale(); },
             },
-            {"particle_scales", AutoParameter::read_only, [this_]() {
-               std::vector<Variant> ret{};
-               auto const map = this_().particle_scales();
-               for (auto const &kv : map) {
-                 auto const kv_vec = std::vector<Variant>{kv.first, kv.second};
-                 ret.push_back(kv_vec);
-               }
-               return ret;
-             }}};
+            {"particle_scales", AutoParameter::read_only,
+             [this_]() { return make_map(this_().particle_scales()); }}};
   }
 };
 
@@ -95,8 +88,8 @@ template <> inline Viscous make_coupling<Viscous>(const VariantMap &params) {
 }
 
 template <> inline Scaled make_coupling<Scaled>(const VariantMap &params) {
-  auto particle_scales =
-      get_value_or<std::vector<Variant>>(params, "particle_scales", {});
+  auto const particle_scales = get_value_or<std::unordered_map<int, Variant>>(
+      params, "particle_scales", {});
   return Scaled{get_map<int, double>(particle_scales),
                 get_value<double>(params, "default_scale")};
 }

--- a/src/script_interface/constraints/couplings.hpp
+++ b/src/script_interface/constraints/couplings.hpp
@@ -27,8 +27,7 @@
 
 #include "script_interface/ScriptInterface.hpp"
 
-#include <utils/serialization/pack.hpp>
-#include <utils/serialization/unordered_map.hpp>
+#include <unordered_map>
 
 namespace ScriptInterface {
 namespace Constraints {
@@ -78,10 +77,17 @@ template <> struct coupling_parameters_impl<Scaled> {
             {"particle_scales",
              [this_](const Variant &v) {
                this_().particle_scales() =
-                   Utils::unpack<std::unordered_map<int, double>>(
-                       boost::get<std::string>(v));
+                   get_map<int, double>(get_value<std::vector<Variant>>(v));
              },
-             [this_]() { return Utils::pack(this_().particle_scales()); }}};
+             [this_]() {
+               std::vector<Variant> ret{};
+               auto const map = this_().particle_scales();
+               for (auto const &kv : map) {
+                 auto const kv_vec = std::vector<Variant>{kv.first, kv.second};
+                 ret.push_back(kv_vec);
+               }
+               return ret;
+             }}};
   }
 };
 
@@ -96,12 +102,10 @@ template <> inline Viscous make_coupling<Viscous>(const VariantMap &params) {
 }
 
 template <> inline Scaled make_coupling<Scaled>(const VariantMap &params) {
-  auto scales = params.count("particle_scale")
-                    ? Utils::unpack<std::unordered_map<int, double>>(
-                          get_value<std::string>(params, "particle_scale"))
-                    : std::unordered_map<int, double>{};
-
-  return Scaled{scales, get_value<double>(params, "default_scale")};
+  auto particle_scales =
+      get_value_or<std::vector<Variant>>(params, "particle_scales", {});
+  return Scaled{get_map<int, double>(particle_scales),
+                get_value<double>(params, "default_scale")};
 }
 } // namespace detail
 } // namespace Constraints

--- a/src/script_interface/constraints/couplings.hpp
+++ b/src/script_interface/constraints/couplings.hpp
@@ -58,7 +58,7 @@ template <> struct coupling_parameters_impl<Viscous> {
   static std::vector<AutoParameter> params(const This &this_) {
     return {{
         "gamma",
-        [this_](const Variant &v) { this_().gamma() = get_value<double>(v); },
+        AutoParameter::read_only,
         [this_]() { return this_().gamma(); },
     }};
   }
@@ -69,17 +69,10 @@ template <> struct coupling_parameters_impl<Scaled> {
   static std::vector<AutoParameter> params(const This &this_) {
     return {{
                 "default_scale",
-                [this_](const Variant &v) {
-                  this_().default_scale() = get_value<double>(v);
-                },
+                AutoParameter::read_only,
                 [this_]() { return this_().default_scale(); },
             },
-            {"particle_scales",
-             [this_](const Variant &v) {
-               this_().particle_scales() =
-                   get_map<int, double>(get_value<std::vector<Variant>>(v));
-             },
-             [this_]() {
+            {"particle_scales", AutoParameter::read_only, [this_]() {
                std::vector<Variant> ret{};
                auto const map = this_().particle_scales();
                for (auto const &kv : map) {

--- a/src/script_interface/constraints/couplings.hpp
+++ b/src/script_interface/constraints/couplings.hpp
@@ -19,6 +19,15 @@
 #ifndef SCRIPT_INTERFACE_CONSTRAINTS_DETAIL_COUPLINGS_HPP
 #define SCRIPT_INTERFACE_CONSTRAINTS_DETAIL_COUPLINGS_HPP
 
+/**
+ * @file
+ * @brief ScriptInterface implementations for the
+ *        various couplings provided.
+ *
+ * These are separated from the Constraints because
+ * they can be reused together with the couplings themselves.
+ */
+
 #include "core/field_coupling/couplings/Charge.hpp"
 #include "core/field_coupling/couplings/Direct.hpp"
 #include "core/field_coupling/couplings/Mass.hpp"
@@ -33,14 +42,6 @@ namespace ScriptInterface {
 namespace Constraints {
 namespace detail {
 using namespace ::FieldCoupling::Coupling;
-
-/**
- * @brief ScriptInterface implementations for the
- *        various couplings provided.
- *
- * These are separated from the Constraints because
- * they can be reused together with the couplings themselves.
- */
 
 /**
  * Default version for parameterless couplings.

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -160,6 +160,26 @@ template <> struct get_value_helper<std::vector<double>, void> {
   }
 };
 
+template <typename K, typename T>
+struct GetMapOrEmpty : boost::static_visitor<std::unordered_map<K, T>> {
+  /* Catch all case -> wrong type. */
+  template <typename U> std::unordered_map<K, T> operator()(U const &) const {
+    throw boost::bad_get{};
+  }
+
+  /* Standard case, correct type */
+  std::unordered_map<K, T> operator()(std::unordered_map<K, T> const &v) const {
+    return v;
+  }
+};
+
+/* std::unordered_map cases */
+template <> struct get_value_helper<std::unordered_map<int, Variant>, void> {
+  std::unordered_map<int, Variant> operator()(Variant const &v) const {
+    return boost::apply_visitor(GetMapOrEmpty<int, Variant>{}, v);
+  }
+};
+
 /* This allows direct retrieval of a shared_ptr to the object from
    an ObjectId variant. If the type is a derived type, the type is
    also checked.
@@ -211,6 +231,33 @@ template <typename T> T get_value(Variant const &v) {
     throw Exception("Provided argument of type " + detail::type_label(v) +
                     " is not convertible to " + Utils::demangle<T>());
   }
+}
+
+template <typename K, typename V>
+std::unordered_map<K, V> get_map(std::unordered_map<K, Variant> const &v) {
+  std::unordered_map<K, V> ret;
+  auto it = v.begin();
+  try {
+    for (; it != v.end(); ++it) {
+      ret.insert({it->first, detail::get_value_helper<V>{}(it->second)});
+    }
+  } catch (const boost::bad_get &) {
+    throw Exception("Provided map value of type " +
+                    detail::type_label(it->second) + " is not convertible to " +
+                    Utils::demangle<V>() +
+                    " (raised during the creation of a " +
+                    Utils::demangle<std::unordered_map<K, V>>() + ")");
+  }
+  return ret;
+}
+
+template <typename K, typename V>
+std::unordered_map<K, Variant> make_map(std::unordered_map<K, V> const &v) {
+  std::unordered_map<K, Variant> ret;
+  for (auto const &it : v) {
+    ret.insert({it.first, Variant(it.second)});
+  }
+  return ret;
 }
 
 /**

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -256,6 +256,21 @@ template <typename T>
 void set_from_args(T &dst, VariantMap const &vals, const char *name) {
   dst = get_value<T>(vals, name);
 }
+
+/**
+ * @brief Convert a list of 2-tuples to an unordered map.
+ * Typically used for python dict objects, which have to be passed as
+ * lists of tuples using <tt>list(argument.items())</tt>.
+ */
+template <typename K, typename T>
+std::unordered_map<K, T> get_map(const std::vector<Variant> &vv) {
+  std::unordered_map<K, T> ret{};
+  for (auto const &kv : vv) {
+    auto const kv_vec = get_value<std::vector<Variant>>(kv);
+    ret.insert({get_value<K>(kv_vec.at(0)), get_value<T>(kv_vec.at(1))});
+  }
+  return ret;
+}
 } /* namespace ScriptInterface */
 
 #endif

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -303,21 +303,6 @@ template <typename T>
 void set_from_args(T &dst, VariantMap const &vals, const char *name) {
   dst = get_value<T>(vals, name);
 }
-
-/**
- * @brief Convert a list of 2-tuples to an unordered map.
- * Typically used for python dict objects, which have to be passed as
- * lists of tuples using <tt>list(argument.items())</tt>.
- */
-template <typename K, typename T>
-std::unordered_map<K, T> get_map(const std::vector<Variant> &vv) {
-  std::unordered_map<K, T> ret{};
-  for (auto const &kv : vv) {
-    auto const kv_vec = get_value<std::vector<Variant>>(kv);
-    ret.insert({get_value<K>(kv_vec.at(0)), get_value<T>(kv_vec.at(1))});
-  }
-  return ret;
-}
 } /* namespace ScriptInterface */
 
 #endif

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -93,7 +93,7 @@ struct vector_conversion_visitor : boost::static_visitor<Utils::Vector<T, N>> {
     return v;
   }
 
-  /* We try do unpack variant vectors and check if they
+  /* We try to unpack variant vectors and check if they
    * are convertible element by element. */
   auto operator()(std::vector<Variant> const &vv) const {
     if (N != vv.size()) {

--- a/src/shapes/unit_tests/CMakeLists.txt
+++ b/src/shapes/unit_tests/CMakeLists.txt
@@ -6,3 +6,5 @@ unit_test(NAME Union_test SRC Union_test.cpp DEPENDS EspressoShapes
           EspressoUtils)
 unit_test(NAME Ellipsoid_test SRC Ellipsoid_test.cpp DEPENDS EspressoShapes
           EspressoUtils)
+unit_test(NAME NoWhere_test SRC NoWhere_test.cpp DEPENDS EspressoShapes
+          EspressoUtils)

--- a/src/shapes/unit_tests/NoWhere_test.cpp
+++ b/src/shapes/unit_tests/NoWhere_test.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2010-2021 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE NoWhere test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <shapes/NoWhere.hpp>
+#include <shapes/Shape.hpp>
+
+#include <utils/Vector.hpp>
+
+#include <limits>
+
+bool check_distance_function(const Shapes::Shape &s) {
+  constexpr auto infinity = std::numeric_limits<double>::infinity();
+  for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
+      for (int k = 0; k < 10; k++) {
+        Utils::Vector3d pos = {i * 0.5, j * 0.5, k * 0.5};
+        Utils::Vector3d dist{};
+        double d;
+
+        s.calculate_dist(pos, d, dist);
+        if (d != infinity) {
+          return false;
+        }
+
+        for (auto xyz : dist) {
+          if (xyz != infinity) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+BOOST_AUTO_TEST_CASE(dist_function) {
+  Shapes::NoWhere nw;
+
+  BOOST_CHECK(check_distance_function(nw));
+}

--- a/src/shapes/unit_tests/NoWhere_test.cpp
+++ b/src/shapes/unit_tests/NoWhere_test.cpp
@@ -30,25 +30,26 @@
 
 #include <limits>
 
-bool check_distance_function(const Shapes::Shape &s) {
+bool dist_is_always_inf(const Shapes::Shape &s) {
   constexpr auto infinity = std::numeric_limits<double>::infinity();
-  for (int i = 0; i < 10; i++) {
-    for (int j = 0; j < 10; j++) {
-      for (int k = 0; k < 10; k++) {
-        Utils::Vector3d pos = {i * 0.5, j * 0.5, k * 0.5};
-        Utils::Vector3d dist{};
-        double d;
 
-        s.calculate_dist(pos, d, dist);
-        if (d != infinity) {
-          return false;
-        }
+  Utils::Vector3d const positions[2] = {
+      {0.0, 1.0, 2.0},
+      {-10.0, 0.1, 5.0},
+  };
 
-        for (auto xyz : dist) {
-          if (xyz != infinity) {
-            return false;
-          }
-        }
+  for (auto const &pos : positions) {
+    Utils::Vector3d dist{};
+    double d;
+
+    s.calculate_dist(pos, d, dist);
+    if (d != infinity) {
+      return false;
+    }
+
+    for (auto xyz : dist) {
+      if (xyz != infinity) {
+        return false;
       }
     }
   }
@@ -59,5 +60,5 @@ bool check_distance_function(const Shapes::Shape &s) {
 BOOST_AUTO_TEST_CASE(dist_function) {
   Shapes::NoWhere nw;
 
-  BOOST_CHECK(check_distance_function(nw));
+  BOOST_CHECK(dist_is_always_inf(nw));
 }

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -205,6 +205,8 @@ class ShapeBasedConstraintTest(ut.TestCase):
         # change ellipsoid parameters instead of creating a new constraint
         e.a = 1.
         e.b = 1.
+        self.assertAlmostEqual(e.a, 1.)
+        self.assertAlmostEqual(e.b, 1.)
 
         radii = np.linspace(1., 6.5, 7)
 

--- a/testsuite/python/elc.py
+++ b/testsuite/python/elc.py
@@ -33,12 +33,12 @@ class ElcTest(ut.TestCase):
     system.cell_system.skin = 0.0
 
     def test_finite_potential_drop(self):
-        s = self.system
+        system = self.system
 
-        p1 = s.part.add(pos=[0, 0, 1], q=+1)
-        p2 = s.part.add(pos=[0, 0, 9], q=-1)
+        p1 = system.part.add(pos=[0, 0, 1], q=+1)
+        p2 = system.part.add(pos=[0, 0, 9], q=-1)
 
-        s.actors.add(
+        system.actors.add(
             electrostatics.P3M(
                 # zero is not allowed
                 prefactor=1e-100,
@@ -47,7 +47,7 @@ class ElcTest(ut.TestCase):
                 accuracy=1e-3,
             ))
 
-        s.actors.add(
+        system.actors.add(
             electrostatic_extensions.ELC(
                 gap_size=GAP[2],
                 maxPWerror=1e-3,
@@ -58,7 +58,7 @@ class ElcTest(ut.TestCase):
             ))
 
         # Calculated energy
-        U_elc = s.analysis.energy()['coulomb']
+        U_elc = system.analysis.energy()['coulomb']
 
         # Expected E-Field is voltage drop over the box
         E_expected = POTENTIAL_DIFFERENCE / (BOX_L[2] - GAP[2])
@@ -67,7 +67,7 @@ class ElcTest(ut.TestCase):
 
         self.assertAlmostEqual(U_elc, U_expected)
 
-        s.integrator.run(0)
+        system.integrator.run(0)
         self.assertAlmostEqual(E_expected, p1.f[2] / p1.q)
         self.assertAlmostEqual(E_expected, p2.f[2] / p2.q)
 
@@ -76,14 +76,14 @@ class ElcTest(ut.TestCase):
         p1.pos = [BOX_L[0] / 2, BOX_L[1] / 2, BOX_L[2] - GAP[2] / 2]
         with self.assertRaises(Exception):
             self.system.analysis.energy()
-        with self.assertRaises(Exception):
-            self.integrator.run(2)
+        with self.assertRaises(Exception, msg='entered ELC gap region'):
+            self.system.integrator.run(2)
         # negative direction
         p1.pos = [BOX_L[0] / 2, BOX_L[1] / 2, -GAP[2] / 2]
         with self.assertRaises(Exception):
             self.system.analysis.energy()
-        with self.assertRaises(Exception):
-            self.integrator.run(2)
+        with self.assertRaises(Exception, msg='entered ELC gap region'):
+            self.system.integrator.run(2)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/field_test.py
+++ b/testsuite/python/field_test.py
@@ -89,6 +89,14 @@ class FieldTest(ut.TestCase):
         self.assertAlmostEqual(self.system.analysis.energy()['total'],
                                self.system.analysis.energy()['external_fields'])
 
+        np.testing.assert_allclose(
+            electric_field.call_method("_eval_field", x=[0, 0, 0]), phi0)
+        np.testing.assert_allclose(
+            electric_field.call_method("_eval_field", x=[3, 2, 1]),
+            np.dot(-E, [3, 2, 1]) + phi0)
+        np.testing.assert_allclose(
+            electric_field.call_method("_eval_jacobian", x=[3, 2, 1]), -E)
+
     @utx.skipIfMissingFeatures("ELECTROSTATICS")
     def test_electric_plane_wave(self):
         E0 = np.array([1., -2., 3.])
@@ -146,10 +154,14 @@ class FieldTest(ut.TestCase):
             box, h, self.potential)
 
         F = constraints.PotentialField(field=field_data, grid_spacing=h,
+                                       particle_scales=[[1, 0.0]],
                                        default_scale=scaling)
 
         p = self.system.part.add(pos=[0, 0, 0])
+        self.system.part.add(pos=[1, 0, 0])
         self.system.constraints.add(F)
+        self.assertAlmostEqual(F.default_scale, scaling, delta=1e-9)
+        self.assertEqual(F.particle_scales, [[1, 0.0]])
 
         for i in product(*map(range, 3 * [10])):
             x = (h * i)
@@ -198,10 +210,13 @@ class FieldTest(ut.TestCase):
         field_data = constraints.ForceField.field_from_fn(box, h, self.force)
 
         F = constraints.ForceField(field=field_data, grid_spacing=h,
+                                   particle_scales=[(1, 0.0)],
                                    default_scale=scaling)
 
         p = self.system.part.add(pos=[0, 0, 0])
         self.system.constraints.add(F)
+        self.assertAlmostEqual(F.default_scale, scaling, delta=1e-9)
+        self.assertEqual(F.particle_scales, [[1, 0.0]])
 
         for i in product(*map(range, 3 * [10])):
             x = (h * i)

--- a/testsuite/python/field_test.py
+++ b/testsuite/python/field_test.py
@@ -162,6 +162,10 @@ class FieldTest(ut.TestCase):
         self.system.constraints.add(F)
         self.assertAlmostEqual(F.default_scale, scaling, delta=1e-9)
         self.assertEqual(F.particle_scales, [[1, 0.0]])
+        with self.assertRaisesRegex(RuntimeError, 'Parameter default_scale is read-only'):
+            F.default_scale = 2.0
+        with self.assertRaisesRegex(RuntimeError, 'Parameter particle_scales is read-only'):
+            F.particle_scales = {0: 0.0}
 
         for i in product(*map(range, 3 * [10])):
             x = (h * i)
@@ -217,6 +221,10 @@ class FieldTest(ut.TestCase):
         self.system.constraints.add(F)
         self.assertAlmostEqual(F.default_scale, scaling, delta=1e-9)
         self.assertEqual(F.particle_scales, [[1, 0.0]])
+        with self.assertRaisesRegex(RuntimeError, 'Parameter default_scale is read-only'):
+            F.default_scale = 2.0
+        with self.assertRaisesRegex(RuntimeError, 'Parameter particle_scales is read-only'):
+            F.particle_scales = {0: 0.0}
 
         for i in product(*map(range, 3 * [10])):
             x = (h * i)
@@ -241,6 +249,8 @@ class FieldTest(ut.TestCase):
 
         p = self.system.part.add(pos=[0, 0, 0], v=[1, 2, 3])
         self.system.constraints.add(F)
+        with self.assertRaisesRegex(RuntimeError, 'Parameter gamma is read-only'):
+            F.gamma = 2.0
 
         for i in product(*map(range, 3 * [10])):
             x = (h * i)

--- a/testsuite/python/field_test.py
+++ b/testsuite/python/field_test.py
@@ -154,14 +154,14 @@ class FieldTest(ut.TestCase):
             box, h, self.potential)
 
         F = constraints.PotentialField(field=field_data, grid_spacing=h,
-                                       particle_scales=[[1, 0.0]],
+                                       particle_scales={1: 0.0},
                                        default_scale=scaling)
 
         p = self.system.part.add(pos=[0, 0, 0])
         self.system.part.add(pos=[1, 0, 0])
         self.system.constraints.add(F)
         self.assertAlmostEqual(F.default_scale, scaling, delta=1e-9)
-        self.assertEqual(F.particle_scales, [[1, 0.0]])
+        self.assertEqual(F.particle_scales, {1: 0.0})
         with self.assertRaisesRegex(RuntimeError, 'Parameter default_scale is read-only'):
             F.default_scale = 2.0
         with self.assertRaisesRegex(RuntimeError, 'Parameter particle_scales is read-only'):
@@ -214,13 +214,13 @@ class FieldTest(ut.TestCase):
         field_data = constraints.ForceField.field_from_fn(box, h, self.force)
 
         F = constraints.ForceField(field=field_data, grid_spacing=h,
-                                   particle_scales=[(1, 0.0)],
+                                   particle_scales={1: 0.0},
                                    default_scale=scaling)
 
         p = self.system.part.add(pos=[0, 0, 0])
         self.system.constraints.add(F)
         self.assertAlmostEqual(F.default_scale, scaling, delta=1e-9)
-        self.assertEqual(F.particle_scales, [[1, 0.0]])
+        self.assertEqual(F.particle_scales, {1: 0.0})
         with self.assertRaisesRegex(RuntimeError, 'Parameter default_scale is read-only'):
             F.default_scale = 2.0
         with self.assertRaisesRegex(RuntimeError, 'Parameter particle_scales is read-only'):

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -138,7 +138,8 @@ pot_field_data = constraints.ElectricPotential.field_from_fn(
     system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
 checkpoint.register("pot_field_data")
 system.constraints.add(constraints.PotentialField(
-    field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6))
+    field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6,
+    particle_scales=[(5, 6.0)]))
 vec_field_data = constraints.ForceField.field_from_fn(
     system.box_l, np.ones(3), lambda x: 10 * np.ones(3) - x)
 checkpoint.register("vec_field_data")

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -139,7 +139,7 @@ pot_field_data = constraints.ElectricPotential.field_from_fn(
 checkpoint.register("pot_field_data")
 system.constraints.add(constraints.PotentialField(
     field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6,
-    particle_scales=[(5, 6.0)]))
+    particle_scales={5: 6.0}))
 vec_field_data = constraints.ForceField.field_from_fn(
     system.box_l, np.ones(3), lambda x: 10 * np.ones(3) - x)
 checkpoint.register("vec_field_data")

--- a/testsuite/python/shapes.py
+++ b/testsuite/python/shapes.py
@@ -27,8 +27,21 @@ class ShapeTests(ut.TestCase):
         union = espressomd.shapes.Union()
         wall1 = espressomd.shapes.Wall(normal=[0, 0, 1], dist=0)
         wall2 = espressomd.shapes.Wall(normal=[0, 0, -1], dist=-10)
+        self.assertTrue(union.call_method('empty'))
         union.add([wall1, wall2])
+        self.assertFalse(union.call_method('empty'))
         self.assertEqual(union.size(), 2)
+
+        # check object retrieval
+        pwall1, pwall2 = union.call_method('get_elements')
+        self.assertIsInstance(pwall1, espressomd.shapes.Wall)
+        self.assertIsInstance(pwall2, espressomd.shapes.Wall)
+        np.testing.assert_almost_equal(
+            np.copy(pwall1.normal), np.copy(wall1.normal))
+        np.testing.assert_almost_equal(
+            np.copy(pwall2.normal), np.copy(wall2.normal))
+        np.testing.assert_almost_equal(pwall1.dist, wall1.dist)
+        np.testing.assert_almost_equal(pwall2.dist, wall2.dist)
 
         self.assertAlmostEqual(union.calc_distance(
             position=[1, 2, 4.5])[0], 4.5)
@@ -41,6 +54,7 @@ class ShapeTests(ut.TestCase):
         with self.assertRaises(ValueError):
             union.calc_distance(position=[1, 2, 11.5])
         union.clear()
+        self.assertTrue(union.call_method('empty'))
         self.assertEqual(union.size(), 0)
         self.assertEqual(union.calc_distance(position=[1, 2, 6.5])[0], np.inf)
 

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -367,6 +367,7 @@ class CheckpointTest(ut.TestCase):
         self.assertIsInstance(c[5], constraints.PotentialField)
         self.assertEqual(c[5].field.shape, (14, 16, 18, 1))
         self.assertAlmostEqual(c[5].default_scale, 1.6, delta=1E-10)
+        np.testing.assert_allclose(c[5].particle_scales, [[5, 6]], atol=1e-10)
         np.testing.assert_allclose(np.copy(c[5].origin), [-0.5, -0.5, -0.5])
         np.testing.assert_allclose(np.copy(c[5].grid_spacing), np.ones(3))
         ref_pot = constraints.PotentialField(

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -367,7 +367,7 @@ class CheckpointTest(ut.TestCase):
         self.assertIsInstance(c[5], constraints.PotentialField)
         self.assertEqual(c[5].field.shape, (14, 16, 18, 1))
         self.assertAlmostEqual(c[5].default_scale, 1.6, delta=1E-10)
-        np.testing.assert_allclose(c[5].particle_scales, [[5, 6]], atol=1e-10)
+        self.assertAlmostEqual(c[5].particle_scales[5], 6.0, delta=1E-10)
         np.testing.assert_allclose(np.copy(c[5].origin), [-0.5, -0.5, -0.5])
         np.testing.assert_allclose(np.copy(c[5].grid_spacing), np.ones(3))
         ref_pot = constraints.PotentialField(


### PR DESCRIPTION
Description of changes:
- fix regressions introduced in the last script interface refactor
- add python `dict` to the list of types allowed in the script interface (gets converted to `std::unordered_map<int, Variant>`)
- make coupling-based fields throw an error when calling a coupling parameter setter, instead of silently ignoring the new value (the coupling object is const), and take a `dict` instead of having the user manually cast `dict_items` to `list` (API change)
- improve testing of field-based constraints and shapes