### PR TITLE
Fix GitHub Actions deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   deploy_docs:
     runs-on: ubuntu-20.04
-    if: github.event_name == 'schedule_deploy'
     environment: deploy_documentation
     steps:
       - name: Install pandoc


### PR DESCRIPTION
The deploy job is currently skipped because the event name is incorrect.