### PR TITLE
MMM1D maintenance

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -294,7 +294,13 @@ General features
 
    .. seealso:: :ref:`Electrostatics`
 
--  ``MMM1D_GPU``
+-  ``MMM1D_GPU``: This enables MMM1D on GPU. It is faster than the CPU version
+   by several orders of magnitude, but has float precision instead of double
+   precision.
+
+-  ``MMM1D_MACHINE_PREC``: This enables high-precision Bessel functions
+   for MMM1D on CPU. Comes with a 60% slow-down penalty. The low-precision
+   functions are in most cases precise enough and are enabled by default.
 
 -  ``DIPOLES`` This activates the dipole-moment property of particles; In addition,
    the various magnetostatics algorithms, such as P3M are switched on.

--- a/maintainer/configs/no_rotation.hpp
+++ b/maintainer/configs/no_rotation.hpp
@@ -36,6 +36,7 @@
 
 // Charges and dipoles
 #define ELECTROSTATICS
+#define MMM1D_MACHINE_PREC
 #ifdef CUDA
 #define MMM1D_GPU
 #endif

--- a/src/config/features.def
+++ b/src/config/features.def
@@ -33,6 +33,7 @@ ROTATIONAL_INERTIA              implies ROTATION
 ELECTROSTATICS
 P3M                             equals ELECTROSTATICS and FFTW
 MMM1D_GPU                       requires CUDA and ELECTROSTATICS
+MMM1D_MACHINE_PREC              requires ELECTROSTATICS
 
 /* Magnetostatics */
 DIPOLES                         implies ROTATION

--- a/src/core/EspressoSystemInterface.hpp
+++ b/src/core/EspressoSystemInterface.hpp
@@ -148,7 +148,7 @@ public:
 
   Utils::Vector3d box() const override;
 
-  unsigned int npart_gpu() override {
+  unsigned int npart_gpu() const override {
 #ifdef CUDA
     return gpu_get_particle_pointer().size();
 #else

--- a/src/core/SystemInterface.hpp
+++ b/src/core/SystemInterface.hpp
@@ -20,7 +20,10 @@
 #define SYSTEMINTERFACE_H
 
 #include "config.hpp"
+
 #include <utils/Vector.hpp>
+
+#include <cstddef>
 
 /** @todo: Turn needsXY in getter/setter **/
 
@@ -93,7 +96,7 @@ public:
     return m_needsDirectorGpu;
   }
 
-  virtual unsigned int npart_gpu() const { return 0; };
+  virtual std::size_t npart_gpu() const { return 0; };
   virtual Vector3 box() const = 0;
 
   virtual bool needsRGpu() { return m_needsRGpu; };

--- a/src/core/SystemInterface.hpp
+++ b/src/core/SystemInterface.hpp
@@ -93,7 +93,7 @@ public:
     return m_needsDirectorGpu;
   }
 
-  virtual unsigned int npart_gpu() { return 0; };
+  virtual unsigned int npart_gpu() const { return 0; };
   virtual Vector3 box() const = 0;
 
   virtual bool needsRGpu() { return m_needsRGpu; };

--- a/src/core/actor/DipolarBarnesHut.hpp
+++ b/src/core/actor/DipolarBarnesHut.hpp
@@ -82,7 +82,8 @@ public:
     buildTreeBH(m_bh_data.blocks);
     summarizeBH(m_bh_data.blocks);
     sortBH(m_bh_data.blocks);
-    if (energyBH(&m_bh_data, m_k, (&(((CUDA_energy *)s.eGpu())->dipolar)))) {
+    if (energyBH(&m_bh_data, m_k,
+                 &(reinterpret_cast<CUDA_energy *>(s.eGpu())->dipolar))) {
       runtimeErrorMsg() << "kernels encountered a functional error";
     }
   };

--- a/src/core/actor/DipolarDirectSum.hpp
+++ b/src/core/actor/DipolarDirectSum.hpp
@@ -74,7 +74,7 @@ public:
     }
     DipolarDirectSum_kernel_wrapper_energy(
         k, static_cast<int>(s.npart_gpu()), s.rGpuBegin(), s.dipGpuBegin(), box,
-        per, (&(((CUDA_energy *)s.eGpu())->dipolar)));
+        per, &(reinterpret_cast<CUDA_energy *>(s.eGpu())->dipolar));
   };
 
 private:

--- a/src/core/actor/Mmm1dgpuForce.hpp
+++ b/src/core/actor/Mmm1dgpuForce.hpp
@@ -48,7 +48,7 @@ public:
 private:
   // CUDA parameters
   unsigned int numThreads;
