### PR TITLE
Make particle id less prominent in the testsuite

### DIFF
--- a/testsuite/python/accumulator_correlator.py
+++ b/testsuite/python/accumulator_correlator.py
@@ -82,9 +82,9 @@ class CorrelatorTest(ut.TestCase):
     def test_square_distance_componentwise(self):
         s = self.system
         v = np.array([1, 2, 3])
-        s.part.add(id=0, pos=(0, 0, 0), v=v)
+        p = s.part.add(pos=(0, 0, 0), v=v)
 
-        obs = espressomd.observables.ParticlePositions(ids=(0,))
+        obs = espressomd.observables.ParticlePositions(ids=(p.id,))
         acc = espressomd.accumulators.Correlator(
             obs1=obs, tau_lin=10, tau_max=2, delta_N=1,
             corr_operation="square_distance_componentwise")
@@ -105,9 +105,9 @@ class CorrelatorTest(ut.TestCase):
     def test_tensor_product(self):
         s = self.system
         v = np.array([1, 2, 3])
-        s.part.add(id=0, pos=(0, 0, 0), v=v)
+        p = s.part.add(pos=(0, 0, 0), v=v)
 
-        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        obs = espressomd.observables.ParticleVelocities(ids=(p.id,))
         acc = espressomd.accumulators.Correlator(
             obs1=obs, tau_lin=12, tau_max=2, delta_N=1,
             corr_operation="tensor_product")
@@ -128,9 +128,9 @@ class CorrelatorTest(ut.TestCase):
     def test_componentwise_product(self):
         s = self.system
         v = np.array([1, 2, 3])
-        s.part.add(id=0, pos=(0, 0, 0), v=v)
+        p = s.part.add(pos=(0, 0, 0), v=v)
 
-        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        obs = espressomd.observables.ParticleVelocities(ids=(p.id,))
         acc = espressomd.accumulators.Correlator(
             obs1=obs, tau_lin=10, tau_max=2, delta_N=1,
             corr_operation="componentwise_product")
@@ -150,9 +150,9 @@ class CorrelatorTest(ut.TestCase):
     def test_scalar_product(self):
         s = self.system
         v = np.array([1, 2, 3])
-        s.part.add(id=0, pos=(0, 0, 0), v=v)
+        p = s.part.add(pos=(0, 0, 0), v=v)
 
-        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        obs = espressomd.observables.ParticleVelocities(ids=(p.id,))
         acc = espressomd.accumulators.Correlator(
             obs1=obs, tau_lin=10, tau_max=2, delta_N=1,
             corr_operation="scalar_product")
@@ -172,10 +172,10 @@ class CorrelatorTest(ut.TestCase):
     def test_fcs(self):
         s = self.system
         v = np.array([1, 2, 3])
-        s.part.add(id=0, pos=(0, 0, 0), v=v)
+        p = s.part.add(pos=(0, 0, 0), v=v)
 
         w = np.array([3, 2, 1])
-        obs = espressomd.observables.ParticlePositions(ids=(0,))
+        obs = espressomd.observables.ParticlePositions(ids=(p.id,))
         acc = espressomd.accumulators.Correlator(
             obs1=obs, tau_lin=10, tau_max=9.9 * self.system.time_step,
             delta_N=1, corr_operation="fcs_acf", args=w)
@@ -202,7 +202,7 @@ class CorrelatorTest(ut.TestCase):
 
     def test_correlator_interface(self):
         # test setters and getters
-        obs = espressomd.observables.ParticleVelocities(ids=(0,))
+        obs = espressomd.observables.ParticleVelocities(ids=(123,))
         acc = espressomd.accumulators.Correlator(
             obs1=obs, tau_lin=10, tau_max=12.0, delta_N=1,
             corr_operation="scalar_product")

--- a/testsuite/python/analyze_distribution.py
+++ b/testsuite/python/analyze_distribution.py
@@ -32,16 +32,14 @@ class AnalyzeDistributions(ut.TestCase):
         # start with a small box
         cls.system.box_l = np.array([box_l, box_l, box_l])
         cls.system.cell_system.set_n_square(use_verlet_lists=False)
-        for p in range(cls.num_part):
-            cls.system.part.add(
-                id=p,
-                pos=np.random.random() * cls.system.box_l)
+        cls.system.part.add(
+            pos=np.outer(np.random.random(cls.num_part), cls.system.box_l))
 
     def calc_min_distribution(self, bins):
         dist = []
-        for i in range(self.num_part):
-            dist.append(np.min([self.system.distance(
-                self.system.part[i], p.pos) for p in self.system.part if p.id != i]))
+        for p1 in self.system.part:
+            dist.append(min(self.system.distance(p1, p2.pos)
+                            for p2 in self.system.part if p1.id != p2.id))
         hist = np.histogram(dist, bins=bins, density=False)[0]
         return hist / (float(np.sum(hist)))
 

--- a/testsuite/python/brownian_dynamics_stats.py
+++ b/testsuite/python/brownian_dynamics_stats.py
@@ -104,7 +104,7 @@ class BrownianThermostat(ut.TestCase, ThermostatsCommon):
         dt = 0.5
 
         system = self.system
-        p = system.part.add(pos=(0, 0, 0), id=0)
+        p = system.part.add(pos=(0, 0, 0))
         system.time_step = dt
         system.thermostat.set_brownian(kT=kT, gamma=gamma, seed=41)
         system.cell_system.skin = 0.4
@@ -140,7 +140,7 @@ class BrownianThermostat(ut.TestCase, ThermostatsCommon):
         system.cell_system.skin = 0.1
         kT = 3.2
         system.thermostat.set_brownian(kT=kT, gamma=2.1, seed=17)
-        system.part.add(id=(0, 1), pos=np.zeros((2, 3)))
+        system.part.add(pos=np.zeros((2, 3)))
         steps = int(1e4)
         error_delta = 0.04
         self.check_noise_correlation(kT, steps, error_delta)

