### PR TITLE
ICC maintenance

### DIFF
--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -158,8 +158,8 @@ void deactivate() {
 }
 
 void update_dependent_particles() {
-  iccp3m_iteration(cell_structure.local_particles(),
-                   cell_structure.ghost_particles());
+  icc_iteration(cell_structure.local_particles(),
+                cell_structure.ghost_particles());
 }
 
 void on_observable_calc() {
@@ -364,23 +364,23 @@ double calc_energy_long_range(const ParticleRange &particles) {
   return energy;
 }
 
-int iccp3m_sanity_check() {
+int icc_sanity_check() {
   switch (coulomb.method) {
 #ifdef P3M
   case COULOMB_ELC_P3M: {
     if (elc_params.dielectric_contrast_on) {
-      runtimeErrorMsg() << "ICCP3M conflicts with ELC dielectric contrast";
+      runtimeErrorMsg() << "ICC conflicts with ELC dielectric contrast";
       return 1;
     }
     break;
   }
 #endif
   case COULOMB_DH: {
-    runtimeErrorMsg() << "ICCP3M does not work with Debye-Hueckel.";
+    runtimeErrorMsg() << "ICC does not work with Debye-Hueckel.";
     return 1;
   }
   case COULOMB_RF: {
-    runtimeErrorMsg() << "ICCP3M does not work with COULOMB_RF.";
+    runtimeErrorMsg() << "ICC does not work with COULOMB_RF.";
     return 1;
   }
   default:
@@ -389,7 +389,7 @@ int iccp3m_sanity_check() {
 
 #ifdef NPT
   if (integ_switch == INTEG_METHOD_NPT_ISO) {
-    runtimeErrorMsg() << "ICCP3M does not work in the NPT ensemble";
+    runtimeErrorMsg() << "ICC does not work in the NPT ensemble";
     return 1;
   }
 #endif

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -75,7 +75,7 @@ void calc_long_range_force(const ParticleRange &particles);
 
 double calc_energy_long_range(const ParticleRange &particles);
 
-int iccp3m_sanity_check();
+int icc_sanity_check();
 
 int elc_sanity_check();
 

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -86,11 +86,6 @@ void icc_iteration(const ParticleRange &particles,
 
   Coulomb::icc_sanity_check();
 
-  if (icc_cfg.eout <= 0) {
-    runtimeErrorMsg()
-        << "ICC: nonpositive dielectric constant is not allowed.";
-  }
-
   auto const pref = 1.0 / (coulomb.prefactor * 2 * Utils::pi());
   icc_cfg.citeration = 0;
 

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -50,10 +50,10 @@
 #include <cstdlib>
 #include <tuple>
 
-iccp3m_struct iccp3m_cfg;
+icc_struct icc_cfg;
 
-void init_forces_iccp3m(const ParticleRange &particles,
-                        const ParticleRange &ghosts_particles);
+void init_forces_icc(const ParticleRange &particles,
+                     const ParticleRange &ghosts_particles);
 
 /** Calculate the electrostatic forces between source charges (= real charges)
  *  and wall charges. For each electrostatic method, the proper functions
@@ -61,15 +61,15 @@ void init_forces_iccp3m(const ParticleRange &particles,
  *  directly, short-range parts need helper functions according to the particle
  *  data organisation. This is a modified version of \ref force_calc.
  */
-void force_calc_iccp3m(const ParticleRange &particles,
-                       const ParticleRange &ghost_particles);
+void force_calc_icc(const ParticleRange &particles,
+                    const ParticleRange &ghost_particles);
 
 /** Variant of @ref add_non_bonded_pair_force where only %Coulomb
  *  contributions are calculated
  */
-inline void add_non_bonded_pair_force_iccp3m(Particle &p1, Particle &p2,
-                                             Utils::Vector3d const &d,
-                                             double dist, double dist2) {
+inline void add_non_bonded_pair_force_icc(Particle &p1, Particle &p2,
+                                          Utils::Vector3d const &d, double dist,
+                                          double dist2) {
   auto forces = Coulomb::pair_force(p1, p2, d, dist);
 
   p1.f.f += std::get<0>(forces);
@@ -80,89 +80,88 @@ inline void add_non_bonded_pair_force_iccp3m(Particle &p1, Particle &p2,
 #endif
 }
 
-void iccp3m_alloc_lists() {
-  auto const n_ic = iccp3m_cfg.n_ic;
+void icc_alloc_lists() {
+  auto const n_ic = icc_cfg.n_ic;
 
-  iccp3m_cfg.areas.resize(n_ic);
-  iccp3m_cfg.ein.resize(n_ic);
-  iccp3m_cfg.normals.resize(n_ic);
-  iccp3m_cfg.sigma.resize(n_ic);
+  icc_cfg.areas.resize(n_ic);
+  icc_cfg.ein.resize(n_ic);
+  icc_cfg.normals.resize(n_ic);
+  icc_cfg.sigma.resize(n_ic);
 }
 
-int iccp3m_iteration(const ParticleRange &particles,
-                     const ParticleRange &ghost_particles) {
-  if (iccp3m_cfg.n_ic == 0)
-    return 0;
+void icc_iteration(const ParticleRange &particles,
+                   const ParticleRange &ghost_particles) {
+  if (icc_cfg.n_ic == 0)
+    return;
 
-  Coulomb::iccp3m_sanity_check();
+  Coulomb::icc_sanity_check();
 
-  if (iccp3m_cfg.eout <= 0) {
+  if (icc_cfg.eout <= 0) {
     runtimeErrorMsg()
-        << "ICCP3M: nonpositive dielectric constant is not allowed.";
+        << "ICC: nonpositive dielectric constant is not allowed.";
   }
 
   auto const pref = 1.0 / (coulomb.prefactor * 2 * Utils::pi());
-  iccp3m_cfg.citeration = 0;
+  icc_cfg.citeration = 0;
 
-  double globalmax = 1e100;
+  double globalmax = 0.;
 
-  for (int j = 0; j < iccp3m_cfg.num_iteration; j++) {
-    double hmax = 0.;
+  for (int j = 0; j < icc_cfg.num_iteration; j++) {
+    double charge_density_max = 0.;
 
-    force_calc_iccp3m(particles, ghost_particles); /* Calculate electrostatic
+    force_calc_icc(particles, ghost_particles); /* Calculate electrostatic
                             forces (SR+LR) excluding source source interaction*/
     cell_structure.ghosts_reduce_forces();
 
     double diff = 0;
 
     for (auto &p : particles) {
-      if (p.p.identity < iccp3m_cfg.n_ic + iccp3m_cfg.first_id &&
-          p.p.identity >= iccp3m_cfg.first_id) {
-        auto const id = p.p.identity - iccp3m_cfg.first_id;
+      if (p.p.identity < icc_cfg.n_ic + icc_cfg.first_id &&
+          p.p.identity >= icc_cfg.first_id) {
+        auto const id = p.p.identity - icc_cfg.first_id;
         /* the dielectric-related prefactor: */
-        auto const del_eps = (iccp3m_cfg.ein[id] - iccp3m_cfg.eout) /
-                             (iccp3m_cfg.ein[id] + iccp3m_cfg.eout);
+        auto const del_eps =
+            (icc_cfg.ein[id] - icc_cfg.eout) / (icc_cfg.ein[id] + icc_cfg.eout);
         /* calculate the electric field at the certain position */
-        auto const E = p.f.f / p.p.q + iccp3m_cfg.ext_field;
+        auto const local_e_field = p.f.f / p.p.q + icc_cfg.ext_field;
 
-        if (E[0] == 0 && E[1] == 0 && E[2] == 0) {
+        if (local_e_field.norm2() == 0) {
           runtimeErrorMsg()
-              << "ICCP3M found zero electric field on a charge. This must "
+              << "ICC found zero electric field on a charge. This must "
                  "never happen";
         }
 
-        /* recalculate the old charge density */
-        auto const hold = p.p.q / iccp3m_cfg.areas[id];
-        /* determine if it is higher than the previously highest charge
-         * density */
-        hmax = std::max(hmax, std::abs(hold));
+        auto const charge_density_old = p.p.q / icc_cfg.areas[id];
 
-        auto const f1 = del_eps * pref * (E * iccp3m_cfg.normals[id]);
-        auto const f2 = (not iccp3m_cfg.sigma.empty())
-                            ? (2 * iccp3m_cfg.eout) /
-                                  (iccp3m_cfg.eout + iccp3m_cfg.ein[id]) *
-                                  (iccp3m_cfg.sigma[id])
-                            : 0.;
+        charge_density_max =
+            std::max(charge_density_max, std::abs(charge_density_old));
+
+        auto const charge_density_update =
+            del_eps * pref * (local_e_field * icc_cfg.normals[id]) +
+            2 * icc_cfg.eout / (icc_cfg.eout + icc_cfg.ein[id]) *
+                icc_cfg.sigma[id];
         /* relative variation: never use an estimator which can be negative
          * here */
-        auto const hnew =
-            (1. - iccp3m_cfg.relax) * hold + (iccp3m_cfg.relax) * (f1 + f2);
+        auto const charge_density_new =
+            (1. - icc_cfg.relax) * charge_density_old +
+            (icc_cfg.relax) * charge_density_update;
 
         /* Take the largest error to check for convergence */
         auto const relative_difference =
-            std::abs(1 * (hnew - hold) / (hmax + std::abs(hnew + hold)));
+            std::abs((charge_density_new - charge_density_old) /
+                     (charge_density_max +
+                      std::abs(charge_density_new + charge_density_old)));
 
         diff = std::max(diff, relative_difference);
 
-        p.p.q = hnew * iccp3m_cfg.areas[id];
+        p.p.q = charge_density_new * icc_cfg.areas[id];
 
         /* check if the charge now is more than 1e6, to determine if ICC still
-         * leads to reasonable results */
-        /* this is kind of an arbitrary measure but does a good job spotting
-         * divergence! */
+         * leads to reasonable results. This is kind of an arbitrary measure
+         * but does a good job spotting divergence! */
         if (std::abs(p.p.q) > 1e6) {
           runtimeErrorMsg()
-              << "too big charge assignment in iccp3m! q >1e6 , assigned "
+              << "too big charge assignment in icc! q >1e6 , assigned "
                  "charge= "
               << p.p.q;
 
@@ -174,59 +173,58 @@ int iccp3m_iteration(const ParticleRange &particles,
     /* Update charges on ghosts. */
     cell_structure.ghosts_update(Cells::DATA_PART_PROPERTIES);
 
-    iccp3m_cfg.citeration++;
+    icc_cfg.citeration++;
 
-    MPI_Allreduce(&diff, &globalmax, 1, MPI_DOUBLE, MPI_MAX, comm_cart);
+    boost::mpi::all_reduce(comm_cart, diff, globalmax,
+                           boost::mpi::maximum<double>());
 
-    if (globalmax < iccp3m_cfg.convergence)
+    if (globalmax < icc_cfg.convergence)
       break;
   } /* iteration */
 
-  if (globalmax > iccp3m_cfg.convergence) {
+  if (globalmax > icc_cfg.convergence) {
     runtimeErrorMsg()
         << "ICC failed to converge in the given number of maximal steps.";
   }
 
   on_particle_charge_change();
-
-  return iccp3m_cfg.citeration;
 }
 
-void force_calc_iccp3m(const ParticleRange &particles,
-                       const ParticleRange &ghost_particles) {
-  init_forces_iccp3m(particles, ghost_particles);
+void force_calc_icc(const ParticleRange &particles,
+                    const ParticleRange &ghost_particles) {
+  init_forces_icc(particles, ghost_particles);
 
-  cell_structure.non_bonded_loop([](Particle &p1, Particle &p2,
-                                    Distance const &d) {
-    /* calc non-bonded interactions */
-    add_non_bonded_pair_force_iccp3m(p1, p2, d.vec21, sqrt(d.dist2), d.dist2);
-  });
+  cell_structure.non_bonded_loop(
+      [](Particle &p1, Particle &p2, Distance const &d) {
+        /* calc non-bonded interactions */
+        add_non_bonded_pair_force_icc(p1, p2, d.vec21, sqrt(d.dist2), d.dist2);
+      });
 
   Coulomb::calc_long_range_force(particles);
 }
 
-void init_forces_iccp3m(const ParticleRange &particles,
-                        const ParticleRange &ghosts_particles) {
+void init_forces_icc(const ParticleRange &particles,
+                     const ParticleRange &ghosts_particles) {
   for (auto &p : particles) {
-    p.f = ParticleForce{};
+    p.f.f = {};
   }
 
   for (auto &p : ghosts_particles) {
-    p.f = ParticleForce{};
+    p.f.f = {};
   }
 }
 
-void mpi_iccp3m_init_local(const iccp3m_struct &iccp3m_cfg_) {
-  iccp3m_cfg = iccp3m_cfg_;
+void mpi_icc_init_local(const icc_struct &icc_cfg_) {
+  icc_cfg = icc_cfg_;
 
   on_particle_charge_change();
   check_runtime_errors(comm_cart);
 }
 
-REGISTER_CALLBACK(mpi_iccp3m_init_local)
+REGISTER_CALLBACK(mpi_icc_init_local)
 
-int mpi_iccp3m_init() {
-  mpi_call(mpi_iccp3m_init_local, iccp3m_cfg);
+int mpi_icc_init() {
+  mpi_call(mpi_icc_init_local, icc_cfg);
 
   on_particle_charge_change();
   return check_runtime_errors(comm_cart);

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -81,7 +81,7 @@ inline void add_non_bonded_pair_force_icc(Particle &p1, Particle &p2,
 }
 void icc_iteration(const ParticleRange &particles,
                    const ParticleRange &ghost_particles) {
-  if (icc_cfg.n_ic == 0)
+  if (icc_cfg.n_icc == 0)
     return;
 
   Coulomb::icc_sanity_check();
@@ -101,7 +101,7 @@ void icc_iteration(const ParticleRange &particles,
     double diff = 0;
 
     for (auto &p : particles) {
-      if (p.p.identity < icc_cfg.n_ic + icc_cfg.first_id &&
+      if (p.p.identity < icc_cfg.n_icc + icc_cfg.first_id &&
           p.p.identity >= icc_cfg.first_id) {
         auto const id = p.p.identity - icc_cfg.first_id;
         /* the dielectric-related prefactor: */
@@ -215,12 +215,12 @@ int mpi_icc_init() {
   return check_runtime_errors(comm_cart);
 }
 
-void icc_set_params(int n_ic, double convergence, double relaxation,
+void icc_set_params(int n_icc, double convergence, double relaxation,
                     Utils::Vector3d &ext_field, int max_iterations,
                     int first_id, double eps_out, std::vector<double> &areas,
                     std::vector<double> &e_in, std::vector<double> &sigma,
                     std::vector<Utils::Vector3d> &normals) {
-  if (n_ic < 0)
+  if (n_icc < 0)
     throw std::runtime_error("ICC: invalid number of particles. " +
                              std::to_string(n_icc));
   if (convergence <= 0)
@@ -238,16 +238,16 @@ void icc_set_params(int n_ic, double convergence, double relaxation,
   if (eps_out <= 0)
     throw std::runtime_error("ICC: invalid eps_out. " +
                              std::to_string(eps_out));
-  if (areas.size() != n_ic)
+  if (areas.size() != n_icc)
     throw std::runtime_error("ICC: invalid areas vector.");
-  if (e_in.size() != n_ic)
+  if (e_in.size() != n_icc)
     throw std::runtime_error("ICC: invalid e_in vector.");
-  if (sigma.size() != n_ic)
+  if (sigma.size() != n_icc)
     throw std::runtime_error("ICC: invalid sigma vector.");
-  if (normals.size() != n_ic)
+  if (normals.size() != n_icc)
     throw std::runtime_error("ICC: invalid normals vector.");
 
-  icc_cfg.n_ic = n_ic;
+  icc_cfg.n_icc = n_icc;
   icc_cfg.convergence = convergence;
   icc_cfg.relax = relaxation;
   icc_cfg.ext_field = ext_field;
@@ -264,7 +264,7 @@ void icc_set_params(int n_ic, double convergence, double relaxation,
 }
 
 void icc_deactivate() {
-  icc_cfg.n_ic = 0;
+  icc_cfg.n_icc = 0;
   icc_cfg.areas.resize(0);
   icc_cfg.ein.resize(0);
   icc_cfg.normals.resize(0);

--- a/src/core/electrostatics_magnetostatics/icc.hpp
+++ b/src/core/electrostatics_magnetostatics/icc.hpp
@@ -57,7 +57,7 @@
 /** ICC data structure */
 struct icc_struct {
   /** First id of ICC particle */
-  int n_ic;
+  int n_icc;
   /** maximum number of iterations */
   int num_iteration = 30;
   /** bulk dielectric constant */
@@ -83,7 +83,7 @@ struct icc_struct {
 
   template <typename Archive>
   void serialize(Archive &ar, long int /* version */) {
-    ar &n_ic;
+    ar &n_icc;
     ar &num_iteration;
     ar &first_id;
     ar &convergence;

--- a/src/core/electrostatics_magnetostatics/icc.hpp
+++ b/src/core/electrostatics_magnetostatics/icc.hpp
@@ -107,14 +107,22 @@ extern icc_struct icc_cfg;
 void icc_iteration(const ParticleRange &particles,
                    const ParticleRange &ghost_particles);
 
-/** The allocation of ICC lists for python interface
- */
-void icc_alloc_lists();
-
 /** Perform ICC initialization.
  *  @return non-zero value on error
  */
 int mpi_icc_init();
+
+/** Set ICC parameters
+ */
+void icc_set_params(int n_ic, double convergence, double relaxation,
+                    Utils::Vector3d &ext_field, int max_iterations,
+                    int first_id, double eps_out, std::vector<double> &areas,
+                    std::vector<double> &e_in, std::vector<double> &sigma,
+                    std::vector<Utils::Vector3d> &normals);
+
+/** clear ICC vector allocations
+ */
+void icc_deactivate();
 
 #endif /* ELECTROSTATICS */
 #endif /* CORE_ICC_HPP */

--- a/src/core/electrostatics_magnetostatics/icc.hpp
+++ b/src/core/electrostatics_magnetostatics/icc.hpp
@@ -20,22 +20,18 @@
  */
 /** \file
  *
- *  ICCP3M is a method that allows to take into account the influence
+ *  ICC is a method that allows to take into account the influence
  *  of arbitrarily shaped dielectric interfaces. The dielectric
  *  properties of a dielectric medium in the bulk of the simulation
  *  box are taken into account by reproducing the jump in the electric
  *  field at the interface with charge surface segments. The charge
  *  density of the surface segments have to be determined
- *  self-consistently using an iterative scheme. It can at present -
- *  despite its name - be used with P3M, ELCP3M and MMM1D. For
- *  details see: @cite tyagi10a
+ *  self-consistently using an iterative scheme. It can at present
+ *  be used with P3M, ELCP3M and MMM1D. For details see: @cite tyagi10a
  *
- *  To set up ICCP3M, first the dielectric boundary has to be modeled
- *  by ESPResSo particles 0..n where n has to be passed as a parameter
- *  to ICCP3M. This is still a bit inconvenient, as it forces the user
- *  to reserve the first n particle ids to wall charges, but as the
- *  other parts of ESPResSo do not suffer from a limitation like this,
- *  it can be tolerated.
+ *  To set up ICC, first the dielectric boundary has to be modeled
+ *  by ESPResSo particles n_0...n_0+n where n_0 and n have to be passed
+ *  as a parameter to ICC.
  *
  *  For the determination of the induced charges only the forces
  *  acting on the induced charges has to be determined. As P3M and the
@@ -45,8 +41,8 @@
  *  particle data organisation schemes this is performed differently.
  */
 
-#ifndef CORE_ICCP3M_HPP
-#define CORE_ICCP3M_HPP
+#ifndef CORE_ICC_HPP
+#define CORE_ICC_HPP
 
 #include "config.hpp"
 
@@ -58,21 +54,32 @@
 #include <algorithm>
 #include <vector>
 
-/** ICCP3M data structure */
-struct iccp3m_struct {
-  int n_ic;                  /**< Last induced id (cannot be smaller than 2) */
-  int num_iteration = 30;    /**< Number of max iterations                   */
-  double eout = 1;           /**< Dielectric constant of the bulk            */
-  std::vector<double> areas; /**< Array of area of the grid elements         */
-  std::vector<double> ein;   /**< Array of dielectric constants at each surface
-                                  element */
-  std::vector<double> sigma; /**< Surface charge density */
-  double convergence = 1e-2; /**< Convergence criterion */
-  std::vector<Utils::Vector3d> normals;  /**< Surface normal vectors */
-  Utils::Vector3d ext_field = {0, 0, 0}; /**< External field */
-  double relax = 0.7; /**< relaxation parameter for iteration */
-  int citeration = 0; /**< current number of iterations */
-  int first_id = 0; /**< id of the first particle in the dielectric boundary */
+/** ICC data structure */
+struct icc_struct {
+  /** First id of ICC particle */
+  int n_ic;
+  /** maximum number of iterations */
+  int num_iteration = 30;
+  /** bulk dielectric constant */
+  double eout;
+  /** areas of the particles */
+  std::vector<double> areas;
+  /** dielectric constants of the particles */
+  std::vector<double> ein;
+  /** surface charge density of the particles */
+  std::vector<double> sigma;
+  /** convergence criteria */
+  double convergence = 1e-2;
+  /** surface normal vectors */
+  std::vector<Utils::Vector3d> normals;
+  /** external electric field */
+  Utils::Vector3d ext_field = {0, 0, 0};
+  /** relaxation parameter */
+  double relax;
+  /** last number of iterations */
+  int citeration = 0;
+  /** first ICC particle id */
+  int first_id = 0;
 
   template <typename Archive>
   void serialize(Archive &ar, long int /* version */) {
@@ -90,27 +97,24 @@ struct iccp3m_struct {
     ar &citeration;
   }
 };
-extern iccp3m_struct iccp3m_cfg; /**< Global state of the ICCP3M solver */
+
+/** ICC parameters */
+extern icc_struct icc_cfg;
 
 /** The main iterative scheme, where the surface element charges are calculated
  *  self-consistently.
  */
-int iccp3m_iteration(const ParticleRange &particles,
-                     const ParticleRange &ghost_particles);
+void icc_iteration(const ParticleRange &particles,
+                   const ParticleRange &ghost_particles);
 
-/** The allocation of ICCP3M lists for python interface
+/** The allocation of ICC lists for python interface
  */
-void iccp3m_alloc_lists();
+void icc_alloc_lists();
 
-/** check sanity of parameters for use with ICCP3M
- */
-int iccp3m_sanity_check();
-
-/** Perform iccp3m initialization.
+/** Perform ICC initialization.
  *  @return non-zero value on error
  */
-int mpi_iccp3m_init();
+int mpi_icc_init();
 
 #endif /* ELECTROSTATICS */
-
-#endif /* ICCP3M_H */
+#endif /* CORE_ICC_HPP */

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -96,7 +96,7 @@ void force_calc(CellStructure &cell_structure, double time_step) {
   auto particles = cell_structure.local_particles();
   auto ghost_particles = cell_structure.ghost_particles();
 #ifdef ELECTROSTATICS
-  iccp3m_iteration(particles, cell_structure.ghost_particles());
+  icc_iteration(particles, cell_structure.ghost_particles());
 #endif
   init_forces(particles, time_step);
 

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -26,7 +26,7 @@ IF ELECTROSTATICS and P3M:
 
     cdef extern from "electrostatics_magnetostatics/icc.hpp":
         ctypedef struct icc_struct:
-            int n_ic
+            int n_icc
             int num_iteration
             double eout
             vector[double] areas
@@ -42,7 +42,7 @@ IF ELECTROSTATICS and P3M:
         # links intern C-struct with python object
         cdef extern icc_struct icc_cfg
 
-        void icc_set_params(int n_ic, double convergence, double relaxation,
+        void icc_set_params(int n_icc, double convergence, double relaxation,
                             Vector3d & ext_field, int max_iterations,
                             int first_id, double eps_out,
                             vector[double] & areas,

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -25,7 +25,7 @@ from .utils cimport Vector3d
 IF ELECTROSTATICS and P3M:
 
     cdef extern from "electrostatics_magnetostatics/icc.hpp":
-        ctypedef struct iccp3m_struct:
+        ctypedef struct icc_struct:
             int n_ic
             int num_iteration
             double eout
@@ -40,7 +40,7 @@ IF ELECTROSTATICS and P3M:
             int first_id
 
         # links intern C-struct with python object
-        iccp3m_struct iccp3m_cfg
+        icc_struct icc_cfg
 
-        void iccp3m_alloc_lists()
-        int mpi_iccp3m_init()
+        void icc_alloc_lists()
+        int mpi_icc_init()

--- a/src/python/espressomd/electrostatic_extensions.pxd
+++ b/src/python/espressomd/electrostatic_extensions.pxd
@@ -40,7 +40,14 @@ IF ELECTROSTATICS and P3M:
             int first_id
 
         # links intern C-struct with python object
-        icc_struct icc_cfg
+        cdef extern icc_struct icc_cfg
 
-        void icc_alloc_lists()
-        int mpi_icc_init()
+        void icc_set_params(int n_ic, double convergence, double relaxation,
+                            Vector3d & ext_field, int max_iterations,
+                            int first_id, double eps_out,
+                            vector[double] & areas,
+                            vector[double] & e_in,
+                            vector[double] & sigma,
+                            vector[Vector3d] & normals) except +
+
+        void icc_deactivate()

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -62,15 +62,16 @@ IF ELECTROSTATICS and P3M:
         sigmas : (``n_icc``, ) array_like :obj:`float`, optional
             Additional surface charge density in the absence of any charge
             induction.
-        epsilons : (``n_icc``, ) array_like :obj:`float`, optional
+        epsilons : (``n_icc``, ) array_like :obj:`float`
             Dielectric constant associated to the areas.
 
         """
 
         def validate_params(self):
-            default_params = self.default_params()
-
             check_type_or_throw_except(self._params["n_icc"], 1, int, "")
+
+            check_type_or_throw_except(
+                self._params["first_id"], 1, int, "")
 
             check_type_or_throw_except(
                 self._params["convergence"], 1, float, "")
@@ -85,14 +86,11 @@ IF ELECTROSTATICS and P3M:
                 self._params["max_iterations"], 1, int, "")
 
             check_type_or_throw_except(
-                self._params["first_id"], 1, int, "")
-
-            check_type_or_throw_except(
                 self._params["eps_out"], 1, float, "")
 
             n_icc = self._params["n_icc"]
+            assert n_icc >= 0, "ICC: invalid number of particles"
 
-            # Required list input
             self._params["normals"] = np.array(self._params["normals"])
             if self._params["normals"].size != n_icc * 3:
                 raise ValueError(
@@ -103,18 +101,14 @@ IF ELECTROSTATICS and P3M:
             check_type_or_throw_except(
                 self._params["areas"], n_icc, float, "Error in area list.")
 
-            # Not Required
             if "sigmas" in self._params.keys():
                 check_type_or_throw_except(
                     self._params["sigmas"], n_icc, float, "Error in sigma list.")
             else:
                 self._params["sigmas"] = np.zeros(n_icc)
 
-            if "epsilons" in self._params.keys():
-                check_type_or_throw_except(
-                    self._params["epsilons"], n_icc, float, "Error in epsilon list.")
-            else:
-                self._params["epsilons"] = np.zeros(n_icc)
+            check_type_or_throw_except(
+                self._params["epsilons"], n_icc, float, "Error in epsilon list.")
 
         def valid_keys(self):
             return ["n_icc", "convergence", "relaxation", "ext_field",
@@ -122,25 +116,20 @@ IF ELECTROSTATICS and P3M:
                     "areas", "sigmas", "epsilons", "check_neutrality"]
 
         def required_keys(self):
-            return ["n_icc", "normals", "areas"]
+            return ["n_icc", "normals", "areas", "epsilons"]
 
         def default_params(self):
-            return {"n_icc": 0,
-                    "convergence": 1e-3,
+            return {"convergence": 1e-3,
                     "relaxation": 0.7,
                     "ext_field": [0, 0, 0],
                     "max_iterations": 100,
                     "first_id": 0,
-                    "esp_out": 1,
-                    "normals": [],
-                    "areas": [],
-                    "sigmas": [],
-                    "epsilons": [],
+                    "eps_out": 1,
                     "check_neutrality": True}
 
         def _get_params_from_es_core(self):
             params = {}
-            params["n_icc"] = icc_cfg.n_ic
+            params["n_icc"] = icc_cfg.n_icc
             params["first_id"] = icc_cfg.first_id
             params["max_iterations"] = icc_cfg.num_iteration
             params["convergence"] = icc_cfg.convergence

--- a/src/python/espressomd/electrostatic_extensions.pyx
+++ b/src/python/espressomd/electrostatic_extensions.pyx
@@ -149,74 +149,75 @@ IF ELECTROSTATICS and P3M:
 
         def _get_params_from_es_core(self):
             params = {}
-            params["n_icc"] = iccp3m_cfg.n_ic
+            params["n_icc"] = icc_cfg.n_ic
 
             # Fill Lists
             normals = []
             areas = []
             sigmas = []
             epsilons = []
-            for i in range(iccp3m_cfg.n_ic):
-                normals.append([iccp3m_cfg.normals[i][0], iccp3m_cfg.normals[
-                               i][1], iccp3m_cfg.normals[i][2]])
-                areas.append(iccp3m_cfg.areas[i])
-                epsilons.append(iccp3m_cfg.ein[i])
-                sigmas.append(iccp3m_cfg.sigma[i])
+            for i in range(icc_cfg.n_ic):
+                normals.append([icc_cfg.normals[i][0], icc_cfg.normals[
+                               i][1], icc_cfg.normals[i][2]])
+                areas.append(icc_cfg.areas[i])
+                epsilons.append(icc_cfg.ein[i])
+                sigmas.append(icc_cfg.sigma[i])
 
             params["normals"] = normals
             params["areas"] = areas
             params["epsilons"] = epsilons
             params["sigmas"] = sigmas
 
-            params["ext_field"] = [iccp3m_cfg.ext_field[0],
-                                   iccp3m_cfg.ext_field[1], iccp3m_cfg.ext_field[2]]
-            params["first_id"] = iccp3m_cfg.first_id
-            params["max_iterations"] = iccp3m_cfg.num_iteration
-            params["convergence"] = iccp3m_cfg.convergence
-            params["relaxation"] = iccp3m_cfg.relax
-            params["eps_out"] = iccp3m_cfg.eout
+            params["ext_field"] = [icc_cfg.ext_field[0],
+                                   icc_cfg.ext_field[1],
+                                   icc_cfg.ext_field[2]]
+            params["first_id"] = icc_cfg.first_id
+            params["max_iterations"] = icc_cfg.num_iteration
+            params["convergence"] = icc_cfg.convergence
+            params["relaxation"] = icc_cfg.relax
+            params["eps_out"] = icc_cfg.eout
 
             return params
 
         def _set_params_in_es_core(self):
             # First set number of icc particles
-            iccp3m_cfg.n_ic = self._params["n_icc"]
+            icc_cfg.n_ic = self._params["n_icc"]
             # Allocate ICC lists
-            iccp3m_alloc_lists()
+            icc_alloc_lists()
 
             # Fill Lists
-            for i in range(iccp3m_cfg.n_ic):
-                iccp3m_cfg.normals[i][0] = self._params["normals"][i][0]
-                iccp3m_cfg.normals[i][1] = self._params["normals"][i][1]
-                iccp3m_cfg.normals[i][2] = self._params["normals"][i][2]
+            for i in range(icc_cfg.n_ic):
+                icc_cfg.normals[i][0] = self._params["normals"][i][0]
+                icc_cfg.normals[i][1] = self._params["normals"][i][1]
+                icc_cfg.normals[i][2] = self._params["normals"][i][2]
 
-                iccp3m_cfg.areas[i] = self._params["areas"][i]
-                iccp3m_cfg.ein[i] = self._params["epsilons"][i]
-                iccp3m_cfg.sigma[i] = self._params["sigmas"][i]
+                icc_cfg.areas[i] = self._params["areas"][i]
+                icc_cfg.ein[i] = self._params["epsilons"][i]
+                icc_cfg.sigma[i] = self._params["sigmas"][i]
 
-            iccp3m_cfg.ext_field[0] = self._params["ext_field"][0]
-            iccp3m_cfg.ext_field[1] = self._params["ext_field"][1]
-            iccp3m_cfg.ext_field[2] = self._params["ext_field"][2]
-            iccp3m_cfg.first_id = self._params["first_id"]
-            iccp3m_cfg.num_iteration = self._params["max_iterations"]
-            iccp3m_cfg.convergence = self._params["convergence"]
-            iccp3m_cfg.relax = self._params["relaxation"]
-            iccp3m_cfg.eout = self._params["eps_out"]
+            icc_cfg.ext_field[0] = self._params["ext_field"][0]
+            icc_cfg.ext_field[1] = self._params["ext_field"][1]
+            icc_cfg.ext_field[2] = self._params["ext_field"][2]
+            icc_cfg.first_id = self._params["first_id"]
+            icc_cfg.num_iteration = self._params["max_iterations"]
+            icc_cfg.convergence = self._params["convergence"]
+            icc_cfg.relax = self._params["relaxation"]
+            icc_cfg.eout = self._params["eps_out"]
 
             # Broadcasts vars
-            mpi_iccp3m_init()
+            mpi_icc_init()
 
         def _activate_method(self):
             check_neutrality(self._params)
             self._set_params_in_es_core()
 
         def _deactivate_method(self):
-            iccp3m_cfg.n_ic = 0
+            icc_cfg.n_ic = 0
             # Allocate ICC lists
-            iccp3m_alloc_lists()
+            icc_alloc_lists()
 
             # Broadcasts vars
-            mpi_iccp3m_init()
+            mpi_icc_init()
 
         def last_iterations(self):
             """
@@ -229,4 +230,4 @@ IF ELECTROSTATICS and P3M:
                 Number of iterations
 
             """
-            return iccp3m_cfg.citeration
+            return icc_cfg.citeration

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -102,6 +102,7 @@ cdef extern from "utils/quaternion.hpp" namespace "Utils":
         T & operator[](int i)
 
 cdef make_array_locked(Vector3d)
+cdef make_array_locked_vector(vector[Vector3d] v)
 cdef Vector3d make_Vector3d(a)
 
 cdef extern from "utils/Factory.hpp" namespace "Utils":

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -218,6 +218,13 @@ Use numpy.copy(<ESPResSo array property>) to get a writable copy."
 cdef make_array_locked(Vector3d v):
     return array_locked([v[0], v[1], v[2]])
 
+cdef make_array_locked_vector(vector[Vector3d] v):
+    ret = np.empty((v.size(), 3))
+    for i in range(v.size()):
+        for j in range(3):
+            ret[i][j] = v[i][j]
+    return array_locked(ret)
+
 
 cdef Vector3d make_Vector3d(a):
     cdef Vector3d v


### PR DESCRIPTION
Description of changes:
- renamed functions/struct in the core to reflect independence of P3M
- provide parameter setter function including validation instead of writing to glubal struct directly, including testcase
- made relative dielectric permittivity a required parameter (what is the purpose of the algorithm if not provided?)
- removed typos and default params for non-optional parameters
- I don't understand the the error-estimation formula in the core, it is different from the one shown in the paper [https://doi.org/10.1063/1.3376011](https://doi.org/10.1063/1.3376011)