### PR TITLE
Pass time step and temperature as function arguments

### DIFF
--- a/src/core/accumulators/Correlator.hpp
+++ b/src/core/accumulators/Correlator.hpp
@@ -155,7 +155,7 @@ public:
              obs_ptr obs2, Utils::Vector3d correlation_args_ = {})
       : AccumulatorBase(delta_N), finalized(false), t(0),
         m_correlation_args(correlation_args_), m_tau_lin(tau_lin),
-        m_dt(delta_N * time_step), m_tau_max(tau_max),
+        m_dt(delta_N * get_time_step()), m_tau_max(tau_max),
         compressA_name(std::move(compress1_)),
         compressB_name(std::move(compress2_)),
         corr_operation_name(std::move(corr_operation)), A_obs(std::move(obs1)),

--- a/src/core/bonded_interactions/thermalized_bond.cpp
+++ b/src/core/bonded_interactions/thermalized_bond.cpp
@@ -24,6 +24,8 @@
  */
 
 #include "thermalized_bond.hpp"
+
+#include "event.hpp"
 #include "global.hpp"
 #include "integrate.hpp"
 
@@ -47,4 +49,5 @@ ThermalizedBond::ThermalizedBond(double temp_com, double gamma_com,
 
   n_thermalized_bonds += 1;
   mpi_bcast_parameter(FIELD_THERMALIZEDBONDS);
+  on_parameter_change(FIELD_THERMALIZEDBONDS);
 }

--- a/src/core/bonded_interactions/thermalized_bond.cpp
+++ b/src/core/bonded_interactions/thermalized_bond.cpp
@@ -27,7 +27,6 @@
 
 #include "event.hpp"
 #include "global.hpp"
-#include "integrate.hpp"
 
 #include <cmath>
 
