### PR TITLE
Script interface maintenance

### DIFF
--- a/src/script_interface/cluster_analysis/Cluster.hpp
+++ b/src/script_interface/cluster_analysis/Cluster.hpp
@@ -61,7 +61,7 @@ public:
     if (method == "center_of_mass") {
       return m_cluster->center_of_mass();
     }
-    return false;
+    return {};
   }
   void set_cluster(std::shared_ptr<::ClusterAnalysis::Cluster> &c) {
     m_cluster = c;

--- a/src/script_interface/cluster_analysis/ClusterStructure.hpp
+++ b/src/script_interface/cluster_analysis/ClusterStructure.hpp
@@ -78,17 +78,14 @@ public:
     }
     if (method == "clear") {
       m_cluster_structure.clear();
-      return true;
     }
     if (method == "run_for_all_pairs") {
       m_cluster_structure.run_for_all_pairs();
-      return true;
     }
     if (method == "run_for_bonded_particles") {
       m_cluster_structure.run_for_bonded_particles();
-      return true;
     }
-    return true;
+    return {};
   }
 
 private:

--- a/src/script_interface/tests/get_value_test.cpp
+++ b/src/script_interface/tests/get_value_test.cpp
@@ -23,6 +23,10 @@
 
 #include "script_interface/get_value.hpp"
 
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
 BOOST_AUTO_TEST_CASE(default_case) {
   using ScriptInterface::get_value;
   using ScriptInterface::Variant;
@@ -95,4 +99,17 @@ BOOST_AUTO_TEST_CASE(get_value_from_map) {
   BOOST_CHECK(3.1 == get_value<double>(map, "e"));
   BOOST_CHECK(13 == get_value_or(map, "a", -1));
   BOOST_CHECK(-1 == get_value_or(map, "nope", -1));
+}
+
+BOOST_AUTO_TEST_CASE(get_map_value) {
+  using ScriptInterface::get_map;
+  using ScriptInterface::Variant;
+
+  std::unordered_map<int, Variant> const map_variant{{1, 1.5}, {2, 2.5}};
+  std::unordered_map<int, double> const map = get_map<int, double>(map_variant);
+  BOOST_CHECK_EQUAL(map.at(1), 1.5);
+  BOOST_CHECK_EQUAL(map.at(2), 2.5);
+
+  std::unordered_map<int, Variant> const mixed{{1, 1}, {2, std::string("2")}};
+  BOOST_CHECK_THROW((get_map<int, double>(mixed)), std::exception);
 }

--- a/testsuite/python/cluster_analysis.py
+++ b/testsuite/python/cluster_analysis.py
@@ -145,6 +145,9 @@ class ClusterAnalysis(ut.TestCase):
             rg = np.sqrt(rg)
             self.assertAlmostEqual(c.radius_of_gyration(), rg, delta=1E-6)
 
+            # Unknown method should return None
+            self.assertIsNone(c.call_method("unknown"))
+
             # Fractal dimension calc require gsl
             if not espressomd.has_features("GSL"):
                 print("Skipping fractal dimension tests due to missing GSL dependency")
@@ -184,6 +187,9 @@ class ClusterAnalysis(ut.TestCase):
         self.assertEqual(self.cs.cid_for_particle(
             self.es.part[0]), self.cs.cluster_ids()[0])
         self.assertEqual(self.cs.cid_for_particle(1), self.cs.cluster_ids()[0])
+
+        # Unknown method should return None
+        self.assertIsNone(self.cs.call_method("unknown"))
 
 
 if __name__ == "__main__":

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -67,6 +67,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
             length=LENGTH,
             central_angle=np.pi)
 
+        # check getters
         np.testing.assert_almost_equal(
             np.copy(shape.cyl_transform_params.center), 3 * [5])
         self.assertAlmostEqual(shape.r1, R1)
@@ -205,6 +206,20 @@ class ShapeBasedConstraintTest(ut.TestCase):
         dist = shape.calc_distance(position=probe_pos)
         self.assertAlmostEqual(dist[0], np.linalg.norm(d_vec_expected))
         np.testing.assert_array_almost_equal(d_vec_expected, np.copy(dist[1]))
+
+        # check setters
+        shape.r1 = R1 - 1
+        shape.r2 = R2 + 1
+        shape.thickness = D - 0.1
+        shape.length = LENGTH - 1
+        shape.central_angle = np.pi / 2
+        shape.direction = 1
+        self.assertAlmostEqual(shape.r1, R1 - 1)
+        self.assertAlmostEqual(shape.r2, R2 + 1)
+        self.assertAlmostEqual(shape.thickness, D - 0.1)
+        self.assertAlmostEqual(shape.length, LENGTH - 1)
+        self.assertAlmostEqual(shape.central_angle, np.pi / 2)
+        self.assertEqual(shape.direction, 1)
 
     def test_simplepore(self):
         """

--- a/testsuite/python/observable_cylindricalLB.py
+++ b/testsuite/python/observable_cylindricalLB.py
@@ -214,6 +214,13 @@ class CylindricalLBObservableCommon:
         self.assertEqual(observable.max_z, 9)
         obs_bin_edges = observable.bin_edges()
         np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
+        # check sampling_density
+        self.assertEqual(
+            observable.sampling_density,
+            params['sampling_density'])
+        observable = espressomd.observables.CylindricalLBVelocityProfile(
+            **{**params, 'sampling_density': 3})
+        self.assertEqual(observable.sampling_density, 3)
         # check center, axis, orientation
         ctp = espressomd.math.CylindricalTransformationParameters(
             center=[1, 2, 3], axis=[0, 1, 0], orientation=[0, 0, 1])


### PR DESCRIPTION
Description of changes:
- improve code coverage of the script interface
- cluster analysis methods that return `void` in the core now return `None` in Python instead of `True`
- unrecognized strings passed to method `call_method()` of cluster analysis now return `None` in Python instead of `False`
