### PR TITLE
Fix rare failures in CI

### DIFF
--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -131,21 +131,6 @@ class CoulombCloudWall(ut.TestCase):
         self.S.integrator.run(0)
         self.compare("scafacos_p3m", energy=True, prefactor=0.5)
 
-    @ut.skipIf(not espressomd.has_features(["SCAFACOS"])
-               or 'p3m' not in scafacos.available_methods(),
-               'Skipping test: missing feature SCAFACOS or p3m method')
-    def test_scafacos_p3m_tuning(self):
-        # check that the tuning function can be called without throwing
-        # an exception or causing an MPI deadlock
-        self.S.actors.add(
-            espressomd.electrostatics.Scafacos(
-                prefactor=0.5,
-                method_name="p3m",
-                method_params={"p3m_grid": 64, "p3m_cao": 7}))
-        self.S.integrator.run(0)
-        # check the scafacos script interface
-        self.assertEqual(self.S.actors[-1].get_params()['prefactor'], 0.5)
-
     @ut.skipIf(not espressomd.has_features("SCAFACOS")
                or 'p2nfft' not in scafacos.available_methods(),
                'Skipping test: missing feature SCAFACOS or p2nfft method')

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -252,7 +252,7 @@ if espressomd.has_features('SCAFACOS') and 'SCAFACOS' in modes:
             "p3m_r_cut": 1.0,
             "p3m_grid": 64,
             "p3m_cao": 7,
-            "p3m_alpha": 2.7}))
+            "p3m_alpha": 2.084652}))
 
 if espressomd.has_features('SCAFACOS_DIPOLES') and 'SCAFACOS' in modes:
     system.actors.add(espressomd.magnetostatics.Scafacos(

--- a/testsuite/python/scafacos_interface.py
+++ b/testsuite/python/scafacos_interface.py
@@ -79,6 +79,7 @@ class ScafacosInterface(ut.TestCase):
             method_name="p3m",
             method_params={
                 "p3m_r_cut": 1.0,
+                "p3m_alpha": 2.799269,
                 "p3m_grid": 32,
                 "p3m_cao": 7}))
         actor = system.actors[0]
@@ -86,7 +87,8 @@ class ScafacosInterface(ut.TestCase):
         self.assertEqual(params["prefactor"], 0.5)
         self.assertEqual(params["method_name"], "p3m")
         self.assertEqual(params["method_params"],
-                         {'p3m_cao': '7', 'p3m_r_cut': '1.0', 'p3m_grid': '32'})
+                         {'p3m_cao': '7', 'p3m_r_cut': '1.0',
+                          'p3m_grid': '32', 'p3m_alpha': '2.799269'})
 
     @utx.skipIfMissingFeatures(["SCAFACOS_DIPOLES"])
     def test_actor_dipoles(self):
@@ -149,6 +151,7 @@ class ScafacosInterface(ut.TestCase):
             method_name="p3m",
             method_params={
                 "p3m_r_cut": 1.0,
+                "p3m_alpha": 2.799269,
                 "p3m_grid": 32,
                 "p3m_cao": 7})
         system.actors.add(scafacos_coulomb)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -379,7 +379,7 @@ class CheckpointTest(ut.TestCase):
                          'p3m_cao': '7',
                          'p3m_r_cut': '1.0',
                          'p3m_grid': '64',
-                         'p3m_alpha': '2.7'}}
+                         'p3m_alpha': '2.084652'}}
         for key in reference:
             self.assertEqual(state[key], reference[key], msg=f'for {key}')
 

--- a/testsuite/scripts/tutorials/test_active_matter__rectification_simulation.py
+++ b/testsuite/scripts/tutorials/test_active_matter__rectification_simulation.py
@@ -20,9 +20,11 @@ import importlib_wrapper
 import os
 import numpy as np
 
+np.random.seed(40)
+
 tutorial, skipIfMissingFeatures = importlib_wrapper.configure_and_import(
     "@TUTORIALS_DIR@/active_matter/solutions/rectification_simulation.py",
-    cmd_arguments=[6.0], PROD_STEPS=100, PROD_LENGTH=150)
+    cmd_arguments=[6.0], PROD_STEPS=100, PROD_LENGTH=100)
 
 
 @skipIfMissingFeatures


### PR DESCRIPTION
Description of changes:
- remove ScaFaCoS tuning checks due to a bug in the FFTW library (fixes #4126, fixes #4131)
- make active matter rectification test deterministic (fixes #4024, fixes #4043, follow-up to #3842)