### PR TITLE
get_mi_... functions as members of BoxGeometry

### DIFF
--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -33,6 +33,10 @@ private:
   std::bitset<3> m_periodic = 0b111;
   /** Side lengths of the box */
   Utils::Vector3d m_length = {1, 1, 1};
+  /** Inverse side lengths of the box */
+  Utils::Vector3d m_length_inv = {1, 1, 1};
+  /** Half side lengths of the box */
+  Utils::Vector3d m_length_half = {0.5, 0.5, 0.5};
 
 public:
   /**
@@ -61,10 +65,26 @@ public:
   Utils::Vector3d const &length() const { return m_length; }
 
   /**
+   * @brief Inverse box length
+   * @return Return vector of inverse side-lengths of the box.
+   */
+  Utils::Vector3d const &length_inv() const { return m_length_inv; }
+
+  /**
+   * @brief Half box length
+   * @return Return vector of half side-lengths of the box.
+   */
+  Utils::Vector3d const &length_half() const { return m_length_half; }
+
+  /**
    * @brief Set box side lengths.
    * @param box_l Length that should be set.
    */
-  void set_length(Utils::Vector3d const &box_l) { m_length = box_l; }
+  void set_length(Utils::Vector3d const &box_l) {
+    m_length = box_l;
+    m_length_inv = {1. / box_l[0], 1. / box_l[1], 1. / box_l[2]};
+    m_length_half = 0.5 * box_l;
+  }
 
   /**
    * @brief Box volume

--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -27,6 +27,45 @@
 #include <cassert>
 #include <cmath>
 
+namespace detail {
+/**
+ * @brief Get the minimum-image distance between two coordinates.
+ * @param a               Coordinate of the terminal point.
+ * @param b               Coordinate of the initial point.
+ * @param box_length      Box length.
+ * @param box_length_inv  Inverse box length
+ * @param box_length_half Half box length
+ * @param periodic        Box periodicity.
+ * @return Shortest distance from @p b to @p a across periodic images,
+ *         i.e. <tt>a - b</tt>. Can be negative.
+ */
+template <typename T>
+T get_mi_coord(T a, T b, T box_length, T box_length_inv, T box_length_half,
+               bool periodic) {
+  auto const dx = a - b;
+
+  if (periodic && (std::abs(dx) > box_length_half)) {
+    return dx - std::round(dx * box_length_inv) * box_length;
+  }
+
+  return dx;
+}
+
+/**
+ * @brief Get the minimum-image distance between two coordinates.
+ * @param a           Coordinate of the terminal point.
+ * @param b           Coordinate of the initial point.
+ * @param box_length  Box length.
+ * @param periodic    Box periodicity.
+ * @return Shortest distance from @p b to @p a across periodic images,
+ *         i.e. <tt>a - b</tt>. Can be negative.
+ */
+template <typename T> T get_mi_coord(T a, T b, T box_length, bool periodic) {
+  return get_mi_coord(a, b, box_length, 1. / box_length, 0.5 * box_length,
+                      periodic);
+}
+} // namespace detail
+
 class BoxGeometry {
 private:
   /** Flags for all three dimensions whether pbc are applied (default). */
@@ -91,46 +130,39 @@ public:
    * @return Return the volume of the box.
    */
   double volume() const { return m_length[0] * m_length[1] * m_length[2]; }
-};
 