--- a/testsuite/python/constant_pH_stats.py
+++ b/testsuite/python/constant_pH_stats.py
@@ -49,11 +49,9 @@ class ReactionEnsembleTest(ut.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        for i in range(0, 2 * cls.N0, 2):
-            cls.system.part.add(id=i, pos=np.random.random(3) *
-                                cls.system.box_l, type=cls.type_A)
-            cls.system.part.add(id=i + 1, pos=np.random.random(3) *
-                                cls.system.box_l, type=cls.type_H)
+        cls.system.part.add(
+            pos=np.random.random((2 * cls.N0, 3)) * cls.system.box_l,
+            type=cls.N0 * [cls.type_A, cls.type_H])
 
         cls.RE.add_reaction(
             gamma=cls.Ka,

--- a/testsuite/python/constraint_homogeneous_magnetic_field.py
+++ b/testsuite/python/constraint_homogeneous_magnetic_field.py
@@ -70,13 +70,13 @@ class HomogeneousMagneticFieldTest(ut.TestCase):
         self.assertEqual(self.S.analysis.energy()["dipolar"], 0.0)
 
         # check dipolar energy when adding dipole moments
-        self.S.part.add(id=0, pos=[0, 0, 0], dip=dip_mom0, rotation=(1, 1, 1))
+        p0 = self.S.part.add(pos=[0, 0, 0], dip=dip_mom0, rotation=(1, 1, 1))
         self.assertEqual(self.S.analysis.energy()["dipolar"],
                          -1.0 * np.dot(H_field, dip_mom0))
-        self.S.part.add(id=1, pos=[1, 1, 1], dip=dip_mom1, rotation=(1, 1, 1))
+        p1 = self.S.part.add(pos=[1, 1, 1], dip=dip_mom1, rotation=(1, 1, 1))
         self.assertEqual(self.S.analysis.energy()["dipolar"],
-                         (-1.0 * np.dot(H_field, dip_mom0)
-                          - 1.0 * np.dot(H_field, dip_mom1)))
+                         -(np.dot(H_field, dip_mom0) +
+                           np.dot(H_field, dip_mom1)))
 
         if espressomd.has_features(["ROTATION"]):
             # check that running the integrator leads to expected torques
@@ -85,11 +85,11 @@ class HomogeneousMagneticFieldTest(ut.TestCase):
             torque_expected1 = np.cross(dip_mom1, H_field)
             for i in range(3):
                 self.assertAlmostEqual(
-                    self.S.part[0].torque_lab[i],
+                    p0.torque_lab[i],
                     torque_expected0[i],
                     places=10)
                 self.assertAlmostEqual(
-                    self.S.part[1].torque_lab[i],
+                    p1.torque_lab[i],
                     torque_expected1[i],
                     places=10)
 

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -186,7 +186,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         system = self.system
         system.time_step = 0.01
         system.cell_system.skin = 0.4
-        system.part.add(pos=[0., 0., 0.], type=0)
+        p = system.part.add(pos=[0., 0., 0.], type=0)
 
         # abuse generic LJ to measure distance via the potential V(r) = r
         system.non_bonded_inter[0, 1].generic_lennard_jones.set_params(
@@ -213,7 +213,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 v = j / float(N - 1) * 2. - 1
                 pos = self.pos_on_surface(
                     theta, v, semiaxes[0], semiaxes[1], semiaxes[1])
-                system.part[0].pos = pos
+                p.pos = pos
                 system.integrator.run(recalc_forces=True, steps=0)
                 energy = system.analysis.energy()
                 self.assertAlmostEqual(energy["total"], 0., places=6)
@@ -239,7 +239,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 v = j / float(N - 1) * 2. - 1
                 pos = self.pos_on_surface(
                     theta, v, semiaxes[0], semiaxes[1], semiaxes[1])
-                system.part[0].pos = pos
+                p.pos = pos
                 system.integrator.run(recalc_forces=True, steps=0)
                 energy = system.analysis.energy()
                 self.assertAlmostEqual(energy["total"], 0., places=6)
@@ -260,7 +260,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 v = j / float(N - 1) * 2. - 1
                 for r in radii:
                     pos = self.pos_on_surface(theta, v, r, r, r)
-                    system.part[0].pos = pos
+                    p.pos = pos
                     system.integrator.run(recalc_forces=True, steps=0)
                     energy = system.analysis.energy()
                     self.assertAlmostEqual(energy["total"], r - 1.)
@@ -282,7 +282,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         rad = self.box_l / 2.0
         length = self.box_l / 2.0
 
-        system.part.add(id=0, pos=[rad, 1.02, rad], type=0)
+        system.part.add(pos=[rad, 1.02, rad], type=0)
 
         # check force calculation of a cylinder without top and bottom
         interaction_dir = -1  # constraint is directed inwards
@@ -316,7 +316,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
 
         # check whether total_summed_outer_normal_force is correct
         y_part2 = self.box_l - 1.02
-        system.part.add(id=1, pos=[rad, y_part2, rad], type=0)
+        system.part.add(pos=[rad, y_part2, rad], type=0)
         system.integrator.run(0)
 
         dist_part2 = self.box_l - y_part2
@@ -404,8 +404,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         system.time_step = 0.01
         system.cell_system.skin = 0.4
 
-        system.part.add(
-            id=0, pos=[self.box_l / 2.0, 1.02, self.box_l / 2.0], type=0)
+        system.part.add(pos=[self.box_l / 2.0, 1.02, self.box_l / 2.0], type=0)
 
         # check force calculation of spherocylinder constraint
         # (1) infinite cylinder
@@ -441,7 +440,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         # check whether total_summed_outer_normal_force is correct
         y_part2 = self.box_l - 1.02
         system.part.add(
-            id=1, pos=[self.box_l / 2.0, y_part2, self.box_l / 2.0], type=0)
+            pos=[self.box_l / 2.0, y_part2, self.box_l / 2.0], type=0)
         system.integrator.run(0)
 
         dist_part2 = self.box_l - y_part2
@@ -478,14 +477,13 @@ class ShapeBasedConstraintTest(ut.TestCase):
         # check hemispherical caps (multiple distances from surface)
         N = 10
         radii = np.linspace(1., 10., 10)
-        system.part.add(pos=[0., 0., 0.], type=0)
+        p = system.part.add(pos=[0., 0., 0.], type=0)
         for i in range(6):
             for j in range(N):
                 theta = 2. * i / float(N) * np.pi
                 v = j / float(N - 1) * 2. - 1
                 for r in radii:
-                    pos = self.pos_on_surface(theta, v, r, r, r) + [0, 3, 0]
-                    system.part[0].pos = pos
+                    p.pos = self.pos_on_surface(theta, v, r, r, r) + [0, 3, 0]
                     system.integrator.run(recalc_forces=True, steps=0)
                     energy = system.analysis.energy()
                     self.assertAlmostEqual(energy["total"], 10. - r)
@@ -512,14 +510,10 @@ class ShapeBasedConstraintTest(ut.TestCase):
         """
         system = self.system
         system.time_step = 0.01
-        system.part.add(id=0, pos=[5., 1.21, 0.83], type=0)
+        p = system.part.add(pos=[5., 1.21, 0.83], type=0)
 
         # Check forces are initialized to zero
-        f_part = system.part[0].f
-
-        self.assertEqual(f_part[0], 0.)
-        self.assertEqual(f_part[1], 0.)
-        self.assertEqual(f_part[2], 0.)
+        np.testing.assert_array_equal(np.copy(p.f), [0., 0., 0.])
 
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
             epsilon=1.0, sigma=1.0, cutoff=2.0, shift=0)
@@ -538,11 +532,10 @@ class ShapeBasedConstraintTest(ut.TestCase):
         wall_xy = system.constraints.add(shape=shape_xy, particle_type=2)
 
         system.integrator.run(0)  # update forces
-        f_part = system.part[0].f
 
-        self.assertEqual(f_part[0], 0.)
+        self.assertEqual(p.f[0], 0.)
         self.assertAlmostEqual(
-            f_part[1],
+            p.f[1],
             tests_common.lj_force(
                 espressomd,
                 cutoff=2.0,
@@ -552,7 +545,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 r=1.21),
             places=10)
         self.assertAlmostEqual(
-            f_part[2],
+            p.f[2],
             tests_common.lj_force(
                 espressomd,
                 cutoff=2.0,
@@ -597,10 +590,10 @@ class ShapeBasedConstraintTest(ut.TestCase):
             places=10)
 
         # this one is closer and should get the mindist()
-        system.part.add(pos=[5., 1.20, 0.82], type=0)
-        self.assertAlmostEqual(constraint_xz.min_dist(), system.part[1].pos[1])
-        self.assertAlmostEqual(wall_xz.min_dist(), system.part[1].pos[1])
-        self.assertAlmostEqual(wall_xy.min_dist(), system.part[1].pos[2])
+        p1 = system.part.add(pos=[5., 1.20, 0.82], type=0)
+        self.assertAlmostEqual(constraint_xz.min_dist(), p1.pos[1])
+        self.assertAlmostEqual(wall_xz.min_dist(), p1.pos[1])
+        self.assertAlmostEqual(wall_xy.min_dist(), p1.pos[2])
 
         # Reset
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
@@ -633,7 +626,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         system.non_bonded_inter[0, 1].generic_lennard_jones.set_params(
             epsilon=1., sigma=1., cutoff=10., shift=0., offset=0., e1=-1, e2=0, b1=1., b2=0.)
 
-        system.part.add(pos=[0., 0., 0.], type=0)
+        p = system.part.add(pos=[0., 0., 0.], type=0)
         x = self.box_l / 2.0
         d = 1 - np.sqrt(2) / 2
         parameters = [
@@ -651,7 +644,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
             ([x, x, 27.], -2., [0., 0., 1.]),  # outside wall
         ]
         for pos, ref_mindist, ref_force in parameters:
-            system.part[0].pos = pos
+            p.pos = pos
             system.integrator.run(recalc_forces=True, steps=0)
             obs_mindist = slitpore_constraint.min_dist()
             self.assertAlmostEqual(obs_mindist, ref_mindist, places=10)
@@ -695,16 +688,15 @@ class ShapeBasedConstraintTest(ut.TestCase):
 
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
             epsilon=1.0, sigma=1.0, cutoff=2.0, shift=0)
-        system.part.add(id=0, pos=[self.box_l / 2.0 + length[0] / 2.0,
-                                   self.box_l / 2.0 + length[1] / 2.0,
-                                   self.box_l / 2.0 - 1], type=0)
+        p = system.part.add(pos=[self.box_l / 2.0 + length[0] / 2.0,
+                                 self.box_l / 2.0 + length[1] / 2.0,
+                                 self.box_l / 2.0 - 1], type=0)
         system.integrator.run(0)  # update forces
-        f_part = system.part[0].f
         self.assertEqual(rhomboid_constraint.min_dist(), 1.)
-        self.assertEqual(f_part[0], 0.)
-        self.assertEqual(f_part[1], 0.)
+        self.assertEqual(p.f[0], 0.)
+        self.assertEqual(p.f[1], 0.)
         self.assertAlmostEqual(
-            -f_part[2],
+            -p.f[2],
             tests_common.lj_force(
                 espressomd,
                 cutoff=2.,
@@ -796,9 +788,10 @@ class ShapeBasedConstraintTest(ut.TestCase):
         rhomboid_shape.b = [0., 0., 5.]
         rhomboid_shape.c = [0., 5., 0.]
 
-        system.part[0].pos = [self.box_l / 2.0 + 2.5,
-                              self.box_l / 2.0 + 2.5,
-                              self.box_l / 2.0 - 1]
+        p.pos = [
+            self.box_l / 2 + 2.5,
+            self.box_l / 2 + 2.5,
+            self.box_l / 2 - 1]
 
         system.integrator.run(0)  # update forces
         self.assertEqual(rhomboid_constraint.min_dist(), 1.)
@@ -813,7 +806,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
                 r=1.),
             places=10)
 
-        system.part[0].pos = system.part[0].pos - [0., 1., 0.]
+        p.pos = p.pos - [0., 1., 0.]
         system.integrator.run(0)  # update forces
         self.assertAlmostEqual(
             rhomboid_constraint.min_dist(), 1.2247448714, 10)
@@ -847,7 +840,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         part_offset = 1.2
 
         system.part.add(
-            id=0, pos=[self.box_l / 2.0, self.box_l / 2.0 + part_offset, self.box_l / 2.0], type=0)
+            pos=[self.box_l / 2.0, self.box_l / 2.0 + part_offset, self.box_l / 2.0], type=0)
 
         # check force calculation of cylinder constraint
         torus_shape = espressomd.shapes.Torus(
@@ -882,7 +875,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
         # check whether total_summed_outer_normal_force is correct
         y_part2 = self.box_l / 2.0 + 2.0 * radius - part_offset
         system.part.add(
-            id=1, pos=[self.box_l / 2.0, y_part2, self.box_l / 2.0], type=0)
+            pos=[self.box_l / 2.0, y_part2, self.box_l / 2.0], type=0)
         system.integrator.run(0)
 
         self.assertAlmostEqual(torus_wall.total_force()[1], 0.0)

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -53,13 +53,13 @@ class CoulombCloudWall(ut.TestCase):
 
         # Add particles to system and store reference forces in hash
         # Input format: id pos q f
-        for particle in data:
-            id = particle[0]
-            pos = particle[1:4]
-            q = particle[4]
-            f = particle[5:]
-            self.S.part.add(id=int(id), pos=pos, q=q)
-            self.forces[id] = f
+        for row in data:
+            pid = int(row[0])
+            pos = row[1:4]
+            q = row[4]
+            f = row[5:]
+            self.S.part.add(id=pid, pos=pos, q=q)
+            self.forces[pid] = f
 
     def tearDown(self):
         self.S.part.clear()

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -32,9 +32,9 @@ class CoulombCloudWall(ut.TestCase):
     """This compares p3m, p3m_gpu electrostatic forces and energy against
     stored data."""
     S = espressomd.System(box_l=[1.0, 1.0, 1.0])
-    np.random.seed(seed=42)
+    data = np.genfromtxt(
+        abspath("data/coulomb_cloud_wall_duplicated_system.data"))
 
-    forces = {}
     tolerance = 1E-3
 
     # Reference energy from p3m in the tcl test case
@@ -45,18 +45,10 @@ class CoulombCloudWall(ut.TestCase):
         self.S.time_step = 0.01
         self.S.cell_system.skin = 0.4
 
-        data = np.genfromtxt(
-            abspath("data/coulomb_cloud_wall_duplicated_system.data"))
-
         # Add particles to system and store reference forces in hash
         # Input format: id pos q f
-        for row in data:
-            pid = int(row[0])
-            pos = row[1:4]
-            q = row[4]
-            f = row[5:]
-            self.S.part.add(id=pid, pos=pos, q=q)
-            self.forces[pid] = f
+        self.S.part.add(pos=self.data[:, 1:4], q=self.data[:, 4])
+        self.forces = self.data[:, 5:8]
 
     def tearDown(self):
         self.S.part.clear()
@@ -66,10 +58,10 @@ class CoulombCloudWall(ut.TestCase):
         # Compare forces and energy now in the system to stored ones
 
         # Force
-        force_abs_diff = 0.
-        for p in self.S.part:
-            force_abs_diff += np.linalg.norm(p.f - self.forces[p.id])
-        force_abs_diff /= len(self.S.part)
+        force_diff = np.linalg.norm(self.S.part[:].f - self.forces, axis=1)
+        self.assertLess(
+            np.mean(force_diff), self.tolerance,
+            msg="Absolute force difference too large for method " + method_name)
 
         # Energy
         if energy:
@@ -77,9 +69,6 @@ class CoulombCloudWall(ut.TestCase):
                 self.S.analysis.energy()["total"], self.reference_energy,
                 delta=self.tolerance,
                 msg="Absolute energy difference too large for " + method_name)
-        self.assertLess(
-            force_abs_diff, self.tolerance,
-            msg="Absolute force difference too large for method " + method_name)
 
     # Tests for individual methods
 

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -50,13 +50,13 @@ class CoulombCloudWall(ut.TestCase):
 
         # Add particles to system and store reference forces in hash
         # Input format: id pos q f
-        for particle in data:
-            id = particle[0]
-            pos = particle[1:4]
-            q = particle[4]
-            f = particle[5:]
-            self.S.part.add(id=int(id), pos=pos, q=q)
-            self.forces[id] = f
+        for row in data:
+            pid = int(row[0])
+            pos = row[1:4]
+            q = row[4]
+            f = row[5:]
+            self.S.part.add(id=pid, pos=pos, q=q)
+            self.forces[pid] = f
 
     def tearDown(self):
         self.S.part.clear()

--- a/testsuite/python/coulomb_mixed_periodicity.py
+++ b/testsuite/python/coulomb_mixed_periodicity.py
@@ -50,13 +50,13 @@ class CoulombMixedPeriodicity(ut.TestCase):
 
         # Add particles to system and store reference forces in hash
         # Input format: id pos q f
-        for particle in data:
-            id = particle[0]
-            pos = particle[1:4]
-            q = particle[4]
-            f = particle[5:]
-            self.S.part.add(id=int(id), pos=pos, q=q)
-            self.forces[id] = f
+        for row in data:
+            pid = int(row[0])
+            pos = row[1:4]
+            q = row[4]
+            f = row[5:]
+            self.S.part.add(id=pid, pos=pos, q=q)
+            self.forces[pid] = f
 
     def tearDown(self):
         self.S.part.clear()

--- a/testsuite/python/dawaanr-and-bh-gpu.py
+++ b/testsuite/python/dawaanr-and-bh-gpu.py
@@ -92,9 +92,6 @@ class BHGPUTest(ut.TestCase):
             self.system.actors.add(bh_gpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            bhgpu_f = []
-            bhgpu_t = []
-
             bhgpu_f = np.copy(self.system.part[:].f)
             bhgpu_t = np.copy(self.system.part[:].torque_lab)
             bhgpu_e = self.system.analysis.energy()["total"]

--- a/testsuite/python/dawaanr-and-bh-gpu.py
+++ b/testsuite/python/dawaanr-and-bh-gpu.py
@@ -79,14 +79,9 @@ class BHGPUTest(ut.TestCase):
             self.system.actors.add(dds_cpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            dawaanr_f = []
-            dawaanr_t = []
-
-            for i in range(n):
-                dawaanr_f.append(self.system.part[i].f)
-                dawaanr_t.append(self.system.part[i].torque_lab)
-            dawaanr_e = espressomd.analyze.Analysis(
-                self.system).energy()["total"]
+            dawaanr_f = np.copy(self.system.part[:].f)
+            dawaanr_t = np.copy(self.system.part[:].torque_lab)
+            dawaanr_e = self.system.analysis.energy()["total"]
 
             del dds_cpu
             self.system.actors.clear()
@@ -100,11 +95,9 @@ class BHGPUTest(ut.TestCase):
             bhgpu_f = []
             bhgpu_t = []
 
-            for i in range(n):
-                bhgpu_f.append(self.system.part[i].f)
-                bhgpu_t.append(self.system.part[i].torque_lab)
-            bhgpu_e = espressomd.analyze.Analysis(
-                self.system).energy()["total"]
+            bhgpu_f = np.copy(self.system.part[:].f)
+            bhgpu_t = np.copy(self.system.part[:].torque_lab)
+            bhgpu_e = self.system.analysis.energy()["total"]
 
             # compare
             for i in range(n):

--- a/testsuite/python/dawaanr-and-dds-gpu.py
+++ b/testsuite/python/dawaanr-and-dds-gpu.py
@@ -75,12 +75,8 @@ class DDSGPUTest(ut.TestCase):
             self.es.actors.add(dds_cpu)
             self.es.integrator.run(steps=0, recalc_forces=True)
 
-            dawaanr_f = []
-            dawaanr_t = []
-
-            for i in range(n):
-                dawaanr_f.append(self.es.part[i].f)
-                dawaanr_t.append(self.es.part[i].torque_lab)
+            dawaanr_f = np.copy(self.es.part[:].f)
+            dawaanr_t = np.copy(self.es.part[:].torque_lab)
             dawaanr_e = self.es.analysis.energy()["total"]
 
             del dds_cpu
@@ -93,12 +89,8 @@ class DDSGPUTest(ut.TestCase):
             self.es.actors.add(dds_gpu)
             self.es.integrator.run(steps=0, recalc_forces=True)
 
-            ddsgpu_f = []
-            ddsgpu_t = []
-
-            for i in range(n):
-                ddsgpu_f.append(self.es.part[i].f)
-                ddsgpu_t.append(self.es.part[i].torque_lab)
+            ddsgpu_f = np.copy(self.es.part[:].f)
+            ddsgpu_t = np.copy(self.es.part[:].torque_lab)
             ddsgpu_e = self.es.analysis.energy()["total"]
 
             # compare

--- a/testsuite/python/dds-and-bh-gpu.py
+++ b/testsuite/python/dds-and-bh-gpu.py
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest as ut
 import unittest_decorators as utx
+import tests_common
 import numpy as np
-from numpy.random import random
 
 import espressomd
 import espressomd.magnetostatics
@@ -52,16 +52,10 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
 
         for n in [128, 541]:
             dipole_modulus = 1.3
-            for i in range(n):
-                part_pos = np.array(random(3)) * l
-                costheta = 2 * random() - 1
-                sintheta = np.sin(np.arccos(costheta))
-                phi = 2 * np.pi * random()
-                part_dip[0] = sintheta * np.cos(phi) * dipole_modulus
-                part_dip[1] = sintheta * np.sin(phi) * dipole_modulus
-                part_dip[2] = costheta * dipole_modulus
-                self.system.part.add(id=i, type=0, pos=part_pos, dip=part_dip,
-                                     v=np.array([0, 0, 0]), omega_body=np.array([0, 0, 0]))
+            part_pos = np.random.random((n, 3)) * l
+            part_dip = dipole_modulus * tests_common.random_dipoles(n)
+            self.system.part.add(pos=part_pos, dip=part_dip,
+                                 v=n * [(0, 0, 0)], omega_body=n * [(0, 0, 0)])
 
             self.system.non_bonded_inter[0, 0].lennard_jones.set_params(
                 epsilon=10.0, sigma=0.5, cutoff=0.55, shift="auto")
@@ -86,14 +80,9 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
             self.system.actors.add(dds_gpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            dawaanr_f = []
-            dawaanr_t = []
-
-            for i in range(n):
-                dawaanr_f.append(self.system.part[i].f)
-                dawaanr_t.append(self.system.part[i].torque_lab)
-            dawaanr_e = espressomd.analyze.Analysis(
-                self.system).energy()["total"]
+            dawaanr_f = np.copy(self.system.part[:].f)
+            dawaanr_t = np.copy(self.system.part[:].torque_lab)
+            dawaanr_e = self.system.analysis.energy()["total"]
 
             del dds_gpu
             self.system.actors.clear()
@@ -104,14 +93,9 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
             self.system.actors.add(bh_gpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            bhgpu_f = []
-            bhgpu_t = []
-
-            for i in range(n):
-                bhgpu_f.append(self.system.part[i].f)
-                bhgpu_t.append(self.system.part[i].torque_lab)
-            bhgpu_e = espressomd.analyze.Analysis(
-                self.system).energy()["total"]
+            bhgpu_f = np.copy(self.system.part[:].f)
+            bhgpu_t = np.copy(self.system.part[:].torque_lab)
+            bhgpu_e = self.system.analysis.energy()["total"]
 
             # compare
             for i in range(n):

--- a/testsuite/python/dipolar_p3m.py
+++ b/testsuite/python/dipolar_p3m.py
@@ -31,8 +31,8 @@ class MagnetostaticsP3M(ut.TestCase):
 
     def setUp(self):
         self.system.box_l = [10., 10., 10.]
-        self.system.part.add(id=0, pos=[4.0, 2.0, 2.0], dip=(1.3, 2.1, -6))
-        self.system.part.add(id=1, pos=[6.0, 2.0, 2.0], dip=(7.3, 6.1, -4))
+        self.system.part.add(pos=[4.0, 2.0, 2.0], dip=(1.3, 2.1, -6.0))
+        self.system.part.add(pos=[6.0, 2.0, 2.0], dip=(7.3, 6.1, -4.0))
 
     def tearDown(self):
         self.system.part.clear()

--- a/testsuite/python/domain_decomposition.py
+++ b/testsuite/python/domain_decomposition.py
@@ -26,21 +26,22 @@ class DomainDecomposition(ut.TestCase):
     original_node_grid = tuple(system.cell_system.node_grid)
 
     def setUp(self):
-        self.system.part.clear()
         self.system.cell_system.set_domain_decomposition(
             use_verlet_lists=False)
         self.system.cell_system.node_grid = self.original_node_grid
+
+    def tearDown(self):
+        self.system.part.clear()
 
     def check_resort(self):
         n_part = 2351
 
         # Add the particles on node 0, so that they have to be resorted
-        for i in range(n_part):
-            self.system.part.add(id=i, pos=[0, 0, 0], type=1)
+        self.system.part.add(pos=n_part * [(0, 0, 0)], type=n_part * [1])
 
         # And now change their positions
-        for i in range(n_part):
-            self.system.part[i].pos = self.system.box_l * np.random.random(3)
+        self.system.part[:].pos = self.system.box_l * \
+            np.random.random((n_part, 3))
 
         # Distribute the particles on the nodes
         part_dist = self.system.cell_system.resort()

--- a/testsuite/python/ek_charged_plate.py
+++ b/testsuite/python/ek_charged_plate.py
@@ -78,16 +78,16 @@ class ek_charged_plate(ut.TestCase):
                 negative_ions[30, i, j].density = 1.0 / agrid
 
         # Setup MD particle and integrate
-        system.part.add(id=0, pos=[0, 0, 0], q=-1.0, type=0)
+        p = system.part.add(pos=[0, 0, 0], q=-1.0, type=0)
         force_difference = 0.0
 
         for i in range(7, 14):
-            system.part[0].pos = [i, 0, 0]
+            p.pos = [i, 0, 0]
             system.integrator.run(0)
 
             # Check Force
             expected_force = -2 * math.pi * bjerrum_length
-            particle_force = system.part[0].f
+            particle_force = p.f
             if abs(expected_force - particle_force[0]) > force_difference:
                 force_difference = abs(expected_force - particle_force[0])
 
@@ -113,12 +113,12 @@ class ek_charged_plate(ut.TestCase):
         force_difference = 0.0
 
         for i in range(7, 14):
-            system.part[0].pos = [0, i, 0]
+            p.pos = [0, i, 0]
             system.integrator.run(0)
 
             # Check Force
             expected_force = -2 * math.pi * bjerrum_length
-            particle_force = system.part[0].f
+            particle_force = p.f
             if abs(expected_force - particle_force[1]) > force_difference:
                 force_difference = abs(expected_force - particle_force[1])
 
@@ -144,12 +144,12 @@ class ek_charged_plate(ut.TestCase):
         force_difference = 0.0
 
         for i in range(7, 14):
-            system.part[0].pos = [0, 0, i]
+            p.pos = [0, 0, i]
             system.integrator.run(0)
 
             # Check Force
             expected_force = -2 * math.pi * bjerrum_length
-            particle_force = system.part[0].f
+            particle_force = p.f
             if abs(expected_force - particle_force[2]) > force_difference:
                 force_difference = abs(expected_force - particle_force[2])
 

--- a/testsuite/python/elc_vs_analytic.py
+++ b/testsuite/python/elc_vs_analytic.py
@@ -49,8 +49,8 @@ class ELC_vs_analytic(ut.TestCase):
         simulation box with dielectric contrast on the bottom of the box,
         which can be calculated analytically with image charges.
         """
-        self.system.part.add(id=1, pos=self.system.box_l / 2., q=self.q[0])
-        self.system.part.add(id=2, pos=self.system.box_l / 2. + [0, 0, self.distance],
+        self.system.part.add(pos=self.system.box_l / 2., q=self.q[0])
+        self.system.part.add(pos=self.system.box_l / 2. + [0, 0, self.distance],
                              q=-self.q[0])
 
         self.system.box_l = [self.box_l, self.box_l, self.box_l + self.elc_gap]
@@ -83,17 +83,18 @@ class ELC_vs_analytic(ut.TestCase):
             elc_results, analytic_results, rtol=0, atol=self.check_accuracy)
 
     def scan(self):
+        p1, p2 = self.system.part[:]
         result_array = np.empty((len(self.q), len(self.zPos), 2))
         for chargeIndex, charge in enumerate(self.q):
-            self.system.part[1].q = charge
-            self.system.part[2].q = -charge
+            p1.q = charge
+            p2.q = -charge
             for i, z in enumerate(self.zPos):
-                pos = self.system.part[1].pos
-                self.system.part[1].pos = [pos[0], pos[1], z]
-                self.system.part[2].pos = [pos[0], pos[1], z + self.distance]
+                pos = np.copy(p1.pos)
+                p1.pos = [pos[0], pos[1], z]
+                p2.pos = [pos[0], pos[1], z + self.distance]
 
                 self.system.integrator.run(0)
-                result_array[chargeIndex, i, 0] = self.system.part[1].f[2]
+                result_array[chargeIndex, i, 0] = p1.f[2]
                 result_array[chargeIndex, i, 1] = self.system.analysis.energy()[
                     "total"]
         return result_array

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -32,8 +32,8 @@ class ElectrostaticInteractionsTests(ut.TestCase):
     def setUp(self):
         self.system.time_step = 0.01
 
-        self.system.part.add(id=0, pos=(9.0, 2.0, 2.0), q=1)
-        self.system.part.add(id=1, pos=(11.0, 2.0, 2.0), q=-1)
+        self.system.part.add(pos=(9.0, 2.0, 2.0), q=1)
+        self.system.part.add(pos=(11.0, 2.0, 2.0), q=-1)
 
     def tearDown(self):
         self.system.part.clear()
@@ -41,8 +41,7 @@ class ElectrostaticInteractionsTests(ut.TestCase):
 
     def calc_dh_potential(self, r, df_params):
         kT = 1.0
-        q1 = self.system.part[0].q
-        q2 = self.system.part[1].q
+        q1, q2 = self.system.part[:].q
         u = np.zeros_like(r)
         # r<r_cut
         i = np.where(r < df_params['r_cut'])[0]
@@ -55,8 +54,7 @@ class ElectrostaticInteractionsTests(ut.TestCase):
 
         kT = 1.0
 
-        q1 = self.system.part[0].q
-        q2 = self.system.part[1].q
+        q1, q2 = self.system.part[:].q
         epsilon1 = rf_params['epsilon1']
         epsilon2 = rf_params['epsilon2']
         kappa = rf_params['kappa']
@@ -146,12 +144,13 @@ class ElectrostaticInteractionsTests(ut.TestCase):
 
         u_dh_core = np.zeros_like(r)
         f_dh_core = np.zeros_like(r)
-        # need to update forces
+
+        p1, p2 = self.system.part[:]
         for i, ri in enumerate(r):
-            self.system.part[1].pos = self.system.part[0].pos + [ri, 0, 0]
+            p2.pos = p1.pos + [ri, 0, 0]
             self.system.integrator.run(0)
             u_dh_core[i] = self.system.analysis.energy()['coulomb']
-            f_dh_core[i] = self.system.part[0].f[0]
+            f_dh_core[i] = p1.f[0]
 
         np.testing.assert_allclose(u_dh_core, u_dh, atol=1e-7)
         np.testing.assert_allclose(f_dh_core, -f_dh, atol=1e-2)
@@ -188,11 +187,12 @@ class ElectrostaticInteractionsTests(ut.TestCase):
         u_rf_core = np.zeros_like(r)
         f_rf_core = np.zeros_like(r)
 
+        p1, p2 = self.system.part[:]
         for i, ri in enumerate(r):
-            self.system.part[1].pos = self.system.part[0].pos + [ri, 0, 0]
+            p2.pos = p1.pos + [ri, 0, 0]
             self.system.integrator.run(0)
             u_rf_core[i] = self.system.analysis.energy()['coulomb']
-            f_rf_core[i] = self.system.part[0].f[0]
+            f_rf_core[i] = p1.f[0]
 
         np.testing.assert_allclose(u_rf_core, u_rf, atol=1e-7)
         np.testing.assert_allclose(f_rf_core, -f_rf, atol=1e-2)

--- a/testsuite/python/engine_langevin.py
+++ b/testsuite/python/engine_langevin.py
@@ -50,8 +50,8 @@ class SwimmerTest(ut.TestCase):
         S.cell_system.skin = 0.1
         S.time_step = tstep
 
-        S.part.add(id=0, pos=pos_0, swimming={"v_swim": v_swim})
-        S.part.add(id=1, pos=pos_1, swimming={"f_swim": f_swim})
+        p0 = S.part.add(pos=pos_0, swimming={"v_swim": v_swim})
+        p1 = S.part.add(pos=pos_1, swimming={"f_swim": f_swim})
         S.part[:].rotation = (1, 1, 1)
 
         S.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)
