### PR TITLE
Rewrite histograms as multi-dimensional arrays

### DIFF
--- a/src/core/observables/CylindricalDensityProfile.hpp
+++ b/src/core/observables/CylindricalDensityProfile.hpp
@@ -37,7 +37,7 @@ public:
   std::vector<double>
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
-    Utils::CylindricalHistogram<double, 3> histogram(n_bins(), 1, limits());
+    Utils::CylindricalHistogram<double, 1> histogram(n_bins(), limits());
 
     for (auto p : particles) {
       histogram.update(Utils::transform_coordinate_cartesian_to_cylinder(

--- a/src/core/observables/CylindricalFluxDensityProfile.hpp
+++ b/src/core/observables/CylindricalFluxDensityProfile.hpp
@@ -39,7 +39,7 @@ public:
   std::vector<double>
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
-    Utils::CylindricalHistogram<double, 3> histogram(n_bins(), 3, limits());
+    Utils::CylindricalHistogram<double, 3> histogram(n_bins(), limits());
 
     // Write data to the histogram
     for (auto p : particles) {

--- a/src/core/observables/CylindricalLBFluxDensityProfileAtParticlePositions.cpp
+++ b/src/core/observables/CylindricalLBFluxDensityProfileAtParticlePositions.cpp
@@ -33,7 +33,7 @@ std::vector<double>
 CylindricalLBFluxDensityProfileAtParticlePositions::evaluate(
     Utils::Span<std::reference_wrapper<const Particle>> particles,
     const ParticleObservables::traits<Particle> &traits) const {
-  Utils::CylindricalHistogram<double, 3> histogram(n_bins(), 3, limits());
+  Utils::CylindricalHistogram<double, 3> histogram(n_bins(), limits());
   // First collect all positions (since we want to call the LB function to
   // get the fluid velocities only once).
 

--- a/src/core/observables/CylindricalLBVelocityProfile.cpp
+++ b/src/core/observables/CylindricalLBVelocityProfile.cpp
@@ -31,7 +31,7 @@
 namespace Observables {
 
 std::vector<double> CylindricalLBVelocityProfile::operator()() const {
-  Utils::CylindricalHistogram<double, 3> histogram(n_bins(), 3, limits());
+  Utils::CylindricalHistogram<double, 3> histogram(n_bins(), limits());
   for (auto const &p : sampling_positions) {
     auto const velocity = lb_lbfluid_get_interpolated_velocity(p) *
                           lb_lbfluid_get_lattice_speed();

--- a/src/core/observables/CylindricalLBVelocityProfileAtParticlePositions.cpp
+++ b/src/core/observables/CylindricalLBVelocityProfileAtParticlePositions.cpp
@@ -33,7 +33,7 @@ namespace Observables {
 std::vector<double> CylindricalLBVelocityProfileAtParticlePositions::evaluate(
     Utils::Span<std::reference_wrapper<const Particle>> particles,
     const ParticleObservables::traits<Particle> &traits) const {
-  Utils::CylindricalHistogram<double, 3> histogram(n_bins(), 3, limits());
+  Utils::CylindricalHistogram<double, 3> histogram(n_bins(), limits());
 
   for (auto p : particles) {
     auto const pos = folded_position(traits.position(p), box_geo);

--- a/src/core/observables/CylindricalVelocityProfile.hpp
+++ b/src/core/observables/CylindricalVelocityProfile.hpp
@@ -40,7 +40,7 @@ public:
   std::vector<double>
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
-    Utils::CylindricalHistogram<double, 3> histogram(n_bins(), 3, limits());
+    Utils::CylindricalHistogram<double, 3> histogram(n_bins(), limits());
 
     for (auto p : particles) {
       auto const pos = folded_position(traits.position(p), box_geo) -

--- a/src/core/observables/DensityProfile.hpp
+++ b/src/core/observables/DensityProfile.hpp
@@ -38,7 +38,7 @@ public:
   std::vector<double>
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
-    Utils::Histogram<double, 3> histogram(n_bins(), 1, limits());
+    Utils::Histogram<double, 1> histogram(n_bins(), limits());
 
     for (auto p : particles) {
       histogram.update(folded_position(traits.position(p), box_geo));

--- a/src/core/observables/FluxDensityProfile.hpp
+++ b/src/core/observables/FluxDensityProfile.hpp
@@ -42,7 +42,7 @@ public:
   std::vector<double>
   evaluate(Utils::Span<std::reference_wrapper<const Particle>> particles,
            const ParticleObservables::traits<Particle> &traits) const override {
-    Utils::Histogram<double, 3> histogram(n_bins(), 3, limits());
+    Utils::Histogram<double, 3> histogram(n_bins(), limits());
 
     for (auto p : particles) {
       auto const ppos = folded_position(traits.position(p), box_geo);

--- a/src/core/observables/ForceDensityProfile.hpp
+++ b/src/core/observables/ForceDensityProfile.hpp
@@ -43,7 +43,7 @@ public:
   std::vector<double>
   evaluate(ParticleReferenceRange particles,
            const ParticleObservables::traits<Particle> &traits) const override {
-    Utils::Histogram<double, 3> histogram(n_bins(), 3, limits());
+    Utils::Histogram<double, 3> histogram(n_bins(), limits());
     for (auto p : particles) {
       histogram.update(folded_position(p.get().r.p, box_geo), p.get().f.f);
     }

--- a/src/core/observables/LBVelocityProfile.cpp
+++ b/src/core/observables/LBVelocityProfile.cpp
@@ -30,7 +30,7 @@
 namespace Observables {
 
 std::vector<double> LBVelocityProfile::operator()() const {
-  Utils::Histogram<double, 3> histogram(n_bins(), 3, limits());
+  Utils::Histogram<double, 3> histogram(n_bins(), limits());
   for (auto const &p : sampling_positions) {
     const auto v = lb_lbfluid_get_interpolated_velocity(p) *
                    lb_lbfluid_get_lattice_speed();

--- a/src/utils/include/utils/Histogram.hpp
+++ b/src/utils/include/utils/Histogram.hpp
@@ -20,8 +20,8 @@
 #define UTILS_HISTOGRAM_HPP
 
 #include "utils/Span.hpp"
-#include "utils/constants.hpp"
-#include "utils/index.hpp"
+
+#include <boost/multi_array.hpp>
 
 #include <algorithm>
 #include <array>
@@ -37,61 +37,56 @@ namespace Utils {
 
 /**
  * \brief Histogram in Cartesian coordinates.
- * \tparam Dims  Histogram dimensionality.
  * \tparam T     Histogram data type.
+ * \tparam N     Histogram data dimensionality.
+ * \tparam M     Coordinates data dimensionality.
  * \tparam U     Coordinates data type.
  */
-template <typename T, std::size_t Dims, typename U = double> class Histogram {
+template <typename T, std::size_t N, std::size_t M = 3, typename U = double>
+class Histogram {
+  using array_type = boost::multi_array<T, M + 1>;
+  using count_type = boost::multi_array<std::size_t, M + 1>;
+  using array_index = typename array_type::index;
+
 public:
   /**
    * \brief Histogram constructor.
    * \param n_bins  the number of bins in each histogram dimension.
-   * \param n_dims_data  the number of dimensions the data has (e.g. 3 for
-   *        vector field).
    * \param limits  the minimum/maximum data values to consider for the
    *        histogram.
    */
-  explicit Histogram(std::array<std::size_t, Dims> n_bins,
-                     std::size_t n_dims_data,
-                     std::array<std::pair<U, U>, Dims> limits)
-      : m_n_bins(n_bins), m_limits(limits), m_n_dims_data(n_dims_data),
-        m_ones(n_dims_data, T{1}) {
-    if (n_bins.size() != limits.size()) {
-      throw std::invalid_argument("Argument for number of bins and limits do "
-                                  "not have same number of dimensions!");
-    }
-    m_bin_sizes = calc_bin_sizes(limits, n_bins);
-    std::size_t n_bins_total =
-        m_n_dims_data * std::accumulate(std::begin(n_bins), std::end(n_bins), 1,
-                                        std::multiplies<std::size_t>());
-    m_hist = std::vector<T>(n_bins_total);
-    m_tot_count = std::vector<std::size_t>(n_bins_total);
+  explicit Histogram(std::array<std::size_t, M> n_bins,
+                     std::array<std::pair<U, U>, M> limits)
+      : m_n_bins(std::move(n_bins)), m_limits(std::move(limits)),
+        m_bin_sizes(calc_bin_sizes()), m_array(m_array_dim()),
+        m_count(m_array_dim()) {
+    m_ones.fill(T{1});
   }
 
   /** \brief Get the number of bins for each dimension. */
-  std::array<std::size_t, Dims> get_n_bins() const { return m_n_bins; }
+  std::array<std::size_t, M> get_n_bins() const { return m_n_bins; }
 
   /** \brief Get the histogram data. */
-  std::vector<T> get_histogram() const { return m_hist; }
+  std::vector<T> get_histogram() const {
+    return {m_array.data(), m_array.data() + m_array.num_elements()};
+  }
 
   /** \brief Get the histogram count data. */
-  std::vector<std::size_t> get_tot_count() const { return m_tot_count; }
+  std::vector<std::size_t> get_tot_count() const {
+    return {m_count.data(), m_count.data() + m_count.num_elements()};
+  }
 
   /** \brief Get the ranges (min, max) for each dimension. */
-  std::array<std::pair<U, U>, Dims> get_limits() const { return m_limits; }
+  std::array<std::pair<U, U>, M> get_limits() const { return m_limits; }
 
   /** \brief Get the bin sizes. */
-  std::array<U, Dims> get_bin_sizes() const { return m_bin_sizes; }
+  std::array<U, M> get_bin_sizes() const { return m_bin_sizes; }
 
   /**
    * \brief Add data to the histogram.
-   * \param pos  Position to increment.
+   * \param pos    Position to update.
    */
-  void update(Span<const U> pos) {
-    if (check_limits(pos, m_limits)) {
-      update(pos, m_ones);
-    }
-  }
+  void update(Span<const U> pos) { update(pos, m_ones); }
 
   /**
    * \brief Add data to the histogram.
@@ -99,29 +94,31 @@ public:
    * \param value  Value to add.
    */
   void update(Span<const U> pos, Span<const T> value) {
-    if (check_limits(pos, m_limits)) {
-      Array<std::size_t, Dims> index;
-      for (std::size_t dim = 0; dim < m_n_bins.size(); ++dim) {
-        index[dim] =
-            calc_bin_index(pos[dim], m_limits[dim].first, m_bin_sizes[dim]);
+    if (pos.size() != M) {
+      throw std::invalid_argument("Wrong dimensions for the coordinates");
+    }
+    if (value.size() != N) {
+      throw std::invalid_argument("Wrong dimensions for the value");
+    }
+    if (check_limits(pos)) {
+      boost::array<array_index, M + 1> index;
+      for (std::size_t i = 0; i < M; ++i) {
+        index[i] = calc_bin_index(pos[i], m_limits[i].first, m_bin_sizes[i]);
       }
-      auto const flat_index =
-          m_n_dims_data * ::Utils::ravel_index(index, m_n_bins);
-      if (value.size() != m_n_dims_data)
-        throw std::invalid_argument("Wrong dimensions for the given value!");
-      for (std::size_t ind = 0; ind < m_n_dims_data; ++ind) {
-        m_hist[flat_index + ind] += value[ind];
-        m_tot_count[flat_index + ind]++;
+      for (array_index i = 0; i < N; ++i) {
+        index.back() = i;
+        m_array(index) += value[i];
+        m_count(index)++;
       }
     }
   }
 
-  /** \brief Histogram normalization. */
+  /** \brief Normalize histogram. */
   virtual void normalize() {
     auto const bin_volume = std::accumulate(
         m_bin_sizes.begin(), m_bin_sizes.end(), U{1}, std::multiplies<U>());
     std::transform(
-        m_hist.begin(), m_hist.end(), m_hist.begin(),
+        m_array.data(), m_array.data() + m_array.num_elements(), m_array.data(),
         [bin_volume](T v) { return static_cast<T>(v / bin_volume); });
   }
 
@@ -132,103 +129,91 @@ private:
    * \param offset Bin offset on that dimension.
    * \param size   Bin size on that dimension.
    */
-  std::size_t calc_bin_index(double value, double offset, double size) const {
-    return static_cast<std::size_t>(std::floor((value - offset) / size));
+  array_index calc_bin_index(double value, double offset, double size) const {
+    return static_cast<array_index>(std::floor((value - offset) / size));
   }
 
   /**
    * \brief Calculate the bin sizes.
-   * \param limits  contains min/max values for each dimension.
-   * \param n_bins  number of bins for each dimension.
-   * \return The bin sizes for each dimension.
    */
-  std::array<U, Dims>
-  calc_bin_sizes(std::array<std::pair<U, U>, Dims> const &limits,
-                 std::array<std::size_t, Dims> const &n_bins) const {
-    std::array<U, Dims> tmp;
-    for (std::size_t ind = 0; ind < Dims; ++ind) {
-      tmp[ind] = static_cast<U>((limits[ind].second - limits[ind].first) /
-                                n_bins[ind]);
+  std::array<U, M> calc_bin_sizes() const {
+    std::array<U, M> bin_sizes;
+    for (std::size_t i = 0; i < M; ++i) {
+      bin_sizes[i] = (m_limits[i].second - m_limits[i].first) /
+                     static_cast<U>(m_n_bins[i]);
     }
-    return tmp;
+    return bin_sizes;
   }
 
   /**
-   * \brief Check if data is within limits.
+   * \brief Check if the position lies within the histogram limits.
    * \param pos     Position to check.
-   * \param limits  the min/max values.
    */
-  bool check_limits(Span<const U> pos,
-                    std::array<std::pair<U, U>, Dims> limits) const {
-    if (pos.size() != limits.size()) {
-      throw std::invalid_argument("Dimension of pos and limits not the same!");
+  bool check_limits(Span<const U> pos) const {
+    if (pos.size() != M) {
+      throw std::invalid_argument("Wrong dimensions for the coordinates");
     }
     bool within_range = true;
     for (std::size_t i = 0; i < pos.size(); ++i) {
-      if (pos[i] < limits[i].first or pos[i] >= limits[i].second)
+      if (pos[i] < m_limits[i].first or pos[i] >= m_limits[i].second)
         within_range = false;
     }
     return within_range;
   }
 
-private:
-  /// Number of bins for each dimension.
-  std::array<std::size_t, Dims> m_n_bins;
-  /// Min and max values for each dimension.
-  std::array<std::pair<U, U>, Dims> m_limits;
-  /// Bin sizes for each dimension.
-  std::array<U, Dims> m_bin_sizes;
+  std::array<std::size_t, M + 1> m_array_dim() const {
+    std::array<std::size_t, M + 1> dimensions;
+    std::copy(m_n_bins.begin(), m_n_bins.end(), dimensions.begin());
+    dimensions.back() = N;
+    return dimensions;
+  }
 
 protected:
-  /// Flat histogram data.
-  std::vector<T> m_hist;
-  /// Number of dimensions for a single data point.
-  std::size_t m_n_dims_data;
+  /// Number of bins for each dimension.
+  std::array<std::size_t, M> m_n_bins;
+  /// Min and max values for each dimension.
+  std::array<std::pair<U, U>, M> m_limits;
+  /// Bin sizes for each dimension.
+  std::array<U, M> m_bin_sizes;
+  /// Histogram data.
+  array_type m_array;
   /// Track the number of total hits per bin entry.
-  std::vector<std::size_t> m_tot_count;
-  std::vector<T> m_ones;
+  count_type m_count;
+  std::array<T, N> m_ones;
 };
 
 /**
  * \brief Histogram in cylindrical coordinates.
- * \tparam Dims  Histogram dimensionality.
  * \tparam T     Histogram data type.
+ * \tparam N     Histogram data dimensionality.
+ * \tparam M     Coordinates data dimensionality.
  * \tparam U     Coordinates data type.
  */
-template <typename T, std::size_t Dims, typename U = double>
-class CylindricalHistogram : public Histogram<T, Dims, U> {
+template <typename T, std::size_t N, std::size_t M = 3, typename U = double>
+class CylindricalHistogram : public Histogram<T, N, M, U> {
+  using Histogram<T, N, M, U>::m_n_bins;
+  using Histogram<T, N, M, U>::m_limits;
+  using Histogram<T, N, M, U>::m_bin_sizes;
+  using Histogram<T, N, M, U>::m_array;
+
 public:
-  using Histogram<T, Dims, U>::Histogram;
-  using Histogram<T, Dims, U>::get_n_bins;
-  using Histogram<T, Dims, U>::get_limits;
-  using Histogram<T, Dims, U>::get_bin_sizes;
-  using Histogram<T, Dims, U>::m_hist;
-  using Histogram<T, Dims, U>::m_n_dims_data;
+  using Histogram<T, N, M, U>::Histogram;
 
   void normalize() override {
-    std::array<std::size_t, 4> unravelled_index;
-    auto const dims = get_n_bins();
-    std::array<std::size_t, 4> extended_dims;
-    std::copy(dims.begin(), dims.end(), extended_dims.begin());
-    extended_dims[3] = m_n_dims_data;
-    for (std::size_t ind = 0; ind < m_hist.size(); ind += m_n_dims_data) {
-      // Get the unraveled indices and calculate the bin volume.
-      ::Utils::unravel_index(extended_dims.begin(), extended_dims.end(),
-                             unravelled_index.begin(), ind);
-      auto const r_bin = static_cast<U>(unravelled_index[0]);
-      auto const min_r = get_limits()[0].first;
-      auto const r_bin_size = get_bin_sizes()[0];
-      auto const phi_bin_size = get_bin_sizes()[1];
-      auto const z_bin_size = get_bin_sizes()[2];
+    auto const min_r = m_limits[0].first;
+    auto const r_bin_size = m_bin_sizes[0];
+    auto const phi_bin_size = m_bin_sizes[1];
+    auto const z_bin_size = m_bin_sizes[2];
+    auto const n_bins_r = m_n_bins[0];
+    for (std::size_t i = 0; i < n_bins_r; i++) {
+      auto const r_left = min_r + static_cast<U>(i) * r_bin_size;
+      auto const r_right = r_left + r_bin_size;
       auto const bin_volume =
-          Utils::pi<U>() *
-          ((min_r + (r_bin + 1) * r_bin_size) *
-               (min_r + (r_bin + 1) * r_bin_size) -
-           (min_r + r_bin * r_bin_size) * (min_r + r_bin * r_bin_size)) *
-          z_bin_size * phi_bin_size / (2 * Utils::pi<U>());
-      for (std::size_t dim = 0; dim < m_n_dims_data; ++dim) {
-        m_hist[ind + dim] /= bin_volume;
-      }
+          (r_right * r_right - r_left * r_left) * z_bin_size * phi_bin_size / 2;
+      auto *begin = m_array[i].origin();
+      std::transform(
+          begin, begin + m_array[i].num_elements(), begin,
+          [bin_volume](T v) { return static_cast<T>(v / bin_volume); });
     }
   }
 };

--- a/src/utils/include/utils/index.hpp
+++ b/src/utils/include/utils/index.hpp
@@ -29,63 +29,7 @@
 
 namespace Utils {
 
-/**
- * @brief Returns the flat index for given multidimensional indices and
- * dimensions.
- * @param unravelled_indices a container with the multidimensional
- * indices.
- * @param dimensions a container with the corresponding dimensions.
- * @retval the flat index
- */
-template <typename T, typename U>
-inline std::size_t ravel_index(const T &unravelled_indices,
-                               const U &dimensions) {
-  const auto n_dims = unravelled_indices.size();
-  if (n_dims != dimensions.size()) {
-    throw std::invalid_argument(
-        "Index vector and dimensions vector must have same dimensions.");
-  }
-  std::size_t res = unravelled_indices.back();
-  std::size_t temp_prod = 1;
-  for (int i = unravelled_indices.size() - 2; i >= 0; --i) {
-    temp_prod *= dimensions[i + 1];
-    res += unravelled_indices[i] * temp_prod;
-  }
-  return res;
-}
-
-/**
- * @brief Returns the unraveled index of the provided flat index.
- *        Therefore is the inversion of flattening an ndims dimensional index.
- * @param[in] dimensions_begin Iterator pointing to the begin of the container
- * with the lengths of the dimensions.
- * @param[in] dimensions_end   Iterator pointing to the end of the container
- * with the lengths of the dimensions.
- * @param[out] begin_out       Outputiterator pointing to the begin of the
- * container where the result should be written to.
- * @param[in] ravelled_index   The flat index.
- */
-template <typename InputIterator, typename OutputIterator, typename T>
-inline void unravel_index(InputIterator dimensions_begin,
-                          InputIterator dimensions_end,
-                          OutputIterator begin_out, T ravelled_index) {
-  auto end_out = begin_out + std::distance(dimensions_begin, dimensions_end);
-  auto rbegin_in = std::make_reverse_iterator(dimensions_begin);
-  auto rend_in = std::make_reverse_iterator(dimensions_end);
-  auto rend_out = std::make_reverse_iterator(end_out);
-  std::size_t mul = 1;
-  for (; rend_in != rbegin_in; ++rend_in, ++rend_out) {
-    *rend_out = (ravelled_index / mul) % (*rend_in);
-    mul *= (*rend_in);
-  }
-}
-
 enum class MemoryOrder { COLUMN_MAJOR, ROW_MAJOR };
-
-/*************************************************************/
-/** \name Three dimensional grid operations                  */
-/*************************************************************/
-/**@{*/
 
 /** get the linear index from the position (@p a,@p b,@p c) in a 3D grid
  *  of dimensions @p adim.
@@ -138,8 +82,6 @@ template <class T> T upper_triangular(T i, T j, T n) {
   assert((j >= i) && (j < n));
   return (n * (n - 1)) / 2 - ((n - i) * (n - i - 1)) / 2 + j;
 }
-
-/**@}*/
 
 } // namespace Utils
 

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ unit_test(NAME bspline_test SRC bspline_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME Span_test SRC Span_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME matrix_vector_product SRC matrix_vector_product.cpp DEPENDS
           EspressoUtils)
-unit_test(NAME ravel_index SRC index_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME index_test SRC index_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME tuple_test SRC tuple_test.cpp DEPENDS EspressoUtils)
 unit_test(NAME Array_test SRC Array_test.cpp DEPENDS Boost::serialization
           EspressoUtils)

--- a/src/utils/tests/histogram.cpp
+++ b/src/utils/tests/histogram.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE(histogram) {
   std::array<std::size_t, 2> n_bins{{10, 10}};
   std::array<std::pair<double, double>, 2> limits{
       {std::make_pair(1.0, 20.0), std::make_pair(5.0, 10.0)}};
-  std::size_t n_dims_data = 2;
-  auto hist = Utils::Histogram<double, 2>(n_bins, n_dims_data, limits);
+  constexpr std::size_t n_dims_data = 2;
+  auto hist = Utils::Histogram<double, n_dims_data, 2>(n_bins, limits);
   // Check getters.
   BOOST_CHECK(hist.get_limits() == limits);
   BOOST_CHECK(hist.get_n_bins() == n_bins);
@@ -59,6 +59,9 @@ BOOST_AUTO_TEST_CASE(histogram) {
   BOOST_CHECK((hist.get_histogram())[1] == 11.0);
   BOOST_CHECK_THROW(hist.update(std::vector<double>{{1.0, 5.0, 3.0}}),
                     std::invalid_argument);
+  BOOST_CHECK_THROW(hist.update(std::vector<double>{{0.0, 0.0}},
+                                std::vector<double>{{0.0, 0.0, 0.0}}),
+                    std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(cylindrical_histogram) {
@@ -67,9 +70,8 @@ BOOST_AUTO_TEST_CASE(cylindrical_histogram) {
   std::array<std::pair<double, double>, 3> limits{{std::make_pair(0.0, 2.0),
                                                    std::make_pair(0.0, 2 * pi),
                                                    std::make_pair(0.0, 10.0)}};
-  std::size_t n_dims_data = 3;
-  auto hist =
-      Utils::CylindricalHistogram<double, 3>(n_bins, n_dims_data, limits);
+  constexpr std::size_t n_dims_data = 3;
+  auto hist = Utils::CylindricalHistogram<double, n_dims_data>(n_bins, limits);
   // Check getters.
   BOOST_CHECK(hist.get_limits() == limits);
   BOOST_CHECK(hist.get_n_bins() == n_bins);
@@ -96,5 +98,8 @@ BOOST_AUTO_TEST_CASE(cylindrical_histogram) {
   BOOST_CHECK((hist.get_histogram())[1] == 11.0);
   BOOST_CHECK((hist.get_histogram())[2] == 11.0);
   BOOST_CHECK_THROW(hist.update(std::vector<double>{{1.0, pi}}),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(hist.update(std::vector<double>{{0.0, 0.0, 0.0}},
+                                std::vector<double>{{0.0, 0.0}}),
                     std::invalid_argument);
 }

--- a/src/utils/tests/index_test.cpp
+++ b/src/utils/tests/index_test.cpp
@@ -15,9 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Unit tests for the Utils::ravel_index and Utils::unravel_index functions. */
-
-#define BOOST_TEST_MODULE Utils::ravel_index test
+#define BOOST_TEST_MODULE Utils index test
 #define BOOST_TEST_DYN_LINK
 
 #include <utils/Vector.hpp>
@@ -27,22 +25,6 @@
 
 #include <array>
 #include <cstddef>
-
-BOOST_AUTO_TEST_CASE(ravel_index_test) {
-  const std::array<std::size_t, 4> unravelled_indices{{12, 23, 5, 51}};
-  const std::array<std::size_t, 4> dimensions{{15, 35, 6, 52}};
-  auto const result = Utils::ravel_index(unravelled_indices, dimensions);
-  BOOST_CHECK(result == 138527);
-}
-
-BOOST_AUTO_TEST_CASE(unravel_index_test) {
-  const std::array<std::size_t, 4> dimensions{{15, 35, 6, 52}};
-  const std::size_t ravelled_index = 138527;
-  std::array<std::size_t, 4> result{};
-  Utils::unravel_index(dimensions.begin(), dimensions.end(), result.begin(),
-                       ravelled_index);
-  BOOST_CHECK((result == std::array<std::size_t, 4>{{12, 23, 5, 51}}));
-}
 
 BOOST_AUTO_TEST_CASE(get_linear_index) {
   using Utils::get_linear_index;

--- a/src/utils/tests/sampling_test.cpp
+++ b/src/utils/tests/sampling_test.cpp
@@ -23,7 +23,6 @@
 
 #include <utils/Histogram.hpp>
 #include <utils/constants.hpp>
-#include <utils/index.hpp>
 #include <utils/sampling.hpp>
 
 #include <array>
@@ -51,16 +50,14 @@ BOOST_AUTO_TEST_CASE(get_cylindrical_sampling_positions_test) {
   std::array<std::size_t, 3> n_bins{{static_cast<std::size_t>(n_r_bins),
                                      static_cast<std::size_t>(n_phi_bins),
                                      static_cast<std::size_t>(n_z_bins)}};
-  Utils::CylindricalHistogram<double, 3> histogram(n_bins, 3, limits);
+  Utils::CylindricalHistogram<double, 3> histogram(n_bins, limits);
   for (auto const &p : sampling_positions) {
     histogram.update(p);
   }
   auto const tot_count = histogram.get_tot_count();
   std::array<std::size_t, 3> const dimensions{{n_r_bins, n_phi_bins, n_z_bins}};
   std::array<std::size_t, 3> index{};
-  for (int c = 0; c < tot_count.size(); ++c) {
-    Utils::unravel_index(dimensions.begin(), dimensions.end(), index.begin(),
-                         c);
-    BOOST_CHECK(tot_count[c] > 0);
+  for (auto const &c : tot_count) {
+    BOOST_CHECK(c > 0);
   }
 }


### PR DESCRIPTION
Closes #2669

Description of changes:
- use a `boost::multi_array` instead of a flat array for the `Histogram` class
- remove the raveling/unraveling utilities