-/**
- * @brief Get the minimum-image distance between two coordinates.
- * @param a           Coordinate of the terminal point.
- * @param b           Coordinate of the initial point.
- * @param box_length  Box length.
- * @param periodic    Box periodicity.
- * @return Shortest distance from @p b to @p a across periodic images,
- *         i.e. <tt>a - b</tt>. Can be negative.
- */
-template <typename T> T get_mi_coord(T a, T b, T box_length, bool periodic) {
-  auto const dx = a - b;
+  /**
+   * @brief Get the minimum-image distance between two coordinates.
+   * @param a     Coordinate of the terminal point.
+   * @param b     Coordinate of the initial point.
+   * @param coord Direction
+   * @return Shortest distance from @p b to @p a across periodic images,
+   *         i.e. <tt>a - b</tt>. Can be negative.
+   */
+  template <typename T> T inline get_mi_coord(T a, T b, unsigned coord) const {
+    assert(coord <= 2);
 
-  if (periodic && (std::fabs(dx) > (0.5 * box_length))) {
-    return dx - std::round(dx * (1. / box_length)) * box_length;
+    return detail::get_mi_coord(a, b, m_length[coord], m_length_inv[coord],
+                                m_length_half[coord], m_periodic[coord]);
   }
 
-  return dx;
-}
-
-/**
- * @brief Get the minimum-image vector between two coordinates.
- *
- * @tparam T Floating point type.
- *
- * @param a     Coordinate of the terminal point.
- * @param b     Coordinate of the initial point.
- * @param box   Box parameters (side lengths, periodicity).
- * @return Vector from @p b to @p a that minimizes the distance across
- *         periodic images, i.e. <tt>a - b</tt>.
- */
-template <typename T>
-Utils::Vector<T, 3> get_mi_vector(const Utils::Vector<T, 3> &a,
-                                  const Utils::Vector<T, 3> &b,
-                                  const BoxGeometry &box) {
-  return {get_mi_coord(a[0], b[0], box.length()[0], box.periodic(0)),
-          get_mi_coord(a[1], b[1], box.length()[1], box.periodic(1)),
-          get_mi_coord(a[2], b[2], box.length()[2], box.periodic(2))};
-}
+  /**
+   * @brief Get the minimum-image vector between two coordinates.
+   *
+   * @tparam T Floating point type.
+   *
+   * @param a     Coordinate of the terminal point.
+   * @param b     Coordinate of the initial point.
+   * @return Vector from @p b to @p a that minimizes the distance across
+   *         periodic images, i.e. <tt>a - b</tt>.
+   */
+  template <typename T>
+  Utils::Vector<T, 3> get_mi_vector(const Utils::Vector<T, 3> &a,
+                                    const Utils::Vector<T, 3> &b) const {
+    return {get_mi_coord(a[0], b[0], 0), get_mi_coord(a[1], b[1], 1),
+            get_mi_coord(a[2], b[2], 2)};
+  }
+};
 
 /** @brief Fold a coordinate to primary simulation box.
  *  @param pos        coordinate to fold

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -100,7 +100,7 @@ struct MinimalImageDistance {
   const BoxGeometry box;
 
   Distance operator()(Particle const &p1, Particle const &p2) const {
-    return Distance(get_mi_vector(p1.r.p, p2.r.p, box));
+    return Distance(box.get_mi_vector(p1.r.p, p2.r.p));
   }
 };
 

--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -97,14 +97,13 @@ void DomainDecomposition::move_left_or_right(ParticleList &src,
                                              ParticleList &right,
                                              int dir) const {
   for (auto it = src.begin(); it != src.end();) {
-    if ((get_mi_coord(it->r.p[dir], m_local_box.my_left()[dir],
-                      m_box.length()[dir], m_box.periodic(dir)) < 0.0) and
+    if ((m_box.get_mi_coord(it->r.p[dir], m_local_box.my_left()[dir], dir) <
+         0.0) and
         (m_box.periodic(dir) || (m_local_box.boundary()[2 * dir] == 0))) {
       left.insert(std::move(*it));
       it = src.erase(it);
-    } else if ((get_mi_coord(it->r.p[dir], m_local_box.my_right()[dir],
-                             m_box.length()[dir],
-                             m_box.periodic(dir)) >= 0.0) and
+    } else if ((m_box.get_mi_coord(it->r.p[dir], m_local_box.my_right()[dir],
+                                   dir) >= 0.0) and
                (m_box.periodic(dir) ||
                 (m_local_box.boundary()[2 * dir + 1] == 0))) {
       right.insert(std::move(*it));

--- a/src/core/bonded_interactions/angle_common.hpp
+++ b/src/core/bonded_interactions/angle_common.hpp
@@ -52,11 +52,11 @@ calc_vectors_and_cosine(Utils::Vector3d const &r_mid,
                         Utils::Vector3d const &r_right,
                         bool sanitize_cosine = false) {
   /* normalized vector from p_mid to p_left */
-  auto vec1 = get_mi_vector(r_left, r_mid, box_geo);
+  auto vec1 = box_geo.get_mi_vector(r_left, r_mid);
   auto const d1i = 1.0 / vec1.norm();
   vec1 *= d1i;
   /* normalized vector from p_mid to p_right */
-  auto vec2 = get_mi_vector(r_right, r_mid, box_geo);
+  auto vec2 = box_geo.get_mi_vector(r_right, r_mid);
   auto const d2i = 1.0 / vec2.norm();
   vec2 *= d2i;
   /* cosine of the angle between vec1 and vec2 */

