### PR TITLE
Refactor reaction method constraints

### DIFF
--- a/src/core/reaction_methods/ReactionAlgorithm.cpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.cpp
@@ -457,6 +457,12 @@ int ReactionAlgorithm::delete_particle(int p_id) {
 
 void ReactionAlgorithm::set_cyl_constraint(double center_x, double center_y,
                                            double radius) {
+  if (center_x < 0. or center_x > box_geo.length()[0])
+    throw std::domain_error("center_x is outside the box");
+  if (center_y < 0. or center_y > box_geo.length()[1])
+    throw std::domain_error("center_y is outside the box");
+  if (radius < 0.)
+    throw std::domain_error("radius is invalid");
   m_cyl_x = center_x;
   m_cyl_y = center_y;
   m_cyl_radius = radius;
@@ -465,6 +471,12 @@ void ReactionAlgorithm::set_cyl_constraint(double center_x, double center_y,
 
 void ReactionAlgorithm::set_slab_constraint(double slab_start_z,
                                             double slab_end_z) {
+  if (slab_start_z < 0. or slab_start_z > box_geo.length()[2])
+    throw std::domain_error("slab_start_z is outside the box");
+  if (slab_end_z < 0. or slab_end_z > box_geo.length()[2])
+    throw std::domain_error("slab_end_z is outside the box");
+  if (slab_end_z < slab_start_z)
+    throw std::domain_error("slab_end_z must be >= slab_start_z");
   m_slab_start_z = slab_start_z;
   m_slab_end_z = slab_end_z;
   m_reaction_constraint = ReactionConstraint::SLAB_Z;

--- a/src/core/reaction_methods/ReactionAlgorithm.cpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.cpp
@@ -32,6 +32,7 @@
 #include <utils/contains.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <iterator>
 #include <limits>
@@ -454,29 +455,44 @@ int ReactionAlgorithm::delete_particle(int p_id) {
   return 0;
 }
 
+void ReactionAlgorithm::set_cyl_constraint(double center_x, double center_y,
+                                           double radius) {
+  m_cyl_x = center_x;
+  m_cyl_y = center_y;
+  m_cyl_radius = radius;
+  m_reaction_constraint = ReactionConstraint::CYL_Z;
+}
+
+void ReactionAlgorithm::set_slab_constraint(double slab_start_z,
+                                            double slab_end_z) {
+  m_slab_start_z = slab_start_z;
+  m_slab_end_z = slab_end_z;
+  m_reaction_constraint = ReactionConstraint::SLAB_Z;
+}
+
 /**
  * Writes a random position inside the central box into the provided array.
  */
 Utils::Vector3d ReactionAlgorithm::get_random_position_in_box() {
   Utils::Vector3d out_pos{};
 
-  if (box_is_cylindric_around_z_axis) {
+  if (m_reaction_constraint == ReactionConstraint::CYL_Z) {
     // see http://mathworld.wolfram.com/DiskPointPicking.html
-    double random_radius =
-        cyl_radius *
-        std::sqrt(m_uniform_real_distribution(
-            m_generator)); // for uniform disk point picking in cylinder
-    double phi = 2.0 * Utils::pi() * m_uniform_real_distribution(m_generator);
-    out_pos[0] = cyl_x + random_radius * cos(phi);
-    out_pos[1] = cyl_y + random_radius * sin(phi);
+    // for uniform disk point picking in cylinder
+    auto const random_radius =
+        m_cyl_radius * std::sqrt(m_uniform_real_distribution(m_generator));
+    auto const random_phi =
+        2. * Utils::pi() * m_uniform_real_distribution(m_generator);
+    out_pos[0] = m_cyl_x + random_radius * cos(random_phi);
+    out_pos[1] = m_cyl_y + random_radius * sin(random_phi);
     out_pos[2] = box_geo.length()[2] * m_uniform_real_distribution(m_generator);
-  } else if (box_has_wall_constraints) {
+  } else if (m_reaction_constraint == ReactionConstraint::SLAB_Z) {
     out_pos[0] = box_geo.length()[0] * m_uniform_real_distribution(m_generator);
     out_pos[1] = box_geo.length()[1] * m_uniform_real_distribution(m_generator);
-    out_pos[2] = slab_start_z + (slab_end_z - slab_start_z) *
-                                    m_uniform_real_distribution(m_generator);
+    out_pos[2] = m_slab_start_z + (m_slab_end_z - m_slab_start_z) *
+                                      m_uniform_real_distribution(m_generator);
   } else {
-    // cubic case
+    assert(m_reaction_constraint == ReactionConstraint::NONE);
     out_pos[0] = box_geo.length()[0] * m_uniform_real_distribution(m_generator);
     out_pos[1] = box_geo.length()[1] * m_uniform_real_distribution(m_generator);
     out_pos[2] = box_geo.length()[2] * m_uniform_real_distribution(m_generator);

--- a/src/core/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.hpp
@@ -62,13 +62,6 @@ public:
    */
   double exclusion_radius = 0.0;
   double volume = -10.0;
-  bool box_is_cylindric_around_z_axis = false;
-  double cyl_radius = -10.0;
-  double cyl_x = -10.0;
-  double cyl_y = -10.0;
-  bool box_has_wall_constraints = false;
-  double slab_start_z = -10.0;
-  double slab_end_z = -10.0;
   int non_interacting_type = 100;
 
   int m_accepted_configurational_MC_moves = 0;
@@ -81,6 +74,12 @@ public:
   void set_cuboid_reaction_ensemble_volume();
   virtual int do_reaction(int reaction_steps);
   void check_reaction_method() const;
+  void remove_constraint() { m_reaction_constraint = ReactionConstraint::NONE; }
+  void set_cyl_constraint(double center_x, double center_y, double radius);
+  void set_slab_constraint(double slab_start_z, double slab_end_z);
+  Utils::Vector2d get_slab_constraint_parameters() const {
+    return {m_slab_start_z, m_slab_end_z};
+  }
 
   int delete_particle(int p_id);
   void add_reaction(double gamma, const std::vector<int> &reactant_types,
@@ -146,6 +145,14 @@ private:
 
   void append_particle_property_of_random_particle(
       int type, std::vector<StoredParticleProperty> &list_of_particles);
+
+  enum class ReactionConstraint { NONE, CYL_Z, SLAB_Z };
+  ReactionConstraint m_reaction_constraint = ReactionConstraint::NONE;
+  double m_cyl_radius = -10.0;
+  double m_cyl_x = -10.0;
+  double m_cyl_y = -10.0;
+  double m_slab_start_z = -10.0;
+  double m_slab_end_z = -10.0;
 
   Utils::Vector3d get_random_position_in_box();
 };

--- a/src/core/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.hpp
@@ -154,6 +154,7 @@ private:
   double m_slab_start_z = -10.0;
   double m_slab_end_z = -10.0;
 
+protected:
   Utils::Vector3d get_random_position_in_box();
 };
 

--- a/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
+++ b/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
@@ -267,6 +267,16 @@ BOOST_AUTO_TEST_CASE(ReactionAlgorithm_test) {
     }
     // restore box geometry
     espresso::system->set_box_l(Utils::Vector3d::broadcast(1.));
+    // check exception mechanism
+    using exception = std::domain_error;
+    BOOST_CHECK_THROW(r_algo.set_slab_constraint(-1., 0.5), exception);
+    BOOST_CHECK_THROW(r_algo.set_slab_constraint(0.5, 1.5), exception);
+    BOOST_CHECK_THROW(r_algo.set_slab_constraint(0.5, 0.2), exception);
+    BOOST_CHECK_THROW(r_algo.set_cyl_constraint(-1., 0.5, 0.5), exception);
+    BOOST_CHECK_THROW(r_algo.set_cyl_constraint(1.5, 0.5, 0.5), exception);
+    BOOST_CHECK_THROW(r_algo.set_cyl_constraint(0.5, -1., 0.5), exception);
+    BOOST_CHECK_THROW(r_algo.set_cyl_constraint(0.5, 1.5, 0.5), exception);
+    BOOST_CHECK_THROW(r_algo.set_cyl_constraint(0.5, 0.5, -1.0), exception);
     r_algo.remove_constraint();
   }
 }

--- a/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
+++ b/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
@@ -51,6 +51,7 @@ BOOST_AUTO_TEST_CASE(ReactionAlgorithm_test) {
   public:
     using ReactionAlgorithm::calculate_acceptance_probability;
     using ReactionAlgorithm::generate_new_particle_positions;
+    using ReactionAlgorithm::get_random_position_in_box;
     using ReactionAlgorithm::ReactionAlgorithm;
   };
   constexpr double tol = 100 * std::numeric_limits<double>::epsilon();
@@ -225,6 +226,48 @@ BOOST_AUTO_TEST_CASE(ReactionAlgorithm_test) {
     // cleanup
     remove_particle(0);
     remove_particle(1);
+  }
+
+  // check random positions generator
+  {
+    // setup box
+    auto const box_l = Utils::Vector3d{0.5, 0.4, 0.7};
+    auto const origin = Utils::Vector3d::broadcast(0.);
+    espresso::system->set_box_l(box_l);
+    // cubic case
+    r_algo.remove_constraint();
+    for (int i = 0; i < 100; ++i) {
+      auto const pos = r_algo.get_random_position_in_box();
+      BOOST_TEST(pos <= box_l, boost::test_tools::per_element());
+      BOOST_TEST(pos >= origin, boost::test_tools::per_element());
+    }
+    // slab case
+    auto const start_z{0.2}, end_z{0.6};
+    auto const slab_lower = Utils::Vector3d{0., 0., start_z};
+    auto const slab_upper = Utils::Vector3d{box_l[0], box_l[1], end_z};
+    r_algo.set_slab_constraint(start_z, end_z);
+    for (int i = 0; i < 100; ++i) {
+      auto const pos = r_algo.get_random_position_in_box();
+      BOOST_TEST(pos <= slab_upper, boost::test_tools::per_element());
+      BOOST_TEST(pos >= slab_lower, boost::test_tools::per_element());
+    }
+    auto const slab_params = r_algo.get_slab_constraint_parameters();
+    BOOST_CHECK_CLOSE(slab_params[0], start_z, tol);
+    BOOST_CHECK_CLOSE(slab_params[1], end_z, tol);
+    // cylindrical case
+    auto const cyl_x{0.2}, cyl_y{0.1}, radius{0.2};
+    r_algo.set_cyl_constraint(cyl_x, cyl_y, radius);
+    for (int i = 0; i < 400; ++i) {
+      auto const pos = r_algo.get_random_position_in_box();
+      auto const z = pos[2];
+      auto const r = Utils::Vector2d{pos[0] - cyl_x, pos[1] - cyl_y}.norm();
+      BOOST_REQUIRE_LE(r, radius);
+      BOOST_REQUIRE_LE(z, box_l[2]);
+      BOOST_REQUIRE_GE(z, 0.);
+    }
+    // restore box geometry
+    espresso::system->set_box_l(Utils::Vector3d::broadcast(1.));
+    r_algo.remove_constraint();
   }
 }
 

--- a/src/python/espressomd/reaction_ensemble.pxd
+++ b/src/python/espressomd/reaction_ensemble.pxd
@@ -21,6 +21,7 @@ from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.map cimport map
+from .utils cimport Vector2d
 
 cdef extern from "reaction_methods/SingleReaction.hpp" namespace "ReactionMethods":
 
@@ -45,19 +46,16 @@ cdef extern from "reaction_methods/ReactionAlgorithm.hpp" namespace "ReactionMet
         int delete_particle(int p_id)
         void add_reaction(double gamma, vector[int] reactant_types, vector[int] reactant_coefficients, vector[int] product_types, vector[int] product_coefficients) except +
         void delete_reaction(int reaction_id)
+        void set_cyl_constraint(double center_x, double center_y, double radius)
+        void set_slab_constraint(double slab_start_z, double slab_end_z)
+        void remove_constraint()
+        Vector2d get_slab_constraint_parameters()
 
         vector[SingleReaction] reactions
         map[int, double] charges_of_types
         double kT
         double exclusion_radius
         double volume
-        bool box_is_cylindric_around_z_axis
-        double cyl_radius
-        double cyl_x
-        double cyl_y
-        bool box_has_wall_constraints
-        double slab_start_z
-        double slab_end_z
         int non_interacting_type
 
 cdef extern from "reaction_methods/ReactionEnsemble.hpp" namespace "ReactionMethods":

--- a/src/python/espressomd/reaction_ensemble.pxd
+++ b/src/python/espressomd/reaction_ensemble.pxd
@@ -46,8 +46,8 @@ cdef extern from "reaction_methods/ReactionAlgorithm.hpp" namespace "ReactionMet
         int delete_particle(int p_id)
         void add_reaction(double gamma, vector[int] reactant_types, vector[int] reactant_coefficients, vector[int] product_types, vector[int] product_coefficients) except +
         void delete_reaction(int reaction_id)
-        void set_cyl_constraint(double center_x, double center_y, double radius)
-        void set_slab_constraint(double slab_start_z, double slab_end_z)
+        void set_cyl_constraint(double center_x, double center_y, double radius) except +
+        void set_slab_constraint(double slab_start_z, double slab_end_z) except +
         void remove_constraint()
         Vector2d get_slab_constraint_parameters()
 

--- a/src/python/espressomd/reaction_ensemble.pyx
+++ b/src/python/espressomd/reaction_ensemble.pyx
@@ -71,6 +71,14 @@ cdef class ReactionAlgorithm:
             deref(self.RE).set_cuboid_reaction_ensemble_volume()
         deref(self.RE).exclusion_radius = self._params["exclusion_radius"]
 
+    def remove_constraint(self):
+        """
+        Remove any previously defined constraint.
+        Requires setting the volume using :meth:`set_volume`.
+
+        """
+        deref(self.RE).remove_constraint()
+
     def set_cylindrical_constraint_in_z_direction(self, center_x, center_y,
                                                   radius_of_cylinder):
         """
@@ -88,10 +96,8 @@ cdef class ReactionAlgorithm:
             radius of the cylinder
 
         """
-        deref(self.RE).cyl_x = center_x
-        deref(self.RE).cyl_y = center_y
-        deref(self.RE).cyl_radius = radius_of_cylinder
-        deref(self.RE).box_is_cylindric_around_z_axis = True
+        deref(self.RE).set_cyl_constraint(
+            center_x, center_y, radius_of_cylinder)
 
     def set_wall_constraints_in_z_direction(self, slab_start_z, slab_end_z):
         """
@@ -99,16 +105,15 @@ cdef class ReactionAlgorithm:
         the volume using :meth:`set_volume`.
 
         """
-        deref(self.RE).slab_start_z = slab_start_z
-        deref(self.RE).slab_end_z = slab_end_z
-        deref(self.RE).box_has_wall_constraints = True
+        deref(self.RE).set_slab_constraint(slab_start_z, slab_end_z)
 
     def get_wall_constraints_in_z_direction(self):
         """
         Returns the restrictions of the sampling area in z-direction.
 
         """
-        return deref(self.RE).slab_start_z, deref(self.RE).slab_end_z
+        v = deref(self.RE).get_slab_constraint_parameters()
+        return [v[0], v[1]]
 
     def set_volume(self, volume):
         """

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -63,7 +63,8 @@ cpdef handle_errors(msg)
 
 cdef extern from "utils/Vector.hpp" namespace "Utils":
     cppclass Vector2d:
-        pass
+        double & operator[](int i)
+        double * data()
     cppclass Vector4d:
         double & operator[](int i)
         double * data()


### PR DESCRIPTION
Description of changes:
- unit test reaction constraints
- make reaction constraint fields private
- make invalid constraint parameters raise a `ValueError`
- make it safe to change a reaction constraint from cylindrical to slab
- make it possible to remove a reaction constraint
