### PR TITLE
script_interface: Moved serialization for ObjectList from cython to C++

### DIFF
--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -360,22 +360,6 @@ class ScriptObjectRegistry(ScriptInterfaceHelper):
     def __len__(self):
         return self.call_method("size")
 
-    def __reduce__(self):
-        res = []
-        for item in self.__iter__():
-            res.append(item)
-
-        return (_unpickle_script_object_registry,
-                (self._so_name, self.get_params(), res))
-
-
-def _unpickle_script_object_registry(so_name, params, items):
-    so = _python_class_by_so_name[so_name](**params)
-    for item in items:
-        so.add(item)
-    return so
-
-
 # Map from script object names to their corresponding python classes
 _python_class_by_so_name = {}
 

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -360,6 +360,7 @@ class ScriptObjectRegistry(ScriptInterfaceHelper):
     def __len__(self):
         return self.call_method("size")
 
+
 # Map from script object names to their corresponding python classes
 _python_class_by_so_name = {}
 
@@ -382,7 +383,7 @@ def script_interface_register(c):
 cdef void init(MpiCallbacks & cb):
     cdef Factory[ObjectHandle] f
 
-    initialize( & f)
+    initialize(& f)
 
     global _om
     _om = make_shared[ContextManager](cb, f)

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -271,7 +271,7 @@ class Union(Shape, ScriptObjectRegistry):
 
         def _add(self, shape):
             if isinstance(shape, Shape):
-                self.call_method("add", shape=shape)
+                self.call_method("add", object=shape)
             else:
                 raise ValueError("Only shapes can be added.")
 
@@ -294,7 +294,7 @@ class Union(Shape, ScriptObjectRegistry):
 
         def _remove(self, shape):
             if isinstance(shape, Shape):
-                self.call_method("remove", shape=shape)
+                self.call_method("remove", object=shape)
             else:
                 raise ValueError("Only shapes can be removed.")
         if isinstance(shape, collections.abc.Iterable):

--- a/src/script_interface/ObjectHandle.hpp
+++ b/src/script_interface/ObjectHandle.hpp
@@ -131,7 +131,7 @@ public:
    */
   Variant call_method(const std::string &name, const VariantMap &params);
 
-private:
+protected:
   /**
    * @brief Local implementation of @c do_call_method.
    *

--- a/src/script_interface/ObjectList.hpp
+++ b/src/script_interface/ObjectList.hpp
@@ -40,8 +40,9 @@ namespace ScriptInterface {
  */
 template <
     typename ManagedType,
+    class BaseType = ObjectHandle,
     class = std::enable_if_t<std::is_base_of<ObjectHandle, ManagedType>::value>>
-class ObjectList : public ObjectHandle {
+class ObjectList : public BaseType {
 public:
   virtual void add_in_core(const std::shared_ptr<ManagedType> &obj_ptr) = 0;
   virtual void remove_in_core(const std::shared_ptr<ManagedType> &obj_ptr) = 0;
@@ -92,7 +93,7 @@ public:
       return m_elements.empty();
     }
 
-    return none;
+    return BaseType::do_call_method(method, parameters);
   }
 
 private:
@@ -110,7 +111,7 @@ private:
 
     for (auto const &packed_object : object_states) {
       auto o = std::dynamic_pointer_cast<ManagedType>(
-          deserialize(packed_object, *context()));
+          BaseType::deserialize(packed_object, *BaseType::context()));
       m_elements.emplace_back(std::move(o));
     }
   }

--- a/src/script_interface/ObjectList.hpp
+++ b/src/script_interface/ObjectList.hpp
@@ -47,19 +47,35 @@ private:
   virtual void remove_in_core(const std::shared_ptr<ManagedType> &obj_ptr) = 0;
 
 public:
+  /**
+   * @brief Add an element to the list.
+   *
+   * @param element The element to add.
+   */
   void add(std::shared_ptr<ManagedType> const &element) {
     add_in_core(element);
     m_elements.push_back(element);
   }
 