@@ -61,8 +61,8 @@ class SwimmerTest(ut.TestCase):
         pos_0[2] = z_v(S.time, pos_0[2])
         pos_1[2] = z_f(S.time, pos_1[2])
 
-        delta_pos_0 = np.linalg.norm(S.part[0].pos - pos_0)
-        delta_pos_1 = np.linalg.norm(S.part[1].pos - pos_1)
+        delta_pos_0 = np.linalg.norm(p0.pos - pos_0)
+        delta_pos_1 = np.linalg.norm(p1.pos - pos_1)
 
         self.assertLess(1.4e-3, delta_pos_0)
         self.assertLess(delta_pos_0, 1.6e-3)

--- a/testsuite/python/field_test.py
+++ b/testsuite/python/field_test.py
@@ -14,11 +14,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from itertools import product
 
 import unittest as ut
 import unittest_decorators as utx
 import numpy as np
+import itertools
 
 import espressomd
 from espressomd import constraints
@@ -167,7 +167,7 @@ class FieldTest(ut.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'Parameter particle_scales is read-only'):
             F.particle_scales = {0: 0.0}
 
-        for i in product(*map(range, 3 * [10])):
+        for i in itertools.product(*map(range, 3 * [10])):
             x = (h * i)
             f_val = F.call_method("_eval_field", x=x)
             np.testing.assert_allclose(f_val, self.potential(x), rtol=1e-3)
@@ -194,7 +194,7 @@ class FieldTest(ut.TestCase):
 
         self.system.constraints.add(F)
 
-        for i in product(*map(range, 3 * [10])):
+        for i in itertools.product(*map(range, 3 * [10])):
             x = (h * i)
             f_val = F.call_method("_eval_field", x=x)
             np.testing.assert_allclose(f_val, self.potential(x), rtol=1e-3)
@@ -226,7 +226,7 @@ class FieldTest(ut.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'Parameter particle_scales is read-only'):
             F.particle_scales = {0: 0.0}
 
-        for i in product(*map(range, 3 * [10])):
+        for i in itertools.product(*map(range, 3 * [10])):
             x = (h * i)
             f_val = np.array(F.call_method("_eval_field", x=x))
             np.testing.assert_allclose(f_val, self.force(x))
@@ -252,7 +252,7 @@ class FieldTest(ut.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'Parameter gamma is read-only'):
             F.gamma = 2.0
 
-        for i in product(*map(range, 3 * [10])):
+        for i in itertools.product(*map(range, 3 * [10])):
             x = (h * i)
             f_val = np.array(F.call_method("_eval_field", x=x))
             np.testing.assert_allclose(f_val, self.force(x))

--- a/testsuite/python/field_test.py
+++ b/testsuite/python/field_test.py
@@ -63,9 +63,9 @@ class FieldTest(ut.TestCase):
 
         # Virtual sites don't feel gravity
         if espressomd.has_features("VIRTUAL_SITES"):
-            self.system.part[0].virtual = True
+            p.virtual = True
             self.system.integrator.run(0)
-            np.testing.assert_allclose(np.copy(self.system.part[0].f), 0)
+            np.testing.assert_allclose(np.copy(p.f), 0)
 
     @utx.skipIfMissingFeatures("ELECTROSTATICS")
     def test_linear_electric_potential(self):

--- a/testsuite/python/hat.py
+++ b/testsuite/python/hat.py
@@ -42,8 +42,8 @@ class HatTest(ut.TestCase):
         s.time_step = 0.01
         s.cell_system.skin = 0.4
 
-        s.part.add(id=0, pos=0.5 * s.box_l, type=0)
-        s.part.add(id=1, pos=0.5 * s.box_l, type=0)
+        p0 = s.part.add(pos=0.5 * s.box_l, type=0)
+        p1 = s.part.add(pos=0.5 * s.box_l, type=0)
 
         F_max = 3.145
         cutoff = 1.3
@@ -55,10 +55,10 @@ class HatTest(ut.TestCase):
 
         for i in range(100):
             r = r0 - i * dx
-            s.part[1].pos = [r, 0.5 * s.box_l[1], 0.5 * s.box_l[2]]
+            p1.pos = [r, 0.5 * s.box_l[1], 0.5 * s.box_l[2]]
             s.integrator.run(0)
             self.assertAlmostEqual(
-                self.force(F_max, cutoff, i * dx), s.part[0].f[0], places=7)
+                self.force(F_max, cutoff, i * dx), p0.f[0], places=7)
             self.assertAlmostEqual(
                 self.pot(F_max, cutoff, i * dx), s.analysis.energy()['total'], places=7)
 

--- a/testsuite/python/integrator_steepest_descent.py
+++ b/testsuite/python/integrator_steepest_descent.py
@@ -56,13 +56,12 @@ class IntegratorSteepestDescent(ut.TestCase):
         self.system.integrator.set_vv()
 
     def test_relaxation_integrator(self):
-        for i in range(self.n_part):
-            p = self.system.part.add(
-                id=i, pos=np.random.random(3) * self.system.box_l)
-            if self.test_rotation:
-                p.dip = np.random.random(3)
-                p.dipm = 1
-                p.rotation = (1, 1, 1)
+        self.system.part.add(
+            pos=np.random.random((self.n_part, 3)) * self.system.box_l)
+        if self.test_rotation:
+            self.system.part[:].dip = np.random.random((self.n_part, 3))
+            self.system.part[:].dipm = 1
+            self.system.part[:].rotation = (1, 1, 1)
 
         self.assertNotAlmostEqual(
             self.system.analysis.energy()["total"], 0, places=10)
@@ -79,7 +78,7 @@ class IntegratorSteepestDescent(ut.TestCase):
         np.testing.assert_allclose(np.copy(self.system.part[:].f), 0.)
         if self.test_rotation:
             np.testing.assert_allclose(np.copy(self.system.part[:].dip),
-                                       np.hstack((-np.ones((self.n_part, 1)), np.zeros((self.n_part, 1)), np.zeros((self.n_part, 1)))), atol=1E-9)
+                                       self.n_part * [(-1, 0, 0)], atol=1E-9)
 
     def test_integration(self):
         max_disp = 0.05

--- a/testsuite/python/interactions_bond_angle.py
+++ b/testsuite/python/interactions_bond_angle.py
@@ -38,15 +38,15 @@ class InteractionsAngleBondTest(ut.TestCase):
         self.system.cell_system.skin = 0.4
         self.system.time_step = .1
 
-        self.system.part.add(id=0, pos=self.start_pos, type=0)
-        self.system.part.add(id=1, pos=self.start_pos + self.rel_pos, type=0)
-        self.system.part.add(id=2, pos=self.start_pos + self.rel_pos, type=0)
+        p0 = self.system.part.add(pos=self.start_pos, type=0)
+        p1 = self.system.part.add(pos=self.start_pos + self.rel_pos, type=0)
+        self.system.part.add(pos=self.start_pos + self.rel_pos, type=0)
 
         # Add a pair bond to make sure that doesn't cause trouble
         harmonic_bond = espressomd.interactions.HarmonicBond(k=0, r_0=0)
         self.system.bonded_inter.add(harmonic_bond)
         self.harmonic_bond = harmonic_bond
-        self.system.part[1].add_bond((harmonic_bond, 0))
+        p1.add_bond((harmonic_bond, p0))
 
     def tearDown(self):
         self.system.part.clear()
@@ -84,9 +84,7 @@ class InteractionsAngleBondTest(ut.TestCase):
 
     def run_test(self, bond_instance, force_func, energy_func, phi0):
         self.system.bonded_inter.add(bond_instance)
-        p0 = self.system.part[0]
-        p1 = self.system.part[1]
-        p2 = self.system.part[2]
+        p0, p1, p2 = self.system.part[:]
         # Add bond angle
         p0.add_bond((bond_instance, 1, 2))
         # Add an extra (strength 0) pair bond, which should change nothing
