### PR TITLE
utils: Made Array streamable

### DIFF
--- a/src/utils/include/utils/Array.hpp
+++ b/src/utils/include/utils/Array.hpp
@@ -26,8 +26,9 @@
 
 #include <cassert>
 #include <cstddef>
+#include <iterator>
+#include <ostream>
 #include <stdexcept>
-
 namespace Utils {
 
 namespace detail {
@@ -151,6 +152,16 @@ private:
   template <typename Archive>
   void serialize(Archive &ar, const unsigned int /* version */) {
     ar &m_storage;
+  }
+
+  friend std::ostream &operator<<(std::ostream &out, Array const &a) {
+    if (not a.empty())
+      out << a[0];
+
+    for (auto it = std::next(a.begin()); it != a.end(); ++it)
+      out << ", " << *it;
+
+    return out;
   }
 };
 

--- a/src/utils/tests/Array_test.cpp
+++ b/src/utils/tests/Array_test.cpp
@@ -117,3 +117,23 @@ BOOST_AUTO_TEST_CASE(tuple_protocol) {
 
   BOOST_CHECK_EQUAL(Utils::get<1>(A{1, 2, 3, 4}), 2);
 }
+
+BOOST_AUTO_TEST_CASE(streaming_operator) {
+  {
+    auto const a = Utils::Array<int, 1>{1};
+
+    std::stringstream ss;
+    ss << a;
+
+    BOOST_CHECK_EQUAL(ss.str(), "1");
+  }
+
+  {
+    auto const a = Utils::Array<int, 3>{1, 2, 3};
+
+    std::stringstream ss;
+    ss << a;
+
+    BOOST_CHECK_EQUAL(ss.str(), "1, 2, 3");
+  }
+}


### PR DESCRIPTION
Fixes #4189.

Description of changes:
- Implemented `operator<<` for Utils::Array

Notes:
It is not easily possible to add a templated `operator<<` (as one normaly would),
because this is picked up by boost.serialization, which in turn breaks. So I implemented
it only for `std::ostream`, which I think is fine for most cases.