### PR TITLE
Unit test ESPResSo simulations

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -43,6 +43,7 @@ set(EspressoCore_SRC
     PartCfg.cpp
     AtomDecomposition.cpp
     reduce_observable_stat.cpp
+    EspressoSystemStandAlone.cpp
     DomainDecomposition.cpp)
 
 if(CUDA)

--- a/src/core/EspressoSystemStandAlone.cpp
+++ b/src/core/EspressoSystemStandAlone.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.hpp"
+
+#include "EspressoSystemStandAlone.hpp"
+#include "communication.hpp"
+#include "global.hpp"
+#include "grid.hpp"
+#include "integrate.hpp"
+#include "virtual_sites.hpp"
+#include "virtual_sites/VirtualSitesOff.hpp"
+
+#include <utils/Vector.hpp>
+
+#include <boost/mpi.hpp>
+
+#include <memory>
+
+EspressoSystemStandAlone::EspressoSystemStandAlone(int argc, char **argv) {
+  auto mpi_env = mpi_init(argc, argv);
+
+  boost::mpi::communicator world;
+  head_node = world.rank() == 0;
+
+  // initialize the MpiCallbacks framework
+  Communication::init(mpi_env);
+
+  // default-construct global state of the system
+#ifdef VIRTUAL_SITES
+  set_virtual_sites(std::make_shared<VirtualSitesOff>());
+#endif
+
+  // initialize the MpiCallbacks loop (blocking on worker nodes)
+  mpi_loop();
+}
+
+void EspressoSystemStandAlone::set_box_l(Utils::Vector3d const &box_l) const {
+  if (!head_node)
+    return;
+  box_geo.set_length(box_l);
+  mpi_bcast_parameter(FIELD_BOXL);
+}
+
+void EspressoSystemStandAlone::set_time_step(double time_step) const {
+  if (!head_node)
+    return;
+  mpi_set_time_step(time_step);
+}
+
+void EspressoSystemStandAlone::set_skin(double new_skin) const {
+  if (!head_node)
+    return;
+  skin = new_skin;
+  mpi_bcast_parameter(FIELD_SKIN);
+}

--- a/src/core/EspressoSystemStandAlone.hpp
+++ b/src/core/EspressoSystemStandAlone.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <utils/Vector.hpp>
+
+/** Manager for a stand-alone ESPResSo system.
+ *  The system is default-initialized, MPI-ready and has no script interface.
+ */
+class EspressoSystemStandAlone {
+public:
+  EspressoSystemStandAlone(int argc, char **argv);
+  void set_box_l(Utils::Vector3d const &box_l) const;
+  void set_time_step(double time_step) const;
+  void set_skin(double new_skin) const;
+
+private:
+  bool head_node;
+};

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -139,13 +139,13 @@ void init(std::shared_ptr<boost::mpi::environment> mpi_env) {
 }
 } // namespace Communication
 
