### PR TITLE
utils: Better constraint for Utils::get

### DIFF
--- a/src/utils/include/utils/get.hpp
+++ b/src/utils/include/utils/get.hpp
@@ -23,7 +23,8 @@
 #include <tuple>
 
 namespace Utils {
-template <std::size_t I, typename T> auto get(const T &v) {
+template <std::size_t I, typename T>
+const std::tuple_element_t<I, T> &get(const T &v) {
   return std::get<I>(v);
 }
 


### PR DESCRIPTION
Description of changes:
- Constraint "Utils::get" to types that actually implement the (std) tuple protocol.
  This avoids this function to be picked up by ADL where it should be in some cases.

