### PR TITLE
ScriptInterface small fixes

### DIFF
--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -51,7 +51,8 @@ cdef class PScriptInterface:
     \*\*kwargs
         Parameters for the core class constructor (method 2).
     policy : :obj:`str`, \{'GLOBAL', 'LOCAL'\}
-        Creation policy.
+        Creation policy. The managed object exists either on all MPI nodes
+        with 'GLOBAL' (default), or only on the head node with 'LOCAL'.
 
     Attributes
     ----------

--- a/src/script_interface/ObjectList.hpp
+++ b/src/script_interface/ObjectList.hpp
@@ -19,8 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_REGISTRY_HPP
-#define SCRIPT_INTERFACE_REGISTRY_HPP
+#ifndef SCRIPT_INTERFACE_OBJECT_LIST_HPP
+#define SCRIPT_INTERFACE_OBJECT_LIST_HPP
 
 #include "script_interface/ScriptInterface.hpp"
 #include "script_interface/get_value.hpp"
@@ -60,7 +60,7 @@ public:
   /**
    * @brief Removes all occurrences of an element from the list.
    *
-   * @param element The element to add.
+   * @param element The element to remove.
    */
   void remove(std::shared_ptr<ManagedType> const &element) {
     remove_in_core(element);

--- a/src/script_interface/ObjectList.hpp
+++ b/src/script_interface/ObjectList.hpp
@@ -93,6 +93,7 @@ protected:
           get_value<std::shared_ptr<ManagedType>>(parameters.at("object"));
 
       add(obj_ptr);
+      return none;
     }
 
     if (method == "remove") {
@@ -100,6 +101,7 @@ protected:
           get_value<std::shared_ptr<ManagedType>>(parameters.at("object"));
 
       remove(obj_ptr);
+      return none;
     }
 
     if (method == "get_elements") {
@@ -114,6 +116,7 @@ protected:
 
     if (method == "clear") {
       clear();
+      return none;
     }
 
     if (method == "size") {

--- a/src/script_interface/tests/ObjectList_test.cpp
+++ b/src/script_interface/tests/ObjectList_test.cpp
@@ -26,6 +26,10 @@
 #include "script_interface/LocalContext.hpp"
 #include "script_interface/ObjectList.hpp"
 
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 using namespace ScriptInterface;
 
 struct ObjectListImpl : ObjectList<ObjectHandle> {
@@ -75,6 +79,7 @@ BOOST_AUTO_TEST_CASE(clearing_elements) {
   list.add(ObjectRef{});
   list.clear();
   BOOST_CHECK(list.elements().empty());
+  BOOST_CHECK(list.mock_core.empty());
 }
 
 BOOST_AUTO_TEST_CASE(serialization) {


### PR DESCRIPTION
Preparing the ground for #4225.

Description of changes:
- document the creation policy of script interface objects
- guard against double parsing in `ObjectList::do_call_method()`