-std::shared_ptr<boost::mpi::environment> mpi_init() {
+std::shared_ptr<boost::mpi::environment> mpi_init(int argc, char **argv) {
 #ifdef OPEN_MPI
   openmpi_fix_vader();
   openmpi_global_namespace();
 #endif
 
-  return std::make_shared<boost::mpi::environment>();
+  return std::make_shared<boost::mpi::environment>(argc, argv);
 }
 
 void mpi_loop() {

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -82,7 +82,8 @@ MpiCallbacks &mpiCallbacks();
  **************************************************/
 
 /** Initialize MPI. */
-std::shared_ptr<boost::mpi::environment> mpi_init();
+std::shared_ptr<boost::mpi::environment> mpi_init(int argc = 0,
+                                                  char **argv = nullptr);
 
 /** @brief Call a slave function.
  *  @tparam Args   Slave function argument types

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -686,22 +686,20 @@ void mpi_place_particle(int node, int p_id, const Utils::Vector3d &pos) {
   on_particle_change();
 }
 
-int place_particle(int p_id, const double *pos) {
-  Utils::Vector3d p{pos[0], pos[1], pos[2]};
-
+int place_particle(int p_id, Utils::Vector3d const &pos) {
   if (particle_exists(p_id)) {
-    mpi_place_particle(get_particle_node(p_id), p_id, p);
+    mpi_place_particle(get_particle_node(p_id), p_id, pos);
 
     return ES_PART_OK;
   }
-  particle_node[p_id] = mpi_place_new_particle(p_id, p);
+  particle_node[p_id] = mpi_place_new_particle(p_id, pos);
 
   return ES_PART_CREATED;
 }
 
-void set_particle_v(int part, double *v) {
+void set_particle_v(int part, Utils::Vector3d const &v) {
   mpi_update_particle<ParticleMomentum, &Particle::m, Utils::Vector3d,
-                      &ParticleMomentum::v>(part, Utils::Vector3d(v, v + 3));
+                      &ParticleMomentum::v>(part, v);
 }
 
 #ifdef ENGINE
@@ -711,9 +709,9 @@ void set_particle_swimming(int part, ParticleParametersSwimming swim) {
 }
 #endif
 
-void set_particle_f(int part, const Utils::Vector3d &F) {
+void set_particle_f(int part, const Utils::Vector3d &f) {
   mpi_update_particle<ParticleForce, &Particle::f, Utils::Vector3d,
-                      &ParticleForce::f>(part, F);
+                      &ParticleForce::f>(part, f);
 }
 
 #if defined(MASS)
@@ -725,9 +723,10 @@ const constexpr double ParticleProperties::mass;
 #endif
 
 #ifdef ROTATIONAL_INERTIA
-void set_particle_rotational_inertia(int part, double *rinertia) {
+void set_particle_rotational_inertia(int part,
+                                     Utils::Vector3d const &rinertia) {
   mpi_update_particle_property<Utils::Vector3d, &ParticleProperties::rinertia>(
-      part, Utils::Vector3d(rinertia, rinertia + 3));
+      part, rinertia);
 }
 #else
 constexpr Utils::Vector3d ParticleProperties::rinertia;
@@ -749,11 +748,10 @@ void set_particle_dipm(int part, double dipm) {
   mpi_update_particle_property<double, &ParticleProperties::dipm>(part, dipm);
 }
 
-void set_particle_dip(int part, double const *const dip) {
+void set_particle_dip(int part, Utils::Vector3d const &dip) {
   Utils::Quaternion<double> quat;
   double dipm;
-  std::tie(quat, dipm) =
-      convert_dip_to_quat(Utils::Vector3d({dip[0], dip[1], dip[2]}));
+  std::tie(quat, dipm) = convert_dip_to_quat(dip);
 
   set_particle_dipm(part, dipm);
   set_particle_quat(part, quat.data());
@@ -807,9 +805,9 @@ void set_particle_mu_E(int part, Utils::Vector3d const &mu_E) {
       part, mu_E);
 }
 
-void get_particle_mu_E(int part, Utils::Vector3d &mu_E) {
+Utils::Vector3d get_particle_mu_E(int part) {
   auto const &p = get_particle_data(part);
-  mu_E = p.p.mu_E;
+  return p.p.mu_E;
 }
 #endif
 
@@ -836,7 +834,7 @@ void set_particle_mol_id(int part, int mid) {
 }
 
 #ifdef ROTATION
-void set_particle_quat(int part, double *quat) {
+void set_particle_quat(int part, double *const quat) {
   mpi_update_particle<ParticlePosition, &Particle::r, Utils::Quaternion<double>,
                       &ParticlePosition::quat>(
       part, Utils::Quaternion<double>{quat[0], quat[1], quat[2], quat[3]});
@@ -876,7 +874,7 @@ void set_particle_gamma(int part, double gamma) {
   mpi_update_particle_property<double, &ParticleProperties::gamma>(part, gamma);
 }
 #else
-void set_particle_gamma(int part, Utils::Vector3d gamma) {
+void set_particle_gamma(int part, Utils::Vector3d const &gamma) {
   mpi_update_particle_property<Utils::Vector3d, &ParticleProperties::gamma>(
       part, gamma);
 }
@@ -889,7 +887,7 @@ void set_particle_gamma_rot(int part, double gamma_rot) {
       part, gamma_rot);
 }
 #else
-void set_particle_gamma_rot(int part, Utils::Vector3d gamma_rot) {
+void set_particle_gamma_rot(int part, Utils::Vector3d const &gamma_rot) {
   mpi_update_particle_property<Utils::Vector3d, &ParticleProperties::gamma_rot>(
       part, gamma_rot);
 }

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -108,13 +108,13 @@ size_t fetch_cache_max_size();
  *  @retval ES_PART_CREATED if created
  *  @retval ES_PART_ERROR if id is illegal
  */
-int place_particle(int part, const double *p);
+int place_particle(int part, Utils::Vector3d const &p);
 
 /** Call only on the master node: set particle velocity.
  *  @param part the particle.
  *  @param v its new velocity.
  */
-void set_particle_v(int part, double *v);
+void set_particle_v(int part, Utils::Vector3d const &v);
 
 #ifdef ENGINE
 /** Call only on the master node: set particle velocity.
@@ -141,7 +141,7 @@ void set_particle_mass(int part, double mass);
  *  @param part the particle.
  *  @param rinertia its new inertia.
  */
-void set_particle_rotational_inertia(int part, double *rinertia);
+void set_particle_rotational_inertia(int part, Utils::Vector3d const &rinertia);
 #endif
 
 /** Call only on the master node: Specifies whether a particle's rotational
@@ -172,7 +172,7 @@ void set_particle_q(int part, double q);
  *  @param mu_E its new mobility.
  */
 void set_particle_mu_E(int part, Utils::Vector3d const &mu_E);
-void get_particle_mu_E(int part, Utils::Vector3d &mu_E);
+Utils::Vector3d get_particle_mu_E(int part);
 #endif
 
 /** Call only on the master node: set particle type.
@@ -225,7 +225,7 @@ void set_particle_torque_lab(int part, const Utils::Vector3d &torque_lab);
  *  @param part the particle.
  *  @param dip its new dipole orientation.
  */
-void set_particle_dip(int part, double const *dip);
+void set_particle_dip(int part, Utils::Vector3d const &dip);
 
 /** Call only on the master node: set particle dipole moment (absolute value).
  *  @param part the particle.
@@ -256,13 +256,13 @@ void set_particle_vs_relative(int part, int vs_relative_to, double vs_distance,
 #ifndef PARTICLE_ANISOTROPY
 void set_particle_gamma(int part, double gamma);
 #else
-void set_particle_gamma(int part, Utils::Vector3d gamma);
+void set_particle_gamma(int part, Utils::Vector3d const &gamma);
 #endif
 #ifdef ROTATION
 #ifndef PARTICLE_ANISOTROPY
 void set_particle_gamma_rot(int part, double gamma);
 #else
-void set_particle_gamma_rot(int part, Utils::Vector3d gamma_rot);
+void set_particle_gamma_rot(int part, Utils::Vector3d const &gamma_rot);
 #endif
 #endif
 #endif // THERMOSTAT_PER_PARTICLE

--- a/src/core/reaction_methods/tests/ParticleFactory.hpp
+++ b/src/core/reaction_methods/tests/ParticleFactory.hpp
@@ -21,6 +21,8 @@
 
 #include "particle_data.hpp"
 
+#include <utils/Vector.hpp>
+
 #include <vector>
 
 /** Fixture to create particles during a test and remove them at the end. */
@@ -32,7 +34,7 @@ struct ParticleFactory {
     }
   }
   void create_particle(int pid, int type) {
-    double pos[3] = {0., 0., 0.};
+    Utils::Vector3d const pos{0., 0., 0.};
     place_particle(pid, pos);
     set_particle_type(pid, type);
     particle_cache.emplace_back(pid);

--- a/src/core/reaction_methods/tests/WangLandauReactionEnsemble_test.cpp
+++ b/src/core/reaction_methods/tests/WangLandauReactionEnsemble_test.cpp
@@ -25,7 +25,7 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
-#include "ParticleFactory.hpp"
+#include "unit_tests/ParticleFactory.hpp"
 
 #include "reaction_methods/WangLandauReactionEnsemble.hpp"
 #include "reaction_methods/utils.hpp"
@@ -73,16 +73,16 @@ BOOST_FIXTURE_TEST_CASE(DegreeOfAssociationCollectiveVariable_test,
   BOOST_CHECK_THROW(doa_cv.determine_current_state(), std::runtime_error);
 
   // add base
-  create_particle(0, type_A);
+  create_particle({}, 0, type_A);
   BOOST_CHECK_CLOSE(doa_cv.determine_current_state(), 1.0, tol);
 
   // add acid
-  create_particle(1, type_AH);
+  create_particle({}, 1, type_AH);
   BOOST_CHECK_CLOSE(doa_cv.determine_current_state(), 0.5, tol);
 
   // add acid
-  create_particle(2, type_AH);
-  create_particle(3, type_AH2);
+  create_particle({}, 2, type_AH);
+  create_particle({}, 3, type_AH2);
   BOOST_CHECK_CLOSE(doa_cv.determine_current_state(), 0.25, tol);
 }
 

--- a/src/core/reaction_methods/tests/particle_tracking_test.cpp
+++ b/src/core/reaction_methods/tests/particle_tracking_test.cpp
@@ -25,7 +25,7 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
-#include "ParticleFactory.hpp"
+#include "unit_tests/ParticleFactory.hpp"
 
 #include "communication.hpp"
 #include "particle_data.hpp"
@@ -54,7 +54,7 @@ BOOST_FIXTURE_TEST_CASE(particle_type_map_test, ParticleFactory) {
   // check particle counting
   init_type_map(type);
   BOOST_CHECK_EQUAL(number_of_particles_with_type(type), 0);
-  create_particle(pid, type);
+  create_particle({}, pid, type);
   BOOST_CHECK_EQUAL(number_of_particles_with_type(type), 1);
 
   // exception for random index that exceeds the number of particles

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -24,7 +24,9 @@ unit_test(NAME RuntimeError_test SRC RuntimeError_test.cpp DEPENDS
           Boost::serialization)
 unit_test(NAME RuntimeErrorCollector_test SRC RuntimeErrorCollector_test.cpp
           DEPENDS EspressoCore Boost::mpi MPI::MPI_CXX)
-
+unit_test(NAME EspressoSystemStandAlone_test SRC
+          EspressoSystemStandAlone_test.cpp DEPENDS EspressoCore Boost::mpi
+          MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME MpiCallbacks_test SRC MpiCallbacks_test.cpp DEPENDS
           EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME ParticleIterator_test SRC ParticleIterator_test.cpp DEPENDS

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -56,6 +56,16 @@ namespace utf = boost::unit_test;
 #include <unordered_map>
 #include <vector>
 
+/* Guard against a bug in Boost versions < 1.68 where fixtures used to skip
+ * test are not propagated correctly to the testsuite, causing skipped tests
+ * to trigger a failure of the complete testsuite without any error message.
+ * More details in ticket https://svn.boost.org/trac10/ticket/12095
+ */
+#include <boost/serialization/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 68
+int main(int argc, char **argv) {}
+#else
+
 namespace espresso {
 // ESPResSo system instance
 std::unique_ptr<EspressoSystemStandAlone> system;
@@ -317,3 +327,4 @@ int main(int argc, char **argv) {
 
   return boost::unit_test::unit_test_main(init_unit_test, argc, argv);
 }
+#endif // Boost version >= 1.68

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2021 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_MODULE EspressoSystemStandAlone test
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+namespace utf = boost::unit_test;
+
+#include "ParticleFactory.hpp"
+
+#include "EspressoSystemStandAlone.hpp"
+#include "Particle.hpp"
+#include "accumulators/TimeSeries.hpp"
+#include "bonded_interactions/bonded_interaction_utils.hpp"
+#include "bonded_interactions/fene.hpp"
+#include "bonded_interactions/harmonic.hpp"
+#include "electrostatics_magnetostatics/coulomb.hpp"
+#include "electrostatics_magnetostatics/p3m.hpp"
+#include "energy.hpp"
+#include "galilei.hpp"
+#include "integrate.hpp"
+#include "nonbonded_interactions/lj.hpp"
+#include "observables/ParticleVelocities.hpp"
+#include "particle_data.hpp"
+
+#include <utils/Vector.hpp>
+#include <utils/index.hpp>
+#include <utils/math/int_pow.hpp>
+#include <utils/math/sqr.hpp>
+
+#include <boost/mpi.hpp>
+#include <boost/range/numeric.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace espresso {
+// ESPResSo system instance
+std::unique_ptr<EspressoSystemStandAlone> system;
+} // namespace espresso
+
+/** Decorator to run a unit test only on the head node. */
+struct if_head_node {
+  boost::test_tools::assertion_result operator()(utf::test_unit_id) {
+    return world.rank() == 0;
+  }
+
+private:
+  boost::mpi::communicator world;
+};
+
+BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory,
+                        *utf::precondition(if_head_node())) {
+  constexpr auto tol = 100. * std::numeric_limits<double>::epsilon();
+
+  auto const box_l = 8.;
+  auto const box_center = box_l / 2.;
+  espresso::system->set_box_l(Utils::Vector3d::broadcast(box_l));
+  auto const &obs_energy = get_obs_energy();
+
+  // particle properties
+  auto const pid1 = 9;
+  auto const pid2 = 2;
+  auto const pid3 = 5;
+  auto const type_a = 1;
+  auto const type_b = 2;
+
+  // we need at least 2 MPI ranks to test the communication logic, therefore
+  // place particles close to the interface between different MPI domains
+  auto const start_positions = std::unordered_map<int, Utils::Vector3d>{
+      {pid1, {box_center - 0.1, box_center - 0.1, 1.0}},
+      {pid2, {box_center + 0.1, box_center - 0.1, 1.0}},
+      {pid3, {box_center + 0.1, box_center + 0.1, 1.0}}};
+  create_particle(start_positions.at(pid1), pid1, type_a);
+  create_particle(start_positions.at(pid2), pid2, type_b);
+  create_particle(start_positions.at(pid3), pid3, type_b);
+
+  {
+    boost::mpi::communicator world;
+    auto const n_nodes = world.size();
+    if (n_nodes % 2 == 0) {
+      BOOST_REQUIRE_EQUAL(get_particle_node(pid1), 0);
+      BOOST_REQUIRE_GE(get_particle_node(pid2), 1);
+      BOOST_REQUIRE_GE(get_particle_node(pid3), 1);
+    }
+  }
+
+  auto const reset_particle_positions = [&start_positions]() {
+    for (auto const &kv : start_positions) {
+      place_particle(kv.first, kv.second);
+    }
+  };
+
+  // check accumulators
+  {
+    auto const pids = std::vector<int>{pid2};
+    auto obs = std::make_shared<Observables::ParticleVelocities>(pids);
+    auto acc = Accumulators::TimeSeries(obs, 1);
+
+    auto const obs_shape = obs->shape();
+    auto const ref_shape = std::vector<std::size_t>{pids.size(), 3u};
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(obs_shape.begin(), obs_shape.end(),
+                                    ref_shape.begin(), ref_shape.end());
+
+    mpi_kill_particle_motion(0);
+    for (int i = 0; i < 5; ++i) {
+      set_particle_v(pid2, {static_cast<double>(i), 0., 0.});
+      auto const &p = get_particle_data(pid2);
+
+      acc.update();
+      auto const time_series = acc.time_series();
+      BOOST_REQUIRE_EQUAL(time_series.size(), i + 1);
+
+      auto const acc_value = time_series.back();
+      auto const obs_value = (*obs)();
+      BOOST_TEST(obs_value == p.m.v, boost::test_tools::per_element());
+      BOOST_TEST(acc_value == p.m.v, boost::test_tools::per_element());
+    }
+  }
+
+  // check kinetic energy
+  {
+    mpi_kill_particle_motion(0);
+    for (int i = 0; i < 5; ++i) {
+      set_particle_v(pid2, {static_cast<double>(i), 0., 0.});
+      auto const &p = get_particle_data(pid2);
+      auto const kinetic_energy = 0.5 * p.p.mass * p.m.v.norm2();
+      update_energy();
+      BOOST_CHECK_CLOSE(obs_energy.kinetic[0], kinetic_energy, tol);
+      BOOST_CHECK_CLOSE(observable_compute_energy(), kinetic_energy, tol);
+    }
+  }
+
+  // check non-bonded energies
+#ifdef LENNARD_JONES
+  {
+    // distance between particles
+    auto const dist = 0.2;
+    // set up LJ potential
+    auto const eps = 1.0;
+    auto const sig = 0.11;
+    auto const shift = 0.0;
+    auto const offset = 0.1;
+    auto const min = 0.0;
+    auto const r_off = dist - offset;
+    auto const cut = r_off + 1e-3; // LJ for only 2 pairs: AA BB
+    lennard_jones_set_params(type_a, type_b, eps, sig, cut, shift, offset, min);
+    lennard_jones_set_params(type_b, type_b, eps, sig, cut, shift, offset, min);
+
+    // matrix indices and reference energy value
+    auto const max_type = type_b + 1;
+    auto const n_pairs = Utils::upper_triangular(type_b, type_b, max_type) + 1;
+    auto const lj_pair_ab = Utils::upper_triangular(type_a, type_b, max_type);
+    auto const lj_pair_bb = Utils::upper_triangular(type_b, type_b, max_type);
+    auto const frac6 = Utils::int_pow<6>(sig / r_off);
+    auto const lj_energy = 4.0 * eps * (Utils::sqr(frac6) - frac6 + shift);
+
+    // measure energies
+    update_energy();
+    for (int i = 0; i < n_pairs; ++i) {
+      auto const ref_inter = (i == lj_pair_ab) ? lj_energy : 0.;
+      auto const ref_intra = (i == lj_pair_bb) ? lj_energy : 0.;
+      BOOST_CHECK_CLOSE(obs_energy.non_bonded_inter[i], ref_inter, 500. * tol);
+      BOOST_CHECK_CLOSE(obs_energy.non_bonded_intra[i], ref_intra, 500. * tol);
+    }
+  }
+#endif // LENNARD_JONES
+
+  // check bonded energies
+  {
+    // distance between particles
+    auto const dist = 0.2;
+    // set up an empty bond
+    auto const none_bond_id = 0;
+    // set up a harmonic bond
+    auto const harm_bond_id = 1;
+    auto const harm_bond = HarmonicBond(200.0, 0.3, 1.0);
+    set_bonded_ia_params(harm_bond_id, harm_bond);
+    add_particle_bond(pid2, std::vector<int>{harm_bond_id, pid1});
+    // set up a FENE bond
+    auto const fene_bond_id = 2;
+    auto const fene_bond = FeneBond(300.0, 1.0, 0.3);
+    set_bonded_ia_params(fene_bond_id, fene_bond);
+    add_particle_bond(pid2, std::vector<int>{fene_bond_id, pid3});
+
+    // measure energies
+    update_energy();
+    auto const &p1 = get_particle_data(pid1);
+    auto const &p2 = get_particle_data(pid2);
+    auto const &p3 = get_particle_data(pid3);
+    auto const none_energy = 0.0;
+    auto const harm_energy = 0.5 * harm_bond.k * Utils::sqr(harm_bond.r - dist);
+    auto const fene_energy =
+        -0.5 * fene_bond.k * Utils::sqr(fene_bond.drmax) *
+        std::log(1.0 - Utils::sqr((dist - fene_bond.r0) / fene_bond.drmax));
+    BOOST_CHECK_CLOSE(obs_energy.bonded[none_bond_id], none_energy, 0.0);
+    BOOST_CHECK_CLOSE(obs_energy.bonded[harm_bond_id], harm_energy, 40. * tol);
+    BOOST_CHECK_CLOSE(obs_energy.bonded[fene_bond_id], fene_energy, 40. * tol);
+  }
+
+  // check electrostatics
+#ifdef P3M
+  {
+    // add charges
+    set_particle_q(pid1, 1.);
+    set_particle_q(pid2, -1.);
+
+    // set up P3M
+    auto const prefactor = 2.0;
+    auto const mesh = std::vector<int>{8, 8, 8};
+    Coulomb::set_prefactor(prefactor);
+    p3m_set_eps(0.0);
+    p3m_set_params(3.5, mesh.data(), 5, 0.654, 1e-3);
+    p3m_set_mesh_offset(0.5, 0.5, 0.5);
+
+    // measure energies
+    auto const step = 0.02;
+    auto const pos1 = get_particle_data(pid1).r.p;
+    Utils::Vector3d pos2{box_center, box_center - 0.1, 1.0};
+    for (int i = 0; i < 10; ++i) {
+      // move particle
+      pos2[0] += step;
+      place_particle(pid2, pos2);
+      auto const r = (pos2 - pos1).norm();
+      // check P3M energy
+      update_energy();
+      // at very short distances, the real-space contribution to
+      // the energy is much larger than the k-space contribution
+      auto const energy_ref = -prefactor / r;
+      auto const energy_p3m = obs_energy.coulomb[0] + obs_energy.coulomb[1];
+      BOOST_CHECK_CLOSE(energy_p3m, energy_ref, 0.01);
+    }
+  }
+#endif // P3M
+
+  // check integration
+  {
+    // set up velocity-Verlet integrator
+    auto const time_step = 0.001;
+    auto const skin = 0.4;
+    espresso::system->set_time_step(time_step);
+    espresso::system->set_skin(skin);
+    integrate_set_nvt();
+
+    // reset system
+    mpi_kill_particle_motion(0);
+    reset_particle_positions();
+
+    // recalculate forces without propagating the system
+    mpi_integrate(0, 0);
+
+    // particles are arranged in a right triangle
+    auto const &p1 = get_particle_data(pid1);
+    auto const &p2 = get_particle_data(pid2);
+    auto const &p3 = get_particle_data(pid3);
+    // forces are symmetric
+    BOOST_CHECK_CLOSE(p1.f.f[0], -p2.f.f[0], tol);
+    BOOST_CHECK_CLOSE(p3.f.f[1], -p2.f.f[1], tol);
+    // periodic image contributions to the electrostatic force are negligible
+    BOOST_CHECK_LE(std::abs(p1.f.f[1]), tol);
+    BOOST_CHECK_LE(std::abs(p1.f.f[2]), tol);
+    BOOST_CHECK_LE(std::abs(p2.f.f[2]), tol);
+    // zero long-range contribution for uncharged particles
+    BOOST_CHECK_EQUAL(p3.f.f[0], 0.);
+    BOOST_CHECK_EQUAL(p3.f.f[2], 0.);
+    // velocities are not propagated
+    BOOST_CHECK_EQUAL(p1.m.v.norm(), 0.);
+    BOOST_CHECK_EQUAL(p2.m.v.norm(), 0.);
+    BOOST_CHECK_EQUAL(p3.m.v.norm(), 0.);
+
+    // check integrated trajectory; the time step is chosen
+    // small enough so that particles don't travel too far
+    auto const pos_com = Utils::Vector3d{box_center, box_center, 1.0};
+    auto const pids = std::vector<int>{pid1, pid2, pid3};
+    for (int i = 0; i < 10; ++i) {
+      std::unordered_map<int, Utils::Vector3d> expected;
+      for (auto pid : pids) {
+        auto p = get_particle_data(pid);
+        p.m.v += 0.5 * time_step * p.f.f / p.p.mass;
+        p.r.p += time_step * p.m.v;
+        expected[pid] = p.r.p;
+      }
+      mpi_integrate(1, 0);
+      for (auto pid : pids) {
+        auto const &p = get_particle_data(pid);
+        BOOST_CHECK_LE((p.r.p - expected[pid]).norm(), tol);
+        assert((p.r.p - pos_com).norm() < 0.5);
+      }
+    }
+  }
+}
+
+int main(int argc, char **argv) {
+  espresso::system = std::make_unique<EspressoSystemStandAlone>(argc, argv);
+
+  return boost::unit_test::unit_test_main(init_unit_test, argc, argv);
+}

--- a/src/core/unit_tests/ParticleFactory.hpp
+++ b/src/core/unit_tests/ParticleFactory.hpp
@@ -28,13 +28,21 @@
 /** Fixture to create particles during a test and remove them at the end. */
 struct ParticleFactory {
   ParticleFactory() = default;
+
   ~ParticleFactory() {
     for (auto pid : particle_cache) {
       remove_particle(pid);
     }
   }
-  void create_particle(int pid, int type) {
-    Utils::Vector3d const pos{0., 0., 0.};
+
+  void create_particle(Utils::Vector3d const &pos, int pid = -1,
+                       int type = -1) {
+    if (pid < 0) {
+      pid = get_maximal_particle_id() + 1;
+    }
+    if (type < 0) {
+      type = 0;
+    }
     place_particle(pid, pos);
     set_particle_type(pid, type);
     particle_cache.emplace_back(pid);

--- a/src/python/espressomd/interactions.pxd
+++ b/src/python/espressomd/interactions.pxd
@@ -195,9 +195,6 @@ cdef extern from "nonbonded_interactions/nonbonded_interaction_data.hpp":
     cdef void ia_params_set_state(string)
     cdef void reset_ia_params()
 
-cdef extern from "bonded_interactions/bonded_interaction_data.hpp":
-    cdef void make_bond_type_exist(int type)
-
 cdef extern from "nonbonded_interactions/lj.hpp":
     cdef int lennard_jones_set_params(int part_type_a, int part_type_b,
                                       double eps, double sig, double cut,

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -3301,7 +3301,6 @@ class BondedInteractions:
         value._bond_id = key
 
         # Set the parameters of the BondedInteraction instance in the Es core
-        make_bond_type_exist(key)
         value._set_params_in_es_core()
 
     def __len__(self):

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -81,11 +81,11 @@ cdef extern from "particle_data.hpp":
     # Setter/getter/modifier functions functions
     void prefetch_particle_data(vector[int] ids)
 
-    int place_particle(int part, double p[3])
+    int place_particle(int part, const Vector3d & p)
 
-    void set_particle_v(int part, double v[3])
+    void set_particle_v(int part, const Vector3d & v)
 
-    void set_particle_f(int part, const Vector3d & F)
+    void set_particle_f(int part, const Vector3d & f)
 
     IF ROTATION:
         void set_particle_rotation(int part, int rot)
@@ -94,7 +94,7 @@ cdef extern from "particle_data.hpp":
         void set_particle_mass(int part, double mass)
 
     IF ROTATIONAL_INERTIA:
-        void set_particle_rotational_inertia(int part, double rinertia[3])
+        void set_particle_rotational_inertia(int part, const Vector3d & rinertia)
         void pointer_to_rotational_inertia(const particle * p, const double * & res)
 
     IF ROTATION:
@@ -104,7 +104,7 @@ cdef extern from "particle_data.hpp":
 
     IF LB_ELECTROHYDRODYNAMICS:
         void set_particle_mu_E(int part, const Vector3d & mu_E)
-        void get_particle_mu_E(int part, Vector3d & mu_E)
+        Vector3d get_particle_mu_E(int part)
 
     void set_particle_type(int part, int type)
 
@@ -113,16 +113,15 @@ cdef extern from "particle_data.hpp":
     IF ROTATION:
         void set_particle_quat(int part, double quat[4])
         void pointer_to_quat(const particle * p, const double * & res)
-        void set_particle_director(int part, Vector3d director)
-        void set_particle_omega_lab(int part, Vector3d omega)
-        void set_particle_omega_body(int part, Vector3d omega)
-        void set_particle_torque_lab(int part, Vector3d torque)
+        void set_particle_director(int part, const Vector3d & director)
+        void set_particle_omega_lab(int part, const Vector3d & omega)
+        void set_particle_omega_body(int part, const Vector3d & omega)
+        void set_particle_torque_lab(int part, const Vector3d & torque)
         void pointer_to_omega_body(const particle * p, const double * & res)
         Vector3d get_torque_body(const particle p)
 
     IF DIPOLES:
-        void set_particle_dip(int part, double dip[3])
-
+        void set_particle_dip(int part, const Vector3d & dip)
         void set_particle_dipm(int part, double dipm)
         void pointer_to_dipm(const particle * P, const double * & res)
 
@@ -132,7 +131,7 @@ cdef extern from "particle_data.hpp":
 
     IF THERMOSTAT_PER_PARTICLE:
         IF PARTICLE_ANISOTROPY:
-            void set_particle_gamma(int part, Vector3d gamma)
+            void set_particle_gamma(int part, const Vector3d & gamma)
         ELSE:
             void set_particle_gamma(int part, double gamma)
 
@@ -140,7 +139,7 @@ cdef extern from "particle_data.hpp":
 
         IF ROTATION:
             IF PARTICLE_ANISOTROPY:
-                void set_particle_gamma_rot(int part, Vector3d gamma_rot)
+                void set_particle_gamma_rot(int part, const Vector3d & gamma_rot)
             ELSE:
                 void set_particle_gamma_rot(int part, double gamma)
 
@@ -185,9 +184,9 @@ cdef extern from "particle_data.hpp":
 
     bool particle_exists(int part)
 
-    int get_particle_node(int id) except +
+    int get_particle_node(int pid) except +
 
-    const particle & get_particle_data(int id) except +
+    const particle & get_particle_data(int pid) except +
 
     vector[int] get_particle_ids() except +
 
@@ -201,7 +200,7 @@ cdef extern from "virtual_sites.hpp":
 cdef extern from "rotation.hpp":
     Vector3d convert_vector_body_to_space(const particle & p, const Vector3d & v)
     Vector3d convert_vector_space_to_body(const particle & p, const Vector3d & v)
-    void rotate_particle(int id, Vector3d axis, double angle)
+    void rotate_particle(int pid, const Vector3d & axis, double angle)
 
 cdef class ParticleHandle:
     cdef public int _id

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -169,14 +169,14 @@ cdef class ParticleHandle:
         """
 
         def __set__(self, _pos):
-            cdef double mypos[3]
+            cdef Vector3d pos
             if np.isnan(_pos).any() or np.isinf(_pos).any():
                 raise ValueError("invalid particle position")
             check_type_or_throw_except(
                 _pos, 3, float, "Position must be 3 floats")
             for i in range(3):
-                mypos[i] = _pos[i]
-            if place_particle(self._id, mypos) == -1:
+                pos[i] = _pos[i]
+            if place_particle(self._id, pos) == -1:
                 raise Exception("particle could not be set")
 
         def __get__(self):
@@ -253,12 +253,12 @@ cdef class ParticleHandle:
         """
 
         def __set__(self, _v):
-            cdef double myv[3]
+            cdef Vector3d v
             check_type_or_throw_except(
                 _v, 3, float, "Velocity has to be floats")
             for i in range(3):
-                myv[i] = _v[i]
-            set_particle_v(self._id, myv)
+                v[i] = _v[i]
+            set_particle_v(self._id, v)
 
         def __get__(self):
             self.update_particle_data()
@@ -473,7 +473,6 @@ cdef class ParticleHandle:
                 self.update_particle_data()
                 return make_array_locked(self.particle_data.r.calc_director())
 
-        # ROTATIONAL_INERTIA
         property omega_body:
             """
             The particle angular velocity in body frame.
@@ -556,7 +555,7 @@ cdef class ParticleHandle:
             """
 
             def __set__(self, _rinertia):
-                cdef double rinertia[3]
+                cdef Vector3d rinertia
                 check_type_or_throw_except(
                     _rinertia, 3, float, "Rotation_inertia has to be 3 floats.")
                 for i in range(3):
@@ -621,7 +620,7 @@ cdef class ParticleHandle:
 
             def __get__(self):
                 cdef Vector3d _mu_E
-                get_particle_mu_E(self._id, _mu_E)
+                _mu_E = get_particle_mu_E(self._id)
                 return make_array_locked(_mu_E)
 
     property virtual:
@@ -762,13 +761,13 @@ cdef class ParticleHandle:
 
             """
 
-            def __set__(self, _q):
-                cdef double myq[3]
+            def __set__(self, _dip):
+                cdef Vector3d dip
                 check_type_or_throw_except(
-                    _q, 3, float, "Dipole moment vector has to be 3 floats.")
+                    _dip, 3, float, "Dipole moment vector has to be 3 floats.")
                 for i in range(3):
-                    myq[i] = _q[i]
-                set_particle_dip(self._id, myq)
+                    dip[i] = _dip[i]
+                set_particle_dip(self._id, dip)
 
             def __get__(self):
                 self.update_particle_data()
@@ -1867,7 +1866,7 @@ Set quat and scalar dipole moment (dipm) instead.")
         # The ParticleList[]-getter ist not valid yet, as the particle
         # doesn't yet exist. Hence, the setting of position has to be
         # done here. the code is from the pos:property of ParticleHandle
-        cdef double mypos[3]
+        cdef Vector3d mypos
         check_type_or_throw_except(
             P["pos"], 3, float, "Position must be 3 floats.")
         for i in range(3):

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1271,16 +1271,13 @@ cdef class ParticleHandle:
             raise Exception("Could not remove particle.")
         del self
 
-    # Bond related methods
-    # Does not work properly with 3 or more partner bonds!
-
     def add_verified_bond(self, bond):
         """
         Add a bond, the validity of which has already been verified.
 
         See Also
         --------
-        add_bond : Delete an unverified bond held by the ``Particle``.
+        add_bond : Add an unverified bond to the ``Particle``.
         bonds : ``Particle`` property containing a list of all current bonds held by ``Particle``.
 
         """


### PR DESCRIPTION
Description of changes:
- create an ESPResSo system manager to set up the MPI callbacks loop
- use `Utils::Vector3d` instead of raw pointers in particle callbacks
- unit test a typical MD simulation (LJ, FENE, P3M) with MPI
