### PR TITLE
Fix ObjectList checkpointing regression

### DIFF
--- a/src/core/accumulators.cpp
+++ b/src/core/accumulators.cpp
@@ -62,9 +62,17 @@ int auto_update_next_update() {
 
 void auto_update_add(AccumulatorBase *acc) {
   assert(acc);
+  assert(std::find_if(auto_update_accumulators.begin(),
+                      auto_update_accumulators.end(), [acc](auto const &a) {
+                        return a.acc == acc;
+                      }) == auto_update_accumulators.end());
   auto_update_accumulators.emplace_back(acc);
 }
 void auto_update_remove(AccumulatorBase *acc) {
+  assert(std::find_if(auto_update_accumulators.begin(),
+                      auto_update_accumulators.end(), [acc](auto const &a) {
+                        return a.acc == acc;
+                      }) != auto_update_accumulators.end());
   auto_update_accumulators.erase(
       boost::remove_if(
           auto_update_accumulators,

--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -23,6 +23,7 @@
 #include "grid.hpp"
 #include "statistics.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -51,11 +52,15 @@ public:
     if (not c->fits_in_box(box_geo.length())) {
       throw std::runtime_error("Constraint not compatible with box size.");
     }
+    assert(std::find(m_constraints.begin(), m_constraints.end(), c) ==
+           m_constraints.end());
 
     m_constraints.emplace_back(c);
     on_constraint_change();
   }
   void remove(std::shared_ptr<Constraint> const &c) {
+    assert(std::find(m_constraints.begin(), m_constraints.end(), c) !=
+           m_constraints.end());
     m_constraints.erase(
         std::remove(m_constraints.begin(), m_constraints.end(), c),
         m_constraints.end());

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -59,12 +59,16 @@ std::vector<std::shared_ptr<LBBoundary>> lbboundaries;
 #if defined(LB_BOUNDARIES) || defined(LB_BOUNDARIES_GPU)
 
 void add(const std::shared_ptr<LBBoundary> &b) {
+  assert(std::find(lbboundaries.begin(), lbboundaries.end(), b) ==
+         lbboundaries.end());
   lbboundaries.emplace_back(b);
 
   on_lbboundary_change();
 }
 
 void remove(const std::shared_ptr<LBBoundary> &b) {
+  assert(std::find(lbboundaries.begin(), lbboundaries.end(), b) !=
+         lbboundaries.end());
   lbboundaries.erase(std::remove(lbboundaries.begin(), lbboundaries.end(), b),
                      lbboundaries.end());
 

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -284,11 +284,25 @@ cdef class HydrodynamicInteraction(Actor):
         lb_lbfluid_print_boundary(utils.to_char_pointer(path))
 
     def save_checkpoint(self, path, binary):
+        '''
+        Write LB node populations to a file.
+        :class:`~espressomd.lbboundaries.LBBoundaries`
+        information is not written to the file.
+        '''
         tmp_path = path + ".__tmp__"
         lb_lbfluid_save_checkpoint(utils.to_char_pointer(tmp_path), binary)
         os.rename(tmp_path, path)
 
     def load_checkpoint(self, path, binary):
+        '''
+        Load LB node populations from a file.
+        :class:`~espressomd.lbboundaries.LBBoundaries`
+        information is not available in the file. The boundary
+        information of the grid will be set to zero,
+        even if :class:`~espressomd.lbboundaries.LBBoundaries`
+        contains :class:`~espressomd.lbboundaries.LBBoundary`
+        objects (they are ignored).
+        '''
         lb_lbfluid_load_checkpoint(utils.to_char_pointer(path), binary)
 
     def _activate_method(self):

--- a/src/script_interface/Context.hpp
+++ b/src/script_interface/Context.hpp
@@ -79,7 +79,8 @@ public:
    * is present.
    */
   virtual std::shared_ptr<ObjectHandle>
-  make_shared(std::string const &name, const VariantMap &parameters) = 0;
+  make_shared(std::string const &name, const VariantMap &parameters,
+              std::string const &internal_state = {}) = 0;
 
 protected:
   /**

--- a/src/script_interface/GlobalContext.hpp
+++ b/src/script_interface/GlobalContext.hpp
@@ -70,7 +70,7 @@ private:
 
 private:
   Communication::CallbackHandle<ObjectId, const std::string &,
-                                const PackedMap &>
+                                const PackedMap &, const std::string &>
       cb_make_handle;
   Communication::CallbackHandle<ObjectId, const std::string &,
                                 const PackedVariant &>
@@ -86,8 +86,9 @@ public:
       : m_node_local_context(std::move(node_local_context)),
         cb_make_handle(&callbacks,
                        [this](ObjectId id, const std::string &name,
-                              const PackedMap &parameters) {
-                         make_handle(id, name, parameters);
+                              const PackedMap &parameters,
+                              std::string const &internal_state) {
+                         make_handle(id, name, parameters, internal_state);
                        }),
         cb_set_parameter(&callbacks,
                          [this](ObjectId id, std::string const &name,
@@ -107,7 +108,8 @@ private:
    * @brief Callback for @c cb_make_handle
    */
   void make_handle(ObjectId id, const std::string &name,
-                   const PackedMap &parameters);
+                   const PackedMap &parameters,
+                   std::string const &internal_state);
   /**
    * @brief Create remote instances
    *
@@ -116,7 +118,8 @@ private:
    * @param parameters Constructor parameters.
    */
   void remote_make_handle(ObjectId id, const std::string &name,
-                          const VariantMap &parameters);
+                          const VariantMap &parameters,
+                          std::string const &internal_state);
 
 private:
   /**
@@ -154,7 +157,8 @@ public:
    * Remote objects are automatically constructed.
    */
   std::shared_ptr<ObjectHandle>
-  make_shared(std::string const &name, const VariantMap &parameters) override;
+  make_shared(std::string const &name, const VariantMap &parameters,
+              std::string const &internal_state = {}) override;
 
   boost::string_ref name(const ObjectHandle *o) const override;
 };

--- a/src/script_interface/LocalContext.hpp
+++ b/src/script_interface/LocalContext.hpp
@@ -51,11 +51,15 @@ public:
                             Variant const &) override {}
 
   std::shared_ptr<ObjectHandle>
-  make_shared(std::string const &name, const VariantMap &parameters) override {
+  make_shared(std::string const &name, const VariantMap &parameters,
+              std::string const &internal_state = {}) override {
     auto sp = m_factory.make(name);
     set_context(sp.get());
 
     sp->construct(parameters);
+    if (!internal_state.empty()) {
+      sp->set_internal_state(internal_state);
+    }
 
     return sp;
   }

--- a/src/script_interface/ObjectHandle.cpp
+++ b/src/script_interface/ObjectHandle.cpp
@@ -91,8 +91,7 @@ ObjectRef ObjectHandle::deserialize(const std::string &packed_state,
     params[kv.first] = boost::apply_visitor(UnpackVisitor(objects), kv.second);
   }
 
-  auto o = ctx.make_shared(state.name, params);
-  o->set_internal_state(state.internal_state);
+  auto o = ctx.make_shared(state.name, params, state.internal_state);
 
   return o;
 }

--- a/src/script_interface/ObjectHandle.hpp
+++ b/src/script_interface/ObjectHandle.hpp
@@ -30,6 +30,8 @@
 
 namespace ScriptInterface {
 class Context;
+class GlobalContext;
+class LocalContext;
 
 /**
  * @brief Base class for interface handles.
@@ -150,6 +152,8 @@ public:
   static ObjectRef deserialize(const std::string &state, Context &ctx);
 
 private:
+  friend class GlobalContext;
+  friend class LocalContext;
   virtual std::string get_internal_state() const { return {}; }
   virtual void set_internal_state(std::string const &state) {}
 };

--- a/src/script_interface/ObjectList.hpp
+++ b/src/script_interface/ObjectList.hpp
@@ -33,6 +33,9 @@
 #include <vector>
 
 namespace ScriptInterface {
+class GlobalContext;
+class LocalContext;
+
 /**
  * @brief Owning list of ObjectHandles
  * @tparam ManagedType Type of the managed objects, needs to be
@@ -131,6 +134,8 @@ protected:
   }
 
 private:
+  friend class GlobalContext;
+  friend class LocalContext;
   std::string get_internal_state() const override {
     std::vector<std::string> object_states(m_elements.size());
 

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -181,18 +181,9 @@ template <> struct get_value_helper<std::unordered_map<int, Variant>, void> {
 };
 
 /* This allows direct retrieval of a shared_ptr to the object from
-   an ObjectId variant. If the type is a derived type, the type is
-   also checked.
-
-   We do a couple of checks: First we check if the id is actually the
-   empty id, which means None and is a valid value, represented by
-   an empty ptr.
-   If the id is not empty, we try to retrieve an instance for that id.
-   If it does not exist we throw, this means the caller supplied an id
-   with no corresponding instance.
-   If we can find an instance, we check if it has the right
-   type, and if so, we return it, otherwise we throw.
-*/
+ * an ObjectRef variant. If the type is a derived type, the type is
+ * also checked.
+ */
 template <typename T>
 struct get_value_helper<
     std::shared_ptr<T>,

--- a/src/script_interface/tests/ObjectHandle_test.cpp
+++ b/src/script_interface/tests/ObjectHandle_test.cpp
@@ -148,7 +148,8 @@ struct LogContext : public Context {
   }
 
   std::shared_ptr<ObjectHandle> make_shared(std::string const &,
-                                            const VariantMap &) override {
+                                            const VariantMap &,
+                                            std::string const &) override {
     auto it = std::make_shared<Testing::LogHandle>();
     set_context(it.get());
 
@@ -167,7 +168,7 @@ struct LogContext : public Context {
 BOOST_AUTO_TEST_CASE(notify_set_parameter_) {
   auto log_ctx = std::make_shared<Testing::LogContext>();
 
-  auto o = log_ctx->make_shared({}, {});
+  auto o = log_ctx->make_shared({}, {}, {});
 
   std::string name;
   Variant value;
@@ -188,7 +189,7 @@ BOOST_AUTO_TEST_CASE(notify_set_parameter_) {
 BOOST_AUTO_TEST_CASE(notify_call_method_) {
   auto log_ctx = std::make_shared<Testing::LogContext>();
 
-  auto o = log_ctx->make_shared({}, {});
+  auto o = log_ctx->make_shared({}, {}, {});
 
   std::string name;
   VariantMap params;

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -164,10 +164,19 @@ class CheckpointTest(ut.TestCase):
         bond. The thermostat friction is negligible compared to the force
         factors used for both the harmonic bond and LJ potential.
         '''
+        # check containers agree on all MPI nodes
         p3, p4 = system.part[3:5]
         np.testing.assert_allclose(np.copy(p3.pos), system.box_l / 2. - 1.)
         np.testing.assert_allclose(np.copy(p4.pos), system.box_l / 2. + 1.)
         np.testing.assert_allclose(np.copy(p3.f), -np.copy(p4.f), rtol=1e-4)
+        # remove a shape-based constraint on all MPI nodes
+        if espressomd.has_features('LENNARD_JONES'):
+            old_force = np.copy(p3.f)
+            system.constraints.remove(system.constraints[0])
+            system.integrator.run(0, recalc_forces=True)
+            np.testing.assert_allclose(
+                np.copy(p3.f), -np.copy(p4.f), rtol=1e-4)
+            self.assertGreater(np.linalg.norm(np.copy(p3.f) - old_force), 1e7)
 
     @ut.skipIf('THERM.LB' not in modes, 'LB thermostat not in modes')
     def test_thermostat_LB(self):
@@ -465,6 +474,7 @@ class CheckpointTest(ut.TestCase):
     @ut.skipIf(not LB or EK or not (espressomd.has_features("LB_BOUNDARIES")
                                     or espressomd.has_features("LB_BOUNDARIES_GPU")), "Missing features")
     def test_lb_boundaries(self):
+        # check boundaries agree on all MPI nodes
         self.assertEqual(len(system.lbboundaries), 2)
         np.testing.assert_allclose(
             np.copy(system.lbboundaries[0].velocity), [1e-4, 1e-4, 0])
@@ -478,6 +488,11 @@ class CheckpointTest(ut.TestCase):
             system.actors[0][-1, :, :].boundary.astype(int), 2)
         np.testing.assert_equal(
             system.actors[0][1:-1, :, :].boundary.astype(int), 0)
+        # remove boundaries on all MPI nodes
+        system.lbboundaries.clear()
+        self.assertEqual(len(system.lbboundaries), 0)
+        np.testing.assert_equal(
+            system.actors[0][:, :, :].boundary.astype(int), 0)
 
     def test_constraints(self):
         from espressomd import constraints

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -63,7 +63,14 @@ class CheckpointTest(ut.TestCase):
             f"system doesn't have an actor of type {actor_type.__name__}")
 
     @ut.skipIf(not LB, "Skipping test due to missing mode.")
-    def test_LB(self):
+    def test_lb_fluid(self):
+        '''
+        Check serialization of the LB fluid. The checkpoint file only stores
+        population information, therefore calling ``lbf.load_checkpoint()``
+        erases all LBBoundaries information but doesn't remove the objects
+        contained in ``system.lbboundaries`. This test method is named such
+        that it is executed after ``self.test_lb_boundaries()``.
+        '''
         lbf = system.actors[0]
         cpt_mode = int("@TEST_BINARY@")
         cpt_path = self.checkpoint.checkpoint_dir + "/lb{}.cpt"

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -144,12 +144,23 @@ class CheckpointTest(ut.TestCase):
             np.copy(system.periodicity), self.ref_periodicity)
 
     def test_part(self):
-        np.testing.assert_allclose(
-            np.copy(system.part[0].pos), np.array([1.0, 2.0, 3.0]))
-        np.testing.assert_allclose(
-            np.copy(system.part[1].pos), np.array([1.0, 1.0, 2.0]))
-        np.testing.assert_allclose(np.copy(system.part[0].f), particle_force0)
-        np.testing.assert_allclose(np.copy(system.part[1].f), particle_force1)
+        p1, p2 = system.part[0:2]
+        np.testing.assert_allclose(np.copy(p1.pos), np.array([1.0, 2.0, 3.0]))
+        np.testing.assert_allclose(np.copy(p2.pos), np.array([1.0, 1.0, 2.0]))
+        np.testing.assert_allclose(np.copy(p1.f), particle_force0)
+        np.testing.assert_allclose(np.copy(p2.f), particle_force1)
+
+    def test_object_containers_serialization(self):
+        '''
+        Check that particles at the interface between two MPI nodes still
+        experience the force from a shape-based constraint and a harmonic
+        bond. The thermostat friction is negligible compared to the force
+        factors used for both the harmonic bond and LJ potential.
+        '''
+        p3, p4 = system.part[3:5]
+        np.testing.assert_allclose(np.copy(p3.pos), system.box_l / 2. - 1.)
+        np.testing.assert_allclose(np.copy(p4.pos), system.box_l / 2. + 1.)
+        np.testing.assert_allclose(np.copy(p3.f), -np.copy(p4.f), rtol=1e-4)
 
     @ut.skipIf('THERM.LB' not in modes, 'LB thermostat not in modes')
     def test_thermostat_LB(self):
@@ -195,7 +206,10 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(thmst['type'], 'DPD')
         self.assertEqual(thmst['kT'], 1.0)
         self.assertEqual(thmst['seed'], 42)
-        self.assertEqual(thmst['counter'], 6)
+        n_nodes = system.cell_system.get_state()["n_nodes"]
+        if n_nodes in {1, 2, 3, 4, 8}:
+            ref_counter = (n_nodes == 3) and 6 or 8
+            self.assertEqual(thmst['counter'], ref_counter)
 
     @utx.skipIfMissingFeatures('NPT')
     @ut.skipIf('THERM.NPT' not in modes, 'NPT thermostat not in modes')
@@ -444,10 +458,19 @@ class CheckpointTest(ut.TestCase):
     @ut.skipIf(not LB or EK or not (espressomd.has_features("LB_BOUNDARIES")
                                     or espressomd.has_features("LB_BOUNDARIES_GPU")), "Missing features")
     def test_lb_boundaries(self):
-        self.assertEqual(len(system.lbboundaries), 1)
+        self.assertEqual(len(system.lbboundaries), 2)
         np.testing.assert_allclose(
             np.copy(system.lbboundaries[0].velocity), [1e-4, 1e-4, 0])
+        np.testing.assert_allclose(
+            np.copy(system.lbboundaries[1].velocity), [0, 0, 0])
         self.assertIsInstance(system.lbboundaries[0].shape, Wall)
+        self.assertIsInstance(system.lbboundaries[1].shape, Wall)
+        np.testing.assert_equal(
+            system.actors[0][0, :, :].boundary.astype(int), 1)
+        np.testing.assert_equal(
+            system.actors[0][-1, :, :].boundary.astype(int), 2)
+        np.testing.assert_equal(
+            system.actors[0][1:-1, :, :].boundary.astype(int), 0)
 
     def test_constraints(self):
         from espressomd import constraints


### PR DESCRIPTION
Fixes #4280

Description of changes:
- deserialize objects contained in `ObjectList` containers on all MPI ranks if the containers have global creation policy
- update checkpointing tests to check that multiple MPI nodes agree on objects contained in `ObjectList` containers