### PR TITLE
lgtm python dependencies

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,3 +8,16 @@ extraction:
       - "cd build && cmake .."
     index:
       build_command: "cd build && make -j2"
+  python:
+    python_setup:
+      requirements:
+        - wheel
+      requirements_files:
+        - requirements.txt
+      exclude_requirements:
+        - PyOpenGL
+        - mayavi
+        - pyface
+        - pygame
+        - traits
+        - traitsui


### PR DESCRIPTION
GUI-related Python packages (e.g. `mayavi`) are currently listed as dependencies of `lgtm`, although it doesn't need them and has trouble installing them (`lgtm` logfiles contain many error and warnings). This PR excludes them from the `pip` command and adds the `wheel` package as a dependency (to fix `wheel`-related warnings).