### PR TITLE
Remove mis-use in Rattle

### DIFF
--- a/src/core/CellStructure.cpp
+++ b/src/core/CellStructure.cpp
@@ -154,6 +154,9 @@ static unsigned map_data_parts(unsigned data_parts) {
          | ((DATA_PART_POSITION & data_parts) ? GHOSTTRANS_POSITION : 0u)
          | ((DATA_PART_MOMENTUM & data_parts) ? GHOSTTRANS_MOMENTUM : 0u)
          | ((DATA_PART_FORCE & data_parts) ? GHOSTTRANS_FORCE : 0u)
+#ifdef BOND_CONSTRAINT
+         | ((DATA_PART_RATTLE & data_parts) ? GHOSTTRANS_RATTLE : 0u)
+#endif
          | ((DATA_PART_BONDS & data_parts) ? GHOSTTRANS_BONDS : 0u);
   /* clang-format on */
 }
@@ -166,6 +169,12 @@ void CellStructure::ghosts_reduce_forces() {
   ghost_communicator(decomposition().collect_ghost_force_comm(),
                      GHOSTTRANS_FORCE);
 }
+#ifdef BOND_CONSTRAINT
+void CellStructure::ghosts_reduce_rattle_correction() {
+  ghost_communicator(decomposition().collect_ghost_force_comm(),
+                     GHOSTTRANS_RATTLE);
+}
+#endif
 
 Utils::Span<Cell *> CellStructure::local_cells() {
   return decomposition().local_cells();

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -66,7 +66,10 @@ enum DataPart : unsigned {
   DATA_PART_POSITION = 2u,   /**< Particle::r */
   DATA_PART_MOMENTUM = 8u,   /**< Particle::m */
   DATA_PART_FORCE = 16u,     /**< Particle::f */
-  DATA_PART_BONDS = 32u      /**< Particle::bonds */
+#ifdef BOND_CONSTRAINT
+  DATA_PART_RATTLE = 32u, /**< Particle::rattle */
+#endif
+  DATA_PART_BONDS = 64u /**< Particle::bonds */
 };
 } // namespace Cells
 
@@ -369,6 +372,12 @@ public:
    * @brief Add forces from ghost particles to real particles.
    */
   void ghosts_reduce_forces();
