### PR TITLE
Introduced a bugfix to solve the infinite loop in constant pH  algorithm 

### DIFF
--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -1497,18 +1497,12 @@ int ConstantpHEnsemble::get_random_valid_p_id() {
  */
 int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
-  bool reaction_possible = false;
 
   for (int reaction_id = 0; reaction_id < reactions.size(); reaction_id++) {
-    if (all_reactant_particles_exist(reaction_id)) {
-      reaction_possible = true;
+    if (all_reactant_particles_exist(reaction_id) == false){return 1;
     }
   }
-
-  if (reaction_possible == false) {
-    return 1;
-  }
-
+      
   for (int i = 0; i < reaction_steps; ++i) {
     // get a list of reactions where a randomly selected particle type occurs in
     // the reactant list. the selection probability of the particle types has to

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -1497,12 +1497,19 @@ int ConstantpHEnsemble::get_random_valid_p_id() {
  */
 int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
+
+  bool reaction_impossible = true;
+
   for (int reaction_id = 0; reaction_id < reactions.size(); reaction_id++) {
-    if (all_reactant_particles_exist(reaction_id) == false) {
-      throw std::runtime_error("There is not enough reactants nor products to "
-                               "perform the reaction in either direction");
-      ;
+    if (all_reactant_particles_exist(reaction_id)) {
+      reaction_impossible = false;
     }
+  }
+
+  if (reaction_impossible){
+   
+   throw std::runtime_error("There is not enough reactants nor products to perform the reaction in either direction");
+
   }
 
   for (int i = 0; i < reaction_steps; ++i) {

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -51,8 +51,6 @@
 #include <utility>
 #include <vector>
 
-
-
 namespace ReactionEnsemble {
 
 /** Load minimum and maximum energies as a function of the other collective
@@ -1499,13 +1497,17 @@ int ConstantpHEnsemble::get_random_valid_p_id() {
  */
 int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
-  bool reaction_possible=false;
+  bool reaction_possible = false;
 
   for (int reaction_id = 0; reaction_id < reactions.size(); reaction_id++) {
-	if (all_reactant_particles_exist(reaction_id)){reaction_possible=true;}	
-	}
+    if (all_reactant_particles_exist(reaction_id)) {
+      reaction_possible = true;
+    }
+  }
 
-  if(reaction_possible==false){return 1;}
+  if (reaction_possible == false) {
+    return 1;
+  }
 
   for (int i = 0; i < reaction_steps; ++i) {
     // get a list of reactions where a randomly selected particle type occurs in

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -51,6 +51,8 @@
 #include <utility>
 #include <vector>
 
+
+
 namespace ReactionEnsemble {
 
 /** Load minimum and maximum energies as a function of the other collective
@@ -1497,6 +1499,14 @@ int ConstantpHEnsemble::get_random_valid_p_id() {
  */
 int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
+  bool reaction_possible=false;
+
+  for (int reaction_id = 0; reaction_id < reactions.size(); reaction_id++) {
+	if (all_reactant_particles_exist(reaction_id)){reaction_possible=true;}	
+	}
+
+  if(reaction_possible==false){return 1;}
+
   for (int i = 0; i < reaction_steps; ++i) {
     // get a list of reactions where a randomly selected particle type occurs in
     // the reactant list. the selection probability of the particle types has to
@@ -1517,6 +1527,7 @@ int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
       // construct list of reactions with the above reactant type
       for (int reaction_i = 0; reaction_i < reactions.size(); reaction_i++) {
+
         SingleReaction &current_reaction = reactions[reaction_i];
         for (int reactant_i = 0; reactant_i < 1;
              reactant_i++) { // reactant_i < 1 since it is assumed in this place
@@ -1531,6 +1542,7 @@ int ConstantpHEnsemble::do_reaction(int reaction_steps) {
         }
       }
     }
+
     // randomly select a reaction to be performed
     int reaction_id =
         list_of_reaction_ids_with_given_reactant_type[i_random(static_cast<int>(

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -1497,13 +1497,14 @@ int ConstantpHEnsemble::get_random_valid_p_id() {
  */
 int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
-
   for (int reaction_id = 0; reaction_id < reactions.size(); reaction_id++) {
-    if (all_reactant_particles_exist(reaction_id) == false){ 
-      throw std::runtime_error("There is not enough reactants nor products to perform the reaction in either direction");  ;
+    if (all_reactant_particles_exist(reaction_id) == false) {
+      throw std::runtime_error("There is not enough reactants nor products to "
+                               "perform the reaction in either direction");
+      ;
     }
   }
-      
+
   for (int i = 0; i < reaction_steps; ++i) {
     // get a list of reactions where a randomly selected particle type occurs in
     // the reactant list. the selection probability of the particle types has to

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -1497,7 +1497,6 @@ int ConstantpHEnsemble::get_random_valid_p_id() {
  */
 int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
-
   bool reaction_impossible = true;
 
   for (int reaction_id = 0; reaction_id < reactions.size(); reaction_id++) {
@@ -1506,10 +1505,10 @@ int ConstantpHEnsemble::do_reaction(int reaction_steps) {
     }
   }
 
-  if (reaction_impossible){
-   
-   throw std::runtime_error("There is not enough reactants nor products to perform the reaction in either direction");
+  if (reaction_impossible) {
 
+    throw std::runtime_error("There is not enough reactants nor products to "
+                             "perform the reaction in either direction");
   }
 
   for (int i = 0; i < reaction_steps; ++i) {

--- a/src/core/reaction_ensemble.cpp
+++ b/src/core/reaction_ensemble.cpp
@@ -1499,7 +1499,8 @@ int ConstantpHEnsemble::do_reaction(int reaction_steps) {
 
 
   for (int reaction_id = 0; reaction_id < reactions.size(); reaction_id++) {
-    if (all_reactant_particles_exist(reaction_id) == false){return 1;
+    if (all_reactant_particles_exist(reaction_id) == false){ 
+      throw std::runtime_error("There is not enough reactants nor products to perform the reaction in either direction");  ;
     }
   }
       


### PR DESCRIPTION
Fixes #4197

When attempting to do a reaction step using the constant pH algorithm, if there are not enough reactants nor product particles, the program simply not does the operation. The apparition of an infinite loop is prevented by existing the reaction subroutine in case that neither direction of the reaction is possible. 

Description of changes:
- The program checks if at least one direction of the reaction is possible and otherwise exits the subroutine returning a 1. This value should be later processed so the user gets a warning message informing of this error (work in progress).
