### PR TITLE
Cleanup non-bonded interaction kernels

### DIFF
--- a/src/core/nonbonded_interactions/bmhtf-nacl.hpp
+++ b/src/core/nonbonded_interactions/bmhtf-nacl.hpp
@@ -54,12 +54,6 @@ inline double BMHTF_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate BMHTF force */
-inline Utils::Vector3d BMHTF_pair_force(IA_parameters const &ia_params,
-                                        Utils::Vector3d const &d, double dist) {
-  return d * BMHTF_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate BMHTF potential energy */
 inline double BMHTF_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < ia_params.bmhtf.cut) {

--- a/src/core/nonbonded_interactions/buckingham.cpp
+++ b/src/core/nonbonded_interactions/buckingham.cpp
@@ -46,17 +46,12 @@ int buckingham_set_params(int part_type_a, int part_type_b, double A, double B,
   data->buckingham.discont = discont;
   data->buckingham.shift = shift;
 
-  /* Replace the Buckingham potential for interatomic dist. less
+  /* Replace the Buckingham potential for interatomic distance less
      than or equal to discontinuity by a straight line (F1+F2*r) */
-  double F1;
-  double F2;
 
-  F1 = buck_energy_r(A, B, C, D, shift, discont) +
-       discont * buck_force_r(A, B, C, D, discont);
-  F2 = -buck_force_r(A, B, C, D, discont);
-
-  data->buckingham.F1 = F1;
-  data->buckingham.F2 = F2;
+  auto const F = buck_force_r(A, B, C, D, discont);
+  data->buckingham.F1 = buck_energy_r(A, B, C, D, shift, discont) + discont * F;
+  data->buckingham.F2 = -F;
 
   /* broadcast interaction parameters */
   mpi_bcast_ia_params(part_type_a, part_type_b);

--- a/src/core/nonbonded_interactions/buckingham.hpp
+++ b/src/core/nonbonded_interactions/buckingham.hpp
@@ -45,6 +45,7 @@ int buckingham_set_params(int part_type_a, int part_type_b, double A, double B,
 inline double buck_force_r(double A, double B, double C, double D, double r) {
   return (A * B * exp(-B * r) - 6.0 * C / pow(r, 7) - 4.0 * D / pow(r, 5));
 }
+
 /**Potential Energy due to a Buckingham potential between two particles at
  * interatomic separation r greater than or equal to discont*/
 inline double buck_energy_r(double A, double B, double C, double D,

--- a/src/core/nonbonded_interactions/buckingham.hpp
+++ b/src/core/nonbonded_interactions/buckingham.hpp
@@ -73,12 +73,6 @@ inline double buck_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate Buckingham force */
-inline Utils::Vector3d buck_pair_force(IA_parameters const &ia_params,
-                                       Utils::Vector3d const &d, double dist) {
-  return d * buck_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Buckingham energy */
 inline double buck_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < ia_params.buckingham.cut) {

--- a/src/core/nonbonded_interactions/gaussian.hpp
+++ b/src/core/nonbonded_interactions/gaussian.hpp
@@ -51,13 +51,6 @@ inline double gaussian_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate Gaussian force */
-inline Utils::Vector3d gaussian_pair_force(IA_parameters const &ia_params,
-                                           Utils::Vector3d const &d,
-                                           double dist) {
-  return d * gaussian_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Gaussian energy */
 inline double gaussian_pair_energy(IA_parameters const &ia_params,
                                    double dist) {

--- a/src/core/nonbonded_interactions/hat.hpp
+++ b/src/core/nonbonded_interactions/hat.hpp
@@ -46,12 +46,6 @@ inline double hat_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate hat force */
-inline Utils::Vector3d hat_pair_force(IA_parameters const &ia_params,
-                                      Utils::Vector3d const &d, double dist) {
-  return d * hat_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate hat energy */
 inline double hat_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < ia_params.hat.r) {

--- a/src/core/nonbonded_interactions/hat.hpp
+++ b/src/core/nonbonded_interactions/hat.hpp
@@ -37,25 +37,11 @@
 
 int hat_set_params(int part_type_a, int part_type_b, double Fmax, double r);
 
-/** Resultant force due to a hat potential between two
- *  particles at interatomic separation dist.
- */
-inline double hat_force_r(double Fmax, double r, double dist) {
-  return dist < r ? Fmax * (1 - dist / r) : 0.0;
-}
-
-/** Potential energy due to a hat potential between two
- *  particles at interatomic separation dist.
- */
-inline double hat_energy_r(double Fmax, double r, double dist) {
-  return dist < r ? Fmax * (dist - r) * ((dist + r) / (2.0 * r) - 1.0) : 0.0;
-}
-
 /** Calculate hat force factor */
 inline double hat_pair_force_factor(IA_parameters const &ia_params,
                                     double dist) {
   if (dist > 0. && dist < ia_params.hat.r) {
-    return hat_force_r(ia_params.hat.Fmax, ia_params.hat.r, dist) / dist;
+    return ia_params.hat.Fmax * (1.0 - dist / ia_params.hat.r) / dist;
   }
   return 0.0;
 }
@@ -69,7 +55,8 @@ inline Utils::Vector3d hat_pair_force(IA_parameters const &ia_params,
 /** Calculate hat energy */
 inline double hat_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < ia_params.hat.r) {
-    return hat_energy_r(ia_params.hat.Fmax, ia_params.hat.r, dist);
+    auto const r = ia_params.hat.r;
+    return ia_params.hat.Fmax * (dist - r) * ((dist + r) / (2.0 * r) - 1.0);
   }
   return 0.0;
 }

--- a/src/core/nonbonded_interactions/hertzian.hpp
+++ b/src/core/nonbonded_interactions/hertzian.hpp
@@ -50,13 +50,6 @@ inline double hertzian_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate Hertzian force */
-inline Utils::Vector3d hertzian_pair_force(IA_parameters const &ia_params,
-                                           Utils::Vector3d const &d,
-                                           double dist) {
-  return d * hertzian_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Hertzian energy */
 inline double hertzian_pair_energy(IA_parameters const &ia_params,
                                    double dist) {

--- a/src/core/nonbonded_interactions/lj.hpp
+++ b/src/core/nonbonded_interactions/lj.hpp
@@ -53,12 +53,6 @@ inline double lj_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate Lennard-Jones force */
-inline Utils::Vector3d lj_pair_force(IA_parameters const &ia_params,
-                                     Utils::Vector3d const &d, double dist) {
-  return d * lj_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Lennard-Jones energy */
 inline double lj_pair_energy(IA_parameters const &ia_params, double dist) {
   if ((dist < ia_params.lj.cut + ia_params.lj.offset) &&

--- a/src/core/nonbonded_interactions/ljcos.cpp
+++ b/src/core/nonbonded_interactions/ljcos.cpp
@@ -44,9 +44,8 @@ int ljcos_set_params(int part_type_a, int part_type_b, double eps, double sig,
   data->ljcos.offset = offset;
 
   /* Calculate dependent parameters */
-  auto const driwu2 = 1.25992104989487316476721060728;
-  auto const facsq = driwu2 * Utils::sqr(sig);
-  data->ljcos.rmin = sqrt(driwu2) * sig;
+  auto const facsq = Utils::cbrt_2() * Utils::sqr(sig);
+  data->ljcos.rmin = sqrt(Utils::cbrt_2()) * sig;
   data->ljcos.alfa = Utils::pi() / (Utils::sqr(data->ljcos.cut) - facsq);
   data->ljcos.beta =
       Utils::pi() * (1. - (1. / (Utils::sqr(data->ljcos.cut) / facsq - 1.)));

--- a/src/core/nonbonded_interactions/ljcos.hpp
+++ b/src/core/nonbonded_interactions/ljcos.hpp
@@ -63,12 +63,6 @@ inline double ljcos_pair_force_factor(IA_parameters const &ia_params,
   return fac;
 }
 
-/** Calculate Lennard-Jones cosine force */
-inline Utils::Vector3d ljcos_pair_force(IA_parameters const &ia_params,
-                                        Utils::Vector3d const &d, double dist) {
-  return d * ljcos_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Lennard-Jones cosine energy */
 inline double ljcos_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < (ia_params.ljcos.cut + ia_params.ljcos.offset)) {

--- a/src/core/nonbonded_interactions/ljcos2.hpp
+++ b/src/core/nonbonded_interactions/ljcos2.hpp
@@ -67,13 +67,6 @@ inline double ljcos2_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate Lennard-Jones cosine squared force */
-inline Utils::Vector3d ljcos2_pair_force(IA_parameters const &ia_params,
-                                         Utils::Vector3d const &d,
-                                         double dist) {
-  return d * ljcos2_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Lennard-Jones cosine squared energy */
 inline double ljcos2_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < (ia_params.ljcos2.cut + ia_params.ljcos2.offset)) {

--- a/src/core/nonbonded_interactions/ljgen.hpp
+++ b/src/core/nonbonded_interactions/ljgen.hpp
@@ -86,12 +86,6 @@ inline double ljgen_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate Lennard-Jones force */
-inline Utils::Vector3d ljgen_pair_force(IA_parameters const &ia_params,
-                                        Utils::Vector3d const &d, double dist) {
-  return d * ljgen_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Lennard-Jones energy */
 inline double ljgen_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < (ia_params.ljgen.cut + ia_params.ljgen.offset)) {

--- a/src/core/nonbonded_interactions/morse.hpp
+++ b/src/core/nonbonded_interactions/morse.hpp
@@ -53,12 +53,6 @@ inline double morse_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate Morse force */
-inline Utils::Vector3d morse_pair_force(IA_parameters const &ia_params,
-                                        Utils::Vector3d const &d, double dist) {
-  return d * morse_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate Morse energy */
 inline double morse_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < ia_params.morse.cut) {

--- a/src/core/nonbonded_interactions/nonbonded_tab.hpp
+++ b/src/core/nonbonded_interactions/nonbonded_tab.hpp
@@ -66,13 +66,6 @@ inline double tabulated_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate a non-bonded pair force by linear interpolation from a table. */
-inline Utils::Vector3d tabulated_pair_force(IA_parameters const &ia_params,
-                                            Utils::Vector3d const &d,
-                                            double dist) {
-  return d * tabulated_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate a non-bonded pair energy by linear interpolation from a table. */
 inline double tabulated_pair_energy(IA_parameters const &ia_params,
                                     double dist) {

--- a/src/core/nonbonded_interactions/smooth_step.hpp
+++ b/src/core/nonbonded_interactions/smooth_step.hpp
@@ -58,12 +58,6 @@ inline double SmSt_pair_force_factor(IA_parameters const &ia_params,
          Utils::sqr(dist);
 }
 
-/** Calculate smooth step force */
-inline Utils::Vector3d SmSt_pair_force(IA_parameters const &ia_params,
-                                       Utils::Vector3d const &d, double dist) {
-  return d * SmSt_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate smooth step energy */
 inline double SmSt_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist >= ia_params.smooth_step.cut) {

--- a/src/core/nonbonded_interactions/soft_sphere.hpp
+++ b/src/core/nonbonded_interactions/soft_sphere.hpp
@@ -40,20 +40,6 @@
 int soft_sphere_set_params(int part_type_a, int part_type_b, double a, double n,
                            double cut, double offset);
 
-/** Resultant force due to a soft-sphere potential between two
- *  particles at interatomic separation r
- */
-inline double soft_force_r(double a, double n, double r) {
-  return (a * n / pow(r, n + 1));
-}
-
-/** Potential energy due to a soft-sphere potential between two
- *  particles at interatomic separation r
- */
-inline double soft_energy_r(double a, double n, double r) {
-  return (a / pow(r, n));
-}
-
 /** Calculate soft-sphere force factor */
 inline double soft_pair_force_factor(IA_parameters const &ia_params,
                                      double dist) {
@@ -61,9 +47,8 @@ inline double soft_pair_force_factor(IA_parameters const &ia_params,
     /* normal case: resulting force/energy smaller than zero. */
     auto const r_off = dist - ia_params.soft_sphere.offset;
     if (r_off > 0.0) {
-      return soft_force_r(ia_params.soft_sphere.a, ia_params.soft_sphere.n,
-                          r_off) /
-             dist;
+      auto const n = ia_params.soft_sphere.n;
+      return ia_params.soft_sphere.a * n / std::pow(r_off, n + 1) / dist;
     }
   }
   return 0.0;
@@ -80,8 +65,7 @@ inline double soft_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < (ia_params.soft_sphere.cut + ia_params.soft_sphere.offset)) {
     auto const r_off = dist - ia_params.soft_sphere.offset;
     /* normal case: resulting force/energy smaller than zero. */
-    return soft_energy_r(ia_params.soft_sphere.a, ia_params.soft_sphere.n,
-                         r_off);
+    return ia_params.soft_sphere.a / std::pow(r_off, ia_params.soft_sphere.n);
   }
   return 0.0;
 }

--- a/src/core/nonbonded_interactions/soft_sphere.hpp
+++ b/src/core/nonbonded_interactions/soft_sphere.hpp
@@ -54,12 +54,6 @@ inline double soft_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate soft-sphere force */
-inline Utils::Vector3d soft_pair_force(IA_parameters const &ia_params,
-                                       Utils::Vector3d const &d, double dist) {
-  return d * soft_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate soft-sphere energy */
 inline double soft_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < (ia_params.soft_sphere.cut + ia_params.soft_sphere.offset)) {

--- a/src/core/nonbonded_interactions/wca.hpp
+++ b/src/core/nonbonded_interactions/wca.hpp
@@ -47,12 +47,6 @@ inline double wca_pair_force_factor(IA_parameters const &ia_params,
   return 0.0;
 }
 
-/** Calculate WCA force */
-inline Utils::Vector3d wca_pair_force(IA_parameters const &ia_params,
-                                      Utils::Vector3d const &d, double dist) {
-  return d * wca_pair_force_factor(ia_params, dist);
-}
-
 /** Calculate WCA energy */
 inline double wca_pair_energy(IA_parameters const &ia_params, double dist) {
   if (dist < ia_params.wca.cut) {

--- a/src/utils/include/utils/constants.hpp
+++ b/src/utils/include/utils/constants.hpp
@@ -65,6 +65,13 @@ template <class T = double> DEVICE_QUALIFIER constexpr T sqrt_2() {
   return T(1.4142135623730950488016887242096981L);
 }
 
+/**
+ * @brief Cube root of 2.
+ */
+template <class T = double> DEVICE_QUALIFIER constexpr T cbrt_2() {
+  return T(1.25992104989487316476721060727822835057025L);
+}
+
 /**@}*/
 
 /// error code if no error occurred

--- a/testsuite/python/interactions_non-bonded.py
+++ b/testsuite/python/interactions_non-bonded.py
@@ -435,6 +435,14 @@ class InteractionsNonBondedTest(ut.TestCase):
             # and has correct value.
             self.assertItemsFractionAlmostEqual(f1_sim, f1_ref)
 
+        # forces and energies are zero beyond the interaction cutoff
+        p1.pos = p0.pos + self.system.box_l / 2
+        self.system.integrator.run(recalc_forces=True, steps=0)
+        E_sim = self.system.analysis.energy()["non_bonded"]
+        np.testing.assert_array_equal(E_sim, 0.)
+        np.testing.assert_array_equal(np.copy(p0.f), 0.)
+        np.testing.assert_array_equal(np.copy(p1.f), 0.)
+
 
 if __name__ == '__main__':
     ut.main()

--- a/testsuite/python/interactions_non-bonded.py
+++ b/testsuite/python/interactions_non-bonded.py
@@ -24,21 +24,17 @@ import tests_common
 
 
 class InteractionsNonBondedTest(ut.TestCase):
-    system = espressomd.System(box_l=[1.0, 1.0, 1.0])
-    box_l = 10.
+    system = espressomd.System(box_l=3 * [10.])
+    system.cell_system.skin = 0.
+    system.time_step = .1
 
-    start_pos = np.random.rand(3) * box_l
+    start_pos = np.random.rand(3) * system.box_l
     axis = np.random.rand(3)
     axis /= np.linalg.norm(axis)
     step = axis * 0.01
     step_width = np.linalg.norm(step)
 
     def setUp(self):
-
-        self.system.box_l = [self.box_l] * 3
-        self.system.cell_system.skin = 0.
-        self.system.time_step = .1
-
         self.system.part.add(pos=self.start_pos, type=0)
         self.system.part.add(pos=self.start_pos, type=0)
 
@@ -410,7 +406,7 @@ class InteractionsNonBondedTest(ut.TestCase):
         getattr(self.system.non_bonded_inter[0, 0], name).set_params(
             **parameters)
         p0, p1 = self.system.part[:]
-        p1.pos = p1.pos + self.step * n_initial_steps
+        p1.pos = p0.pos + self.step * n_initial_steps
 
         force_parameters = parameters.copy()
         if "shift" in force_parameters and force_kernel_remove_shift:


### PR DESCRIPTION
Description of changes:
- merge kernel helper functions into their respective kernels if there are no other consumers in the core
- remove unused (and untested) `Utils::Vector3d` wrappers around force-factor-based kernels
- reduce code complexity and replace magic values by mathematical constants