### PR TITLE
'Classify' drude_helpers; remove ids from interface

### DIFF
--- a/doc/sphinx/advanced_methods.rst
+++ b/doc/sphinx/advanced_methods.rst
@@ -1528,8 +1528,8 @@ It returns an `espressomd.particle_data.ParticleHandle` to the created Drude
 particle. Note that as the function also adds the first two bonds between Drude
 and core, these bonds have to be already available.::
 
-    from espressomd.drude_helpers import DrudeHelpers
-    dh = DrudeHelper()
+    import espressomd.drude_helpers
+    dh = espressomd.drude_helpers.DrudeHelpers()
     drude_part = dh.add_drude_particle_to_core(<system>, <harmonic_bond>,
         <thermalized_bond>, <core particle>, <type drude>, <alpha>,
         <mass drude>, <coulomb_prefactor>, <thole damping>, <verbose>)
@@ -1559,11 +1559,11 @@ One bond type of this kind is needed per Drude type. The above helper function a
 tracks particle types, ids and charges of Drude and core particles, so a simple call of
 another helper function::
 
-    dh.setup_and_add_drude_exclusion_bonds(S)
+    dh.setup_and_add_drude_exclusion_bonds(system)
 
 will use this data to create a :ref:`Subtract P3M short-range bond` per Drude type
 and set it up it between all Drude and core particles collected in calls of
-:meth:`~espressomd.drude_helpers.DrudeHelper.add_drude_particle_to_core`.
+:meth:`~espressomd.drude_helpers.DrudeHelpers.add_drude_particle_to_core`.
 
 .. _Canceling intramolecular electrostatics:
 

