### PR TITLE
Improve code portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "8.0.0")
     target_compile_options(cxx_interface INTERFACE -Wimplicit-float-conversion)
   endif()
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
+     AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0")
+    target_compile_options(cxx_interface INTERFACE -Wnon-c-typedef-for-linkage)
+  endif()
 endif()
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ if(WITH_STOKESIAN_DYNAMICS)
   FetchContent_Declare(
     stokesian_dynamics
     GIT_REPOSITORY https://github.com/hmenke/espresso-stokesian-dynamics.git
-    GIT_TAG c14e57655e929)
+    GIT_TAG 862a7537a366f0c32f0c25e46bd107bea590faea)
   FetchContent_GetProperties(stokesian_dynamics)
   set(STOKESIAN_DYNAMICS 1)
   if(NOT stokesian_dynamics_POPULATED)

--- a/src/core/AtomDecomposition.cpp
+++ b/src/core/AtomDecomposition.cpp
@@ -54,7 +54,8 @@ GhostCommunicator AtomDecomposition::prepare_comm() {
     return GhostCommunicator{comm, 0};
   }
 
-  auto ghost_comm = GhostCommunicator{comm, static_cast<size_t>(comm.size())};
+  auto ghost_comm =
+      GhostCommunicator{comm, static_cast<std::size_t>(comm.size())};
   /* every node has its dedicated comm step */
   for (int n = 0; n < comm.size(); n++) {
     ghost_comm.communications[n].part_lists.resize(1);

--- a/src/core/BondList.hpp
+++ b/src/core/BondList.hpp
@@ -29,7 +29,10 @@
 #include <boost/serialization/array.hpp>
 #include <boost/version.hpp>
 
+#include <algorithm>
+#include <cassert>
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 
 /**

--- a/src/core/BondList.hpp
+++ b/src/core/BondList.hpp
@@ -107,7 +107,7 @@ private:
   friend boost::serialization::access;
   template <class Archive> void serialize(Archive &ar, long int /* version */) {
     if (Archive::is_loading::value) {
-      size_t size{};
+      std::size_t size{};
       ar &size;
       m_storage.resize(size);
     }
@@ -149,7 +149,7 @@ public:
   using value_type = BondView;
   using reference = std::add_lvalue_reference_t<BondView>;
   using const_reference = std::add_const_t<reference>;
-  using size_type = size_t;
+  using size_type = std::size_t;
   using difference_type = ptrdiff_t;
   using iterator = Iterator;
   using const_iterator = Iterator;

--- a/src/core/BondList.hpp
+++ b/src/core/BondList.hpp
@@ -150,7 +150,7 @@ public:
   using reference = std::add_lvalue_reference_t<BondView>;
   using const_reference = std::add_const_t<reference>;
   using size_type = std::size_t;
-  using difference_type = ptrdiff_t;
+  using difference_type = std::ptrdiff_t;
   using iterator = Iterator;
   using const_iterator = Iterator;
 

--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -26,6 +26,8 @@
 #include <bitset>
 #include <cassert>
 #include <cmath>
+#include <limits>
+#include <utility>
 
 namespace detail {
 /**

--- a/src/core/Cell.hpp
+++ b/src/core/Cell.hpp
@@ -26,7 +26,9 @@
 
 #include <boost/range/iterator_range.hpp>
 
+#include <algorithm>
 #include <functional>
+#include <utility>
 #include <vector>
 
 template <class CellRef> class Neighbors {

--- a/src/core/CellStructure.cpp
+++ b/src/core/CellStructure.cpp
@@ -26,7 +26,13 @@
 
 #include <utils/contains.hpp>
 
+#include <algorithm>
+#include <iterator>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 void CellStructure::check_particle_index() {
   auto const max_id = get_max_local_particle_id();

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -40,6 +40,10 @@
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/transform.hpp>
 
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <utility>
 #include <vector>
 
 /** Cell Structure */

--- a/src/core/CudaDeviceAllocator.hpp
+++ b/src/core/CudaDeviceAllocator.hpp
@@ -60,8 +60,10 @@ template <class T> struct CudaDeviceAllocator {
     return false;
   }
 
-  pointer allocate(const size_t n) const { return thrust::device_malloc<T>(n); }
-  void deallocate(pointer p, size_t) const noexcept {
+  pointer allocate(const std::size_t n) const {
+    return thrust::device_malloc<T>(n);
+  }
+  void deallocate(pointer p, std::size_t) const noexcept {
     try {
       thrust::device_free(p);
     } catch (thrust::system::system_error const &) {

--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -40,6 +40,7 @@
 #include <functional>
 #include <iterator>
 #include <utility>
+#include <vector>
 
 /** Returns pointer to the cell which corresponds to the position if the
  *  position is in the nodes spatial domain otherwise a nullptr pointer.

--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -211,7 +211,7 @@ void DomainDecomposition::resort(bool global,
       exchange_neighbors(displaced_parts, diff);
 
       auto left_over = boost::mpi::all_reduce(m_comm, displaced_parts.size(),
-                                              std::plus<size_t>());
+                                              std::plus<std::size_t>());
 
       if (left_over == 0) {
         break;
@@ -475,7 +475,7 @@ GhostCommunicator DomainDecomposition::prepare_comm() {
   auto const node_neighbors = Utils::Mpi::cart_neighbors<3>(m_comm);
 
   /* calculate number of communications */
-  size_t num = 0;
+  std::size_t num = 0;
   for (dir = 0; dir < 3; dir++) {
     for (lr = 0; lr < 2; lr++) {
       /* No communication for border of non periodic direction */

--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -50,12 +50,14 @@
 #include <boost/optional.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 
+#include <cassert>
 #include <functional>
 #include <initializer_list>
 #include <memory>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace Communication {
 

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -31,7 +31,8 @@
 #include <cstddef>
 #include <vector>
 
-Observable_stat::Observable_stat(size_t chunk_size) : m_chunk_size(chunk_size) {
+Observable_stat::Observable_stat(std::size_t chunk_size)
+    : m_chunk_size(chunk_size) {
   // number of chunks for different interaction types
   auto constexpr n_coulomb = 2;
   auto constexpr n_dipolar = 2;
@@ -42,8 +43,8 @@ Observable_stat::Observable_stat(size_t chunk_size) : m_chunk_size(chunk_size) {
 #endif
   auto const n_bonded = bonded_ia_params.size();
   auto const n_non_bonded = max_non_bonded_pairs();
-  constexpr size_t n_ext_fields = 1; // energies from all fields: accumulated
-  constexpr size_t n_kinetic = 1; // linear+angular kinetic energy: accumulated
+  constexpr std::size_t n_ext_fields = 1; // reduction over all fields
+  constexpr std::size_t n_kinetic = 1; // linear+angular kinetic contributions
 
   // resize vector
   auto const total = n_kinetic + n_bonded + 2 * n_non_bonded + n_coulomb +

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -27,7 +27,9 @@
 
 #include <utils/Span.hpp>
 
+#include <cassert>
 #include <cstddef>
+#include <vector>
 
 Observable_stat::Observable_stat(size_t chunk_size) : m_chunk_size(chunk_size) {
   // number of chunks for different interaction types

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -36,14 +36,14 @@ class Observable_stat {
   /** Array for observables on each node. */
   std::vector<double> m_data;
   /** Number of doubles per data item */
-  size_t m_chunk_size;
+  std::size_t m_chunk_size;
 
   /** Calculate the maximal number of non-bonded interaction pairs in the
    *  system.
    */
-  static size_t max_non_bonded_pairs() {
+  static std::size_t max_non_bonded_pairs() {
     extern int max_seen_particle_type;
-    return static_cast<size_t>(
+    return static_cast<std::size_t>(
         (max_seen_particle_type * (max_seen_particle_type + 1)) / 2);
   }
 
@@ -57,7 +57,7 @@ class Observable_stat {
   }
 
 public:
-  explicit Observable_stat(size_t chunk_size);
+  explicit Observable_stat(std::size_t chunk_size);
 
   auto chunk_size() const { return m_chunk_size; }
   Utils::Span<double> data_() { return {m_data.data(), m_data.size()}; }
@@ -70,7 +70,7 @@ public:
    *  @param column Which column to sum up (only relevant for multi-dimensional
    *                observables).
    */
-  double accumulate(double acc = 0.0, size_t column = 0) const {
+  double accumulate(double acc = 0.0, std::size_t column = 0) const {
     assert(column < m_chunk_size);
     if (m_chunk_size == 1)
       return boost::accumulate(m_data, acc);

--- a/src/core/PartCfg.cpp
+++ b/src/core/PartCfg.cpp
@@ -38,7 +38,7 @@ void PartCfg::update() {
   auto const ids = get_particle_ids();
   auto const chunk_size = fetch_cache_max_size();
 
-  for (size_t offset = 0; offset < ids.size();) {
+  for (std::size_t offset = 0; offset < ids.size();) {
     auto const this_size =
         boost::algorithm::clamp(chunk_size, 0, ids.size() - offset);
     auto const chunk_ids =

--- a/src/core/PartCfg.hpp
+++ b/src/core/PartCfg.hpp
@@ -109,7 +109,7 @@ private:
 public:
   /** Number of particles in the config.
    */
-  size_t size() {
+  std::size_t size() {
     if (!m_valid)
       update();
 

--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -30,6 +30,8 @@
 #include <boost/serialization/vector.hpp>
 
 #include <cstdint>
+#include <stdexcept>
+#include <vector>
 
 enum : uint8_t {
   ROTATION_FIXED = 0u,

--- a/src/core/ParticleIterator.hpp
+++ b/src/core/ParticleIterator.hpp
@@ -20,7 +20,10 @@
 #define CORE_PARTICLE_ITERATOR_HPP
 
 #include <boost/iterator/iterator_facade.hpp>
+
+#include <cassert>
 #include <iterator>
+#include <utility>
 
 namespace detail {
 /* Detect the particle iterator type for a given cell iterator type. */

--- a/src/core/RuntimeErrorCollector.cpp
+++ b/src/core/RuntimeErrorCollector.cpp
@@ -26,7 +26,9 @@
 #include <functional>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 using boost::mpi::all_reduce;
 using boost::mpi::communicator;

--- a/src/core/RuntimeErrorStream.cpp
+++ b/src/core/RuntimeErrorStream.cpp
@@ -19,6 +19,8 @@
 #include "RuntimeErrorStream.hpp"
 
 #include "RuntimeErrorCollector.hpp"
+
+#include <string>
 #include <utility>
 
 namespace ErrorHandling {

--- a/src/core/accumulators/AccumulatorBase.hpp
+++ b/src/core/accumulators/AccumulatorBase.hpp
@@ -32,7 +32,7 @@ public:
 
   virtual void update() = 0;
   /** Dimensions needed to reshape the flat array returned by the accumulator */
-  virtual std::vector<size_t> shape() const = 0;
+  virtual std::vector<std::size_t> shape() const = 0;
 
 private:
   // Number of timesteps between automatic updates.

--- a/src/core/accumulators/Correlator.cpp
+++ b/src/core/accumulators/Correlator.cpp
@@ -151,7 +151,7 @@ std::vector<double> fcs_acf(std::vector<double> const &A,
 
   std::vector<double> C(C_size, 0);
 
-  for (size_t i = 0; i < C_size; i++) {
+  for (std::size_t i = 0; i < C_size; i++) {
     for (int j = 0; j < 3; j++) {
       auto const &a = A[3 * i + j];
       auto const &b = B[3 * i + j];
@@ -283,19 +283,19 @@ void Correlator::initialize() {
   B_accumulated_average = std::vector<double>(dim_B, 0);
 
   auto const n_result = n_values();
-  n_sweeps = std::vector<size_t>(n_result, 0);
+  n_sweeps = std::vector<std::size_t>(n_result, 0);
   n_vals = std::vector<unsigned int>(m_hierarchy_depth, 0);
 
-  result.resize(std::array<size_t, 2>{{n_result, m_dim_corr}});
+  result.resize(std::array<std::size_t, 2>{{n_result, m_dim_corr}});
 
-  for (size_t i = 0; i < n_result; i++) {
-    for (size_t j = 0; j < m_dim_corr; j++) {
+  for (std::size_t i = 0; i < n_result; i++) {
+    for (std::size_t j = 0; j < m_dim_corr; j++) {
       // and initialize the values
       result[i][j] = 0;
     }
   }
 
-  newest = std::vector<size_t>(m_hierarchy_depth, m_tau_lin);
+  newest = std::vector<std::size_t>(m_hierarchy_depth, m_tau_lin);
 
   tau.resize(n_result);
   for (int i = 0; i < m_tau_lin + 1; i++) {
@@ -365,11 +365,11 @@ void Correlator::update() {
 
   // Now we update the cumulated averages and variances of A and B
   n_data++;
-  for (size_t k = 0; k < dim_A; k++) {
+  for (std::size_t k = 0; k < dim_A; k++) {
     A_accumulated_average[k] += A[0][newest[0]][k];
   }
 
-  for (size_t k = 0; k < dim_B; k++) {
+  for (std::size_t k = 0; k < dim_B; k++) {
     B_accumulated_average[k] += B[0][newest[0]][k];
   }
 
@@ -382,7 +382,7 @@ void Correlator::update() {
     assert(temp.size() == m_dim_corr);
 
     n_sweeps[j]++;
-    for (size_t k = 0; k < m_dim_corr; k++) {
+    for (std::size_t k = 0; k < m_dim_corr; k++) {
       result[j][k] += temp[k];
     }
   }
@@ -399,7 +399,7 @@ void Correlator::update() {
       assert(temp.size() == m_dim_corr);
 
       n_sweeps[index_res]++;
-      for (size_t k = 0; k < m_dim_corr; k++) {
+      for (std::size_t k = 0; k < m_dim_corr; k++) {
         result[index_res][k] += temp[k];
       }
     }
@@ -480,7 +480,7 @@ int Correlator::finalize() {
           assert(temp.size() == m_dim_corr);
 
           n_sweeps[index_res]++;
-          for (size_t k = 0; k < m_dim_corr; k++) {
+          for (std::size_t k = 0; k < m_dim_corr; k++) {
             result[index_res][k] += temp[k];
           }
         }
@@ -494,9 +494,9 @@ std::vector<double> Correlator::get_correlation() {
   auto const n_result = n_values();
   std::vector<double> res(n_result * m_dim_corr);
 
-  for (size_t i = 0; i < n_result; i++) {
+  for (std::size_t i = 0; i < n_result; i++) {
     auto const index = m_dim_corr * i;
-    for (size_t k = 0; k < m_dim_corr; k++) {
+    for (std::size_t k = 0; k < m_dim_corr; k++) {
       if (n_sweeps[i]) {
         res[index + k] = result[i][k] / static_cast<double>(n_sweeps[i]);
       }

--- a/src/core/accumulators/Correlator.cpp
+++ b/src/core/accumulators/Correlator.cpp
@@ -41,6 +41,8 @@
 #include <numeric>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace {
 int min(int i, unsigned int j) { return std::min(i, static_cast<int>(j)); }

--- a/src/core/accumulators/Correlator.hpp
+++ b/src/core/accumulators/Correlator.hpp
@@ -186,11 +186,11 @@ public:
 
   /** Return correlation result */
   std::vector<double> get_correlation();
-  size_t n_values() const {
+  std::size_t n_values() const {
     return m_tau_lin + 1 + (m_tau_lin + 1) / 2 * (m_hierarchy_depth - 1);
   }
-  std::vector<size_t> shape() const override {
-    std::vector<size_t> shape = m_shape;
+  std::vector<std::size_t> shape() const override {
+    std::vector<std::size_t> shape = m_shape;
     shape.insert(shape.begin(), n_values());
     return shape;
   }
@@ -227,12 +227,12 @@ private:
                                       ///< correlation may need (currently
                                       ///< only used by fcs_acf)
 
-  int m_hierarchy_depth; ///< maximum level of data compression
-  int m_tau_lin;         ///< number of frames in the linear correlation
-  size_t m_dim_corr;     ///< number of columns for the correlation
-  double m_dt;           ///< time interval at which samples arrive
-  double m_tau_max;      ///< maximum time for which the correlation should be
-                         ///< calculated
+  int m_hierarchy_depth;  ///< maximum level of data compression
+  int m_tau_lin;          ///< number of frames in the linear correlation
+  std::size_t m_dim_corr; ///< number of columns for the correlation
+  double m_dt;            ///< time interval at which samples arrive
+  double m_tau_max;       ///< maximum time for which the correlation should be
+                          ///< calculated
 
   std::string compressA_name;
   std::string compressB_name;
@@ -248,19 +248,19 @@ private:
   boost::multi_array<double, 2> result; ///< output quantity
 
   /// number of correlation sweeps at a particular value of tau
-  std::vector<size_t> n_sweeps;
+  std::vector<std::size_t> n_sweeps;
   /// number of data values already present at a particular value of tau
   std::vector<unsigned> n_vals;
   /// index of the newest entry in each hierarchy level
-  std::vector<size_t> newest;
+  std::vector<std::size_t> newest;
 
   std::vector<double> A_accumulated_average; ///< all A values are added up here
   std::vector<double> B_accumulated_average; ///< all B values are added up here
-  size_t n_data; ///< a counter for calculated averages and variances
+  std::size_t n_data; ///< a counter for calculated averages and variances
 
-  size_t dim_A;                ///< dimensionality of A
-  size_t dim_B;                ///< dimensionality of B
-  std::vector<size_t> m_shape; ///< dimensionality of the correlation
+  std::size_t dim_A;                ///< dimensionality of A
+  std::size_t dim_B;                ///< dimensionality of B
+  std::vector<std::size_t> m_shape; ///< dimensionality of the correlation
 
   using correlation_operation_type = std::vector<double> (*)(
       std::vector<double> const &, std::vector<double> const &,

--- a/src/core/accumulators/MeanVarianceCalculator.cpp
+++ b/src/core/accumulators/MeanVarianceCalculator.cpp
@@ -29,6 +29,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace Accumulators {
 void MeanVarianceCalculator::update() { m_acc(m_obs->operator()()); }

--- a/src/core/accumulators/MeanVarianceCalculator.hpp
+++ b/src/core/accumulators/MeanVarianceCalculator.hpp
@@ -46,7 +46,7 @@ public:
      via the interface. */
   std::string get_internal_state() const;
   void set_internal_state(std::string const &);
-  std::vector<size_t> shape() const override { return m_obs->shape(); }
+  std::vector<std::size_t> shape() const override { return m_obs->shape(); }
 
 private:
   std::shared_ptr<Observables::Observable> m_obs;

--- a/src/core/accumulators/TimeSeries.hpp
+++ b/src/core/accumulators/TimeSeries.hpp
@@ -48,8 +48,8 @@ public:
   void set_internal_state(std::string const &);
 
   const std::vector<std::vector<double>> &time_series() const { return m_data; }
-  std::vector<size_t> shape() const override {
-    std::vector<size_t> shape{m_data.size()};
+  std::vector<std::size_t> shape() const override {
+    std::vector<std::size_t> shape{m_data.size()};
     auto obs_shape = m_obs->shape();
     shape.insert(shape.end(), obs_shape.begin(), obs_shape.end());
     return shape;

--- a/src/core/actor/DipolarBarnesHut_cuda.cuh
+++ b/src/core/actor/DipolarBarnesHut_cuda.cuh
@@ -25,7 +25,7 @@
 
 #ifdef DIPOLAR_BARNES_HUT
 
-typedef struct {
+struct BHData {
   /// CUDA blocks
   int blocks;
   /// each node corresponds to a split of the cubic box in 3D space to equal
@@ -57,7 +57,7 @@ typedef struct {
   int *start;
   /// trace the max loops for a threads' sync
   int *max_lps;
-} BHData;
+};
 
 /// @name Barnes-Hut thread count for different kernels.
 /// @{

--- a/src/core/actor/Mmm1dgpuForce_cuda.cu
+++ b/src/core/actor/Mmm1dgpuForce_cuda.cu
@@ -38,6 +38,7 @@
 
 #include <cuda.h>
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdio>

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -40,6 +40,7 @@
 #include <boost/optional.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 
+#include <cassert>
 #include <cmath>
 #include <memory>
 #include <tuple>

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -45,6 +45,7 @@
 #include <boost/range/algorithm/min_element.hpp>
 #include <functional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 /** Type of cell structure in use */

--- a/src/core/cluster_analysis/Cluster.cpp
+++ b/src/core/cluster_analysis/Cluster.cpp
@@ -171,8 +171,8 @@ std::pair<double, double> Cluster::fractal_dimension(double dr) {
     log_diameters.push_back(log(current_rg * 2.0));
   }
   // usage: Function: int gsl_fit_linear (const double * x, const size_t
-  // xstride, const double * y, const size_t ystride, size_t n, double * c0,
-  // double * c1, double * cov00, double * cov01, double * cov11, double *
+  // xstride, const double * y, const std::size_t ystride, std::size_t n, double
+  // * c0, double * c1, double * cov00, double * cov01, double * cov11, double *
   // sumsq)
   const int n = log_pcounts.size();
   double c0, c1, cov00, cov01, cov11, sumsq;

--- a/src/core/cluster_analysis/Cluster.cpp
+++ b/src/core/cluster_analysis/Cluster.cpp
@@ -33,9 +33,11 @@
 
 #include <utils/Vector.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <numeric>
+#include <utility>
 #include <vector>
 
 namespace ClusterAnalysis {

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -51,15 +51,15 @@
 #include <vector>
 
 /// Data type holding the info about a single collision
-typedef struct {
+struct CollisionPair {
   int pp1; // 1st particle id
   int pp2; // 2nd particle id
-} collision_struct;
+};
 
 namespace boost {
 namespace serialization {
 template <typename Archive>
-void serialize(Archive &ar, collision_struct &c, const unsigned int) {
+void serialize(Archive &ar, CollisionPair &c, const unsigned int) {
   ar &c.pp1;
   ar &c.pp2;
 }
@@ -69,7 +69,7 @@ void serialize(Archive &ar, collision_struct &c, const unsigned int) {
 /// During force calculation, colliding particles are recorded in the queue.
 /// The queue is processed after force calculation, when it is safe to add
 /// particles.
-static std::vector<collision_struct> local_collision_queue;
+static std::vector<CollisionPair> local_collision_queue;
 
 /// Parameters for collision detection
 Collision_parameters collision_params;
@@ -380,7 +380,7 @@ void place_vs_and_relate_to_particle(const int current_vs_pid,
 }
 
 void bind_at_poc_create_bond_between_vs(const int current_vs_pid,
-                                        const collision_struct &c) {
+                                        const CollisionPair &c) {
   switch (get_bond_num_partners(collision_params.bond_vs)) {
   case 1: {
     // Create bond between the virtual particles
@@ -412,7 +412,7 @@ void bind_at_poc_create_bond_between_vs(const int current_vs_pid,
 void glue_to_surface_bind_part_to_vs(const Particle *const p1,
                                      const Particle *const p2,
                                      const int vs_pid_plus_one,
-                                     const collision_struct &c) {
+                                     const CollisionPair &c) {
   // Create bond between the virtual particles
   const int bondG[] = {vs_pid_plus_one - 1};
 
@@ -425,8 +425,8 @@ void glue_to_surface_bind_part_to_vs(const Particle *const p1,
 
 #endif
 
-std::vector<collision_struct> gather_global_collision_queue() {
-  std::vector<collision_struct> res = local_collision_queue;
+std::vector<CollisionPair> gather_global_collision_queue() {
+  std::vector<CollisionPair> res = local_collision_queue;
   Utils::Mpi::gather_buffer(res, comm_cart);
   boost::mpi::broadcast(comm_cart, res, 0);
 
@@ -474,7 +474,7 @@ static void three_particle_binding_do_search(Cell *basecell, Particle &p1,
 // looks for a third particle by using the domain decomposition
 // cell system. If found, it performs three particle binding
 void three_particle_binding_domain_decomposition(
-    const std::vector<collision_struct> &gathered_queue) {
+    const std::vector<CollisionPair> &gathered_queue) {
 
   for (auto &c : gathered_queue) {
     // If we have both particles, at least as ghosts, Get the corresponding cell

--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -24,7 +24,9 @@
 #include "statistics.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 void on_constraint_change();

--- a/src/core/cuda_common_cuda.cu
+++ b/src/core/cuda_common_cuda.cu
@@ -48,7 +48,7 @@ T *raw_data_pointer(thrust::device_vector<T, A> &vec) {
   return thrust::raw_pointer_cast(vec.data());
 }
 
-template <class SpanLike> size_t byte_size(SpanLike const &v) {
+template <class SpanLike> std::size_t byte_size(SpanLike const &v) {
   return v.size() * sizeof(typename SpanLike::value_type);
 }
 
@@ -98,7 +98,8 @@ void cuda_check_errors_exit(const dim3 &block, const dim3 &grid,
  * @param vec Vector To resize.
  * @param n Desired new size of the element.
  */
-template <class T> void resize_or_replace(device_vector<T> &vec, size_t n) {
+template <class T>
+void resize_or_replace(device_vector<T> &vec, std::size_t n) {
   if (vec.capacity() == 0) {
     vec = device_vector<T>(n);
   } else {
@@ -106,7 +107,7 @@ template <class T> void resize_or_replace(device_vector<T> &vec, size_t n) {
   }
 }
 
-void resize_buffers(size_t number_of_particles) {
+void resize_buffers(std::size_t number_of_particles) {
   particle_data_host.resize(number_of_particles);
   resize_or_replace(particle_data_device, number_of_particles);
 

--- a/src/core/cuda_init.cpp
+++ b/src/core/cuda_init.cpp
@@ -35,6 +35,7 @@
 #include <cstring>
 #include <iterator>
 #include <set>
+#include <vector>
 
 /** Helper class for device sets.
  */

--- a/src/core/cuda_init.hpp
+++ b/src/core/cuda_init.hpp
@@ -44,7 +44,7 @@ struct EspressoGpuDevice {
   /** Compute capability (minor) */
   int compute_capability_minor;
   /** Total Memory */
-  size_t total_memory;
+  std::size_t total_memory;
   /** Number of cores */
   int n_cores;
 };

--- a/src/core/cuda_init.hpp
+++ b/src/core/cuda_init.hpp
@@ -23,6 +23,7 @@
 
 #ifdef CUDA
 
+#include <cstddef>
 #include <vector>
 
 /** Struct to hold information relevant to ESPResSo

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -31,6 +31,8 @@
 #include <utils/mpi/gather_buffer.hpp>
 #include <utils/mpi/scatter_buffer.hpp>
 
+#include <vector>
+
 /* TODO: We should only transfer data for enabled methods,
          not for those that are barely compiled in. (fw)
 */

--- a/src/core/cuda_interface.hpp
+++ b/src/core/cuda_interface.hpp
@@ -90,19 +90,19 @@ struct CUDA_particle_data {
 };
 
 /** data structure for the different kinds of energies */
-typedef struct {
+struct CUDA_energy {
   float coulomb, dipolar;
-} CUDA_energy;
+};
 
 /** Global variables associated with all of the particles and not with
  *  one individual particle.
  */
-typedef struct {
+struct CUDA_global_part_vars {
   /** Boolean flag to indicate if particle info should be communicated
    *  between the cpu and gpu
    */
   unsigned int communication_enabled;
-} CUDA_global_part_vars;
+};
 
 void copy_forces_from_GPU(ParticleRange &particles);
 CUDA_energy copy_energy_from_GPU();

--- a/src/core/electrostatics_magnetostatics/coulomb.cpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.cpp
@@ -404,7 +404,7 @@ void bcast_coulomb_params() {
     break;
 #ifdef P3M
   case COULOMB_ELC_P3M:
-    MPI_Bcast(&elc_params, sizeof(ELC_struct), MPI_BYTE, 0, comm_cart);
+    MPI_Bcast(&elc_params, sizeof(ELCParameters), MPI_BYTE, 0, comm_cart);
     // fall through
   case COULOMB_P3M_GPU:
   case COULOMB_P3M:
@@ -412,14 +412,15 @@ void bcast_coulomb_params() {
     break;
 #endif
   case COULOMB_DH:
-    MPI_Bcast(&dh_params, sizeof(Debye_hueckel_params), MPI_BYTE, 0, comm_cart);
+    MPI_Bcast(&dh_params, sizeof(DebyeHueckelParameters), MPI_BYTE, 0,
+              comm_cart);
     break;
   case COULOMB_MMM1D:
   case COULOMB_MMM1D_GPU:
-    MPI_Bcast(&mmm1d_params, sizeof(MMM1D_struct), MPI_BYTE, 0, comm_cart);
+    MPI_Bcast(&mmm1d_params, sizeof(MMM1DParameters), MPI_BYTE, 0, comm_cart);
     break;
   case COULOMB_RF:
-    MPI_Bcast(&rf_params, sizeof(Reaction_field_params), MPI_BYTE, 0,
+    MPI_Bcast(&rf_params, sizeof(ReactionFieldParameters), MPI_BYTE, 0,
               comm_cart);
     break;
   default:

--- a/src/core/electrostatics_magnetostatics/coulomb.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb.hpp
@@ -92,8 +92,8 @@ void update_dependent_particles();
 } // namespace Coulomb
 #else  // ELECTROSTATICS
 namespace Coulomb {
-constexpr size_t pressure_n() { return 0; }
-constexpr size_t energy_n() { return 0; }
+constexpr std::size_t pressure_n() { return 0; }
+constexpr std::size_t energy_n() { return 0; }
 } // namespace Coulomb
 #endif // ELECTROSTATICS
 #endif // ESPRESSO_COULOMB_HPP

--- a/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics_magnetostatics/coulomb_inline.hpp
@@ -35,6 +35,8 @@
 #include <utils/math/tensor_product.hpp>
 #include <utils/matrix.hpp>
 
+#include <tuple>
+
 namespace Coulomb {
 inline Utils::Vector3d central_force(double const q1q2,
                                      Utils::Vector3d const &d, double dist) {

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.cpp
@@ -30,7 +30,7 @@
 
 #include <stdexcept>
 
-Debye_hueckel_params dh_params{};
+DebyeHueckelParameters dh_params{};
 
 void dh_set_params(double kappa, double r_cut) {
   if (kappa < 0.0)

--- a/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
+++ b/src/core/electrostatics_magnetostatics/debye_hueckel.hpp
@@ -33,7 +33,7 @@
 #include <cmath>
 
 /** Debye-Hückel parameters. */
-struct Debye_hueckel_params {
+struct DebyeHueckelParameters {
   /** Interaction cutoff. */
   double r_cut;
   /** Ionic strength. */
@@ -41,7 +41,7 @@ struct Debye_hueckel_params {
 };
 
 /** Global state of the Debye-Hückel method. */
-extern Debye_hueckel_params dh_params;
+extern DebyeHueckelParameters dh_params;
 
 void dh_set_params(double kappa, double r_cut);
 

--- a/src/core/electrostatics_magnetostatics/dipole.hpp
+++ b/src/core/electrostatics_magnetostatics/dipole.hpp
@@ -91,8 +91,8 @@ void set_method_local(DipolarInteraction method);
 } // namespace Dipole
 #else  // DIPOLES
 namespace Dipole {
-constexpr size_t pressure_n() { return 0; }
-constexpr size_t energy_n() { return 0; }
+constexpr std::size_t pressure_n() { return 0; }
+constexpr std::size_t energy_n() { return 0; }
 } // namespace Dipole
 #endif // DIPOLES
 #endif // ESPRESSO_DIPOLE_HPP

--- a/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
@@ -33,6 +33,9 @@
 #include <boost/range/numeric.hpp>
 
 #include <cmath>
+#include <cstddef>
+#include <functional>
+#include <vector>
 
 #if defined(DP3M)
 

--- a/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/dp3m_influence_function.hpp
@@ -51,7 +51,7 @@
  *  \param d_op        differential operator for a given n-vector
  *  \return The result of the fraction.
  */
-template <size_t S>
+template <std::size_t S>
 double G_opt_dipolar(P3MParameters const &params, Utils::Vector3i const &shift,
                      Utils::Vector3i const &d_op) {
   using Utils::int_pow;
@@ -102,7 +102,7 @@ double G_opt_dipolar(P3MParameters const &params, Utils::Vector3i const &shift,
  * @param box_l Box size
  * @return Values of the influence function at regular grid points.
  */
-template <size_t S>
+template <std::size_t S>
 std::vector<double> grid_influence_function(P3MParameters const &params,
                                             Utils::Vector3i const &n_start,
                                             Utils::Vector3i const &n_end,

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -112,7 +112,7 @@ static void add_z_force(const ParticleRange &particles);
  * @param u Inverse box length
  * @return Calculated values.
  */
-template <size_t dir>
+template <std::size_t dir>
 static std::vector<SCCache> calc_sc_cache(const ParticleRange &particles,
                                           std::size_t n_freq, double u) {
   constexpr double c_2pi = 2 * Utils::pi();
@@ -122,7 +122,7 @@ static std::vector<SCCache> calc_sc_cache(const ParticleRange &particles,
   for (std::size_t freq = 1; freq <= n_freq; freq++) {
     auto const pref = c_2pi * u * static_cast<double>(freq);
 
-    size_t o = (freq - 1) * n_part;
+    std::size_t o = (freq - 1) * n_part;
     for (auto const &part : particles) {
       auto const arg = pref * part.r.p[dir];
       ret[o++] = {sin(arg), cos(arg)};

--- a/src/core/electrostatics_magnetostatics/elc.cpp
+++ b/src/core/electrostatics_magnetostatics/elc.cpp
@@ -50,8 +50,8 @@
 #include <cstddef>
 #include <vector>
 
-ELC_struct elc_params = {1e100, 10,    1, 0, true, true, false, 1,
-                         1,     false, 0, 0, 0,    0,    0.0};
+ELCParameters elc_params = {1e100, 10,    1, 0, true, true, false, 1,
+                            1,     false, 0, 0, 0,    0,    0.0};
 
 /** \name Product decomposition data organization
  *  For the cell blocks it is assumed that the lower blocks part is in the
@@ -82,9 +82,9 @@ static std::vector<double> partblk;
 static double gblcblk[8];
 
 /** structure for caching sin and cos values */
-typedef struct {
+struct SCCache {
   double s, c;
-} SCCache;
+};
 
 /** Cached sin/cos values along the x-axis and y-axis */
 /**@{*/
@@ -962,7 +962,7 @@ double ELC_energy(const ParticleRange &particles) {
   return 0.5 * energy;
 }
 
-double ELC_tune_far_cut(ELC_struct const &params) {
+double ELC_tune_far_cut(ELCParameters const &params) {
   // Largest reasonable cutoff for far formula
   constexpr auto maximal_far_cut = 50.;
   double const h = params.h;
@@ -1006,7 +1006,7 @@ double ELC_tune_far_cut(ELC_struct const &params) {
  * COMMON PARTS
  ****************************************/
 
-void ELC_sanity_checks(ELC_struct const &params) {
+void ELC_sanity_checks(ELCParameters const &params) {
   if (!box_geo.periodic(0) || !box_geo.periodic(1) || !box_geo.periodic(2)) {
     throw std::runtime_error("ELC requires periodicity 1 1 1");
   }
@@ -1091,7 +1091,7 @@ void ELC_set_params(double maxPWerror, double gap_size, double far_cut,
     throw std::domain_error("gap size too large");
   }
 
-  ELC_struct new_elc_params;
+  ELCParameters new_elc_params;
   if (delta_top != 0.0 || delta_bot != 0.0) {
     // setup with dielectric contrast (neutralize is automatic)
 
@@ -1100,27 +1100,27 @@ void ELC_set_params(double maxPWerror, double gap_size, double far_cut,
     auto const space_layer = gap_size / 3.;
     auto const space_box = gap_size - 2. * space_layer;
 
-    new_elc_params = ELC_struct{maxPWerror,
-                                far_cut,
-                                0.,
-                                gap_size,
-                                far_cut == -1.,
-                                false,
-                                true,
-                                delta_top,
-                                delta_bot,
-                                const_pot,
-                                (const_pot) ? pot_diff : 0.,
-                                std::min(space_box, space_layer),
-                                space_layer,
-                                space_box,
-                                h};
+    new_elc_params = ELCParameters{maxPWerror,
+                                   far_cut,
+                                   0.,
+                                   gap_size,
+                                   far_cut == -1.,
+                                   false,
+                                   true,
+                                   delta_top,
+                                   delta_bot,
+                                   const_pot,
+                                   (const_pot) ? pot_diff : 0.,
+                                   std::min(space_box, space_layer),
+                                   space_layer,
+                                   space_box,
+                                   h};
   } else {
     // setup without dielectric contrast
     new_elc_params =
-        ELC_struct{maxPWerror, far_cut,  0., gap_size, far_cut == -1.,
-                   neutralize, false,    0., 0.,       false,
-                   0.,         gap_size, 0., gap_size, h};
+        ELCParameters{maxPWerror, far_cut,  0., gap_size, far_cut == -1.,
+                      neutralize, false,    0., 0.,       false,
+                      0.,         gap_size, 0., gap_size, h};
   }
 
   ELC_sanity_checks(new_elc_params);

--- a/src/core/electrostatics_magnetostatics/elc.hpp
+++ b/src/core/electrostatics_magnetostatics/elc.hpp
@@ -39,7 +39,7 @@
 #include <utils/Vector.hpp>
 
 /** @brief Parameters for the ELC method */
-struct ELC_struct {
+struct ELCParameters {
   /** Maximal allowed pairwise error for the potential and force.
    *  Used at least by the near formula, since this does the error control at
    *  runtime.
@@ -92,24 +92,24 @@ struct ELC_struct {
   /** Up to where particles can be found. */
   double h;
 };
-extern ELC_struct elc_params;
+extern ELCParameters elc_params;
 
 /** Set parameters for ELC.
- *  @param maxPWerror    @copybrief ELC_struct::maxPWerror
+ *  @param maxPWerror    @copybrief ELCParameters::maxPWerror
  *                       Note that this counts for the plain 1/r contribution
  *                       alone, without the prefactor and the charge prefactor.
- *  @param min_dist      @copybrief ELC_struct::minimal_dist
- *  @param far_cut       @copybrief ELC_struct::far_cut
+ *  @param min_dist      @copybrief ELCParameters::minimal_dist
+ *  @param far_cut       @copybrief ELCParameters::far_cut
  *                       If -1, the cutoff is automatically calculated using
  *                       the error formulas.
  *  @param neutralize    whether to add a neutralizing background.
  *                       WARNING: This background exerts forces, which are
  *                       dependent on the simulation box; especially the gap
  *                       size enters into the value of the forces.
- *  @param delta_mid_top @copybrief ELC_struct::delta_mid_top
- *  @param delta_mid_bot @copybrief ELC_struct::delta_mid_bot
- *  @param const_pot     @copybrief ELC_struct::const_pot
- *  @param pot_diff      @copybrief ELC_struct::pot_diff
+ *  @param delta_mid_top @copybrief ELCParameters::delta_mid_top
+ *  @param delta_mid_bot @copybrief ELCParameters::delta_mid_bot
+ *  @param const_pot     @copybrief ELCParameters::const_pot
+ *  @param pot_diff      @copybrief ELCParameters::pot_diff
  */
 void ELC_set_params(double maxPWerror, double min_dist, double far_cut,
                     bool neutralize, double delta_mid_top, double delta_mid_bot,
@@ -122,7 +122,7 @@ void ELC_add_force(const ParticleRange &particles);
 double ELC_energy(const ParticleRange &particles);
 
 /// check the ELC parameters
-void ELC_sanity_checks(ELC_struct const &params);
+void ELC_sanity_checks(ELCParameters const &params);
 
 /// initialize the ELC constants
 void ELC_init();

--- a/src/core/electrostatics_magnetostatics/fft.cpp
+++ b/src/core/electrostatics_magnetostatics/fft.cpp
@@ -47,6 +47,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 using Utils::get_linear_index;
 using Utils::permute_ifield;

--- a/src/core/electrostatics_magnetostatics/fft.hpp
+++ b/src/core/electrostatics_magnetostatics/fft.hpp
@@ -67,11 +67,11 @@ template <class T> struct fft_allocator {
     return false;
   }
 
-  T *allocate(const size_t n) const {
+  T *allocate(const std::size_t n) const {
     if (n == 0) {
       return nullptr;
     }
-    if (n > static_cast<size_t>(-1) / sizeof(T)) {
+    if (n > static_cast<std::size_t>(-1) / sizeof(T)) {
       throw std::bad_array_new_length();
     }
     void *const pv = fftw_malloc(n * sizeof(T));
@@ -80,7 +80,7 @@ template <class T> struct fft_allocator {
     }
     return static_cast<T *>(pv);
   }
-  void deallocate(T *const p, size_t) const noexcept { fftw_free(p); }
+  void deallocate(T *const p, std::size_t) const noexcept { fftw_free(p); }
 };
 
 template <class T> using fft_vector = std::vector<T, fft_allocator<T>>;

--- a/src/core/electrostatics_magnetostatics/icc.cpp
+++ b/src/core/electrostatics_magnetostatics/icc.cpp
@@ -48,7 +48,9 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <stdexcept>
 #include <tuple>
+#include <vector>
 
 icc_struct icc_cfg;
 

--- a/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
+++ b/src/core/electrostatics_magnetostatics/magnetic_non_p3m_methods.cpp
@@ -36,6 +36,7 @@
 #include <utils/constants.hpp>
 #include <utils/math/sqr.hpp>
 
+#include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <stdexcept>

--- a/src/core/electrostatics_magnetostatics/mmm-modpsi.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm-modpsi.cpp
@@ -27,6 +27,7 @@
 #include <utils/constants.hpp>
 
 #include <cmath>
+#include <vector>
 
 std::vector<std::vector<double>> modPsi;
 

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -71,7 +71,7 @@ constexpr int MAXIMAL_B_CUT = 30;
 static double uz2, prefuz2, prefL3_i;
 /**@}*/
 
-MMM1D_struct mmm1d_params = {0.05, 1e-5, 0};
+MMM1DParameters mmm1d_params = {0.05, 1e-5, 0};
 /** From which distance a certain Bessel cutoff is valid.
  *  Can't be part of the params since these get broadcasted.
  */

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -46,6 +46,7 @@
 #include <utils/math/sqr.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <limits>

--- a/src/core/electrostatics_magnetostatics/mmm1d.hpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.hpp
@@ -37,7 +37,7 @@
 #ifdef ELECTROSTATICS
 
 /** @brief Parameters for the MMM1D electrostatic interaction */
-typedef struct {
+struct MMM1DParameters {
   /** square of the switching radius */
   double far_switch_radius_2;
   /** Maximal allowed pairwise error for the potential and force.
@@ -46,8 +46,8 @@ typedef struct {
   double maxPWerror;
   /** cutoff of the Bessel sum. Only used by the GPU implementation */
   int bessel_cutoff;
-} MMM1D_struct;
-extern MMM1D_struct mmm1d_params;
+};
+extern MMM1DParameters mmm1d_params;
 
 /** Set parameters for MMM1D.
  *  Most of the parameters can also be tuned automatically. Unlike P3M, this
@@ -55,7 +55,7 @@ extern MMM1D_struct mmm1d_params;
  *  immediately if you set these parameters.
  *  @param switch_rad at which xy-distance the calculation switches from the far
  *      to the near formula. If -1, this parameter will be tuned automatically.
- *  @param maxPWerror @copydoc MMM1D_struct::maxPWerror
+ *  @param maxPWerror @copydoc MMM1DParameters::maxPWerror
  */
 void MMM1D_set_params(double switch_rad, double maxPWerror);
 
@@ -72,8 +72,8 @@ double mmm1d_coulomb_pair_energy(double q1q2, Utils::Vector3d const &d,
                                  double r2, double r);
 
 /** Tuning of the parameters which are not set by the user. Tune either the
- *  @ref MMM1D_struct::far_switch_radius_2 "switching radius" or the
- *  @ref MMM1D_struct::bessel_cutoff "Bessel cutoff". Call this only
+ *  @ref MMM1DParameters::far_switch_radius_2 "switching radius" or the
+ *  @ref MMM1DParameters::bessel_cutoff "Bessel cutoff". Call this only
  *  on the master node.
  *
  *  @param verbose output information about the tuning (tried values and errors)

--- a/src/core/electrostatics_magnetostatics/p3m-common.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.cpp
@@ -113,7 +113,7 @@ double p3m_analytic_cotangent_sum(int n, double mesh_i, int cao) {
   return res;
 }
 
-void p3m_calc_local_ca_mesh(p3m_local_mesh &local_mesh,
+void p3m_calc_local_ca_mesh(P3MLocalMesh &local_mesh,
                             const P3MParameters &params,
                             const LocalBox<double> &local_geo, double skin,
                             double space_layer) {
@@ -190,8 +190,7 @@ void p3m_calc_local_ca_mesh(p3m_local_mesh &local_mesh,
   local_mesh.q_21_off = local_mesh.dim[2] * (local_mesh.dim[1] - params.cao);
 }
 
-void p3m_calc_lm_ld_pos(p3m_local_mesh &local_mesh,
-                        const P3MParameters &params) {
+void p3m_calc_lm_ld_pos(P3MLocalMesh &local_mesh, const P3MParameters &params) {
   /* spatial position of left down mesh point */
   for (int i = 0; i < 3; i++) {
     local_mesh.ld_pos[i] =

--- a/src/core/electrostatics_magnetostatics/p3m-common.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-common.hpp
@@ -83,7 +83,7 @@ enum FFT_WAVE_VECTOR : int { KY = 0, KZ = 1, KX = 2 };
  ************************************************/
 
 /** Structure for local mesh parameters. */
-typedef struct {
+struct P3MLocalMesh {
   /* local mesh characterization. */
   /** dimension (size) of local mesh. */
   Utils::Vector3i dim;
@@ -108,10 +108,10 @@ typedef struct {
   int q_2_off;
   /** offset between mesh lines of the two last dimensions */
   int q_21_off;
-} p3m_local_mesh;
+};
 
 /** Structure to hold P3M parameters and some dependent variables. */
-typedef struct {
+struct P3MParameters {
   /** tuning or production? */
   bool tuning = false;
   /** Ewald splitting parameter (0<alpha<1), rescaled to
@@ -153,8 +153,7 @@ typedef struct {
     ar &mesh_off &cao &accuracy &epsilon &cao_cut;
     ar &a &ai &alpha &r_cut &cao3;
   }
-
-} P3MParameters;
+};
 
 /** Add values of a 3d-grid input block (size[3]) to values of 3d-grid
  *  output array with dimension dim[3] at start position start[3].
@@ -181,20 +180,19 @@ double p3m_analytic_cotangent_sum(int n, double mesh_i, int cao);
 /** Calculate properties of the local FFT mesh for the
  *   charge assignment process.
  */
-void p3m_calc_local_ca_mesh(p3m_local_mesh &local_mesh,
+void p3m_calc_local_ca_mesh(P3MLocalMesh &local_mesh,
                             const P3MParameters &params,
                             const LocalBox<double> &local_geo, double skin,
                             double space_layer);
 
 /** Calculate the spatial position of the left down mesh
  *  point of the local mesh, to be stored in
- *  @ref p3m_local_mesh::ld_pos "ld_pos".
+ *  @ref P3MLocalMesh::ld_pos "ld_pos".
  *
  *  Function called by @ref p3m_calc_local_ca_mesh() once and by
  *  @ref p3m_scaleby_box_l() whenever the box size changes.
  */
-void p3m_calc_lm_ld_pos(p3m_local_mesh &local_mesh,
-                        const P3MParameters &params);
+void p3m_calc_lm_ld_pos(P3MLocalMesh &local_mesh, const P3MParameters &params);
 
 #endif /* P3M || DP3M */
 

--- a/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-data_struct.hpp
@@ -27,6 +27,9 @@
 
 #include "p3m-common.hpp"
 
+#include <array>
+#include <vector>
+
 struct p3m_data_struct_base {
   P3MParameters params;
 

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -303,7 +303,7 @@ void dp3m_set_eps(double eps) {
 }
 
 namespace {
-template <size_t cao> struct AssignDipole {
+template <std::size_t cao> struct AssignDipole {
   void operator()(Utils::Vector3d const &real_pos,
                   Utils::Vector3d const &dip) const {
     auto const weights = p3m_calculate_interpolation_weights<cao>(
@@ -336,7 +336,7 @@ void dp3m_dipole_assign(const ParticleRange &particles) {
 }
 
 namespace {
-template <size_t cao> struct AssignTorques {
+template <std::size_t cao> struct AssignTorques {
   void operator()(double prefac, int d_rs,
                   const ParticleRange &particles) const {
     /* particle counter */
@@ -354,7 +354,7 @@ template <size_t cao> struct AssignTorques {
   }
 };
 
-template <size_t cao> struct AssignForces {
+template <std::size_t cao> struct AssignForces {
   void operator()(double prefac, int d_rs,
                   const ParticleRange &particles) const {
     /* particle counter */

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.hpp
@@ -59,7 +59,7 @@ struct dp3m_data_struct : public p3m_data_struct_base {
   dp3m_data_struct();
 
   /** local mesh. */
-  p3m_local_mesh local_mesh;
+  P3MLocalMesh local_mesh;
   /** real space mesh (local) for CA/FFT. */
   fft_vector<double> rs_mesh;
   /** real space mesh (local) for CA/FFT of the dipolar field. */

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -61,6 +61,7 @@
 #include <boost/range/numeric.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <complex>
 #include <cstddef>

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -294,7 +294,7 @@ void p3m_set_eps(double eps) {
 }
 
 namespace {
-template <size_t cao> struct AssignCharge {
+template <std::size_t cao> struct AssignCharge {
   void operator()(double q, const Utils::Vector3d &real_pos,
                   const Utils::Vector3d &ai, p3m_local_mesh const &local_mesh,
                   p3m_interpolation_cache &inter_weights) {
@@ -349,7 +349,7 @@ void p3m_assign_charge(double q, const Utils::Vector3d &real_pos) {
 }
 
 namespace {
-template <size_t cao> struct AssignForces {
+template <std::size_t cao> struct AssignForces {
   void operator()(double force_prefac, const ParticleRange &particles) const {
     using Utils::make_const_span;
     using Utils::Span;

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -296,7 +296,7 @@ void p3m_set_eps(double eps) {
 namespace {
 template <std::size_t cao> struct AssignCharge {
   void operator()(double q, const Utils::Vector3d &real_pos,
-                  const Utils::Vector3d &ai, p3m_local_mesh const &local_mesh,
+                  const Utils::Vector3d &ai, P3MLocalMesh const &local_mesh,
                   p3m_interpolation_cache &inter_weights) {
     auto const w =
         p3m_calculate_interpolation_weights<cao>(real_pos, ai, local_mesh);
@@ -308,7 +308,7 @@ template <std::size_t cao> struct AssignCharge {
   }
 
   void operator()(double q, const Utils::Vector3d &real_pos,
-                  const Utils::Vector3d &ai, p3m_local_mesh const &local_mesh) {
+                  const Utils::Vector3d &ai, P3MLocalMesh const &local_mesh) {
     p3m_interpolate(
         local_mesh,
         p3m_calculate_interpolation_weights<cao>(real_pos, ai, local_mesh),

--- a/src/core/electrostatics_magnetostatics/p3m.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m.hpp
@@ -60,7 +60,7 @@ struct p3m_data_struct : public p3m_data_struct_base {
   p3m_data_struct();
 
   /** local mesh. */
-  p3m_local_mesh local_mesh;
+  P3MLocalMesh local_mesh;
   /** real space mesh (local) for CA/FFT. */
   fft_vector<double> rs_mesh;
   /** mesh (local) for the electric field. */

--- a/src/core/electrostatics_magnetostatics/p3m_gpu_error_cuda.cu
+++ b/src/core/electrostatics_magnetostatics/p3m_gpu_error_cuda.cu
@@ -319,7 +319,7 @@ double p3m_k_space_error_gpu(double prefactor, const int *mesh, int cao,
                              const double *box) {
   static thrust::device_vector<double> he_q;
 
-  const size_t mesh_size = mesh[0] * mesh[1] * mesh[2];
+  const std::size_t mesh_size = mesh[0] * mesh[1] * mesh[2];
 
   he_q.resize(mesh_size);
 

--- a/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
@@ -32,6 +32,9 @@
 
 #include <cmath>
 #include <cstddef>
+#include <functional>
+#include <utility>
+#include <vector>
 
 namespace detail {
 template <typename T> T g_ewald(T alpha, T k2) {

--- a/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_influence_function.hpp
@@ -44,8 +44,8 @@ template <typename T> T g_ewald(T alpha, T k2) {
                             : 0.0;
 }
 
-template <size_t S, size_t m>
-std::pair<double, double> aliasing_sums_ik(size_t cao, double alpha,
+template <std::size_t S, std::size_t m>
+std::pair<double, double> aliasing_sums_ik(std::size_t cao, double alpha,
                                            const Utils::Vector3d &k,
                                            const Utils::Vector3d &h) {
   using namespace detail::FFT_indexing;
@@ -94,8 +94,8 @@ std::pair<double, double> aliasing_sums_ik(size_t cao, double alpha,
  * @param k k Vector to evaluate the function for.
  * @param h Grid spacing.
  */
-template <size_t S, size_t m, class T>
-double G_opt(size_t cao, T alpha, const Utils::Vector3<T> &k,
+template <std::size_t S, std::size_t m, class T>
+double G_opt(std::size_t cao, T alpha, const Utils::Vector3<T> &k,
              const Utils::Vector3<T> &h) {
   using Utils::int_pow;
   using Utils::sqr;
@@ -125,7 +125,7 @@ double G_opt(size_t cao, T alpha, const Utils::Vector3<T> &k,
  * @param box_l Box size
  * @return Values of G_opt at regular grid points.
  */
-template <size_t S, size_t m = 0>
+template <std::size_t S, std::size_t m = 0>
 std::vector<double> grid_influence_function(const P3MParameters &params,
                                             const Utils::Vector3i &n_start,
                                             const Utils::Vector3i &n_end,

--- a/src/core/electrostatics_magnetostatics/p3m_interpolation.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_interpolation.hpp
@@ -53,7 +53,7 @@ template <int cao> struct InterpolationWeights {
  * type InterpolationWeights.
  */
 class p3m_interpolation_cache {
-  size_t m_cao = 0;
+  std::size_t m_cao = 0;
   /** Charge fractions for mesh assignment. */
   std::vector<double> ca_frac;
   /** index of first mesh point for charge assignment. */
@@ -100,7 +100,7 @@ public:
    * @param i Index of the entry to load.
    * @return i-it interpolation weights.
    */
-  template <int cao> InterpolationWeights<cao> load(size_t i) const {
+  template <int cao> InterpolationWeights<cao> load(std::size_t i) const {
     assert(cao == m_cao);
 
     using Utils::make_const_span;

--- a/src/core/electrostatics_magnetostatics/p3m_interpolation.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_interpolation.hpp
@@ -139,7 +139,7 @@ template <int cao>
 InterpolationWeights<cao>
 p3m_calculate_interpolation_weights(const Utils::Vector3d &position,
                                     const Utils::Vector3d &ai,
-                                    p3m_local_mesh const &local_mesh) {
+                                    P3MLocalMesh const &local_mesh) {
   /** position shift for calc. of first assignment mesh point. */
   static auto const pos_shift = std::floor((cao - 1) / 2.0) - (cao % 2) / 2.0;
 
@@ -189,7 +189,7 @@ p3m_calculate_interpolation_weights(const Utils::Vector3d &position,
  * @param kernel The kernel to run.
  */
 template <int cao, class Kernel>
-void p3m_interpolate(p3m_local_mesh const &local_mesh,
+void p3m_interpolate(P3MLocalMesh const &local_mesh,
                      InterpolationWeights<cao> const &weights, Kernel kernel) {
   auto q_ind = weights.ind;
   for (int i0 = 0; i0 < cao; i0++) {

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
@@ -121,7 +121,7 @@ void p3m_send_mesh::gather_grid(Utils::Span<double *> meshes,
 
     /* pack send block */
     if (s_size[s_dir] > 0)
-      for (size_t i = 0; i < meshes.size(); i++) {
+      for (std::size_t i = 0; i < meshes.size(); i++) {
         fft_pack_block(meshes[i], send_grid.data() + i * s_size[s_dir],
                        s_ld[s_dir], s_dim[s_dir], dim.data(), 1);
       }
@@ -138,7 +138,7 @@ void p3m_send_mesh::gather_grid(Utils::Span<double *> meshes,
     }
     /* add recv block */
     if (r_size[r_dir] > 0) {
-      for (size_t i = 0; i < meshes.size(); i++) {
+      for (std::size_t i = 0; i < meshes.size(); i++) {
         p3m_add_block(recv_grid.data() + i * r_size[r_dir], meshes[i],
                       r_ld[r_dir], r_dim[r_dir], dim.data());
       }
@@ -159,7 +159,7 @@ void p3m_send_mesh::spread_grid(Utils::Span<double *> meshes,
 
     /* pack send block */
     if (r_size[r_dir] > 0)
-      for (size_t i = 0; i < meshes.size(); i++) {
+      for (std::size_t i = 0; i < meshes.size(); i++) {
         fft_pack_block(meshes[i], send_grid.data() + i * r_size[r_dir],
                        r_ld[r_dir], r_dim[r_dir], dim.data(), 1);
       }
@@ -175,7 +175,7 @@ void p3m_send_mesh::spread_grid(Utils::Span<double *> meshes,
     }
     /* un pack recv block */
     if (s_size[s_dir] > 0) {
-      for (size_t i = 0; i < meshes.size(); i++) {
+      for (std::size_t i = 0; i < meshes.size(); i++) {
         fft_unpack_block(recv_grid.data() + i * s_size[s_dir], meshes[i],
                          s_ld[s_dir], s_dim[s_dir], dim.data(), 1);
       }

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.cpp
@@ -34,7 +34,7 @@
 #include <cstddef>
 
 void p3m_send_mesh::resize(const boost::mpi::communicator &comm,
-                           const p3m_local_mesh &local_mesh) {
+                           const P3MLocalMesh &local_mesh) {
   int done[3] = {0, 0, 0};
   /* send grids */
   for (int i = 0; i < 3; i++) {

--- a/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
+++ b/src/core/electrostatics_magnetostatics/p3m_send_mesh.hpp
@@ -67,7 +67,7 @@ class p3m_send_mesh {
 
 public:
   void resize(const boost::mpi::communicator &comm,
-              const p3m_local_mesh &local_mesh);
+              const P3MLocalMesh &local_mesh);
   void gather_grid(Utils::Span<double *> meshes,
                    const boost::mpi::communicator &comm,
                    const Utils::Vector3i &dim);

--- a/src/core/electrostatics_magnetostatics/reaction_field.cpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.cpp
@@ -27,7 +27,7 @@
 #ifdef ELECTROSTATICS
 #include "common.hpp"
 
-Reaction_field_params rf_params{};
+ReactionFieldParameters rf_params{};
 
 void rf_set_params(double kappa, double epsilon1, double epsilon2,
                    double r_cut) {

--- a/src/core/electrostatics_magnetostatics/reaction_field.hpp
+++ b/src/core/electrostatics_magnetostatics/reaction_field.hpp
@@ -35,7 +35,7 @@
 #include <utils/math/int_pow.hpp>
 
 /** Reaction Field parameters. */
-struct Reaction_field_params {
+struct ReactionFieldParameters {
   /** Ionic strength. */
   double kappa;
   /** Continuum dielectric constant inside the cavity. */
@@ -51,7 +51,7 @@ struct Reaction_field_params {
 };
 
 /** Global state of the Reaction Field method. */
-extern Reaction_field_params rf_params;
+extern ReactionFieldParameters rf_params;
 
 void rf_set_params(double kappa, double epsilon1, double epsilon2,
                    double r_cut);

--- a/src/core/errorhandling.cpp
+++ b/src/core/errorhandling.cpp
@@ -33,6 +33,8 @@
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace ErrorHandling {
 namespace {

--- a/src/core/field_coupling/fields/AffineMap.hpp
+++ b/src/core/field_coupling/fields/AffineMap.hpp
@@ -32,7 +32,7 @@ namespace Fields {
  *
  * Returns A * x + b, where * is matrix multiplication.
  */
-template <typename T, size_t codim> class AffineMap {
+template <typename T, std::size_t codim> class AffineMap {
 public:
   using value_type =
       typename Utils::decay_to_scalar<Utils::Vector<T, codim>>::type;

--- a/src/core/field_coupling/fields/Constant.hpp
+++ b/src/core/field_coupling/fields/Constant.hpp
@@ -29,7 +29,7 @@ namespace Fields {
 /**
  * @brief A vector field that is constant in space.
  */
-template <typename T, size_t codim> class Constant {
+template <typename T, std::size_t codim> class Constant {
 public:
   using value_type =
       typename Utils::decay_to_scalar<Utils::Vector<T, codim>>::type;

--- a/src/core/field_coupling/fields/Interpolated.hpp
+++ b/src/core/field_coupling/fields/Interpolated.hpp
@@ -62,7 +62,7 @@ void deep_copy(boost::multi_array<T, 3> &dst,
  *  @tparam codim  Dimension of the field: 3 for a vector field,
  *                 1 for a scalar field.
  */
-template <typename T, size_t codim> class Interpolated {
+template <typename T, std::size_t codim> class Interpolated {
 public:
   /** Type of the values, usually @ref Utils::Vector<T, 3> for vector fields
    *  and @p T for scalar fields

--- a/src/core/field_coupling/fields/PlaneWave.hpp
+++ b/src/core/field_coupling/fields/PlaneWave.hpp
@@ -37,7 +37,7 @@ namespace Fields {
  *
  * See https://en.wikipedia.org/wiki/Plane_wave
  */
-template <typename T, size_t codim> class PlaneWave {
+template <typename T, std::size_t codim> class PlaneWave {
 public:
   using value_type =
       typename Utils::decay_to_scalar<Utils::Vector<T, codim>>::type;

--- a/src/core/field_coupling/fields/jacobian_type.hpp
+++ b/src/core/field_coupling/fields/jacobian_type.hpp
@@ -27,7 +27,7 @@
 namespace FieldCoupling {
 namespace Fields {
 namespace detail {
-template <class T, size_t codim> struct jacobian_type_impl {
+template <class T, std::size_t codim> struct jacobian_type_impl {
   using type = Utils::Matrix<double, codim, 3>;
 };
 
@@ -42,7 +42,7 @@ template <class T> struct jacobian_type_impl<T, 1> {
  * and Utils::Vector<codim, Utils::Vector<3, T>> otherwise to avoid
  * using Vectors of size one, where scalars would do.
  */
-template <class T, size_t codim>
+template <class T, std::size_t codim>
 using jacobian_type = typename jacobian_type_impl<T, codim>::type;
 } // namespace detail
 } // namespace Fields

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -45,6 +45,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <vector>

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -66,13 +66,13 @@ public:
 
   /** Returns the number of elements in the non-bond storage.
    */
-  size_t size() const { return buf.size(); }
+  std::size_t size() const { return buf.size(); }
 
   /** Resizes the underlying storage s.t. the object is capable
    * of holding "new_size" chars.
    * @param new_size new size
    */
-  void resize(size_t new_size) { buf.resize(new_size); }
+  void resize(std::size_t new_size) { buf.resize(new_size); }
 
   /** Returns a reference to the bond storage.
    */
@@ -84,8 +84,8 @@ private:
   std::vector<char> bondbuf; ///< Buffer for bond lists
 };
 
-static size_t calc_transmit_size(unsigned data_parts) {
-  size_t size = {};
+static std::size_t calc_transmit_size(unsigned data_parts) {
+  std::size_t size = {};
   if (data_parts & GHOSTTRANS_PROPRTS)
     size += Utils::MemcpyOArchive::packing_size<ParticleProperties>();
   if (data_parts & GHOSTTRANS_POSITION)
@@ -102,14 +102,14 @@ static size_t calc_transmit_size(unsigned data_parts) {
   return size;
 }
 
-static size_t calc_transmit_size(const GhostCommunication &ghost_comm,
-                                 unsigned int data_parts) {
+static std::size_t calc_transmit_size(const GhostCommunication &ghost_comm,
+                                      unsigned int data_parts) {
   if (data_parts & GHOSTTRANS_PARTNUM)
     return sizeof(int) * ghost_comm.part_lists.size();
 
   auto const n_part = boost::accumulate(
       ghost_comm.part_lists, 0ul,
-      [](size_t sum, auto part_list) { return sum + part_list->size(); });
+      [](std::size_t sum, auto part_list) { return sum + part_list->size(); });
 
   return n_part * calc_transmit_size(data_parts);
 }
@@ -271,7 +271,7 @@ static void cell_cell_transfer(const GhostCommunication &ghost_comm,
                                unsigned int data_parts) {
   /* transfer data */
   auto const offset = ghost_comm.part_lists.size() / 2;
-  for (size_t pl = 0; pl < offset; pl++) {
+  for (std::size_t pl = 0; pl < offset; pl++) {
     const auto *src_list = ghost_comm.part_lists[pl];
     auto *dst_list = ghost_comm.part_lists[pl + offset];
 
@@ -282,7 +282,7 @@ static void cell_cell_transfer(const GhostCommunication &ghost_comm,
       auto &dst_part = *dst_list;
       assert(src_part.size() == dst_part.size());
 
-      for (size_t i = 0; i < src_part.size(); i++) {
+      for (std::size_t i = 0; i < src_part.size(); i++) {
         auto const &part1 = src_part.begin()[i];
         auto &part2 = dst_part.begin()[i];
 

--- a/src/core/ghosts.hpp
+++ b/src/core/ghosts.hpp
@@ -158,7 +158,7 @@ struct GhostCommunication {
 /** Properties for a ghost communication. */
 struct GhostCommunicator {
   GhostCommunicator() = default;
-  GhostCommunicator(boost::mpi::communicator comm, size_t size)
+  GhostCommunicator(boost::mpi::communicator comm, std::size_t size)
       : mpi_comm(std::move(comm)), communications(size) {}
 
   /** Attached mpi communicator */

--- a/src/core/grid_based_algorithms/electrokinetics.hpp
+++ b/src/core/grid_based_algorithms/electrokinetics.hpp
@@ -32,7 +32,7 @@
 
 /* Data structure holding parameters and memory pointers for the link flux
  * system. */
-typedef struct {
+struct EKParameters {
   float agrid;
   float time_step; // MD time step
   float lb_density;
@@ -83,7 +83,7 @@ typedef struct {
   float valency[MAX_NUMBER_OF_SPECIES];
   float ext_force_density[3][MAX_NUMBER_OF_SPECIES];
   char *node_is_catalyst;
-} EK_parameters;
+};
 
 #endif
 
@@ -129,7 +129,7 @@ typedef struct {
 #define EK_LINK_DUD 24
 #define EK_LINK_DUU 25
 
-extern EK_parameters ek_parameters;
+extern EKParameters ek_parameters;
 extern bool ek_initialized;
 
 void ek_integrate();

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -1792,7 +1792,7 @@ __global__ void ek_gather_species_charge_density() {
 
 __global__ void
 ek_gather_particle_charge_density(CUDA_particle_data *particle_data,
-                                  size_t number_of_particles,
+                                  std::size_t number_of_particles,
                                   LB_parameters_gpu *ek_lbparameters_gpu) {
   unsigned int index = ek_getThreadIndex();
   unsigned int lowernode[3];
@@ -1876,10 +1876,9 @@ ek_gather_particle_charge_density(CUDA_particle_data *particle_data,
   }
 }
 
-__global__ void
-ek_spread_particle_force(CUDA_particle_data *particle_data,
-                         size_t number_of_particles, float *particle_forces,
-                         LB_parameters_gpu *ek_lbparameters_gpu) {
+__global__ void ek_spread_particle_force(
+    CUDA_particle_data *particle_data, std::size_t number_of_particles,
+    float *particle_forces, LB_parameters_gpu *ek_lbparameters_gpu) {
 
   unsigned int index = ek_getThreadIndex();
   unsigned int lowernode[3];

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -73,7 +73,7 @@ void LBBoundaries::lb_init_boundaries();
 
 static constexpr unsigned int threads_per_block = 64;
 
-EK_parameters ek_parameters = {
+EKParameters ek_parameters = {
     // agrid
     -1.0,
     // time_step
@@ -174,7 +174,7 @@ EK_parameters ek_parameters = {
     nullptr,
 };
 
-__device__ __constant__ EK_parameters ek_parameters_gpu[1];
+__device__ __constant__ EKParameters ek_parameters_gpu[1];
 float *charge_gpu;
 LB_parameters_gpu *ek_lbparameters_gpu;
 CUDA_particle_data *particle_data_gpu;
@@ -189,7 +189,7 @@ FdElectrostatics *electrostatics = nullptr;
 extern LB_parameters_gpu lbpar_gpu;
 extern LB_node_force_density_gpu node_f, node_f_buf;
 extern LB_nodes_gpu *current_nodes;
-extern EK_parameters *lb_ek_parameters;
+extern EKParameters *lb_ek_parameters;
 
 LB_rho_v_gpu *ek_lb_device_values;
 
@@ -2281,7 +2281,7 @@ int ek_init() {
 #endif
 
     cuda_safe_mem(cudaMemcpyToSymbol(ek_parameters_gpu, &ek_parameters,
-                                     sizeof(EK_parameters)));
+                                     sizeof(EKParameters)));
 
     lb_get_para_pointer(&ek_lbparameters_gpu);
 
@@ -2335,7 +2335,7 @@ int ek_init() {
 
     ek_parameters.charge_potential = electrostatics->getGrid().grid;
     cuda_safe_mem(cudaMemcpyToSymbol(ek_parameters_gpu, &ek_parameters,
-                                     sizeof(EK_parameters)));
+                                     sizeof(EKParameters)));
 
     // clear initial LB force and finish up
     dim3 dim_grid = calculate_dim_grid(
@@ -2361,7 +2361,7 @@ int ek_init() {
       return 1;
     }
     cuda_safe_mem(cudaMemcpyToSymbol(ek_parameters_gpu, &ek_parameters,
-                                     sizeof(EK_parameters)));
+                                     sizeof(EKParameters)));
 
     dim3 dim_grid =
         calculate_dim_grid(ek_parameters.number_of_nodes, 4, threads_per_block);
@@ -2374,7 +2374,7 @@ int ek_init() {
     lb_get_boundary_force_pointer(&ek_lb_boundary_force);
 
     cuda_safe_mem(cudaMemcpyToSymbol(ek_parameters_gpu, &ek_parameters,
-                                     sizeof(EK_parameters)));
+                                     sizeof(EKParameters)));
 #endif
 
     ek_integrate_electrostatics();

--- a/src/core/grid_based_algorithms/halo.hpp
+++ b/src/core/grid_based_algorithms/halo.hpp
@@ -84,7 +84,7 @@ struct FieldType {
 };
 
 /** Structure describing a Halo region */
-typedef struct {
+struct HaloInfo {
 
   int type; /**< type of halo communication */
 
@@ -97,8 +97,7 @@ typedef struct {
   std::shared_ptr<FieldType>
       fieldtype;         /**< type layout of the data being exchanged */
   MPI_Datatype datatype; /**< MPI datatype of data being communicated */
-
-} HaloInfo;
+};
 
 /** Structure holding a set of \ref HaloInfo which comprise a certain
  *  parallelization scheme */

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -54,6 +54,7 @@
 #include <profiler/profiler.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cinttypes>
 #include <cmath>
@@ -64,6 +65,7 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
+#include <vector>
 
 using Utils::get_linear_index;
 

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -890,7 +890,7 @@ auto lb_next_offsets(const Lattice &lb_lattice,
 
 template <typename T>
 void lb_stream(LB_Fluid &lb_fluid, const std::array<T, 19> &populations,
-               size_t index, std::array<ptrdiff_t, 19> const &offsets) {
+               std::size_t index, std::array<ptrdiff_t, 19> const &offsets) {
   for (int i = 0; i < populations.size(); i++) {
     lb_fluid[i][index + offsets[i]] = populations[i];
   }

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -876,12 +876,12 @@ std::array<T, 19> lb_apply_forces(const std::array<T, 19> &modes,
  */
 auto lb_next_offsets(const Lattice &lb_lattice,
                      std::array<Utils::Vector3i, 19> const &c) {
-  const Utils::Vector3<ptrdiff_t> strides = {
+  const Utils::Vector3<std::ptrdiff_t> strides = {
       {1, lb_lattice.halo_grid[0],
-       static_cast<ptrdiff_t>(lb_lattice.halo_grid[0]) *
-           static_cast<ptrdiff_t>(lb_lattice.halo_grid[1])}};
+       static_cast<std::ptrdiff_t>(lb_lattice.halo_grid[0]) *
+           static_cast<std::ptrdiff_t>(lb_lattice.halo_grid[1])}};
 
-  std::array<ptrdiff_t, 19> offsets;
+  std::array<std::ptrdiff_t, 19> offsets;
   boost::transform(c, offsets.begin(),
                    [&strides](auto const &ci) { return strides * ci; });
 
@@ -890,7 +890,8 @@ auto lb_next_offsets(const Lattice &lb_lattice,
 
 template <typename T>
 void lb_stream(LB_Fluid &lb_fluid, const std::array<T, 19> &populations,
-               std::size_t index, std::array<ptrdiff_t, 19> const &offsets) {
+               std::size_t index,
+               std::array<std::ptrdiff_t, 19> const &offsets) {
   for (int i = 0; i < populations.size(); i++) {
     lb_fluid[i][index + offsets[i]] = populations[i];
   }

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -45,6 +45,7 @@
 #include <boost/range/algorithm.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <iterator>
 #include <memory>

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -169,7 +169,7 @@ void lb_init_boundaries() {
     unsigned number_of_boundnodes = 0;
     std::vector<int> host_boundary_node_list;
     std::vector<int> host_boundary_index_list;
-    size_t size_of_index;
+    std::size_t size_of_index;
 
     for (int z = 0; z < int(lbpar_gpu.dim[2]); z++) {
       for (int y = 0; y < int(lbpar_gpu.dim[1]); y++) {

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -44,6 +44,7 @@ using Utils::get_linear_index;
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 ActiveLB lattice_switch = ActiveLB::NONE;
 

--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -175,7 +175,8 @@ namespace {
 using Utils::Vector;
 using Utils::Vector3d;
 
-template <class T, size_t N> using Box = std::pair<Vector<T, N>, Vector<T, N>>;
+template <class T, std::size_t N>
+using Box = std::pair<Vector<T, N>, Vector<T, N>>;
 
 /**
  * @brief Check if a position is in a box.
@@ -189,7 +190,7 @@ template <class T, size_t N> using Box = std::pair<Vector<T, N>, Vector<T, N>>;
  *
  * @return True iff the point is inside of the box.
  */
-template <class T, size_t N>
+template <class T, std::size_t N>
 bool in_box(Vector<T, N> const &pos, Box<T, N> const &box) {
   return (pos >= box.first) and (pos < box.second);
 }

--- a/src/core/grid_based_algorithms/lbgpu_cuda.cu
+++ b/src/core/grid_based_algorithms/lbgpu_cuda.cu
@@ -643,7 +643,7 @@ __device__ void bounce_back_boundaries(LB_nodes_gpu n_curr,
   int c[3];
   float shift, weight, pop_to_bounce_back;
   float boundary_force[3] = {0.0f, 0.0f, 0.0f};
-  size_t to_index, to_index_x, to_index_y, to_index_z;
+  std::size_t to_index, to_index_x, to_index_y, to_index_z;
   unsigned population, inverse;
 
   if (boundaries.index[index] != 0) {
@@ -1823,8 +1823,8 @@ __global__ void init_boundaries(int const *boundary_node_list,
 
 /** Reset the boundary flag of every node */
 __global__ void reset_boundaries(LB_boundaries_gpu boundaries) {
-  size_t index = blockIdx.y * gridDim.x * blockDim.x + blockDim.x * blockIdx.x +
-                 threadIdx.x;
+  std::size_t index = blockIdx.y * gridDim.x * blockDim.x +
+                      blockDim.x * blockIdx.x + threadIdx.x;
   if (index < para->number_of_nodes) {
     boundaries.index[index] = 0;
   }

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -96,7 +96,7 @@ void velocity_verlet_npt_propagate_pos(const ParticleRange &particles,
   /* finalize derivation of p_inst */
   velocity_verlet_npt_finalize_p_inst(time_step);
 
-  /* adjust \ref nptiso_struct::nptiso.volume; prepare pos- and
+  /* adjust \ref NptIsoParameters::nptiso.volume; prepare pos- and
    * vel-rescaling
    */
   if (this_node == 0) {

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -87,8 +87,8 @@ namespace Mpiio {
  * \param MPI_T The MPI_Datatype corresponding to the template parameter T.
  */
 template <typename T>
-static void mpiio_dump_array(const std::string &fn, T *arr, size_t len,
-                             size_t pref, MPI_Datatype MPI_T) {
+static void mpiio_dump_array(const std::string &fn, T *arr, std::size_t len,
+                             std::size_t pref, MPI_Datatype MPI_T) {
   MPI_File f;
   int ret;
 
@@ -139,8 +139,9 @@ static void dump_info(const std::string &fn, unsigned fields) {
   for (int i = 0; i < bonded_ia_params.size(); ++i) {
     npartners[i] = number_of_partners(bonded_ia_params[i]);
   }
-  auto ia_params_size = static_cast<size_t>(bonded_ia_params.size());
-  success = success && (fwrite(&ia_params_size, sizeof(size_t), 1, f) == 1);
+  auto ia_params_size = static_cast<std::size_t>(bonded_ia_params.size());
+  success =
+      success && (fwrite(&ia_params_size, sizeof(std::size_t), 1, f) == 1);
   success =
       success && (fwrite(npartners.data(), sizeof(int), bonded_ia_params.size(),
                          f) == bonded_ia_params.size());
@@ -246,7 +247,7 @@ void mpi_mpiio_common_write(const char *filename, unsigned fields,
  * \param elem_sz Sizeof a single element
  * \return The number of elements stored binary in the file
  */
-static int get_num_elem(const std::string &fn, size_t elem_sz) {
+static int get_num_elem(const std::string &fn, std::size_t elem_sz) {
   // Could also be done via MPI_File_open, MPI_File_get_size,
   // MPI_File_close.
   struct stat st;
@@ -264,8 +265,8 @@ static int get_num_elem(const std::string &fn, size_t elem_sz) {
  *  have to match!
  */
 template <typename T>
-static void mpiio_read_array(const std::string &fn, T *arr, size_t len,
-                             size_t pref, MPI_Datatype MPI_T) {
+static void mpiio_read_array(const std::string &fn, T *arr, std::size_t len,
+                             std::size_t pref, MPI_Datatype MPI_T) {
   MPI_File f;
   int ret;
 

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -263,7 +263,7 @@ void File::close() {
 
 namespace detail {
 
-template <size_t rank> struct slice_info {};
+template <std::size_t rank> struct slice_info {};
 
 template <> struct slice_info<3> {
   static auto extent(hsize_t n_part_diff) {
@@ -284,7 +284,7 @@ template <> struct slice_info<2> {
 };
 
 } // namespace detail
-template <size_t dim, typename Op>
+template <std::size_t dim, typename Op>
 void write_td_particle_property(hsize_t prefix, hsize_t n_part_global,
                                 ParticleRange const &particles,
                                 h5xx::dataset &dataset, Op op) {

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -35,7 +35,9 @@
 #include <cstddef>
 #include <fstream>
 #include <functional>
+#include <iterator>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace Writer {

--- a/src/core/io/writer/h5md_core.hpp
+++ b/src/core/io/writer/h5md_core.hpp
@@ -40,7 +40,7 @@
 #include <utility>
 
 namespace h5xx {
-template <typename T, size_t size>
+template <typename T, std::size_t size>
 struct is_array<Utils::Vector<T, size>> : std::true_type {};
 } // namespace h5xx
 

--- a/src/core/io/writer/h5md_specification.cpp
+++ b/src/core/io/writer/h5md_specification.cpp
@@ -22,6 +22,8 @@
 #include "h5md_specification.hpp"
 #include "hdf5.h"
 
+#include <array>
+
 namespace Writer {
 namespace H5md {
 

--- a/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
+++ b/src/core/nonbonded_interactions/nonbonded_interaction_data.cpp
@@ -41,8 +41,11 @@
 
 #include <utils/index.hpp>
 
+#include <algorithm>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 /****************************************
  * variables

--- a/src/core/npt.cpp
+++ b/src/core/npt.cpp
@@ -36,19 +36,19 @@
 #include <cmath>
 #include <stdexcept>
 
-nptiso_struct nptiso = {0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        {0.0, 0.0, 0.0},
-                        {0.0, 0.0, 0.0},
-                        0,
-                        {NPTGEOM_XDIR, NPTGEOM_YDIR, NPTGEOM_ZDIR},
-                        0,
-                        false,
-                        0};
+NptIsoParameters nptiso = {0.0,
+                           0.0,
+                           0.0,
+                           0.0,
+                           0.0,
+                           0.0,
+                           {0.0, 0.0, 0.0},
+                           {0.0, 0.0, 0.0},
+                           0,
+                           {NPTGEOM_XDIR, NPTGEOM_YDIR, NPTGEOM_ZDIR},
+                           0,
+                           false,
+                           0};
 
 void synchronize_npt_state() {
   boost::mpi::broadcast(comm_cart, nptiso.p_inst, 0);
@@ -73,7 +73,8 @@ void mpi_bcast_nptiso_geom_barostat() {
   mpi_call_all(mpi_bcast_nptiso_geom_barostat_worker);
 }
 
-void integrator_npt_coulomb_dipole_sanity_checks(nptiso_struct const &params) {
+void integrator_npt_coulomb_dipole_sanity_checks(
+    NptIsoParameters const &params) {
 #ifdef ELECTROSTATICS
   if (params.dimension < 3 && !params.cubic_box && coulomb.prefactor > 0) {
     throw std::runtime_error("If electrostatics is being used you must "
@@ -105,19 +106,19 @@ void nptiso_init(double ext_pressure, double piston, bool xdir_rescale,
     throw std::runtime_error("The piston mass must be positive.");
   }
 
-  nptiso_struct new_nptiso = {piston,
-                              nptiso.inv_piston,
-                              nptiso.volume,
-                              ext_pressure,
-                              nptiso.p_inst,
-                              nptiso.p_diff,
-                              nptiso.p_vir,
-                              nptiso.p_vel,
-                              0,
-                              nptiso.nptgeom_dir,
-                              0,
-                              cubic_box,
-                              -1};
+  NptIsoParameters new_nptiso = {piston,
+                                 nptiso.inv_piston,
+                                 nptiso.volume,
+                                 ext_pressure,
+                                 nptiso.p_inst,
+                                 nptiso.p_diff,
+                                 nptiso.p_vir,
+                                 nptiso.p_vel,
+                                 0,
+                                 nptiso.nptgeom_dir,
+                                 0,
+                                 cubic_box,
+                                 -1};
 
   /* set the NpT geometry */
   if (xdir_rescale) {

--- a/src/core/npt.hpp
+++ b/src/core/npt.hpp
@@ -33,7 +33,7 @@
 #include <utils/Vector.hpp>
 
 /** Parameters of the isotropic NpT-integration scheme. */
-typedef struct {
+struct NptIsoParameters {
   /** mass of a virtual piston representing the shaken box */
   double piston;
   /** inverse of \ref piston */
@@ -74,9 +74,9 @@ typedef struct {
    *  the variable box_l
    */
   int non_const_dim;
-} nptiso_struct;
+};
 
-extern nptiso_struct nptiso;
+extern NptIsoParameters nptiso;
 
 /** @brief NpT initializer.
  *
@@ -94,7 +94,7 @@ void nptiso_init(double ext_pressure, double piston, bool xdir_rescale,
                  bool ydir_rescale, bool zdir_rescale, bool cubic_box);
 
 /** @name NpT geometry bitmasks.
- *  Allowed values for @ref nptiso_struct::geometry.
+ *  Allowed values for @ref NptIsoParameters::geometry.
  */
 /**@{*/
 #define NPTGEOM_XDIR 1

--- a/src/core/observables/BondAngles.hpp
+++ b/src/core/observables/BondAngles.hpp
@@ -53,7 +53,7 @@ public:
     auto v1 = box_geo.get_mi_vector(traits.position(particles[1]),
                                     traits.position(particles[0]));
     auto n1 = v1.norm();
-    for (size_t i = 0, end = n_values(); i < end; i++) {
+    for (std::size_t i = 0, end = n_values(); i < end; i++) {
       auto v2 = box_geo.get_mi_vector(traits.position(particles[i + 2]),
                                       traits.position(particles[i + 1]));
       auto n2 = v2.norm();
@@ -74,7 +74,7 @@ public:
     }
     return res;
   }
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     assert(ids().size() >= 2);
     return {ids().size() - 2};
   }

--- a/src/core/observables/BondDihedrals.hpp
+++ b/src/core/observables/BondDihedrals.hpp
@@ -61,7 +61,7 @@ public:
     auto v2 = box_geo.get_mi_vector(traits.position(particles[2]),
                                     traits.position(particles[1]));
     auto c1 = Utils::vector_product(v1, v2);
-    for (size_t i = 0, end = n_values(); i < end; i++) {
+    for (std::size_t i = 0, end = n_values(); i < end; i++) {
       auto v3 = box_geo.get_mi_vector(traits.position(particles[i + 3]),
                                       traits.position(particles[i + 2]));
       auto c2 = vector_product(v2, v3);
@@ -74,7 +74,7 @@ public:
     }
     return res;
   }
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     assert(ids().size() >= 3);
     return {ids().size() - 3};
   }

--- a/src/core/observables/CosPersistenceAngles.hpp
+++ b/src/core/observables/CosPersistenceAngles.hpp
@@ -59,14 +59,14 @@ public:
       return box_geo.get_mi_vector(traits.position(particles[index + 1]),
                                    traits.position(particles[index]));
     };
-    for (size_t i = 0; i < no_of_bonds; ++i) {
+    for (std::size_t i = 0; i < no_of_bonds; ++i) {
       auto const tmp = get_bond_vector(i);
       bond_vectors[i] = tmp / tmp.norm();
     }
     // calculate angles between neighbouring bonds, next neighbours, etc...
-    for (size_t i = 0; i < no_of_angles; ++i) {
+    for (std::size_t i = 0; i < no_of_angles; ++i) {
       auto average = 0.0;
-      for (size_t j = 0; j < no_of_angles - i; ++j) {
+      for (std::size_t j = 0; j < no_of_angles - i; ++j) {
         average += bond_vectors[j] * bond_vectors[j + i + 1];
       }
       angles[i] = average / static_cast<double>(no_of_angles - i);
@@ -74,7 +74,7 @@ public:
 
     return angles;
   }
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     assert(ids().size() >= 2);
     return {ids().size() - 2};
   }

--- a/src/core/observables/CylindricalFluxDensityProfile.hpp
+++ b/src/core/observables/CylindricalFluxDensityProfile.hpp
@@ -54,7 +54,7 @@ public:
     histogram.normalize();
     return histogram.get_histogram();
   }
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/CylindricalLBFluxDensityProfileAtParticlePositions.hpp
+++ b/src/core/observables/CylindricalLBFluxDensityProfileAtParticlePositions.hpp
@@ -40,7 +40,7 @@ public:
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override;
 
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/CylindricalLBProfileObservable.hpp
+++ b/src/core/observables/CylindricalLBProfileObservable.hpp
@@ -27,6 +27,11 @@
 #include <utils/math/vec_rotate.hpp>
 #include <utils/sampling.hpp>
 
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
 namespace Observables {
 
 class CylindricalLBProfileObservable : public CylindricalProfileObservable {

--- a/src/core/observables/CylindricalLBVelocityProfile.hpp
+++ b/src/core/observables/CylindricalLBVelocityProfile.hpp
@@ -29,7 +29,7 @@ class CylindricalLBVelocityProfile : public CylindricalLBProfileObservable {
 public:
   using CylindricalLBProfileObservable::CylindricalLBProfileObservable;
   std::vector<double> operator()() const override;
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/CylindricalLBVelocityProfileAtParticlePositions.hpp
+++ b/src/core/observables/CylindricalLBVelocityProfileAtParticlePositions.hpp
@@ -40,7 +40,7 @@ public:
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override;
 
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/CylindricalPidProfileObservable.hpp
+++ b/src/core/observables/CylindricalPidProfileObservable.hpp
@@ -19,10 +19,12 @@
 #ifndef OBSERVABLES_CYLINDRICALPIDPROFILEOBSERVABLE_HPP
 #define OBSERVABLES_CYLINDRICALPIDPROFILEOBSERVABLE_HPP
 
-#include <utility>
-
 #include "CylindricalProfileObservable.hpp"
 #include "PidObservable.hpp"
+
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace Observables {
 

--- a/src/core/observables/CylindricalVelocityProfile.hpp
+++ b/src/core/observables/CylindricalVelocityProfile.hpp
@@ -54,14 +54,14 @@ public:
 
     auto hist_tmp = histogram.get_histogram();
     auto tot_count = histogram.get_tot_count();
-    for (size_t ind = 0; ind < hist_tmp.size(); ++ind) {
+    for (std::size_t ind = 0; ind < hist_tmp.size(); ++ind) {
       if (tot_count[ind] > 0) {
         hist_tmp[ind] /= static_cast<double>(tot_count[ind]);
       }
     }
     return hist_tmp;
   }
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/DPDStress.hpp
+++ b/src/core/observables/DPDStress.hpp
@@ -29,7 +29,7 @@ namespace Observables {
 
 class DPDStress : public Observable {
 public:
-  std::vector<size_t> shape() const override { return {3, 3}; }
+  std::vector<std::size_t> shape() const override { return {3, 3}; }
   std::vector<double> operator()() const override { return dpd_stress(); }
 };
 

--- a/src/core/observables/EnergyObservable.hpp
+++ b/src/core/observables/EnergyObservable.hpp
@@ -29,7 +29,7 @@ namespace Observables {
 
 class Energy : public Observable {
 public:
-  std::vector<size_t> shape() const override { return {1}; }
+  std::vector<std::size_t> shape() const override { return {1}; }
   std::vector<double> operator()() const override {
     std::vector<double> res{1};
     res[0] = observable_compute_energy();

--- a/src/core/observables/FluxDensityProfile.hpp
+++ b/src/core/observables/FluxDensityProfile.hpp
@@ -34,7 +34,7 @@ namespace Observables {
 class FluxDensityProfile : public PidProfileObservable {
 public:
   using PidProfileObservable::PidProfileObservable;
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/ForceDensityProfile.hpp
+++ b/src/core/observables/ForceDensityProfile.hpp
@@ -35,7 +35,7 @@ namespace Observables {
 class ForceDensityProfile : public PidProfileObservable {
 public:
   using PidProfileObservable::PidProfileObservable;
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/LBFluidPressureTensor.hpp
+++ b/src/core/observables/LBFluidPressureTensor.hpp
@@ -28,7 +28,7 @@
 namespace Observables {
 class LBFluidPressureTensor : public Observable {
 public:
-  std::vector<size_t> shape() const override { return {3, 3}; }
+  std::vector<std::size_t> shape() const override { return {3, 3}; }
   std::vector<double> operator()() const override {
 
     auto const unit_conversion =

--- a/src/core/observables/LBProfileObservable.hpp
+++ b/src/core/observables/LBProfileObservable.hpp
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <cstddef>
 #include <stdexcept>
+#include <vector>
 
 namespace Observables {
 

--- a/src/core/observables/LBProfileObservable.hpp
+++ b/src/core/observables/LBProfileObservable.hpp
@@ -72,15 +72,15 @@ public:
            sampling_delta[2] > 0.);
     assert(sampling_offset[0] >= 0. and sampling_offset[1] >= 0. and
            sampling_offset[2] >= 0.);
-    const auto n_samples_x = static_cast<size_t>(
+    const auto n_samples_x = static_cast<std::size_t>(
         std::rint((lim[0].second - lim[0].first) / sampling_delta[0]));
-    const auto n_samples_y = static_cast<size_t>(
+    const auto n_samples_y = static_cast<std::size_t>(
         std::rint((lim[1].second - lim[1].first) / sampling_delta[1]));
-    const auto n_samples_z = static_cast<size_t>(
+    const auto n_samples_z = static_cast<std::size_t>(
         std::rint((lim[2].second - lim[2].first) / sampling_delta[2]));
-    for (size_t x = 0; x < n_samples_x; ++x) {
-      for (size_t y = 0; y < n_samples_y; ++y) {
-        for (size_t z = 0; z < n_samples_z; ++z) {
+    for (std::size_t x = 0; x < n_samples_x; ++x) {
+      for (std::size_t y = 0; y < n_samples_y; ++y) {
+        for (std::size_t z = 0; z < n_samples_z; ++z) {
           sampling_positions.push_back(Utils::Vector3d{
               {lim[0].first + sampling_offset[0] +
                    static_cast<double>(x) * sampling_delta[0],

--- a/src/core/observables/LBVelocityProfile.cpp
+++ b/src/core/observables/LBVelocityProfile.cpp
@@ -38,7 +38,7 @@ std::vector<double> LBVelocityProfile::operator()() const {
   }
   auto hist_tmp = histogram.get_histogram();
   auto const tot_count = histogram.get_tot_count();
-  for (size_t ind = 0; ind < hist_tmp.size(); ++ind) {
+  for (std::size_t ind = 0; ind < hist_tmp.size(); ++ind) {
     if (tot_count[ind] == 0 and not allow_empty_bins) {
       auto const error = "Decrease sampling delta(s), bin " +
                          std::to_string(ind) + " has no hit";

--- a/src/core/observables/LBVelocityProfile.hpp
+++ b/src/core/observables/LBVelocityProfile.hpp
@@ -29,7 +29,7 @@ namespace Observables {
 class LBVelocityProfile : public LBProfileObservable {
 public:
   using LBProfileObservable::LBProfileObservable;
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     auto const b = n_bins();
     return {b[0], b[1], b[2], 3};
   }

--- a/src/core/observables/Observable.hpp
+++ b/src/core/observables/Observable.hpp
@@ -45,13 +45,13 @@ public:
   virtual std::vector<double> operator()() const = 0;
 
   /** Size of the flat array returned by the observable */
-  size_t n_values() const {
+  std::size_t n_values() const {
     auto const v = shape();
     return std::accumulate(v.begin(), v.end(), 1u, std::multiplies<>());
   }
 
   /** Dimensions needed to reshape the flat array returned by the observable */
-  virtual std::vector<size_t> shape() const = 0;
+  virtual std::vector<std::size_t> shape() const = 0;
 };
 
 } // Namespace Observables

--- a/src/core/observables/ParticleAngularVelocities.hpp
+++ b/src/core/observables/ParticleAngularVelocities.hpp
@@ -39,7 +39,7 @@ public:
     std::vector<double> res(n_values());
 
 #ifdef ROTATION
-    size_t i = 0;
+    std::size_t i = 0;
     for (auto p : particles) {
       const Utils::Vector3d omega =
           convert_vector_body_to_space(p.get(), p.get().m.omega);
@@ -52,7 +52,7 @@ public:
     return res;
   }
 
-  std::vector<size_t> shape() const override { return {ids().size(), 3}; }
+  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
 };
 
 } // Namespace Observables

--- a/src/core/observables/ParticleBodyAngularVelocities.hpp
+++ b/src/core/observables/ParticleBodyAngularVelocities.hpp
@@ -37,7 +37,7 @@ public:
            const ParticleObservables::traits<Particle> &traits) const override {
     std::vector<double> res(n_values());
 #ifdef ROTATION
-    for (size_t i = 0; i < particles.size(); i++) {
+    for (std::size_t i = 0; i < particles.size(); i++) {
       res[3 * i + 0] = particles[i].get().m.omega[0];
       res[3 * i + 1] = particles[i].get().m.omega[1];
       res[3 * i + 2] = particles[i].get().m.omega[2];
@@ -46,7 +46,7 @@ public:
     return res;
   }
 
-  std::vector<size_t> shape() const override { return {ids().size(), 3}; }
+  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
 };
 
 } // Namespace Observables

--- a/src/core/observables/ParticleBodyVelocities.hpp
+++ b/src/core/observables/ParticleBodyVelocities.hpp
@@ -38,7 +38,7 @@ public:
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
     std::vector<double> res(n_values());
-    for (size_t i = 0; i < particles.size(); i++) {
+    for (std::size_t i = 0; i < particles.size(); i++) {
 #ifdef ROTATION
       const Utils::Vector3d vel_body = convert_vector_space_to_body(
           particles[i].get(), traits.velocity(particles[i]));
@@ -50,7 +50,7 @@ public:
     }
     return res;
   }
-  std::vector<size_t> shape() const override { return {ids().size(), 3}; }
+  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
 };
 
 } // Namespace Observables

--- a/src/core/observables/ParticleDistances.hpp
+++ b/src/core/observables/ParticleDistances.hpp
@@ -52,14 +52,14 @@ public:
            const ParticleObservables::traits<Particle> &traits) const override {
     std::vector<double> res(n_values());
 
-    for (size_t i = 0, end = n_values(); i < end; i++) {
+    for (std::size_t i = 0, end = n_values(); i < end; i++) {
       auto const v = box_geo.get_mi_vector(traits.position(particles[i]),
                                            traits.position(particles[i + 1]));
       res[i] = v.norm();
     }
     return res;
   }
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     assert(!ids().empty());
     return {ids().size() - 1};
   }

--- a/src/core/observables/ParticleForces.hpp
+++ b/src/core/observables/ParticleForces.hpp
@@ -38,14 +38,14 @@ public:
   evaluate(ParticleReferenceRange particles,
            const ParticleObservables::traits<Particle> &traits) const override {
     std::vector<double> res(n_values());
-    for (size_t i = 0; i < particles.size(); i++) {
+    for (std::size_t i = 0; i < particles.size(); i++) {
       res[3 * i + 0] = particles[i].get().f.f[0];
       res[3 * i + 1] = particles[i].get().f.f[1];
       res[3 * i + 2] = particles[i].get().f.f[2];
     }
     return res;
   };
-  std::vector<size_t> shape() const override { return {ids().size(), 3}; }
+  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
 };
 
 } // Namespace Observables

--- a/src/core/observables/PidObservable.hpp
+++ b/src/core/observables/PidObservable.hpp
@@ -72,14 +72,14 @@ namespace detail {
 template <class T> struct shape_impl;
 
 template <> struct shape_impl<double> {
-  static std::vector<size_t> eval(size_t /* n_part */) { return {1}; }
+  static std::vector<std::size_t> eval(std::size_t /* n_part */) { return {1}; }
 };
-template <class _, size_t N> struct shape_impl<Utils::Vector<_, N>> {
-  static std::vector<size_t> eval(size_t /* n_part */) { return {N}; }
+template <class _, std::size_t N> struct shape_impl<Utils::Vector<_, N>> {
+  static std::vector<std::size_t> eval(std::size_t /* n_part */) { return {N}; }
 };
 template <class T> struct shape_impl<std::vector<T>> {
-  static std::vector<size_t> eval(size_t n_part) {
-    std::vector<size_t> ret{n_part};
+  static std::vector<std::size_t> eval(std::size_t n_part) {
+    std::vector<std::size_t> ret{n_part};
     boost::copy(shape_impl<T>::eval(n_part), std::back_inserter(ret));
 
     return ret;
@@ -104,7 +104,7 @@ template <class T> struct shape_impl<std::vector<T>> {
 template <class ObsType> class ParticleObservable : public PidObservable {
 public:
   using PidObservable::PidObservable;
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     using std::declval;
 
     return detail::shape_impl<decltype(declval<ObsType>()(

--- a/src/core/observables/PressureObservable.hpp
+++ b/src/core/observables/PressureObservable.hpp
@@ -28,7 +28,7 @@ namespace Observables {
 
 class Pressure : public Observable {
 public:
-  std::vector<size_t> shape() const override { return {1}; }
+  std::vector<std::size_t> shape() const override { return {1}; }
   std::vector<double> operator()() const override {
     auto const ptensor = observable_compute_pressure_tensor();
     std::vector<double> res{1};

--- a/src/core/observables/PressureTensor.hpp
+++ b/src/core/observables/PressureTensor.hpp
@@ -28,7 +28,7 @@ namespace Observables {
 
 class PressureTensor : public Observable {
 public:
-  std::vector<size_t> shape() const override { return {3, 3}; }
+  std::vector<std::size_t> shape() const override { return {3, 3}; }
   std::vector<double> operator()() const override {
     return observable_compute_pressure_tensor().as_vector();
   }

--- a/src/core/observables/ProfileObservable.hpp
+++ b/src/core/observables/ProfileObservable.hpp
@@ -39,7 +39,7 @@ private:
   /** Range of the profile edges. */
   std::array<std::pair<double, double>, 3> m_limits;
   /** Number of bins for each coordinate. */
-  std::array<size_t, 3> m_n_bins;
+  std::array<std::size_t, 3> m_n_bins;
 
 public:
   ProfileObservable(int n_x_bins, int n_y_bins, int n_z_bins, double min_x,
@@ -47,8 +47,9 @@ public:
                     double max_z)
       : m_limits{{std::make_pair(min_x, max_x), std::make_pair(min_y, max_y),
                   std::make_pair(min_z, max_z)}},
-        m_n_bins{{static_cast<size_t>(n_x_bins), static_cast<size_t>(n_y_bins),
-                  static_cast<size_t>(n_z_bins)}} {
+        m_n_bins{{static_cast<std::size_t>(n_x_bins),
+                  static_cast<std::size_t>(n_y_bins),
+                  static_cast<std::size_t>(n_z_bins)}} {
     if (max_x <= min_x)
       throw std::runtime_error("max_x has to be > min_x");
     if (max_y <= min_y)
@@ -63,7 +64,7 @@ public:
       throw std::domain_error("n_z_bins has to be >= 1");
   }
 
-  std::vector<size_t> shape() const override {
+  std::vector<std::size_t> shape() const override {
     return {m_n_bins[0], m_n_bins[1], m_n_bins[2]};
   }
 

--- a/src/core/observables/RDF.cpp
+++ b/src/core/observables/RDF.cpp
@@ -29,8 +29,11 @@
 #include <utils/math/int_pow.hpp>
 
 #include <boost/range/algorithm/transform.hpp>
+
 #include <cmath>
 #include <functional>
+#include <memory>
+#include <vector>
 
 namespace Observables {
 std::vector<double> RDF::operator()() const {

--- a/src/core/observables/RDF.hpp
+++ b/src/core/observables/RDF.hpp
@@ -48,9 +48,9 @@ public:
   // Range of the profile.
   double min_r, max_r;
   // Number of bins
-  size_t n_r_bins;
+  std::size_t n_r_bins;
 
-  std::vector<size_t> shape() const override { return {n_r_bins}; }
+  std::vector<std::size_t> shape() const override { return {n_r_bins}; }
 
   explicit RDF(std::vector<int> ids1, std::vector<int> ids2, int n_r_bins,
                double min_r, double max_r)

--- a/src/core/observables/TotalForce.hpp
+++ b/src/core/observables/TotalForce.hpp
@@ -28,7 +28,7 @@ namespace Observables {
 class TotalForce : public PidObservable {
 public:
   using PidObservable::PidObservable;
-  std::vector<size_t> shape() const override { return {3}; }
+  std::vector<std::size_t> shape() const override { return {3}; }
 
   std::vector<double>
   evaluate(ParticleReferenceRange particles,

--- a/src/core/observables/fetch_particles.hpp
+++ b/src/core/observables/fetch_particles.hpp
@@ -40,7 +40,7 @@ inline std::vector<Particle> fetch_particles(std::vector<int> const &ids) {
   particles.reserve(ids.size());
 
   auto const chunk_size = fetch_cache_max_size();
-  for (size_t offset = 0; offset < ids.size();) {
+  for (std::size_t offset = 0; offset < ids.size();) {
     auto const this_size =
         boost::algorithm::clamp(chunk_size, 0, ids.size() - offset);
     auto const chunk_ids =

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -50,10 +50,16 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/variant.hpp>
 
+#include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace {
 /**

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -482,7 +482,7 @@ Utils::Cache<int, Particle> particle_fetch_cache(max_cache_size);
 } // namespace
 
 void invalidate_fetch_cache() { particle_fetch_cache.invalidate(); }
-size_t fetch_cache_max_size() { return particle_fetch_cache.max_size(); }
+std::size_t fetch_cache_max_size() { return particle_fetch_cache.max_size(); }
 
 boost::optional<const Particle &> get_particle_data_local(int id) {
   auto p = cell_structure.get_local_particle(id);

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -44,7 +44,7 @@
 #include <utils/quaternion.hpp>
 
 #include <cstddef>
-#include <memory>
+#include <vector>
 
 /************************************************
  * defines

--- a/src/core/particle_data.hpp
+++ b/src/core/particle_data.hpp
@@ -97,7 +97,7 @@ void invalidate_fetch_cache();
 /** @brief Return the maximal number of particles that are
  *         kept in the fetch cache.
  */
-size_t fetch_cache_max_size();
+std::size_t fetch_cache_max_size();
 
 /** Call only on the master node.
  *  Move a particle to a new position.

--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -142,7 +142,7 @@ draw_polymer_positions(PartCfg &partCfg, int const n_polymers,
                              respect_constraints);
   };
 
-  for (size_t p = 0; p < start_positions.size(); p++) {
+  for (std::size_t p = 0; p < start_positions.size(); p++) {
     if (is_valid_pos(start_positions[p])) {
       positions[p].push_back(start_positions[p]);
     } else {

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -133,7 +133,7 @@ void update_pressure() { mpi_call_all(update_pressure_local, -1, -1); }
 Utils::Vector9d observable_compute_pressure_tensor() {
   update_pressure();
   Utils::Vector9d pressure_tensor{};
-  for (size_t j = 0; j < 9; j++) {
+  for (std::size_t j = 0; j < 9; j++) {
     pressure_tensor[j] = obs_pressure.accumulate(0, j);
   }
   return pressure_tensor;

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -107,18 +107,18 @@ auto philox_4_uint64s(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
  *
  * @return Vector of uniform random numbers.
  */
-template <RNGSalt salt, size_t N = 3,
+template <RNGSalt salt, std::size_t N = 3,
           std::enable_if_t<(N > 1) and (N <= 4), int> = 0>
 auto noise_uniform(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
 
   auto const integers = philox_4_uint64s<salt>(counter, seed, key1, key2);
   Utils::VectorXd<N> noise{};
   std::transform(integers.begin(), integers.begin() + N, noise.begin(),
-                 [](size_t value) { return Utils::uniform(value) - 0.5; });
+                 [](std::size_t value) { return Utils::uniform(value) - 0.5; });
   return noise;
 }
 
-template <RNGSalt salt, size_t N, std::enable_if_t<N == 1, int> = 0>
+template <RNGSalt salt, std::size_t N, std::enable_if_t<N == 1, int> = 0>
 auto noise_uniform(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
 
   auto const integers = philox_4_uint64s<salt>(counter, seed, key1, key2);
@@ -145,17 +145,17 @@ auto noise_uniform(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
  * @return Vector of Gaussian random numbers.
  *
  */
-template <RNGSalt salt, size_t N = 3,
+template <RNGSalt salt, std::size_t N = 3,
           class = std::enable_if_t<(N >= 1) and (N <= 4)>>
 auto noise_gaussian(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
 
   auto const integers = philox_4_uint64s<salt>(counter, seed, key1, key2);
   static const double epsilon = std::numeric_limits<double>::min();
 
-  constexpr size_t M = (N <= 2) ? 2 : 4;
+  constexpr std::size_t M = (N <= 2) ? 2 : 4;
   Utils::VectorXd<M> u{};
   std::transform(integers.begin(), integers.begin() + M, u.begin(),
-                 [](size_t value) {
+                 [](std::size_t value) {
                    auto u = Utils::uniform(value);
                    return (u < epsilon) ? epsilon : u;
                  });

--- a/src/core/reaction_methods/ReactionAlgorithm.cpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.cpp
@@ -40,6 +40,7 @@
 #include <stdexcept>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace ReactionMethods {

--- a/src/core/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.hpp
@@ -30,6 +30,7 @@
 #include <map>
 #include <random>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace ReactionMethods {

--- a/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
+++ b/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
@@ -38,6 +38,8 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace espresso {
 // ESPResSo system instance

--- a/src/core/rotation.hpp
+++ b/src/core/rotation.hpp
@@ -37,7 +37,9 @@
 #include <utils/matrix.hpp>
 #include <utils/quaternion.hpp>
 
+#include <cassert>
 #include <cmath>
+#include <limits>
 #include <utility>
 
 /** @brief Propagate angular velocities and update quaternions on a

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -43,6 +43,7 @@
 #include <cstdlib>
 #include <limits>
 #include <stdexcept>
+#include <vector>
 
 /****************************************************************************************
  *                                 basic observables calculation

--- a/src/core/statistics_chain.cpp
+++ b/src/core/statistics_chain.cpp
@@ -29,6 +29,7 @@
 
 #include <utils/Vector.hpp>
 
+#include <array>
 #include <cmath>
 #include <stdexcept>
 

--- a/src/core/thermostats/npt_inline.hpp
+++ b/src/core/thermostats/npt_inline.hpp
@@ -62,7 +62,7 @@ friction_therm0_nptiso(IsotropicNptThermostat const &npt_iso,
 }
 
 /** Add p_diff-dependent noise and friction for NpT-sims to \ref
- *  nptiso_struct::p_diff
+ *  NptIsoParameters::p_diff
  */
 inline double friction_thermV_nptiso(IsotropicNptThermostat const &npt_iso,
                                      double p_diff) {

--- a/src/core/thermostats/npt_inline.hpp
+++ b/src/core/thermostats/npt_inline.hpp
@@ -42,7 +42,7 @@
  *  @return noise added to the velocity, already rescaled by
  *          dt/2 (contained in prefactors)
  */
-template <size_t step>
+template <std::size_t step>
 inline Utils::Vector3d
 friction_therm0_nptiso(IsotropicNptThermostat const &npt_iso,
                        Utils::Vector3d const &vel, int p_identity) {

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -49,6 +49,7 @@ namespace utf = boost::unit_test;
 #include <boost/mpi.hpp>
 #include <boost/range/numeric.hpp>
 
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <limits>

--- a/src/core/unit_tests/p3m_test.cpp
+++ b/src/core/unit_tests/p3m_test.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE(calc_meshift_false) {
 
   auto const val = detail::calc_meshift({1, 4, 7}, false);
 
-  for (size_t i = 0; i < 3; ++i) {
-    for (size_t j = 0; j < ref[i].size(); ++j) {
+  for (std::size_t i = 0; i < 3; ++i) {
+    for (std::size_t j = 0; j < ref[i].size(); ++j) {
       BOOST_CHECK_EQUAL(val[i][j], ref[i][j]);
     }
   }
@@ -48,8 +48,8 @@ BOOST_AUTO_TEST_CASE(calc_meshift_true) {
 
   auto const val = detail::calc_meshift({1, 4, 7}, true);
 
-  for (size_t i = 0; i < 3; ++i) {
-    for (size_t j = 0; j < ref[i].size(); ++j) {
+  for (std::size_t i = 0; i < 3; ++i) {
+    for (std::size_t j = 0; j < ref[i].size(); ++j) {
       BOOST_CHECK_EQUAL(val[i][j], ref[i][j]);
     }
   }

--- a/src/core/unit_tests/random_test.cpp
+++ b/src/core/unit_tests/random_test.cpp
@@ -34,8 +34,8 @@
 #include <vector>
 
 BOOST_AUTO_TEST_CASE(test_noise_statistics) {
-  constexpr size_t const sample_size = 60'000;
-  constexpr size_t const x = 0, y = 1, z = 2;
+  constexpr std::size_t const sample_size = 60'000;
+  constexpr std::size_t const x = 0, y = 1, z = 2;
   constexpr double const tol = 1e-12;
 
   double value = 1;
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(test_noise_statistics) {
 }
 
 BOOST_AUTO_TEST_CASE(test_noise_uniform_1d) {
-  constexpr size_t const sample_size = 60'000;
+  constexpr std::size_t const sample_size = 60'000;
 
   std::vector<double> means, variances;
   std::vector<std::vector<double>> covariance;
@@ -80,8 +80,8 @@ BOOST_AUTO_TEST_CASE(test_noise_uniform_1d) {
 }
 
 BOOST_AUTO_TEST_CASE(test_noise_uniform_3d) {
-  constexpr size_t const sample_size = 60'000;
-  constexpr size_t const x = 0, y = 1, z = 2;
+  constexpr std::size_t const sample_size = 60'000;
+  constexpr std::size_t const x = 0, y = 1, z = 2;
 
   std::vector<double> means, variances;
   std::vector<std::vector<double>> covariance;
@@ -105,8 +105,8 @@ BOOST_AUTO_TEST_CASE(test_noise_uniform_3d) {
 }
 
 BOOST_AUTO_TEST_CASE(test_noise_gaussian_4d) {
-  constexpr size_t const sample_size = 100'000;
-  constexpr size_t const x = 0, y = 1, z = 2, t = 3;
+  constexpr std::size_t const sample_size = 100'000;
+  constexpr std::size_t const x = 0, y = 1, z = 2, t = 3;
 
   std::vector<double> means, variances;
   std::vector<std::vector<double>> covariance;
@@ -137,9 +137,9 @@ BOOST_AUTO_TEST_CASE(test_noise_gaussian_4d) {
 BOOST_AUTO_TEST_CASE(test_uncorrelated_consecutive_ids) {
   // setup: 2 particles with the same seed and consecutive ids
   // check thermostats with pid offset by 2 aren't cross-correlated with lag 2
-  constexpr size_t const sample_size = 50'000;
-  constexpr size_t const x = 0, y = 1, z = 2;
-  constexpr size_t seed = 0;
+  constexpr std::size_t const sample_size = 50'000;
+  constexpr std::size_t const x = 0, y = 1, z = 2;
+  constexpr std::size_t seed = 0;
   constexpr int pid = 1;
   constexpr int pid_offset = 2;
 
@@ -161,11 +161,11 @@ BOOST_AUTO_TEST_CASE(test_uncorrelated_consecutive_ids) {
 BOOST_AUTO_TEST_CASE(test_uncorrelated_consecutive_seeds) {
   // setup: 2 particles with the same id with 2 rngs with consecutive seeds
   // check thermostats with seed offset by 2 aren't cross-correlated with lag 2
-  constexpr size_t const sample_size = 50'000;
-  constexpr size_t const x = 0, y = 1, z = 2;
+  constexpr std::size_t const sample_size = 50'000;
+  constexpr std::size_t const x = 0, y = 1, z = 2;
   constexpr int pid = 1;
-  constexpr size_t seed = 0;
-  constexpr size_t seed_offset = 2;
+  constexpr std::size_t seed = 0;
+  constexpr std::size_t seed_offset = 2;
 
   auto const correlation = std::get<3>(noise_statistics(
       [counter = 0]() mutable -> std::array<VariantVectorXd, 3> {

--- a/src/core/unit_tests/thermostats_test.cpp
+++ b/src/core/unit_tests/thermostats_test.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(test_langevin_dynamics) {
 BOOST_AUTO_TEST_CASE(test_noise_statistics) {
   constexpr double time_step = 1.0;
   constexpr double kT = 2.0;
-  constexpr size_t const sample_size = 10'000;
+  constexpr std::size_t const sample_size = 10'000;
   auto thermostat = thermostat_factory<LangevinThermostat>(kT, time_step);
   auto p1 = particle_factory();
   auto p2 = particle_factory();
@@ -232,8 +232,8 @@ BOOST_AUTO_TEST_CASE(test_noise_statistics) {
                 friction_thermo_langevin(thermostat, p2, time_step, kT)};
       },
       sample_size));
-  for (size_t i = 0; i < correlation.size(); ++i) {
-    for (size_t j = i; j < correlation.size(); ++j) {
+  for (std::size_t i = 0; i < correlation.size(); ++i) {
+    for (std::size_t j = i; j < correlation.size(); ++j) {
       double expected;
       if (i == j) {
         expected = 1.0;
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(test_noise_statistics) {
 BOOST_AUTO_TEST_CASE(test_brownian_randomness) {
   constexpr double time_step = 1.0;
   constexpr double kT = 2.0;
-  constexpr size_t const sample_size = 10'000;
+  constexpr std::size_t const sample_size = 10'000;
   auto thermostat = thermostat_factory<BrownianThermostat>(kT);
   auto p = particle_factory();
 #ifdef ROTATION
@@ -273,8 +273,8 @@ BOOST_AUTO_TEST_CASE(test_brownian_randomness) {
         };
       },
       sample_size));
-  for (size_t i = 0; i < correlation.size(); ++i) {
-    for (size_t j = i + 1; j < correlation.size(); ++j) {
+  for (std::size_t i = 0; i < correlation.size(); ++i) {
+    for (std::size_t j = i + 1; j < correlation.size(); ++j) {
       BOOST_CHECK(correlation_almost_equal(correlation, i, j, 0.0, 4e-2));
     }
   }
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(test_brownian_randomness) {
 BOOST_AUTO_TEST_CASE(test_langevin_randomness) {
   constexpr double time_step = 1.0;
   constexpr double kT = 2.0;
-  constexpr size_t const sample_size = 10'000;
+  constexpr std::size_t const sample_size = 10'000;
   auto thermostat = thermostat_factory<LangevinThermostat>(kT, time_step);
   auto p = particle_factory();
 #ifdef ROTATION
@@ -303,8 +303,8 @@ BOOST_AUTO_TEST_CASE(test_langevin_randomness) {
         };
       },
       sample_size));
-  for (size_t i = 0; i < correlation.size(); ++i) {
-    for (size_t j = i + 1; j < correlation.size(); ++j) {
+  for (std::size_t i = 0; i < correlation.size(); ++i) {
+    for (std::size_t j = i + 1; j < correlation.size(); ++j) {
       BOOST_CHECK(correlation_almost_equal(correlation, i, j, 0.0, 3e-2));
     }
   }
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(test_npt_iso_randomness) {
   thermo_switch |= THERMO_NPT_ISO;
   constexpr double time_step = 1.0;
   constexpr double kT = 2.0;
-  constexpr size_t const sample_size = 10'000;
+  constexpr std::size_t const sample_size = 10'000;
   IsotropicNptThermostat thermostat{};
   thermostat.rng_initialize(0);
   thermostat.gamma0 = 2.0;
@@ -334,8 +334,8 @@ BOOST_AUTO_TEST_CASE(test_npt_iso_randomness) {
         };
       },
       sample_size));
-  for (size_t i = 0; i < correlation.size(); ++i) {
-    for (size_t j = i + 1; j < correlation.size(); ++j) {
+  for (std::size_t i = 0; i < correlation.size(); ++i) {
+    for (std::size_t j = i + 1; j < correlation.size(); ++j) {
       BOOST_CHECK(correlation_almost_equal(correlation, i, j, 0.0, 2e-2));
     }
   }

--- a/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
+++ b/src/core/virtual_sites/lb_inertialess_tracers_cuda.cu
@@ -66,7 +66,7 @@ static constexpr unsigned int threads_per_block = 64;
 
 __global__ void
 ForcesIntoFluid_Kernel(const IBM_CUDA_ParticleDataInput *const particle_input,
-                       size_t number_of_particles,
+                       std::size_t number_of_particles,
                        LB_node_force_density_gpu node_f,
                        const LB_parameters_gpu *const paraP) {
   const unsigned int particleIndex = blockIdx.y * gridDim.x * blockDim.x +
@@ -148,7 +148,7 @@ ForcesIntoFluid_Kernel(const IBM_CUDA_ParticleDataInput *const particle_input,
 __global__ void ParticleVelocitiesFromLB_Kernel(
     LB_nodes_gpu n_curr,
     const IBM_CUDA_ParticleDataInput *const particles_input,
-    size_t number_of_particles,
+    std::size_t number_of_particles,
     IBM_CUDA_ParticleDataOutput *const particles_output,
     LB_node_force_density_gpu node_f, const float *const lb_boundary_velocity,
     const LB_parameters_gpu *const paraP) {
@@ -264,8 +264,8 @@ __global__ void ParticleVelocitiesFromLB_Kernel(
 __global__ void ResetLBForces_Kernel(LB_node_force_density_gpu node_f,
                                      const LB_parameters_gpu *const paraP) {
 
-  const size_t index = blockIdx.y * gridDim.x * blockDim.x +
-                       blockDim.x * blockIdx.x + threadIdx.x;
+  const std::size_t index = blockIdx.y * gridDim.x * blockDim.x +
+                            blockDim.x * blockIdx.x + threadIdx.x;
   const LB_parameters_gpu &para = *paraP;
 
   if (index < para.number_of_nodes) {

--- a/src/core/virtual_sites/lb_inertialess_tracers_cuda_interface.hpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers_cuda_interface.hpp
@@ -41,15 +41,15 @@ void IBM_cuda_mpi_get_particles(ParticleRange const &particles);
 void ParticleVelocitiesFromLB_GPU(ParticleRange const &particles);
 
 // ******** data types for CUDA and MPI communication ******
-typedef struct {
+struct IBM_CUDA_ParticleDataInput {
   float pos[3];
   float f[3];
   bool is_virtual;
-} IBM_CUDA_ParticleDataInput;
+};
 
-typedef struct {
+struct IBM_CUDA_ParticleDataOutput {
   float v[3];
-} IBM_CUDA_ParticleDataOutput;
+};
 
 // ******** global variables for CUDA and MPI communication ******
 extern std::vector<IBM_CUDA_ParticleDataInput> IBM_ParticleDataInput_host;

--- a/src/python/espressomd/electrokinetics.pxd
+++ b/src/python/espressomd/electrokinetics.pxd
@@ -24,7 +24,7 @@ IF ELECTROKINETICS and CUDA:
 
         # EK data struct
         IF EK_DEBUG:
-            ctypedef struct EK_parameters:
+            ctypedef struct EKParameters:
                 float agrid
                 float time_step
                 float lb_density
@@ -73,7 +73,7 @@ IF ELECTROKINETICS and CUDA:
                 float * charge_potential_buffer
                 float * electric_field
         ELSE:
-            ctypedef struct EK_parameters:
+            ctypedef struct EKParameters:
                 float agrid
                 float time_step
                 float lb_density
@@ -121,7 +121,7 @@ IF ELECTROKINETICS and CUDA:
                 float * charge_potential_buffer
                 float * electric_field
 
-        cdef extern EK_parameters ek_parameters
+        cdef extern EKParameters ek_parameters
 
         # EK functions
         void ek_print_parameters()

--- a/src/python/espressomd/electrostatics.pxd
+++ b/src/python/espressomd/electrostatics.pxd
@@ -84,7 +84,7 @@ IF ELECTROSTATICS:
                 void p3m_gpu_init(int cao, int * mesh, double alpha) except +
 
         cdef extern from "electrostatics_magnetostatics/elc.hpp":
-            ctypedef struct ELC_struct:
+            ctypedef struct ELCParameters:
                 double maxPWerror
                 double gap_size
                 double far_cut
@@ -99,37 +99,37 @@ IF ELECTROSTATICS:
                                 double delta_mid_bot, bool const_pot, double pot_diff) except +
 
             # links intern C-struct with python object
-            ELC_struct elc_params
+            ELCParameters elc_params
 
     cdef extern from "electrostatics_magnetostatics/debye_hueckel.hpp":
-        ctypedef struct Debye_hueckel_params:
+        ctypedef struct DebyeHueckelParameters:
             double r_cut
             double kappa
 
-        cdef extern Debye_hueckel_params dh_params
+        cdef extern DebyeHueckelParameters dh_params
 
         void dh_set_params(double kappa, double r_cut) except +
 
     cdef extern from "electrostatics_magnetostatics/reaction_field.hpp":
-        ctypedef struct Reaction_field_params:
+        ctypedef struct ReactionFieldParameters:
             double kappa
             double epsilon1
             double epsilon2
             double r_cut
 
-        cdef extern Reaction_field_params rf_params
+        cdef extern ReactionFieldParameters rf_params
 
         void rf_set_params(double kappa, double epsilon1, double epsilon2,
                            double r_cut) except +
 
 IF ELECTROSTATICS:
     cdef extern from "electrostatics_magnetostatics/mmm1d.hpp":
-        ctypedef struct MMM1D_struct:
+        ctypedef struct MMM1DParameters:
             double far_switch_radius_2
             double maxPWerror
             int    bessel_cutoff
 
-        cdef extern MMM1D_struct mmm1d_params
+        cdef extern MMM1DParameters mmm1d_params
 
         void MMM1D_set_params(double switch_rad, double maxPWerror)
         int MMM1D_init()

--- a/src/python/espressomd/thermostat.pxd
+++ b/src/python/espressomd/thermostat.pxd
@@ -117,9 +117,9 @@ cdef extern from "stokesian_dynamics/sd_interface.hpp":
 
 IF NPT:
     cdef extern from "npt.hpp":
-        ctypedef struct nptiso_struct:
+        ctypedef struct NptIsoParameters:
             double p_ext
             double p_inst
             double p_diff
             double piston
-        extern nptiso_struct nptiso
+        extern NptIsoParameters nptiso

--- a/src/script_interface/LocalContext.hpp
+++ b/src/script_interface/LocalContext.hpp
@@ -24,6 +24,7 @@
 
 #include <utils/Factory.hpp>
 
+#include <cassert>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -68,7 +68,7 @@ constexpr const None none{};
  * (defaults to 20).
  */
 using Variant = boost::make_recursive_variant<
-    None, bool, int, size_t, double, std::string, std::vector<int>,
+    None, bool, int, std::size_t, double, std::string, std::vector<int>,
     std::vector<double>, ObjectRef, std::vector<boost::recursive_variant_>,
     Utils::Vector2d, Utils::Vector3d, Utils::Vector4d,
     std::unordered_map<int, boost::recursive_variant_>>::type;

--- a/src/script_interface/accumulators/AccumulatorBase.hpp
+++ b/src/script_interface/accumulators/AccumulatorBase.hpp
@@ -23,6 +23,10 @@
 #include "script_interface/ScriptInterface.hpp"
 #include "script_interface/auto_parameters/AutoParameters.hpp"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace ScriptInterface {
 namespace Accumulators {
 

--- a/src/script_interface/accumulators/Correlator.hpp
+++ b/src/script_interface/accumulators/Correlator.hpp
@@ -34,6 +34,7 @@
 #include <utils/as_const.hpp>
 
 #include <memory>
+#include <string>
 
 namespace ScriptInterface {
 namespace Accumulators {

--- a/src/script_interface/accumulators/MeanVarianceCalculator.hpp
+++ b/src/script_interface/accumulators/MeanVarianceCalculator.hpp
@@ -30,6 +30,7 @@
 #include "utils/as_const.hpp"
 
 #include <memory>
+#include <string>
 
 namespace ScriptInterface {
 namespace Accumulators {

--- a/src/script_interface/accumulators/TimeSeries.hpp
+++ b/src/script_interface/accumulators/TimeSeries.hpp
@@ -28,6 +28,8 @@
 #include <utils/as_const.hpp>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace ScriptInterface {
 namespace Accumulators {

--- a/src/script_interface/constraints/ExternalField.hpp
+++ b/src/script_interface/constraints/ExternalField.hpp
@@ -34,6 +34,7 @@
 #include <utils/Vector.hpp>
 
 #include <memory>
+#include <string>
 
 namespace ScriptInterface {
 namespace Constraints {

--- a/src/script_interface/constraints/ExternalPotential.hpp
+++ b/src/script_interface/constraints/ExternalPotential.hpp
@@ -33,6 +33,7 @@
 #include <utils/Vector.hpp>
 
 #include <memory>
+#include <string>
 
 namespace ScriptInterface {
 namespace Constraints {

--- a/src/script_interface/constraints/ShapeBasedConstraint.hpp
+++ b/src/script_interface/constraints/ShapeBasedConstraint.hpp
@@ -30,6 +30,7 @@
 #include "script_interface/shapes/Shape.hpp"
 
 #include <memory>
+#include <string>
 
 namespace ScriptInterface {
 namespace Constraints {

--- a/src/script_interface/constraints/couplings.hpp
+++ b/src/script_interface/constraints/couplings.hpp
@@ -37,6 +37,7 @@
 #include "script_interface/ScriptInterface.hpp"
 
 #include <unordered_map>
+#include <vector>
 
 namespace ScriptInterface {
 namespace Constraints {

--- a/src/script_interface/constraints/fields.hpp
+++ b/src/script_interface/constraints/fields.hpp
@@ -51,7 +51,7 @@ using namespace ::FieldCoupling::Fields;
  */
 template <typename Field> struct field_params_impl;
 
-template <typename T, size_t codim>
+template <typename T, std::size_t codim>
 struct field_params_impl<Constant<T, codim>> {
   static Constant<T, codim> make(const VariantMap &params) {
     return Constant<T, codim>{
@@ -64,7 +64,7 @@ struct field_params_impl<Constant<T, codim>> {
   }
 };
 
-template <typename T, size_t codim>
+template <typename T, std::size_t codim>
 struct field_params_impl<AffineMap<T, codim>> {
   using jacobian_type = typename AffineMap<T, codim>::jacobian_type;
   using value_type = typename AffineMap<T, codim>::value_type;
@@ -82,7 +82,7 @@ struct field_params_impl<AffineMap<T, codim>> {
   }
 };
 
-template <typename T, size_t codim>
+template <typename T, std::size_t codim>
 struct field_params_impl<PlaneWave<T, codim>> {
   using jacobian_type = typename PlaneWave<T, codim>::jacobian_type;
   using value_type = typename PlaneWave<T, codim>::value_type;
@@ -107,7 +107,7 @@ struct field_params_impl<PlaneWave<T, codim>> {
   }
 };
 
-template <typename T, size_t codim>
+template <typename T, std::size_t codim>
 struct field_params_impl<Interpolated<T, codim>> {
   static Interpolated<T, codim> make(const VariantMap &params) {
     auto const field_data =

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -87,7 +87,7 @@ template <typename T, typename = void> struct get_value_helper {
   }
 };
 
-template <class T, size_t N>
+template <class T, std::size_t N>
 struct vector_conversion_visitor : boost::static_visitor<Utils::Vector<T, N>> {
   Utils::Vector<T, N> operator()(Utils::Vector<T, N> const &v) const {
     return v;
@@ -121,7 +121,8 @@ struct vector_conversion_visitor : boost::static_visitor<Utils::Vector<T, N>> {
 };
 
 /* Utils::Vector<T, N> case */
-template <typename T, size_t N> struct get_value_helper<Utils::Vector<T, N>> {
+template <typename T, std::size_t N>
+struct get_value_helper<Utils::Vector<T, N>> {
   Utils::Vector<T, N> operator()(Variant const &v) const {
     return boost::apply_visitor(detail::vector_conversion_visitor<T, N>{}, v);
   }

--- a/src/script_interface/mpiio/si_mpiio.hpp
+++ b/src/script_interface/mpiio/si_mpiio.hpp
@@ -29,6 +29,8 @@
 #include "script_interface/get_value.hpp"
 #include <core/cells.hpp>
 
+#include <string>
+
 #define field_value(use, v) ((use) ? (v) : 0u)
 
 namespace ScriptInterface {

--- a/src/script_interface/observables/CylindricalLBProfileObservable.hpp
+++ b/src/script_interface/observables/CylindricalLBProfileObservable.hpp
@@ -35,6 +35,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/src/script_interface/observables/CylindricalPidProfileObservable.hpp
+++ b/src/script_interface/observables/CylindricalPidProfileObservable.hpp
@@ -31,10 +31,11 @@
 #include <utils/constants.hpp>
 
 #include <boost/range/algorithm.hpp>
+
 #include <cstddef>
 #include <iterator>
 #include <memory>
-
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/src/script_interface/observables/LBProfileObservable.hpp
+++ b/src/script_interface/observables/LBProfileObservable.hpp
@@ -32,6 +32,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/src/script_interface/observables/Observable.hpp
+++ b/src/script_interface/observables/Observable.hpp
@@ -28,6 +28,8 @@
 
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace ScriptInterface {
 namespace Observables {

--- a/src/script_interface/observables/PidProfileObservable.hpp
+++ b/src/script_interface/observables/PidProfileObservable.hpp
@@ -35,6 +35,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/src/script_interface/observables/ProfileObservable.hpp
+++ b/src/script_interface/observables/ProfileObservable.hpp
@@ -49,7 +49,7 @@ public:
         {{"n_x_bins",
           [this](const Variant &v) {
             profile_observable()->n_bins[0] =
-                static_cast<size_t>(get_value<int>(v));
+                static_cast<std::size_t>(get_value<int>(v));
           },
           [this]() {
             return static_cast<int>(profile_observable()->n_bins[0]);
@@ -57,7 +57,7 @@ public:
          {"n_y_bins",
           [this](const Variant &v) {
             profile_observable()->n_bins[1] =
-                static_cast<size_t>(get_value<int>(v));
+                static_cast<std::size_t>(get_value<int>(v));
           },
           [this]() {
             return static_cast<int>(profile_observable()->n_bins[1]);
@@ -65,7 +65,7 @@ public:
          {"n_z_bins",
           [this](const Variant &v) {
             profile_observable()->n_bins[2] =
-                static_cast<size_t>(get_value<int>(v));
+                static_cast<std::size_t>(get_value<int>(v));
           },
           [this]() {
             return static_cast<int>(profile_observable()->n_bins[2]);

--- a/src/script_interface/observables/ProfileObservable.hpp
+++ b/src/script_interface/observables/ProfileObservable.hpp
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace ScriptInterface {

--- a/src/script_interface/shapes/Union.hpp
+++ b/src/script_interface/shapes/Union.hpp
@@ -27,6 +27,10 @@
 
 #include <shapes/Union.hpp>
 
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace ScriptInterface {
 namespace Shapes {
 

--- a/src/script_interface/tests/GlobalContext_test.cpp
+++ b/src/script_interface/tests/GlobalContext_test.cpp
@@ -26,6 +26,10 @@
 
 #include "script_interface/GlobalContext.hpp"
 
+#include <algorithm>
+#include <memory>
+#include <string>
+
 namespace si = ScriptInterface;
 
 struct Dummy : si::ObjectHandle {

--- a/src/script_interface/tests/LocalContext_test.cpp
+++ b/src/script_interface/tests/LocalContext_test.cpp
@@ -23,6 +23,10 @@
 
 #include "script_interface/LocalContext.hpp"
 
+#include <algorithm>
+#include <memory>
+#include <string>
+
 namespace si = ScriptInterface;
 
 struct Dummy : si::ObjectHandle {

--- a/src/script_interface/tests/ObjectHandle_test.cpp
+++ b/src/script_interface/tests/ObjectHandle_test.cpp
@@ -29,6 +29,11 @@
 
 #include "script_interface/ScriptInterface.hpp"
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 using namespace ScriptInterface;
 
 namespace Testing {

--- a/src/script_interface/tests/Variant_test.cpp
+++ b/src/script_interface/tests/Variant_test.cpp
@@ -22,9 +22,11 @@
 #include <boost/test/unit_test.hpp>
 
 #include "script_interface/Variant.hpp"
-using namespace ScriptInterface;
-
 #include "script_interface/get_value.hpp"
+
+#include <string>
+
+using namespace ScriptInterface;
 
 BOOST_AUTO_TEST_CASE(is_a) {
   BOOST_CHECK(is_type<None>(Variant(None{})));

--- a/src/script_interface/tests/get_value_test.cpp
+++ b/src/script_interface/tests/get_value_test.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 BOOST_AUTO_TEST_CASE(default_case) {
   using ScriptInterface::get_value;

--- a/src/script_interface/tests/packed_variant_test.cpp
+++ b/src/script_interface/tests/packed_variant_test.cpp
@@ -23,6 +23,9 @@
 
 #include <script_interface/packed_variant.hpp>
 
+#include <unordered_map>
+#include <vector>
+
 BOOST_AUTO_TEST_CASE(object_id_) {
   using ScriptInterface::object_id;
 

--- a/src/shapes/include/shapes/Union.hpp
+++ b/src/shapes/include/shapes/Union.hpp
@@ -22,9 +22,14 @@
 
 #include <boost/algorithm/cxx11/all_of.hpp>
 
-#include <memory>
-
 #include "Shape.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace Shapes {
 

--- a/src/shapes/src/SimplePore.cpp
+++ b/src/shapes/src/SimplePore.cpp
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cmath>
 #include <tuple>
+#include <utility>
 
 namespace Shapes {
 /**

--- a/src/utils/include/utils/Bag.hpp
+++ b/src/utils/include/utils/Bag.hpp
@@ -84,7 +84,7 @@ public:
   /**
    * @brief Number of elements in the container.
    */
-  size_t size() const { return m_storage.size(); }
+  std::size_t size() const { return m_storage.size(); }
 
   /**
    * @brief Is the container empty?
@@ -98,12 +98,12 @@ public:
    * Number of elements the container can at least hold
    * without reallocating.
    */
-  size_t capacity() const { return m_storage.capacity(); }
+  std::size_t capacity() const { return m_storage.capacity(); }
 
   /**
    * @brief Maximum number of elements the container can hold.
    */
-  size_t max_size() const { return m_storage.max_size(); }
+  std::size_t max_size() const { return m_storage.max_size(); }
 
   /**
    * @brief Reserve storage.
@@ -112,7 +112,7 @@ public:
    *
    *     @param new_capacity New minimum capacity.
    */
-  void reserve(size_t new_capacity) { m_storage.reserve(new_capacity); }
+  void reserve(std::size_t new_capacity) { m_storage.reserve(new_capacity); }
 
   /**
    * @brief Resize container.
@@ -123,7 +123,7 @@ public:
    *
    *     @param new_size Size to resize to.
    */
-  void resize(size_t new_size) { m_storage.resize(new_size); }
+  void resize(std::size_t new_size) { m_storage.resize(new_size); }
 
   /**
    * @brief Remove all elements form container.

--- a/src/utils/include/utils/Factory.hpp
+++ b/src/utils/include/utils/Factory.hpp
@@ -22,8 +22,10 @@
 #ifndef UTILS_FACTORY_HPP
 #define UTILS_FACTORY_HPP
 
+#include <cassert>
 #include <exception>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <typeindex>
 #include <unordered_map>

--- a/src/utils/include/utils/Histogram.hpp
+++ b/src/utils/include/utils/Histogram.hpp
@@ -30,6 +30,7 @@
 #include <functional>
 #include <numeric>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace Utils {

--- a/src/utils/include/utils/Histogram.hpp
+++ b/src/utils/include/utils/Histogram.hpp
@@ -35,9 +35,9 @@
 
 namespace Utils {
 
-inline size_t calculate_bin_index(double value, double bin_size,
-                                  double offset) {
-  return static_cast<size_t>(std::floor((value - offset) / bin_size));
+inline std::size_t calculate_bin_index(double value, double bin_size,
+                                       double offset) {
+  return static_cast<std::size_t>(std::floor((value - offset) / bin_size));
 }
 
 /**
@@ -46,12 +46,12 @@ inline size_t calculate_bin_index(double value, double bin_size,
  * \param n_bins  number of bins for each dimension.
  * \return The bin sizes for each dimension.
  */
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 std::array<T, Dims>
 calc_bin_sizes(std::array<std::pair<T, T>, Dims> const &limits,
-               std::array<size_t, Dims> const &n_bins) {
+               std::array<std::size_t, Dims> const &n_bins) {
   std::array<T, Dims> tmp;
-  for (size_t ind = 0; ind < Dims; ++ind) {
+  for (std::size_t ind = 0; ind < Dims; ++ind) {
     tmp[ind] = (limits[ind].second - limits[ind].first) / T(n_bins[ind]);
   }
   return tmp;
@@ -62,27 +62,28 @@ calc_bin_sizes(std::array<std::pair<T, T>, Dims> const &limits,
  * \param data  data value to check.
  * \param limits  the min/max values.
  */
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 inline bool check_limits(Span<const T> data,
                          std::array<std::pair<T, T>, Dims> limits) {
   if (data.size() != limits.size()) {
     throw std::invalid_argument("Dimension of data and limits not the same!");
   }
   bool within_range = true;
-  for (size_t i = 0; i < data.size(); ++i) {
+  for (std::size_t i = 0; i < data.size(); ++i) {
     if (data[i] < limits[i].first or data[i] >= limits[i].second)
       within_range = false;
   }
   return within_range;
 }
 
-template <typename T, size_t Dims> class Histogram {
+template <typename T, std::size_t Dims> class Histogram {
 public:
-  explicit Histogram(std::array<size_t, Dims> n_bins, size_t n_dims_data,
+  explicit Histogram(std::array<std::size_t, Dims> n_bins,
+                     std::size_t n_dims_data,
                      std::array<std::pair<T, T>, Dims> limits);
-  std::array<size_t, Dims> get_n_bins() const;
+  std::array<std::size_t, Dims> get_n_bins() const;
   std::vector<T> get_histogram() const;
-  std::vector<size_t> get_tot_count() const;
+  std::vector<std::size_t> get_tot_count() const;
   std::array<std::pair<T, T>, Dims> get_limits() const;
   std::array<T, Dims> get_bin_sizes() const;
   void update(Span<const T> data);
@@ -91,7 +92,7 @@ public:
 
 private:
   // Number of bins for each dimension.
-  std::array<size_t, Dims> m_n_bins;
+  std::array<std::size_t, Dims> m_n_bins;
   // Min and max values for each dimension.
   std::array<std::pair<T, T>, Dims> m_limits;
   // Bin sizes for each dimension.
@@ -102,9 +103,9 @@ protected:
   // Flat histogram data.
   std::vector<T> m_hist;
   // Number of dimensions for a single data point.
-  size_t m_n_dims_data;
+  std::size_t m_n_dims_data;
   // Track the number of total hits per bin entry.
-  std::vector<size_t> m_tot_count;
+  std::vector<std::size_t> m_tot_count;
   std::vector<T> m_ones;
 };
 
@@ -116,9 +117,9 @@ protected:
  * \param limits  the minimum/maximum data values to consider for the
  *        histogram.
  */
-template <typename T, size_t Dims>
-Histogram<T, Dims>::Histogram(std::array<size_t, Dims> n_bins,
-                              size_t n_dims_data,
+template <typename T, std::size_t Dims>
+Histogram<T, Dims>::Histogram(std::array<std::size_t, Dims> n_bins,
+                              std::size_t n_dims_data,
                               std::array<std::pair<T, T>, Dims> limits)
     : m_n_bins(n_bins), m_limits(limits), m_n_dims_data(n_dims_data),
       m_ones(n_dims_data, T{1.}) {
@@ -127,11 +128,11 @@ Histogram<T, Dims>::Histogram(std::array<size_t, Dims> n_bins,
                                 "not have same number of dimensions!");
   }
   m_bin_sizes = calc_bin_sizes(limits, n_bins);
-  size_t n_bins_total =
+  std::size_t n_bins_total =
       m_n_dims_data * std::accumulate(std::begin(n_bins), std::end(n_bins), 1,
-                                      std::multiplies<size_t>());
+                                      std::multiplies<std::size_t>());
   m_hist = std::vector<T>(n_bins_total);
-  m_tot_count = std::vector<size_t>(n_bins_total);
+  m_tot_count = std::vector<std::size_t>(n_bins_total);
 }
 
 /**
@@ -140,7 +141,7 @@ Histogram<T, Dims>::Histogram(std::array<size_t, Dims> n_bins,
  *              The size of the given vector has to match the number
  *              of dimensions of the histogram.
  */
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 void Histogram<T, Dims>::update(Span<const T> data) {
   if (check_limits(data, m_limits)) {
     update(data, m_ones);
@@ -154,11 +155,11 @@ void Histogram<T, Dims>::update(Span<const T> data) {
  *              of dimensions of the histogram.
  * \param weights  m_n_dims_data dimensional weights.
  */
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 void Histogram<T, Dims>::update(Span<const T> data, Span<const T> weights) {
   if (check_limits(data, m_limits)) {
-    Array<size_t, Dims> index;
-    for (size_t dim = 0; dim < m_n_bins.size(); ++dim) {
+    Array<std::size_t, Dims> index;
+    for (std::size_t dim = 0; dim < m_n_bins.size(); ++dim) {
       index[dim] =
           calculate_bin_index(data[dim], m_bin_sizes[dim], m_limits[dim].first);
     }
@@ -166,7 +167,7 @@ void Histogram<T, Dims>::update(Span<const T> data, Span<const T> weights) {
         m_n_dims_data * ::Utils::ravel_index(index, m_n_bins);
     if (weights.size() != m_n_dims_data)
       throw std::invalid_argument("Wrong dimensions of given weights!");
-    for (size_t ind = 0; ind < m_n_dims_data; ++ind) {
+    for (std::size_t ind = 0; ind < m_n_dims_data; ++ind) {
       m_hist[flat_index + ind] += weights[ind];
       m_tot_count[flat_index + ind] += 1;
     }
@@ -176,7 +177,7 @@ void Histogram<T, Dims>::update(Span<const T> data, Span<const T> weights) {
 /**
  * \brief Get the bin sizes.
  */
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 std::array<T, Dims> Histogram<T, Dims>::get_bin_sizes() const {
   return m_bin_sizes;
 }
@@ -184,15 +185,15 @@ std::array<T, Dims> Histogram<T, Dims>::get_bin_sizes() const {
 /**
  * \brief Get the number of bins for each dimension.
  */
-template <typename T, size_t Dims>
-std::array<size_t, Dims> Histogram<T, Dims>::get_n_bins() const {
+template <typename T, std::size_t Dims>
+std::array<std::size_t, Dims> Histogram<T, Dims>::get_n_bins() const {
   return m_n_bins;
 }
 
 /**
  * \brief Get the ranges (min, max) for each dimension.
  */
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 std::array<std::pair<T, T>, Dims> Histogram<T, Dims>::get_limits() const {
   return m_limits;
 }
@@ -200,7 +201,7 @@ std::array<std::pair<T, T>, Dims> Histogram<T, Dims>::get_limits() const {
 /**
  * \brief Get the histogram data.
  */
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 std::vector<T> Histogram<T, Dims>::get_histogram() const {
   return m_hist;
 }
@@ -208,15 +209,15 @@ std::vector<T> Histogram<T, Dims>::get_histogram() const {
 /**
  * \brief Get the histogram count data.
  */
-template <typename T, size_t Dims>
-std::vector<size_t> Histogram<T, Dims>::get_tot_count() const {
+template <typename T, std::size_t Dims>
+std::vector<std::size_t> Histogram<T, Dims>::get_tot_count() const {
   return m_tot_count;
 }
 /**
  * \brief Histogram normalization. (private member function can be overridden by
  * subclasses).
  */
-template <typename T, size_t Dims> void Histogram<T, Dims>::normalize() {
+template <typename T, std::size_t Dims> void Histogram<T, Dims>::normalize() {
   do_normalize();
 }
 
@@ -224,14 +225,15 @@ template <typename T, size_t Dims> void Histogram<T, Dims>::normalize() {
  * \brief Histogram normalization.
  *        Divide by the bin volume.
  */
-template <typename T, size_t Dims> void Histogram<T, Dims>::do_normalize() {
+template <typename T, std::size_t Dims>
+void Histogram<T, Dims>::do_normalize() {
   T bin_volume = std::accumulate(m_bin_sizes.begin(), m_bin_sizes.end(),
                                  static_cast<T>(1.0), std::multiplies<T>());
   std::transform(m_hist.begin(), m_hist.end(), m_hist.begin(),
                  [bin_volume](T v) { return v / bin_volume; });
 }
 
-template <typename T, size_t Dims>
+template <typename T, std::size_t Dims>
 class CylindricalHistogram : public Histogram<T, Dims> {
 public:
   using Histogram<T, Dims>::Histogram;
@@ -250,7 +252,7 @@ private:
     std::array<std::size_t, 4> extended_dims;
     std::copy(dims.begin(), dims.end(), extended_dims.begin());
     extended_dims[3] = m_n_dims_data;
-    for (size_t ind = 0; ind < m_hist.size(); ind += m_n_dims_data) {
+    for (std::size_t ind = 0; ind < m_hist.size(); ind += m_n_dims_data) {
       // Get the unraveled indices and calculate the bin volume.
       ::Utils::unravel_index(extended_dims.begin(), extended_dims.end(),
                              unravelled_index.begin(), ind);
@@ -265,7 +267,7 @@ private:
                (min_r + (r_bin + 1) * r_bin_size) -
            (min_r + r_bin * r_bin_size) * (min_r + r_bin * r_bin_size)) *
           z_bin_size * phi_bin_size / (2 * Utils::pi());
-      for (size_t dim = 0; dim < m_n_dims_data; ++dim) {
+      for (std::size_t dim = 0; dim < m_n_dims_data; ++dim) {
         m_hist[ind + dim] /= bin_volume;
       }
     }

--- a/src/utils/include/utils/NumeratedContainer.hpp
+++ b/src/utils/include/utils/NumeratedContainer.hpp
@@ -158,7 +158,7 @@ public:
    */
   const_iterator find(int id) const { return m_container.find(id); }
 
-  size_t size() const { return m_container.size(); }
+  std::size_t size() const { return m_container.size(); }
 
 private:
   /** Data storage */

--- a/src/utils/include/utils/Span.hpp
+++ b/src/utils/include/utils/Span.hpp
@@ -52,12 +52,12 @@ public:
   using const_iterator = const_pointer;
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-  using size_type = size_t;
+  using size_type = std::size_t;
   using difference_type = ptrdiff_t;
 
 private:
   T *m_ptr;
-  size_t m_size{};
+  std::size_t m_size{};
 
   template <typename U>
   using enable_if_const_t =
@@ -77,7 +77,7 @@ public:
   DEVICE_QUALIFIER
   constexpr Span(pointer array, size_type length)
       : m_ptr(array), m_size(length) {}
-  template <size_t N>
+  template <std::size_t N>
   DEVICE_QUALIFIER constexpr Span(T (&a)[N]) noexcept : Span(a, N) {}
 
   template <typename C, typename = enable_if_mutable_t<C>,
@@ -113,7 +113,7 @@ public:
 };
 
 template <typename T>
-DEVICE_QUALIFIER constexpr Span<T> make_span(T *p, size_t N) {
+DEVICE_QUALIFIER constexpr Span<T> make_span(T *p, std::size_t N) {
   return Span<T>(p, N);
 }
 
@@ -122,8 +122,8 @@ template <class C> DEVICE_QUALIFIER constexpr auto make_span(C &c) {
 }
 
 template <typename T>
-DEVICE_QUALIFIER constexpr Span<std::add_const_t<T>> make_const_span(T *p,
-                                                                     size_t N) {
+DEVICE_QUALIFIER constexpr Span<std::add_const_t<T>>
+make_const_span(T *p, std::size_t N) {
   return Span<std::add_const_t<T>>(p, N);
 }
 

--- a/src/utils/include/utils/Span.hpp
+++ b/src/utils/include/utils/Span.hpp
@@ -53,7 +53,7 @@ public:
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
   using size_type = std::size_t;
-  using difference_type = ptrdiff_t;
+  using difference_type = std::ptrdiff_t;
 
 private:
   T *m_ptr;

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -146,7 +146,7 @@ public:
 
 template <class T> using Vector3 = Vector<T, 3>;
 
-template <size_t N> using VectorXd = Vector<double, N>;
+template <std::size_t N> using VectorXd = Vector<double, N>;
 using Vector2d = VectorXd<2>;
 using Vector3d = VectorXd<3>;
 using Vector4d = VectorXd<4>;
@@ -154,14 +154,14 @@ using Vector6d = VectorXd<6>;
 using Vector9d = VectorXd<9>;
 using Vector19d = VectorXd<19>;
 
-template <size_t N> using VectorXf = Vector<float, N>;
+template <std::size_t N> using VectorXf = Vector<float, N>;
 using Vector3f = VectorXf<3>;
 
-template <size_t N> using VectorXi = Vector<int, N>;
+template <std::size_t N> using VectorXi = Vector<int, N>;
 using Vector3i = VectorXi<3>;
 
 namespace detail {
-template <size_t N, typename T, typename U, typename Op>
+template <std::size_t N, typename T, typename U, typename Op>
 auto binary_op(Vector<T, N> const &a, Vector<U, N> const &b, Op op) {
   using std::declval;
 
@@ -174,13 +174,13 @@ auto binary_op(Vector<T, N> const &a, Vector<U, N> const &b, Op op) {
   return ret;
 }
 
-template <size_t N, typename T, typename Op>
+template <std::size_t N, typename T, typename Op>
 Vector<T, N> &binary_op_assign(Vector<T, N> &a, Vector<T, N> const &b, Op op) {
   std::transform(std::begin(a), std::end(a), std::begin(b), std::begin(a), op);
   return a;
 }
 
-template <size_t N, typename T, typename Op>
+template <std::size_t N, typename T, typename Op>
 constexpr bool all_of(Vector<T, N> const &a, Vector<T, N> const &b, Op op) {
   for (int i = 0; i < a.size(); i++) {
     /* Short circuit */
@@ -193,52 +193,53 @@ constexpr bool all_of(Vector<T, N> const &a, Vector<T, N> const &b, Op op) {
 }
 } // namespace detail
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 constexpr bool operator<(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::less<T>());
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 constexpr bool operator>(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::greater<T>());
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 constexpr bool operator<=(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::less_equal<T>());
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 constexpr bool operator>=(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::greater_equal<T>());
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 constexpr bool operator==(Vector<T, N> const &a, Vector<T, N> const &b) {
   return detail::all_of(a, b, std::equal_to<T>());
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 constexpr bool operator!=(Vector<T, N> const &a, Vector<T, N> const &b) {
   return not(a == b);
 }
 
-template <size_t N, typename T, typename U>
+template <std::size_t N, typename T, typename U>
 auto operator+(Vector<T, N> const &a, Vector<U, N> const &b) {
   return detail::binary_op(a, b, std::plus<>());
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 Vector<T, N> &operator+=(Vector<T, N> &a, Vector<T, N> const &b) {
   return detail::binary_op_assign(a, b, std::plus<T>());
 }
 
-template <size_t N, typename T, typename U>
+template <std::size_t N, typename T, typename U>
 auto operator-(Vector<T, N> const &a, Vector<U, N> const &b) {
   return detail::binary_op(a, b, std::minus<>());
 }
 
-template <size_t N, typename T> Vector<T, N> operator-(Vector<T, N> const &a) {
+template <std::size_t N, typename T>
+Vector<T, N> operator-(Vector<T, N> const &a) {
   Vector<T, N> ret;
 
   std::transform(std::begin(a), std::end(a), std::begin(ret),
@@ -247,13 +248,13 @@ template <size_t N, typename T> Vector<T, N> operator-(Vector<T, N> const &a) {
   return ret;
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 Vector<T, N> &operator-=(Vector<T, N> &a, Vector<T, N> const &b) {
   return detail::binary_op_assign(a, b, std::minus<T>());
 }
 
 /* Scalar multiplication */
-template <size_t N, typename T, class U,
+template <std::size_t N, typename T, class U,
           std::enable_if_t<std::is_arithmetic<U>::value, bool> = true>
 auto operator*(U const &a, Vector<T, N> const &b) {
   using R = decltype(a * std::declval<T>());
@@ -265,7 +266,7 @@ auto operator*(U const &a, Vector<T, N> const &b) {
   return ret;
 }
 
-template <size_t N, typename T, class U,
+template <std::size_t N, typename T, class U,
           std::enable_if_t<std::is_arithmetic<U>::value, bool> = true>
 auto operator*(Vector<T, N> const &b, U const &a) {
   using R = decltype(std::declval<T>() * a);
@@ -277,7 +278,7 @@ auto operator*(Vector<T, N> const &b, U const &a) {
   return ret;
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 Vector<T, N> &operator*=(Vector<T, N> &b, T const &a) {
   std::transform(std::begin(b), std::end(b), std::begin(b),
                  [a](T const &val) { return a * val; });
@@ -285,7 +286,7 @@ Vector<T, N> &operator*=(Vector<T, N> &b, T const &a) {
 }
 
 /* Scalar division */
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 Vector<T, N> operator/(Vector<T, N> const &a, T const &b) {
   Vector<T, N> ret;
 
@@ -294,7 +295,7 @@ Vector<T, N> operator/(Vector<T, N> const &a, T const &b) {
   return ret;
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 Vector<T, N> &operator/=(Vector<T, N> &a, T const &b) {
   std::transform(std::begin(a), std::end(a), std::begin(a),
                  [b](T const &val) { return val / b; });
@@ -303,11 +304,12 @@ Vector<T, N> &operator/=(Vector<T, N> &a, T const &b) {
 
 namespace detail {
 template <class T> struct is_vector : std::false_type {};
-template <class T, size_t N> struct is_vector<Vector<T, N>> : std::true_type {};
+template <class T, std::size_t N>
+struct is_vector<Vector<T, N>> : std::true_type {};
 } // namespace detail
 
 /* Scalar product */
-template <size_t N, typename T, class U,
+template <std::size_t N, typename T, class U,
           class = std::enable_if_t<not(detail::is_vector<T>::value or
                                        detail::is_vector<U>::value)>>
 auto operator*(Vector<T, N> const &a, Vector<U, N> const &b) {
@@ -317,7 +319,7 @@ auto operator*(Vector<T, N> const &a, Vector<U, N> const &b) {
   return std::inner_product(std::begin(a), std::end(a), std::begin(b), R{});
 }
 
-template <size_t N, typename T, class U,
+template <std::size_t N, typename T, class U,
           class = std::enable_if_t<std::is_integral<T>::value &&
                                    std::is_integral<U>::value>>
 auto operator%(Vector<T, N> const &a, Vector<U, N> const &b) {
@@ -332,7 +334,7 @@ auto operator%(Vector<T, N> const &a, Vector<U, N> const &b) {
 }
 
 /* Componentwise square root */
-template <size_t N, typename T> Vector<T, N> sqrt(Vector<T, N> const &a) {
+template <std::size_t N, typename T> Vector<T, N> sqrt(Vector<T, N> const &a) {
   using std::sqrt;
   Vector<T, N> ret;
 
@@ -348,7 +350,7 @@ Vector<T, 3> vector_product(Vector<T, 3> const &a, Vector<T, 3> const &b) {
           a[0] * b[1] - a[1] * b[0]};
 }
 
-template <class T, class U, size_t N>
+template <class T, class U, std::size_t N>
 auto hadamard_product(Vector<T, N> const &a, Vector<U, N> const &b) {
   using std::declval;
   using R = decltype(declval<T>() * declval<U>());
@@ -362,7 +364,7 @@ auto hadamard_product(Vector<T, N> const &a, Vector<U, N> const &b) {
 
 // specializations for when one or both operands is a scalar depending on
 // compile time features (e.g. when PARTICLE_ANISOTROPY is not enabled)
-template <class T, class U, size_t N,
+template <class T, class U, std::size_t N,
           class = std::enable_if_t<not(detail::is_vector<T>::value)>>
 auto hadamard_product(T const &a, Vector<U, N> const &b) {
   using std::declval;
@@ -373,7 +375,7 @@ auto hadamard_product(T const &a, Vector<U, N> const &b) {
   return ret;
 }
 
-template <class T, class U, size_t N,
+template <class T, class U, std::size_t N,
           class = std::enable_if_t<not(detail::is_vector<U>::value)>>
 auto hadamard_product(Vector<T, N> const &a, U const &b) {
   using std::declval;
@@ -391,7 +393,7 @@ auto hadamard_product(T const &a, U const &b) {
   return a * b;
 }
 
-template <class T, class U, size_t N>
+template <class T, class U, std::size_t N>
 auto hadamard_division(Vector<T, N> const &a, Vector<U, N> const &b) {
   using std::declval;
   using R = decltype(declval<T>() * declval<U>());
@@ -405,7 +407,7 @@ auto hadamard_division(Vector<T, N> const &a, Vector<U, N> const &b) {
 
 // specializations for when one or both operands is a scalar depending on
 // compile time features (e.g. when PARTICLE_ANISOTROPY is not enabled)
-template <class T, class U, size_t N,
+template <class T, class U, std::size_t N,
           class = std::enable_if_t<not(detail::is_vector<U>::value)>>
 auto hadamard_division(Vector<T, N> const &a, U const &b) {
   using std::declval;
@@ -416,7 +418,7 @@ auto hadamard_division(Vector<T, N> const &a, U const &b) {
   return ret;
 }
 
-template <class T, class U, size_t N,
+template <class T, class U, std::size_t N,
           class = std::enable_if_t<not(detail::is_vector<T>::value)>>
 auto hadamard_division(T const &a, Vector<U, N> const &b) {
   using std::declval;
@@ -439,7 +441,7 @@ auto hadamard_division(T const &a, U const &b) {
  * @brief Meta function to turns a Vector<1, T> into T.
  */
 template <typename T> struct decay_to_scalar {};
-template <typename T, size_t N> struct decay_to_scalar<Vector<T, N>> {
+template <typename T, std::size_t N> struct decay_to_scalar<Vector<T, N>> {
   using type = Vector<T, N>;
 };
 

--- a/src/utils/include/utils/demangle.hpp
+++ b/src/utils/include/utils/demangle.hpp
@@ -21,6 +21,8 @@
 
 #include <boost/core/demangle.hpp>
 
+#include <string>
+
 namespace Utils {
 /**
  * @brief Get a human-readable name for a type.

--- a/src/utils/include/utils/device_qualifier.hpp
+++ b/src/utils/include/utils/device_qualifier.hpp
@@ -24,6 +24,7 @@
 #define DEVICE_QUALIFIER __host__ __device__
 #define DEVICE_ASSERT(A) void((A))
 #else
+#include <cassert>
 #define DEVICE_THROW(E) throw(E)
 #define DEVICE_QUALIFIER
 #define DEVICE_ASSERT(A) assert((A))

--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -19,6 +19,7 @@
 #ifndef UTILS_INDEX_HPP
 #define UTILS_INDEX_HPP
 
+#include <cassert>
 #include <cstddef>
 #include <iterator>
 #include <numeric>

--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -38,7 +38,8 @@ namespace Utils {
  * @retval the flat index
  */
 template <typename T, typename U>
-inline size_t ravel_index(const T &unravelled_indices, const U &dimensions) {
+inline std::size_t ravel_index(const T &unravelled_indices,
+                               const U &dimensions) {
   const auto n_dims = unravelled_indices.size();
   if (n_dims != dimensions.size()) {
     throw std::invalid_argument(

--- a/src/utils/include/utils/integral_parameter.hpp
+++ b/src/utils/include/utils/integral_parameter.hpp
@@ -27,10 +27,10 @@
 
 namespace Utils {
 namespace detail {
-template <template <size_t> class F, size_t I, size_t N>
+template <template <std::size_t> class F, std::size_t I, std::size_t N>
 struct integral_parameter_impl {
   template <class... Args>
-  static decltype(auto) eval(size_t i, Args &&... args) {
+  static decltype(auto) eval(std::size_t i, Args &&... args) {
     if (i == I)
       return F<I>{}(std::forward<Args>(args)...);
 
@@ -39,10 +39,10 @@ struct integral_parameter_impl {
   }
 };
 
-template <template <size_t> class F, size_t N>
+template <template <std::size_t> class F, std::size_t N>
 struct integral_parameter_impl<F, N, N> {
   template <class... Args>
-  static decltype(auto) eval(size_t i, Args &&... args) {
+  static decltype(auto) eval(std::size_t i, Args &&... args) {
     if (i == N)
       return F<N>{}(std::forward<Args>(args)...);
 
@@ -54,8 +54,9 @@ struct integral_parameter_impl<F, N, N> {
 /**
  * @brief Generate a call table for a integral non-type template parameter.
  */
-template <template <size_t> class F, size_t min, size_t max, class... Args>
-decltype(auto) integral_parameter(size_t i, Args &&... args) {
+template <template <std::size_t> class F, std::size_t min, std::size_t max,
+          class... Args>
+decltype(auto) integral_parameter(std::size_t i, Args &&... args) {
   return detail::integral_parameter_impl<F, min, max>::eval(
       i, std::forward<Args>(args)...);
 }

--- a/src/utils/include/utils/interpolation/bspline_3d.hpp
+++ b/src/utils/include/utils/interpolation/bspline_3d.hpp
@@ -41,7 +41,7 @@ namespace Interpolation {
  * @param grid_spacing The distance between the grid points.
  * @param offset Shift of the grid relative to the origin.
  */
-template <size_t order, typename Kernel>
+template <std::size_t order, typename Kernel>
 void bspline_3d(const Vector3d &pos, const Kernel &kernel,
                 const Vector3d &grid_spacing, const Vector3d &offset) {
   using Utils::bspline;
@@ -75,7 +75,7 @@ void bspline_3d(const Vector3d &pos, const Kernel &kernel,
 /**
  * @brief cardinal B-spline weighted sum.
  */
-template <size_t order, typename T, typename Kernel>
+template <std::size_t order, typename T, typename Kernel>
 T bspline_3d_accumulate(const Vector3d &pos, const Kernel &kernel,
                         const Vector3d &grid_spacing, const Vector3d &offset,
                         T const &init) {

--- a/src/utils/include/utils/interpolation/bspline_3d_gradient.hpp
+++ b/src/utils/include/utils/interpolation/bspline_3d_gradient.hpp
@@ -42,7 +42,7 @@ namespace Interpolation {
  * @param grid_spacing The distance between the grid points.
  * @param offset Shift of the grid relative to the origin.
  */
-template <size_t order, typename Kernel>
+template <std::size_t order, typename Kernel>
 void bspline_3d_gradient(const Vector3d &pos, const Kernel &kernel,
                          const Vector3d &grid_spacing, const Vector3d &offset) {
   using Utils::bspline;
@@ -81,7 +81,7 @@ void bspline_3d_gradient(const Vector3d &pos, const Kernel &kernel,
 /**
  * @brief cardinal B-spline weighted sum.
  */
-template <size_t order, typename T, typename Kernel>
+template <std::size_t order, typename T, typename Kernel>
 T bspline_3d_gradient_accumulate(const Vector3d &pos, const Kernel &kernel,
                                  const Vector3d &grid_spacing,
                                  const Vector3d &offset, T const &init) {

--- a/src/utils/include/utils/interpolation/detail/ll_and_dist.hpp
+++ b/src/utils/include/utils/interpolation/detail/ll_and_dist.hpp
@@ -38,9 +38,9 @@ struct Block {
   const Vector3d distance;
 };
 
-template <size_t order, typename = void> struct ll_and_dist_;
+template <std::size_t order, typename = void> struct ll_and_dist_;
 
-template <size_t order>
+template <std::size_t order>
 struct ll_and_dist_<order, std::enable_if_t<(order % 2) == 1>> {
   Block operator()(const Vector3d &pos, const Vector3d &grid_spacing,
                    const Vector3d &offset) const {
@@ -59,7 +59,7 @@ struct ll_and_dist_<order, std::enable_if_t<(order % 2) == 1>> {
   }
 };
 
-template <size_t order>
+template <std::size_t order>
 struct ll_and_dist_<order, std::enable_if_t<(order % 2) == 0>> {
   Block operator()(const Vector3d &pos, const Vector3d &grid_spacing,
                    const Vector3d &offset) const {
@@ -82,7 +82,7 @@ struct ll_and_dist_<order, std::enable_if_t<(order % 2) == 0>> {
  * @brief Calculate the lower left index of a block
  *        stencil with order points side length.
  */
-template <size_t order>
+template <std::size_t order>
 Block ll_and_dist(const Vector3d &pos, const Vector3d &grid_spacing,
                   const Vector3d &offset) {
   return ll_and_dist_<order>{}(pos, grid_spacing, offset);

--- a/src/utils/include/utils/mask.hpp
+++ b/src/utils/include/utils/mask.hpp
@@ -29,7 +29,7 @@
 
 namespace Utils {
 namespace detail {
-template <class T, class Integral, size_t... I>
+template <class T, class Integral, std::size_t... I>
 auto mask_impl(Integral mask, T t, std::index_sequence<I...>) {
   return T{((mask & (1u << I)) ? get<I>(t) : tuple_element_t<I, T>{})...};
 }

--- a/src/utils/include/utils/math/make_lin_space.hpp
+++ b/src/utils/include/utils/math/make_lin_space.hpp
@@ -42,16 +42,16 @@ namespace Utils {
  * @return Range of equally spaced values
  */
 template <class T>
-auto make_lin_space(T start, T stop, size_t number, bool endpoint = true) {
+auto make_lin_space(T start, T stop, std::size_t number, bool endpoint = true) {
   using boost::make_counting_iterator;
   using boost::make_iterator_range;
   using boost::make_transform_iterator;
 
   auto const dx = (stop - start) / T(number - endpoint);
-  auto x = [dx, start](size_t i) { return start + T(i) * dx; };
+  auto x = [dx, start](std::size_t i) { return start + T(i) * dx; };
 
   return make_iterator_range(
-      make_transform_iterator(make_counting_iterator(size_t(0)), x),
+      make_transform_iterator(make_counting_iterator(std::size_t(0)), x),
       make_transform_iterator(make_counting_iterator(number), x));
 }
 } // namespace Utils

--- a/src/utils/include/utils/math/orthonormal_vec.hpp
+++ b/src/utils/include/utils/math/orthonormal_vec.hpp
@@ -22,6 +22,8 @@
 #include "utils/Vector.hpp"
 #include "utils/constants.hpp"
 
+#include <cstddef>
+
 namespace Utils {
 /**
  * @brief Return a vector that is orthonormal to vec

--- a/src/utils/include/utils/math/tensor_product.hpp
+++ b/src/utils/include/utils/math/tensor_product.hpp
@@ -26,7 +26,7 @@
 #include <cstddef>
 
 namespace Utils {
-template <typename T, size_t N, size_t M>
+template <typename T, std::size_t N, std::size_t M>
 Matrix<T, N, M> tensor_product(const Vector<T, N> &x, const Vector<T, M> &y) {
   return boost::qvm::col_mat(x) * boost::qvm::row_mat(y);
 }
@@ -34,7 +34,7 @@ Matrix<T, N, M> tensor_product(const Vector<T, N> &x, const Vector<T, M> &y) {
 /*
  * @brief Overload if left operand is scalar.
  */
-template <typename T, size_t N>
+template <typename T, std::size_t N>
 Vector<T, N> tensor_product(const T &x, const Vector<T, N> &y) {
   return x * y;
 }

--- a/src/utils/include/utils/matrix.hpp
+++ b/src/utils/include/utils/matrix.hpp
@@ -23,7 +23,12 @@
 #include "utils/Vector.hpp"
 #include "utils/flatten.hpp"
 
+#include <algorithm>
 #include <array>
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
 
 // These includes need to come first due to ADL reasons.
 // clang-format off

--- a/src/utils/include/utils/mpi/cart_comm.hpp
+++ b/src/utils/include/utils/mpi/cart_comm.hpp
@@ -37,7 +37,7 @@ namespace Mpi {
  *
  * @tparam dim Number of dimensions
  */
-template <size_t dim> Vector<int, dim> dims_create(int nodes) {
+template <std::size_t dim> Vector<int, dim> dims_create(int nodes) {
   Vector<int, dim> dims{};
   BOOST_MPI_CHECK_RESULT(MPI_Dims_create,
                          (nodes, static_cast<int>(dim), dims.data()))
@@ -50,7 +50,7 @@ template <size_t dim> Vector<int, dim> dims_create(int nodes) {
  *
  * @tparam dim Number of dimensions
  */
-template <size_t dim>
+template <std::size_t dim>
 boost::mpi::communicator cart_create(
     boost::mpi::communicator const &comm, Vector<int, dim> const &dims,
     bool reorder = true,
@@ -68,7 +68,7 @@ boost::mpi::communicator cart_create(
  *
  * @tparam dims Number of dimensions
  */
-template <size_t dims>
+template <std::size_t dims>
 Vector3i cart_coords(boost::mpi::communicator const &comm, int rank) {
   Vector3i pos;
   BOOST_MPI_CHECK_RESULT(MPI_Cart_coords, (comm, rank, dims, pos.data()))
@@ -80,7 +80,7 @@ Vector3i cart_coords(boost::mpi::communicator const &comm, int rank) {
  *
  * @tparam dims Number of dimensions
  */
-template <size_t dims>
+template <std::size_t dims>
 int cart_rank(boost::mpi::communicator const &comm,
               const Vector<int, dims> &pos) {
   int rank;
@@ -110,14 +110,14 @@ inline std::pair<int, int> cart_shift(boost::mpi::communicator const &comm,
  *
  * @return Ranks of 2*dim neighbors
  */
-template <size_t dim>
+template <std::size_t dim>
 Utils::Vector<int, 2 * dim>
 cart_neighbors(const boost::mpi::communicator &comm) {
   using std::get;
 
   Vector<int, 2 * dim> ret;
 
-  for (size_t i = 0; i < dim; i++) {
+  for (std::size_t i = 0; i < dim; i++) {
     ret[2 * i + 0] = get<1>(cart_shift(comm, i, -1));
     ret[2 * i + 1] = get<1>(cart_shift(comm, i, +1));
   }
@@ -133,7 +133,7 @@ cart_neighbors(const boost::mpi::communicator &comm) {
  *
  * @tparam dim Number of dimensions.
  */
-template <size_t dim> struct CartInfo {
+template <std::size_t dim> struct CartInfo {
   Utils::Vector<int, dim> dims;
   Utils::Vector<int, dim> periods;
   Utils::Vector<int, dim> coords;
@@ -147,7 +147,7 @@ template <size_t dim> struct CartInfo {
  *
  * @return Struct with information about the communicator.
  */
-template <size_t dim>
+template <std::size_t dim>
 CartInfo<dim> cart_get(const boost::mpi::communicator &comm) {
   CartInfo<dim> ret{};
 

--- a/src/utils/include/utils/mpi/gatherv.hpp
+++ b/src/utils/include/utils/mpi/gatherv.hpp
@@ -23,6 +23,9 @@
 #include <boost/mpi/datatype.hpp>
 #include <boost/mpi/exception.hpp>
 #include <boost/mpi/nonblocking.hpp>
+
+#include <algorithm>
+#include <cassert>
 #include <vector>
 
 namespace Utils {

--- a/src/utils/include/utils/quaternion.hpp
+++ b/src/utils/include/utils/quaternion.hpp
@@ -33,6 +33,10 @@
 #include "utils/Vector.hpp"
 #include "utils/matrix.hpp"
 
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+
 /**
  * @file quaternion.hpp
  *

--- a/src/utils/include/utils/sampling.hpp
+++ b/src/utils/include/utils/sampling.hpp
@@ -44,12 +44,11 @@ namespace Utils {
  * @param sampling_density The number of samples per unit volume.
  * @retval Cartesian sampling coordinates.
  */
-std::vector<Vector3d>
-get_cylindrical_sampling_positions(std::pair<double, double> const &r_limits,
-                                   std::pair<double, double> const &phi_limits,
-                                   std::pair<double, double> const &z_limits,
-                                   size_t n_r_bins, size_t n_phi_bins,
-                                   size_t n_z_bins, double sampling_density) {
+std::vector<Vector3d> get_cylindrical_sampling_positions(
+    std::pair<double, double> const &r_limits,
+    std::pair<double, double> const &phi_limits,
+    std::pair<double, double> const &z_limits, std::size_t n_r_bins,
+    std::size_t n_phi_bins, std::size_t n_z_bins, double sampling_density) {
   auto const delta_r =
       (r_limits.second - r_limits.first) / static_cast<double>(n_r_bins);
   auto const delta_phi =
@@ -60,9 +59,9 @@ get_cylindrical_sampling_positions(std::pair<double, double> const &r_limits,
   // requirement.
   auto const smallest_bin_volume =
       pi() * Utils::sqr(r_limits.first + delta_r) * delta_phi / (2.0 * pi());
-  auto const min_n_samples = std::max(
-      n_z_bins,
-      static_cast<size_t>(std::round(smallest_bin_volume * sampling_density)));
+  auto const min_n_samples =
+      std::max(n_z_bins, static_cast<std::size_t>(std::round(
+                             smallest_bin_volume * sampling_density)));
   auto const delta_z =
       (z_limits.second - z_limits.first) / static_cast<double>(min_n_samples);
 
@@ -94,7 +93,7 @@ get_cylindrical_sampling_positions(std::pair<double, double> const &r_limits,
   auto phis = [n_phi_samples, n_phi_bins, phi_limits](int r_bin) {
     auto const phis_range = make_lin_space(
         phi_limits.first, phi_limits.second,
-        n_phi_bins * static_cast<size_t>(std::round(n_phi_samples(r_bin))),
+        n_phi_bins * static_cast<std::size_t>(std::round(n_phi_samples(r_bin))),
         /*endpoint */ false);
     return phis_range;
   };

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -72,23 +72,23 @@ public:
   explicit BasicMemcpyArchive(Utils::Span<char> buf)
       : buf(buf), insert(buf.data()) {}
 
-  size_t get_library_version() const { return 4; }
+  std::size_t get_library_version() const { return 4; }
 
-  size_t bytes_processed() const { return insert - buf.data(); }
-  void skip(size_t bytes) {
+  std::size_t bytes_processed() const { return insert - buf.data(); }
+  void skip(std::size_t bytes) {
     assert((insert + bytes) <= buf.end());
     insert += bytes;
   }
 
 private:
-  void read(void *data, size_t bytes) {
+  void read(void *data, std::size_t bytes) {
     /* check that there is enough space left in the buffer */
     assert((insert + bytes) <= buf.end());
     std::memcpy(data, insert, bytes);
     insert += bytes;
   }
 
-  void write(const void *data, size_t bytes) {
+  void write(const void *data, std::size_t bytes) {
     /* check that there is enough space left in the buffer */
     assert((insert + bytes) <= buf.end());
     std::memcpy(insert, data, bytes);
@@ -144,7 +144,7 @@ public:
    * @tparam T Type to consider.
    * @return Packed size in bytes.
    */
-  template <class T> static constexpr size_t packing_size() {
+  template <class T> static constexpr std::size_t packing_size() {
     return sizeof(T);
   }
 };
@@ -176,7 +176,7 @@ public:
    * @brief Number of bytes read from the buffer.
    * @return Number of bytes read.
    */
-  size_t bytes_read() const { return bytes_processed(); }
+  std::size_t bytes_read() const { return bytes_processed(); }
 
   /** @copydoc base_type::packing_size */
   using base_type::packing_size;
@@ -210,7 +210,7 @@ public:
    * @brief Number of bytes written to the buffer.
    * @return Number of bytes written.
    */
-  size_t bytes_written() const { return bytes_processed(); }
+  std::size_t bytes_written() const { return bytes_processed(); }
 
   /** @copydoc base_type::packing_size */
   using base_type::packing_size;

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -26,8 +26,10 @@
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/serialization.hpp>
 
+#include <cassert>
 #include <cstddef>
 #include <cstring>
+#include <memory>
 #include <type_traits>
 
 namespace Utils {

--- a/src/utils/include/utils/tuple.hpp
+++ b/src/utils/include/utils/tuple.hpp
@@ -82,7 +82,7 @@ template <class F, class Tuple> void for_each(F &&f, Tuple &&t) {
 }
 
 namespace detail {
-template <size_t I, size_t N> struct find_if_impl {
+template <std::size_t I, std::size_t N> struct find_if_impl {
   template <class Pred, class Tuple, class F>
   static constexpr bool eval(Pred &&pred, Tuple const &t, F &&f) {
     using Utils::get;
@@ -98,7 +98,7 @@ template <size_t I, size_t N> struct find_if_impl {
   }
 };
 
-template <size_t N> struct find_if_impl<N, N> {
+template <std::size_t N> struct find_if_impl<N, N> {
   template <class Pred, class Tuple, class F>
   static constexpr bool eval(Pred, Tuple, F) {
     return false;
@@ -129,7 +129,7 @@ constexpr auto find_if(Pred &&pred, Tuple const &t, F &&f) {
 }
 
 namespace detail {
-template <template <class> class Predicate, size_t I, size_t N>
+template <template <class> class Predicate, std::size_t I, std::size_t N>
 struct filter_impl {
   template <class Tuple>
   constexpr static auto get(Tuple const &t, std::true_type) {
@@ -154,7 +154,7 @@ struct filter_impl {
   }
 };
 
-template <template <class> class Predicate, size_t I>
+template <template <class> class Predicate, std::size_t I>
 struct filter_impl<Predicate, I, I> {
   template <class Tuple> constexpr static auto eval(Tuple const &) {
     return std::make_tuple();

--- a/src/utils/include/utils/type_traits.hpp
+++ b/src/utils/include/utils/type_traits.hpp
@@ -52,7 +52,8 @@ struct conjunction<B1, Bn...>
  * On posix platforms this is 8 * sizeof(T).
  */
 template <class T>
-struct size_in_bits : std::integral_constant<size_t, CHAR_BIT * sizeof(T)> {};
+struct size_in_bits
+    : std::integral_constant<std::size_t, CHAR_BIT * sizeof(T)> {};
 } // namespace Utils
 
 #endif

--- a/src/utils/tests/Bag_test.cpp
+++ b/src/utils/tests/Bag_test.cpp
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(reserve_) {
   auto bag = Utils::Bag<int>();
 
   /* Memory can be reserved */
-  const size_t size = 11;
+  const std::size_t size = 11;
   bag.reserve(size);
   /* and the capacity of the bag is at least
    * the reserved size */
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(resize_) {
   }
 
   /* It can be resized */
-  const size_t size = 11;
+  const std::size_t size = 11;
   bag.resize(size);
   /* The size matches */
   BOOST_CHECK_EQUAL(bag.size(), size);

--- a/src/utils/tests/RunningAverage_test.cpp
+++ b/src/utils/tests/RunningAverage_test.cpp
@@ -81,7 +81,8 @@ BOOST_AUTO_TEST_CASE(simple_variance_check) {
 
 BOOST_AUTO_TEST_CASE(mean_and_variance) {
   Utils::Statistics::RunningAverage<double> running_average;
-  const size_t sample_size = sizeof(RandomSequence::values) / sizeof(double);
+  const std::size_t sample_size =
+      sizeof(RandomSequence::values) / sizeof(double);
 
   for (auto const &val : RandomSequence::values) {
     running_average.add_sample(val);

--- a/src/utils/tests/Span_test.cpp
+++ b/src/utils/tests/Span_test.cpp
@@ -114,12 +114,12 @@ BOOST_AUTO_TEST_CASE(make_span_) {
   using std::declval;
   using Utils::make_span;
 
-  static_assert(
-      std::is_same<decltype(make_span(declval<int *>(), declval<size_t>())),
-                   Span<int>>::value,
-      "");
+  static_assert(std::is_same<decltype(make_span(declval<int *>(),
+                                                declval<std::size_t>())),
+                             Span<int>>::value,
+                "");
   static_assert(std::is_same<decltype(make_span(declval<const int *>(),
-                                                declval<size_t>())),
+                                                declval<std::size_t>())),
                              Span<const int>>::value,
                 "");
 
@@ -145,11 +145,11 @@ BOOST_AUTO_TEST_CASE(make_const_span_) {
   using Utils::make_const_span;
 
   static_assert(std::is_same<decltype(make_const_span(declval<int *>(),
-                                                      declval<size_t>())),
+                                                      declval<std::size_t>())),
                              Span<const int>>::value,
                 "");
   static_assert(std::is_same<decltype(make_const_span(declval<const int *>(),
-                                                      declval<size_t>())),
+                                                      declval<std::size_t>())),
                              Span<const int>>::value,
                 "");
 

--- a/src/utils/tests/for_each_pair_test.cpp
+++ b/src/utils/tests/for_each_pair_test.cpp
@@ -35,29 +35,33 @@ using Utils::for_each_pair;
 #include <utility>
 #include <vector>
 
-using PairContainer = std::vector<std::pair<size_t, size_t>>;
+using PairContainer = std::vector<std::pair<std::size_t, size_t>>;
 
 struct F {
-  std::vector<size_t> vec1;
-  std::vector<size_t> vec2;
+  std::vector<std::size_t> vec1;
+  std::vector<std::size_t> vec2;
   PairContainer pairs;
-  F() : vec1(std::vector<size_t>(14)), vec2(std::vector<size_t>(15)), pairs() {
+  F()
+      : vec1(std::vector<std::size_t>(14)), vec2(std::vector<std::size_t>(15)),
+        pairs() {
     std::iota(vec1.begin(), vec1.end(), 0);
     std::iota(vec2.begin(), vec2.end(), 0);
   }
   auto pair_inserter() {
-    return [&pairs = pairs](size_t a, size_t b) { pairs.emplace_back(a, b); };
+    return [&pairs = pairs](std::size_t a, std::size_t b) {
+      pairs.emplace_back(a, b);
+    };
   }
 };
 
-void check_pairs(size_t n_values, PairContainer const &pairs) {
+void check_pairs(std::size_t n_values, PairContainer const &pairs) {
   /* Check number of pairs */
   BOOST_CHECK(pairs.size() == ((n_values - 1) * n_values) / 2);
 
   /* Check that all were visited in order */
   auto it = pairs.begin();
-  for (size_t i = 0; i < n_values; i++)
-    for (size_t j = i + 1; j < n_values; j++) {
+  for (std::size_t i = 0; i < n_values; i++)
+    for (std::size_t j = i + 1; j < n_values; j++) {
       BOOST_CHECK((it->first == i) && (it->second == j));
       ++it;
     }
@@ -79,7 +83,7 @@ BOOST_FIXTURE_TEST_CASE(range, F) {
   check_pairs(vec1.size(), pairs);
 }
 
-void check_cartesian_pairs(size_t n_values_1, size_t n_values_2,
+void check_cartesian_pairs(std::size_t n_values_1, std::size_t n_values_2,
                            PairContainer const &pairs,
                            bool exclude_diagonal = false) {
   /* Check number of pairs */
@@ -89,8 +93,8 @@ void check_cartesian_pairs(size_t n_values_1, size_t n_values_2,
 
   /* Check that all were visited in order */
   auto it = pairs.begin();
-  for (size_t i = 0; i < n_values_1; ++i) {
-    for (size_t j = 0; j < n_values_2; ++j) {
+  for (std::size_t i = 0; i < n_values_1; ++i) {
+    for (std::size_t j = 0; j < n_values_2; ++j) {
       if (!(exclude_diagonal and i == j)) {
         BOOST_CHECK((it->first == i) && (it->second == j));
         ++it;
@@ -119,7 +123,7 @@ BOOST_FIXTURE_TEST_CASE(range_cartesian, F) {
 BOOST_FIXTURE_TEST_CASE(basic_check_cartesian_if, F) {
   /* Collect pairs */
   for_each_cartesian_pair_if(vec1.begin(), vec1.end(), vec2.begin(), vec2.end(),
-                             pair_inserter(), std::not_equal_to<size_t>{});
+                             pair_inserter(), std::not_equal_to<std::size_t>{});
 
   /* Check the result */
   check_cartesian_pairs(vec1.size(), vec2.size(), pairs, true);
@@ -128,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(basic_check_cartesian_if, F) {
 BOOST_FIXTURE_TEST_CASE(range_cartesian_if, F) {
   /* Collect pairs */
   for_each_cartesian_pair_if(vec1, vec2, pair_inserter(),
-                             std::not_equal_to<size_t>{});
+                             std::not_equal_to<std::size_t>{});
 
   /* Check the result */
   check_cartesian_pairs(vec1.size(), vec2.size(), pairs, true);

--- a/src/utils/tests/histogram.cpp
+++ b/src/utils/tests/histogram.cpp
@@ -31,10 +31,10 @@
 #include <vector>
 
 BOOST_AUTO_TEST_CASE(histogram) {
-  std::array<size_t, 2> n_bins{{10, 10}};
+  std::array<std::size_t, 2> n_bins{{10, 10}};
   std::array<std::pair<double, double>, 2> limits{
       {std::make_pair(1.0, 20.0), std::make_pair(5.0, 10.0)}};
-  size_t n_dims_data = 2;
+  std::size_t n_dims_data = 2;
   auto hist = Utils::Histogram<double, 2>(n_bins, n_dims_data, limits);
   // Check getters.
   BOOST_CHECK(hist.get_limits() == limits);
@@ -63,11 +63,11 @@ BOOST_AUTO_TEST_CASE(histogram) {
 
 BOOST_AUTO_TEST_CASE(cylindrical_histogram) {
   constexpr auto pi = Utils::pi<double>();
-  std::array<size_t, 3> n_bins{{10, 10, 10}};
+  std::array<std::size_t, 3> n_bins{{10, 10, 10}};
   std::array<std::pair<double, double>, 3> limits{{std::make_pair(0.0, 2.0),
                                                    std::make_pair(0.0, 2 * pi),
                                                    std::make_pair(0.0, 10.0)}};
-  size_t n_dims_data = 3;
+  std::size_t n_dims_data = 3;
   auto hist =
       Utils::CylindricalHistogram<double, 3>(n_bins, n_dims_data, limits);
   // Check getters.

--- a/src/utils/tests/integral_parameter_test.cpp
+++ b/src/utils/tests/integral_parameter_test.cpp
@@ -26,7 +26,7 @@
 #include <type_traits>
 #include <utility>
 
-template <size_t I> struct F {
+template <std::size_t I> struct F {
   template <class T> auto operator()(T arg) const {
     return std::make_pair(I, arg);
   }
@@ -35,7 +35,7 @@ template <size_t I> struct F {
 BOOST_AUTO_TEST_CASE(integral_parameter_) {
   static_assert(
       std::is_same<decltype(Utils::integral_parameter<F, 1, 5>(5, 13)),
-                   std::pair<size_t, int>>::value,
+                   std::pair<std::size_t, int>>::value,
       "");
 
   BOOST_CHECK(std::make_pair(1ul, 13) ==

--- a/src/utils/tests/memcpy_archive_test.cpp
+++ b/src/utils/tests/memcpy_archive_test.cpp
@@ -39,6 +39,8 @@
 #include <boost/serialization/optional.hpp>
 
 #include <array>
+#include <cstddef>
+#include <type_traits>
 
 struct NonTrivial {
   boost::optional<Utils::Vector3d> ov;


### PR DESCRIPTION
Description of changes:
- include what you use (#3977)
- use the namespaced version of `std::size_t` and `std::ptrdiff_t` (#4313)
- remove C-style struct typedefs: they are useless in C++, trigger a warning on Clang 11 and later versions, and will break in C++20 for structs containing static members or lambdas ([cppreference.com:  typedef-name for linkage purposes](https://en.cppreference.com/w/cpp/language/typedef#typedef-name_for_linkage_purposes))