### PR TITLE
Document matrix and quaternion types in utils.

### DIFF
--- a/src/utils/include/utils/matrix.hpp
+++ b/src/utils/include/utils/matrix.hpp
@@ -42,8 +42,21 @@
 #include <boost/qvm/mat_access.hpp>
 #include <boost/qvm/mat_traits.hpp>
 
+/**
+ * @file matrix.hpp
+ *
+ * @brief This file contains a matrix implementation and the trait types needed
+ * for the boost qvm interoperability.
+ */
+
 namespace Utils {
 
+/**
+ * @brief Matrix representation with static size.
+ * @tparam T The data type.
+ * @tparam Rows Number of rows.
+ * @tparam Cols Number of columns.
+ */
 template <typename T, std::size_t Rows, std::size_t Cols> struct Matrix {
   using container = Utils::Array<T, Cols * Rows>;
   using pointer = typename container::pointer;
@@ -71,54 +84,119 @@ template <typename T, std::size_t Rows, std::size_t Cols> struct Matrix {
     assert(init_list.size() == Rows);
     Utils::flatten(init_list, begin());
   }
+
+  /**
+   * @brief Element access (const).
+   * @param row The row used for access.
+   * @param col The column used for access.
+   * @return The matrix element at row @p row and column @p col.
+   */
   constexpr value_type operator()(std::size_t row, std::size_t col) const {
     assert(row < Rows);
     assert(col < Cols);
     return m_data[Cols * row + col];
   }
+  /**
+   * @brief Element access (non const).
+   * @param row The row used for access.
+   * @param col The column used for access.
+   * @return The matrix element at row @p row and column @p col.
+   */
   constexpr reference operator()(std::size_t row, std::size_t col) {
     assert(row < Rows);
     assert(col < Cols);
     return m_data[Cols * row + col];
   }
-  constexpr pointer data() { return m_data.data(); }
-  constexpr const_pointer data() const noexcept { return m_data.data(); }
-  constexpr iterator begin() noexcept { return m_data.begin(); };
-  constexpr const_iterator begin() const noexcept { return m_data.begin(); };
-  constexpr iterator end() noexcept { return m_data.end(); };
-  constexpr const_iterator end() const noexcept { return m_data.end(); };
 
+  /**
+   * @brief Access to the underlying data pointer (non const).
+   * @return Pointer to first element of the data.
+   */
+  constexpr pointer data() { return m_data.data(); }
+  /**
+   * @brief Access to the underlying data pointer (non const).
+   * @return Pointer to first element of the data.
+   */
+  constexpr const_pointer data() const noexcept { return m_data.data(); }
+  /**
+   * @brief Iterator access (non const).
+   * @return Returns an iterator to the first element of the matrix.
+   */
+  constexpr iterator begin() noexcept { return m_data.begin(); };
+  /**
+   * @brief Iterator access (const).
+   * @return Returns an iterator to the first element of the matrix.
+   */
+  constexpr const_iterator begin() const noexcept { return m_data.begin(); };
+  /**
+   * @brief Iterator access (non const).
+   * @return Returns an iterator to the element following the last element of
+   * the matrix.
+   */
+  constexpr iterator end() noexcept { return m_data.end(); };
+  /**
+   * @brief Iterator access (non const).
+   * @return Returns an iterator to the element following the last element of
+   * the matrix.
+   */
+  constexpr const_iterator end() const noexcept { return m_data.end(); };
+  /**
+   * @brief Retrieve an entire matrix row.
+   * @tparam R The row index.
+   * @return A vector containing the elements of row @p R.
+   */
   template <std::size_t R> Vector<T, Cols> row() const {
     static_assert(R < Rows, "Invalid row index.");
     return boost::qvm::row<R>(*this);
   }
-
+  /**
+   * @brief Retrieve an entire matrix column.
+   * @tparam C The column index.
+   * @return A vector containing the elements of column @p C.
+   */
   template <std::size_t C> Vector<T, Rows> col() const {
     static_assert(C < Cols, "Invalid column index.");
     return boost::qvm::col<C>(*this);
   }
-
+  /**
+   * @brief Retrieve the diagonal.
+   * @return Vector containing the diagonal elements of the matrix.
+   */
   Vector<T, Cols> diagonal() const {
     static_assert(Rows == Cols,
                   "Diagonal can only be retrieved from square matrices.");
     return boost::qvm::diag(*this);
   }
-
+  /**
+   * @brief Retrieve the trace.
+   * @return Vector containing the sum of diagonal matrix elements.
+   */
   T trace() const {
     auto const d = diagonal();
     return std::accumulate(d.begin(), d.end(), T{}, std::plus<T>{});
   }
 
+  /**
+   * @brief Retrieve a transposed copy of the matrix.
+   * @return Transposed matrix.
+   */
   Matrix<T, Cols, Rows> transposed() const {
     return boost::qvm::transposed(*this);
   }
 
+  /**
+   * @brief Retrieve an inversed copy of the matrix.
+   * @return Inversed matrix.
+   */
   Matrix<T, Rows, Cols> inversed() const {
     static_assert(Rows == Cols,
                   "Inversion of a non-square matrix not implemented.");
     return boost::qvm::inverse(*this);
   }
-
+  /**
+   * @brief Retrieve the shape of the matrix.
+   * @return Pair containing number of rows and number of columns of the matrix.
+   */
   constexpr std::pair<std::size_t, std::size_t> shape() const noexcept {
     return {Rows, Cols};
   }

--- a/src/utils/include/utils/quaternion.hpp
+++ b/src/utils/include/utils/quaternion.hpp
@@ -33,7 +33,19 @@
 #include "utils/Vector.hpp"
 #include "utils/matrix.hpp"
 
+/**
+ * @file quaternion.hpp
+ *
+ * @brief This file contains a matrix implementation and the trait types needed
+ * for the boost qvm interoperability.
+ */
+
 namespace Utils {
+
+/**
+ * Quaternion representation.
+ * @tparam T Element data type.
+ */
 template <typename T> struct Quaternion {
   using container = typename Utils::Array<T, 4>;
   container m_data;
@@ -47,30 +59,86 @@ template <typename T> struct Quaternion {
   void serialize(Archive &ar, const unsigned int version) {
     ar &m_data;
   }
-
+  /**
+   * @brief Normalize the quaternion in place.
+   */
   void normalize() { boost::qvm::normalize(*this); }
 
+  /**
+   * @brief Retrieve a normalized copy of the quaternion.
+   * @return Normalized quaternion.
+   */
   Quaternion<T> normalized() const { return boost::qvm::normalized(*this); }
 
+  /**
+   * @brief Element access (const).
+   * @param i Element index.
+   * @return Value of element @p i.
+   */
   value_type operator[](std::size_t i) const { return m_data[i]; }
+  /**
+   * @brief Element access (non const).
+   * @param i Element index.
+   * @return Value of element @p i.
+   */
   reference operator[](std::size_t i) { return m_data[i]; }
 
+  /**
+   * @brief Retrieve the norm of the quaternion.
+   * @return The norm.
+   */
   value_type norm() const { return boost::qvm::mag(*this); }
+  /**
+   * @brief Retrieve the square of the norm of the quaternion.
+   * @return The squared norm.
+   */
   value_type norm2() const { return boost::qvm::mag_sqr(*this); }
 
+  /**
+   * @brief Construct an identity quaternion.
+   * @return Identity quaternion.
+   */
   static Quaternion<T> identity() { return boost::qvm::identity_quat<T>(); }
 
+  /**
+   * @brief Construct a zero quaternion.
+   * @return Quaternion with all elements set to zero.
+   */
   static Quaternion<T> zero() { return boost::qvm::zero_quat<T>(); }
+
+  /**
+   * @brief Access to the underlying data (non const).
+   * @return Pointer to the first data member.
+   */
   constexpr pointer data() { return m_data.data(); }
+
+  /**
+   * @brief Access to the underlying data (const).
+   * @return Pointer to the first data member.
+   */
   constexpr const_pointer data() const noexcept { return m_data.data(); }
 };
 
+/**
+ * @brief Product quaternion and arithmetic type.
+ * @tparam T Data type of quaternion @p a.
+ * @tparam U Type of multiplier @p b.
+ * @param b Quaternion.
+ * @param a Multiplier.
+ * @return Multiplied quaternion.
+ */
 template <typename T, typename U,
           std::enable_if_t<std::is_arithmetic<U>::value, bool> = true>
 Quaternion<T> operator*(const U &b, const Quaternion<T> &a) {
   return boost::qvm::operator*(a, b);
 }
 
+/**
+ * @brief Convert quaternion to rotation matrix.
+ * @tparam T Data type of quaternion.
+ * @param q Quaternion.
+ * @return Rotation matrix.
+ */
 template <typename T> Matrix<T, 3, 3> rotation_matrix(Quaternion<T> const &q) {
   auto const normed_q = q.normalized();
   auto const id_mat = Utils::identity_mat<double, 3, 3>();


### PR DESCRIPTION
Fixes #4048 

Description of changes:
- Added documentation for quaternion and matrix.