@@ -42,10 +41,10 @@ ThermalizedBond::ThermalizedBond(double temp_com, double gamma_com,
   this->gamma_distance = gamma_distance;
   this->r_cut = r_cut;
 
-  pref1_com = gamma_com;
-  pref2_com = std::sqrt(24.0 * gamma_com / time_step * temp_com);
-  pref1_dist = gamma_distance;
-  pref2_dist = std::sqrt(24.0 * gamma_distance / time_step * temp_distance);
+  pref1_com = -1.;
+  pref2_com = -1.;
+  pref1_dist = -1.;
+  pref2_dist = -1.;
 
   n_thermalized_bonds += 1;
   mpi_bcast_parameter(FIELD_THERMALIZEDBONDS);

--- a/src/core/bonded_interactions/thermalized_bond_utils.cpp
+++ b/src/core/bonded_interactions/thermalized_bond_utils.cpp
@@ -27,7 +27,7 @@
 
 #include <boost/variant.hpp>
 
-void thermalized_bond_init() {
+void thermalized_bond_init(double time_step) {
   for (auto &bonded_ia_param : bonded_ia_params) {
     if (auto *t = boost::get<ThermalizedBond>(&bonded_ia_param)) {
       t->pref1_com = t->gamma_com;

--- a/src/core/bonded_interactions/thermalized_bond_utils.hpp
+++ b/src/core/bonded_interactions/thermalized_bond_utils.hpp
@@ -26,6 +26,6 @@
  *
  *  Implementation in \ref thermalized_bond_utils.cpp.
  */
-void thermalized_bond_init();
+void thermalized_bond_init(double time_step);
 
 #endif

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -77,15 +77,15 @@ int dpd_set_params(int part_type_a, int part_type_b, double gamma, double k,
   return ES_OK;
 }
 
-void dpd_init(double time_step) {
+void dpd_init(double kT, double time_step) {
   for (int type_a = 0; type_a < max_seen_particle_type; type_a++) {
     for (int type_b = 0; type_b < max_seen_particle_type; type_b++) {
       IA_parameters &ia_params = *get_ia_param(type_a, type_b);
 
       ia_params.dpd_radial.pref =
-          sqrt(24.0 * temperature * ia_params.dpd_radial.gamma / time_step);
+          sqrt(24.0 * kT * ia_params.dpd_radial.gamma / time_step);
       ia_params.dpd_trans.pref =
-          sqrt(24.0 * temperature * ia_params.dpd_trans.gamma / time_step);
+          sqrt(24.0 * kT * ia_params.dpd_trans.gamma / time_step);
     }
   }
 }

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -68,10 +68,8 @@ int dpd_set_params(int part_type_a, int part_type_b, double gamma, double k,
                    double r_c, int wf, double tgamma, double tr_c, int twf) {
   IA_parameters &ia_params = *get_ia_param_safe(part_type_a, part_type_b);
 
-  ia_params.dpd_radial = DPDParameters{
-      gamma, k, r_c, wf, sqrt(24.0 * temperature * gamma / time_step)};
-  ia_params.dpd_trans = DPDParameters{
-      tgamma, k, tr_c, twf, sqrt(24.0 * temperature * tgamma / time_step)};
+  ia_params.dpd_radial = DPDParameters{gamma, k, r_c, wf, -1.};
+  ia_params.dpd_trans = DPDParameters{tgamma, k, tr_c, twf, -1.};
 
   /* broadcast interaction parameters */
   mpi_bcast_ia_params(part_type_a, part_type_b);
@@ -79,7 +77,7 @@ int dpd_set_params(int part_type_a, int part_type_b, double gamma, double k,
   return ES_OK;
 }
 
-void dpd_init() {
+void dpd_init(double time_step) {
   for (int type_a = 0; type_a < max_seen_particle_type; type_a++) {
     for (int type_b = 0; type_b < max_seen_particle_type; type_b++) {
       IA_parameters &ia_params = *get_ia_param(type_a, type_b);

--- a/src/core/dpd.hpp
+++ b/src/core/dpd.hpp
@@ -37,7 +37,7 @@ struct IA_parameters;
 
 int dpd_set_params(int part_type_a, int part_type_b, double gamma, double k,
                    double r_c, int wf, double tgamma, double tr_c, int twf);
-void dpd_init();
+void dpd_init(double time_step);
 
 Utils::Vector3d dpd_pair_force(Particle const &p1, Particle const &p2,
                                IA_parameters const &ia_params,

--- a/src/core/dpd.hpp
+++ b/src/core/dpd.hpp
@@ -37,7 +37,7 @@ struct IA_parameters;
 
 int dpd_set_params(int part_type_a, int part_type_b, double gamma, double k,
                    double r_c, int wf, double tgamma, double tr_c, int twf);
-void dpd_init(double time_step);
+void dpd_init(double kT, double time_step);
 
 Utils::Vector3d dpd_pair_force(Particle const &p1, Particle const &p2,
                                IA_parameters const &ia_params,

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -105,7 +105,7 @@ void energy_calc(const double time) {
   }
 }
 
-void update_energy_local(int, int) { energy_calc(sim_time); }
+void update_energy_local(int, int) { energy_calc(get_sim_time()); }
 
 REGISTER_CALLBACK(update_energy_local)
 

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -110,11 +110,13 @@ void on_integration_start(double time_step) {
   integrator_npt_sanity_checks();
 #endif
   interactions_sanity_checks();
-  lb_lbfluid_on_integration_start();
+  lb_lbfluid_sanity_checks(time_step);
 
   /********************************************/
   /* end sanity checks                        */
   /********************************************/
+
+  lb_lbfluid_on_integration_start();
 
 #ifdef CUDA
   MPI_Bcast(gpu_get_global_particle_vars_pointer_host(),

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -100,7 +100,7 @@ void on_program_start() {
   }
 }
 
-void on_integration_start() {
+void on_integration_start(double time_step) {
   /********************************************/
   /* sanity checks                            */
   /********************************************/
@@ -123,7 +123,7 @@ void on_integration_start() {
 
   /* Prepare the thermostat */
   if (reinit_thermo) {
-    thermo_init();
+    thermo_init(time_step);
     reinit_thermo = false;
     recalc_forces = true;
   }

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -328,6 +328,7 @@ void on_parameter_change(int field) {
   case FIELD_NPTISO_G0:
   case FIELD_NPTISO_GV:
   case FIELD_NPTISO_PISTON:
+  case FIELD_THERMALIZEDBONDS:
     reinit_thermo = true;
     break;
   case FIELD_FORCE_CAP:
@@ -337,7 +338,6 @@ void on_parameter_change(int field) {
   case FIELD_THERMO_SWITCH:
   case FIELD_LATTICE_SWITCH:
   case FIELD_RIGIDBONDS:
-  case FIELD_THERMALIZEDBONDS:
     break;
   case FIELD_SIMTIME:
     recalc_forces = true;

--- a/src/core/event.hpp
+++ b/src/core/event.hpp
@@ -54,7 +54,7 @@ void on_program_start();
 /** called every time the simulation is continued/started, i.e.
  *  when switching from the script interface to the simulation core.
  */
-void on_integration_start();
+void on_integration_start(double time_step);
 
 /** called before calculating observables, i.e. energy, pressure or
  *  the integrator (forces). Initialize any methods here which are not

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -155,7 +155,7 @@ void force_calc(CellStructure &cell_structure, double time_step) {
   immersed_boundaries.volume_conservation(cell_structure);
 
   lb_lbcoupling_calc_particle_lattice_ia(thermo_virtual, particles,
-                                         ghost_particles);
+                                         ghost_particles, time_step);
 
 #ifdef CUDA
   copy_forces_from_GPU(particles);

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -53,7 +53,7 @@
 
 ActorList forceActors;
 
-void init_forces(const ParticleRange &particles, double time_step) {
+void init_forces(const ParticleRange &particles, double time_step, double kT) {
   ESPRESSO_PROFILER_CXX_MARK_FUNCTION;
   /* The force initialization depends on the used thermostat and the
      thermodynamic ensemble */
@@ -67,7 +67,7 @@ void init_forces(const ParticleRange &particles, double time_step) {
      set torque to zero for all and rescale quaternions
   */
   for (auto &p : particles) {
-    p.f = init_local_particle_force(p, time_step);
+    p.f = init_local_particle_force(p, time_step, kT);
   }
 
   /* initialize ghost forces with zero
@@ -84,7 +84,7 @@ void init_forces_ghosts(const ParticleRange &particles) {
   }
 }
 
-void force_calc(CellStructure &cell_structure, double time_step) {
+void force_calc(CellStructure &cell_structure, double time_step, double kT) {
   ESPRESSO_PROFILER_CXX_MARK_FUNCTION;
 
   espressoSystemInterface.update();
@@ -98,7 +98,7 @@ void force_calc(CellStructure &cell_structure, double time_step) {
 #ifdef ELECTROSTATICS
   icc_iteration(particles, cell_structure.ghost_particles());
 #endif
-  init_forces(particles, time_step);
+  init_forces(particles, time_step, kT);
 
   for (auto &forceActor : forceActors) {
     forceActor->computeForces(espressoSystemInterface);

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -134,7 +134,7 @@ void force_calc(CellStructure &cell_structure, double time_step) {
       VerletCriterion{skin, interaction_range(), coulomb_cutoff, dipole_cutoff,
                       collision_detection_cutoff()});
 
-  Constraints::constraints.add_forces(particles, sim_time);
+  Constraints::constraints.add_forces(particles, get_sim_time());
 
   if (max_oif_objects) {
     // There are two global quantities that need to be evaluated:

--- a/src/core/forces.hpp
+++ b/src/core/forces.hpp
@@ -55,7 +55,7 @@ void init_forces_ghosts(const ParticleRange &particles);
  *  <li> Calculate long range interaction forces
  *  </ol>
  */
-void force_calc(CellStructure &cell_structure, double time_step);
+void force_calc(CellStructure &cell_structure, double time_step, double kT);
 
 /** Calculate long range forces (P3M, ...). */
 void calc_long_range_forces(const ParticleRange &particles);

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -100,27 +100,28 @@ inline ParticleForce external_force(Particle const &p) {
   return f;
 }
 
-inline ParticleForce thermostat_force(Particle const &p, double time_step) {
+inline ParticleForce thermostat_force(Particle const &p, double time_step,
+                                      double kT) {
   extern LangevinThermostat langevin;
   if (!(thermo_switch & THERMO_LANGEVIN)) {
     return {};
   }
 
 #ifdef ROTATION
-  return {friction_thermo_langevin(langevin, p, time_step),
+  return {friction_thermo_langevin(langevin, p, time_step, kT),
           p.p.rotation ? convert_vector_body_to_space(
-                             p, friction_thermo_langevin_rotation(langevin, p,
-                                                                  time_step))
+                             p, friction_thermo_langevin_rotation(
+                                    langevin, p, time_step, kT))
                        : Utils::Vector3d{}};
 #else
-  return friction_thermo_langevin(langevin, p, time_step);
+  return friction_thermo_langevin(langevin, p, time_step, kT);
 #endif
 }
 
 /** Initialize the forces for a real particle */
 inline ParticleForce init_local_particle_force(Particle const &part,
-                                               double time_step) {
-  return thermostat_force(part, time_step) + external_force(part);
+                                               double time_step, double kT) {
+  return thermostat_force(part, time_step, kT) + external_force(part);
 }
 
 inline ParticleForce calc_non_bonded_pair_force(Particle const &p1,

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -983,7 +983,7 @@ void lb_collide_stream() {
  *  for the lattice dynamics can be coarser than the MD time step, we
  *  monitor the time since the last lattice update.
  */
-void lattice_boltzmann_update() {
+void lattice_boltzmann_update(double time_step) {
   auto const factor = static_cast<int>(round(lbpar.tau / time_step));
 
   fluidstep += 1;

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -35,7 +35,6 @@
 #include "grid.hpp"
 #include "grid_based_algorithms/lb_boundaries.hpp"
 #include "halo.hpp"
-#include "integrate.hpp"
 #include "lb-d3q19.hpp"
 #include "random.hpp"
 
@@ -983,13 +982,10 @@ void lb_collide_stream() {
  *  for the lattice dynamics can be coarser than the MD time step, we
  *  monitor the time since the last lattice update.
  */
-void lattice_boltzmann_update(double time_step) {
-  auto const factor = static_cast<int>(round(lbpar.tau / time_step));
-
+void lattice_boltzmann_update(int lb_steps_per_md_step) {
   fluidstep += 1;
-  if (fluidstep >= factor) {
+  if (fluidstep >= lb_steps_per_md_step) {
     fluidstep = 0;
-
     lb_collide_stream();
   }
 }

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -186,11 +186,6 @@ std::vector<LB_FluidNode> lbfields;
 
 HaloCommunicator update_halo_comm = HaloCommunicator(0);
 
-/** measures the MD time since the last fluid update */
-static double fluidstep = 0.0;
-
-/********************** The Main LB Part *************************************/
-
 /**
  * @brief Initialize fluid nodes.
  * @param[out] fields         Vector containing the fluid nodes
@@ -900,7 +895,7 @@ void lb_stream(LB_Fluid &lb_fluid, const std::array<T, 19> &populations,
 }
 
 /* Collisions and streaming (push scheme) */
-void lb_collide_stream() {
+void lb_integrate() {
   ESPRESSO_PROFILER_CXX_MARK_FUNCTION;
   /* loop over all lattice cells (halo excluded) */
 #ifdef LB_BOUNDARIES
@@ -974,20 +969,6 @@ void lb_collide_stream() {
 #ifdef ADDITIONAL_CHECKS
   lb_check_halo_regions(lbfluid, lblattice);
 #endif
-}
-
-/** Update the lattice Boltzmann fluid.
- *
- *  This function is called from the integrator. Since the time step
- *  for the lattice dynamics can be coarser than the MD time step, we
- *  monitor the time since the last lattice update.
- */
-void lattice_boltzmann_update(int lb_steps_per_md_step) {
-  fluidstep += 1;
-  if (fluidstep >= lb_steps_per_md_step) {
-    fluidstep = 0;
-    lb_collide_stream();
-  }
 }
 
 /***********************************************************************/

--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -183,7 +183,7 @@ extern std::vector<LB_FluidNode> lbfields;
  *  collisions. If boundaries are present, it also applies the boundary
  *  conditions.
  */
-void lattice_boltzmann_update(double time_step);
+void lattice_boltzmann_update(int lb_steps_per_md_step);
 
 void lb_sanity_checks(const LB_Parameters &lb_parameters);
 

--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -183,7 +183,7 @@ extern std::vector<LB_FluidNode> lbfields;
  *  collisions. If boundaries are present, it also applies the boundary
  *  conditions.
  */
-void lattice_boltzmann_update();
+void lattice_boltzmann_update(double time_step);
 
 void lb_sanity_checks(const LB_Parameters &lb_parameters);
 

--- a/src/core/grid_based_algorithms/lb.hpp
+++ b/src/core/grid_based_algorithms/lb.hpp
@@ -24,8 +24,7 @@
  *
  *  For performance reasons it is clever to do streaming and collision at the
  *  same time because every fluid node has to be read and written only once.
- *  This increases mainly cache efficiency. This is achieved by
- *  @ref lb_collide_stream.
+ *  This increases mainly cache efficiency.
  *
  *  The hydrodynamic fields, corresponding to density, velocity and pressure,
  *  are stored in @ref LB_FluidNode in the array @ref lbfields, the populations
@@ -177,13 +176,13 @@ extern std::vector<LB_FluidNode> lbfields;
 /************************************************************/
 /**@{*/
 
-/** Update the lattice Boltzmann system for one time step.
+/** Integrate the lattice-Boltzmann system for one time step.
  *  This function performs the collision step and the streaming step.
  *  If external force densities are present, they are applied prior to the
  *  collisions. If boundaries are present, it also applies the boundary
  *  conditions.
  */
-void lattice_boltzmann_update(int lb_steps_per_md_step);
+void lb_integrate();
 
 void lb_sanity_checks(const LB_Parameters &lb_parameters);
 

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -52,9 +52,9 @@ struct NoLBActive : public std::exception {
   const char *what() const noexcept override { return "LB not activated"; }
 };
 
-void lb_lbfluid_update() {
+void lb_lbfluid_update(double time_step) {
   if (lattice_switch == ActiveLB::CPU) {
-    lattice_boltzmann_update();
+    lattice_boltzmann_update(time_step);
   } else if (lattice_switch == ActiveLB::GPU and this_node == 0) {
 #ifdef CUDA
 #ifdef ELECTROKINETICS
@@ -62,7 +62,7 @@ void lb_lbfluid_update() {
       ek_integrate();
     } else {
 #endif
-      lattice_boltzmann_update_gpu();
+      lattice_boltzmann_update_gpu(time_step);
 #ifdef ELECTROKINETICS
     }
 #endif
@@ -70,9 +70,9 @@ void lb_lbfluid_update() {
   }
 }
 
-void lb_lbfluid_propagate() {
+void lb_lbfluid_propagate(double time_step) {
   if (lattice_switch != ActiveLB::NONE) {
-    lb_lbfluid_update();
+    lb_lbfluid_update(time_step);
     if (lb_lbfluid_get_kT() > 0.0) {
       if (lattice_switch == ActiveLB::GPU) {
 #ifdef CUDA

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -70,11 +70,9 @@ void lb_lbfluid_integrate() {
   }
 }
 
-void lb_lbfluid_propagate(bool integrate_lb) {
+void lb_lbfluid_propagate() {
   if (lattice_switch != ActiveLB::NONE) {
-    if (integrate_lb) {
-      lb_lbfluid_integrate();
-    }
+    lb_lbfluid_integrate();
     if (lb_lbfluid_get_kT() > 0.0) {
       if (lattice_switch == ActiveLB::GPU) {
 #ifdef CUDA

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -52,9 +52,9 @@ struct NoLBActive : public std::exception {
   const char *what() const noexcept override { return "LB not activated"; }
 };
 
-void lb_lbfluid_update(int lb_steps_per_md_step) {
+void lb_lbfluid_integrate() {
   if (lattice_switch == ActiveLB::CPU) {
-    lattice_boltzmann_update(lb_steps_per_md_step);
+    lb_integrate();
   } else if (lattice_switch == ActiveLB::GPU and this_node == 0) {
 #ifdef CUDA
 #ifdef ELECTROKINETICS
@@ -62,7 +62,7 @@ void lb_lbfluid_update(int lb_steps_per_md_step) {
       ek_integrate();
     } else {
 #endif
-      lattice_boltzmann_update_gpu(lb_steps_per_md_step);
+      lb_integrate_GPU();
 #ifdef ELECTROKINETICS
     }
 #endif
@@ -70,9 +70,11 @@ void lb_lbfluid_update(int lb_steps_per_md_step) {
   }
 }
 
-void lb_lbfluid_propagate(int lb_steps_per_md_step) {
+void lb_lbfluid_propagate(bool integrate_lb) {
   if (lattice_switch != ActiveLB::NONE) {
-    lb_lbfluid_update(lb_steps_per_md_step);
+    if (integrate_lb) {
+      lb_lbfluid_integrate();
+    }
     if (lb_lbfluid_get_kT() > 0.0) {
       if (lattice_switch == ActiveLB::GPU) {
 #ifdef CUDA

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -52,9 +52,9 @@ struct NoLBActive : public std::exception {
   const char *what() const noexcept override { return "LB not activated"; }
 };
 
-void lb_lbfluid_update(double time_step) {
+void lb_lbfluid_update(int lb_steps_per_md_step) {
   if (lattice_switch == ActiveLB::CPU) {
-    lattice_boltzmann_update(time_step);
+    lattice_boltzmann_update(lb_steps_per_md_step);
   } else if (lattice_switch == ActiveLB::GPU and this_node == 0) {
 #ifdef CUDA
 #ifdef ELECTROKINETICS
@@ -62,7 +62,7 @@ void lb_lbfluid_update(double time_step) {
       ek_integrate();
     } else {
 #endif
-      lattice_boltzmann_update_gpu(time_step);
+      lattice_boltzmann_update_gpu(lb_steps_per_md_step);
 #ifdef ELECTROKINETICS
     }
 #endif
@@ -70,9 +70,9 @@ void lb_lbfluid_update(double time_step) {
   }
 }
 
-void lb_lbfluid_propagate(double time_step) {
+void lb_lbfluid_propagate(int lb_steps_per_md_step) {
   if (lattice_switch != ActiveLB::NONE) {
-    lb_lbfluid_update(time_step);
+    lb_lbfluid_update(lb_steps_per_md_step);
     if (lb_lbfluid_get_kT() > 0.0) {
       if (lattice_switch == ActiveLB::GPU) {
 #ifdef CUDA
@@ -104,8 +104,7 @@ void lb_boundary_mach_check() {
   }
 }
 
-void lb_lbfluid_sanity_checks() {
-  extern double time_step;
+void lb_lbfluid_sanity_checks(double time_step) {
   if (lattice_switch == ActiveLB::GPU && this_node == 0) {
 #ifdef CUDA
     lb_GPU_sanity_checks();
@@ -123,7 +122,6 @@ void lb_lbfluid_sanity_checks() {
 }
 
 void lb_lbfluid_on_integration_start() {
-  lb_lbfluid_sanity_checks();
   if (lattice_switch == ActiveLB::CPU) {
     halo_communication(update_halo_comm,
                        reinterpret_cast<char *>(lbfluid[0].data()));
@@ -418,18 +416,18 @@ void lb_lbfluid_set_tau(double tau) {
   }
 }
 
-void check_tau_time_step_consistency(double tau, double time_s) {
+void check_tau_time_step_consistency(double tau, double time_step) {
   auto const eps = std::numeric_limits<float>::epsilon();
-  if ((tau - time_s) / (tau + time_s) < -eps)
+  if ((tau - time_step) / (tau + time_step) < -eps)
     throw std::invalid_argument("LB tau (" + std::to_string(tau) +
                                 ") must be >= MD time_step (" +
-                                std::to_string(time_s) + ")");
-  auto const factor = tau / time_s;
+                                std::to_string(time_step) + ")");
+  auto const factor = tau / time_step;
   if (fabs(round(factor) - factor) / factor > eps)
     throw std::invalid_argument("LB tau (" + std::to_string(tau) +
                                 ") must be integer multiple of "
                                 "MD time_step (" +
-                                std::to_string(time_s) + "). Factor is " +
+                                std::to_string(time_step) + "). Factor is " +
                                 std::to_string(factor));
 }
 

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -36,9 +36,8 @@ extern ActiveLB lattice_switch;
 
 /**
  * @brief Propagate the LB fluid.
- * @param integrate_lb Whether to run the collide-stream scheme.
  */
-void lb_lbfluid_propagate(bool integrate_lb);
+void lb_lbfluid_propagate();
 
 /**
  * @brief Event handler for integration start.

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -37,7 +37,7 @@ extern ActiveLB lattice_switch;
 /**
  * @brief Propagate the LB fluid.
  */
-void lb_lbfluid_propagate(double time_step);
+void lb_lbfluid_propagate(int lb_steps_per_md_step);
 
 /**
  * @brief Event handler for integration start.
@@ -133,7 +133,7 @@ void lb_lbfluid_set_kT(double kT);
 /**
  * @brief Perform LB parameter and boundary velocity checks.
  */
-void lb_lbfluid_sanity_checks();
+void lb_lbfluid_sanity_checks(double time_step);
 
 /**
  * @brief Set the LB density for a single node.

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -36,8 +36,9 @@ extern ActiveLB lattice_switch;
 
 /**
  * @brief Propagate the LB fluid.
+ * @param integrate_lb Whether to run the collide-stream scheme.
  */
-void lb_lbfluid_propagate(int lb_steps_per_md_step);
+void lb_lbfluid_propagate(bool integrate_lb);
 
 /**
  * @brief Event handler for integration start.

--- a/src/core/grid_based_algorithms/lb_interface.hpp
+++ b/src/core/grid_based_algorithms/lb_interface.hpp
@@ -37,7 +37,7 @@ extern ActiveLB lattice_switch;
 /**
  * @brief Propagate the LB fluid.
  */
-void lb_lbfluid_propagate();
+void lb_lbfluid_propagate(double time_step);
 
 /**
  * @brief Event handler for integration start.

--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -225,7 +225,7 @@ bool in_local_halo(Vector3d const &pos) {
 }
 
 #ifdef ENGINE
-void add_swimmer_force(Particle &p, double time_step) {
+void add_swimmer_force(Particle const &p, double time_step) {
   if (p.p.swim.swimming) {
     // calculate source position
     const double direction =

--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -122,6 +122,7 @@ namespace {
  * @brief Add a force to the lattice force density.
  * @param pos Position of the force
  * @param force Force in MD units.
+ * @param time_step MD time step.
  */
 void add_md_force(Utils::Vector3d const &pos, Utils::Vector3d const &force,
                   double time_step) {
@@ -137,9 +138,10 @@ void add_md_force(Utils::Vector3d const &pos, Utils::Vector3d const &force,
  *  Section II.C. @cite ahlrichs99a
  *
  *  @param[in] p             The coupled particle.
- *  @param[in]     f_random  Additional force to be included.
+ *  @param[in] f_random      Additional force to be included.
+ *  @param[in] time_step     MD time step.
  *
- *  @return The viscous coupling force plus f_random.
+ *  @return The viscous coupling force plus @p f_random.
  */
 Utils::Vector3d lb_viscous_coupling(Particle const &p,
                                     Utils::Vector3d const &f_random,

--- a/src/core/grid_based_algorithms/lb_particle_coupling.hpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.hpp
@@ -31,9 +31,10 @@
  *  Include all particle-lattice forces in this function.
  *  The function is called from \ref force_calc.
  */
-void lb_lbcoupling_calc_particle_lattice_ia(
-    bool couple_virtual, const ParticleRange &particles,
-    const ParticleRange &more_particles);
+void lb_lbcoupling_calc_particle_lattice_ia(bool couple_virtual,
+                                            const ParticleRange &particles,
+                                            const ParticleRange &more_particles,
+                                            double time_step);
 void lb_lbcoupling_propagate();
 uint64_t lb_lbcoupling_get_rng_state();
 void lb_lbcoupling_set_rng_state(uint64_t counter);

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -64,8 +64,6 @@ LB_parameters_gpu lbpar_gpu = {
     -1.0,
     // tau
     -1.0,
-    // time_step
-    0.0,
     // dim_x;
     0,
     // dim_y;
@@ -102,9 +100,9 @@ bool ek_initialized = false;
 /*-----------------------------------------------------------*/
 
 /** %Lattice Boltzmann update gpu called from integrate.cpp */
-void lattice_boltzmann_update_gpu() {
+void lattice_boltzmann_update_gpu(double time_step) {
 
-  auto factor = (int)round(lbpar_gpu.tau / time_step);
+  auto factor = static_cast<int>(round(lbpar_gpu.tau / time_step));
 
   fluidstep += 1;
 
@@ -130,7 +128,6 @@ void lb_reinit_fluid_gpu() {
  *  See @cite dunweg07a and @cite dhumieres09a.
  */
 void lb_reinit_parameters_gpu() {
-  lbpar_gpu.time_step = static_cast<float>(time_step);
   lbpar_gpu.mu = 0.0;
 
   if (lbpar_gpu.viscosity > 0.0 && lbpar_gpu.agrid > 0.0 &&
@@ -172,7 +169,7 @@ void lb_reinit_parameters_gpu() {
 
 #ifdef ELECTROKINETICS
   if (ek_initialized) {
-    lbpar_gpu.tau = static_cast<float>(time_step);
+    lbpar_gpu.tau = static_cast<float>(get_time_step());
   }
 #endif
 

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -90,23 +90,7 @@ LB_parameters_gpu lbpar_gpu = {
 /** this is the array that stores the hydrodynamic fields for the output */
 std::vector<LB_rho_v_pi_gpu> host_values(0);
 
-/** measures the MD time since the last fluid update */
-static int fluidstep = 0;
-
 bool ek_initialized = false;
-
-/*-----------------------------------------------------------*/
-/** main of lb_gpu_programm */
-/*-----------------------------------------------------------*/
-
-/** %Lattice Boltzmann update gpu called from integrate.cpp */
-void lattice_boltzmann_update_gpu(int lb_steps_per_md_step) {
-  fluidstep += 1;
-  if (fluidstep >= lb_steps_per_md_step) {
-    fluidstep = 0;
-    lb_integrate_GPU();
-  }
-}
 
 /** (Re-)initialize the fluid according to the given value of rho. */
 void lb_reinit_fluid_gpu() {

--- a/src/core/grid_based_algorithms/lbgpu.cpp
+++ b/src/core/grid_based_algorithms/lbgpu.cpp
@@ -100,14 +100,9 @@ bool ek_initialized = false;
 /*-----------------------------------------------------------*/
 
 /** %Lattice Boltzmann update gpu called from integrate.cpp */
-void lattice_boltzmann_update_gpu(double time_step) {
-
-  auto factor = static_cast<int>(round(lbpar_gpu.tau / time_step));
-
+void lattice_boltzmann_update_gpu(int lb_steps_per_md_step) {
   fluidstep += 1;
-
-  if (fluidstep >= factor) {
-
+  if (fluidstep >= lb_steps_per_md_step) {
     fluidstep = 0;
     lb_integrate_GPU();
   }

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -150,7 +150,6 @@ void lb_GPU_sanity_checks();
 void lb_get_device_values_pointer(LB_rho_v_gpu **pointer_address);
 void lb_get_boundary_force_pointer(float **pointer_address);
 void lb_get_para_pointer(LB_parameters_gpu **pointer_address);
-void lattice_boltzmann_update_gpu(int lb_steps_per_md_step);
 
 /** Perform a full initialization of the lattice Boltzmann system.
  *  All derived parameters and the fluid are reset to their default values.
@@ -169,6 +168,8 @@ void lb_reinit_fluid_gpu();
 void reset_LB_force_densities_GPU(bool buffer = true);
 
 void lb_init_GPU(const LB_parameters_gpu &lbpar_gpu);
+
+/** Integrate the lattice-Boltzmann system for one time step. */
 void lb_integrate_GPU();
 
 void lb_get_values_GPU(LB_rho_v_pi_gpu *host_values);

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -74,9 +74,6 @@ struct LB_parameters_gpu {
    */
   float tau;
 
-  /** MD timestep */
-  float time_step;
-
   Utils::Array<unsigned int, 3> dim;
 
   unsigned int number_of_nodes;
@@ -153,7 +150,7 @@ void lb_GPU_sanity_checks();
 void lb_get_device_values_pointer(LB_rho_v_gpu **pointer_address);
 void lb_get_boundary_force_pointer(float **pointer_address);
 void lb_get_para_pointer(LB_parameters_gpu **pointer_address);
-void lattice_boltzmann_update_gpu();
+void lattice_boltzmann_update_gpu(double time_step);
 
 /** Perform a full initialization of the lattice Boltzmann system.
  *  All derived parameters and the fluid are reset to their default values.
@@ -188,7 +185,8 @@ void lb_init_boundaries_GPU(std::size_t n_lb_boundaries,
 void lb_set_agrid_gpu(double agrid);
 
 template <std::size_t no_of_neighbours>
-void lb_calc_particle_lattice_ia_gpu(bool couple_virtual, double friction);
+void lb_calc_particle_lattice_ia_gpu(bool couple_virtual, double friction,
+                                     double time_step);
 
 void lb_calc_fluid_mass_GPU(double *mass);
 void lb_calc_fluid_momentum_GPU(double *host_mom);

--- a/src/core/grid_based_algorithms/lbgpu.hpp
+++ b/src/core/grid_based_algorithms/lbgpu.hpp
@@ -150,7 +150,7 @@ void lb_GPU_sanity_checks();
 void lb_get_device_values_pointer(LB_rho_v_gpu **pointer_address);
 void lb_get_boundary_force_pointer(float **pointer_address);
 void lb_get_para_pointer(LB_parameters_gpu **pointer_address);
-void lattice_boltzmann_update_gpu(double time_step);
+void lattice_boltzmann_update_gpu(int lb_steps_per_md_step);
 
 /** Perform a full initialization of the lattice Boltzmann system.
  *  All derived parameters and the fluid are reset to their default values.

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -457,6 +457,10 @@ double interaction_range() {
   return (max_cut > 0.) ? max_cut + skin : INACTIVE_CUTOFF;
 }
 
+double get_sim_time() { return sim_time; }
+
+void increment_sim_time(double amount) { sim_time += amount; }
+
 void mpi_set_time_step_local(double dt) {
   time_step = dt;
   on_parameter_change(FIELD_TIMESTEP);

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -294,13 +294,11 @@ int integrate(int n_steps, int reuse_forces) {
         auto const tau = lb_lbfluid_get_tau();
         auto const lb_steps_per_md_step =
             static_cast<int>(std::round(tau / time_step));
-        bool integrate_lb = false;
         fluid_step += 1;
         if (fluid_step >= lb_steps_per_md_step) {
           fluid_step = 0;
-          integrate_lb = true;
+          lb_lbfluid_propagate();
         }
-        lb_lbfluid_propagate(integrate_lb);
         lb_lbcoupling_propagate();
       }
 

--- a/src/core/integrate.hpp
+++ b/src/core/integrate.hpp
@@ -163,6 +163,9 @@ void integrate_set_npt_isotropic(double ext_pressure, double piston,
                                  bool zdir_rescale, bool cubic_box);
 #endif
 
+/** Get time step */
+double get_time_step();
+
 /** Get simulation time */
 double get_sim_time();
 

--- a/src/core/integrate.hpp
+++ b/src/core/integrate.hpp
@@ -163,6 +163,12 @@ void integrate_set_npt_isotropic(double ext_pressure, double piston,
                                  bool zdir_rescale, bool cubic_box);
 #endif
 
+/** Get simulation time */
+double get_sim_time();
+
+/** Increase simulation time (only on head node) */
+void increment_sim_time(double amount);
+
 /** Send new \ref time_step and rescale the velocities accordingly. */
 void mpi_set_time_step(double time_step);
 

--- a/src/core/integrators/brownian_inline.hpp
+++ b/src/core/integrators/brownian_inline.hpp
@@ -56,7 +56,7 @@ inline void brownian_dynamics_propagator(BrownianThermostat const &brownian,
     p.m.omega += bd_random_walk_vel_rot(brownian, p);
 #endif // ROTATION
   }
-  sim_time += time_step;
+  increment_sim_time(time_step);
 }
 
 #endif // INTEGRATORS_BROWNIAN_INLINE_HPP

--- a/src/core/integrators/brownian_inline.hpp
+++ b/src/core/integrators/brownian_inline.hpp
@@ -34,7 +34,8 @@
 #include <utils/math/sqr.hpp>
 
 inline void brownian_dynamics_propagator(BrownianThermostat const &brownian,
-                                         const ParticleRange &particles) {
+                                         const ParticleRange &particles,
+                                         double time_step) {
   for (auto &p : particles) {
     // Don't propagate translational degrees of freedom of vs
     if (!(p.p.is_virtual) or thermo_virtual) {

--- a/src/core/integrators/brownian_inline.hpp
+++ b/src/core/integrators/brownian_inline.hpp
@@ -35,13 +35,13 @@
 
 inline void brownian_dynamics_propagator(BrownianThermostat const &brownian,
                                          const ParticleRange &particles,
-                                         double time_step) {
+                                         double time_step, double kT) {
   for (auto &p : particles) {
     // Don't propagate translational degrees of freedom of vs
     if (!(p.p.is_virtual) or thermo_virtual) {
       p.r.p += bd_drag(brownian.gamma, p, time_step);
       p.m.v = bd_drag_vel(brownian.gamma, p);
-      p.r.p += bd_random_walk(brownian, p, time_step);
+      p.r.p += bd_random_walk(brownian, p, time_step, kT);
       p.m.v += bd_random_walk_vel(brownian, p);
       /* Verlet criterion check */
       if ((p.r.p - p.l.p_old).norm2() > Utils::sqr(0.5 * skin))
@@ -53,7 +53,7 @@ inline void brownian_dynamics_propagator(BrownianThermostat const &brownian,
     convert_torque_to_body_frame_apply_fix(p);
     p.r.quat = bd_drag_rot(brownian.gamma_rotation, p, time_step);
     p.m.omega = bd_drag_vel_rot(brownian.gamma_rotation, p);
-    p.r.quat = bd_random_walk_rot(brownian, p, time_step);
+    p.r.quat = bd_random_walk_rot(brownian, p, time_step, kT);
     p.m.omega += bd_random_walk_vel_rot(brownian, p);
 #endif // ROTATION
   }

--- a/src/core/integrators/stokesian_dynamics_inline.hpp
+++ b/src/core/integrators/stokesian_dynamics_inline.hpp
@@ -60,7 +60,7 @@ stokesian_dynamics_propagate_vel_pos(const ParticleRange &particles) {
 
 inline void stokesian_dynamics_step_1(const ParticleRange &particles) {
   stokesian_dynamics_propagate_vel_pos(particles);
-  sim_time += time_step;
+  increment_sim_time(time_step);
 }
 
 inline void stokesian_dynamics_step_2(const ParticleRange &particles) {}

--- a/src/core/integrators/stokesian_dynamics_inline.hpp
+++ b/src/core/integrators/stokesian_dynamics_inline.hpp
@@ -33,8 +33,8 @@
 #include <utils/Vector.hpp>
 #include <utils/math/sqr.hpp>
 
-inline void
-stokesian_dynamics_propagate_vel_pos(const ParticleRange &particles) {
+inline void stokesian_dynamics_propagate_vel_pos(const ParticleRange &particles,
+                                                 double time_step) {
   auto const skin2 = Utils::sqr(0.5 * skin);
 
   // Compute new (translational and rotational) velocities
@@ -58,8 +58,9 @@ stokesian_dynamics_propagate_vel_pos(const ParticleRange &particles) {
   }
 }
 
-inline void stokesian_dynamics_step_1(const ParticleRange &particles) {
-  stokesian_dynamics_propagate_vel_pos(particles);
+inline void stokesian_dynamics_step_1(const ParticleRange &particles,
+                                      double time_step) {
+  stokesian_dynamics_propagate_vel_pos(particles, time_step);
   increment_sim_time(time_step);
 }
 

--- a/src/core/integrators/velocity_verlet_inline.hpp
+++ b/src/core/integrators/velocity_verlet_inline.hpp
@@ -85,7 +85,7 @@ velocity_verlet_propagate_vel_final(const ParticleRange &particles) {
 
 inline void velocity_verlet_step_1(const ParticleRange &particles) {
   velocity_verlet_propagate_vel_pos(particles);
-  sim_time += time_step;
+  increment_sim_time(time_step);
 }
 
 inline void velocity_verlet_step_2(const ParticleRange &particles) {

--- a/src/core/integrators/velocity_verlet_inline.hpp
+++ b/src/core/integrators/velocity_verlet_inline.hpp
@@ -35,7 +35,8 @@
  *  v(t) + 0.5 \Delta t f(t)/m \f] <br> \f[ p(t+\Delta t) = p(t) + \Delta t
  *  v(t+0.5 \Delta t) \f]
  */
-inline void velocity_verlet_propagate_vel_pos(const ParticleRange &particles) {
+inline void velocity_verlet_propagate_vel_pos(const ParticleRange &particles,
+                                              double time_step) {
 
   auto const skin2 = Utils::sqr(0.5 * skin);
   for (auto &p : particles) {
@@ -66,8 +67,8 @@ inline void velocity_verlet_propagate_vel_pos(const ParticleRange &particles) {
 /** Final integration step of the Velocity Verlet integrator
  *  \f[ v(t+\Delta t) = v(t+0.5 \Delta t) + 0.5 \Delta t f(t+\Delta t)/m \f]
  */
-inline void
-velocity_verlet_propagate_vel_final(const ParticleRange &particles) {
+inline void velocity_verlet_propagate_vel_final(const ParticleRange &particles,
+                                                double time_step) {
 
   for (auto &p : particles) {
     // Virtual sites are not propagated during integration
@@ -83,13 +84,15 @@ velocity_verlet_propagate_vel_final(const ParticleRange &particles) {
   }
 }
 
-inline void velocity_verlet_step_1(const ParticleRange &particles) {
-  velocity_verlet_propagate_vel_pos(particles);
+inline void velocity_verlet_step_1(const ParticleRange &particles,
+                                   double time_step) {
+  velocity_verlet_propagate_vel_pos(particles, time_step);
   increment_sim_time(time_step);
 }
 
-inline void velocity_verlet_step_2(const ParticleRange &particles) {
-  velocity_verlet_propagate_vel_final(particles);
+inline void velocity_verlet_step_2(const ParticleRange &particles,
+                                   double time_step) {
+  velocity_verlet_propagate_vel_final(particles, time_step);
 #ifdef ROTATION
   convert_torques_propagate_omega(particles, time_step);
 #endif

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -45,7 +45,8 @@
 #include <cmath>
 #include <functional>
 
-void velocity_verlet_npt_propagate_vel_final(const ParticleRange &particles) {
+void velocity_verlet_npt_propagate_vel_final(const ParticleRange &particles,
+                                             double time_step) {
   extern IsotropicNptThermostat npt_iso;
   nptiso.p_vel[0] = nptiso.p_vel[1] = nptiso.p_vel[2] = 0.0;
 
@@ -68,7 +69,7 @@ void velocity_verlet_npt_propagate_vel_final(const ParticleRange &particles) {
 }
 
 /** Scale and communicate instantaneous NpT pressure */
-void velocity_verlet_npt_finalize_p_inst() {
+void velocity_verlet_npt_finalize_p_inst(double time_step) {
   extern IsotropicNptThermostat npt_iso;
   /* finalize derivation of p_inst */
   nptiso.p_inst = 0.0;
@@ -89,11 +90,12 @@ void velocity_verlet_npt_finalize_p_inst() {
   }
 }
 
-void velocity_verlet_npt_propagate_pos(const ParticleRange &particles) {
+void velocity_verlet_npt_propagate_pos(const ParticleRange &particles,
+                                       double time_step) {
   double scal[3] = {0., 0., 0.}, L_new = 0.0;
 
   /* finalize derivation of p_inst */
-  velocity_verlet_npt_finalize_p_inst();
+  velocity_verlet_npt_finalize_p_inst(time_step);
 
   /* adjust \ref nptiso_struct::nptiso.volume; prepare pos- and
    * vel-rescaling
@@ -162,7 +164,8 @@ void velocity_verlet_npt_propagate_pos(const ParticleRange &particles) {
   on_boxl_change(true);
 }
 
-void velocity_verlet_npt_propagate_vel(const ParticleRange &particles) {
+void velocity_verlet_npt_propagate_vel(const ParticleRange &particles,
+                                       double time_step) {
   extern IsotropicNptThermostat npt_iso;
   nptiso.p_vel[0] = nptiso.p_vel[1] = nptiso.p_vel[2] = 0.0;
 
@@ -190,17 +193,19 @@ void velocity_verlet_npt_propagate_vel(const ParticleRange &particles) {
   }
 }
 
-void velocity_verlet_npt_step_1(const ParticleRange &particles) {
-  velocity_verlet_npt_propagate_vel(particles);
-  velocity_verlet_npt_propagate_pos(particles);
+void velocity_verlet_npt_step_1(const ParticleRange &particles,
+                                double time_step) {
+  velocity_verlet_npt_propagate_vel(particles, time_step);
+  velocity_verlet_npt_propagate_pos(particles, time_step);
   increment_sim_time(time_step);
 }
 
-void velocity_verlet_npt_step_2(const ParticleRange &particles) {
-  velocity_verlet_npt_propagate_vel_final(particles);
+void velocity_verlet_npt_step_2(const ParticleRange &particles,
+                                double time_step) {
+  velocity_verlet_npt_propagate_vel_final(particles, time_step);
 #ifdef ROTATION
   convert_torques_propagate_omega(particles, time_step);
 #endif
-  velocity_verlet_npt_finalize_p_inst();
+  velocity_verlet_npt_finalize_p_inst(time_step);
 }
 #endif

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -193,7 +193,7 @@ void velocity_verlet_npt_propagate_vel(const ParticleRange &particles) {
 void velocity_verlet_npt_step_1(const ParticleRange &particles) {
   velocity_verlet_npt_propagate_vel(particles);
   velocity_verlet_npt_propagate_pos(particles);
-  sim_time += time_step;
+  increment_sim_time(time_step);
 }
 
 void velocity_verlet_npt_step_2(const ParticleRange &particles) {

--- a/src/core/integrators/velocity_verlet_npt.hpp
+++ b/src/core/integrators/velocity_verlet_npt.hpp
@@ -33,14 +33,16 @@
  *  Propagate pressure, box_length (2 times) and positions, rescale
  *  positions and velocities and check Verlet list criterion (only NpT).
  */
-void velocity_verlet_npt_step_1(const ParticleRange &particles);
+void velocity_verlet_npt_step_1(const ParticleRange &particles,
+                                double time_step);
 
 /** Final integration step of the Velocity Verlet+NpT integrator.
  *  Finalize instantaneous pressure calculation:
  *  \f[ v(t+\Delta t) = v(t+0.5 \Delta t)
  *      + 0.5 \Delta t \cdot F(t+\Delta t)/m \f]
  */
-void velocity_verlet_npt_step_2(const ParticleRange &particles);
+void velocity_verlet_npt_step_2(const ParticleRange &particles,
+                                double time_step);
 #endif
 
 #endif

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -95,10 +95,10 @@ REGISTER_THERMOSTAT_CALLBACKS(dpd)
 REGISTER_THERMOSTAT_CALLBACKS(stokesian)
 #endif
 
-void thermo_init() {
+void thermo_init(double time_step) {
   // initialize thermalized bond regardless of the current thermostat
   if (n_thermalized_bonds) {
-    thermalized_bond_init();
+    thermalized_bond_init(time_step);
   }
   if (thermo_switch == THERMO_OFF) {
     return;
@@ -107,7 +107,7 @@ void thermo_init() {
     langevin.recalc_prefactors(time_step);
 #ifdef DPD
   if (thermo_switch & THERMO_DPD)
-    dpd_init();
+    dpd_init(time_step);
 #endif
 #ifdef NPT
   if (thermo_switch & THERMO_NPT_ISO) {

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -104,18 +104,18 @@ void thermo_init(double time_step) {
     return;
   }
   if (thermo_switch & THERMO_LANGEVIN)
-    langevin.recalc_prefactors(time_step);
+    langevin.recalc_prefactors(temperature, time_step);
 #ifdef DPD
   if (thermo_switch & THERMO_DPD)
-    dpd_init(time_step);
+    dpd_init(temperature, time_step);
 #endif
 #ifdef NPT
   if (thermo_switch & THERMO_NPT_ISO) {
-    npt_iso.recalc_prefactors(nptiso.piston, time_step);
+    npt_iso.recalc_prefactors(temperature, nptiso.piston, time_step);
   }
 #endif
   if (thermo_switch & THERMO_BROWNIAN)
-    brownian.recalc_prefactors();
+    brownian.recalc_prefactors(temperature);
 }
 
 void philox_counter_increment() {

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -120,14 +120,14 @@ public:
   /** Recalculate prefactors.
    *  Needs to be called every time the parameters are changed.
    */
-  void recalc_prefactors(double time_step) {
+  void recalc_prefactors(double kT, double time_step) {
     pref_friction = -gamma;
-    pref_noise = sigma(temperature, time_step, gamma);
+    pref_noise = sigma(kT, time_step, gamma);
     // If gamma_rotation is not set explicitly, use the translational one.
     if (gamma_rotation < GammaType{}) {
       gamma_rotation = gamma;
     }
-    pref_noise_rotation = sigma(temperature, time_step, gamma_rotation);
+    pref_noise_rotation = sigma(kT, time_step, gamma_rotation);
   }
   /** Calculate the noise prefactor.
    *  Evaluates the quantity @f$ \sqrt{2 k_B T \gamma / dt} / \sigma_\eta @f$
@@ -174,17 +174,17 @@ public:
   /** Recalculate prefactors.
    *  Needs to be called every time the parameters are changed.
    */
-  void recalc_prefactors() {
+  void recalc_prefactors(double kT) {
     /** The heat velocity dispersion corresponds to the Gaussian noise only,
      *  which is only valid for the BD. Just a square root of kT, see (10.2.17)
      *  and comments in 2 paragraphs afterwards, @cite Pottier2010.
      */
-    sigma_vel = sigma(temperature);
+    sigma_vel = sigma(kT);
     /** The random walk position dispersion is defined by the second eq. (14.38)
      *  of @cite Schlick2010. Its time interval factor will be added in the
      *  Brownian Dynamics functions. Its square root is the standard deviation.
      */
-    sigma_pos = sigma(temperature, gamma);
+    sigma_pos = sigma(kT, gamma);
 #ifdef ROTATION
     /** Note: the BD thermostat assigns the brownian viscous parameters as well.
      *  They correspond to the friction tensor Z from the eq. (14.31) of
@@ -194,8 +194,8 @@ public:
     if (gamma_rotation < GammaType{}) {
       gamma_rotation = gamma;
     }
-    sigma_vel_rotation = sigma(temperature);
-    sigma_pos_rotation = sigma(temperature, gamma_rotation);
+    sigma_vel_rotation = sigma(kT);
+    sigma_pos_rotation = sigma(kT, gamma_rotation);
 #endif // ROTATION
   }
   /** Calculate the noise prefactor.
@@ -258,13 +258,13 @@ public:
   /** Recalculate prefactors.
    *  Needs to be called every time the parameters are changed.
    */
-  void recalc_prefactors(double piston, double time_step) {
+  void recalc_prefactors(double kT, double piston, double time_step) {
     assert(piston > 0.0);
     auto const half_time_step = time_step / 2.0;
     pref_rescale_0 = -gamma0 * half_time_step;
-    pref_noise_0 = sigma(temperature, gamma0, time_step);
+    pref_noise_0 = sigma(kT, gamma0, time_step);
     pref_rescale_V = -gammav * half_time_step / piston;
-    pref_noise_V = sigma(temperature, gammav, time_step);
+    pref_noise_V = sigma(kT, gammav, time_step);
   }
   /** Calculate the noise prefactor.
    *  Evaluates the quantity @f$ \sqrt{2 k_B T \gamma dt / 2} / \sigma_\eta @f$
@@ -275,7 +275,7 @@ public:
     // random uniform noise has variance 1/12; the temperature
     // coefficient of 2 is canceled out by the half time step
     constexpr auto const temp_coeff = 12.0;
-    return sqrt(temp_coeff * temperature * gamma * time_step);
+    return sqrt(temp_coeff * kT * gamma * time_step);
   }
   /** @name Parameters */
   /**@{*/

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -362,7 +362,7 @@ extern StokesianThermostat stokesian;
 #endif
 
 /** Initialize constants of the thermostat at the start of integration */
-void thermo_init();
+void thermo_init(double time_step);
 
 /** Increment RNG counters */
 void philox_counter_increment();

--- a/src/core/thermostats/brownian_inline.hpp
+++ b/src/core/thermostats/brownian_inline.hpp
@@ -37,7 +37,7 @@
  *  From eq. (14.39) in @cite Schlick2010.
  *  @param[in]     brownian_gamma Brownian translational gamma
  *  @param[in]     p              %Particle
- *  @param[in]     dt             Time interval
+ *  @param[in]     dt             Time step
  */
 inline Utils::Vector3d bd_drag(Thermostat::GammaType const &brownian_gamma,
                                Particle const &p, double dt) {
@@ -163,10 +163,11 @@ inline Utils::Vector3d bd_drag_vel(Thermostat::GammaType const &brownian_gamma,
  *  From eq. (14.37) in @cite Schlick2010.
  *  @param[in]     brownian       Parameters
  *  @param[in]     p              %Particle
- *  @param[in]     dt             Time interval
+ *  @param[in]     dt             Time step
+ *  @param[in]     kT             Temperature
  */
 inline Utils::Vector3d bd_random_walk(BrownianThermostat const &brownian,
-                                      Particle const &p, double dt) {
+                                      Particle const &p, double dt, double kT) {
   // skip the translation thermalizing for virtual sites unless enabled
   if (p.p.is_virtual && !thermo_virtual)
     return {};
@@ -175,8 +176,8 @@ inline Utils::Vector3d bd_random_walk(BrownianThermostat const &brownian,
 #ifdef THERMOSTAT_PER_PARTICLE
   // override default if particle-specific gamma
   if (p.p.gamma >= Thermostat::GammaType{}) {
-    if (temperature > 0.0) {
-      sigma_pos = BrownianThermostat::sigma(temperature, p.p.gamma);
+    if (kT > 0.0) {
+      sigma_pos = BrownianThermostat::sigma(kT, p.p.gamma);
     } else {
       sigma_pos = Thermostat::GammaType{};
     }
@@ -273,7 +274,7 @@ inline Utils::Vector3d bd_random_walk_vel(BrownianThermostat const &brownian,
  *  An analogy of eq. (14.39) in @cite Schlick2010.
  *  @param[in]     brownian_gamma_rotation Brownian rotational gamma
  *  @param[in]     p              %Particle
- *  @param[in]     dt             Time interval
+ *  @param[in]     dt             Time step
  */
 inline Utils::Quaternion<double>
 bd_drag_rot(Thermostat::GammaType const &brownian_gamma_rotation, Particle &p,
@@ -352,18 +353,19 @@ bd_drag_vel_rot(Thermostat::GammaType const &brownian_gamma_rotation,
  *  An analogy of eq. (14.37) in @cite Schlick2010.
  *  @param[in]     brownian       Parameters
  *  @param[in]     p              %Particle
- *  @param[in]     dt             Time interval
+ *  @param[in]     dt             Time step
+ *  @param[in]     kT             Temperature
  */
 inline Utils::Quaternion<double>
 bd_random_walk_rot(BrownianThermostat const &brownian, Particle const &p,
-                   double dt) {
+                   double dt, double kT) {
 
   Thermostat::GammaType sigma_pos = brownian.sigma_pos_rotation;
 #ifdef THERMOSTAT_PER_PARTICLE
   // override default if particle-specific gamma
   if (p.p.gamma_rot >= Thermostat::GammaType{}) {
-    if (temperature > 0.) {
-      sigma_pos = BrownianThermostat::sigma(temperature, p.p.gamma_rot);
+    if (kT > 0.) {
+      sigma_pos = BrownianThermostat::sigma(kT, p.p.gamma_rot);
     } else {
       sigma_pos = {}; // just an indication of the infinity
     }

--- a/src/core/thermostats/langevin_inline.hpp
+++ b/src/core/thermostats/langevin_inline.hpp
@@ -39,10 +39,11 @@
  *  @param[in]     langevin       Parameters
  *  @param[in]     p              %Particle
  *  @param[in]     time_step      Time step
+ *  @param[in]     kT             Temperature
  */
 inline Utils::Vector3d
 friction_thermo_langevin(LangevinThermostat const &langevin, Particle const &p,
-                         double time_step) {
+                         double time_step, double kT) {
   // Early exit for virtual particles without thermostat
   if (p.p.is_virtual && !thermo_virtual) {
     return {};
@@ -57,7 +58,7 @@ friction_thermo_langevin(LangevinThermostat const &langevin, Particle const &p,
     auto const gamma =
         p.p.gamma >= Thermostat::GammaType{} ? p.p.gamma : langevin.gamma;
     pref_friction = -gamma;
-    pref_noise = LangevinThermostat::sigma(temperature, time_step, gamma);
+    pref_noise = LangevinThermostat::sigma(kT, time_step, gamma);
   }
 #endif // THERMOSTAT_PER_PARTICLE
 
@@ -100,10 +101,12 @@ friction_thermo_langevin(LangevinThermostat const &langevin, Particle const &p,
  *  @param[in]     langevin       Parameters
  *  @param[in]     p              %Particle
  *  @param[in]     time_step      Time step
+ *  @param[in]     kT             Temperature
  */
 inline Utils::Vector3d
 friction_thermo_langevin_rotation(LangevinThermostat const &langevin,
-                                  Particle const &p, double time_step) {
+                                  Particle const &p, double time_step,
+                                  double kT) {
 
   auto pref_friction = -langevin.gamma_rotation;
   auto pref_noise = langevin.pref_noise_rotation;
@@ -115,7 +118,7 @@ friction_thermo_langevin_rotation(LangevinThermostat const &langevin,
                            ? p.p.gamma_rot
                            : langevin.gamma_rotation;
     pref_friction = -gamma;
-    pref_noise = LangevinThermostat::sigma(temperature, time_step, gamma);
+    pref_noise = LangevinThermostat::sigma(kT, time_step, gamma);
   }
 #endif // THERMOSTAT_PER_PARTICLE
 

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -50,7 +50,7 @@ public:
   virtual void back_transfer_forces_and_torques() const {}
   /** @brief Called after force calculation (and before rattle/shake) */
   virtual void after_force_calc(){};
-  virtual void after_lb_propagation(){};
+  virtual void after_lb_propagation(double){};
   /** @brief Pressure contribution. */
   virtual Utils::Matrix<double, 3, 3> pressure_tensor() const { return {}; };
   /** @brief Enable/disable quaternion calculations for vs.*/

--- a/src/core/virtual_sites/VirtualSitesInertialessTracers.cpp
+++ b/src/core/virtual_sites/VirtualSitesInertialessTracers.cpp
@@ -47,9 +47,9 @@ void VirtualSitesInertialessTracers::after_force_calc() {
   }
 }
 
-void VirtualSitesInertialessTracers::after_lb_propagation() {
+void VirtualSitesInertialessTracers::after_lb_propagation(double time_step) {
 #ifdef VIRTUAL_SITES_INERTIALESS_TRACERS
-  IBM_UpdateParticlePositions(cell_structure.local_particles());
+  IBM_UpdateParticlePositions(cell_structure.local_particles(), time_step);
 #endif // VS inertialess tracers
 }
 #endif

--- a/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
+++ b/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
@@ -29,7 +29,7 @@
  */
 class VirtualSitesInertialessTracers : public VirtualSites {
   void after_force_calc() override;
-  void after_lb_propagation() override;
+  void after_lb_propagation(double time_step) override;
 };
 
 #endif

--- a/src/core/virtual_sites/lb_inertialess_tracers.cpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers.cpp
@@ -94,7 +94,8 @@ void IBM_ForcesIntoFluid_CPU() {
  *  particles.
  *  Called from the integration loop right after the LB update.
  */
-void IBM_UpdateParticlePositions(ParticleRange const &particles) {
+void IBM_UpdateParticlePositions(ParticleRange const &particles,
+                                 double time_step) {
   // Get velocities
   if (lattice_switch == ActiveLB::CPU)
     ParticleVelocitiesFromLB_CPU();

--- a/src/core/virtual_sites/lb_inertialess_tracers.cpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers.cpp
@@ -94,7 +94,7 @@ void IBM_ForcesIntoFluid_CPU() {
  *  particles.
  *  Called from the integration loop right after the LB update.
  */
-void IBM_UpdateParticlePositions(ParticleRange particles) {
+void IBM_UpdateParticlePositions(ParticleRange const &particles) {
   // Get velocities
   if (lattice_switch == ActiveLB::CPU)
     ParticleVelocitiesFromLB_CPU();

--- a/src/core/virtual_sites/lb_inertialess_tracers.hpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers.hpp
@@ -29,14 +29,14 @@
 #include "ParticleRange.hpp"
 
 // Main functions for CPU & GPU
-void IBM_UpdateParticlePositions(ParticleRange particles);
+void IBM_UpdateParticlePositions(ParticleRange const &particles);
 
 // Main functions for CPU implementation - called from integrate.cpp
 void IBM_ForcesIntoFluid_CPU();
 
 // Main functions for GPU implementation - called from integrate.cpp
 // These are in ibm_cuda.cu
-void IBM_ForcesIntoFluid_GPU(ParticleRange particles);
+void IBM_ForcesIntoFluid_GPU(ParticleRange const &particles);
 void IBM_ResetLBForces_GPU();
 
 #endif

--- a/src/core/virtual_sites/lb_inertialess_tracers.hpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers.hpp
@@ -29,7 +29,8 @@
 #include "ParticleRange.hpp"
 
 // Main functions for CPU & GPU
-void IBM_UpdateParticlePositions(ParticleRange const &particles);
+void IBM_UpdateParticlePositions(ParticleRange const &particles,
+                                 double time_step);
 
 // Main functions for CPU implementation - called from integrate.cpp
 void IBM_ForcesIntoFluid_CPU();

--- a/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
+++ b/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
@@ -296,7 +296,7 @@ void IBM_ResetLBForces_GPU() {
  *  This must be the first CUDA-IBM function to be called because it also does
  *  some initialization.
  */
-void IBM_ForcesIntoFluid_GPU(ParticleRange particles) {
+void IBM_ForcesIntoFluid_GPU(ParticleRange const &particles) {
   // This function does
   // (1) Gather forces from all particles via MPI
   // (2) Copy forces to the GPU
@@ -394,7 +394,7 @@ void InitCUDA_IBM(std::size_t const numParticles) {
 /** Call a kernel function to interpolate the velocity at each IBM particle's
  *  position. Store velocity in the particle data structure.
  */
-void ParticleVelocitiesFromLB_GPU(ParticleRange particles) {
+void ParticleVelocitiesFromLB_GPU(ParticleRange const &particles) {
   // This function performs three steps:
   // (1) interpolate velocities on GPU
   // (2) transfer velocities back to CPU

--- a/src/core/virtual_sites/lb_inertialess_tracers_cuda_interface.cpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers_cuda_interface.cpp
@@ -41,7 +41,7 @@
 std::vector<IBM_CUDA_ParticleDataInput> IBM_ParticleDataInput_host = {};
 std::vector<IBM_CUDA_ParticleDataOutput> IBM_ParticleDataOutput_host = {};
 
-static void pack_particles(ParticleRange particles,
+static void pack_particles(ParticleRange const &particles,
                            std::vector<IBM_CUDA_ParticleDataInput> &buffer) {
 
   int i = 0;
@@ -67,7 +67,7 @@ static void pack_particles(ParticleRange particles,
  *  only need the virtual ones. Room for improvement...
  *  Analogous to @ref cuda_mpi_get_particles.
  */
-void IBM_cuda_mpi_get_particles(ParticleRange particles) {
+void IBM_cuda_mpi_get_particles(ParticleRange const &particles) {
   auto const n_part = particles.size();
 
   if (this_node > 0) {
@@ -85,7 +85,7 @@ void IBM_cuda_mpi_get_particles(ParticleRange particles) {
   }
 }
 
-static void set_velocities(ParticleRange particles,
+static void set_velocities(ParticleRange const &particles,
                            std::vector<IBM_CUDA_ParticleDataOutput> &buffer) {
   int i = 0;
   for (auto &part : particles) {
@@ -100,7 +100,7 @@ static void set_velocities(ParticleRange particles,
 /** Particle velocities have been communicated from GPU, now transmit to all
  *  nodes. Analogous to @ref cuda_mpi_send_forces.
  */
-void IBM_cuda_mpi_send_velocities(ParticleRange particles) {
+void IBM_cuda_mpi_send_velocities(ParticleRange const &particles) {
   auto const n_part = particles.size();
 
   if (this_node > 0) {

--- a/src/core/virtual_sites/lb_inertialess_tracers_cuda_interface.hpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers_cuda_interface.hpp
@@ -35,10 +35,10 @@
 
 // *********** Communication functions ********
 // Implemented in real C++, but called from the ibm_cuda.cu
-void IBM_cuda_mpi_send_velocities(ParticleRange particles);
-void IBM_cuda_mpi_get_particles(ParticleRange particles);
+void IBM_cuda_mpi_send_velocities(ParticleRange const &particles);
+void IBM_cuda_mpi_get_particles(ParticleRange const &particles);
 
-void ParticleVelocitiesFromLB_GPU(ParticleRange particles);
+void ParticleVelocitiesFromLB_GPU(ParticleRange const &particles);
 
 // ******** data types for CUDA and MPI communication ******
 typedef struct {

--- a/src/python/espressomd/lb.pxd
+++ b/src/python/espressomd/lb.pxd
@@ -66,7 +66,6 @@ cdef extern from "grid_based_algorithms/lb_interface.hpp":
     const Vector3d lb_lbfluid_get_ext_force_density() except +
     void lb_lbfluid_set_bulk_viscosity(double c_bulk_visc) except +
     double lb_lbfluid_get_bulk_viscosity() except +
-    void lb_lbfluid_sanity_checks() except +
     void lb_lbfluid_print_vtk_velocity(string filename) except +
     void lb_lbfluid_print_vtk_velocity(string filename, vector[int] bb1, vector[int] bb2) except +
     void lb_lbfluid_print_vtk_boundary(string filename) except +

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -54,7 +54,7 @@ cdef class HydrodynamicInteraction(Actor):
         Lattice constant. The box size in every direction must be an integer
         multiple of ``agrid``.
     tau : :obj:`float`
-        LB time step. The MD time step must be an integer multiple of ``tau``.
+        LB time step, must be an integer multiple of the MD time step.
     dens : :obj:`float`
         Fluid density.
     visc : :obj:`float`
@@ -157,7 +157,6 @@ cdef class HydrodynamicInteraction(Actor):
         if "gamma_even" in self._params:
             python_lbfluid_set_gamma_even(self._params["gamma_even"])
 
-        lb_lbfluid_sanity_checks()
         utils.handle_errors("LB fluid activation")
 
     def _get_params_from_es_core(self):

--- a/src/script_interface/h5md/h5md.cpp
+++ b/src/script_interface/h5md/h5md.cpp
@@ -37,8 +37,9 @@ namespace Writer {
 Variant H5md::do_call_method(const std::string &name,
                              const VariantMap &parameters) {
   if (name == "write")
-    m_h5md->write(cell_structure.local_particles(), sim_time,
-                  static_cast<int>(std::round(sim_time / time_step)), box_geo);
+    m_h5md->write(cell_structure.local_particles(), get_sim_time(),
+                  static_cast<int>(std::round(get_sim_time() / time_step)),
+                  box_geo);
   else if (name == "flush")
     m_h5md->flush();
   else if (name == "close")

--- a/src/script_interface/h5md/h5md.cpp
+++ b/src/script_interface/h5md/h5md.cpp
@@ -37,9 +37,10 @@ namespace Writer {
 Variant H5md::do_call_method(const std::string &name,
                              const VariantMap &parameters) {
   if (name == "write")
-    m_h5md->write(cell_structure.local_particles(), get_sim_time(),
-                  static_cast<int>(std::round(get_sim_time() / time_step)),
-                  box_geo);
+    m_h5md->write(
+        cell_structure.local_particles(), get_sim_time(),
+        static_cast<int>(std::round(get_sim_time() / get_time_step())),
+        box_geo);
   else if (name == "flush")
     m_h5md->flush();
   else if (name == "close")


### PR DESCRIPTION
Fixes #4247, partial fix for #2628

Description of changes:
- reduce usage of the `temperature` and `time_step` globals
- combine the `int fluidstep` and `double fluidstep` static globals into a single static global
- only increment LB RNG during LB integration (changes the thermalization random sequence when `tau != time_step`)
- reduce code duplication, replace raw pointers by references, improve separation of concerns