### PR TITLE
fix clang-tidy-10 not recognized

### DIFF
--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -2,12 +2,12 @@
 
 # get Clang version
 string(REGEX
-        REPLACE "^([1-9]+)\\.[0-9]+.*$"
+        REPLACE "^([0-9]+)\\.[0-9]+.*$"
         "\\1"
         CLANG_MAJOR_VERSION
         "${CMAKE_CXX_COMPILER_VERSION}")
 string(REGEX
-       REPLACE "^[1-9]+\\.([0-9]+).*$"
+       REPLACE "^[0-9]+\\.([0-9]+).*$"
                "\\1"
                CLANG_MINOR_VERSION
                "${CMAKE_CXX_COMPILER_VERSION}")


### PR DESCRIPTION
Fixes the issue that clang-tidy-10 was not recognized by the CMake logic.
