### PR TITLE
Improve support for fast-math mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,6 +213,27 @@ clang-sanitizer:
     - linux
     - cuda
 
+fast_math:
+  <<: *global_job_definition
+  stage: build
+  image: docker.pkg.github.com/espressomd/docker/cuda:08d67d67a4d3c3279cacee975b68c02ec89b2a21
+  variables:
+     CC: 'gcc-9'
+     CXX: 'g++-9'
+     myconfig: 'maxset'
+     with_cuda: 'true'
+     with_coverage: 'false'
+     with_scafacos: 'false'
+     with_stokesian_dynamics: 'true'
+     with_fast_math: 'true'
+  script:
+    - bash maintainer/CI/build_cmake.sh
+  tags:
+    - docker
+    - linux
+    - cuda
+  when: manual
+
 cuda11-maxset:
   <<: *global_job_definition
   stage: build

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -684,6 +684,38 @@ correct one with ``CUDA_BIN_PATH=/usr/local/cuda-10.0 cmake .. -DWITH_CUDA=ON``
 (with Clang as the CUDA compiler, you also need to override its default CUDA
 path with ``-DCMAKE_CXX_FLAGS=--cuda-path=/usr/local/cuda-10.0``).
 
+.. _Build types and compiler flags:
+
+Build types and compiler flags
+""""""""""""""""""""""""""""""
+
+The build type is controlled by ``-D CMAKE_BUILD_TYPE=<type>`` where
+``<type>`` can take one of the following values:
+
+* ``Release``: for production use: disables assertions and debug information,
+  enables ``-O3`` optimization (this is the default)
+* ``RelWithAssert``: for debugging purposes: enables assertions and
+  ``-O3`` optimization (use this to track the source of a fatal error)
+* ``Debug``: for debugging in GDB
+* ``Coverage``: for code coverage
+
+Cluster users and HPC developers may be interested in manually editing the
+``cxx_interface`` variable in the top-level ``CMakeLists.txt`` file for
+finer control over compiler flags. The variable declaration is followed
+by a series of conditionals to enable or disable compiler-specific flags.
+Compiler flags passed to CMake via the ``-DCMAKE_CXX_FLAGS`` option
+(such as ``cmake . -DCMAKE_CXX_FLAGS="-ffast-math -fno-finite-math-only"``)
+will appear in the compiler command before the flags in ``cxx_interface``,
+and will therefore have lower precedence.
+
+Be aware that fast-math mode can break |es|. It is incompatible with the
+``ADDITIONAL_CHECKS`` feature due to the loss of precision in the LB code
+on CPU. The Clang 10 compiler breaks field couplings with ``-ffast-math``.
+The Intel compiler enables the ``-fp-model fast=1`` flag by default;
+it can be disabled by adding the ``-fp-model=strict`` flag.
+
+|es| currently doesn't fully support link-time optimization (LTO).
+
 
 .. _Configuring without a network connection:
 