+  /**
+   * @brief Removes all occurences of an element from the list.
+   *
+   * @param element The element to add.
+   */
   void remove(std::shared_ptr<ManagedType> const &element) {
     remove_in_core(element);
     m_elements.erase(std::remove(m_elements.begin(), m_elements.end(), element),
                      m_elements.end());
   }
 
+  /**
+   * @brief List elements.
+   */
   auto const &elements() const { return m_elements; }
 
+  /**
+   * @brief Clear the list.
+   */
   void clear() {
     for (auto const &e : m_elements) {
       remove_in_core(e);

--- a/src/script_interface/ObjectList.hpp
+++ b/src/script_interface/ObjectList.hpp
@@ -39,8 +39,7 @@ namespace ScriptInterface {
  *         derived from ObjectHandle
  */
 template <
-    typename ManagedType,
-    class BaseType = ObjectHandle,
+    typename ManagedType, class BaseType = ObjectHandle,
     class = std::enable_if_t<std::is_base_of<ObjectHandle, ManagedType>::value>>
 class ObjectList : public BaseType {
 public:

--- a/src/script_interface/shapes/Union.hpp
+++ b/src/script_interface/shapes/Union.hpp
@@ -30,42 +30,19 @@
 namespace ScriptInterface {
 namespace Shapes {
 
-class Union : public Shape {
+class Union : public ObjectList<Shape, Shape> {
 public:
   Union() : m_core_shape(new ::Shapes::Union()) {}
 
-  Variant do_call_method(std::string const &name,
-                         VariantMap const &params) override {
-    if (name == "add") {
-      auto const shape =
-          get_value<std::shared_ptr<Shapes::Shape>>(params.at("shape"));
-      m_core_shape->add(shape->shape());
-      m_shapes.push_back(shape);
-    } else if (name == "remove") {
-      auto const shape =
-          get_value<std::shared_ptr<Shapes::Shape>>(params.at("shape"));
-      m_core_shape->remove(shape->shape());
-      m_shapes.erase(std::remove(m_shapes.begin(), m_shapes.end(), shape),
-                     m_shapes.end());
-    } else if (name == "get_elements") {
-      std::vector<Variant> ret;
-      ret.reserve(m_shapes.size());
-      for (auto const &s : m_shapes) {
-        ret.emplace_back(s);
-      }
-      return ret;
-    } else if (name == "clear") {
-      for (auto &s : m_shapes) {
-        m_core_shape->remove(s->shape());
-      }
-      m_shapes.clear();
-    } else if (name == "size") {
-      return static_cast<int>(m_shapes.size());
-    } else if (name == "empty") {
-      return m_shapes.empty();
-    }
-    return Shape::do_call_method(name, params);
+private:
+  void add_in_core(const std::shared_ptr<Shape> &obj_ptr) override {
+    m_core_shape->add(obj_ptr->shape());
   }
+  void remove_in_core(const std::shared_ptr<Shape> &obj_ptr) override {
+    m_core_shape->remove(obj_ptr->shape());
+  }
+
+public:
   std::shared_ptr<::Shapes::Shape> shape() const override {
     return m_core_shape;
   }

--- a/src/script_interface/tests/CMakeLists.txt
+++ b/src/script_interface/tests/CMakeLists.txt
@@ -35,3 +35,4 @@ unit_test(NAME GlobalContext_test SRC GlobalContext_test.cpp DEPENDS
 unit_test(NAME Exception_test SRC Exception_test.cpp DEPENDS ScriptInterface)
 unit_test(NAME packed_variant_test SRC packed_variant_test.cpp DEPENDS
           ScriptInterface)
+unit_test(NAME ObjectList_test SRC ObjectList_test.cpp DEPENDS ScriptInterface)

--- a/src/script_interface/tests/ObjectList_test.cpp
+++ b/src/script_interface/tests/ObjectList_test.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2021 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE ObjectList test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <boost/range/algorithm/find.hpp>
+
+#include "script_interface/LocalContext.hpp"
+#include "script_interface/ObjectList.hpp"
+
+using namespace ScriptInterface;
+
+struct ObjectListImpl : ObjectList<ObjectHandle> {
+  std::vector<ObjectRef> mock_core;
+
+private:
+  void add_in_core(const ObjectRef &obj_ptr) override {
+    mock_core.push_back(obj_ptr);
+  }
+  void remove_in_core(const ObjectRef &obj_ptr) override {
+    mock_core.erase(std::remove(mock_core.begin(), mock_core.end(), obj_ptr),
+                    mock_core.end());
+  }
+};
+
+BOOST_AUTO_TEST_CASE(default_construction) {
+  // A defaulted ObjectList has no elements.
+  BOOST_CHECK(ObjectListImpl{}.elements().empty());
+}
+
+BOOST_AUTO_TEST_CASE(adding_elements) {
+  // Added elements are on the back of the list of elements.
+  auto e = ObjectRef{};
+  ObjectListImpl list;
+  list.add(e);
+  BOOST_CHECK(list.elements().back() == e);
+  // And is added to the core
+  BOOST_CHECK(boost::find(list.mock_core, e) != list.mock_core.end());
+}
+
+BOOST_AUTO_TEST_CASE(removing_elements) {
+  // An element that is removed from the list is
+  // no longer an element of the list.
+  auto e = ObjectRef{};
+  ObjectListImpl list;
+  list.add(e);
+  list.remove(e);
+  BOOST_CHECK(boost::find(list.elements(), e) == list.elements().end());
+  // And is removed from the core
+  BOOST_CHECK(boost::find(list.mock_core, e) == list.mock_core.end());
+}
+
+BOOST_AUTO_TEST_CASE(clearing_elements) {
+  // A cleared list is empty.
+  ObjectListImpl list;
+  list.add(ObjectRef{});
+  list.add(ObjectRef{});
+  list.clear();
+  BOOST_CHECK(list.elements().empty());
+}
+
+BOOST_AUTO_TEST_CASE(serialization) {
+  // In a context
+  Utils::Factory<ObjectHandle> f;
+  f.register_new<ObjectHandle>("ObjectHandle");
+  f.register_new<ObjectListImpl>("ObjectList");
+  auto ctx = std::make_shared<LocalContext>(f);
+  // A list of some elements
+  auto list = std::dynamic_pointer_cast<ObjectListImpl>(
+      ctx->make_shared("ObjectList", {}));
+  // with a bunch of elements
+
+  list->add(ctx->make_shared("ObjectHandle", {}));
+  list->add(ctx->make_shared("ObjectHandle", {}));
+  // can be serialized to a string
+  auto const s = list->serialize();
+  // and can be restored to a list with the same elements
+  auto const list2 = std::dynamic_pointer_cast<ObjectListImpl>(
+      ObjectHandle::deserialize(s, *ctx));
+  BOOST_CHECK(list2->elements().size() == list->elements().size());
+  BOOST_CHECK(list2->elements().front()->name() == "ObjectHandle");
+  BOOST_CHECK(list2->elements().back()->name() == "ObjectHandle");
+  // and the elements are restored to the core
+  BOOST_CHECK(list2->mock_core.size() == 2);
+  BOOST_CHECK(list2->mock_core.front()->name() == "ObjectHandle");
+  BOOST_CHECK(list2->mock_core.back()->name() == "ObjectHandle");
+}


### PR DESCRIPTION
Fixes #4101 

Description of changes:
- Handle serialization of elements contained in `ScriptInterface::ObjectList` to the core code
- Added an injectable base to `ScriptInterface::ObjectList`
- Make `ScriptInterface::Shapes::Union` an `ObjectList`
