### PR TITLE
fix math in error calculation

### DIFF
--- a/samples/gibbs_ensemble/Readme.md
+++ b/samples/gibbs_ensemble/Readme.md
@@ -13,5 +13,8 @@ only allows one instance of a system in one process, the system is created using
 the `set_up_system()` function and initialized once the `run()` method in the
 `Client` class is called.
 
+As a side note: Do not trust the critical point too much as it is quite sensitive to
+the init values chosen for the fit.
+
 All equations are taken from Frenkel, Smit: *Understanding Molecular Simulation* 2002,
 doi:[10.1016/B978-0-12-267351-1.X5000-7](https://doi.org/10.1016/B978-0-12-267351-1.X5000-7).

--- a/samples/gibbs_ensemble/create_fits.py
+++ b/samples/gibbs_ensemble/create_fits.py
@@ -51,7 +51,7 @@ logging.basicConfig(
 )
 
 # Warmup length to skip at beginning
-WARMUP_LENGTH = 3000
+WARMUP_LENGTH = 300000
 
 # Lists for (unsorted) densities and temperature
 dens_liquid = []
@@ -76,8 +76,8 @@ def relaxation_time(x):
     """ Compute the relaxation time """
     corr = autocorr(x)
     popt, _ = scipy.optimize.curve_fit(lambda x, a: np.exp(-a * x),
-                                       range(np.size(corr)), corr, p0=(1. / 15000))
-    return popt[0]
+                                       range(np.size(corr)), corr, p0=(1.))
+    return 1. / popt[0]
 
 
 def std_error_mean(x):
@@ -117,8 +117,8 @@ for f in args.files:
     # Calculate errors
     if density1 < density2:
         key1, key2 = (key2, key1)
-    errors_liquid.append(std_error_mean(data[key2]))
-    errors_gas.append(std_error_mean(data[key1]))
+    errors_liquid.append(std_error_mean(data[key2][WARMUP_LENGTH:]))
+    errors_gas.append(std_error_mean(data[key1][WARMUP_LENGTH:]))
     kTs.append(kT)
 
 # Sort temperatures and densities respectively
@@ -152,7 +152,7 @@ y_rectilinear = 0.5 * (dens_liquid + dens_gas)
 
 # Fit using scaling law
 fit_scaling, p_cov_scaling = scipy.optimize.curve_fit(
-    scaling_law, kTs, y_scaling, p0=(1., 1.), maxfev=6000)
+    scaling_law, kTs, y_scaling, p0=(1., 1.1), maxfev=6000)
 
 # Print fit values
 logging.info(f"Fits using scaling law: B, T_c: {fit_scaling}")

--- a/samples/gibbs_ensemble/run_sim.py
+++ b/samples/gibbs_ensemble/run_sim.py
@@ -341,8 +341,6 @@ def perform_particle_exchange(boxes):
     # Send moves, update num_part
     donor_box.send_data([MessageID.PART_REMOVE])
     recipient_box.send_data([MessageID.PART_ADD])
-    donor_box.num_part -= 1
-    recipient_box.num_part += 1
     [box.recv_energy() for box in boxes]
 
     # Debugging purposes
@@ -360,8 +358,8 @@ def perform_particle_exchange(boxes):
     # This is the acceptance probability if the donor_box is chosen with equal
     # probability
     acc = np.exp(
-        np.log((donor_box.num_part + 1) * recipient_box.volume /
-               (recipient_box.num_part * donor_box.volume))
+        np.log(donor_box.num_part * recipient_box.volume /
+               ((recipient_box.num_part + 1) * donor_box.volume))
         - 1. / kT * donor_box.diff_energy
         - 1. / kT * recipient_box.diff_energy)
 
@@ -373,11 +371,12 @@ def perform_particle_exchange(boxes):
         # Reject move, restore old configuration
         donor_box.send_data([MessageID.PART_REMOVE_REVERT])
         recipient_box.send_data([MessageID.PART_ADD_REVERT])
-        donor_box.num_part += 1
-        recipient_box.num_part -= 1
         donor_box.energy = donor_box.old_energy
         recipient_box.energy = recipient_box.old_energy
         return False
+
+    donor_box.num_part -= 1
+    recipient_box.num_part += 1
 
     # Debug
     logging.debug("Particle exchange accepted.")


### PR DESCRIPTION
Fixes the calculation of the autocorrelation time in the `create_fits.py` script, also updates the particle exchange code for clarity

