### PR TITLE
Non-P3M Coulomb methods maintenance

### DIFF
--- a/doc/doxygen/bibliography.bib
+++ b/doc/doxygen/bibliography.bib
@@ -567,6 +567,17 @@ doi = {10.1002/jcc.540130508},
   doi       = {10.1016/0301-0104(81)85176-2},
 }
 
+@Article{tironi95a,
+  author    = {Tironi, Ilario G. and Sperb, Ren\'{e} and Smith, Paul E. and van Gunsteren, Wilfred F.},
+  title     = {A generalized Reaction Field Method for Molecular-Dynamics Simulations},
+  journal   = {The Journal of Chemical Physics},
+  year      = {1995},
+  volume    = {102},
+  number    = {13},
+  pages     = {5451--5459},
+  doi       = {10.1063/1.469273},
+}
+
 @Article{troester05a,
   title = {{Wang-Landau sampling with self-adaptive range}},
   author = {Tr\"{o}ster, Andreas and Dellago, Christoph},

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -138,7 +138,8 @@ The Debye-Hückel electrostatic potential is defined by
 
   .. math:: U^{C-DH} = C \cdot \frac{q_1 q_2 \exp(-\kappa r)}{r}\quad \mathrm{for}\quad r<r_{\mathrm{cut}}
 
-where :math:`C` is defined as in Eqn. :eq:`coulomb_prefactor`.
+where :math:`C` is defined as in Eqn. :eq:`coulomb_prefactor` and
+:math:`\kappa` is the ionic strength.
 The Debye-Hückel potential is an approximate method for calculating
 electrostatic interactions, but technically it is treated as other
 short-ranged non-bonding potentials. For :math:`r > r_{\textrm{cut}}` it is
@@ -146,6 +147,29 @@ set to zero which introduces a step in energy. Therefore, it introduces
 fluctuations in energy.
 
 For :math:`\kappa = 0`, this corresponds to the plain Coulomb potential.
+
+.. _Reaction Field method:
+
+Reaction Field method
+---------------------
+
+:class:`espressomd.electrostatics.ReactionField`
+
+The Reaction Field electrostatic potential is defined by
+
+  .. math:: U^{C-RF} = C \cdot q_1 q_2 \left[\frac{1}{r} - \frac{B r^2}{2r_{\mathrm{cut}}^3} -\frac{1 - B/2}{r_{\mathrm{cut}}}\right] \quad \mathrm{for}\quad r<r_{\mathrm{cut}}
+
+where :math:`C` is defined as in Eqn. :eq:`coulomb_prefactor` and :math:`B`
+is defined as:
+
+  .. math:: B = \frac{2(\varepsilon_1 - \varepsilon_2)(1 + \kappa r_{\mathrm{cut}}) - \varepsilon_2 (\kappa r_{\mathrm{cut}})^2}{(\varepsilon_1 + 2\varepsilon_2)(1 + \kappa r_{\mathrm{cut}}) + \varepsilon_2 (\kappa r_{\mathrm{cut}})^2}
+
+with :math:`\kappa` the ionic strength, :math:`\varepsilon_1` the dielectric
+constant inside the cavity and :math:`\varepsilon_2` the dielectric constant
+outside the cavity :cite:`tironi95a`.
+
+The term in :math:`1 - B/2` is a correction to make the
+potential continuous at :math:`r = r_{\mathrm{cut}}`.
 
 
 .. _Dielectric interfaces with the ICC algorithm:

--- a/doc/sphinx/zrefs.bib
+++ b/doc/sphinx/zrefs.bib
@@ -884,6 +884,17 @@ pages = {1483--1489}
   pages = {154107},
 }
 
+@Article{tironi95a,
+  author    = {Tironi, Ilario G. and Sperb, Ren\'{e} and Smith, Paul E. and van Gunsteren, Wilfred F.},
+  title     = {A generalized Reaction Field Method for Molecular-Dynamics Simulations},
+  journal   = {The Journal of Chemical Physics},
+  year      = {1995},
+  volume    = {102},
+  number    = {13},
+  pages     = {5451--5459},
+  doi       = {10.1063/1.469273},
+}
+
 @article{turner2008simulation,
   title={Simulation of chemical reaction equilibria by the reaction ensemble {M}onte {C}arlo method: a review},
   author={Heath Turner, C and Brennan, John K and Lisal, Martin and Smith, William R and Karl Johnson, J and Gubbins, Keith E},

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -139,15 +139,10 @@ void deactivate() {
     break;
 #endif
   case COULOMB_DH:
-    dh_params.r_cut = 0.0;
-    dh_params.kappa = 0.0;
+    dh_params = {};
     break;
   case COULOMB_RF:
-    rf_params.kappa = 0.0;
-    rf_params.epsilon1 = 0.0;
-    rf_params.epsilon2 = 0.0;
-    rf_params.r_cut = 0.0;
-    rf_params.B = 0.0;
+    rf_params = {};
     break;
   case COULOMB_MMM1D:
     mmm1d_params.maxPWerror = 1e40;

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -447,7 +447,7 @@ void bcast_coulomb_params() {
 
 void set_prefactor(double prefactor) {
   if (prefactor < 0.0) {
-    throw std::invalid_argument("Coulomb prefactor has to be >= 0");
+    throw std::domain_error("Coulomb prefactor has to be >= 0");
   }
 
   coulomb.prefactor = prefactor;

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
@@ -28,21 +28,21 @@
 #ifdef ELECTROSTATICS
 #include "electrostatics_magnetostatics/common.hpp"
 
+#include <stdexcept>
+
 Debye_hueckel_params dh_params{};
 
-int dh_set_params(double kappa, double r_cut) {
-  if (dh_params.kappa < 0.0)
-    return -1;
+void dh_set_params(double kappa, double r_cut) {
+  if (kappa < 0.0)
+    throw std::domain_error("kappa should be a non-negative number");
 
-  if (dh_params.r_cut < 0.0)
-    return -2;
+  if (r_cut < 0.0)
+    throw std::domain_error("r_cut should be a non-negative number");
 
   dh_params.kappa = kappa;
   dh_params.r_cut = r_cut;
 
   mpi_bcast_coulomb_params();
-
-  return 1;
 }
 
 #endif

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
@@ -35,12 +35,10 @@ Debye_hueckel_params dh_params{};
 void dh_set_params(double kappa, double r_cut) {
   if (kappa < 0.0)
     throw std::domain_error("kappa should be a non-negative number");
-
   if (r_cut < 0.0)
     throw std::domain_error("r_cut should be a non-negative number");
 
-  dh_params.kappa = kappa;
-  dh_params.r_cut = r_cut;
+  dh_params = {r_cut, kappa};
 
   mpi_bcast_coulomb_params();
 }

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
@@ -33,12 +33,12 @@
 #include <cmath>
 
 /** Structure to hold Debye-Hueckel parameters. */
-typedef struct {
+struct Debye_hueckel_params {
   /** Cutoff for Debye-Hueckel interaction. */
   double r_cut;
   /** Debye kappa (inverse Debye length) . */
   double kappa;
-} Debye_hueckel_params;
+};
 
 /** Debye-Hueckel parameters. */
 extern Debye_hueckel_params dh_params;

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
@@ -21,7 +21,7 @@
 #ifndef DEBYE_HUECKEL_H
 #define DEBYE_HUECKEL_H
 /** \file
- *  Routines to calculate the Debye-Hueckel energy and force
+ *  Routines to calculate the Debye-Hückel energy and force
  *  for a particle pair.
  */
 #include "config.hpp"
@@ -32,15 +32,15 @@
 
 #include <cmath>
 
-/** Structure to hold Debye-Hueckel parameters. */
+/** Debye-Hückel parameters. */
 struct Debye_hueckel_params {
-  /** Cutoff for Debye-Hueckel interaction. */
+  /** Interaction cutoff. */
   double r_cut;
-  /** Debye kappa (inverse Debye length) . */
+  /** Ionic strength. */
   double kappa;
 };
 
-/** Debye-Hueckel parameters. */
+/** Global state of the Debye-Hückel method. */
 extern Debye_hueckel_params dh_params;
 
 void dh_set_params(double kappa, double r_cut);

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
@@ -43,7 +43,7 @@ typedef struct {
 /** Debye-Hueckel parameters. */
 extern Debye_hueckel_params dh_params;
 
-int dh_set_params(double kappa, double r_cut);
+void dh_set_params(double kappa, double r_cut);
 
 /** Compute the Debye-Hueckel pair force.
  *  @param[in]  q1q2      Product of the charges on p1 and p2.

--- a/src/core/electrostatics_magnetostatics/reaction_field.cpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.cpp
@@ -29,8 +29,17 @@
 
 Reaction_field_params rf_params{};
 
-int rf_set_params(double kappa, double epsilon1, double epsilon2,
-                  double r_cut) {
+void rf_set_params(double kappa, double epsilon1, double epsilon2,
+                   double r_cut) {
+  if (kappa < 0.0)
+    throw std::domain_error("kappa should be a non-negative number");
+  if (epsilon1 < 0.0)
+    throw std::domain_error("epsilon1 should be a non-negative number");
+  if (epsilon2 < 0.0)
+    throw std::domain_error("epsilon2 should be a non-negative number");
+  if (r_cut < 0.0)
+    throw std::domain_error("r_cut should be a non-negative number");
+
   rf_params.kappa = kappa;
   rf_params.epsilon1 = epsilon1;
   rf_params.epsilon2 = epsilon2;
@@ -39,17 +48,7 @@ int rf_set_params(double kappa, double epsilon1, double epsilon2,
                  epsilon2 * kappa * kappa * r_cut * r_cut) /
                 ((epsilon1 + 2 * epsilon2) * (1 + kappa * r_cut) +
                  epsilon2 * kappa * kappa * r_cut * r_cut);
-  if (rf_params.epsilon1 < 0.0)
-    return -1;
-
-  if (rf_params.epsilon2 < 0.0)
-    return -1;
-
-  if (rf_params.r_cut < 0.0)
-    return -2;
 
   mpi_bcast_coulomb_params();
-
-  return 1;
 }
 #endif

--- a/src/core/electrostatics_magnetostatics/reaction_field.cpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.cpp
@@ -40,14 +40,11 @@ void rf_set_params(double kappa, double epsilon1, double epsilon2,
   if (r_cut < 0.0)
     throw std::domain_error("r_cut should be a non-negative number");
 
-  rf_params.kappa = kappa;
-  rf_params.epsilon1 = epsilon1;
-  rf_params.epsilon2 = epsilon2;
-  rf_params.r_cut = r_cut;
-  rf_params.B = (2 * (epsilon1 - epsilon2) * (1 + kappa * r_cut) -
-                 epsilon2 * kappa * kappa * r_cut * r_cut) /
-                ((epsilon1 + 2 * epsilon2) * (1 + kappa * r_cut) +
-                 epsilon2 * kappa * kappa * r_cut * r_cut);
+  auto const B = (2 * (epsilon1 - epsilon2) * (1 + kappa * r_cut) -
+                  epsilon2 * kappa * kappa * r_cut * r_cut) /
+                 ((epsilon1 + 2 * epsilon2) * (1 + kappa * r_cut) +
+                  epsilon2 * kappa * kappa * r_cut * r_cut);
+  rf_params = {kappa, epsilon1, epsilon2, r_cut, B};
 
   mpi_bcast_coulomb_params();
 }

--- a/src/core/electrostatics_magnetostatics/reaction_field.hpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.hpp
@@ -35,7 +35,7 @@
 #include <utils/math/int_pow.hpp>
 
 /** Structure to hold Reaction Field Parameters. */
-typedef struct {
+struct Reaction_field_params {
   /** ionic strength. */
   double kappa;
   /** epsilon1 (continuum dielectric constant inside). */
@@ -46,7 +46,7 @@ typedef struct {
   double r_cut;
   /** B important prefactor. */
   double B;
-} Reaction_field_params;
+};
 
 /** Structure containing the Reaction Field parameters. */
 extern Reaction_field_params rf_params;

--- a/src/core/electrostatics_magnetostatics/reaction_field.hpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.hpp
@@ -22,7 +22,7 @@
 #define REACTION_FIELD_H
 /** \file
  *  Routines to calculate the Reaction Field energy or/and force
- *  for a particle pair @cite neumann85b.
+ *  for a particle pair @cite neumann85b, @cite tironi95a.
  *
  *  Implementation in \ref reaction_field.cpp
  */
@@ -34,31 +34,33 @@
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
 
-/** Structure to hold Reaction Field Parameters. */
+/** Reaction Field parameters. */
 struct Reaction_field_params {
-  /** ionic strength. */
+  /** Ionic strength. */
   double kappa;
-  /** epsilon1 (continuum dielectric constant inside). */
+  /** Continuum dielectric constant inside the cavity. */
   double epsilon1;
-  /** epsilon2 (continuum dielectric constant outside). */
+  /** Continuum dielectric constant outside the cavity. */
   double epsilon2;
-  /** Cutoff for Reaction Field interaction. */
+  /** Interaction cutoff. */
   double r_cut;
-  /** B important prefactor. */
+  /** Interaction prefactor. Corresponds to the quantity
+   *  @f$ 1 + B_1 @f$ from eq. 22 in @cite tironi95a.
+   */
   double B;
 };
 
-/** Structure containing the Reaction Field parameters. */
+/** Global state of the Reaction Field method. */
 extern Reaction_field_params rf_params;
 
 void rf_set_params(double kappa, double epsilon1, double epsilon2,
                    double r_cut);
 
 /** Compute the Reaction Field pair force.
- *  @param q1q2      Product of the charges on p1 and p2.
- *  @param d         Vector pointing from p1 to p2.
- *  @param dist      Distance between p1 and p2.
- *  @param force     returns the force on particle 1.
+ *  @param[in]  q1q2      Product of the charges on p1 and p2.
+ *  @param[in]  d         Vector pointing from p1 to p2.
+ *  @param[in]  dist      Distance between p1 and p2.
+ *  @param[out] force     Calculated force on p1.
  */
 inline void add_rf_coulomb_pair_force(double const q1q2,
                                       Utils::Vector3d const &d,
@@ -80,6 +82,7 @@ inline double rf_coulomb_pair_energy(double const q1q2, double const dist) {
   if (dist < rf_params.r_cut) {
     auto fac = 1.0 / dist - (rf_params.B * dist * dist) /
                                 (2 * Utils::int_pow<3>(rf_params.r_cut));
+    // remove discontinuity at dist = r_cut
     fac -= (1 - rf_params.B / 2) / rf_params.r_cut;
     fac *= q1q2;
     return fac;

--- a/src/core/electrostatics_magnetostatics/reaction_field.hpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.hpp
@@ -50,7 +50,8 @@ typedef struct {
 /** Structure containing the Reaction Field parameters. */
 extern Reaction_field_params rf_params;
 
-int rf_set_params(double kappa, double epsilon1, double epsilon2, double r_cut);
+void rf_set_params(double kappa, double epsilon1, double epsilon2,
+                   double r_cut);
 
 inline void add_rf_coulomb_pair_force_no_cutoff(double const q1q2,
                                                 Utils::Vector3d const &d,

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -60,7 +60,7 @@ IF ELECTROSTATICS:
 
     cdef extern from "electrostatics_magnetostatics/coulomb.hpp" namespace "Coulomb":
 
-        int set_prefactor(double prefactor) except+
+        int set_prefactor(double prefactor) except +
         void deactivate_method()
 
     IF P3M:
@@ -108,7 +108,7 @@ IF ELECTROSTATICS:
 
         cdef extern Debye_hueckel_params dh_params
 
-        int dh_set_params(double kappa, double r_cut)
+        void dh_set_params(double kappa, double r_cut) except +
 
     cdef extern from "electrostatics_magnetostatics/reaction_field.hpp":
         ctypedef struct Reaction_field_params:

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -119,8 +119,8 @@ IF ELECTROSTATICS:
 
         cdef extern Reaction_field_params rf_params
 
-        int rf_set_params(double kappa, double epsilon1, double epsilon2,
-                          double r_cut)
+        void rf_set_params(double kappa, double epsilon1, double epsilon2,
+                           double r_cut) except +
 
 IF ELECTROSTATICS:
     cdef extern from "electrostatics_magnetostatics/mmm1d.hpp":

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -142,16 +142,7 @@ IF ELECTROSTATICS:
         """
 
         def validate_params(self):
-            if self._params["prefactor"] <= 0:
-                raise ValueError("prefactor should be a positive float")
-            if self._params["kappa"] < 0:
-                raise ValueError("kappa should be a non-negative double")
-            if self._params["epsilon1"] < 0:
-                raise ValueError("epsilon1 should be a non-negative double")
-            if self._params["epsilon2"] < 0:
-                raise ValueError("epsilon2 should be a non-negative double")
-            if self._params["r_cut"] < 0:
-                raise ValueError("r_cut should be a non-negative double")
+            pass
 
         def valid_keys(self):
             return ["prefactor", "kappa", "epsilon1", "epsilon2", "r_cut",

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -89,7 +89,7 @@ IF ELECTROSTATICS:
         kappa : :obj:`float`
             Inverse Debye screening length.
         r_cut : :obj:`float`
-            Cut off radius for this interaction.
+            Cutoff radius for this interaction.
 
         """
 
@@ -124,7 +124,8 @@ IF ELECTROSTATICS:
 
     cdef class ReactionField(ElectrostaticInteraction):
         """
-        Electrostatics solver based on the Reaction-Field framework.
+        Electrostatics solver based on the Reaction Field framework.
+        See :ref:`Reaction Field method` for more details.
 
         Parameters
         ----------
@@ -137,7 +138,7 @@ IF ELECTROSTATICS:
         epsilon2 : :obj:`float`
             exterior dielectric constant
         r_cut : :obj:`float`
-            Cut off radius for this interaction.
+            Cutoff radius for this interaction.
 
         """
 

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -94,12 +94,7 @@ IF ELECTROSTATICS:
         """
 
         def validate_params(self):
-            if self._params["prefactor"] <= 0:
-                raise ValueError("prefactor should be a positive float")
-            if self._params["kappa"] < 0:
-                raise ValueError("kappa should be a non-negative double")
-            if self._params["r_cut"] < 0:
-                raise ValueError("r_cut should be a non-negative double")
+            pass
 
         def valid_keys(self):
             return ["prefactor", "kappa", "r_cut", "check_neutrality"]

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -180,6 +180,19 @@ class ElectrostaticInteractionsTests(ut.TestCase):
         np.testing.assert_allclose(u_dh_core, u_dh, atol=1e-7)
         np.testing.assert_allclose(f_dh_core, -f_dh, atol=1e-7)
 
+    def test_dh_exceptions(self):
+        dh = espressomd.electrostatics.DH(prefactor=-1.0, kappa=1.0, r_cut=1.0)
+        with self.assertRaisesRegex(ValueError, 'Coulomb prefactor has to be >= 0'):
+            self.system.actors.add(dh)
+        self.system.actors.clear()
+        dh = espressomd.electrostatics.DH(prefactor=1.0, kappa=-1.0, r_cut=1.0)
+        with self.assertRaisesRegex(ValueError, 'kappa should be a non-negative number'):
+            self.system.actors.add(dh)
+        self.system.actors.clear()
+        dh = espressomd.electrostatics.DH(prefactor=1.0, kappa=1.0, r_cut=-1.0)
+        with self.assertRaisesRegex(ValueError, 'r_cut should be a non-negative number'):
+            self.system.actors.add(dh)
+
     def test_rf(self):
         """Tests the ReactionField coulomb interaction by comparing the
            potential and force against the analytic values"""

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -235,6 +235,15 @@ class ElectrostaticInteractionsTests(ut.TestCase):
         np.testing.assert_allclose(u_rf_core, u_rf, atol=1e-7)
         np.testing.assert_allclose(f_rf_core, -f_rf, atol=1e-2)
 
+    def test_rf_exceptions(self):
+        params = dict(kappa=1.0, epsilon1=1.0, epsilon2=2.0, r_cut=1.0)
+        for key in params:
+            invalid_params = {**params, 'prefactor': 1.0, key: -1.0}
+            rf = espressomd.electrostatics.ReactionField(**invalid_params)
+            with self.assertRaisesRegex(ValueError, f'{key} should be a non-negative number'):
+                self.system.actors.add(rf)
+            self.system.actors.clear()
+
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
Fixes #4217

Description of changes:
- remove the broken range checks in the python interface of Debye-Hückel
- refactor exception mechanism for Reaction Field and Debye-Hückel
- document Reaction Field method