@@ -124,7 +122,7 @@ class InteractionsAngleBondTest(ut.TestCase):
 
             # Total force =0?
             np.testing.assert_allclose(
-                np.sum(np.copy(self.system.part[0:3].f), 0), [0, 0, 0], atol=1E-12)
+                np.sum(np.copy(self.system.part[:].f), 0), [0, 0, 0], atol=1E-12)
 
             # No pressure (isotropic compression preserves angles)
             self.assertAlmostEqual(

--- a/testsuite/python/interactions_bonded.py
+++ b/testsuite/python/interactions_bonded.py
@@ -41,8 +41,8 @@ class InteractionsBondedTest(ut.TestCase):
         self.system.cell_system.skin = 0.4
         self.system.time_step = .2
 
-        self.system.part.add(id=0, pos=self.start_pos, type=0)
-        self.system.part.add(id=1, pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
 
     def tearDown(self):
         self.system.part.clear()

--- a/testsuite/python/interactions_bonded.py
+++ b/testsuite/python/interactions_bonded.py
@@ -82,8 +82,9 @@ class InteractionsBondedTest(ut.TestCase):
         coulomb_k = 1
         q1 = 1
         q2 = -1
-        self.system.part[0].q = q1
-        self.system.part[1].q = q2
+        p1, p2 = self.system.part[:]
+        p1.q = q1
+        p2.q = q2
         self.run_test(
             espressomd.interactions.BondedCoulomb(prefactor=coulomb_k),
             lambda r: tests_common.coulomb_force(r, coulomb_k, q1, q2),
@@ -96,8 +97,9 @@ class InteractionsBondedTest(ut.TestCase):
         # interactions
         q1 = 1.2
         q2 = -q1
-        self.system.part[0].q = q1
-        self.system.part[1].q = q2
+        p1, p2 = self.system.part[:]
+        p1.q = q1
+        p2.q = q2
         r_cut = 2
 
         sr_solver = espressomd.electrostatics.DH(
@@ -140,13 +142,13 @@ class InteractionsBondedTest(ut.TestCase):
     def run_test(self, bond_instance, force_func, energy_func, min_dist,
                  cutoff, test_breakage=False):
         self.system.bonded_inter.add(bond_instance)
-        self.system.part[0].bonds = ((bond_instance, 1),)
+        p1, p2 = self.system.part[:]
+        p1.bonds = ((bond_instance, p2),)
 
         # n+1 steps from min_dist to cut, then we remove the cut, because that
         # may break the bond due to rounding errors
         for dist in np.linspace(min_dist, cutoff, self.steps + 1)[:-1]:
-            self.system.part[1].pos = self.system.part[
-                0].pos + self.axis * dist
+            p2.pos = p1.pos + self.axis * dist
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -154,8 +156,8 @@ class InteractionsBondedTest(ut.TestCase):
             E_ref = energy_func(dist)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p1.f)
+            f1_sim = np.copy(p2.f)
             f1_ref = self.axis * force_func(dist)
 
             # Check that energies match, ...
@@ -182,8 +184,7 @@ class InteractionsBondedTest(ut.TestCase):
             np.testing.assert_allclose(
                 p_tensor_sim, p_tensor_expected, atol=1E-12)
         if test_breakage:
-            self.system.part[1].pos = self.system.part[0].pos \
-                + self.axis * cutoff * (1.01)
+            p2.pos = p1.pos + self.axis * cutoff * 1.01
             with self.assertRaisesRegex(Exception, "Encountered errors during integrate"):
                 self.system.integrator.run(recalc_forces=True, steps=0)
 

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -27,7 +27,7 @@ class ParticleProperties(ut.TestCase):
     system = espressomd.System(box_l=[20.0, 20.0, 20.0])
 
     # Particle id to work on
-    pid = 17
+    system.part.add(id=17, pos=(0, 0, 0))
 
     def bondsMatch(self, inType, outBond, inParams, outParams, msg_long):
         """Check, if the bond type set and gotten back as well as the bond
@@ -73,10 +73,6 @@ class ParticleProperties(ut.TestCase):
         self.assertSetEqual(default_keys, valid_keys - required_keys,
                             "{}.set_default_params() should have keys: {}, got: {}".format(
                                 classname, valid_keys - required_keys, default_keys))
-
-    def setUp(self):
-        if not self.system.part.exists(self.pid):
-            self.system.part.add(id=self.pid, pos=(0, 0, 0))
 
     def generateTestForBondParams(_bondId, _bondClass, _params):
         """Generates test cases for checking bond parameters set and gotten

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -26,8 +26,8 @@ import espressomd
 class ParticleProperties(ut.TestCase):
     system = espressomd.System(box_l=[20.0, 20.0, 20.0])
 
-    # Particle id to work on
-    system.part.add(id=17, pos=(0, 0, 0))
+    # Particle to work on
+    system.part.add(pos=(0, 0, 0))
 
     def bondsMatch(self, inType, outBond, inParams, outParams, msg_long):
         """Check, if the bond type set and gotten back as well as the bond

--- a/testsuite/python/interactions_dihedral.py
+++ b/testsuite/python/interactions_dihedral.py
@@ -92,10 +92,7 @@ class InteractionsBondedTest(ut.TestCase):
         self.system.cell_system.skin = 0.4
         self.system.time_step = .1
 
-        self.system.part.add(pos=self.start_pos, type=0)
-        self.system.part.add(pos=self.start_pos, type=0)
-        self.system.part.add(pos=self.start_pos, type=0)
-        self.system.part.add(pos=self.start_pos, type=0)
+        self.system.part.add(pos=4 * [self.start_pos], type=4 * [0])
 
     def tearDown(self):
         self.system.part.clear()

--- a/testsuite/python/interactions_dihedral.py
+++ b/testsuite/python/interactions_dihedral.py
@@ -92,10 +92,10 @@ class InteractionsBondedTest(ut.TestCase):
         self.system.cell_system.skin = 0.4
         self.system.time_step = .1
 
-        self.system.part.add(id=0, pos=self.start_pos, type=0)
-        self.system.part.add(id=1, pos=self.start_pos, type=0)
-        self.system.part.add(id=2, pos=self.start_pos, type=0)
-        self.system.part.add(id=3, pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
 
     def tearDown(self):
         self.system.part.clear()
@@ -124,6 +124,8 @@ class InteractionsBondedTest(ut.TestCase):
 
     # Test Dihedral Angle
     def test_dihedral(self):
+        p0, p1, p2, p3 = self.system.part[:]
+
         dh_k = 1
         dh_phase = np.pi / 6
         dh_n = 1
@@ -131,33 +133,27 @@ class InteractionsBondedTest(ut.TestCase):
         dh = espressomd.interactions.Dihedral(
             bend=dh_k, mult=dh_n, phase=dh_phase)
         self.system.bonded_inter.add(dh)
-        self.system.part[1].add_bond((dh, 0, 2, 3))
-        self.system.part[2].pos = self.system.part[1].pos + [1, 0, 0]
+        p1.add_bond((dh, p0, p2, p3))
+        p2.pos = p1.pos + [1, 0, 0]
 
         N = 111
         d_phi = np.pi / (N * 4)
         for i in range(N):
-            self.system.part[0].pos = self.system.part[1].pos + \
+            p0.pos = p1.pos + \
                 rotate_vector(self.rel_pos_1, self.axis, i * d_phi)
-            self.system.part[3].pos = self.system.part[2].pos + \
+            p3.pos = p2.pos + \
                 rotate_vector(self.rel_pos_2, self.axis, -i * d_phi)
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
             E_sim = self.system.analysis.energy()["bonded"]
-            phi = self.dihedral_angle(self.system.part[0].pos,
-                                      self.system.part[1].pos,
-                                      self.system.part[2].pos,
-                                      self.system.part[3].pos)
+            phi = self.dihedral_angle(p0.pos, p1.pos, p2.pos, p3.pos)
             E_ref = dihedral_potential(dh_k, phi, dh_n, dh_phase)
 
             # Calculate forces
-            f2_sim = self.system.part[1].f
+            f2_sim = p1.f
             _, f2_ref, _ = dihedral_force(dh_k, dh_n, dh_phase,
-                                          self.system.part[0].pos,
-                                          self.system.part[1].pos,
-                                          self.system.part[2].pos,
-                                          self.system.part[3].pos)
+                                          p0.pos, p1.pos, p2.pos, p3.pos)
 
             # Check that energies match, ...
             np.testing.assert_almost_equal(E_sim, E_ref)
@@ -168,6 +164,8 @@ class InteractionsBondedTest(ut.TestCase):
     # Test Tabulated Dihedral Angle
     @utx.skipIfMissingFeatures(["TABULATED"])
     def test_tabulated_dihedral(self):
+        p0, p1, p2, p3 = self.system.part[:]
+
         N = 111
         d_phi = 2 * np.pi / N
         # tabulated values for the range [0, 2*pi]
@@ -177,8 +175,8 @@ class InteractionsBondedTest(ut.TestCase):
         dihedral_tabulated = espressomd.interactions.TabulatedDihedral(
             energy=tab_energy, force=tab_force)
         self.system.bonded_inter.add(dihedral_tabulated)
-        self.system.part[1].add_bond((dihedral_tabulated, 0, 2, 3))
-        self.system.part[2].pos = self.system.part[1].pos + [1, 0, 0]
+        p1.add_bond((dihedral_tabulated, p0, p2, p3))
+        p2.pos = p1.pos + [1, 0, 0]
 
         # check stored parameters
         interaction_id = len(self.system.bonded_inter) - 1
@@ -191,9 +189,9 @@ class InteractionsBondedTest(ut.TestCase):
         # measure at half the angular resolution to observe interpolation
         for i in range(2 * N - 1):
             # increase dihedral angle by d_phi (phi ~ 0 at i = 0)
-            self.system.part[0].pos = self.system.part[1].pos + \
+            p0.pos = p1.pos + \
                 rotate_vector(self.rel_pos_1, self.axis, -i * d_phi / 4)
-            self.system.part[3].pos = self.system.part[2].pos + \
+            p3.pos = p2.pos + \
                 rotate_vector(self.rel_pos_1, self.axis, i * d_phi / 4)
             self.system.integrator.run(recalc_forces=True, steps=0)
 

--- a/testsuite/python/interactions_non-bonded.py
+++ b/testsuite/python/interactions_non-bonded.py
@@ -39,8 +39,8 @@ class InteractionsNonBondedTest(ut.TestCase):
         self.system.cell_system.skin = 0.
         self.system.time_step = .1
 
-        self.system.part.add(id=0, pos=self.start_pos, type=0)
-        self.system.part.add(id=1, pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
+        self.system.part.add(pos=self.start_pos, type=0)
 
     def tearDown(self):
         self.system.non_bonded_inter.reset()
@@ -84,16 +84,17 @@ class InteractionsNonBondedTest(ut.TestCase):
             cutoff=lj_cut, offset=lj_off, b1=lj_b1, b2=lj_b2, e1=lj_e1,
             e2=lj_e2, shift=lj_shift)
 
+        p0, p1 = self.system.part[:]
         for i in range(231):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
             E_sim = self.system.analysis.energy()["non_bonded"]
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.lj_generic_force(
                 espressomd, r=(i + 1) * self.step_width, eps=lj_eps, sig=lj_sig,
                 cutoff=lj_cut, offset=lj_off, b1=lj_b1, b2=lj_b2, e1=lj_e1,
@@ -125,16 +126,17 @@ class InteractionsNonBondedTest(ut.TestCase):
             r=np.arange(1, 232) * self.step_width, eps=wca_eps, sig=wca_sig,
             cutoff=wca_cutoff, shift=4. * wca_shift)
 
+        p0, p1 = self.system.part[:]
         for i in range(231):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
             E_sim = self.system.analysis.energy()["non_bonded"]
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.lj_generic_force(
                 espressomd, r=(i + 1) * self.step_width, eps=wca_eps,
                 sig=wca_sig, cutoff=wca_cutoff)
@@ -168,8 +170,9 @@ class InteractionsNonBondedTest(ut.TestCase):
             b1=lj_b1, b2=lj_b2, e1=lj_e1, e2=lj_e2, shift=lj_shift,
             delta=lj_delta, lam=lj_lam)
 
+        p0, p1 = self.system.part[:]
         for i in range(231):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -180,8 +183,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 e2=lj_e2, shift=lj_shift, delta=lj_delta, lam=lj_lam)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.lj_generic_force(
                 espressomd, r=(i + 1) * self.step_width, eps=lj_eps, sig=lj_sig,
                 cutoff=lj_cut, offset=lj_off, b1=lj_b1, b2=lj_b2, e1=lj_e1,
@@ -209,8 +212,9 @@ class InteractionsNonBondedTest(ut.TestCase):
         self.system.non_bonded_inter[0, 0].lennard_jones.set_params(
             epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift=lj_shift)
 
+        p0, p1 = self.system.part[:]
         for i in range(113):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -220,8 +224,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 shift=lj_shift)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * \
                 tests_common.lj_force(espressomd, r=(i + 1) * self.step_width,
                                       eps=lj_eps, sig=lj_sig, cutoff=lj_cut)
@@ -248,8 +252,9 @@ class InteractionsNonBondedTest(ut.TestCase):
             epsilon=ljcos_eps, sigma=ljcos_sig, cutoff=ljcos_cut,
             offset=ljcos_offset)
 
+        p0, p1 = self.system.part[:]
         for i in range(175):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -259,8 +264,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 cutoff=ljcos_cut, offset=ljcos_offset)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.lj_cos_force(
                 espressomd, (i + 1) * self.step_width, eps=ljcos_eps,
                 sig=ljcos_sig, cutoff=ljcos_cut, offset=ljcos_offset)
@@ -288,8 +293,9 @@ class InteractionsNonBondedTest(ut.TestCase):
             epsilon=ljcos2_eps, sigma=ljcos2_sig, offset=ljcos2_offset,
             width=ljcos2_width)
 
+        p0, p1 = self.system.part[:]
         for i in range(267):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -299,8 +305,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 offset=ljcos2_offset, width=ljcos2_width)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.lj_cos2_force(
                 espressomd, r=(i + 1) * self.step_width, eps=ljcos2_eps,
                 sig=ljcos2_sig, offset=ljcos2_offset, width=ljcos2_width)
@@ -330,8 +336,9 @@ class InteractionsNonBondedTest(ut.TestCase):
             eps=sst_eps, sig=sst_sig, cutoff=sst_cut, d=sst_d, n=sst_n,
             k0=sst_k0)
 
+        p0, p1 = self.system.part[:]
         for i in range(126):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -341,8 +348,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 cutoff=sst_cut, d=sst_d, n=sst_n, k0=sst_k0)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.smooth_step_force(
                 r=(i + 1) * self.step_width, eps=sst_eps, sig=sst_sig,
                 cutoff=sst_cut, d=sst_d, n=sst_n, k0=sst_k0)
@@ -371,8 +378,9 @@ class InteractionsNonBondedTest(ut.TestCase):
             a=bmhtf_a, b=bmhtf_b, c=bmhtf_c, d=bmhtf_d, sig=bmhtf_sig,
             cutoff=bmhtf_cut)
 
+        p0, p1 = self.system.part[:]
         for i in range(126):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -382,8 +390,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 d=bmhtf_d, sig=bmhtf_sig, cutoff=bmhtf_cut)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.bmhtf_force(
                 r=(i + 1) * self.step_width, a=bmhtf_a, b=bmhtf_b, c=bmhtf_c,
                 d=bmhtf_d, sig=bmhtf_sig, cutoff=bmhtf_cut)
@@ -409,8 +417,9 @@ class InteractionsNonBondedTest(ut.TestCase):
         self.system.non_bonded_inter[0, 0].morse.set_params(
             eps=m_eps, alpha=m_alpha, cutoff=m_cut, rmin=m_rmin)
 
+        p0, p1 = self.system.part[:]
         for i in range(126):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -420,8 +429,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 cutoff=m_cut, rmin=m_rmin)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.morse_force(
                 r=(i + 1) * self.step_width, eps=m_eps, alpha=m_alpha,
                 cutoff=m_cut, rmin=m_rmin)
@@ -451,8 +460,9 @@ class InteractionsNonBondedTest(ut.TestCase):
             a=b_a, b=b_b, c=b_c, d=b_d, discont=b_disc, cutoff=b_cut,
             shift=b_shift)
 
+        p0, p1 = self.system.part[:]
         for i in range(226):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -462,8 +472,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 discont=b_disc, cutoff=b_cut, shift=b_shift)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.buckingham_force(
                 r=(i + 1) * self.step_width, a=b_a, b=b_b, c=b_c, d=b_d,
                 discont=b_disc, cutoff=b_cut, shift=b_shift)
@@ -489,10 +499,11 @@ class InteractionsNonBondedTest(ut.TestCase):
         self.system.non_bonded_inter[0, 0].soft_sphere.set_params(
             a=ss_a, n=ss_n, cutoff=ss_cut, offset=ss_off)
 
+        p0, p1 = self.system.part[:]
         for i in range(12):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
         for i in range(113):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -502,8 +513,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 offset=ss_off)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.soft_sphere_force(
                 r=(i + 13) * self.step_width, a=ss_a, n=ss_n, cutoff=ss_cut,
                 offset=ss_off)
@@ -527,8 +538,9 @@ class InteractionsNonBondedTest(ut.TestCase):
         self.system.non_bonded_inter[0, 0].hertzian.set_params(
             eps=h_eps, sig=h_sig)
 
+        p0, p1 = self.system.part[:]
         for i in range(244):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -537,8 +549,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 r=(i + 1) * self.step_width, eps=h_eps, sig=h_sig)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.hertzian_force(
                 r=(i + 1) * self.step_width, eps=h_eps, sig=h_sig)
 
@@ -562,8 +574,9 @@ class InteractionsNonBondedTest(ut.TestCase):
         self.system.non_bonded_inter[0, 0].gaussian.set_params(
             eps=g_eps, sig=g_sig, cutoff=g_cut)
 
+        p0, p1 = self.system.part[:]
         for i in range(125):
-            self.system.part[1].pos = self.system.part[1].pos + self.step
+            p1.pos = p1.pos + self.step
             self.system.integrator.run(recalc_forces=True, steps=0)
 
             # Calculate energies
@@ -572,8 +585,8 @@ class InteractionsNonBondedTest(ut.TestCase):
                 r=(i + 1) * self.step_width, eps=g_eps, sig=g_sig, cutoff=g_cut)
 
             # Calculate forces
-            f0_sim = np.copy(self.system.part[0].f)
-            f1_sim = np.copy(self.system.part[1].f)
+            f0_sim = np.copy(p0.f)
+            f1_sim = np.copy(p1.f)
             f1_ref = self.axis * tests_common.gaussian_force(
                 r=(i + 1) * self.step_width, eps=g_eps, sig=g_sig, cutoff=g_cut)
 
@@ -621,9 +634,9 @@ class InteractionsNonBondedTest(ut.TestCase):
 
             self.system.part.clear()
             self.system.part.add(
-                id=0, pos=(1, 2, 3), rotation=(1, 1, 1), type=0)
+                pos=(1, 2, 3), rotation=(1, 1, 1), type=0)
             self.system.part.add(
-                id=1, pos=(2.2, 2.1, 2.9), rotation=(1, 1, 1), type=0)
+                pos=(2.2, 2.1, 2.9), rotation=(1, 1, 1), type=0)
 
             self.system.non_bonded_inter[0, 0].gay_berne.set_params(
                 sig=sigma_0, cut=cut, eps=epsilon_0, k1=k_1, k2=k_2, mu=mu,
@@ -675,8 +688,7 @@ class InteractionsNonBondedTest(ut.TestCase):
 
         setup_system(gb_params)
 
-        p1 = self.system.part[0]
-        p2 = self.system.part[1]
+        p1, p2 = self.system.part[:]
 
         delta = 1.0e-6
 

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -125,8 +125,9 @@ class TestLB:
         """
         system = self.system
         self.n_col_part = 1000
-        system.part.add(pos=np.random.random(
-            (self.n_col_part, 3)) * self.system.box_l[0], v=np.random.random((self.n_col_part, 3)))
+        system.part.add(
+            pos=np.random.random((self.n_col_part, 3)) * self.system.box_l[0],
+            v=np.random.random((self.n_col_part, 3)))
         system.thermostat.turn_off()
 
         self.lbf = self.lb_class(
@@ -272,15 +273,14 @@ class TestLB:
             LB_fluid=self.lbf,
             seed=3,
             gamma=self.params['friction'])
-        self.system.part.add(
+        p = self.system.part.add(
             pos=[0.5 * self.params['agrid']] * 3, v=v_part, fix=[1, 1, 1])
         self.lbf[0, 0, 0].velocity = v_fluid
         if self.interpolation:
-            v_fluid = self.lbf.get_interpolated_velocity(
-                self.system.part[0].pos)
+            v_fluid = self.lbf.get_interpolated_velocity(p.pos)
         self.system.integrator.run(1)
         np.testing.assert_allclose(
-            np.copy(self.system.part[0].f), -self.params['friction'] * (v_part - v_fluid), atol=1E-6)
+            np.copy(p.f), -self.params['friction'] * (v_part - v_fluid), atol=1E-6)
 
     @utx.skipIfMissingFeatures("EXTERNAL_FORCES")
     def test_ext_force_density(self):
@@ -310,7 +310,7 @@ class TestLB:
         where particles don't move.
 
         """
-        self.system.part.add(pos=[0.1, 0.2, 0.3], fix=[1, 1, 1])
+        p = self.system.part.add(pos=[0.1, 0.2, 0.3], fix=[1, 1, 1])
         ext_force_density = [2.3, 1.2, 0.1]
         lbf = self.lb_class(
             visc=self.params['viscosity'],
@@ -326,7 +326,7 @@ class TestLB:
             int(round(sim_time / self.system.time_step)))
         probe_pos = np.array(self.system.box_l) / 2.
         v1 = np.copy(lbf.get_interpolated_velocity(probe_pos))
-        f1 = np.copy(self.system.part[0].f)
+        f1 = np.copy(p.f)
         self.system.actors.clear()
         # get fresh LBfluid and change time steps
         lbf = self.lb_class(
@@ -352,7 +352,7 @@ class TestLB:
             int(round(sim_time / self.system.time_step)))
         self.system.time_step = self.params['time_step']
         v2 = np.copy(lbf.get_interpolated_velocity(probe_pos))
-        f2 = np.copy(self.system.part[0].f)
+        f2 = np.copy(p.f)
         np.testing.assert_allclose(v1, v2, rtol=1e-5)
         np.testing.assert_allclose(f1, f2, rtol=1e-5)
 

--- a/testsuite/python/lb_boundary.py
+++ b/testsuite/python/lb_boundary.py
@@ -20,7 +20,7 @@ import espressomd
 import espressomd.lb
 import espressomd.shapes
 import espressomd.lbboundaries
-from itertools import product
+import itertools
 
 
 class LBBoundariesBase:
@@ -79,17 +79,17 @@ class LBBoundariesBase:
     def check_boundary_flags(self, boundarynumbers):
         rng = range(20)
 
-        for i in product(range(0, 5), rng, rng):
+        for i in itertools.product(range(0, 5), rng, rng):
             self.assertEqual(self.lbf[i].boundary, boundarynumbers[0])
 
-        for i in product(range(5, 15), rng, rng):
+        for i in itertools.product(range(5, 15), rng, rng):
             self.assertEqual(self.lbf[i].boundary, boundarynumbers[1])
 
-        for i in product(range(15, 20), rng, rng):
+        for i in itertools.product(range(15, 20), rng, rng):
             self.assertEqual(self.lbf[i].boundary, boundarynumbers[2])
 
         self.system.lbboundaries.clear()
-        for i in product(rng, rng, rng):
+        for i in itertools.product(rng, rng, rng):
             self.assertEqual(self.lbf[i].boundary, 0)
 
     def test_boundary_flags(self):

--- a/testsuite/python/lb_electrohydrodynamics.py
+++ b/testsuite/python/lb_electrohydrodynamics.py
@@ -59,7 +59,7 @@ class LBEHTest(ut.TestCase):
     def test(self):
         s = self.s
 
-        s.part.add(pos=0.5 * s.box_l, mu_E=self.params['muE'])
+        p = s.part.add(pos=0.5 * s.box_l, mu_E=self.params['muE'])
 
         mu_E = np.array(self.params['muE'])
         # Terminal velocity is mu_E minus the momentum the fluid
@@ -68,7 +68,7 @@ class LBEHTest(ut.TestCase):
 
         s.integrator.run(steps=500)
 
-        np.testing.assert_allclose(v_term, np.copy(s.part[0].v), atol=1e-5)
+        np.testing.assert_allclose(v_term, np.copy(p.v), atol=1e-5)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/lb_get_u_at_pos.py
+++ b/testsuite/python/lb_get_u_at_pos.py
@@ -49,8 +49,7 @@ class TestLBGetUAtPos(ut.TestCase):
         cls.n_nodes_per_dim = int(cls.system.box_l[0] / cls.params['agrid'])
         for p in range(cls.n_nodes_per_dim):
             # Set particles exactly between two LB nodes in x direction.
-            cls.system.part.add(id=p,
-                                pos=[(p + 1) * cls.params['agrid'],
+            cls.system.part.add(pos=[(p + 1) * cls.params['agrid'],
                                      0.5 * cls.params['agrid'],
                                      0.5 * cls.params['agrid']])
         cls.lb_fluid = lb.LBFluidGPU(

--- a/testsuite/python/lb_switch.py
+++ b/testsuite/python/lb_switch.py
@@ -19,7 +19,7 @@ import unittest_decorators as utx
 import numpy as np
 import espressomd
 import espressomd.lb
-from itertools import product
+import itertools
 
 
 @utx.skipIfMissingFeatures(["EXTERNAL_FORCES"])
@@ -67,7 +67,7 @@ class LBSwitchActor(ut.TestCase):
         system.actors.add(lb_fluid_2)
         system.thermostat.set_lb(LB_fluid=lb_fluid_2, gamma=friction_2)
 
-        for pid in product(range(5), range(5), range(5)):
+        for pid in itertools.product(range(5), repeat=3):
             np.testing.assert_allclose(
                 np.copy(lb_fluid_2[pid].velocity), np.zeros((3,)))
 

--- a/testsuite/python/lb_switch.py
+++ b/testsuite/python/lb_switch.py
@@ -32,7 +32,7 @@ class LBSwitchActor(ut.TestCase):
     def switch_test(self, GPU=False):
         system = self.system
         system.actors.clear()
-        system.part.add(pos=[1., 1., 1.], v=[1., 0, 0], fix=[1, 1, 1])
+        p = system.part.add(pos=[1., 1., 1.], v=[1., 0, 0], fix=[1, 1, 1])
 
         lb_fluid_params = {'agrid': 2.0, 'dens': 1.0, 'visc': 1.0, 'tau': 0.03}
         friction_1 = 1.5
@@ -50,33 +50,33 @@ class LBSwitchActor(ut.TestCase):
 
         system.integrator.run(1)
 
-        force_on_part = -friction_1 * np.copy(system.part[0].v)
+        force_on_part = -friction_1 * np.copy(p.v)
 
-        np.testing.assert_allclose(np.copy(system.part[0].f), force_on_part)
+        np.testing.assert_allclose(np.copy(p.f), force_on_part)
 
         system.integrator.run(100)
         self.assertNotAlmostEqual(lb_fluid_1[3, 3, 3].velocity[0], 0.0)
 
         system.actors.remove(lb_fluid_1)
 
-        system.part[0].v = [1, 0, 0]
+        p.v = [1, 0, 0]
         system.integrator.run(0)
 
-        np.testing.assert_allclose(np.copy(system.part[0].f), 0.0)
+        np.testing.assert_allclose(np.copy(p.f), 0.0)
 
         system.actors.add(lb_fluid_2)
         system.thermostat.set_lb(LB_fluid=lb_fluid_2, gamma=friction_2)
 
-        for p in product(range(5), range(5), range(5)):
+        for pid in product(range(5), range(5), range(5)):
             np.testing.assert_allclose(
-                np.copy(lb_fluid_2[p].velocity), np.zeros((3,)))
+                np.copy(lb_fluid_2[pid].velocity), np.zeros((3,)))
 
-        system.part[0].v = [1, 0, 0]
+        p.v = [1, 0, 0]
 
         system.integrator.run(1)
 
         np.testing.assert_allclose(
-            np.copy(system.part[0].f), [-friction_2, 0.0, 0.0])
+            np.copy(p.f), [-friction_2, 0.0, 0.0])
 
     def test_CPU_LB(self):
         self.switch_test()

--- a/testsuite/python/mmm1d.py
+++ b/testsuite/python/mmm1d.py
@@ -68,7 +68,7 @@ class ElectrostaticInteractionsTests:
     def test_with_analytical_result(self, prefactor=1.0, accuracy=1e-4):
         self.system.part.clear()
         p = self.system.part.add(pos=[0, 0, 0], q=1)
-        _ = self.system.part.add(pos=[0, 0, 1], q=1)
+        self.system.part.add(pos=[0, 0, 1], q=1)
 
         self.system.integrator.run(steps=0)
         f_measured = p.f

--- a/testsuite/python/mmm1d.py
+++ b/testsuite/python/mmm1d.py
@@ -67,11 +67,11 @@ class ElectrostaticInteractionsTests:
 
     def test_with_analytical_result(self, prefactor=1.0, accuracy=1e-4):
         self.system.part.clear()
-        self.system.part.add(pos=[0, 0, 0], q=1)
-        self.system.part.add(pos=[0, 0, 1], q=1)
+        p = self.system.part.add(pos=[0, 0, 0], q=1)
+        _ = self.system.part.add(pos=[0, 0, 1], q=1)
 
         self.system.integrator.run(steps=0)
-        f_measured = self.system.part[0].f
+        f_measured = p.f
         energy_measured = self.system.analysis.energy()["total"]
         target_energy_config = 1.00242505606 * prefactor
         target_force_z_config = -0.99510759 * prefactor

--- a/testsuite/python/mpiio.py
+++ b/testsuite/python/mpiio.py
@@ -24,7 +24,7 @@ Testmodule for MPI-IO.
 import espressomd
 import espressomd.io
 from espressomd.interactions import AngleHarmonic
-import numpy
+import numpy as np
 import unittest as ut
 import random
 import os
@@ -61,8 +61,8 @@ def random_particles():
         p = Namespace()
         p.id = i
         p.type = random.randint(0, 100)
-        p.pos = numpy.random.rand(3)
-        p.v = numpy.random.rand(3)
+        p.pos = np.random.rand(3)
+        p.v = np.random.rand(3)
         p.bonds = []
         # Up to 20 bonds; otherwise this test will take ages
         for _ in range(random.randint(0, 20)):
@@ -114,15 +114,15 @@ class MPIIOTest(ut.TestCase):
         for p, q in zip(self.s.part, self.test_particles):
             self.assertEqual(p.id, q.id)
             self.assertEqual(p.type, q.type)
-            numpy.testing.assert_array_equal(numpy.copy(p.pos), q.pos)
-            numpy.testing.assert_array_equal(numpy.copy(p.v), q.v)
+            np.testing.assert_array_equal(np.copy(p.pos), q.pos)
+            np.testing.assert_array_equal(np.copy(p.v), q.v)
             self.assertEqual(len(p.bonds), len(q.bonds))
             # Check all bonds
             for bp, bq in zip(p.bonds, q.bonds):
                 # Bond type - "bend" stores the index of the bond
                 self.assertEqual(bp[0].params["bend"], bq[0])
                 # Bond partners
-                numpy.testing.assert_array_equal(bp[1:], bq[1:])
+                np.testing.assert_array_equal(bp[1:], bq[1:])
 
     def test_mpiio(self):
         espressomd.io.mpiio.mpiio.write(

--- a/testsuite/python/nsquare.py
+++ b/testsuite/python/nsquare.py
@@ -22,21 +22,23 @@ import numpy as np
 
 
 class NSquare(ut.TestCase):
-    S = espressomd.System(box_l=[1.0, 1.0, 1.0])
+    system = espressomd.System(box_l=[1.0, 1.0, 1.0])
 
     def setUp(self):
-        self.S.part.clear()
-        self.S.cell_system.set_n_square(use_verlet_lists=False)
+        self.system.cell_system.set_n_square(use_verlet_lists=False)
+
+    def tearDown(self):
+        self.system.part.clear()
 
     def test_load_balancing(self):
         n_part = 235
-        n_nodes = self.S.cell_system.get_state()['n_nodes']
+        n_nodes = self.system.cell_system.get_state()['n_nodes']
         n_part_avg = n_part // n_nodes
 
-        for i in range(n_part):
-            self.S.part.add(id=i, pos=np.random.random(3), type=1)
+        self.system.part.add(pos=np.random.random((n_part, 3)),
+                             type=n_part * [1])
 
-        part_dist = self.S.cell_system.resort()
+        part_dist = self.system.cell_system.resort()
 
         # Check that we did not lose particles
         self.assertEqual(sum(part_dist), n_part)
@@ -48,7 +50,7 @@ class NSquare(ut.TestCase):
         # Check that we can still access all the particles
         # This basically checks if part_node and local_particles
         # are still in a valid state after the particle exchange
-        self.assertEqual(sum(self.S.part[:].type), n_part)
+        self.assertEqual(sum(self.system.part[:].type), n_part)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/observable_chain.py
+++ b/testsuite/python/observable_chain.py
@@ -66,15 +66,15 @@ class ObservableTests(ut.TestCase):
         # half the box size along the smallest axis
         min_dim = np.min(self.system.box_l)
         max_bond_length = min_dim / 2.01
-        p = self.system.part
 
         for _ in range(self.n_tries):
             # build polymer
             pos = np.zeros((self.n_parts, 3), dtype=float)
-            pos[0] = p[0].pos = np.random.uniform(low=0, high=min_dim, size=3)
-            for i in range(self.n_parts):
-                pos[i] = p[i].pos = pos[i - 1] + np.random.uniform(
+            pos[0] = np.random.uniform(low=0, high=min_dim, size=3)
+            for i in range(1, self.n_parts):
+                pos[i] = pos[i - 1] + np.random.uniform(
                     low=0, high=max_bond_length, size=3)
+            self.system.part[:].pos = pos
             # expected values
             distances = np.linalg.norm(pos[1:] - pos[:-1], axis=1)
             # observed values
@@ -100,15 +100,15 @@ class ObservableTests(ut.TestCase):
         # half the box size along the smallest axis
         min_dim = np.min(self.system.box_l)
         max_bond_length = min_dim / 2.01
-        p = self.system.part
 
         for _ in range(self.n_tries):
             # build polymer
             pos = np.zeros((self.n_parts, 3), dtype=float)
-            pos[0] = p[0].pos = np.random.uniform(low=0, high=min_dim, size=3)
-            for i in range(self.n_parts):
-                pos[i] = p[i].pos = pos[i - 1] + np.random.uniform(
+            pos[0] = np.random.uniform(low=0, high=min_dim, size=3)
+            for i in range(1, self.n_parts):
+                pos[i] = pos[i - 1] + np.random.uniform(
                     low=0, high=max_bond_length, size=3)
+            self.system.part[:].pos = pos
             # expected values
             v1 = pos[:-2] - pos[1:-1]
             v2 = pos[2:] - pos[1:-1]
@@ -165,8 +165,7 @@ class ObservableTests(ut.TestCase):
             pos[3] = pos[2] + [bl * np.cos(np.pi - phi), bl * np.sin(phi), 0.]
             pos[4] = pos[3] + [bl, 0., 0.]
             pos += offset
-            for i in range(self.n_parts):
-                self.system.part[i].pos = pos[i]
+            self.system.part[:].pos = pos
             return pos
 
         pids = list(range(self.n_parts))
@@ -208,7 +207,7 @@ class ObservableTests(ut.TestCase):
         self.system.part.add(pos=np.array(
             [np.linspace(0, self.system.box_l[0], 20)] * 3).T + np.random.random((20, 3)))
         obs = espressomd.observables.CosPersistenceAngles(
-            ids=range(len(self.system.part)))
+            ids=self.system.part[:].id)
         np.testing.assert_allclose(
             obs.calculate(), cos_persistence_angles(self.system.part[:].pos))
         self.system.part.clear()
@@ -219,7 +218,7 @@ class ObservableTests(ut.TestCase):
             pos = [np.cos(i * delta_phi), np.sin(i * delta_phi), 0.0]
             self.system.part.add(pos=pos)
         obs = espressomd.observables.CosPersistenceAngles(
-            ids=range(len(self.system.part)))
+            ids=self.system.part[:].id)
         expected = np.arange(1, 9) * delta_phi
         np.testing.assert_allclose(obs.calculate(), np.cos(expected))
 

--- a/testsuite/python/observable_cylindrical.py
+++ b/testsuite/python/observable_cylindrical.py
@@ -204,12 +204,12 @@ class TestCylindricalObservable(ut.TestCase):
         params['n_r_bins'] = 4
         params['n_phi_bins'] = 6
         params['n_z_bins'] = 8
-        params['ids'] = [0, 1]
-        self.system.part.add(id=0, pos=[0, 0, 0], type=0)
-        self.system.part.add(id=1, pos=[0, 0, 0], type=1)
+        self.system.part.add(pos=[0, 0, 0], type=0)
+        self.system.part.add(pos=[0, 0, 0], type=1)
+        params['ids'] = self.system.part[:].id
         observable = espressomd.observables.CylindricalDensityProfile(**params)
         # check pids
-        self.assertEqual(observable.ids, params['ids'])
+        np.testing.assert_array_equal(np.copy(observable.ids), params['ids'])
         new_pids = [params['ids'][0]]
         observable.ids = new_pids
         self.assertEqual(observable.ids, new_pids)

--- a/testsuite/python/observable_profile.py
+++ b/testsuite/python/observable_profile.py
@@ -26,10 +26,10 @@ class ProfileObservablesTest(ut.TestCase):
     system = espressomd.System(box_l=[10.0, 15.0, 20.0])
     system.cell_system.skin = 0.1
     system.time_step = 0.01
-    system.part.add(id=0, pos=[4.0, 4.0, 6.0], v=[0.0, 0.0, 1.0])
-    system.part.add(id=1, pos=[4.0, 4.0, 6.0], v=[0.0, 0.0, 1.0])
+    system.part.add(pos=[4.0, 4.0, 6.0], v=[0.0, 0.0, 1.0])
+    system.part.add(pos=[4.0, 4.0, 6.0], v=[0.0, 0.0, 1.0])
     bin_volume = 5.0**3
-    kwargs = {'ids': [0, 1],
+    kwargs = {'ids': list(system.part[:].id),
               'n_x_bins': 2,
               'n_y_bins': 3,
               'n_z_bins': 4,
@@ -69,8 +69,7 @@ class ProfileObservablesTest(ut.TestCase):
     def test_force_density_profile(self):
         density_profile = espressomd.observables.ForceDensityProfile(
             **self.kwargs)
-        self.system.part[0].ext_force = [0.0, 0.0, 1.0]
-        self.system.part[1].ext_force = [0.0, 0.0, 1.0]
+        self.system.part[:].ext_force = [0.0, 0.0, 1.0]
         self.system.integrator.run(0)
         obs_data = density_profile.calculate()
         np.testing.assert_array_equal(
@@ -92,7 +91,7 @@ class ProfileObservablesTest(ut.TestCase):
 
     def test_pid_profile_interface(self):
         # test setters and getters
-        params = {'ids': [0, 1],
+        params = {'ids': list(self.system.part[:].id),
                   'n_x_bins': 4,
                   'n_y_bins': 6,
                   'n_z_bins': 8,
@@ -104,10 +103,10 @@ class ProfileObservablesTest(ut.TestCase):
                   'max_z': 5.0}
         observable = espressomd.observables.DensityProfile(**params)
         # check pids
-        self.assertEqual(observable.ids, params['ids'])
+        np.testing.assert_array_equal(np.copy(observable.ids), params['ids'])
         new_pids = [params['ids'][0]]
         observable.ids = new_pids
-        self.assertEqual(observable.ids, new_pids)
+        np.testing.assert_array_equal(np.copy(observable.ids), new_pids)
         # check bins
         self.assertEqual(observable.n_x_bins, params['n_x_bins'])
         self.assertEqual(observable.n_y_bins, params['n_y_bins'])

--- a/testsuite/python/pair_criteria.py
+++ b/testsuite/python/pair_criteria.py
@@ -33,9 +33,8 @@ class PairCriteria(ut.TestCase):
     es.bonded_inter.add(f1)
     f2 = FeneBond(k=1, d_r_max=0.05)
     es.bonded_inter.add(f2)
-    es.part.add(pos=(0, 0, 0))
-    es.part.add(pos=(0.91, 0, 0))
-    p1, p2 = es.part[:]
+    p1 = es.part.add(pos=(0, 0, 0))
+    p2 = es.part.add(pos=(0.91, 0, 0))
     epsilon = 1E-8
 
     def test_distance_crit_periodic(self):

--- a/testsuite/python/pair_criteria.py
+++ b/testsuite/python/pair_criteria.py
@@ -33,10 +33,9 @@ class PairCriteria(ut.TestCase):
     es.bonded_inter.add(f1)
     f2 = FeneBond(k=1, d_r_max=0.05)
     es.bonded_inter.add(f2)
-    es.part.add(id=0, pos=(0, 0, 0))
-    es.part.add(id=1, pos=(0.91, 0, 0))
-    p1 = es.part[0]
-    p2 = es.part[1]
+    es.part.add(pos=(0, 0, 0))
+    es.part.add(pos=(0.91, 0, 0))
+    p1, p2 = es.part[:]
     epsilon = 1E-8
 
     def test_distance_crit_periodic(self):
@@ -91,10 +90,11 @@ class PairCriteria(ut.TestCase):
         self.assertTrue(not ec.decide(self.p1.id, self.p2.id))
 
     def test_bond_crit(self):
-        bc = pair_criteria.BondCriterion(bond_type=0)
+        bt = 0
+        bc = pair_criteria.BondCriterion(bond_type=bt)
         # Interface
         self.assertEqual(list(bc.get_params().keys()), ["bond_type", ])
-        self.assertEqual(bc.get_params()["bond_type"], 0)
+        self.assertEqual(bc.get_params()["bond_type"], bt)
 
         # Decisions
         # No bond yet. Should return false
@@ -102,13 +102,13 @@ class PairCriteria(ut.TestCase):
         self.assertTrue(not bc.decide(self.p1.id, self.p2.id))
 
         # Add bond. Then the criterion should match
-        self.es.part[0].bonds = ((0, 1),)
+        self.es.part[self.p1.id].bonds = ((bt, self.p2.id),)
         self.assertTrue(bc.decide(self.p1, self.p2))
         self.assertTrue(bc.decide(self.p1.id, self.p2.id))
 
         # Place bond on the 2nd particle. The criterion should still match
-        self.es.part[0].bonds = ()
-        self.es.part[1].bonds = ((0, 0),)
+        self.es.part[self.p1.id].bonds = ()
+        self.es.part[self.p2.id].bonds = ((bt, self.p1.id),)
         self.assertTrue(bc.decide(self.p1, self.p2))
         self.assertTrue(bc.decide(self.p1.id, self.p2.id))
 

--- a/testsuite/python/pressure.py
+++ b/testsuite/python/pressure.py
@@ -106,15 +106,15 @@ class PressureLJ(ut.TestCase):
         system.periodicity = [1, 1, 1]
 
         # particles and bond
-        system.part.add(id=0, pos=[9.9, 9.75, 9.9], type=0, mol_id=0)
-        system.part.add(id=1, pos=[9.9, 10.25, 9.9], type=0, mol_id=0)
-        system.part.add(id=2, pos=[0.1, 9.7, 0.1], type=1, mol_id=1)
-        system.part.add(id=3, pos=[0.1, 10.3, 0.1], type=2, mol_id=2)
+        p0 = system.part.add(pos=[9.9, 9.75, 9.9], type=0, mol_id=0)
+        p1 = system.part.add(pos=[9.9, 10.25, 9.9], type=0, mol_id=0)
+        p2 = system.part.add(pos=[0.1, 9.7, 0.1], type=1, mol_id=1)
+        p3 = system.part.add(pos=[0.1, 10.3, 0.1], type=2, mol_id=2)
 
         harmonic = HarmonicBond(k=1e4, r_0=0)
         system.bonded_inter.add(harmonic)
-        system.part[0].add_bond((harmonic, 1))
-        system.part[2].add_bond((harmonic, 3))
+        p0.add_bond((harmonic, p1))
+        p2.add_bond((harmonic, p3))
 
         system.non_bonded_inter[0, 0].lennard_jones.set_params(
             epsilon=1.0, sigma=1.0, cutoff=2.0, shift=0)
@@ -123,10 +123,10 @@ class PressureLJ(ut.TestCase):
 
         system.integrator.run(steps=0)
 
-        system.part[0].v = [10.0, 20.0, 30.0]
-        system.part[1].v = [-15, -25, -35]
-        system.part[2].v = [27.0, 23.0, 17.0]
-        system.part[3].v = [13.0, 11.0, 19.0]
+        p0.v = [10.0, 20.0, 30.0]
+        p1.v = [-15., -25., -35.]
+        p2.v = [27.0, 23.0, 17.0]
+        p3.v = [13.0, 11.0, 19.0]
 
         pos = system.part[:].pos
         vel = system.part[:].v
@@ -280,10 +280,10 @@ class PressureFENE(ut.TestCase):
         system.periodicity = [1, 1, 1]
 
         # particles and bond
-        system.part.add(
-            id=0, pos=[9.9, 9.75, 9.9], type=0, mol_id=0, fix=[1, 1, 1])
-        system.part.add(
-            id=1, pos=[9.9, 10.25, 9.9], type=0, mol_id=0, fix=[1, 1, 1])
+        p0 = system.part.add(
+            pos=[9.9, 9.75, 9.9], type=0, mol_id=0, fix=[1, 1, 1])
+        p1 = system.part.add(
+            pos=[9.9, 10.25, 9.9], type=0, mol_id=0, fix=[1, 1, 1])
 
         k = 1e4
         d_r_max = 1.5
@@ -291,7 +291,7 @@ class PressureFENE(ut.TestCase):
 
         fene = FeneBond(k=k, d_r_max=d_r_max, r_0=r_0)
         system.bonded_inter.add(fene)
-        system.part[0].add_bond((fene, 1))
+        p0.add_bond((fene, p1))
         system.integrator.run(steps=0)
 
         sim_pressure_tensor = system.analysis.pressure_tensor()
@@ -304,7 +304,7 @@ class PressureFENE(ut.TestCase):
             total_bonded_pressure_tensor += sim_pressure_tensor['bonded', i]
 
         anal_pressure_tensor_fene = self.get_anal_pressure_tensor_fene(
-            system.part[0].pos, system.part[1].pos, k, d_r_max, r_0)
+            p0.pos, p1.pos, k, d_r_max, r_0)
         np.testing.assert_allclose(
             sim_pressure_tensor_bonded, anal_pressure_tensor_fene, atol=tol,
             err_msg='bonded pressure tensor does not match analytical result')

--- a/testsuite/python/rdf.py
+++ b/testsuite/python/rdf.py
@@ -107,12 +107,9 @@ class RdfTest(ut.TestCase):
     def test_rdf_interface(self):
         # test setters and getters
         s = self.s
-        s.part.add(pos=[0, 0, 0], type=0)
-        s.part.add(pos=[0, 0, 0], type=1)
-        s.part.add(pos=[0, 0, 0], type=0)
-        s.part.add(pos=[0, 0, 0], type=1)
-        pids1 = [s.part[:].id[0]]
-        pids2 = [s.part[:].id[1]]
+        s.part.add(pos=4 * [(0, 0, 0)], type=[0, 1, 0, 1])
+        pids1 = s.part[:].id[0::2]
+        pids2 = s.part[:].id[1::2]
         observable = espressomd.observables.RDF(ids1=pids1, ids2=pids2,
                                                 min_r=1, max_r=2, n_r_bins=3)
         # check pids

--- a/testsuite/python/rdf.py
+++ b/testsuite/python/rdf.py
@@ -49,7 +49,7 @@ class RdfTest(ut.TestCase):
 
         for i in range(n_part):
             s.part.add(
-                id=i, pos=[i * dx, 0.5 * s.box_l[1], 0.5 * s.box_l[2]], type=0)
+                pos=[i * dx, 0.5 * s.box_l[1], 0.5 * s.box_l[2]], type=0)
 
         r_bins = 50
         r_min = 0.5 * dx
@@ -74,7 +74,7 @@ class RdfTest(ut.TestCase):
 
         for i in range(n_part):
             s.part.add(
-                id=i, pos=[i * dx, 0.5 * s.box_l[1], 0.5 * s.box_l[2]], type=(i % 2))
+                pos=[i * dx, 0.5 * s.box_l[1], 0.5 * s.box_l[2]], type=(i % 2))
 
         r_bins = 50
         r_min = 0.5 * dx
@@ -107,20 +107,23 @@ class RdfTest(ut.TestCase):
     def test_rdf_interface(self):
         # test setters and getters
         s = self.s
-        s.part.add(id=0, pos=[0, 0, 0], type=0)
-        s.part.add(id=1, pos=[0, 0, 0], type=1)
-        observable = espressomd.observables.RDF(ids1=s.part[:].id[0::2],
-                                                ids2=s.part[:].id[1::2],
+        s.part.add(pos=[0, 0, 0], type=0)
+        s.part.add(pos=[0, 0, 0], type=1)
+        s.part.add(pos=[0, 0, 0], type=0)
+        s.part.add(pos=[0, 0, 0], type=1)
+        pids1 = [s.part[:].id[0]]
+        pids2 = [s.part[:].id[1]]
+        observable = espressomd.observables.RDF(ids1=pids1, ids2=pids2,
                                                 min_r=1, max_r=2, n_r_bins=3)
         # check pids
-        self.assertEqual(observable.ids1, s.part[:].id[0::2])
-        self.assertEqual(observable.ids2, s.part[:].id[1::2])
+        np.testing.assert_array_equal(np.copy(observable.ids1), pids1)
+        np.testing.assert_array_equal(np.copy(observable.ids2), pids2)
         new_pids1 = [s.part[:].id[0]]
         new_pids2 = [s.part[:].id[1]]
         observable.ids1 = new_pids1
         observable.ids2 = new_pids2
-        self.assertEqual(observable.ids1, new_pids1)
-        self.assertEqual(observable.ids2, new_pids2)
+        np.testing.assert_array_equal(np.copy(observable.ids1), new_pids1)
+        np.testing.assert_array_equal(np.copy(observable.ids2), new_pids2)
         # check bins
         self.assertEqual(observable.n_r_bins, 3)
         observable.n_r_bins = 2

--- a/testsuite/python/reaction_ensemble.py
+++ b/testsuite/python/reaction_ensemble.py
@@ -66,11 +66,9 @@ class ReactionEnsembleTest(ut.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        for i in range(0, 2 * cls.N0, 2):
-            cls.system.part.add(id=i, pos=np.random.random(3) *
-                                cls.system.box_l, type=cls.type_A)
-            cls.system.part.add(id=i + 1, pos=np.random.random(3) *
-                                cls.system.box_l, type=cls.type_H)
+        cls.system.part.add(
+            pos=np.random.random((2 * cls.N0, 3)) * cls.system.box_l,
+            type=cls.N0 * [cls.type_A, cls.type_H])
 
         cls.RE.add_reaction(
             gamma=cls.gamma,

--- a/testsuite/python/rotate_system.py
+++ b/testsuite/python/rotate_system.py
@@ -27,55 +27,55 @@ import espressomd
 
 
 class RotateSystemTest(ut.TestCase):
-    s = espressomd.System(box_l=3 * [10.])
+    system = espressomd.System(box_l=3 * [10.])
 
     def tearDown(self):
-        self.s.part.clear()
+        self.system.part.clear()
 
     def test_no_mass(self):
-        s = self.s
-        s.part.add(id=0, pos=[4, 4, 4])
-        s.part.add(id=1, pos=[6, 6, 6])
+        system = self.system
+        p0 = system.part.add(pos=[4, 4, 4])
+        p1 = system.part.add(pos=[6, 6, 6])
 
         pi = np.pi
-        s.rotate_system(phi=0., theta=0., alpha=pi / 2.)
+        system.rotate_system(phi=0., theta=0., alpha=pi / 2.)
 
-        np.testing.assert_allclose(np.copy(s.part[0].pos), [6, 4, 4])
-        np.testing.assert_allclose(np.copy(s.part[1].pos), [4, 6, 6])
+        np.testing.assert_allclose(np.copy(p0.pos), [6, 4, 4])
+        np.testing.assert_allclose(np.copy(p1.pos), [4, 6, 6])
 
-        s.rotate_system(phi=0., theta=0., alpha=-pi / 2.)
+        system.rotate_system(phi=0., theta=0., alpha=-pi / 2.)
 
-        np.testing.assert_allclose(np.copy(s.part[0].pos), [4, 4, 4])
-        np.testing.assert_allclose(np.copy(s.part[1].pos), [6, 6, 6])
+        np.testing.assert_allclose(np.copy(p0.pos), [4, 4, 4])
+        np.testing.assert_allclose(np.copy(p1.pos), [6, 6, 6])
 
-        s.rotate_system(phi=pi / 2., theta=0., alpha=pi / 2.)
+        system.rotate_system(phi=pi / 2., theta=0., alpha=pi / 2.)
 
-        np.testing.assert_allclose(np.copy(s.part[0].pos), [6, 4, 4])
-        np.testing.assert_allclose(np.copy(s.part[1].pos), [4, 6, 6])
+        np.testing.assert_allclose(np.copy(p0.pos), [6, 4, 4])
+        np.testing.assert_allclose(np.copy(p1.pos), [4, 6, 6])
 
-        s.rotate_system(phi=pi / 2., theta=0., alpha=-pi / 2.)
+        system.rotate_system(phi=pi / 2., theta=0., alpha=-pi / 2.)
 
-        np.testing.assert_allclose(np.copy(s.part[0].pos), [4, 4, 4])
-        np.testing.assert_allclose(np.copy(s.part[1].pos), [6, 6, 6])
+        np.testing.assert_allclose(np.copy(p0.pos), [4, 4, 4])
+        np.testing.assert_allclose(np.copy(p1.pos), [6, 6, 6])
 
-        s.rotate_system(phi=pi / 2., theta=pi / 2., alpha=pi / 2.)
+        system.rotate_system(phi=pi / 2., theta=pi / 2., alpha=pi / 2.)
 
-        np.testing.assert_allclose(np.copy(s.part[0].pos), [4, 4, 6])
-        np.testing.assert_allclose(np.copy(s.part[1].pos), [6, 6, 4])
+        np.testing.assert_allclose(np.copy(p0.pos), [4, 4, 6])
+        np.testing.assert_allclose(np.copy(p1.pos), [6, 6, 4])
 
-        s.rotate_system(phi=pi / 2., theta=pi / 2., alpha=-pi / 2.)
+        system.rotate_system(phi=pi / 2., theta=pi / 2., alpha=-pi / 2.)
 
-        np.testing.assert_allclose(np.copy(s.part[0].pos), [4, 4, 4])
-        np.testing.assert_allclose(np.copy(s.part[1].pos), [6, 6, 6])
+        np.testing.assert_allclose(np.copy(p0.pos), [4, 4, 4])
+        np.testing.assert_allclose(np.copy(p1.pos), [6, 6, 6])
 
         # Check that virtual sites do not influence the center of mass
         # calculation
         if espressomd.has_features("VIRTUAL_SITES"):
-            s.part.add(id=2, pos=s.part[1].pos, virtual=True)
-            s.rotate_system(phi=pi / 2., theta=pi / 2., alpha=-pi / 2.)
-            np.testing.assert_allclose(np.copy(s.part[0].pos), [6, 4, 4])
-            np.testing.assert_allclose(np.copy(s.part[1].pos), [4, 6, 6])
-            np.testing.assert_allclose(np.copy(s.part[2].pos), [4, 6, 6])
+            p2 = system.part.add(pos=p1.pos, virtual=True)
+            system.rotate_system(phi=pi / 2., theta=pi / 2., alpha=-pi / 2.)
+            np.testing.assert_allclose(np.copy(p0.pos), [6, 4, 4])
+            np.testing.assert_allclose(np.copy(p1.pos), [4, 6, 6])
+            np.testing.assert_allclose(np.copy(p2.pos), [4, 6, 6])
 
 
 if __name__ == "__main__":

--- a/testsuite/python/rotation_per_particle.py
+++ b/testsuite/python/rotation_per_particle.py
@@ -28,47 +28,49 @@ class Rotation(ut.TestCase):
     s.cell_system.skin = 0
     s.time_step = 0.01
 
+    def tearDown(self):
+        self.s.part.clear()
+
     def test_langevin(self):
         """Applies langevin thermostat and checks that correct axes get
            thermalized"""
         s = self.s
         s.thermostat.set_langevin(gamma=1, kT=1, seed=42)
-        for x in (0, 1):
-            for y in (0, 1):
-                for z in (0, 1):
+        for x in (False, True):
+            for y in (False, True):
+                for z in (False, True):
                     s.part.clear()
-                    s.part.add(id=0, pos=(0, 0, 0), rotation=(x, y, z),
-                               quat=(1, 0, 0, 0), omega_body=(0, 0, 0),
-                               torque_lab=(0, 0, 0))
+                    p = s.part.add(pos=(0, 0, 0), rotation=(x, y, z),
+                                   quat=(1, 0, 0, 0), omega_body=(0, 0, 0),
+                                   torque_lab=(0, 0, 0))
                     s.integrator.run(500)
-                    self.validate(x, 0)
-                    self.validate(y, 1)
-                    self.validate(z, 2)
+                    self.validate(p, x, 0)
+                    self.validate(p, y, 1)
+                    self.validate(p, z, 2)
 
-    def validate(self, rotate, coord):
+    def validate(self, p, rotate, coord):
         if rotate:
-            # self.assertNotEqual(self.s.part[0].torque_body[coord],0)
-            self.assertNotEqual(self.s.part[0].omega_body[coord], 0)
+            self.assertNotEqual(p.torque_lab[coord], 0)
+            self.assertNotEqual(p.omega_body[coord], 0)
         else:
-            # self.assertEqual(self.s.part[0].torque_body[coord],0)
-            self.assertEqual(self.s.part[0].omega_body[coord], 0)
+            # self.assertEqual(p.torque_lab[coord], 0)
+            self.assertEqual(p.omega_body[coord], 0)
 
     @utx.skipIfMissingFeatures("EXTERNAL_FORCES")
     def test_axes_changes(self):
         """Verifies that rotation axes in body and space frame stay the same
            and other axes don't"""
         s = self.s
-        s.part.clear()
-        s.part.add(id=0, pos=(0.9, 0.9, 0.9), ext_torque=(1, 1, 1))
+        p = s.part.add(pos=(0.9, 0.9, 0.9), ext_torque=(1, 1, 1))
         s.thermostat.turn_off()
-        for dir in (0, 1, 2):
+        for direction in (0, 1, 2):
             # Reset orientation
-            s.part[0].quat = [1, 0, 0, 0]
+            p.quat = [1, 0, 0, 0]
 
             # Enable rotation in a single direction
             rot = [0, 0, 0]
-            rot[dir] = 1
-            s.part[0].rotation = rot
+            rot[direction] = 1
+            p.rotation = rot
 
             s.integrator.run(30)
 
@@ -80,15 +82,14 @@ class Rotation(ut.TestCase):
                     # The axis for which rotation is on should coincide in body
                     # and space frame
                     self.assertAlmostEqual(
-                        np.dot(rot, s.part[0].convert_vector_body_to_space(rot)), 1, places=8)
+                        np.dot(rot, p.convert_vector_body_to_space(rot)), 1, places=8)
                 else:
                     # For non-rotation axis, body and space frame should differ
                     self.assertLess(
-                        np.dot(axis, s.part[0].convert_vector_body_to_space(axis)), 0.95)
+                        np.dot(axis, p.convert_vector_body_to_space(axis)), 0.95)
 
     def test_frame_conversion_and_rotation(self):
         s = self.s
-        s.part.clear()
         p = s.part.add(pos=np.random.random(3), rotation=(1, 1, 1))
 
         # Space and body frame co-incide?

--- a/testsuite/python/rotation_per_particle.py
+++ b/testsuite/python/rotation_per_particle.py
@@ -20,6 +20,7 @@ import unittest as ut
 import unittest_decorators as utx
 import espressomd
 import numpy as np
+import itertools
 
 
 @utx.skipIfMissingFeatures("ROTATION")
@@ -36,17 +37,15 @@ class Rotation(ut.TestCase):
            thermalized"""
         s = self.s
         s.thermostat.set_langevin(gamma=1, kT=1, seed=42)
-        for x in (False, True):
-            for y in (False, True):
-                for z in (False, True):
-                    s.part.clear()
-                    p = s.part.add(pos=(0, 0, 0), rotation=(x, y, z),
-                                   quat=(1, 0, 0, 0), omega_body=(0, 0, 0),
-                                   torque_lab=(0, 0, 0))
-                    s.integrator.run(500)
-                    self.validate(p, x, 0)
-                    self.validate(p, y, 1)
-                    self.validate(p, z, 2)
+        for rot_x, rot_y, rot_z in itertools.product((False, True), repeat=3):
+            p = s.part.add(pos=(0, 0, 0), rotation=(rot_x, rot_y, rot_z),
+                           quat=(1, 0, 0, 0), omega_body=(0, 0, 0),
+                           torque_lab=(0, 0, 0))
+            s.integrator.run(500)
+            self.validate(p, rot_x, 0)
+            self.validate(p, rot_y, 1)
+            self.validate(p, rot_z, 2)
+            s.part.clear()
 
     def validate(self, p, rotate, coord):
         if rotate:
@@ -72,9 +71,7 @@ class Rotation(ut.TestCase):
             rot[direction] = 1
             p.rotation = rot
 
-            s.integrator.run(30)
-
-            s.integrator.run(100)
+            s.integrator.run(130)
 
             # Check other axes:
             for axis in [1, 0, 0], [0, 1, 0], [0, 0, 1]:

--- a/testsuite/python/rotational-diffusion-aniso.py
+++ b/testsuite/python/rotational-diffusion-aniso.py
@@ -28,8 +28,11 @@ class RotDiffAniso(ut.TestCase):
     longMessage = True
     round_error_prec = 1E-14
     # Handle for espresso system
-    system = espressomd.System(box_l=[1.0, 1.0, 1.0])
+    system = espressomd.System(box_l=3 * [10.])
     system.cell_system.skin = 5.0
+    system.periodicity = [0, 0, 0]
+    # The time step should be less than t0 ~ mass / gamma
+    system.time_step = 3E-3
 
     # The NVT thermostat parameters
     kT = 0.0
@@ -37,34 +40,26 @@ class RotDiffAniso(ut.TestCase):
 
     # Particle properties
     J = [0.0, 0.0, 0.0]
+    n_part = 800
 
     np.random.seed(4)
 
     def setUp(self):
         self.system.time = 0.0
+        self.system.integrator.set_nvt()
+        # Just some temperature range to cover by the test
+        self.kT = np.random.uniform(0.5, 1.5)
+
+    def tearDown(self):
         self.system.part.clear()
         self.system.thermostat.turn_off()
-        self.system.integrator.set_nvt()
 
-    def add_particles_setup(self, n):
-        """
-        Adding particles according to the
-        previously set parameters.
-
-        Parameters
-        ----------
-        n : :obj:`int`
-            Number of particles.
-
-        """
-
-        for ind in range(n):
-            part_pos = np.random.random(3) * self.box
-            self.system.part.add(rotation=(1, 1, 1), id=ind,
-                                 pos=part_pos)
-            self.system.part[ind].rinertia = self.J
-            if espressomd.has_features("ROTATION"):
-                self.system.part[ind].omega_body = [0.0, 0.0, 0.0]
+    def add_particles(self):
+        positions = np.random.random((self.n_part, 3)) * self.system.box_l[0]
+        self.system.part.add(pos=positions, rotation=self.n_part * [(1, 1, 1)],
+                             rinertia=self.n_part * [self.J])
+        if espressomd.has_features("ROTATION"):
+            self.system.part[:].omega_body = [0.0, 0.0, 0.0]
 
     def set_anisotropic_param(self):
         """
@@ -120,27 +115,7 @@ class RotDiffAniso(ut.TestCase):
         self.J[1] = self.J[0]
         self.J[2] = self.J[0]
 
-    def rot_diffusion_param_setup(self):
-        """
-        Setup the parameters for the rotational diffusion
-        test check_rot_diffusion().
-
-        """
-
-        # Time
-        # The time step should be less than t0 ~ mass / gamma
-        self.system.time_step = 3E-3
-
-        # Space
-        self.box = 10.0
-        self.system.box_l = 3 * [self.box]
-        self.system.periodicity = [0, 0, 0]
-
-        # NVT thermostat
-        # Just some temperature range to cover by the test:
-        self.kT = np.random.uniform(0.5, 1.5)
-
-    def check_rot_diffusion(self, n):
+    def check_rot_diffusion(self):
         """
         The rotational diffusion tests based on the reference work
         [Perrin, F. (1936) Journal de Physique et Le Radium, 7(1), 1-11.
@@ -167,8 +142,7 @@ class RotDiffAniso(ut.TestCase):
         # The body angular velocity is rotated now, but there is only the
         # thermal velocity, hence, this does not impact the test and its
         # physical context.
-        for ind in range(n):
-            self.system.part[ind].quat = [1.0, 0.0, 0.0, 0.0]
+        self.system.part[:].quat = [1.0, 0.0, 0.0, 0.0]
         # Average direction cosines
         # Diagonal ones:
         dcosjj_validate = np.zeros((3))
@@ -196,9 +170,9 @@ class RotDiffAniso(ut.TestCase):
             dcosijpp = np.zeros((3, 3))
             dcosijnn = np.zeros((3, 3))
             dcosij2 = np.zeros((3, 3))
-            for ind in range(n):
+            for p in self.system.part:
                 # Just a direction cosines functions averaging..
-                dir_cos = tests_common.rotation_matrix_quat(self.system, ind)
+                dir_cos = tests_common.rotation_matrix_quat(p)
                 for j in range(3):
                     # the LHS of eq. (23) [Perrin1936].
                     dcosjj[j] += dir_cos[j, j]
@@ -214,11 +188,11 @@ class RotDiffAniso(ut.TestCase):
                                 dir_cos[i, j] * dir_cos[j, i]
                             # the LHS of eq. (33) [Perrin1936].
                             dcosij2[i, j] += dir_cos[i, j]**2.0
-            dcosjj /= n
-            dcosjj2 /= n
-            dcosijpp /= n
-            dcosijnn /= n
-            dcosij2 /= n
+            dcosjj /= self.n_part
+            dcosjj2 /= self.n_part
+            dcosijpp /= self.n_part
+            dcosijnn /= self.n_part
+            dcosij2 /= self.n_part
 
             # Actual comparison.
 
@@ -349,37 +323,31 @@ class RotDiffAniso(ut.TestCase):
 
     # Langevin Dynamics / Anisotropic
     def test_case_00(self):
-        n = 800
-        self.rot_diffusion_param_setup()
         self.set_anisotropic_param()
-        self.add_particles_setup(n)
+        self.add_particles()
         self.system.thermostat.set_langevin(
             kT=self.kT, gamma=self.gamma_global, seed=42)
         # Actual integration and validation run
-        self.check_rot_diffusion(n)
+        self.check_rot_diffusion()
 
     # Langevin Dynamics / Isotropic
     def test_case_01(self):
-        n = 800
-        self.rot_diffusion_param_setup()
         self.set_isotropic_param()
-        self.add_particles_setup(n)
+        self.add_particles()
         self.system.thermostat.set_langevin(
             kT=self.kT, gamma=self.gamma_global, seed=42)
         # Actual integration and validation run
-        self.check_rot_diffusion(n)
+        self.check_rot_diffusion()
 
     # Brownian Dynamics / Isotropic
     def test_case_10(self):
-        n = 800
-        self.rot_diffusion_param_setup()
         self.set_isotropic_param()
-        self.add_particles_setup(n)
+        self.add_particles()
         self.system.thermostat.set_brownian(
             kT=self.kT, gamma=self.gamma_global, seed=42)
         self.system.integrator.set_brownian_dynamics()
         # Actual integration and validation run
-        self.check_rot_diffusion(n)
+        self.check_rot_diffusion()
 
 
 if __name__ == '__main__':

--- a/testsuite/python/rotational_dynamics.py
+++ b/testsuite/python/rotational_dynamics.py
@@ -49,8 +49,7 @@ class Integrate(ut.TestCase):
         # check angular velocity increases linearly
         for j in range(1, 200):
             system.integrator.run(1)
-            for i in range(3):
-                p = system.part[i]
+            for i, p in enumerate(system.part):
                 ref_omega = [0, 0, 0]
                 ref_omega[i] = j * time_step * p.torque_lab[i] / p.rinertia[i]
                 val_omega = np.copy(p.omega_lab)
@@ -94,8 +93,7 @@ class Integrate(ut.TestCase):
         # check quaternion follows a sine (the quaternion period is 4 pi)
         for j in range(1, 4 * n_steps + 1):
             system.integrator.run(1)
-            for i in range(3):
-                p = system.part[i]
+            for i, p in enumerate(system.part):
                 ref_omega = [0, 0, 0]
                 ref_omega[i] = 1
                 val_omega = np.copy(p.omega_lab)

--- a/testsuite/python/rotational_inertia.py
+++ b/testsuite/python/rotational_inertia.py
@@ -54,11 +54,10 @@ class RotationalInertia(ut.TestCase):
 
         tol = 4E-3
         # Anisotropic inertial moment. Stable axes correspond to J[1] and J[2].
-        # The unstable axis corresponds to J[0]. These values relation is J[1]
-        # < J[0] < J[2].
-        J = np.array([5, 0.5, 18.5])
+        # The unstable axis corresponds to J[0]. These values relation is
+        # J[1] < J[0] < J[2].
+        p.rinertia = [5, 0.5, 18.5]
 
-        p.rinertia = J[:]
         # Validation of J[1] stability
         # ----------------------------
         self.system.time_step = 0.0006

--- a/testsuite/python/rotational_inertia.py
+++ b/testsuite/python/rotational_inertia.py
@@ -31,26 +31,24 @@ class RotationalInertia(ut.TestCase):
     L_0_lab = np.zeros((3))
     L_lab = np.zeros((3))
 
+    def tearDown(self):
+        self.system.part.clear()
+
     # Angular momentum
-    def L_body(self, part):
-        return self.system.part[part].omega_body[:] * \
-            self.system.part[part].rinertia[:]
+    def L_body(self, p):
+        return p.omega_body[:] * p.rinertia[:]
 
     # Set the angular momentum
-    def set_L_0(self, part):
-        L_0_body = self.L_body(part)
-        self.L_0_lab = tests_common.convert_vec_body_to_space(
-            self.system, part, L_0_body)
+    def set_L_0(self, p):
+        L_0_body = self.L_body(p)
+        self.L_0_lab = tests_common.convert_vec_body_to_space(p, L_0_body)
 
-    def set_L(self, part):
-        L_body = self.L_body(part)
-        self.L_lab = tests_common.convert_vec_body_to_space(
-            self.system, part, L_body)
+    def set_L(self, p):
+        L_body = self.L_body(p)
+        self.L_lab = tests_common.convert_vec_body_to_space(p, L_body)
 
     def test_stability(self):
-        self.system.part.clear()
-        self.system.part.add(
-            pos=np.array([0.0, 0.0, 0.0]), id=0, rotation=(1, 1, 1))
+        p = self.system.part.add(pos=[0.0, 0.0, 0.0], rotation=(1, 1, 1))
 
         # Inertial motion around the stable and unstable axes
 
@@ -60,17 +58,17 @@ class RotationalInertia(ut.TestCase):
         # < J[0] < J[2].
         J = np.array([5, 0.5, 18.5])
 
-        self.system.part[0].rinertia = J[:]
+        p.rinertia = J[:]
         # Validation of J[1] stability
         # ----------------------------
         self.system.time_step = 0.0006
         # Stable omega component should be larger than other components.
         stable_omega = 57.65
-        self.system.part[0].omega_body = np.array([0.15, stable_omega, -0.043])
-        self.set_L_0(0)
+        p.omega_body = np.array([0.15, stable_omega, -0.043])
+        self.set_L_0(p)
 
         for i in range(100):
-            self.set_L(0)
+            self.set_L(p)
             for k in range(3):
                 self.assertAlmostEqual(
                     self.L_lab[k], self.L_0_lab[k], delta=tol,
@@ -79,10 +77,10 @@ class RotationalInertia(ut.TestCase):
                         '{1}, expected {2}, got {3}'.format(
                         i, k, self.L_0_lab[k], self.L_lab[k]))
             self.assertAlmostEqual(
-                self.system.part[0].omega_body[1], stable_omega, delta=tol,
+                p.omega_body[1], stable_omega, delta=tol,
                 msg='Inertial motion around stable axis J1: Deviation in omega '
                     'is too large. Step {0}, coordinate 1, expected {1}, got {2}'
-                    .format(i, stable_omega, self.system.part[0].omega_body[1]))
+                    .format(i, stable_omega, p.omega_body[1]))
             self.system.integrator.run(10)
 
         # Validation of J[2] stability
@@ -90,12 +88,11 @@ class RotationalInertia(ut.TestCase):
         self.system.time_step = 0.01
         # Stable omega component should be larger than other components.
         stable_omega = 3.2
-        self.system.part[0].omega_body = np.array(
-            [0.011, -0.043, stable_omega])
-        self.set_L_0(0)
+        p.omega_body = np.array([0.011, -0.043, stable_omega])
+        self.set_L_0(p)
 
         for i in range(100):
-            self.set_L(0)
+            self.set_L(p)
             for k in range(3):
                 self.assertAlmostEqual(
                     self.L_lab[k], self.L_0_lab[k], delta=tol,
@@ -104,10 +101,10 @@ class RotationalInertia(ut.TestCase):
                         '{1}, expected {2}, got {3}'.format(
                         i, k, self.L_0_lab[k], self.L_lab[k]))
             self.assertAlmostEqual(
-                self.system.part[0].omega_body[2], stable_omega, delta=tol,
+                p.omega_body[2], stable_omega, delta=tol,
                 msg='Inertial motion around stable axis J2: Deviation in omega '
                     'is too large. Step {0}, coordinate 2, expected {1}, got {2}'
-                    .format(i, stable_omega, self.system.part[0].omega_body[2]))
+                    .format(i, stable_omega, p.omega_body[2]))
             self.system.integrator.run(10)
 
         # Validation of J[0]
@@ -115,12 +112,11 @@ class RotationalInertia(ut.TestCase):
         self.system.time_step = 0.001
         # Unstable omega component should be larger than other components.
         unstable_omega = 5.76
-        self.system.part[0].omega_body = np.array(
-            [unstable_omega, -0.043, 0.15])
-        self.set_L_0(0)
+        p.omega_body = np.array([unstable_omega, -0.043, 0.15])
+        self.set_L_0(p)
 
         for i in range(100):
-            self.set_L(0)
+            self.set_L(p)
             for k in range(3):
                 self.assertAlmostEqual(
                     self.L_lab[k], self.L_0_lab[k], delta=tol,
@@ -138,8 +134,6 @@ class RotationalInertia(ut.TestCase):
 
     def test_energy_and_momentum_conservation(self):
         system = self.system
-        system.part.clear()
-        system.thermostat.turn_off()
         p = system.part.add(pos=(0, 0, 0), rinertia=(1.1, 1.3, 1.5),
                             rotation=(1, 1, 1), omega_body=(2, 1, 4))
         E0 = self.energy(p)

--- a/testsuite/python/simple_pore.py
+++ b/testsuite/python/simple_pore.py
@@ -68,7 +68,7 @@ class SimplePoreConstraint(ut.TestCase):
 
         for i in range(200):
             rpos = [i * (box_x / 200.), 0.5 * box_yz, 0.5 * box_yz]
-            s.part.add(id=i, pos=rpos, type=1, v=[1., 1., 1.])
+            s.part.add(pos=rpos, type=1, v=[1., 1., 1.])
 
         start_energy = s.analysis.energy()['total']
         s.integrator.run(1000)

--- a/testsuite/python/stokesian_dynamics.py
+++ b/testsuite/python/stokesian_dynamics.py
@@ -121,14 +121,13 @@ class StokesianDiffusionTest(ut.TestCase):
         self.system.time_step = 1.0
         self.system.cell_system.skin = 0.4
 
-        self.system.part.add(pos=[0, 0, 0], rotation=[1, 1, 1])
-
     def tearDown(self):
         self.system.constraints.clear()
         self.system.part.clear()
         self.system.thermostat.set_stokesian(kT=0)
 
     def test(self):
+        p = self.system.part.add(pos=[0, 0, 0], rotation=[1, 1, 1])
         self.system.integrator.set_stokesian_dynamics(
             viscosity=self.eta, radii={0: self.R})
         self.system.thermostat.set_stokesian(kT=self.kT, seed=42)
@@ -137,12 +136,12 @@ class StokesianDiffusionTest(ut.TestCase):
         pos = np.empty([intsteps + 1, 3])
         orientation = np.empty((intsteps + 1, 3))
 
-        pos[0, :] = self.system.part[0].pos
-        orientation[0, :] = self.system.part[0].director
+        pos[0, :] = p.pos
+        orientation[0, :] = p.director
         for i in range(intsteps):
             self.system.integrator.run(1)
-            pos[i + 1, :] = self.system.part[0].pos
-            orientation[i + 1, :] = self.system.part[0].director
+            pos[i + 1, :] = p.pos
+            orientation[i + 1, :] = p.director
 
         # translational diffusion coefficient
         D_expected = self.kT / (6 * np.pi * self.eta * self.R)

--- a/testsuite/python/tabulated.py
+++ b/testsuite/python/tabulated.py
@@ -39,21 +39,23 @@ class TabulatedTest(ut.TestCase):
             self.force[i] = 5 + i * 2.3 * self.dx
             self.energy[i] = 5 - i * 2.3 * self.dx
 
+        self.s.part.add(type=0, pos=[5., 5., 5.0])
+        self.s.part.add(type=0, pos=[5., 5., 5.5])
+
+    def tearDown(self):
         self.s.part.clear()
-        self.s.part.add(id=0, type=0, pos=[5., 5., 5.0])
-        self.s.part.add(id=1, type=0, pos=[5., 5., 5.5])
 
     def check(self):
+        p0, p1 = self.s.part[:]
         # Below cutoff
         np.testing.assert_allclose(np.copy(self.s.part[:].f), 0.0)
 
         for z in np.linspace(0, self.max_ - self.min_, 200, endpoint=False):
-            self.s.part[1].pos = [5., 5., 6. + z]
+            p1.pos = [5., 5., 6. + z]
             self.s.integrator.run(0)
             np.testing.assert_allclose(
-                np.copy(self.s.part[0].f), [0., 0., -(5. + z * 2.3)])
-            np.testing.assert_allclose(
-                np.copy(self.s.part[0].f), -np.copy(self.s.part[1].f))
+                np.copy(p0.f), [0., 0., -(5. + z * 2.3)])
+            np.testing.assert_allclose(np.copy(p0.f), -np.copy(p1.f))
             self.assertAlmostEqual(
                 self.s.analysis.energy()['total'], 5. - z * 2.3)
 
@@ -89,11 +91,9 @@ class TabulatedTest(ut.TestCase):
         self.assertAlmostEqual(self.min_, tb.params['min'])
         self.assertAlmostEqual(self.max_, tb.params['max'])
 
-        self.s.part[0].add_bond((tb, 1))
-
+        p0, p1 = self.s.part[:]
+        p0.add_bond((tb, p1))
         self.check()
-
-        self.s.part[0].delete_bond((tb, 1))
 
 
 if __name__ == "__main__":

--- a/testsuite/python/thermalized_bond.py
+++ b/testsuite/python/thermalized_bond.py
@@ -66,8 +66,8 @@ class ThermalizedBond(ut.TestCase, ThermostatsCommon):
             gamma_distance=g_dist, r_cut=2.0, seed=55)
         self.system.bonded_inter.add(thermalized_dist_bond)
 
-        for i in range(0, N, 2):
-            self.system.part[i].add_bond((thermalized_dist_bond, i + 1))
+        for p1, p2 in zip(self.system.part[::2], self.system.part[1::2]):
+            p1.add_bond((thermalized_dist_bond, p2))
 
         # Warmup
         self.system.integrator.run(50)
@@ -114,8 +114,8 @@ class ThermalizedBond(ut.TestCase, ThermostatsCommon):
             gamma_distance=g_dist, r_cut=9, seed=51)
         self.system.bonded_inter.add(thermalized_dist_bond)
 
-        for i in range(0, N, 2):
-            self.system.part[i].add_bond((thermalized_dist_bond, i + 1))
+        for p1, p2 in zip(self.system.part[::2], self.system.part[1::2]):
+            p1.add_bond((thermalized_dist_bond, p2))
 
         # Warmup
         self.system.integrator.run(50)

--- a/testsuite/python/virtual_sites_tracers.py
+++ b/testsuite/python/virtual_sites_tracers.py
@@ -30,6 +30,9 @@ class VirtualSitesTracers(ut.TestCase, VirtualSitesTracersCommon):
     def setUp(self):
         self.LBClass = lb.LBFluid
 
+    def tearDown(self):
+        VirtualSitesTracersCommon.tearDown(self)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/virtual_sites_tracers_common.py
+++ b/testsuite/python/virtual_sites_tracers_common.py
@@ -35,10 +35,13 @@ class VirtualSitesTracersCommon:
     system.time_step = 0.05
     system.cell_system.skin = 0.1
 
-    def reset_lb(self, ext_force_density=(0, 0, 0)):
+    def tearDown(self):
+        self.system.part.clear()
         self.system.actors.clear()
-        self.system.lbboundaries.clear()
         self.system.thermostat.turn_off()
+
+    def reset_lb(self, ext_force_density=(0, 0, 0)):
+        self.system.lbboundaries.clear()
         self.lbf = self.LBClass(
             kT=0.0, agrid=1, dens=1, visc=1.8,
             tau=self.system.time_step, ext_force_density=ext_force_density)
@@ -74,31 +77,22 @@ class VirtualSitesTracersCommon:
         system = self.system
 
         system.virtual_sites = VirtualSitesInertialessTracers()
-        system.part.clear()
 
         # Establish steady state flow field
-        system.part.add(id=0, pos=(0, 5.5, 5.5), virtual=True)
+        p = system.part.add(pos=(0, 5.5, 5.5), virtual=True)
         system.integrator.run(400)
 
-        system.part[0].pos = (0, 5.5, 5.5)
+        p.pos = (0, 5.5, 5.5)
         system.time = 0
 
         # Perform integration
         for _ in range(2):
             system.integrator.run(100)
             # compute expected position
-            X = self.lbf.get_interpolated_velocity(
-                system.part[0].pos)[0] * system.time
-            self.assertAlmostEqual(
-                system.part[0].pos[0] / X - 1, 0, delta=0.005)
+            dist = self.lbf.get_interpolated_velocity(p.pos)[0] * system.time
+            self.assertAlmostEqual(p.pos[0] / dist, 1, delta=0.005)
 
-    def compute_angle(self):
-        system = self.system
-        pos0 = system.part[0].pos
-        pos1 = system.part[1].pos
-        pos2 = system.part[2].pos
-        pos3 = system.part[3].pos
-
+    def compute_dihedral_angle(self, pos0, pos1, pos2, pos3):
         # first normal vector
         n1 = np.cross((pos1 - pos0), (pos2 - pos0))
         n2 = np.cross((pos2 - pos0), (pos3 - pos0))
@@ -118,64 +112,58 @@ class VirtualSitesTracersCommon:
 
         system = self.system
         system.virtual_sites = VirtualSitesInertialessTracers()
-        system.part.clear()
-        system.actors.clear()
-        system.thermostat.turn_off()
         system.thermostat.set_langevin(kT=0, gamma=10, seed=1)
 
         # Add four particles
-        system.part.add(id=0, pos=[5, 5, 5])
-        system.part.add(id=1, pos=[5, 5, 6])
-        system.part.add(id=2, pos=[5, 6, 6])
-        system.part.add(id=3, pos=[5, 6, 5])
+        p0 = system.part.add(pos=[5, 5, 5])
+        p1 = system.part.add(pos=[5, 5, 6])
+        p2 = system.part.add(pos=[5, 6, 6])
+        p3 = system.part.add(pos=[5, 6, 5])
 
         # Add first triel, weak modulus
         tri1 = espressomd.interactions.IBM_Triel(
-            ind1=0, ind2=1, ind3=2, elasticLaw="Skalak", k1=0.1, k2=0, maxDist=2.4)
+            ind1=p0.id, ind2=p1.id, ind3=p2.id, elasticLaw="Skalak", k1=0.1, k2=0, maxDist=2.4)
         system.bonded_inter.add(tri1)
-        system.part[0].add_bond((tri1, 1, 2))
+        p0.add_bond((tri1, p1, p2))
 
         # Add second triel, strong modulus
         tri2 = espressomd.interactions.IBM_Triel(
-            ind1=0, ind2=2, ind3=3, elasticLaw="Skalak", k1=10, k2=0, maxDist=2.4)
+            ind1=p0.id, ind2=p2.id, ind3=p3.id, elasticLaw="Skalak", k1=10, k2=0, maxDist=2.4)
         system.bonded_inter.add(tri2)
-        system.part[0].add_bond((tri2, 2, 3))
+        p0.add_bond((tri2, p2, p3))
 
         # Add bending
         tribend = espressomd.interactions.IBM_Tribend(
-            ind1=0, ind2=1, ind3=2, ind4=3, kb=1, refShape="Initial")
+            ind1=p0.id, ind2=p1.id, ind3=p2.id, ind4=p3.id, kb=1, refShape="Initial")
         system.bonded_inter.add(tribend)
-        system.part[0].add_bond((tribend, 1, 2, 3))
+        p0.add_bond((tribend, p1, p2, p3))
 
         # twist
         system.part[:].pos = system.part[:].pos + np.random.random((4, 3))
 
         # Perform integration
         system.integrator.run(200)
-        angle = self.compute_angle()
+        angle = self.compute_dihedral_angle(p0.pos, p1.pos, p2.pos, p3.pos)
         self.assertLess(angle, 2E-2)
 
     def test_triel(self):
         system = self.system
         system.virtual_sites = VirtualSitesInertialessTracers()
-        system.part.clear()
-        system.actors.clear()
-        system.thermostat.turn_off()
         system.thermostat.set_langevin(kT=0, gamma=1, seed=1)
 
         # Add particles: 0-2 are not bonded, 3-5 are bonded
-        non_bound = system.part.add(
-            id=[0, 1, 2], pos=[[5, 5, 5], [5, 5, 6], [5, 6, 6]])
+        non_bound = system.part.add(pos=[[5, 5, 5], [5, 5, 6], [5, 6, 6]])
 
-        system.part.add(id=3, pos=[2, 5, 5])
-        system.part.add(id=4, pos=[2, 5, 6])
-        system.part.add(id=5, pos=[2, 6, 6])
+        p3 = system.part.add(pos=[2, 5, 5])
+        p4 = system.part.add(pos=[2, 5, 6])
+        p5 = system.part.add(pos=[2, 6, 6])
 
         # Add triel for 3-5
         tri = espressomd.interactions.IBM_Triel(
-            ind1=3, ind2=4, ind3=5, elasticLaw="Skalak", k1=15, k2=0, maxDist=2.4)
+            ind1=p3.id, ind2=p4.id, ind3=p5.id, elasticLaw="Skalak", k1=15,
+            k2=0, maxDist=2.4)
         system.bonded_inter.add(tri)
-        system.part[3].add_bond((tri, 4, 5))
+        p3.add_bond((tri, p4, p5))
 
         system.part[:].pos = system.part[:].pos + np.array((
             (0, 0, 0), (1, -.2, .3), (1, 1, 1),
@@ -184,8 +172,8 @@ class VirtualSitesTracersCommon:
         distorted_pos = np.copy(non_bound.pos)
 
         system.integrator.run(110)
-        dist1bound = system.distance(system.part[3], system.part[4])
-        dist2bound = system.distance(system.part[3], system.part[5])
+        dist1bound = system.distance(p3, p4)
+        dist2bound = system.distance(p3, p5)
 
         # check bonded particles. Distance should restore to initial config
         self.assertAlmostEqual(dist1bound, 1, delta=0.05)

--- a/testsuite/python/virtual_sites_tracers_gpu.py
+++ b/testsuite/python/virtual_sites_tracers_gpu.py
@@ -31,6 +31,9 @@ class VirtualSitesTracers(ut.TestCase, VirtualSitesTracersCommon):
     def setUp(self):
         self.LBClass = lb.LBFluidGPU
 
+    def tearDown(self):
+        VirtualSitesTracersCommon.tearDown(self)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/wang_landau.py
+++ b/testsuite/python/wang_landau.py
@@ -49,14 +49,15 @@ class WangLandauReactionEnsembleTest(ut.TestCase):
 
     K_diss = 0.0088
 
-    system.part.add(id=0, type=3, pos=[0, 0, 0] * system.box_l)
-    system.part.add(id=1, type=1, pos=[1.0, 1.0, 1.0] * system.box_l / 2.0)
-    system.part.add(id=2, type=2, pos=np.random.random() * system.box_l)
-    system.part.add(id=3, type=2, pos=np.random.random() * system.box_l)
+    p1 = system.part.add(type=3, pos=[0, 0, 0])
+    p2 = system.part.add(type=1, pos=system.box_l / 2.0)
+    system.part.add(type=2, pos=np.random.random() * system.box_l)
+    system.part.add(type=2, pos=np.random.random() * system.box_l)
 
-    h = espressomd.interactions.HarmonicBond(r_0=0, k=1)
-    system.bonded_inter[0] = h
-    system.part[0].add_bond((h, 1))
+    harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0, k=1)
+    system.bonded_inter[0] = harmonic_bond
+    p1.add_bond((harmonic_bond, p2))
+
     WLRE = espressomd.reaction_ensemble.WangLandauReactionEnsemble(
         temperature=temperature, exclusion_radius=0, seed=86)
     WLRE.add_reaction(

--- a/testsuite/python/wang_landau_stats.py
+++ b/testsuite/python/wang_landau_stats.py
@@ -54,14 +54,15 @@ class WangLandauReactionEnsembleTest(ut.TestCase):
 
     K_diss = 0.0088
 
-    system.part.add(id=0, type=3, pos=[0, 0, 0] * system.box_l)
-    system.part.add(id=1, type=1, pos=[1.0, 1.0, 1.0] * system.box_l / 2.0)
-    system.part.add(id=2, type=2, pos=np.random.random() * system.box_l)
-    system.part.add(id=3, type=2, pos=np.random.random() * system.box_l)
+    p1 = system.part.add(type=3, pos=[0, 0, 0])
+    p2 = system.part.add(type=1, pos=system.box_l / 2.0)
+    system.part.add(type=2, pos=np.random.random() * system.box_l)
+    system.part.add(type=2, pos=np.random.random() * system.box_l)
 
-    h = espressomd.interactions.HarmonicBond(r_0=0, k=1)
-    system.bonded_inter[0] = h
-    system.part[0].add_bond((h, 1))
+    harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0, k=1)
+    system.bonded_inter[0] = harmonic_bond
+    p1.add_bond((harmonic_bond, p2))
+
     WLRE = espressomd.reaction_ensemble.WangLandauReactionEnsemble(
         temperature=temperature, exclusion_radius=0, seed=86)
     WLRE.add_reaction(

--- a/testsuite/python/widom_insertion.py
+++ b/testsuite/python/widom_insertion.py
@@ -75,8 +75,7 @@ class WidomInsertionTest(ut.TestCase):
         temperature=TEMPERATURE, seed=1)
 
     def setUp(self):
-        self.system.part.add(id=0, pos=0.5 * self.system.box_l,
-                             type=self.TYPE_HA)
+        self.system.part.add(pos=0.5 * self.system.box_l, type=self.TYPE_HA)
 
         self.system.non_bonded_inter[self.TYPE_HA, self.TYPE_HA].lennard_jones.set_params(
             epsilon=self.LJ_EPS, sigma=self.LJ_SIG, cutoff=self.LJ_CUT,


### PR DESCRIPTION
Partial fix for #4029

Description of changes:
- use `ParticleHandle` objects instead of `system.part[pid]` in the python tests
- improve tests clarity (batch particle creation, utility functions from `itertools` and `tests_common.py`, etc.)
