### PR TITLE
BoxGeometry members private

### DIFF
--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -28,12 +28,13 @@
 #include <cmath>
 
 class BoxGeometry {
-public:
+private:
   /** Flags for all three dimensions whether pbc are applied (default). */
   std::bitset<3> m_periodic = 0b111;
   /** Side lengths of the box */
   Utils::Vector3d m_length = {1, 1, 1};
 
+public:
   /**
    * @brief Set periodicity for direction
    *

--- a/src/core/EspressoSystemStandAlone.cpp
+++ b/src/core/EspressoSystemStandAlone.cpp
@@ -54,8 +54,7 @@ EspressoSystemStandAlone::EspressoSystemStandAlone(int argc, char **argv) {
 void EspressoSystemStandAlone::set_box_l(Utils::Vector3d const &box_l) const {
   if (!head_node)
     return;
-  box_geo.set_length(box_l);
-  mpi_bcast_parameter(FIELD_BOXL);
+  mpi_set_box_length(box_l);
 }
 
 void EspressoSystemStandAlone::set_time_step(double time_step) const {

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -309,9 +309,6 @@ void on_skin_change() {
 
 void on_parameter_change(int field) {
   switch (field) {
-  case FIELD_PERIODIC:
-    on_periodicity_change();
-    break;
   case FIELD_MIN_GLOBAL_CUT:
   case FIELD_SKIN:
     on_skin_change();

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -277,9 +277,6 @@ void on_temperature_change() { lb_lbfluid_reinit_parameters(); }
 
 void on_parameter_change(int field) {
   switch (field) {
-  case FIELD_BOXL:
-    on_boxl_change();
-    break;
   case FIELD_PERIODIC:
 #ifdef SCAFACOS
 #ifdef ELECTROSTATICS

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -277,35 +277,44 @@ void on_cell_structure_change() {
 
 void on_temperature_change() { lb_lbfluid_reinit_parameters(); }
 
-void on_parameter_change(int field) {
-  switch (field) {
-  case FIELD_PERIODIC:
+void on_periodicity_change() {
 #ifdef SCAFACOS
 #ifdef ELECTROSTATICS
-    if (coulomb.method == COULOMB_SCAFACOS) {
-      Scafacos::fcs_coulomb()->update_system_params();
-    }
+  if (coulomb.method == COULOMB_SCAFACOS) {
+    Scafacos::fcs_coulomb()->update_system_params();
+  }
 #endif
 #ifdef SCAFACOS_DIPOLES
-    if (dipole.method == DIPOLAR_SCAFACOS) {
-      Scafacos::fcs_dipoles()->update_system_params();
-    }
+  if (dipole.method == DIPOLAR_SCAFACOS) {
+    Scafacos::fcs_dipoles()->update_system_params();
+  }
 #endif
 #endif
 #ifdef STOKESIAN_DYNAMICS
-    if (integ_switch == INTEG_METHOD_SD) {
-      if (box_geo.periodic(0) || box_geo.periodic(1) || box_geo.periodic(2))
-        runtimeErrorMsg() << "Illegal box periodicity for Stokesian Dynamics: "
-                          << box_geo.periodic(0) << " " << box_geo.periodic(1)
-                          << " " << box_geo.periodic(2) << "\n"
-                          << "  Required: 0 0 0\n";
-    }
-#endif
-  case FIELD_MIN_GLOBAL_CUT:
-  case FIELD_SKIN: {
-    cells_re_init(cell_structure.decomposition_type());
+  if (integ_switch == INTEG_METHOD_SD) {
+    if (box_geo.periodic(0) || box_geo.periodic(1) || box_geo.periodic(2))
+      runtimeErrorMsg() << "Illegal box periodicity for Stokesian Dynamics: "
+                        << box_geo.periodic(0) << " " << box_geo.periodic(1)
+                        << " " << box_geo.periodic(2) << "\n"
+                        << "  Required: 0 0 0\n";
   }
-    on_coulomb_change();
+#endif
+  on_skin_change();
+}
+
+void on_skin_change() {
+  cells_re_init(cell_structure.decomposition_type());
+  on_coulomb_change();
+}
+
+void on_parameter_change(int field) {
+  switch (field) {
+  case FIELD_PERIODIC:
+    on_periodicity_change();
+    break;
+  case FIELD_MIN_GLOBAL_CUT:
+  case FIELD_SKIN:
+    on_skin_change();
     break;
   case FIELD_NODEGRID:
     grid_changed_n_nodes();

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -237,25 +237,27 @@ void on_lbboundary_change() {
 #endif
 }
 
-void on_boxl_change() {
+void on_boxl_change(bool skip_method_adaption) {
   grid_changed_box_l(box_geo);
   /* Electrostatics cutoffs mostly depend on the system size,
    * therefore recalculate them. */
   cells_re_init(cell_structure.decomposition_type());
 
-  /* Now give methods a chance to react to the change in box length */
+  if (not skip_method_adaption) {
+    /* Now give methods a chance to react to the change in box length */
 #ifdef ELECTROSTATICS
-  Coulomb::on_boxl_change();
+    Coulomb::on_boxl_change();
 #endif
 
 #ifdef DIPOLES
-  Dipole::on_boxl_change();
+    Dipole::on_boxl_change();
 #endif
 
-  lb_lbfluid_init();
+    lb_lbfluid_init();
 #ifdef LB_BOUNDARIES
-  LBBoundaries::lb_init_boundaries();
+    LBBoundaries::lb_init_boundaries();
 #endif
+  }
 }
 
 void on_cell_structure_change() {

--- a/src/core/event.hpp
+++ b/src/core/event.hpp
@@ -78,11 +78,14 @@ void on_short_range_ia_change();
 /** called every time a constraint is changed. */
 void on_constraint_change();
 
-/** called every time the box length has changed. This routine
- *  is relatively fast, and changing the box length every time step
- *  as for example necessary for NpT is more or less ok.
+/**
+ * @brief Called when the box length has changed. This routine is relatively
+ * fast, and changing the box length every time step as for example necessary
+ * for NpT is more or less ok.
+ *
+ * @param skip_method_adaption skip the long-range methods adaptions
  */
-void on_boxl_change();
+void on_boxl_change(bool skip_method_adaption = false);
 
 /** called every time a major change to the cell structure has happened,
  *  like the skin or grid have changed. This one is potentially slow.

--- a/src/core/event.hpp
+++ b/src/core/event.hpp
@@ -95,6 +95,15 @@ void on_cell_structure_change();
 /** called every time the temperature changes. This one is potentially slow. */
 void on_temperature_change();
 
+/** @brief Called when the periodicity changes. Internally calls @ref
+ * on_skin_change.
+ */
+void on_periodicity_change();
+
+/** @brief Called when the skin is changed.
+ */
+void on_skin_change();
+
 /** called every time other parameters (timestep,...) are changed. Note that
  *  this does not happen automatically. The callback procedure of the changed
  *  variable is responsible for that.

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -105,9 +105,6 @@ const std::unordered_map<int, Datafield> fields{
     {FIELD_NPTISO_GV,
      {&npt_iso.gammav, 1, "npt_iso.gammav"}}, /* 22 from thermostat.cpp */
 #endif
-    {FIELD_PERIODIC,
-     {reinterpret_cast<size_t *>(&box_geo.m_periodic), 1,
-      "periodicity"}},                /* 28 from BoxGeometry.hpp */
     {FIELD_SKIN, {&skin, 1, "skin"}}, /* 29 from integrate.cpp */
     {FIELD_TEMPERATURE,
      {&temperature, 1, "temperature"}}, /* 30 from thermostat.cpp */

--- a/src/core/global.cpp
+++ b/src/core/global.cpp
@@ -87,7 +87,6 @@ struct Datafield {
  *  Please declare where the variables come from.
  */
 const std::unordered_map<int, Datafield> fields{
-    {FIELD_BOXL, {box_geo.m_length.data(), 3, "box_l"}}, /* 0  from grid.cpp */
 #ifndef PARTICLE_ANISOTROPY
     {FIELD_LANGEVIN_GAMMA,
      {&langevin.gamma, 1, "langevin.gamma"}}, /* 5  from thermostat.cpp */

--- a/src/core/global.hpp
+++ b/src/core/global.hpp
@@ -52,7 +52,6 @@ enum Fields {
   FIELD_NPTISO_GV,
   /** index of \ref nptiso_struct::piston (only used for the events) */
   FIELD_NPTISO_PISTON,
-  FIELD_PERIODIC,
   /** index of \ref #skin */
   FIELD_SKIN,
   /** index of \ref #temperature */

--- a/src/core/global.hpp
+++ b/src/core/global.hpp
@@ -38,7 +38,6 @@ void check_global_consistency();
  *  for use with @ref mpi_bcast_parameter.
  */
 enum Fields {
-  FIELD_BOXL = 0,
   /** index of \ref LangevinThermostat::gamma */
   FIELD_LANGEVIN_GAMMA,
   /** index of \ref integ_switch */

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -147,3 +147,17 @@ void mpi_set_box_length(const Utils::Vector3d &length) {
 
   mpi_call_all(mpi_set_box_length_local, length);
 }
+
+void mpi_set_periodicity_local(bool x, bool y, bool z) {
+  box_geo.set_periodic(0, x);
+  box_geo.set_periodic(1, y);
+  box_geo.set_periodic(2, z);
+
+  on_periodicity_change();
+}
+
+REGISTER_CALLBACK(mpi_set_periodicity_local)
+
+void mpi_set_periodicity(bool x, bool y, bool z) {
+  mpi_call_all(mpi_set_periodicity_local, x, y, z);
+}

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -122,12 +122,10 @@ void rescale_boxl(int dir, double d_new) {
   if (dir < 3) {
     auto box_l = box_geo.length();
     box_l[dir] = d_new;
-    box_geo.set_length(box_l);
+    mpi_set_box_length(box_l);
   } else {
-    box_geo.set_length({d_new, d_new, d_new});
+    mpi_set_box_length({d_new, d_new, d_new});
   }
-
-  mpi_bcast_parameter(FIELD_BOXL);
 
   if (scale > 1.) {
     mpi_rescale_particles(dir, scale);

--- a/src/core/grid.hpp
+++ b/src/core/grid.hpp
@@ -112,4 +112,9 @@ inline Utils::Vector3d unfolded_position(const Utils::Vector3d &pos,
 LocalBox<double> regular_decomposition(const BoxGeometry &box,
                                        Utils::Vector3i const &node_pos,
                                        Utils::Vector3i const &node_grid);
+
+/** @brief Set and broadcast the box length.
+ *  @param length new box length
+ */
+void mpi_set_box_length(const Utils::Vector3d &length);
 #endif

--- a/src/core/grid.hpp
+++ b/src/core/grid.hpp
@@ -117,4 +117,11 @@ LocalBox<double> regular_decomposition(const BoxGeometry &box,
  *  @param length new box length
  */
 void mpi_set_box_length(const Utils::Vector3d &length);
+
+/** @brief Set and broadcast the periodicity.
+ *  @param x periodicity in x direction
+ *  @param y periodicity in y direction
+ *  @param z periodicity in z direction
+ */
+void mpi_set_periodicity(bool x, bool y, bool z);
 #endif

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -27,6 +27,7 @@
 #include "cells.hpp"
 #include "communication.hpp"
 #include "errorhandling.hpp"
+#include "event.hpp"
 #include "grid.hpp"
 #include "integrate.hpp"
 #include "npt.hpp"
@@ -142,23 +143,23 @@ void velocity_verlet_npt_propagate_pos(const ParticleRange &particles) {
 
   /* Apply new volume to the box-length, communicate it, and account for
    * necessary adjustments to the cell geometry */
+  Utils::Vector3d new_box;
+
   if (this_node == 0) {
-    Utils::Vector3d new_box = box_geo.length();
+    new_box = box_geo.length();
 
     for (int i = 0; i < 3; i++) {
       if (nptiso.geometry & nptiso.nptgeom_dir[i] || nptiso.cubic_box) {
         new_box[i] = L_new;
       }
     }
-
-    box_geo.set_length(new_box);
   }
 
-  MPI_Bcast(box_geo.m_length.data(), 3, MPI_DOUBLE, 0, comm_cart);
+  boost::mpi::broadcast(comm_cart, new_box, 0);
 
-  /* fast box length update */
-  grid_changed_box_l(box_geo);
-  cells_re_init(cell_structure.decomposition_type());
+  box_geo.set_length(new_box);
+  // fast box length update
+  on_boxl_change(true);
 }
 
 void velocity_verlet_npt_propagate_vel(const ParticleRange &particles) {

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -24,7 +24,6 @@ cdef extern from "grid.hpp":
     void mpi_set_box_length(Vector3d length) except +
 
 cdef extern from "global.hpp":
-    int FIELD_BOXL
     int FIELD_SKIN
     int FIELD_NODEGRID
     int FIELD_PERIODIC

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -27,7 +27,6 @@ cdef extern from "grid.hpp":
 cdef extern from "global.hpp":
     int FIELD_SKIN
     int FIELD_NODEGRID
-    int FIELD_PERIODIC
     int FIELD_SIMTIME
     int FIELD_MIN_GLOBAL_CUT
     int FIELD_THERMO_SWITCH

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -22,6 +22,7 @@ from .utils cimport Vector3d
 
 cdef extern from "grid.hpp":
     void mpi_set_box_length(Vector3d length) except +
+    void mpi_set_periodicity(bool x, bool y, bool z)
 
 cdef extern from "global.hpp":
     int FIELD_SKIN

--- a/src/python/espressomd/globals.pxd
+++ b/src/python/espressomd/globals.pxd
@@ -18,6 +18,10 @@
 #
 include "myconfig.pxi"
 from libcpp cimport bool
+from .utils cimport Vector3d
+
+cdef extern from "grid.hpp":
+    void mpi_set_box_length(Vector3d length) except +
 
 cdef extern from "global.hpp":
     int FIELD_BOXL

--- a/src/python/espressomd/globals.pyx
+++ b/src/python/espressomd/globals.pyx
@@ -57,14 +57,11 @@ cdef class Globals:
 
     property periodicity:
         def __set__(self, _periodic):
-            for i in range(3):
-                box_geo.set_periodic(i, _periodic[i])
-
-            mpi_bcast_parameter(FIELD_PERIODIC)
+            mpi_set_periodicity(_periodic[0], _periodic[1], _periodic[2])
             handle_errors("Error while assigning system periodicity")
 
         def __get__(self):
-            periodicity = np.zeros(3)
+            periodicity = np.empty(3, dtype=np.bool)
 
             for i in range(3):
                 periodicity[i] = box_geo.periodic(i)

--- a/src/python/espressomd/globals.pyx
+++ b/src/python/espressomd/globals.pyx
@@ -25,21 +25,14 @@ from .globals cimport timing_samples
 from .globals cimport forcecap_set
 from .globals cimport forcecap_get
 from .utils import array_locked, handle_errors
-from .utils cimport Vector3d, make_array_locked
+from .utils cimport Vector3d, make_array_locked, make_Vector3d
 
 cdef class Globals:
     property box_l:
         def __set__(self, _box_l):
-            cdef Vector3d temp_box_l
             if len(_box_l) != 3:
                 raise ValueError("Box length must be of length 3")
-            for i in range(3):
-                if _box_l[i] <= 0:
-                    raise ValueError(
-                        "Box length must be > 0  in all directions")
-                temp_box_l[i] = _box_l[i]
-            box_geo.set_length(temp_box_l)
-            mpi_bcast_parameter(FIELD_BOXL)
+            mpi_set_box_length(make_Vector3d(_box_l))
 
         def __get__(self):
             return make_array_locked(< Vector3d > box_geo.length())

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -234,6 +234,7 @@ python_test(FILE p3m_tuning_exceptions.py MAX_NUM_PROC 1 LABELS gpu)
 python_test(FILE integrator_exceptions.py MAX_NUM_PROC 1)
 python_test(FILE utils.py MAX_NUM_PROC 1)
 python_test(FILE npt_thermostat.py MAX_NUM_PROC 4)
+python_test(FILE box_geometry.py MAX_NUM_PROC 1)
 
 add_custom_target(
   python_test_data

--- a/testsuite/python/box_geometry.py
+++ b/testsuite/python/box_geometry.py
@@ -39,6 +39,24 @@ class BoxGeometry(ut.TestCase):
         with self.assertRaisesRegex(Exception, 'Box length must be of length 3'):
             self.system.box_l = self.box_l[:2]
 
+    def test_periodicity(self):
+        import itertools
+        for periodicity in itertools.product((True, False), repeat=3):
+            self.system.periodicity = periodicity
+
+            np.testing.assert_equal(np.copy(self.system.periodicity),
+                                    periodicity)
+
+        default_periodicity = (True, True, True)
+        self.system.periodicity = default_periodicity
+
+        with self.assertRaisesRegex(Exception, 'periodicity must be of length 3'):
+            self.system.periodicity = (True, True)
+
+        # the periodicity should not be updated
+        np.testing.assert_equal(np.copy(self.system.periodicity),
+                                default_periodicity)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/box_geometry.py
+++ b/testsuite/python/box_geometry.py
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2021 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import unittest as ut
+import espressomd
+import numpy as np
+
+
+class BoxGeometry(ut.TestCase):
+    box_l = [5.0, 5.0, 5.0]
+    system = espressomd.System(box_l=box_l)
+
+    def test_box_length_interface(self):
+        for i in range(3):
+            local_box_l = self.box_l.copy()
+            local_box_l[i] = -1.
+
+            with self.assertRaisesRegex(Exception, 'Box length must be >0'):
+                self.system.box_l = local_box_l
+
+            # the box length should not be updated
+            np.testing.assert_equal(self.box_l, np.copy(self.system.box_l))
+
+        with self.assertRaisesRegex(Exception, 'Box length must be of length 3'):
+            self.system.box_l = self.box_l[:2]
+
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
Fixes #4170

Description of changes:
- privatized BoxGeometry members
- mpi-callbacks for periodicity and box_l
- extracted `on_periodicity_change` and `on_skin_change` from `on_parameter_change`
- added `skip_method_adaption` parameter to `on_boxl_change` to replace custom implementation in `velocity_verlet_npt`
- added python test for box_l and periodicity interface