--- a/src/core/bonded_interactions/dihedral.hpp
+++ b/src/core/bonded_interactions/dihedral.hpp
@@ -101,9 +101,9 @@ calc_dihedral_angle(Utils::Vector3d const &r1, Utils::Vector3d const &r2,
                     Utils::Vector3d &a, Utils::Vector3d &b, Utils::Vector3d &c,
                     Utils::Vector3d &aXb, double *l_aXb, Utils::Vector3d &bXc,
                     double *l_bXc, double *cosphi, double *phi) {
-  a = get_mi_vector(r2, r1, box_geo);
-  b = get_mi_vector(r3, r2, box_geo);
-  c = get_mi_vector(r4, r3, box_geo);
+  a = box_geo.get_mi_vector(r2, r1);
+  b = box_geo.get_mi_vector(r3, r2);
+  c = box_geo.get_mi_vector(r4, r3);
 
   /* calculate vector product a X b and b X c */
   aXb = vector_product(a, b);

--- a/src/core/cluster_analysis/Cluster.cpp
+++ b/src/core/cluster_analysis/Cluster.cpp
@@ -62,9 +62,8 @@ Cluster::center_of_mass_subcluster(std::vector<int> &subcl_partcicle_ids) {
   {
     auto const folded_pos =
         folded_position(get_particle_data(pid).r.p, box_geo);
-    auto const dist_to_reference =
-        get_mi_vector(folded_pos, reference_position,
-                      box_geo); // add current particle positions
+    auto const dist_to_reference = box_geo.get_mi_vector(
+        folded_pos, reference_position); // add current particle positions
     com += dist_to_reference * get_particle_data(pid).p.mass;
     total_mass += get_particle_data(pid).p.mass;
   }
@@ -87,8 +86,9 @@ double Cluster::longest_distance() {
   double ld = 0.;
   for (auto a = particles.begin(); a != particles.end(); a++) {
     for (auto b = a; ++b != particles.end();) {
-      auto const dist = get_mi_vector(get_particle_data(*a).r.p,
-                                      get_particle_data(*b).r.p, box_geo)
+      auto const dist = box_geo
+                            .get_mi_vector(get_particle_data(*a).r.p,
+                                           get_particle_data(*b).r.p)
                             .norm();
 
       // Larger than previous largest distance?
@@ -111,7 +111,7 @@ Cluster::radius_of_gyration_subcluster(std::vector<int> &subcl_particle_ids) {
   for (auto const pid : subcl_particle_ids) {
     // calculate square length of this distance
     sum_sq_dist +=
-        get_mi_vector(com, get_particle_data(pid).r.p, box_geo).norm2();
+        box_geo.get_mi_vector(com, get_particle_data(pid).r.p).norm2();
   }
 
   return sqrt(sum_sq_dist / static_cast<double>(subcl_particle_ids.size()));
@@ -141,7 +141,7 @@ std::pair<double, double> Cluster::fractal_dimension(double dr) {
   std::vector<double> distances;
 
   for (auto const &it : particles) {
-    distances.push_back(get_mi_vector(com, get_particle_data(it).r.p, box_geo)
+    distances.push_back(box_geo.get_mi_vector(com, get_particle_data(it).r.p)
                             .norm()); // add distance from the current particle
                                       // to the com in the distances vectors
   }

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -268,7 +268,7 @@ const Particle &glue_to_surface_calc_vs_pos(const Particle &p1,
                                             const Particle &p2,
                                             Utils::Vector3d &pos) {
   double c;
-  auto const vec21 = get_mi_vector(p1.r.p, p2.r.p, box_geo);
+  auto const vec21 = box_geo.get_mi_vector(p1.r.p, p2.r.p);
   const double dist_betw_part = vec21.norm();
 
   // Find out, which is the particle to be glued.
@@ -294,7 +294,7 @@ void bind_at_point_of_collision_calc_vs_pos(const Particle *const p1,
                                             const Particle *const p2,
                                             Utils::Vector3d &pos1,
                                             Utils::Vector3d &pos2) {
-  auto const vec21 = get_mi_vector(p1->r.p, p2->r.p, box_geo);
+  auto const vec21 = box_geo.get_mi_vector(p1->r.p, p2->r.p);
   pos1 = p1->r.p - vec21 * collision_params.vs_placement;
   pos2 = p1->r.p - vec21 * (1. - collision_params.vs_placement);
 }
@@ -305,10 +305,10 @@ void coldet_do_three_particle_bond(Particle &p, Particle const &p1,
                                    Particle const &p2) {
   // If p1 and p2 are not closer or equal to the cutoff distance, skip
   // p1:
-  if (get_mi_vector(p.r.p, p1.r.p, box_geo).norm() > collision_params.distance)
+  if (box_geo.get_mi_vector(p.r.p, p1.r.p).norm() > collision_params.distance)
     return;
   // p2:
-  if (get_mi_vector(p.r.p, p2.r.p, box_geo).norm() > collision_params.distance)
+  if (box_geo.get_mi_vector(p.r.p, p2.r.p).norm() > collision_params.distance)
     return;
 
   // Check, if there already is a three-particle bond centered on p
@@ -341,9 +341,9 @@ void coldet_do_three_particle_bond(Particle &p, Particle const &p1,
   // First, find the angle between the particle p, p1 and p2
 
   /* vector from p to p1 */
-  auto const vec1 = get_mi_vector(p.r.p, p1.r.p, box_geo).normalize();
+  auto const vec1 = box_geo.get_mi_vector(p.r.p, p1.r.p).normalize();
   /* vector from p to p2 */
-  auto const vec2 = get_mi_vector(p.r.p, p2.r.p, box_geo).normalize();
+  auto const vec2 = box_geo.get_mi_vector(p.r.p, p2.r.p).normalize();
 
   auto const cosine =
       boost::algorithm::clamp(vec1 * vec2, -TINY_COS_VALUE, TINY_COS_VALUE);

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -1186,15 +1186,15 @@ Utils::Vector3d ELC_P3M_dielectric_layers_force_contribution(
 
   if (pos1[2] < elc_params.space_layer) {
     auto const q = elc_params.delta_mid_bot * q1q2;
-    auto const d = get_mi_vector(pos2, {pos1[0], pos1[1], -pos1[2]}, box_geo);
+    auto const d = box_geo.get_mi_vector(pos2, {pos1[0], pos1[1], -pos1[2]});
 
     p3m_add_pair_force(q, d, d.norm(), force);
   }
 
   if (pos1[2] > (elc_params.h - elc_params.space_layer)) {
     auto const q = elc_params.delta_mid_top * q1q2;
-    auto const d = get_mi_vector(
-        pos2, {pos1[0], pos1[1], 2 * elc_params.h - pos1[2]}, box_geo);
+    auto const d = box_geo.get_mi_vector(
+        pos2, {pos1[0], pos1[1], 2 * elc_params.h - pos1[2]});
 
     p3m_add_pair_force(q, d, d.norm(), force);
   }
@@ -1212,15 +1212,16 @@ double ELC_P3M_dielectric_layers_energy_contribution(
     auto const q = elc_params.delta_mid_bot * q1q2;
 
     eng += p3m_pair_energy(
-        q, get_mi_vector(pos2, {pos1[0], pos1[1], -pos1[2]}, box_geo).norm());
+        q, box_geo.get_mi_vector(pos2, {pos1[0], pos1[1], -pos1[2]}).norm());
   }
 
   if (pos1[2] > (elc_params.h - elc_params.space_layer)) {
     auto const q = elc_params.delta_mid_top * q1q2;
     eng += p3m_pair_energy(
-        q, get_mi_vector(pos2, {pos1[0], pos1[1], 2 * elc_params.h - pos1[2]},
-                         box_geo)
-               .norm());
+        q,
+        box_geo
+            .get_mi_vector(pos2, {pos1[0], pos1[1], 2 * elc_params.h - pos1[2]})
+            .norm());
   }
 
   return eng;

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -50,7 +50,7 @@ static double calc_dipole_dipole_ia(Particle &p1, Utils::Vector3d const &dip1,
   auto const dip2 = p2.calc_dip();
 
   // Distance between particles
-  auto const dr = get_mi_vector(p1.r.p, p2.r.p, box_geo);
+  auto const dr = box_geo.get_mi_vector(p1.r.p, p2.r.p);
 
   // Powers of distance
   auto const r2 = dr.norm2();

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -211,7 +211,7 @@ calc_bonded_energy(Bonded_IA_Parameters const &iaparams, Particle const &p1,
   auto p4 = (n_partners > 2) ? partners[2] : nullptr;
 
   if (n_partners == 1) {
-    auto const dx = get_mi_vector(p1.r.p, p2->r.p, box_geo);
+    auto const dx = box_geo.get_mi_vector(p1.r.p, p2->r.p);
     if (auto const *iap = boost::get<FeneBond>(&iaparams)) {
       return iap->energy(dx);
     }

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -337,7 +337,7 @@ calc_bond_pair_force(Particle const &p1, Particle const &p2,
 
 inline bool add_bonded_two_body_force(Bonded_IA_Parameters const &iaparams,
                                       Particle &p1, Particle &p2) {
-  auto const dx = get_mi_vector(p1.r.p, p2.r.p, box_geo);
+  auto const dx = box_geo.get_mi_vector(p1.r.p, p2.r.p);
 
   if (auto const *iap = boost::get<ThermalizedBond>(&iaparams)) {
     auto result = iap->forces(p1, p2, dx);

--- a/src/core/immersed_boundary/ImmersedBoundaries.cpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.cpp
@@ -117,8 +117,8 @@ void ImmersedBoundaries::calc_volumes(CellStructure &cs) {
           // This is to get a continuous trajectory with no jumps when box
           // boundaries are crossed.
           auto const x1 = unfolded_position(p1.r.p, p1.l.i, box_geo.length());
-          auto const x2 = x1 + get_mi_vector(p2.r.p, x1, box_geo);
-          auto const x3 = x1 + get_mi_vector(p3.r.p, x1, box_geo);
+          auto const x2 = x1 + box_geo.get_mi_vector(p2.r.p, x1);
+          auto const x3 = x1 + box_geo.get_mi_vector(p3.r.p, x1);
 
           // Volume of this tetrahedron
           // See @cite zhang01b
@@ -181,8 +181,8 @@ void ImmersedBoundaries::calc_volume_force(CellStructure &cs) {
 
           // Unfolding seems to work only for the first particle of a triel
           // so get the others from relative vectors considering PBC
-          auto const a12 = get_mi_vector(p2.r.p, x1, box_geo);
-          auto const a13 = get_mi_vector(p3.r.p, x1, box_geo);
+          auto const a12 = box_geo.get_mi_vector(p2.r.p, x1);
+          auto const a13 = box_geo.get_mi_vector(p3.r.p, x1);
 
           // Now we have the true and good coordinates
           // This is eq. (9) in @cite dupin08a.

--- a/src/core/immersed_boundary/ibm_tribend.cpp
+++ b/src/core/immersed_boundary/ibm_tribend.cpp
@@ -34,9 +34,9 @@ IBMTribend::calc_forces(Particle const &p1, Particle const &p2,
                         Particle const &p3, Particle const &p4) const {
 
   // Get vectors making up the two triangles
-  auto const dx1 = get_mi_vector(p1.r.p, p3.r.p, box_geo);
-  auto const dx2 = get_mi_vector(p2.r.p, p3.r.p, box_geo);
-  auto const dx3 = get_mi_vector(p4.r.p, p3.r.p, box_geo);
+  auto const dx1 = box_geo.get_mi_vector(p1.r.p, p3.r.p);
+  auto const dx2 = box_geo.get_mi_vector(p2.r.p, p3.r.p);
+  auto const dx3 = box_geo.get_mi_vector(p4.r.p, p3.r.p);
 
   // Get normals on triangle; pointing outwards by definition of indices
   // sequence
@@ -75,15 +75,15 @@ IBMTribend::calc_forces(Particle const &p1, Particle const &p2,
 
   // Force on particles: eq. (C.28-C.31)
   auto const force1 =
-      Pre * (vector_product(get_mi_vector(p2.r.p, p3.r.p, box_geo), v1) / Ai +
-             vector_product(get_mi_vector(p3.r.p, p4.r.p, box_geo), v2) / Aj);
+      Pre * (vector_product(box_geo.get_mi_vector(p2.r.p, p3.r.p), v1) / Ai +
+             vector_product(box_geo.get_mi_vector(p3.r.p, p4.r.p), v2) / Aj);
   auto const force2 =
-      Pre * (vector_product(get_mi_vector(p3.r.p, p1.r.p, box_geo), v1) / Ai);
+      Pre * (vector_product(box_geo.get_mi_vector(p3.r.p, p1.r.p), v1) / Ai);
   auto const force3 =
-      Pre * (vector_product(get_mi_vector(p1.r.p, p2.r.p, box_geo), v1) / Ai +
-             vector_product(get_mi_vector(p4.r.p, p1.r.p, box_geo), v2) / Aj);
+      Pre * (vector_product(box_geo.get_mi_vector(p1.r.p, p2.r.p), v1) / Ai +
+             vector_product(box_geo.get_mi_vector(p4.r.p, p1.r.p), v2) / Aj);
   auto const force4 =
-      Pre * (vector_product(get_mi_vector(p1.r.p, p3.r.p, box_geo), v2) / Aj);
+      Pre * (vector_product(box_geo.get_mi_vector(p1.r.p, p3.r.p), v2) / Aj);
   return std::make_tuple(force1, force2, force3, force4);
 }
 
@@ -101,9 +101,9 @@ IBMTribend::IBMTribend(const int ind1, const int ind2, const int ind3,
     auto const p4 = get_particle_data(ind4);
 
     // Get vectors of triangles
-    auto const dx1 = get_mi_vector(p1.r.p, p3.r.p, box_geo);
-    auto const dx2 = get_mi_vector(p2.r.p, p3.r.p, box_geo);
-    auto const dx3 = get_mi_vector(p4.r.p, p3.r.p, box_geo);
+    auto const dx1 = box_geo.get_mi_vector(p1.r.p, p3.r.p);
+    auto const dx2 = box_geo.get_mi_vector(p2.r.p, p3.r.p);
+    auto const dx3 = box_geo.get_mi_vector(p4.r.p, p3.r.p);
 
     // Get normals on triangle; pointing outwards by definition of indices
     // sequence

--- a/src/core/immersed_boundary/ibm_triel.cpp
+++ b/src/core/immersed_boundary/ibm_triel.cpp
@@ -81,11 +81,11 @@ IBMTriel::calc_forces(Particle const &p1, Particle const &p2,
   // Calculate the current shape of the triangle (l,lp,cos(phi),sin(phi));
   // l = length between 1 and 3
   // get_mi_vector is an ESPResSo function which considers PBC
-  auto const vec2 = get_mi_vector(p3.r.p, p1.r.p, box_geo);
+  auto const vec2 = box_geo.get_mi_vector(p3.r.p, p1.r.p);
   auto const l = vec2.norm();
 
   // lp = length between 1 and 2
-  auto const vec1 = get_mi_vector(p2.r.p, p1.r.p, box_geo);
+  auto const vec1 = box_geo.get_mi_vector(p2.r.p, p1.r.p);
   auto const lp = vec1.norm();
 
   // Check for sanity
@@ -208,10 +208,10 @@ IBMTriel::IBMTriel(const int ind1, const int ind2, const int ind3,
 
   // Calculate equilibrium lengths and angle; Note the sequence of the points!
   // l0 = length between 1 and 3
-  auto const temp_l0 = get_mi_vector(part3.r.p, part1.r.p, box_geo);
+  auto const temp_l0 = box_geo.get_mi_vector(part3.r.p, part1.r.p);
   l0 = temp_l0.norm();
   // lp0 = length between 1 and 2
-  auto const temp_lp0 = get_mi_vector(part2.r.p, part1.r.p, box_geo);
+  auto const temp_lp0 = box_geo.get_mi_vector(part2.r.p, part1.r.p);
   lp0 = temp_lp0.norm();
 
   // cospo / sinpo angle functions between these vectors; calculated directly

--- a/src/core/object-in-fluid/oif_global_forces.cpp
+++ b/src/core/object-in-fluid/oif_global_forces.cpp
@@ -56,8 +56,8 @@ void calc_oif_global(Utils::Vector2d &area_volume, int molType,
             nullptr) {
           // remaining neighbors fetched
           auto const p11 = unfolded_position(p1.r.p, p1.l.i, box_geo.length());
-          auto const p22 = p11 + get_mi_vector(partners[0]->r.p, p11, box_geo);
-          auto const p33 = p11 + get_mi_vector(partners[1]->r.p, p11, box_geo);
+          auto const p22 = p11 + box_geo.get_mi_vector(partners[0]->r.p, p11);
+          auto const p33 = p11 + box_geo.get_mi_vector(partners[1]->r.p, p11);
 
           // unfolded positions correct
           auto const VOL_A = area_triangle(p11, p22, p33);
@@ -93,8 +93,8 @@ void add_oif_global_forces(Utils::Vector2d const &area_volume, int molType,
     if (auto const *iaparams =
             boost::get<OifGlobalForcesBond>(&bonded_ia_params[bond_id])) {
       auto const p11 = unfolded_position(p1.r.p, p1.l.i, box_geo.length());
-      auto const p22 = p11 + get_mi_vector(partners[0]->r.p, p11, box_geo);
-      auto const p33 = p11 + get_mi_vector(partners[1]->r.p, p11, box_geo);
+      auto const p22 = p11 + box_geo.get_mi_vector(partners[0]->r.p, p11);
+      auto const p33 = p11 + box_geo.get_mi_vector(partners[1]->r.p, p11);
 
       // unfolded positions correct
       // starting code from volume force

--- a/src/core/object-in-fluid/oif_local_forces.hpp
+++ b/src/core/object-in-fluid/oif_local_forces.hpp
@@ -120,9 +120,9 @@ OifLocalForcesBond::calc_forces(Particle const &p2, Particle const &p1,
 
   // first-fold-then-the-same approach
   auto const fp2 = unfolded_position(p2.r.p, p2.l.i, box_geo.length());
-  auto const fp1 = fp2 + get_mi_vector(p1.r.p, fp2, box_geo);
-  auto const fp3 = fp2 + get_mi_vector(p3.r.p, fp2, box_geo);
-  auto const fp4 = fp2 + get_mi_vector(p4.r.p, fp2, box_geo);
+  auto const fp1 = fp2 + box_geo.get_mi_vector(p1.r.p, fp2);
+  auto const fp3 = fp2 + box_geo.get_mi_vector(p3.r.p, fp2);
+  auto const fp4 = fp2 + box_geo.get_mi_vector(p4.r.p, fp2);
 
   Utils::Vector3d force1{}, force2{}, force3{}, force4{};
 

--- a/src/core/observables/BondAngles.hpp
+++ b/src/core/observables/BondAngles.hpp
@@ -43,12 +43,12 @@ public:
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
     std::vector<double> res(n_values());
-    auto v1 = get_mi_vector(traits.position(particles[1]),
-                            traits.position(particles[0]), box_geo);
+    auto v1 = box_geo.get_mi_vector(traits.position(particles[1]),
+                                    traits.position(particles[0]));
     auto n1 = v1.norm();
     for (size_t i = 0, end = n_values(); i < end; i++) {
-      auto v2 = get_mi_vector(traits.position(particles[i + 2]),
-                              traits.position(particles[i + 1]), box_geo);
+      auto v2 = box_geo.get_mi_vector(traits.position(particles[i + 2]),
+                                      traits.position(particles[i + 1]));
       auto n2 = v2.norm();
       auto cosine = (v1 * v2) / (n1 * n2);
       // sanitize cosine value

--- a/src/core/observables/BondDihedrals.hpp
+++ b/src/core/observables/BondDihedrals.hpp
@@ -49,14 +49,14 @@ public:
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
     std::vector<double> res(n_values());
-    auto v1 = get_mi_vector(traits.position(particles[1]),
-                            traits.position(particles[0]), box_geo);
-    auto v2 = get_mi_vector(traits.position(particles[2]),
-                            traits.position(particles[1]), box_geo);
+    auto v1 = box_geo.get_mi_vector(traits.position(particles[1]),
+                                    traits.position(particles[0]));
+    auto v2 = box_geo.get_mi_vector(traits.position(particles[2]),
+                                    traits.position(particles[1]));
     auto c1 = Utils::vector_product(v1, v2);
     for (size_t i = 0, end = n_values(); i < end; i++) {
-      auto v3 = get_mi_vector(traits.position(particles[i + 3]),
-                              traits.position(particles[i + 2]), box_geo);
+      auto v3 = box_geo.get_mi_vector(traits.position(particles[i + 3]),
+                                      traits.position(particles[i + 2]));
       auto c2 = vector_product(v2, v3);
       /* the 2-argument arctangent returns an angle in the range [-pi, pi] that
        * allows for an unambiguous determination of the 4th particle position */

--- a/src/core/observables/CosPersistenceAngles.hpp
+++ b/src/core/observables/CosPersistenceAngles.hpp
@@ -47,8 +47,8 @@ public:
     auto const no_of_bonds = n_values() + 1;
     std::vector<Utils::Vector3d> bond_vectors(no_of_bonds);
     auto get_bond_vector = [&](auto index) {
-      return get_mi_vector(traits.position(particles[index + 1]),
-                           traits.position(particles[index]), box_geo);
+      return box_geo.get_mi_vector(traits.position(particles[index + 1]),
+                                   traits.position(particles[index]));
     };
     for (size_t i = 0; i < no_of_bonds; ++i) {
       auto const tmp = get_bond_vector(i);

--- a/src/core/observables/ParticleDistances.hpp
+++ b/src/core/observables/ParticleDistances.hpp
@@ -45,8 +45,8 @@ public:
     std::vector<double> res(n_values());
 
     for (size_t i = 0, end = n_values(); i < end; i++) {
-      auto const v = get_mi_vector(traits.position(particles[i]),
-                                   traits.position(particles[i + 1]), box_geo);
+      auto const v = box_geo.get_mi_vector(traits.position(particles[i]),
+                                           traits.position(particles[i + 1]));
       res[i] = v.norm();
     }
     return res;

--- a/src/core/observables/RDF.cpp
+++ b/src/core/observables/RDF.cpp
@@ -59,7 +59,7 @@ RDF::evaluate(Utils::Span<const Particle *const> particles1,
   long int cnt = 0;
   auto op = [=, &cnt, &res](const Particle *const p1,
                             const Particle *const p2) {
-    auto const dist = get_mi_vector(p1->r.p, p2->r.p, box_geo).norm();
+    auto const dist = box_geo.get_mi_vector(p1->r.p, p2->r.p).norm();
     if (dist > min_r && dist < max_r) {
       auto const ind =
           static_cast<int>(std::floor((dist - min_r) * inv_bin_width));

--- a/src/core/pair_criteria/pair_criteria.hpp
+++ b/src/core/pair_criteria/pair_criteria.hpp
@@ -48,7 +48,7 @@ public:
 class DistanceCriterion : public PairCriterion {
 public:
   bool decide(const Particle &p1, const Particle &p2) const override {
-    return get_mi_vector(p1.r.p, p2.r.p, box_geo).norm() <= m_cut_off;
+    return box_geo.get_mi_vector(p1.r.p, p2.r.p).norm() <= m_cut_off;
   };
   double get_cut_off() { return m_cut_off; }
   void set_cut_off(double c) { m_cut_off = c; }
@@ -62,7 +62,7 @@ class EnergyCriterion : public PairCriterion {
 public:
   bool decide(const Particle &p1, const Particle &p2) const override {
     // Distance between particles
-    auto const vec21 = get_mi_vector(p1.r.p, p2.r.p, box_geo);
+    auto const vec21 = box_geo.get_mi_vector(p1.r.p, p2.r.p);
     const double dist_betw_part = vec21.norm();
 
     // Interaction parameters for particle types

--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -111,7 +111,7 @@ is_valid_position(Utils::Vector3d const &pos,
 
     for (auto const &p : positions) {
       for (auto const &m : p) {
-        if (get_mi_vector(pos, m, box_geo).norm() < min_distance) {
+        if (box_geo.get_mi_vector(pos, m).norm() < min_distance) {
           return false;
         }
       }

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -96,7 +96,7 @@ inline void add_non_bonded_pair_virials(Particle const &p1, Particle const &p2,
 boost::optional<Utils::Matrix<double, 3, 3>>
 calc_bonded_virial_pressure_tensor(Bonded_IA_Parameters const &iaparams,
                                    Particle const &p1, Particle const &p2) {
-  auto const dx = get_mi_vector(p1.r.p, p2.r.p, box_geo);
+  auto const dx = box_geo.get_mi_vector(p1.r.p, p2.r.p);
   auto const result = calc_bond_pair_force(p1, p2, iaparams, dx);
   if (result) {
     auto const &force = result.get();
@@ -117,8 +117,8 @@ calc_bonded_three_body_pressure_tensor(Bonded_IA_Parameters const &iaparams,
       (boost::get<TabulatedAngleBond>(&iaparams) != nullptr) ||
 #endif
       (boost::get<AngleCossquareBond>(&iaparams) != nullptr)) {
-    auto const dx21 = -get_mi_vector(p1.r.p, p2.r.p, box_geo);
-    auto const dx31 = get_mi_vector(p3.r.p, p1.r.p, box_geo);
+    auto const dx21 = -box_geo.get_mi_vector(p1.r.p, p2.r.p);
+    auto const dx31 = box_geo.get_mi_vector(p3.r.p, p1.r.p);
 
     auto const result = calc_bonded_three_body_force(iaparams, p1, p2, p3);
     if (result) {

--- a/src/core/rattle.cpp
+++ b/src/core/rattle.cpp
@@ -70,12 +70,12 @@ static void init_correction_vector(const ParticleRange &particles,
  */
 static bool calculate_positional_correction(RigidBond const &ia_params,
                                             Particle &p1, Particle &p2) {
-  auto const r_ij = get_mi_vector(p1.r.p, p2.r.p, box_geo);
+  auto const r_ij = box_geo.get_mi_vector(p1.r.p, p2.r.p);
   auto const r_ij2 = r_ij.norm2();
 
   if (std::abs(1.0 - r_ij2 / ia_params.d2) > ia_params.p_tol) {
     auto const r_ij_t =
-        get_mi_vector(p1.r.p_last_timestep, p2.r.p_last_timestep, box_geo);
+        box_geo.get_mi_vector(p1.r.p_last_timestep, p2.r.p_last_timestep);
     auto const r_ij_dot = r_ij_t * r_ij;
     auto const G =
         0.50 * (ia_params.d2 - r_ij2) / r_ij_dot / (p1.p.mass + p2.p.mass);
@@ -174,7 +174,7 @@ void correct_position_shake(CellStructure &cs) {
 static bool calculate_velocity_correction(RigidBond const &ia_params,
                                           Particle &p1, Particle &p2) {
   auto const v_ij = p1.m.v - p2.m.v;
-  auto const r_ij = get_mi_vector(p1.r.p, p2.r.p, box_geo);
+  auto const r_ij = box_geo.get_mi_vector(p1.r.p, p2.r.p);
 
   auto const v_proj = v_ij * r_ij;
   if (std::abs(v_proj) > ia_params.v_tol) {

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -69,8 +69,8 @@ double mindist(PartCfg &partCfg, const std::vector<int> &set1,
        * versa. */
       if (((in_set & 1u) && (set2.empty() || contains(set2, it->p.type))) ||
           ((in_set & 2u) && (set1.empty() || contains(set1, it->p.type))))
-        mindist2 = std::min(mindist2,
-                            get_mi_vector(jt->r.p, it->r.p, box_geo).norm2());
+        mindist2 =
+            std::min(mindist2, box_geo.get_mi_vector(jt->r.p, it->r.p).norm2());
   }
 
   return std::sqrt(mindist2);
@@ -171,7 +171,7 @@ std::vector<int> nbhood(PartCfg &partCfg, const Utils::Vector3d &pos,
 
   for (auto const &p : partCfg) {
     if ((planedims[0] + planedims[1] + planedims[2]) == 3) {
-      d = get_mi_vector(pt, p.r.p, box_geo);
+      d = box_geo.get_mi_vector(pt, p.r.p);
     } else {
       /* Calculate the in plane distance */
       for (int j = 0; j < 3; j++) {
@@ -192,7 +192,7 @@ double distto(PartCfg &partCfg, const Utils::Vector3d &pos, int pid) {
 
   for (auto const &part : partCfg) {
     if (pid != part.p.identity) {
-      auto const d = get_mi_vector({pos[0], pos[1], pos[2]}, part.r.p, box_geo);
+      auto const d = box_geo.get_mi_vector({pos[0], pos[1], pos[2]}, part.r.p);
       mindist = std::min(mindist, d.norm2());
     }
   }
@@ -229,7 +229,7 @@ void calc_part_distribution(PartCfg &partCfg, std::vector<int> const &p1_types,
             for (int t2 : p2_types) {
               if (p2.p.type == t2) {
                 auto const act_dist2 =
-                    get_mi_vector(p1.r.p, p2.r.p, box_geo).norm2();
+                    box_geo.get_mi_vector(p1.r.p, p2.r.p).norm2();
                 if (act_dist2 < min_dist2) {
                   min_dist2 = act_dist2;
                 }

--- a/src/core/unit_tests/BoxGeometry_test.cpp
+++ b/src/core/unit_tests/BoxGeometry_test.cpp
@@ -57,15 +57,21 @@ BOOST_AUTO_TEST_CASE(length_test) {
     auto const box = BoxGeometry{};
 
     BOOST_CHECK(Utils::Vector3d::broadcast(1.) == box.length());
+    BOOST_CHECK(Utils::Vector3d::broadcast(1.) == box.length_inv());
+    BOOST_CHECK(Utils::Vector3d::broadcast(0.5) == box.length_half());
   }
 
   /* setter */
   {
     auto box = BoxGeometry{};
     auto const box_l = Utils::Vector3d{1., 2., 3.};
+    auto const box_l_inv =
+        Utils::Vector3d{1. / box_l[0], 1. / box_l[1], 1. / box_l[2]};
 
     box.set_length(box_l);
 
     BOOST_CHECK(box.length() == box_l);
+    BOOST_CHECK(box.length_inv() == box_l_inv);
+    BOOST_CHECK(box.length_half() == 0.5 * box_l);
   }
 }

--- a/src/core/unit_tests/grid_test.cpp
+++ b/src/core/unit_tests/grid_test.cpp
@@ -32,6 +32,8 @@
 template <class T> auto const epsilon = std::numeric_limits<T>::epsilon();
 
 BOOST_AUTO_TEST_CASE(get_mi_coord_test) {
+  using detail::get_mi_coord;
+
   auto const box_l = 3.1415;
 
   /* Non-periodic */
@@ -112,6 +114,7 @@ BOOST_AUTO_TEST_CASE(get_mi_coord_test) {
 }
 
 BOOST_AUTO_TEST_CASE(get_mi_vector_test) {
+  using detail::get_mi_coord;
   using Utils::Vector3d;
 
   Vector3d box_l = {1., 2., 3.};
@@ -122,7 +125,7 @@ BOOST_AUTO_TEST_CASE(get_mi_vector_test) {
   auto const a = Vector3d{1.1, 12.2, -13.4};
   auto const b = Vector3d{-0.9, 8.8, 21.1};
 
-  auto const result = get_mi_vector(a, b, box);
+  auto const result = box.get_mi_vector(a, b);
 
   for (int i = 0; i < 3; i++) {
     auto const expected = get_mi_coord(a[i], b[i], box_l[i], box.periodic(i));

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -58,7 +58,7 @@ inline std::tuple<Utils::Quaternion<double>, double>
 calculate_vs_relate_to_params(Particle const &p_current,
                               Particle const &p_relate_to) {
   // get the distance between the particles
-  Utils::Vector3d d = get_mi_vector(p_current.r.p, p_relate_to.r.p, box_geo);
+  Utils::Vector3d d = box_geo.get_mi_vector(p_current.r.p, p_relate_to.r.p);
 
   // Check if the distance between virtual and non-virtual particles is larger
   // than minimum global cutoff. If so, warn user.

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -162,7 +162,7 @@ void VirtualSitesRelative::update() const {
     /* The shift has to respect periodic boundaries: if the reference
      * particles is not in the same image box, we potentially avoid to shift
      * to the other side of the box. */
-    p.r.p += get_mi_vector(new_pos, p.r.p, box_geo);
+    p.r.p += box_geo.get_mi_vector(new_pos, p.r.p);
 
     p.m.v = velocity(p_ref, p.p.vs_relative);
 

--- a/src/python/espressomd/grid.pxd
+++ b/src/python/espressomd/grid.pxd
@@ -26,9 +26,9 @@ cdef extern from "grid.hpp":
         bool periodic(unsigned coord)
         const Vector3d & length()
         void set_length(Vector3d)
+        Vector3d get_mi_vector(Vector3d, Vector3d)
 
     BoxGeometry box_geo
 
-    Vector3d get_mi_vector(Vector3d, Vector3d, const BoxGeometry & )
     Vector3d folded_position(Vector3d, const BoxGeometry &)
     Vector3d unfolded_position(Vector3d, Vector3i, const Vector3d & )

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -22,7 +22,7 @@ include "myconfig.pxi"
 import numpy as np
 import collections
 
-from .grid cimport get_mi_vector, box_geo
+from .grid cimport box_geo
 from . cimport integrate
 from . import interactions
 from . import integrate
@@ -380,7 +380,7 @@ cdef class System:
             check_type_or_throw_except(
                 p2, 3, float, "p2 must be a particle or 3 floats")
             pos2 = make_Vector3d(p2)
-        cdef Vector3d mi_vec = get_mi_vector(pos2, pos1, box_geo)
+        cdef Vector3d mi_vec = box_geo.get_mi_vector(pos2, pos1)
 
         return make_array_locked(mi_vec)
 

--- a/src/python/espressomd/visualization_mayavi.pyx
+++ b/src/python/espressomd/visualization_mayavi.pyx
@@ -23,7 +23,7 @@ from .particle_data import ParticleHandle
 from .particle_data cimport *
 from .interactions import NonBondedInteractions
 from .interactions cimport IA_parameters, get_ia_param
-from .grid cimport get_mi_vector, box_geo
+from .grid cimport box_geo
 from .utils cimport make_array_locked
 
 include "myconfig.pxi"
@@ -245,7 +245,7 @@ cdef class mayaviLive:
             p1 = &get_particle_data(i)
             p2 = &get_particle_data(j)
             bond_coords[n, :3] = numpy.array([p1.r.p[0], p1.r.p[1], p1.r.p[2]])
-            bond_coords[n, 3:6] = make_array_locked( < const Vector3d > get_mi_vector(Vector3d(p2.r.p), Vector3d(p1.r.p), box_geo))
+            bond_coords[n, 3:6] = make_array_locked( < const Vector3d > box_geo.get_mi_vector(Vector3d(p2.r.p), Vector3d(p1.r.p)))
             bond_coords[n, 6] = t
 
         boxl = self.system.box_l


### PR DESCRIPTION
Fixes #3247

Description of changes:
- introduced `m_length_inv` and `m_length_half` in `BoxGeometry` with interfaces and unittest
- introduced `get_mi_vector` and `get_mi_coord` member functions using the pre-calculated values
- moved implementation of `get_mi_coord` into `detail`-namespace together with overload for old signature