+#ifdef BOND_CONSTRAINT
+  /**
+   * @brief Add rattle corrections from ghost particles to real particles.
+   */
+  void ghosts_reduce_rattle_correction();
+#endif
 
 private:
   /**

--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -365,6 +365,26 @@ struct ParticleLocal {
   }
 };
 
+#ifdef BOND_CONSTRAINT
+struct ParticleRattle {
+  /** position/velocity correction */
+  Utils::Vector3d correction = {0, 0, 0};
+
+  friend ParticleRattle operator+(ParticleRattle const &lhs,
+                                  ParticleRattle const &rhs) {
+    return {lhs.correction + rhs.correction};
+  }
+
+  ParticleRattle &operator+=(ParticleRattle const &rhs) {
+    return *this = *this + rhs;
+  }
+
+  template <class Archive> void serialize(Archive &ar, long int /* version */) {
+    ar &correction;
+  }
+};
+#endif
+
 /** Struct holding all information for one particle. */
 struct Particle { // NOLINT(bugprone-exception-escape)
   int &identity() { return p.identity; }
@@ -391,6 +411,10 @@ struct Particle { // NOLINT(bugprone-exception-escape)
   ParticleForce f;
   ///
   ParticleLocal l;
+#ifdef BOND_CONSTRAINT
+  ///
+  ParticleRattle rattle;
+#endif
 
 private:
   BondList bl;

--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -268,7 +268,7 @@ struct ParticlePosition {
 
 #ifdef BOND_CONSTRAINT
   /** particle position at the previous time step (RATTLE algorithm) */
-  Utils::Vector3d p_old = {0., 0., 0.};
+  Utils::Vector3d p_last_timestep = {0., 0., 0.};
 #endif
 
   template <class Archive> void serialize(Archive &ar, long int /* version */) {
@@ -277,7 +277,7 @@ struct ParticlePosition {
     ar &quat;
 #endif
 #ifdef BOND_CONSTRAINT
-    ar &p_old;
+    ar &p_last_timestep;
 #endif
   }
 };

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -45,6 +45,7 @@
  *  - @ref GHOSTTRANS_POSITION transfers the @ref ParticlePosition
  *  - @ref GHOSTTRANS_MOMENTUM transfers the @ref ParticleMomentum
  *  - @ref GHOSTTRANS_FORCE transfers the @ref ParticleForce
+ *  - @ref GHOSTTRANS_RATTLE transfers the @ref ParticleRattle
  *  - @ref GHOSTTRANS_PARTNUM transfers the cell sizes
  *
  *  Each ghost communication describes a single communication of the local with
@@ -127,6 +128,10 @@ enum : unsigned {
   GHOSTTRANS_MOMENTUM = 8u,
   /// transfer \ref ParticleForce
   GHOSTTRANS_FORCE = 16u,
+#ifdef BOND_CONSTRAINT
+  /// transfer \ref ParticleRattle
+  GHOSTTRANS_RATTLE = 32u,
+#endif
   /// resize the receiver particle arrays to the size of the senders
   GHOSTTRANS_PARTNUM = 64u,
   GHOSTTRANS_BONDS = 128u

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -239,7 +239,7 @@ int integrate(int n_steps, int reuse_forces) {
 
 #ifdef BOND_CONSTRAINT
     if (n_rigidbonds)
-      save_old_pos(particles, cell_structure.ghost_particles());
+      save_old_position(particles, cell_structure.ghost_particles());
 #endif
 
     bool early_exit = integrator_step_1(particles);
@@ -253,7 +253,7 @@ int integrate(int n_steps, int reuse_forces) {
     /* Correct those particle positions that participate in a rigid/constrained
      * bond */
     if (n_rigidbonds) {
-      correct_pos_shake(cell_structure);
+      correct_position_shake(cell_structure);
     }
 #endif
 
@@ -278,7 +278,7 @@ int integrate(int n_steps, int reuse_forces) {
 #ifdef BOND_CONSTRAINT
     // SHAKE velocity updates
     if (n_rigidbonds) {
-      correct_vel_shake(cell_structure);
+      correct_velocity_shake(cell_structure);
     }
 #endif
 

--- a/src/core/rattle.cpp
+++ b/src/core/rattle.cpp
@@ -135,9 +135,8 @@ void correct_position_shake(CellStructure &cs) {
   auto particles = cs.local_particles();
   auto ghost_particles = cs.ghost_particles();
 
-  int cnt = 0;
-
-  while (cnt < SHAKE_MAX_ITERATIONS) {
+  int cnt;
+  for (cnt = 0; cnt < SHAKE_MAX_ITERATIONS; ++cnt) {
     init_correction_vector(particles, ghost_particles);
     bool const repeat_ =
         compute_correction_vector(cs, calculate_positional_correction);
@@ -152,9 +151,7 @@ void correct_position_shake(CellStructure &cs) {
 
     apply_positional_correction(particles);
     cs.ghosts_update(Cells::DATA_PART_POSITION | Cells::DATA_PART_MOMENTUM);
-
-    cnt++;
-  } // while(repeat) loop
+  }
   if (cnt >= SHAKE_MAX_ITERATIONS) {
     runtimeErrorMsg() << "RATTLE failed to converge after " << cnt
                       << " iterations";
@@ -209,8 +206,8 @@ void correct_velocity_shake(CellStructure &cs) {
   auto particles = cs.local_particles();
   auto ghost_particles = cs.ghost_particles();
 
-  int cnt = 0;
-  while (cnt < SHAKE_MAX_ITERATIONS) {
+  int cnt;
+  for (cnt = 0; cnt < SHAKE_MAX_ITERATIONS; ++cnt) {
     init_correction_vector(particles, ghost_particles);
     bool const repeat_ =
         compute_correction_vector(cs, calculate_velocity_correction);
@@ -225,8 +222,6 @@ void correct_velocity_shake(CellStructure &cs) {
 
     apply_velocity_correction(particles);
     cs.ghosts_update(Cells::DATA_PART_MOMENTUM);
-
-    cnt++;
   }
 
   if (cnt >= SHAKE_MAX_ITERATIONS) {

--- a/src/core/rattle.hpp
+++ b/src/core/rattle.hpp
@@ -35,7 +35,8 @@
 #ifdef BOND_CONSTRAINT
 
 /** Transfer the current particle positions from @ref ParticlePosition::p
- *  "Particle::r::p" to @ref ParticlePosition::p_old "Particle::r::p_old"
+ *  "Particle::r::p" to @ref ParticlePosition::p_last_timestep
+ *  "Particle::r::p_last_timestep"
  */
 void save_old_pos(const ParticleRange &particles,
                   const ParticleRange &ghost_particles);

--- a/src/core/rattle.hpp
+++ b/src/core/rattle.hpp
@@ -38,16 +38,23 @@
  *  "Particle::r::p" to @ref ParticlePosition::p_last_timestep
  *  "Particle::r::p_last_timestep"
  */
-void save_old_pos(const ParticleRange &particles,
-                  const ParticleRange &ghost_particles);
+void save_old_position(const ParticleRange &particles,
+                       const ParticleRange &ghost_particles);
 
-/** Propagate velocity and position while using SHAKE algorithm for bond
- *  constraint.
+/**
+ * @brief Propagate velocity and position while using SHAKE algorithm for bond
+ * constraint.
+ *
+ * @param cs cell structure
  */
-void correct_pos_shake(CellStructure &cs);
+void correct_position_shake(CellStructure &cs);
 
-/** Correction of current velocities using RATTLE algorithm. */
-void correct_vel_shake(CellStructure &cs);
+/**
+ * @brief Correction of current velocities using RATTLE algorithm.
+ *
+ * @param cs cell structure
+ */
+void correct_velocity_shake(CellStructure &cs);
 
 #endif
 #endif

--- a/src/core/unit_tests/Particle_test.cpp
+++ b/src/core/unit_tests/Particle_test.cpp
@@ -187,3 +187,58 @@ BOOST_AUTO_TEST_CASE(force_constructors) {
     check_particle_force(out, pf);
   }
 }
+
+#ifdef BOND_CONSTRAINT
+
+void check_particle_rattle(ParticleRattle const &out,
+                           ParticleRattle const &ref) {
+  BOOST_TEST(out.correction == ref.correction,
+             boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(rattle_serialization) {
+  auto const expected_size =
+      Utils::MemcpyOArchive::packing_size<ParticleRattle>();
+
+  BOOST_CHECK_LE(expected_size, sizeof(ParticleRattle));
+
+  std::vector<char> buf(expected_size);
+
+  auto pr = ParticleRattle{{1, 2, 3}};
+
+  {
+    auto oa = Utils::MemcpyOArchive{Utils::make_span(buf)};
+
+    oa << pr;
+
+    BOOST_CHECK_EQUAL(oa.bytes_written(), expected_size);
+  }
+
+  {
+    auto ia = Utils::MemcpyIArchive{Utils::make_span(buf)};
+    ParticleRattle out;
+
+    ia >> out;
+
+    BOOST_CHECK_EQUAL(ia.bytes_read(), expected_size);
+    check_particle_rattle(out, pr);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(rattle_constructors) {
+  auto pr = ParticleRattle{{1, 2, 3}};
+
+  // check copy constructor
+  {
+    ParticleRattle out(pr);
+    check_particle_rattle(out, pr);
+  }
+
+  // check copy assignment operator
+  {
+    ParticleRattle out; // avoid copy elision
+    out = pr;
+    check_particle_rattle(out, pr);
+  }
+}
+#endif


### PR DESCRIPTION
Fixes #4141

Description of changes:
- removed mis-use of the force-reduction mechanism by introducing new particle property
- reduction mechanism for the new particle property
- cleanup of the rattle-implementation
- introduced early-breakout