--- a/src/core/algorithm/periodic_fold.hpp
+++ b/src/core/algorithm/periodic_fold.hpp
@@ -57,6 +57,7 @@ std::pair<T, I> periodic_fold(T x, I i, T const &l) {
  * @return x folded into [0, l).
  */
 template <typename T> T periodic_fold(T x, T const &l) {
+#ifndef __FAST_MATH__
   /* Can't fold if either x or l is nan or inf. */
   if (std::isnan(x) or std::isnan(l) or std::isinf(x) or (l == 0)) {
     return std::nan("");
@@ -64,6 +65,7 @@ template <typename T> T periodic_fold(T x, T const &l) {
   if (std::isinf(l)) {
     return x;
   }
+#endif // __FAST_MATH__
 
   while (x < 0) {
     x += l;

--- a/src/core/unit_tests/field_coupling_fields_test.cpp
+++ b/src/core/unit_tests/field_coupling_fields_test.cpp
@@ -37,6 +37,8 @@
 #include <limits>
 #include <type_traits>
 
+constexpr auto eps = 10 * std::numeric_limits<double>::epsilon();
+
 using namespace FieldCoupling::Fields;
 
 BOOST_AUTO_TEST_CASE(jacobian_type_test) {
@@ -280,8 +282,7 @@ BOOST_AUTO_TEST_CASE(interpolated_scalar_field) {
 
     auto const field_value = field(p);
 
-    BOOST_CHECK(std::abs(interpolated_value - field_value) <
-                std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_SMALL(std::abs(interpolated_value - field_value), eps);
   }
 
   /* jacobian value */
@@ -309,8 +310,7 @@ BOOST_AUTO_TEST_CASE(interpolated_scalar_field) {
         p, [&data](const std::array<int, 3> &ind) { return data(ind); },
         grid_spacing, origin, Utils::Vector3d{});
 
-    BOOST_CHECK((interpolated_value - field_value).norm() <
-                2 * std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_SMALL((interpolated_value - field_value).norm(), eps);
   }
 }
 
@@ -358,8 +358,7 @@ BOOST_AUTO_TEST_CASE(interpolated_vector_field) {
         p, [&data](const std::array<int, 3> &ind) { return data(ind); },
         grid_spacing, origin, Utils::Vector2d{});
 
-    BOOST_CHECK_SMALL((interpolated_value - field_value).norm(),
-                      std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_SMALL((interpolated_value - field_value).norm(), eps);
   }
 
   /* jacobian value */
@@ -396,10 +395,8 @@ BOOST_AUTO_TEST_CASE(interpolated_vector_field) {
         grid_spacing, origin, Field::jacobian_type{});
 
     BOOST_CHECK_SMALL(
-        (interpolated_value.row<0>() - field_value.row<0>()).norm(),
-        3 * std::numeric_limits<double>::epsilon());
+        (interpolated_value.row<0>() - field_value.row<0>()).norm(), eps);
     BOOST_CHECK_SMALL(
-        (interpolated_value.row<1>() - field_value.row<1>()).norm(),
-        3 * std::numeric_limits<double>::epsilon());
+        (interpolated_value.row<1>() - field_value.row<1>()).norm(), eps);
   }
 }

--- a/src/core/unit_tests/periodic_fold_test.cpp
+++ b/src/core/unit_tests/periodic_fold_test.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(with_image_count) {
     auto const box = 10.;
     auto const res = periodic_fold(x, 0, box);
     BOOST_CHECK(res.first >= 0.);
-    BOOST_CHECK(res.first < box);
+    BOOST_CHECK(res.first <= box);
     BOOST_CHECK(std::abs(res.first - x + res.second * box) <=
                 std::numeric_limits<double>::epsilon());
   }

--- a/src/core/unit_tests/periodic_fold_test.cpp
+++ b/src/core/unit_tests/periodic_fold_test.cpp
@@ -69,6 +69,7 @@ BOOST_AUTO_TEST_CASE(with_image_count) {
     BOOST_CHECK_EQUAL(res.second, i + 1);
   }
 
+#ifndef __FAST_MATH__
   /* Pathological (NaN) */
   {
     auto const x = std::nan("");
@@ -77,6 +78,7 @@ BOOST_AUTO_TEST_CASE(with_image_count) {
     auto const res = periodic_fold(x, i, box);
     BOOST_CHECK(std::isnan(res.first));
   }
+#endif // __FAST_MATH__
 
   /* Overflow right */
   {
@@ -155,6 +157,7 @@ BOOST_AUTO_TEST_CASE(without_image_count) {
     BOOST_CHECK_EQUAL(res, x - box);
   }
 
+#ifndef __FAST_MATH__
   /* Pathological (NaN value) */
   {
     auto const x = std::nan("");
@@ -170,6 +173,7 @@ BOOST_AUTO_TEST_CASE(without_image_count) {
     auto const res = periodic_fold(x, box);
     BOOST_CHECK(std::isnan(res));
   }
+#endif // __FAST_MATH__
 
   /* Corner left */
   {

--- a/src/utils/include/utils/checks/charge_neutrality.hpp
+++ b/src/utils/include/utils/checks/charge_neutrality.hpp
@@ -28,13 +28,13 @@
 
 namespace Utils {
 template <typename ParticleRange>
-bool check_charge_neutrality(ParticleRange &prange,
-                             double relative_tolerance = 1e-12) {
+bool check_charge_neutrality(ParticleRange &prange) {
   using namespace boost::accumulators;
   using KahanSum = accumulator_set<double, features<tag::sum_kahan>>;
 
   KahanSum q_sum;
   auto q_min = std::numeric_limits<double>::infinity();
+  constexpr auto relative_tolerance = 2e-12;
 
   for (auto const &p : prange) {
     auto const &q = p.p.q;

--- a/testsuite/python/accumulator_correlator.py
+++ b/testsuite/python/accumulator_correlator.py
@@ -234,7 +234,7 @@ class CorrelatorTest(ut.TestCase):
                 corr = accumulators[compression].result().flatten()
                 corr_ref = np.repeat(compressed_ref[compression], corr.shape)
                 corr_ref[:tau_lin + 1] = uncompressed[:tau_lin + 1]
-                np.testing.assert_array_equal(corr, corr_ref)
+                np.testing.assert_allclose(corr, corr_ref, rtol=0., atol=1e-14)
             self.system.auto_update_accumulators.clear()
 
     def test_correlator_interface(self):

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -134,7 +134,7 @@ class DPDThermostat(ut.TestCase):
         system.integrator.run(0)
 
         # Only trans, so x component should be zero
-        self.assertLess(abs(p0.f[0]), 1e-16)
+        self.assertLess(abs(p0.f[0]), 1e-14)
         np.testing.assert_allclose(
             np.copy(p0.f[1:2]), gamma * v[1:2], rtol=0, atol=1e-11)
         np.testing.assert_array_equal(np.copy(p0.f), -np.copy(p1.f))
@@ -176,7 +176,7 @@ class DPDThermostat(ut.TestCase):
         system.integrator.run(0)
 
         # Only trans, so x component should be zero
-        self.assertLess(abs(p0.f[0]), 1e-16)
+        self.assertLess(abs(p0.f[0]), 1e-14)
         omega = calc_omega(1.3, 1.4)**2
         np.testing.assert_allclose(
             np.copy(p0.f[1:2]), omega * gamma * v[1:2], rtol=0, atol=1e-11)

--- a/testsuite/python/galilei.py
+++ b/testsuite/python/galilei.py
@@ -96,7 +96,7 @@ class Galilei(ut.TestCase):
         g.galilei_transform()
 
         np.testing.assert_allclose(
-            np.copy(g.system_CMS_velocity()), np.zeros((3,)), atol=1e-15)
+            np.copy(g.system_CMS_velocity()), np.zeros((3,)), atol=1e-14)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/lb_interpolation.py
+++ b/testsuite/python/lb_interpolation.py
@@ -90,7 +90,9 @@ class LBInterpolation:
         np.testing.assert_allclose(
             np.copy(self.lbf.get_interpolated_velocity(
                 [self.system.box_l[0] - AGRID, 0, 0])),
-            0.5 * (np.array([0, 0, V_BOUNDARY]) + node_next_to_boundary.velocity))
+            0.5 * (np.array([0, 0, V_BOUNDARY]) +
+                   node_next_to_boundary.velocity),
+            rtol=2e-7)
 
         # Bulk
         for pos in itertools.product(

--- a/testsuite/python/observable_cylindrical.py
+++ b/testsuite/python/observable_cylindrical.py
@@ -235,7 +235,8 @@ class TestCylindricalObservable(ut.TestCase):
         self.assertEqual(observable.min_phi, 2)
         self.assertEqual(observable.min_z, 1)
         obs_bin_edges = observable.bin_edges()
-        np.testing.assert_array_almost_equal(obs_bin_edges[0, 0, 0], [1, 2, 1])
+        np.testing.assert_allclose(obs_bin_edges[0, 0, 0], [1, 2, 1],
+                                   rtol=0., atol=1e-14)
         # check edges upper corner
         self.assertEqual(observable.max_r, params['max_r'])
         self.assertEqual(observable.max_phi, params['max_phi'])
@@ -246,7 +247,8 @@ class TestCylindricalObservable(ut.TestCase):
         self.assertEqual(observable.max_phi, 8)
         self.assertEqual(observable.max_z, 9)
         obs_bin_edges = observable.bin_edges()
-        np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
+        np.testing.assert_allclose(obs_bin_edges[-1, -1, -1], [7, 8, 9],
+                                   rtol=0., atol=1e-14)
         # check center, axis, orientation
         ctp = espressomd.math.CylindricalTransformationParameters(
             center=[1, 2, 3], axis=[0, 1, 0], orientation=[0, 0, 1])

--- a/testsuite/python/observable_cylindricalLB.py
+++ b/testsuite/python/observable_cylindricalLB.py
@@ -202,7 +202,8 @@ class CylindricalLBObservableCommon:
         self.assertEqual(observable.min_phi, 1.0)
         self.assertEqual(observable.min_z, 1.0)
         obs_bin_edges = observable.bin_edges()
-        np.testing.assert_array_equal(obs_bin_edges[0, 0, 0], [4, 1, 1])
+        np.testing.assert_allclose(obs_bin_edges[0, 0, 0], [4, 1, 1],
+                                   rtol=0., atol=1e-14)
         # check edges upper corner
         self.assertEqual(observable.max_r, params['max_r'])
         self.assertEqual(observable.max_phi, params['max_phi'])
@@ -213,7 +214,8 @@ class CylindricalLBObservableCommon:
         self.assertEqual(observable.max_phi, 8)
         self.assertEqual(observable.max_z, 9)
         obs_bin_edges = observable.bin_edges()
-        np.testing.assert_array_equal(obs_bin_edges[-1, -1, -1], [7, 8, 9])
+        np.testing.assert_allclose(obs_bin_edges[-1, -1, -1], [7, 8, 9],
+                                   rtol=0., atol=1e-14)
         # check sampling_density
         self.assertEqual(
             observable.sampling_density,


### PR DESCRIPTION
Fixes #2977

Description of changes:
- relax tolerances that can potentially break on fast-math mode and on 32bit architectures
- add fast-math guards around code that handles NaN values and infinity values
- document supported build types and how to tweak compiler flags in CMake
- document known issues with fast-math mode and link-time optimization
- test fast-math mode in CI (job is triggered manually, e.g. before releases)