-  unsigned int numBlocks(SystemInterface &s);
+  unsigned int numBlocks(SystemInterface const &s) const;
 
   // the box length currently set on the GPU
   // Needed to make sure it hasn't been modified after inter coulomb was used.

--- a/src/core/actor/Mmm1dgpuForce.hpp
+++ b/src/core/actor/Mmm1dgpuForce.hpp
@@ -55,7 +55,7 @@ private:
   float host_boxz;
   // the number of particles we had during the last run. Needed to check if we
   // have to realloc dev_forcePairs
-  int host_npart;
+  unsigned int host_npart;
   bool need_tune;
 
   // pairs==0: return forces using atomicAdd

--- a/src/core/actor/Mmm1dgpuForce_cuda.cu
+++ b/src/core/actor/Mmm1dgpuForce_cuda.cu
@@ -66,40 +66,40 @@ constexpr int modpsi_constant_size = modpsi_order * modpsi_order * 2;
 
 // linearized array on device
 __constant__ int device_n_modPsi[1] = {0};
-__constant__ int device_linModPsi_offsets[2 * modpsi_order],
-    device_linModPsi_lengths[2 * modpsi_order];
+__constant__ unsigned int device_linModPsi_offsets[2 * modpsi_order];
+__constant__ unsigned int device_linModPsi_lengths[2 * modpsi_order];
 __constant__ float device_linModPsi[modpsi_constant_size];
 
 __device__ float dev_mod_psi_even(int n, float x) {
   return evaluateAsTaylorSeriesAt(
       &device_linModPsi[device_linModPsi_offsets[2 * n]],
-      device_linModPsi_lengths[2 * n], x * x);
+      static_cast<int>(device_linModPsi_lengths[2 * n]), x * x);
 }
 
 __device__ float dev_mod_psi_odd(int n, float x) {
   return x * evaluateAsTaylorSeriesAt(
                  &device_linModPsi[device_linModPsi_offsets[2 * n + 1]],
-                 device_linModPsi_lengths[2 * n + 1], x * x);
+                 static_cast<int>(device_linModPsi_lengths[2 * n + 1]), x * x);
 }
 
 int modpsi_init() {
   create_mod_psi_up_to(modpsi_order);
 
   // linearized array on host
-  std::vector<int> linModPsi_offsets(modPsi.size());
-  std::vector<int> linModPsi_lengths(modPsi.size());
-  for (size_t i = 0; i < modPsi.size(); i++) {
+  std::vector<unsigned int> linModPsi_offsets(modPsi.size());
+  std::vector<unsigned int> linModPsi_lengths(modPsi.size());
+  for (std::size_t i = 0; i < modPsi.size(); i++) {
     if (i)
       linModPsi_offsets[i] =
           linModPsi_offsets[i - 1] + linModPsi_lengths[i - 1];
-    linModPsi_lengths[i] = modPsi[i].size();
+    linModPsi_lengths[i] = static_cast<unsigned int>(modPsi[i].size());
   }
 
   // linearize the coefficients array
   std::vector<float> linModPsi(linModPsi_offsets[modPsi.size() - 1] +
                                linModPsi_lengths[modPsi.size() - 1]);
-  for (size_t i = 0; i < modPsi.size(); i++) {
-    for (size_t j = 0; j < modPsi[i].size(); j++) {
+  for (std::size_t i = 0; i < modPsi.size(); i++) {
+    for (std::size_t j = 0; j < modPsi[i].size(); j++) {
       linModPsi[linModPsi_offsets[i] + j] = static_cast<float>(modPsi[i][j]);
     }
   }
@@ -110,7 +110,7 @@ int modpsi_init() {
     // copy to GPU
     auto const linModPsiSize = linModPsi_offsets[modPsi.size() - 1] +
                                linModPsi_lengths[modPsi.size() - 1];
-    if (linModPsiSize > modpsi_constant_size) {
+    if (linModPsiSize > static_cast<unsigned int>(modpsi_constant_size)) {
       throw std::runtime_error(
           "__constant__ device_linModPsi[] is not large enough");
     }
@@ -153,18 +153,18 @@ Mmm1dgpuForce::Mmm1dgpuForce(SystemInterface &s, float _coulomb_prefactor,
 }
 
 void Mmm1dgpuForce::setup(SystemInterface &s) {
-  if (s.box()[2] <= 0) {
+  auto const box_z = static_cast<float>(s.box()[2]);
+  if (box_z <= 0) {
     throw std::runtime_error(
         "Please set box length before initializing MMM1D!");
   }
   if (need_tune && s.npart_gpu() > 0) {
-    set_params(static_cast<float>(s.box()[2]),
-               static_cast<float>(coulomb.prefactor), maxPWerror,
+    set_params(box_z, static_cast<float>(coulomb.prefactor), maxPWerror,
                far_switch_radius, bessel_cutoff);
     tune(s, maxPWerror, far_switch_radius, bessel_cutoff);
   }
-  if (s.box()[2] != host_boxz) {
-    set_params(static_cast<float>(s.box()[2]), 0, -1, -1, -1);
+  if (box_z != host_boxz) {
+    set_params(box_z, 0, -1, -1, -1);
   }
   if (s.npart_gpu() == host_npart) { // unchanged
     return;
@@ -178,7 +178,7 @@ void Mmm1dgpuForce::setup(SystemInterface &s) {
   for (int d = 0; d < deviceCount; d++) {
     cudaSetDevice(d);
 
-    size_t freeMem, totalMem;
+    std::size_t freeMem, totalMem;
     cudaMemGetInfo(&freeMem, &totalMem);
     if (freeMem / 2 < part_mem_size) {
       // don't use more than half the device's memory
@@ -198,11 +198,12 @@ void Mmm1dgpuForce::setup(SystemInterface &s) {
     cudaFree(dev_energyBlocks);
   cuda_safe_mem(
       cudaMalloc((void **)&dev_energyBlocks, numBlocks(s) * sizeof(float)));
-  host_npart = static_cast<int>(s.npart_gpu());
+  host_npart = static_cast<unsigned int>(s.npart_gpu());
 }
 
 unsigned int Mmm1dgpuForce::numBlocks(SystemInterface const &s) const {
-  auto b = static_cast<int>(s.npart_gpu() * s.npart_gpu() / numThreads) + 1;
+  auto b = 1 + static_cast<unsigned int>(Utils::sqr(s.npart_gpu()) /
+                                         static_cast<std::size_t>(numThreads));
   if (b > 65535)
     b = 65535;
   return b;
@@ -214,8 +215,8 @@ __forceinline__ __device__ float sqpow(float x) { return x * x; }
 __forceinline__ __device__ float cbpow(float x) { return x * x * x; }
 
 __device__ void sumReduction(float *input, float *sum) {
-  auto tid = static_cast<int>(threadIdx.x);
-  for (auto i = static_cast<int>(blockDim.x) / 2; i > 0; i /= 2) {
+  auto const tid = threadIdx.x;
+  for (auto i = blockDim.x / 2; i > 0; i /= 2) {
     __syncthreads();
     if (tid < i)
       input[tid] += input[i + tid];
@@ -225,23 +226,23 @@ __device__ void sumReduction(float *input, float *sum) {
     sum[0] = input[0];
 }
 
-__global__ void sumKernel(float *data, int N) {
+__global__ void sumKernel(float *data, std::size_t N) {
   extern __shared__ float partialsums[];
   if (blockIdx.x != 0)
     return;
-  auto const tid = static_cast<int>(threadIdx.x);
+  std::size_t const tid = threadIdx.x;
   auto result = 0.f;
 
-  for (int i = 0; i < N; i += static_cast<int>(blockDim.x)) {
+  for (std::size_t i = 0; i < N; i += blockDim.x) {
     if (i + tid >= N)
-      partialsums[tid] = 0;
+      partialsums[tid] = 0.f;
     else
       partialsums[tid] = data[i + tid];
 
     sumReduction(partialsums, &result);
     if (tid == 0) {
       if (i == 0)
-        data[0] = 0;
+        data[0] = 0.f;
       data[0] += result;
     }
   }
@@ -249,9 +250,9 @@ __global__ void sumKernel(float *data, int N) {
 
 __global__ void besselTuneKernel(int *result, float far_switch_radius,
                                  int maxCut) {
-  const float c_2pif = 2 * Utils::pi<float>();
-  float arg = c_2pif * *uz * far_switch_radius;
-  float pref = 4 * *uz * max(1.0f, c_2pif * *uz);
+  constexpr auto c_2pif = 2 * Utils::pi<float>();
+  auto const arg = c_2pif * *uz * far_switch_radius;
+  auto const pref = 4 * *uz * max(1.0f, c_2pif * *uz);
   float err;
   int P = 1;
   do {
@@ -367,17 +368,16 @@ void Mmm1dgpuForce::set_params(float _boxz, float _coulomb_prefactor,
 
 __global__ void forcesKernel(const float *__restrict__ r,
                              const float *__restrict__ q,
-                             float *__restrict__ force, int N, int pairs,
-                             int tStart) {
+                             float *__restrict__ force, std::size_t N,
+                             int pairs, std::size_t tStart) {
 
-  auto const c_2pif = 2 * Utils::pi<float>();
+  constexpr auto c_2pif = 2 * Utils::pi<float>();
   auto const tStop = Utils::sqr(N);
 
-  for (int tid =
-           static_cast<int>(threadIdx.x + blockIdx.x * blockDim.x) + tStart;
-       tid < tStop; tid += static_cast<int>(blockDim.x * gridDim.x)) {
+  for (std::size_t tid = threadIdx.x + blockIdx.x * blockDim.x + tStart;
+       tid < tStop; tid += blockDim.x * gridDim.x) {
     auto const p1 = tid % N, p2 = tid / N;
-    auto x = r[3 * p2] - r[3 * p1];
+    auto x = r[3 * p2 + 0] - r[3 * p1 + 0];
     auto y = r[3 * p2 + 1] - r[3 * p1 + 1];
     auto z = r[3 * p2 + 2] - r[3 * p1 + 2];
     auto const rxy2 = sqpow(x) + sqpow(y);
@@ -392,8 +392,8 @@ __global__ void forcesKernel(const float *__restrict__ r,
 
     if (p1 == p2) // particle exerts no force on itself
     {
-      rxy = 1; // so the division at the end doesn't fail with NaN (sum_r is 0
-               // anyway)
+      rxy = 1.f; // so the division at the end doesn't fail with NaN
+                 // (sum_r is 0 anyway)
     } else if (rxy2 <= *far_switch_radius_2) // near formula
     {
       auto const uzz = *uz * z;
@@ -428,8 +428,8 @@ __global__ void forcesKernel(const float *__restrict__ r,
       if (rxy == 0) // particles at the same radial position only exert a force
                     // in z direction
       {
-        rxy = 1; // so the division at the end doesn't fail with NaN (sum_r is 0
-                 // anyway)
+        rxy = 1.f; // so the division at the end doesn't fail with NaN
+                   // (sum_r is 0 anyway)
       }
     } else // far formula
     {
@@ -445,11 +445,11 @@ __global__ void forcesKernel(const float *__restrict__ r,
 
     auto const pref = *coulomb_prefactor * q[p1] * q[p2];
     if (pairs) {
-      force[3 * (p1 + p2 * N - tStart)] = pref * sum_r / rxy * x;
+      force[3 * (p1 + p2 * N - tStart) + 0] = pref * sum_r / rxy * x;
       force[3 * (p1 + p2 * N - tStart) + 1] = pref * sum_r / rxy * y;
       force[3 * (p1 + p2 * N - tStart) + 2] = pref * sum_z;
     } else {
-      atomicAdd(&force[3 * p2], pref * sum_r / rxy * x);
+      atomicAdd(&force[3 * p2 + 0], pref * sum_r / rxy * x);
       atomicAdd(&force[3 * p2 + 1], pref * sum_r / rxy * y);
       atomicAdd(&force[3 * p2 + 2], pref * sum_z);
     }
@@ -458,11 +458,11 @@ __global__ void forcesKernel(const float *__restrict__ r,
 
 __global__ void energiesKernel(const float *__restrict__ r,
                                const float *__restrict__ q,
-                               float *__restrict__ energy, int N, int pairs,
-                               int tStart) {
+                               float *__restrict__ energy, std::size_t N,
+                               int pairs, std::size_t tStart) {
 
-  auto const c_2pif = 2 * Utils::pi<float>();
-  auto const c_gammaf = Utils::gamma<float>();
+  constexpr auto c_2pif = 2 * Utils::pi<float>();
+  constexpr auto c_gammaf = Utils::gamma<float>();
   auto const tStop = Utils::sqr(N);
 
   extern __shared__ float partialsums[];
@@ -470,13 +470,12 @@ __global__ void energiesKernel(const float *__restrict__ r,
     partialsums[threadIdx.x] = 0;
     __syncthreads();
   }
-  for (int tid =
-           static_cast<int>(threadIdx.x + blockIdx.x * blockDim.x) + tStart;
-       tid < tStop; tid += static_cast<int>(blockDim.x * gridDim.x)) {
+  for (std::size_t tid = threadIdx.x + blockIdx.x * blockDim.x + tStart;
+       tid < tStop; tid += blockDim.x * gridDim.x) {
     auto const p1 = tid % N, p2 = tid / N;
     auto z = r[3 * p2 + 2] - r[3 * p1 + 2];
-    auto const rxy2 =
-        sqpow(r[3 * p2] - r[3 * p1]) + sqpow(r[3 * p2 + 1] - r[3 * p1 + 1]);
+    auto const rxy2 = sqpow(r[3 * p2 + 0] - r[3 * p1 + 0]) +
+                      sqpow(r[3 * p2 + 1] - r[3 * p1 + 1]);
     auto rxy = sqrt(rxy2);
     auto sum_e = 0.f;
 
@@ -529,18 +528,17 @@ __global__ void energiesKernel(const float *__restrict__ r,
   }
 }
 
-__global__ void vectorReductionKernel(float const *src, float *dst, int N,
-                                      int tStart) {
+__global__ void vectorReductionKernel(float const *src, float *dst,
+                                      std::size_t N, std::size_t tStart) {
 
   auto const tStop = Utils::sqr(N);
 
-  for (auto tid = static_cast<int>(threadIdx.x + blockIdx.x * blockDim.x);
-       tid < N; tid += static_cast<int>(blockDim.x * gridDim.x)) {
+  for (std::size_t tid = threadIdx.x + blockIdx.x * blockDim.x; tid < N;
+       tid += blockDim.x * gridDim.x) {
     auto const offset = (tid + (tStart % N)) % N;
-
-    for (int i = 0; tid + i * N < (tStop - tStart); i++) {
+    for (std::size_t i = 0; tid + i * N < (tStop - tStart); i++) {
 #pragma unroll 3
-      for (int d = 0; d < 3; d++) {
+      for (std::size_t d = 0; d < 3; d++) {
         dst[3 * offset + d] -= src[3 * (tid + i * N) + d];
       }
     }
@@ -561,7 +559,9 @@ void Mmm1dgpuForce::computeForces(SystemInterface &s) {
 
   if (pairs) // if we calculate force pairs, we need to reduce them to forces
   {
-    auto blocksRed = static_cast<int>(s.npart_gpu() / numThreads) + 1;
+    auto const blocksRed =
+        1 + static_cast<unsigned>(s.npart_gpu() /
+                                  static_cast<std::size_t>(numThreads));
     KERNELCALL(forcesKernel, numBlocks(s), numThreads, s.rGpuBegin(),
                s.qGpuBegin(), dev_forcePairs, s.npart_gpu(), pairs, 0)
     KERNELCALL(vectorReductionKernel, blocksRed, numThreads, dev_forcePairs,
@@ -572,10 +572,10 @@ void Mmm1dgpuForce::computeForces(SystemInterface &s) {
   }
 }
 
-__global__ void scaleAndAddKernel(float *dst, float const *src, int N,
+__global__ void scaleAndAddKernel(float *dst, float const *src, std::size_t N,
                                   float factor) {
-  for (auto tid = static_cast<int>(threadIdx.x + blockIdx.x * blockDim.x);
-       tid < N; tid += static_cast<int>(blockDim.x * gridDim.x)) {
+  for (std::size_t tid = threadIdx.x + blockIdx.x * blockDim.x; tid < N;
+       tid += blockDim.x * gridDim.x) {
     dst[tid] += src[tid] * factor;
   }
 }
@@ -591,17 +591,18 @@ void Mmm1dgpuForce::computeEnergy(SystemInterface &s) {
   if (pairs < 0) {
     throw std::runtime_error("MMM1D was not initialized correctly");
   }
-  auto const shared = numThreads * static_cast<int>(sizeof(float));
 
+  auto const shared = numThreads * static_cast<unsigned>(sizeof(float));
   KERNELCALL_shared(energiesKernel, numBlocks(s), numThreads, shared,
                     s.rGpuBegin(), s.qGpuBegin(), dev_energyBlocks,
                     s.npart_gpu(), 0, 0);
   KERNELCALL_shared(sumKernel, 1, numThreads, shared, dev_energyBlocks,
                     numBlocks(s));
-  KERNELCALL(scaleAndAddKernel, 1, 1, &(((CUDA_energy *)s.eGpu())->coulomb),
+  KERNELCALL(scaleAndAddKernel, 1, 1,
+             &(reinterpret_cast<CUDA_energy *>(s.eGpu())->coulomb),
              &dev_energyBlocks[0], 1,
-             0.5); // we have counted every interaction twice, so halve the
-                   // total energy
+             0.5f); // we have counted every interaction twice, so halve the
+                    // total energy
 }
 
 float Mmm1dgpuForce::force_benchmark(SystemInterface &s) {

--- a/src/core/actor/specfunc_cuda.hpp
+++ b/src/core/actor/specfunc_cuda.hpp
@@ -132,11 +132,11 @@ __constant__ static int bi1_size = 11;
 /**@}*/
 
 __device__ float evaluateAsChebychevSeriesAt(float const *c, int n, float x) {
-  float x2 = 2 * x;
-  float dd = c[n - 1];
-  float d = x2 * dd + c[n - 2];
+  auto const x2 = 2 * x;
+  auto dd = c[n - 1];
+  auto d = x2 * dd + c[n - 2];
   for (int j = n - 3; j >= 1; j--) {
-    float tmp = d;
+    auto const tmp = d;
     d = x2 * d - dd + c[j];
     dd = tmp;
   }
@@ -145,7 +145,7 @@ __device__ float evaluateAsChebychevSeriesAt(float const *c, int n, float x) {
 
 __device__ float evaluateAsTaylorSeriesAt(float const *c, int n, float x) {
   int cnt = n - 1;
-  float r = c[cnt];
+  auto r = c[cnt];
   while (--cnt >= 0)
     r = r * x + c[cnt];
   return r;

--- a/src/core/actor/specfunc_cuda.hpp
+++ b/src/core/actor/specfunc_cuda.hpp
@@ -132,7 +132,7 @@ __constant__ static int bi1_size = 11;
 /**@}*/
 
 __device__ float evaluateAsChebychevSeriesAt(float const *c, int n, float x) {
-  auto const x2 = 2 * x;
+  auto const x2 = 2.0f * x;
   auto dd = c[n - 1];
   auto d = x2 * dd + c[n - 2];
   for (int j = n - 3; j >= 1; j--) {
@@ -140,7 +140,7 @@ __device__ float evaluateAsChebychevSeriesAt(float const *c, int n, float x) {
     d = x2 * d - dd + c[j];
     dd = tmp;
   }
-  return x * d - dd + c[0] / 2;
+  return x * d - dd + c[0] / 2.0f;
 }
 
 __device__ float evaluateAsTaylorSeriesAt(float const *c, int n, float x) {
@@ -152,13 +152,13 @@ __device__ float evaluateAsTaylorSeriesAt(float const *c, int n, float x) {
 }
 
 __device__ float dev_K0(float x) {
-  float c = evaluateAsChebychevSeriesAt(
-      x <= 2 ? bk0_data : x <= 8 ? ak0_data : ak02_data,
-      x <= 2 ? bk0_size : x <= 8 ? ak0_size : ak02_size,
-      x <= 2 ? x * x / 2 - 1.0f
-             : x <= 8 ? (16 / x - 5.0f) / 3.0f : (16 / x - 1.0f));
-  if (x <= 2) {
-    float I0 =
+  auto const c = evaluateAsChebychevSeriesAt(
+      x <= 2.0f ? bk0_data : x <= 8.0f ? ak0_data : ak02_data,
+      x <= 2.0f ? bk0_size : x <= 8.0f ? ak0_size : ak02_size,
+      x <= 2.0f ? x * x / 2.0f - 1.0f
+                : x <= 8.0f ? (16.0f / x - 5.0f) / 3.0f : (16.0f / x - 1.0f));
+  if (x <= 2.0f) {
+    auto const I0 =
         evaluateAsChebychevSeriesAt(bi0_data, bi0_size, x * x / 4.5f - 1.0f);
     return (-log(x) + Utils::ln_2<float>()) * I0 + c;
   }
@@ -166,14 +166,14 @@ __device__ float dev_K0(float x) {
 }
 
 __device__ float dev_K1(float x) {
-  float c = evaluateAsChebychevSeriesAt(
-      x <= 2 ? bk1_data : x <= 8 ? ak1_data : ak12_data,
-      x <= 2 ? bk1_size : x <= 8 ? ak1_size : ak12_size,
-      x <= 2 ? x * x / 2 - 1.0f
-             : x <= 8 ? (16 / x - 5.0f) / 3.0f : (16 / x - 1.0f));
-  if (x <= 2) {
-    float I1 = x * evaluateAsChebychevSeriesAt(bi1_data, bi1_size,
-                                               x * x / 4.5f - 1.0f);
+  auto const c = evaluateAsChebychevSeriesAt(
+      x <= 2.0f ? bk1_data : x <= 8.0f ? ak1_data : ak12_data,
+      x <= 2.0f ? bk1_size : x <= 8.0f ? ak1_size : ak12_size,
+      x <= 2.0f ? x * x / 2.0f - 1.0f
+                : x <= 8.0f ? (16.0f / x - 5.0f) / 3.0f : (16.0f / x - 1.0f));
+  if (x <= 2.0f) {
+    auto const I1 = x * evaluateAsChebychevSeriesAt(bi1_data, bi1_size,
+                                                    x * x / 4.5f - 1.0f);
     return (log(x) - Utils::ln_2<float>()) * I1 + c / x;
   }
   return exp(-x) * c * rsqrt(x);

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -77,10 +77,10 @@ MMM1D_struct mmm1d_params = {0.05, 1e-5, 0};
 static std::array<double, MAXIMAL_B_CUT> bessel_radii;
 
 static double far_error(int P, double minrad) {
+  auto const wavenumber = 2 * Utils::pi() * box_geo.length_inv()[2];
   // this uses an upper bound to all force components and the potential
-  auto const rhores = 2 * Utils::pi() * box_geo.length_inv()[2] * minrad;
-  auto const pref = 4 * box_geo.length_inv()[2] *
-                    std::max(1.0, 2 * Utils::pi() * box_geo.length_inv()[2]);
+  auto const rhores = wavenumber * minrad;
+  auto const pref = 4 * box_geo.length_inv()[2] * std::max(1.0, wavenumber);
 
   return pref * K1(rhores * P) * exp(rhores) / rhores * (P - 1 + 1 / rhores);
 }
@@ -177,7 +177,7 @@ int MMM1D_init() {
 
 void add_mmm1d_coulomb_pair_force(double chpref, Utils::Vector3d const &d,
                                   double r, Utils::Vector3d &force) {
-  constexpr double c_2pi = 2 * Utils::pi();
+  constexpr auto c_2pi = 2 * Utils::pi();
   auto const n_modPsi = static_cast<int>(modPsi.size() >> 1);
   auto const rxy2 = d[0] * d[0] + d[1] * d[1];
   auto const rxy2_d = rxy2 * uz2;
@@ -186,9 +186,9 @@ void add_mmm1d_coulomb_pair_force(double chpref, Utils::Vector3d const &d,
 
   if (rxy2 <= mmm1d_params.far_switch_radius_2) {
     /* polygamma summation */
-    double sr = 0;
-    double sz = mod_psi_odd(0, z_d);
-    double r2nm1 = 1.0;
+    auto sr = 0.;
+    auto sz = mod_psi_odd(0, z_d);
+    auto r2nm1 = 1.0;
     for (int n = 1; n < n_modPsi; n++) {
       auto const deriv = static_cast<double>(2 * n);
       auto const mpe = mod_psi_even(n, z_d);
@@ -238,7 +238,7 @@ void add_mmm1d_coulomb_pair_force(double chpref, Utils::Vector3d const &d,
     /* far range formula */
     auto const rxy = sqrt(rxy2);
     auto const rxy_d = rxy * box_geo.length_inv()[2];
-    double sr = 0, sz = 0;
+    auto sr = 0., sz = 0.;
 
     for (int bp = 1; bp < MAXIMAL_B_CUT; bp++) {
       if (bessel_radii[bp - 1] < rxy)
@@ -271,7 +271,7 @@ double mmm1d_coulomb_pair_energy(double const chpref, Utils::Vector3d const &d,
   if (chpref == 0)
     return 0;
 
-  constexpr double c_2pi = 2 * Utils::pi();
+  constexpr auto c_2pi = 2 * Utils::pi();
   auto const n_modPsi = static_cast<int>(modPsi.size() >> 1);
   auto const rxy2 = d[0] * d[0] + d[1] * d[1];
   auto const rxy2_d = rxy2 * uz2;
@@ -299,15 +299,15 @@ double mmm1d_coulomb_pair_energy(double const chpref, Utils::Vector3d const &d,
 
     double rt, shift_z;
 
-    E += 1 / r;
+    E += 1. / r;
 
     shift_z = d[2] + box_geo.length()[2];
     rt = sqrt(rxy2 + shift_z * shift_z);
-    E += 1 / rt;
+    E += 1. / rt;
 
     shift_z = d[2] - box_geo.length()[2];
     rt = sqrt(rxy2 + shift_z * shift_z);
-    E += 1 / rt;
+    E += 1. / rt;
   } else {
     /* far range formula */
     auto const rxy = sqrt(rxy2);

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -60,12 +60,10 @@
 /** Minimal radius for the far formula in multiples of box_l[2] */
 #define MIN_RAD 0.01
 
-/* if you define this, the Bessel functions are calculated up
+/* if you define this feature, the Bessel functions are calculated up
  * to machine precision, otherwise 10^-14, which should be
  * definitely enough for daily life. */
-#undef BESSEL_MACHINE_PREC
-
-#ifndef BESSEL_MACHINE_PREC
+#ifndef MMM1D_MACHINE_PREC
 #define K0 LPK0
 #define K1 LPK1
 #endif
@@ -250,7 +248,7 @@ void add_mmm1d_coulomb_pair_force(double chpref, Utils::Vector3d const &d,
 
       auto const fq = c_2pi * bp;
       double k0, k1;
-#ifdef BESSEL_MACHINE_PREC
+#ifdef MMM1D_MACHINE_PREC
       k0 = K0(fq * rxy_d);
       k1 = K1(fq * rxy_d);
 #else

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -210,7 +210,7 @@ std::array<std::vector<int>, 3> inline calc_meshift(
     std::array<int, 3> const &mesh_size, bool zero_out_midpoint = false) {
   std::array<std::vector<int>, 3> ret{};
 
-  for (size_t i = 0; i < 3; i++) {
+  for (std::size_t i = 0; i < 3; i++) {
     ret[i] = std::vector<int>(mesh_size[i]);
 
     for (int j = 1; j <= mesh_size[i] / 2; j++) {

--- a/src/core/electrostatics_magnetostatics/specfunc.hpp
+++ b/src/core/electrostatics_magnetostatics/specfunc.hpp
@@ -38,7 +38,7 @@
 #include <utils/Span.hpp>
 
 #include <cassert>
-#include <tuple>
+#include <utility>
 
 /** Hurwitz zeta function. This function was taken from the GSL code. */
 double hzeta(double order, double x);
@@ -74,7 +74,7 @@ double LPK1(double x);
  *  comparable to the relative precision sqrt implementation of current
  *  hardware.
  */
-std::tuple<double, double> LPK01(double x);
+std::pair<double, double> LPK01(double x);
 
 /** Evaluate the polynomial interpreted as a Taylor series via the
  *  Horner scheme.

--- a/src/core/electrostatics_magnetostatics/specfunc.hpp
+++ b/src/core/electrostatics_magnetostatics/specfunc.hpp
@@ -45,31 +45,31 @@ double hzeta(double order, double x);
 
 /** Modified Bessel function of second kind, order 0. This function was taken
  *  from the GSL code. Precise roughly up to machine precision.
- *  If @c BESSEL_MACHINE_PREC is not defined, @ref LPK0 is used instead.
+ *  If @c MMM1D_MACHINE_PREC is not defined, @ref LPK0 is used instead.
  */
 double K0(double x);
 
 /** Modified Bessel function of second kind, order 1. This function was taken
  *  from the GSL code. Precise roughly up to machine precision.
- *  If @c BESSEL_MACHINE_PREC is not defined, @ref LPK1 is used instead.
+ *  If @c MMM1D_MACHINE_PREC is not defined, @ref LPK1 is used instead.
  */
 double K1(double x);
 
-/** Bessel function K0 at x.
+/** Bessel function of second kind, order 0, low precision.
  *  The implementation has an absolute precision of around 10^(-14), which is
  *  comparable to the relative precision sqrt implementation of current
  *  hardware.
  */
 double LPK0(double x);
 
-/** Bessel function K1 at x.
+/** Bessel function of second kind, order 1, low precision.
  *  The implementation has an absolute precision of around 10^(-14), which is
  *  comparable to the relative precision sqrt implementation of current
  *  hardware.
  */
 double LPK1(double x);
 
-/** Bessel functions K0 and K1 at x.
+/** Bessel functions of second kind, order 0 and order 1, low precision.
  *  The implementation has an absolute precision of around 10^(-14), which is
  *  comparable to the relative precision sqrt implementation of current
  *  hardware.

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -151,7 +151,7 @@ IF ELECTROSTATICS and MMM1D_GPU:
             unsigned int numBlocks(SystemInterface & s)
 
             float host_boxz
-            int host_npart
+            unsigned int host_npart
             bool need_tune
 
             int pairs


### PR DESCRIPTION
Closes #2071

Description of changes:
- compile and test the Chebychev series for MMM1D on CPU
- cleanup exceptions and assertions
- fix `-Wconversion` compiler warnings
   - most were due to mixing `signed int` with CUDA's `blockDim` and `blockId` (`dim` structs have `unsigned int` fields)