--- a/doc/sphinx/advanced_methods.rst
+++ b/doc/sphinx/advanced_methods.rst
@@ -1524,13 +1524,15 @@ polarizability :math:`\alpha` (in units of inverse volume) with :math:`q_d =
 
 The following helper method takes into account all the preceding considerations
 and can be used to conveniently add a Drude particle to a given core particle.
-As it also adds the first two bonds between Drude and core, these bonds have to
-be created beforehand::
+It returns an `espressomd.particle_data.ParticleHandle` to the created Drude
+particle. Note that as the function also adds the first two bonds between Drude
+and core, these bonds have to be already available.::
 
-    import espressomd.drude_helpers
-    espressomd.drude_helpers(<system>, <harmonic_bond>, <thermalized_bond>,
-        <core particle>, <id drude>, <type drude>, <alpha>, <mass drude>,
-        <coulomb_prefactor>, <thole damping>, <verbose>)
+    from espressomd.drude_helpers import DrudeHelpers
+    dh = DrudeHelper()
+    drude_part = dh.add_drude_particle_to_core(<system>, <harmonic_bond>,
+        <thermalized_bond>, <core particle>, <type drude>, <alpha>,
+        <mass drude>, <coulomb_prefactor>, <thole damping>, <verbose>)
 
 The arguments of the helper function are:
     * ``<system>``: The :class:`espressomd.System() <espressomd.system.System>`.
@@ -1539,7 +1541,6 @@ The arguments of the helper function are:
     * ``<thermalized_bond>``: The thermalized distance bond for the cold and hot
       thermostats.
     * ``<core particle>``: The core particle on which the Drude particle is added.
-    * ``<id drude>``: The user-defined id of the Drude particle that is created.
     * ``<type drude>``: The user-defined type of the Drude particle.
       Each Drude particle of each complex should have an
       individual type (e.g. in an ionic system with Anions (type 0) and Cations
@@ -1558,10 +1559,11 @@ One bond type of this kind is needed per Drude type. The above helper function a
 tracks particle types, ids and charges of Drude and core particles, so a simple call of
 another helper function::
 
-    espressomd.drude_helpers.setup_and_add_drude_exclusion_bonds(S)
+    dh.setup_and_add_drude_exclusion_bonds(S)
 
 will use this data to create a :ref:`Subtract P3M short-range bond` per Drude type
-and set it up it between all Drude and core particles collected in calls of :meth:`~espressomd.drude_helpers.add_drude_particle_to_core`.
+and set it up it between all Drude and core particles collected in calls of
+:meth:`~espressomd.drude_helpers.DrudeHelper.add_drude_particle_to_core`.
 
 .. _Canceling intramolecular electrostatics:
 

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -635,7 +635,7 @@ cores, except the one it's connected to.  This exception is handled internally
 by disabling Thole interaction between particles connected via Drude bonds.
 Also, each Drude core has a Thole correction interaction with all other Drude
 cores and Drude charges. To assist with the bookkeeping of mixed scaling
-coefficients, the helper method :meth:`~espressomd.drude_helpers.add_drude_particle_to_core` (see
+coefficients, the helper method :meth:`~espressomd.drude_helpers.DrudeHelpers.add_drude_particle_to_core` (see
 :ref:`Particle polarizability with thermalized cold Drude oscillators`)
 collects all core types, Drude types and relevant parameters when a Drude
 particle is created. The user already provided all the information when
@@ -647,7 +647,7 @@ given the :class:`espressomd.System() <espressomd.system.System>` object, uses t
 necessary Thole interactions. The method calculates the mixed scaling
 coefficient ``s`` and creates the non-bonded Thole interactions between the
 collected types to cover all the Drude-Drude, Drude-core and core-core
-combinations. No further calls of :meth:`~espressomd.drude_helpers.add_drude_particle_to_core` should
+combinations. No further calls of :meth:`~espressomd.drude_helpers.DrudeHelpers.add_drude_particle_to_core` should
 follow. Set ``verbose`` to ``True`` to print out the coefficients, charge factors
 and involved types.
 

--- a/samples/drude_bmimpf6.py
+++ b/samples/drude_bmimpf6.py
@@ -30,8 +30,8 @@ import espressomd.accumulators
 import espressomd.electrostatics
 import espressomd.interactions
 import espressomd.virtual_sites
-import espressomd.drude_helpers
 import espressomd.visualization_opengl
+from espressomd.drude_helpers import DrudeHelpers
 
 required_features = ["LENNARD_JONES", "P3M", "MASS", "ROTATION",
                      "ROTATIONAL_INERTIA", "VIRTUAL_SITES_RELATIVE",
@@ -193,59 +193,36 @@ for i in range(len(lj_types)):
             epsilon=lj_eps, sigma=lj_sig, cutoff=lj_cut, shift="auto")
 
 # Place Particles
-rid = 0
-anion_ids = []
-cation_sites_ids = []
-cation_com_ids = []
-cation_c1_ids = []
-cation_c2_ids = []
-cation_c3_ids = []
+anions = []
+cations = []
 
 for i in range(n_ionpairs):
-    system.part.add(id=rid, type=types["PF6"], pos=np.random.random(3) * box_l,
-                    q=charges["PF6"], mass=masses["PF6"])
-    anion_ids.append(rid)
-    if args.drude:
-        rid += 2
-    else:
-        rid += 1
+    # Add an anion ...
+    anions.append(
+        system.part.add(type=types["PF6"], pos=np.random.random(3) * box_l,
+                        q=charges["PF6"], mass=masses["PF6"]))    
 
-for i in range(n_ionpairs):
+    # ... and a cation
     pos_com = np.random.random(3) * box_l
-    system.part.add(
-        id=rid, type=types["BMIM_COM"], pos=pos_com,
+    cation_com = system.part.add(
+        type=types["BMIM_COM"], pos=pos_com,
         mass=masses["BMIM_COM"], rinertia=[646.284, 585.158, 61.126],
         gamma=0, rotation=[1, 1, 1])
-    cation_com_ids.append(rid)
-    com_id = rid
-    rid += 1
-    system.part.add(id=rid, type=types["BMIM_C1"],
-                    pos=pos_com + [0, -0.527, 1.365], q=charges["BMIM_C1"])
-    system.part[rid].vs_auto_relate_to(com_id)
-    cation_c1_ids.append(rid)
-    cation_sites_ids.append(rid)
-    if args.drude:
-        rid += 2
-    else:
-        rid += 1
-    system.part.add(id=rid, type=types["BMIM_C2"],
-                    pos=pos_com + [0, 1.641, 2.987], q=charges["BMIM_C2"])
-    system.part[rid].vs_auto_relate_to(com_id)
-    cation_c2_ids.append(rid)
-    cation_sites_ids.append(rid)
-    if args.drude:
-        rid += 2
-    else:
-        rid += 1
-    system.part.add(id=rid, type=types["BMIM_C3"],
-                    pos=pos_com + [0, 0.187, -2.389], q=charges["BMIM_C3"])
-    system.part[rid].vs_auto_relate_to(com_id)
-    cation_c3_ids.append(rid)
-    cation_sites_ids.append(rid)
-    if args.drude:
-        rid += 2
-    else:
-        rid += 1
+
+    cation_c1 = system.part.add(type=types["BMIM_C1"],
+                                pos=pos_com + [0, -0.527, 1.365], q=charges["BMIM_C1"])
+    cation_c1.vs_auto_relate_to(cation_com)
+    cations.append([cation_c1])
+
+    cation_c2 = system.part.add(type=types["BMIM_C2"],
+                                pos=pos_com + [0, 1.641, 2.987], q=charges["BMIM_C2"])
+    cation_c2.vs_auto_relate_to(cation_com)
+    cations[-1].append(cation_c2)
+
+    cation_c3 = system.part.add(type=types["BMIM_C3"],
+                                pos=pos_com + [0, 0.187, -2.389], q=charges["BMIM_C3"])
+    cation_c3.vs_auto_relate_to(cation_com)
+    cations[-1].append(cation_c3)
 
 # ENERGY MINIMIZATION
 print("\n-->E minimization")
@@ -275,6 +252,8 @@ else:
 
 system.actors.add(p3m)
 
+cation_drude_parts = []
+
 if args.drude:
     print("-->Adding Drude related bonds")
     thermalized_dist_bond = espressomd.interactions.ThermalizedBond(
@@ -286,52 +265,58 @@ if args.drude:
     system.bonded_inter.add(thermalized_dist_bond)
     system.bonded_inter.add(harmonic_bond)
 
-    for i in anion_ids:
-        espressomd.drude_helpers.add_drude_particle_to_core(
-            system, harmonic_bond, thermalized_dist_bond, system.part[i],
-            i + 1, types["PF6_D"], polarizations["PF6"],
-            args.mass_drude, coulomb_prefactor)
-    for i in cation_c1_ids:
-        espressomd.drude_helpers.add_drude_particle_to_core(
-            system, harmonic_bond, thermalized_dist_bond, system.part[i],
-            i + 1, types["BMIM_C1_D"], polarizations["BMIM_C1"],
-            args.mass_drude, coulomb_prefactor)
-    for i in cation_c2_ids:
-        espressomd.drude_helpers.add_drude_particle_to_core(
-            system, harmonic_bond, thermalized_dist_bond, system.part[i],
-            i + 1, types["BMIM_C2_D"], polarizations["BMIM_C2"],
-            args.mass_drude, coulomb_prefactor)
-    for i in cation_c3_ids:
-        espressomd.drude_helpers.add_drude_particle_to_core(
-            system, harmonic_bond, thermalized_dist_bond, system.part[i],
-            i + 1, types["BMIM_C3_D"], polarizations["BMIM_C3"],
+    dh = DrudeHelpers()
+
+    # Add Drude particles for the anions ...
+    for anion in anions:
+        dh.add_drude_particle_to_core(
+            system, harmonic_bond, thermalized_dist_bond, anion,
+            types["PF6_D"], polarizations["PF6"],
             args.mass_drude, coulomb_prefactor)
 
-    espressomd.drude_helpers.setup_and_add_drude_exclusion_bonds(system)
+    # ... and for the cations
+    for cation in cations:
+        cation_c1_drude = dh.add_drude_particle_to_core(
+            system, harmonic_bond, thermalized_dist_bond, cation[0],
+            types["BMIM_C1_D"], polarizations["BMIM_C1"],
+            args.mass_drude, coulomb_prefactor)
+        cation_drude_parts.append([cation_c1_drude])
+
+        cation_c2_drude = dh.add_drude_particle_to_core(
+            system, harmonic_bond, thermalized_dist_bond, cation[1],
+            types["BMIM_C2_D"], polarizations["BMIM_C2"],
+            args.mass_drude, coulomb_prefactor)
+        cation_drude_parts[-1].append(cation_c2_drude)
+
+        cation_c3_drude = dh.add_drude_particle_to_core(
+            system, harmonic_bond, thermalized_dist_bond, cation[2],
+            types["BMIM_C3_D"], polarizations["BMIM_C3"],
+            args.mass_drude, coulomb_prefactor)
+        cation_drude_parts[-1].append(cation_c3_drude)
+
+    dh.setup_and_add_drude_exclusion_bonds(system)
 
     if args.thole:
         print("-->Adding Thole interactions")
-        espressomd.drude_helpers.add_all_thole(system)
+        dh.add_all_thole(system)
 
     if args.intra_ex:
         # SETUP BONDS ONCE
         print("-->Adding intramolecular exclusions")
-        espressomd.drude_helpers.setup_intramol_exclusion_bonds(
+        dh.setup_intramol_exclusion_bonds(
             system,
             [types["BMIM_C1_D"], types["BMIM_C2_D"], types["BMIM_C3_D"]],
             [types["BMIM_C1"], types["BMIM_C2"], types["BMIM_C3"]],
             [charges["BMIM_C1"], charges["BMIM_C2"], charges["BMIM_C3"]])
 
         # ADD SR EX BONDS PER MOLECULE
-        for i in cation_c1_ids:
-            espressomd.drude_helpers.add_intramol_exclusion_bonds(
-                system, [i + 1, i + 3, i + 5], [i, i + 2, i + 4])
+        for cation_drude_part, cation in zip(cation_drude_parts, cations):
+            dh.add_intramol_exclusion_bonds(cation_drude_part, cation)
 
 print("\n-->Short equilibration with smaller time step")
 system.time_step = 0.1 * fs_to_md_time
 system.integrator.run(1000)
 system.time_step = time_step_fs * fs_to_md_time
-
 
 print("\n-->Timing")
 start = time.time()

--- a/samples/drude_bmimpf6.py
+++ b/samples/drude_bmimpf6.py
@@ -29,9 +29,9 @@ import espressomd.observables
 import espressomd.accumulators
 import espressomd.electrostatics
 import espressomd.interactions
+import espressomd.drude_helpers
 import espressomd.virtual_sites
 import espressomd.visualization_opengl
-from espressomd.drude_helpers import DrudeHelpers
 
 required_features = ["LENNARD_JONES", "P3M", "MASS", "ROTATION",
                      "ROTATIONAL_INERTIA", "VIRTUAL_SITES_RELATIVE",
@@ -200,7 +200,7 @@ for i in range(n_ionpairs):
     # Add an anion ...
     anions.append(
         system.part.add(type=types["PF6"], pos=np.random.random(3) * box_l,
-                        q=charges["PF6"], mass=masses["PF6"]))    
+                        q=charges["PF6"], mass=masses["PF6"]))
 
     # ... and a cation
     pos_com = np.random.random(3) * box_l
@@ -265,7 +265,7 @@ if args.drude:
     system.bonded_inter.add(thermalized_dist_bond)
     system.bonded_inter.add(harmonic_bond)
 
-    dh = DrudeHelpers()
+    dh = espressomd.drude_helpers.DrudeHelpers()
 
     # Add Drude particles for the anions ...
     for anion in anions:

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -20,7 +20,7 @@ from .__init__ import has_features
 
 class DrudeHelpers:
     """
-    Provides helper functions the creation of Drude particles.
+    Provides helper functions to assist in the creation of Drude particles.
 
     """
 
@@ -92,8 +92,7 @@ class DrudeHelpers:
 
         if verbose:
             print(
-                "Adding to core", p_core.id, "  pol", alpha, "  core charge",
-                p_core.q, "->", p_core.q - q_drude, "  drude charge", q_drude)
+                f"Adding to core {p_core.id}   pol {alpha}   core charge {p_core.q} -> {p_core.q - q_drude}   drude charge {q_drude}")
 
         p_core.q -= q_drude
         p_core.mass -= mass_drude
@@ -170,8 +169,8 @@ class DrudeHelpers:
             scaling_coeff=s, q1q2=qq)
 
         if verbose:
-            print("Added THOLE non-bonded interaction for types",
-                  t1, "<->", t2, "S", s, "q1q2", qq)
+            print(
+                f"Added THOLE non-bonded interaction for types {t1} <-> {t2} S {s} q1q2 {qq}")
 
     def add_all_thole(self, system, verbose=False):
         """
@@ -228,8 +227,8 @@ class DrudeHelpers:
             system.bonded_inter.add(subtr_sr_bond)
             self.drude_dict[td]["subtr_sr_bonds_drude-core"] = subtr_sr_bond
             if verbose:
-                print("Added drude-core SR exclusion bond ",
-                      subtr_sr_bond, "for drude", qd, "<-> core", qc, "to system")
+                print(
+                    f"Added drude-core SR exclusion bond {subtr_sr_bond} for drude {qd} <-> core {qc} to system")
 
         for drude_id in self.drude_id_list:
             core_id = self.core_id_from_drude_id[drude_id]
@@ -238,8 +237,8 @@ class DrudeHelpers:
             bond = self.drude_dict[pd.type]["subtr_sr_bonds_drude-core"]
             pc.add_bond((bond, drude_id))
             if verbose:
-                print("Added drude-core SR bond", bond,
-                      "between ids", drude_id, "and", core_id)
+                print(
+                    f"Added drude-core SR bond {bond} between ids {drude_id} and {core_id}")
 
     def setup_intramol_exclusion_bonds(self, system, mol_drude_types, mol_core_types,
                                        mol_core_partial_charges, verbose=False):
@@ -278,8 +277,8 @@ class DrudeHelpers:
                     self.drude_dict[td]["subtr_sr_bonds_intramol"][
                         tc] = subtr_sr_bond
                     if verbose:
-                        print("Added intramolecular exclusion", subtr_sr_bond,
-                              "for drude", qd, "<-> core", qp, "to system")
+                        print(
+                            f"Added intramolecular exclusion {subtr_sr_bond} for drude {qd} <-> core {qp} to system")
 
     def add_intramol_exclusion_bonds(
             self, drude_parts, core_parts, verbose=False):
@@ -311,5 +310,5 @@ class DrudeHelpers:
                         "subtr_sr_bonds_intramol"][pc.type]
                     pd.add_bond((bond, core_id))
                     if verbose:
-                        print("Added subtr_sr bond", bond,
-                              "between ids", drude_id, "and", core_id)
+                        print(
+                            f"Added subtr_sr bond {bond} between ids {drude_id} and {core_id}")

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -17,284 +17,299 @@
 from . import interactions
 from .__init__ import has_features
 
-# Dict with Drude type infos
-drude_dict = {}
-# Lists with unique Drude and core types
-core_type_list = []
-drude_type_list = []
-# Get core id from Drude id
-core_id_from_drude_id = {}
-# Drude IDs
-drude_id_list = []
 
-
-def add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
-                               p_core, id_drude, type_drude, alpha,
-                               mass_drude, coulomb_prefactor,
-                               thole_damping=2.6, verbose=False):
+class DrudeHelpers:
     """
-    Adds a Drude particle with specified id, type, and mass to the system.
-    Checks if different Drude particles have different types.
-    Collects types/charges/polarizations/Thole factors for intramolecular
-    core-Drude short-range exclusion and Thole interaction.
-
-    Parameters
-    ----------
-
-    system : :class:`espressomd.system.System`
-    harmonic_bond: :class:`espressomd.interactions.HarmonicBond`
-        Add this harmonic bond to between Drude particle and core
-    thermalized_bond: :class:`espressomd.interactions.ThermalizedBond`
-        Add this thermalized_bond to between Drude particle and core
-    p_core: :class:`espressomd.particle_data.ParticleHandle`
-        The existing core particle
-    id_drude: :obj:`int`
-        This method creates the Drude particle and assigns this id.
-    type_drude: :obj:`int`
-        The type of the newly created Drude particle
-    alpha : :obj:`float`
-        The polarizability in units of inverse volume. Related to the charge
-        of the Drude particle.
-    mass_drude : :obj:`float`
-        The mass of the newly created Drude particle
-    coulomb_prefactor : :obj:`float`
-        Required to calculate the charge of the Drude particle.
-    thole_damping : :obj:`float`
-        Thole damping factor of the Drude pair. Comes to effect if
-        :meth:`add_all_thole()` method is used.
-    verbose : :obj:`bool`
-        Turns on verbosity.
+    Provides helper functions the creation of Drude particles.
 
     """
 
-    k = harmonic_bond.params["k"]
-    q_drude = -1.0 * pow(k * alpha / coulomb_prefactor, 0.5)
+    def __init__(self):
+        # Dict with Drude type infos
+        self.drude_dict = {}
+        # Lists with unique Drude and core types
+        self.core_type_list = []
+        self.drude_type_list = []
+        # Get core id from Drude id
+        self.core_id_from_drude_id = {}
+        # Drude IDs
+        self.drude_id_list = []
 
-    if has_features("PARTICLE_ANISOTROPY"):
-        gamma_off = [0.0, 0.0, 0.0]
-    else:
-        gamma_off = 0.0
+    def add_drude_particle_to_core(self, system, harmonic_bond,
+                                   thermalized_bond, p_core, type_drude, alpha,
+                                   mass_drude, coulomb_prefactor,
+                                   thole_damping=2.6, verbose=False):
+        """
+        Adds a Drude particle with specified type and mass to the system and
+        returns its `espressomd.particle_data.ParticleHandle`.
+        Checks if different Drude particles have different types.
+        Collects types/charges/polarizations/Thole factors for intramolecular
+        core-Drude short-range exclusion and Thole interaction.
 
-    system.part.add(id=id_drude, pos=p_core.pos, type=type_drude,
-                    q=q_drude, mass=mass_drude, gamma=gamma_off)
+        Parameters
+        ----------
 
-    if verbose:
-        print(
-            "Adding to core", p_core.id, "drude id", id_drude, "  pol", alpha,
-            "  core charge", p_core.q, "->", p_core.q - q_drude, "   drude charge", q_drude)
+        system : :class:`espressomd.system.System`
+        harmonic_bond: :class:`espressomd.interactions.HarmonicBond`
+            Add this harmonic bond to between Drude particle and core
+        thermalized_bond: :class:`espressomd.interactions.ThermalizedBond`
+            Add this thermalized_bond to between Drude particle and core
+        p_core: :class:`espressomd.particle_data.ParticleHandle`
+            The existing core particle
+        type_drude: :obj:`int`
+            The type of the newly created Drude particle
+        alpha : :obj:`float`
+            The polarizability in units of inverse volume. Related to the charge
+            of the Drude particle.
+        mass_drude : :obj:`float`
+            The mass of the newly created Drude particle
+        coulomb_prefactor : :obj:`float`
+            Required to calculate the charge of the Drude particle.
+        thole_damping : :obj:`float`
+            Thole damping factor of the Drude pair. Comes to effect if
+            :meth:`add_all_thole()` method is used.
+        verbose : :obj:`bool`
+            Turns on verbosity.
 
-    p_core.q -= q_drude
-    p_core.mass -= mass_drude
-    p_core.add_bond((harmonic_bond, id_drude))
-    p_core.add_bond((thermalized_bond, id_drude))
+        Returns
+        -------
+        :class:`espressomd.particle_data.ParticleHandle`
+            The created Drude Particle.
 
-    p_core.gamma = gamma_off
+        """
 
-    if type_drude in drude_dict and not (
-            drude_dict[type_drude]["q"] == q_drude and drude_dict[type_drude]["thole_damping"] == thole_damping):
-        raise Exception(
-            "Drude particles with different drude charges have to have different types for THOLE")
+        k = harmonic_bond.params["k"]
+        q_drude = -1.0 * pow(k * alpha / coulomb_prefactor, 0.5)
 
-    core_id_from_drude_id[id_drude] = p_core.id
+        if has_features("PARTICLE_ANISOTROPY"):
+            gamma_off = [0.0, 0.0, 0.0]
+        else:
+            gamma_off = 0.0
 
-    # Add new Thole nonbonded interaction for D-D, D-C, C-C for all existing
-    # Drude types if this type is seen for the first time
-    if type_drude not in drude_dict:
+        drude_part = system.part.add(pos=p_core.pos, type=type_drude,
+                                     q=q_drude, mass=mass_drude, gamma=gamma_off)
+        id_drude = drude_part.id
 
-        # Bookkeeping of q, alphas and damping parameter
-        drude_dict[type_drude] = {}
-        drude_dict[type_drude]["q"] = q_drude
-        drude_dict[type_drude]["qc"] = p_core.q
-        drude_dict[type_drude]["alpha"] = alpha
-        drude_dict[type_drude]["thole_damping"] = thole_damping
-        drude_dict[type_drude]["core_type"] = p_core.type
-        # Save same information to get access to the parameters via core types
-        drude_dict[p_core.type] = {}
-        drude_dict[p_core.type]["q"] = -q_drude
-        drude_dict[p_core.type]["qc"] = p_core.q
-        drude_dict[p_core.type]["alpha"] = alpha
-        drude_dict[p_core.type]["thole_damping"] = thole_damping
-        drude_dict[p_core.type]["drude_type"] = type_drude
-
-    # Collect unique Drude types
-    if type_drude not in drude_type_list:
-        drude_type_list.append(type_drude)
-
-    # Collect unique core types
-    if p_core.type not in core_type_list:
-        core_type_list.append(p_core.type)
-
-    # Collect unique Drude ids
-    if id_drude not in drude_id_list:
-        drude_id_list.append(id_drude)
-
-
-def add_thole_pair_damping(system, t1, t2, verbose=False):
-    """
-    Calculates mixed Thole factors depending on Thole damping and polarization.
-    Adds non-bonded Thole interactions to the system.
-
-    Parameters
-    ----------
-
-    system : :class:`espressomd.system.System`
-    t1 : :obj:`int`
-        Type 1
-    t2 : :obj:`int`
-        Type 2
-    verbose : :obj:`bool`
-        Turns on verbosity.
-
-    """
-
-    qq = drude_dict[t1]["q"] * drude_dict[t2]["q"]
-    s = 0.5 * (drude_dict[t1]["thole_damping"] + drude_dict[t2]["thole_damping"]
-               ) / (drude_dict[t1]["alpha"] * drude_dict[t2]["alpha"])**(1.0 / 6.0)
-
-    system.non_bonded_inter[t1, t2].thole.set_params(scaling_coeff=s, q1q2=qq)
-
-    if verbose:
-        print("Added THOLE non-bonded interaction for types",
-              t1, "<->", t2, "S", s, "q1q2", qq)
-
-
-def add_all_thole(system, verbose=False):
-    """
-    Calls :meth:`add_thole_pair_damping()` for all necessary combinations to
-    create the interactions.
-
-    Parameters
-    ----------
-
-    system : :class:`espressomd.system.System`
-    verbose : :obj:`bool`
-        Turns on verbosity.
-
-    """
-
-    # Drude <-> Drude
-    for i in range(len(drude_type_list)):
-        for j in range(i, len(drude_type_list)):
-            add_thole_pair_damping(
-                system, drude_type_list[i], drude_type_list[j], verbose)
-    # core <-> core
-    for i in range(len(core_type_list)):
-        for j in range(i, len(core_type_list)):
-            add_thole_pair_damping(
-                system, core_type_list[i], core_type_list[j], verbose)
-    # Drude <-> core
-    for i in drude_type_list:
-        for j in core_type_list:
-            add_thole_pair_damping(system, i, j, verbose)
-
-
-def setup_and_add_drude_exclusion_bonds(system, verbose=False):
-    """
-    Creates electrostatic short-range exclusion bonds for global exclusion
-    between Drude particles and core charges and adds the bonds to the cores.
-    Has to be called once after all Drude particles have been created.
-
-    Parameters
-    ----------
-
-    system : :class:`espressomd.system.System`
-    verbose: :obj:`bool`
-        Turns on verbosity.
-
-    """
-
-    # All Drude types need...
-    for td in drude_type_list:
-
-        # ...exclusions with core
-        qd = drude_dict[td]["q"]  # Drude charge
-        qc = drude_dict[td]["qc"]  # Core charge
-        subtr_sr_bond = interactions.BondedCoulombSRBond(
-            q1q2=-qd * qc)
-        system.bonded_inter.add(subtr_sr_bond)
-        drude_dict[td]["subtr_sr_bonds_drude-core"] = subtr_sr_bond
         if verbose:
-            print("Added drude-core SR exclusion bond ",
-                  subtr_sr_bond, "for drude", qd, "<-> core", qc, "to system")
+            print(
+                "Adding to core", p_core.id, "  pol", alpha, "  core charge",
+                p_core.q, "->", p_core.q - q_drude, "  drude charge", q_drude)
 
-    for drude_id in drude_id_list:
-        core_id = core_id_from_drude_id[drude_id]
-        pd = system.part[drude_id]
-        pc = system.part[core_id]
-        bond = drude_dict[pd.type]["subtr_sr_bonds_drude-core"]
-        pc.add_bond((bond, drude_id))
+        p_core.q -= q_drude
+        p_core.mass -= mass_drude
+        p_core.add_bond((harmonic_bond, id_drude))
+        p_core.add_bond((thermalized_bond, id_drude))
+
+        p_core.gamma = gamma_off
+
+        if type_drude in self.drude_dict and not (
+                self.drude_dict[type_drude]["q"] == q_drude and
+                self.drude_dict[type_drude]["thole_damping"] == thole_damping):
+            raise Exception(
+                "Drude particles with different drude charges have to have different types for THOLE")
+
+        self.core_id_from_drude_id[id_drude] = p_core.id
+
+        # Add new Thole non-bonded interaction for D-D, D-C, C-C for all existing
+        # Drude types if this type is seen for the first time
+        if type_drude not in self.drude_dict:
+
+            # Bookkeeping of q, alphas and damping parameter
+            self.drude_dict[type_drude] = {}
+            self.drude_dict[type_drude]["q"] = q_drude
+            self.drude_dict[type_drude]["qc"] = p_core.q
+            self.drude_dict[type_drude]["alpha"] = alpha
+            self.drude_dict[type_drude]["thole_damping"] = thole_damping
+            self.drude_dict[type_drude]["core_type"] = p_core.type
+            # Save same information to get access to the parameters via core
+            # types
+            self.drude_dict[p_core.type] = {}
+            self.drude_dict[p_core.type]["q"] = -q_drude
+            self.drude_dict[p_core.type]["qc"] = p_core.q
+            self.drude_dict[p_core.type]["alpha"] = alpha
+            self.drude_dict[p_core.type]["thole_damping"] = thole_damping
+            self.drude_dict[p_core.type]["drude_type"] = type_drude
+
+        # Collect unique Drude types
+        if type_drude not in self.drude_type_list:
+            self.drude_type_list.append(type_drude)
+
+        # Collect unique core types
+        if p_core.type not in self.core_type_list:
+            self.core_type_list.append(p_core.type)
+
+        # Collect unique Drude ids
+        if id_drude not in self.drude_id_list:
+            self.drude_id_list.append(id_drude)
+
+        return drude_part
+
+    def add_thole_pair_damping(self, system, t1, t2, verbose=False):
+        """
+        Calculates mixed Thole factors depending on Thole damping and polarization.
+        Adds non-bonded Thole interactions to the system.
+
+        Parameters
+        ----------
+
+        system : :class:`espressomd.system.System`
+        t1 : :obj:`int`
+            Type 1
+        t2 : :obj:`int`
+            Type 2
+        verbose : :obj:`bool`
+            Turns on verbosity.
+
+        """
+
+        qq = self.drude_dict[t1]["q"] * self.drude_dict[t2]["q"]
+        s = 0.5 * (self.drude_dict[t1]["thole_damping"] + self.drude_dict[t2]["thole_damping"]
+                   ) / (self.drude_dict[t1]["alpha"] * self.drude_dict[t2]["alpha"])**(1.0 / 6.0)
+
+        system.non_bonded_inter[t1, t2].thole.set_params(
+            scaling_coeff=s, q1q2=qq)
+
         if verbose:
-            print("Added drude-core SR bond", bond,
-                  "between ids", drude_id, "and", core_id)
+            print("Added THOLE non-bonded interaction for types",
+                  t1, "<->", t2, "S", s, "q1q2", qq)
 
+    def add_all_thole(self, system, verbose=False):
+        """
+        Calls :meth:`add_thole_pair_damping()` for all necessary combinations to
+        create the interactions.
 
-def setup_intramol_exclusion_bonds(system, mol_drude_types, mol_core_types,
-                                   mol_core_partial_charges, verbose=False):
-    """
-    Creates electrostatic short-range exclusion bonds for intramolecular exclusion
-    between Drude particles and partial charges of the cores. Has to be called once
-    after all Drude particles have been created.
+        Parameters
+        ----------
 
-    Parameters
-    ----------
+        system : :class:`espressomd.system.System`
+        verbose : :obj:`bool`
+            Turns on verbosity.
 
-    system : :class:`espressomd.system.System`
-    mol_drude_types :
-        List of types of Drude particles within the molecule
-    mol_core_types :
-        List of types of core particles within the molecule
-    mol_core_partial_charges :
-        List of partial charges of core particles within the molecule
-    verbose : :obj:`bool`
-        Turns on verbosity.
+        """
 
-    """
+        # Drude <-> Drude
+        for i in range(len(self.drude_type_list)):
+            for j in range(i, len(self.drude_type_list)):
+                self.add_thole_pair_damping(
+                    system, self.drude_type_list[i], self.drude_type_list[j], verbose)
+        # core <-> core
+        for i in range(len(self.core_type_list)):
+            for j in range(i, len(self.core_type_list)):
+                self.add_thole_pair_damping(
+                    system, self.core_type_list[i], self.core_type_list[j], verbose)
+        # Drude <-> core
+        for i in self.drude_type_list:
+            for j in self.core_type_list:
+                self.add_thole_pair_damping(system, i, j, verbose)
 
-    # All Drude types need...
-    for td in mol_drude_types:
-        drude_dict[td]["subtr_sr_bonds_intramol"] = {}
+    def setup_and_add_drude_exclusion_bonds(self, system, verbose=False):
+        """
+        Creates electrostatic short-range exclusion bonds for global exclusion
+        between Drude particles and core charges and adds the bonds to the cores.
+        Has to be called once after all Drude particles have been created.
 
-        # ... sr exclusion bond with other partial core charges...
-        for tc, qp in zip(mol_core_types, mol_core_partial_charges):
-            # ...excluding the Drude core partner
-            if drude_dict[td]["core_type"] != tc:
-                qd = drude_dict[td]["q"]  # Drude charge
-                subtr_sr_bond = interactions.BondedCoulombSRBond(
-                    q1q2=-qd * qp)
-                system.bonded_inter.add(subtr_sr_bond)
-                drude_dict[td]["subtr_sr_bonds_intramol"][
-                    tc] = subtr_sr_bond
-                if verbose:
-                    print("Added intramolecular exclusion", subtr_sr_bond,
-                          "for drude", qd, "<-> core", qp, "to system")
+        Parameters
+        ----------
 
+        system : :class:`espressomd.system.System`
+        verbose: :obj:`bool`
+            Turns on verbosity.
 
-def add_intramol_exclusion_bonds(system, drude_ids, core_ids, verbose=False):
-    """
-    Applies electrostatic short-range exclusion bonds for the given ids.
-    Has to be applied for all molecules.
+        """
 
-    Parameters
-    ----------
+        # All Drude types need...
+        for td in self.drude_type_list:
 
-    system : :class:`espressomd.system.System`
-    drude_ids :
-        IDs of Drude particles within a molecule.
-    core_ids :
-        IDs of core particles within a molecule.
-    verbose : :obj:`bool`
-        Turns on verbosity.
+            # ...exclusions with core
+            qd = self.drude_dict[td]["q"]  # Drude charge
+            qc = self.drude_dict[td]["qc"]  # Core charge
+            subtr_sr_bond = interactions.BondedCoulombSRBond(
+                q1q2=-qd * qc)
+            system.bonded_inter.add(subtr_sr_bond)
+            self.drude_dict[td]["subtr_sr_bonds_drude-core"] = subtr_sr_bond
+            if verbose:
+                print("Added drude-core SR exclusion bond ",
+                      subtr_sr_bond, "for drude", qd, "<-> core", qc, "to system")
 
-    """
+        for drude_id in self.drude_id_list:
+            core_id = self.core_id_from_drude_id[drude_id]
+            pd = system.part[drude_id]
+            pc = system.part[core_id]
+            bond = self.drude_dict[pd.type]["subtr_sr_bonds_drude-core"]
+            pc.add_bond((bond, drude_id))
+            if verbose:
+                print("Added drude-core SR bond", bond,
+                      "between ids", drude_id, "and", core_id)
 
-    for drude_id in drude_ids:
-        for core_id in core_ids:
-            if core_id_from_drude_id[drude_id] != core_id:
-                pd = system.part[drude_id]
-                pc = system.part[core_id]
-                bond = drude_dict[pd.type][
-                    "subtr_sr_bonds_intramol"][pc.type]
-                pd.add_bond((bond, core_id))
-                if verbose:
-                    print("Added subtr_sr bond", bond,
-                          "between ids", drude_id, "and", core_id)
+    def setup_intramol_exclusion_bonds(self, system, mol_drude_types, mol_core_types,
+                                       mol_core_partial_charges, verbose=False):
+        """
+        Creates electrostatic short-range exclusion bonds for intramolecular exclusion
+        between Drude particles and partial charges of the cores. Has to be called once
+        after all Drude particles have been created.
+
+        Parameters
+        ----------
+
+        system : :class:`espressomd.system.System`
+        mol_drude_types :
+            List of types of Drude particles within the molecule
+        mol_core_types :
+            List of types of core particles within the molecule
+        mol_core_partial_charges :
+            List of partial charges of core particles within the molecule
+        verbose : :obj:`bool`
+            Turns on verbosity.
+
+        """
+
+        # All Drude types need...
+        for td in mol_drude_types:
+            self.drude_dict[td]["subtr_sr_bonds_intramol"] = {}
+
+            # ... sr exclusion bond with other partial core charges...
+            for tc, qp in zip(mol_core_types, mol_core_partial_charges):
+                # ...excluding the Drude core partner
+                if self.drude_dict[td]["core_type"] != tc:
+                    qd = self.drude_dict[td]["q"]  # Drude charge
+                    subtr_sr_bond = interactions.BondedCoulombSRBond(
+                        q1q2=-qd * qp)
+                    system.bonded_inter.add(subtr_sr_bond)
+                    self.drude_dict[td]["subtr_sr_bonds_intramol"][
+                        tc] = subtr_sr_bond
+                    if verbose:
+                        print("Added intramolecular exclusion", subtr_sr_bond,
+                              "for drude", qd, "<-> core", qp, "to system")
+
+    def add_intramol_exclusion_bonds(
+            self, drude_parts, core_parts, verbose=False):
+        """
+        Applies electrostatic short-range exclusion bonds for the given ids.
+        Has to be applied for all molecules.
+
+        Parameters
+        ----------
+
+        system : :class:`espressomd.system.System`
+        drude_parts :
+            List of Drude particles within a molecule.
+        core_parts :
+            List of core particles within a molecule.
+        verbose : :obj:`bool`
+            Turns on verbosity.
+
+        """
+
+        for drude_part in drude_parts:
+            drude_id = drude_part.id
+            for core_part in core_parts:
+                core_id = core_part.id
+                if self.core_id_from_drude_id[drude_id] != core_id:
+                    pd = drude_part
+                    pc = core_part
+                    bond = self.drude_dict[pd.type][
+                        "subtr_sr_bonds_intramol"][pc.type]
+                    pd.add_bond((bond, core_id))
+                    if verbose:
+                        print("Added subtr_sr bond", bond,
+                              "between ids", drude_id, "and", core_id)

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -23,6 +23,7 @@ import espressomd.checkpointing
 import espressomd.electrostatics
 import espressomd.magnetostatics
 import espressomd.interactions
+import espressomd.drude_helpers
 import espressomd.virtual_sites
 import espressomd.accumulators
 import espressomd.observables
@@ -214,6 +215,11 @@ if 'THERM.LB' not in modes:
         r_cut=2, seed=51)
     system.bonded_inter.add(thermalized_bond)
     p2.add_bond((thermalized_bond, p1))
+    if espressomd.has_features(['ELECTROSTATICS', 'MASS']):
+        dh = espressomd.drude_helpers.DrudeHelpers()
+        dh.add_drude_particle_to_core(system, harmonic_bond, thermalized_bond,
+                                      p2, 10, 1., 4.6, 0.8, 2.)
+        checkpoint.register("dh")
 strong_harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0.0, k=5e5)
 system.bonded_inter.add(strong_harmonic_bond)
 p4.add_bond((strong_harmonic_bond, p3))

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -303,6 +303,25 @@ class CheckpointTest(ut.TestCase):
             state = system.part[1].bonds[1][0].params
             self.assertEqual(state, reference)
 
+    @ut.skipIf('THERM.LB' in modes, 'LB thermostat in modes')
+    @utx.skipIfMissingFeatures(['MASS'])
+    def test_drude_helpers(self):
+        drude_type = 10
+        core_type = 0
+        self.assertIn(drude_type, dh.drude_dict)
+        self.assertEqual(dh.drude_dict[drude_type]['alpha'], 1.)
+        self.assertEqual(dh.drude_dict[drude_type]['thole_damping'], 2.)
+        self.assertEqual(dh.drude_dict[drude_type]['core_type'], core_type)
+        self.assertIn(core_type, dh.drude_dict)
+        self.assertEqual(dh.drude_dict[core_type]['alpha'], 1.)
+        self.assertEqual(dh.drude_dict[core_type]['thole_damping'], 2.)
+        self.assertEqual(dh.drude_dict[core_type]['drude_type'], drude_type)
+        self.assertEqual(len(dh.drude_dict), 2)
+        self.assertEqual(dh.core_type_list, [core_type])
+        self.assertEqual(dh.drude_type_list, [drude_type])
+        self.assertEqual(dh.core_id_from_drude_id, {5: 1})
+        self.assertEqual(dh.drude_id_list, [5])
+
     @utx.skipIfMissingFeatures(['VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE'])
     def test_virtual_sites(self):
         self.assertTrue(system.part[1].virtual)


### PR DESCRIPTION
Fixes #4224, partial fix for #3992

Description of changes:
- gather the Drude helpers global variables and free functions in a checkpointable class `DrudeHelpers`
- make the helper functions take particle handles instead of particle ids as arguments