### PR TITLE
Widom excess chemical potential calculation and RxMC performance improvement

### DIFF
--- a/samples/widom_insertion.py
+++ b/samples/widom_insertion.py
@@ -118,18 +118,21 @@ system.setup_type_map([0, 1, 2])
 # up the simulation
 widom.set_non_interacting_type(max(types) + 1)
 
-n_iterations = 100
+particle_insertion_potential_energy_samples = []
+
+n_iterations = 500
 for i in range(n_iterations):
-    for j in range(50):
-        widom.measure_excess_chemical_potential(insertion_reaction_id)
+    particle_insertion_potential_energy_samples.append(
+        widom.calculate_particle_insertion_potential_energy(0))
     system.integrator.run(steps=500)
+
     if i % 20 == 0:
-        print("mu_ex_pair ({:.4f}, +/- {:.4f})".format(
-            *widom.measure_excess_chemical_potential(insertion_reaction_id)))
         print(f"HA {system.number_of_particles(type=0)}",
               f"A- {system.number_of_particles(type=1)}",
               f"H+ {system.number_of_particles(type=2)}")
 
+mu_ex_mean, mu_ex_Delta = widom.calculate_excess_chemical_potential(
+    particle_insertion_potential_energy_samples=particle_insertion_potential_energy_samples)
 
-print("excess chemical potential for an ion pair ",
-      widom.measure_excess_chemical_potential(insertion_reaction_id))
+print(
+    f"excess chemical potential for an ion pair {mu_ex_mean:.4g} +/- {mu_ex_Delta:.4g}")

--- a/src/core/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.hpp
@@ -98,7 +98,26 @@ public:
 
 protected:
   std::vector<int> m_empty_p_ids_smaller_than_max_seen_particle;
-  void generic_oneway_reaction(SingleReaction &current_reaction);
+  /**
+   * @brief Carry out a generic one-way chemical reaction.
+   *
+   * Generic one way reaction of the type
+   * <tt>A+B+...+G +... --> K+...X + Z +...</tt>
+   * You need to use <tt>2A --> B</tt> instead of <tt>A+A --> B</tt> since
+   * in the latter you assume distinctness of the particles, however both
+   * ways to describe the reaction are equivalent in the thermodynamic limit
+   * (large particle numbers). Furthermore, it is crucial for the function
+   * in which order you provide the reactant and product types since particles
+   * will be replaced correspondingly! If there are less reactants than
+   * products, new product particles are created randomly in the box.
+   * Matching particles simply change the types. If there are more reactants
+   * than products, old reactant particles are deleted.
+   *
+   * @param[in,out] current_reaction  The reaction to attempt.
+   * @param[in,out] E_pot_old         The current potential energy.
+   */
+  void generic_oneway_reaction(SingleReaction &current_reaction,
+                               double &E_pot_old);
 
   std::tuple<std::vector<StoredParticleProperty>, std::vector<int>,
              std::vector<StoredParticleProperty>>

--- a/src/core/reaction_methods/WidomInsertion.hpp
+++ b/src/core/reaction_methods/WidomInsertion.hpp
@@ -29,8 +29,8 @@ namespace ReactionMethods {
 class WidomInsertion : public ReactionAlgorithm {
 public:
   WidomInsertion(int seed) : ReactionAlgorithm(seed) {}
-  std::pair<double, double>
-  measure_excess_chemical_potential(SingleReaction &current_reaction);
+  double calculate_particle_insertion_potential_energy(
+      SingleReaction &current_reaction);
 };
 
 } // namespace ReactionMethods

--- a/src/core/reaction_methods/tests/ReactionEnsemble_test.cpp
+++ b/src/core/reaction_methods/tests/ReactionEnsemble_test.cpp
@@ -28,8 +28,11 @@
 #include "reaction_methods/ReactionEnsemble.hpp"
 #include "reaction_methods/utils.hpp"
 
+#include "EspressoSystemStandAlone.hpp"
 #include "communication.hpp"
 #include "particle_data.hpp"
+
+#include <utils/Vector.hpp>
 
 #include <boost/mpi.hpp>
 
@@ -39,6 +42,11 @@
 #include <memory>
 #include <stdexcept>
 
+namespace espresso {
+// ESPResSo system instance
+std::unique_ptr<EspressoSystemStandAlone> system;
+} // namespace espresso
+
 // Check the Monte Carlo algorithm where moves depend on the system
 // configuration and energy.
 BOOST_AUTO_TEST_CASE(ReactionEnsemble_test) {
@@ -46,47 +54,101 @@ BOOST_AUTO_TEST_CASE(ReactionEnsemble_test) {
   class ReactionEnsembleTest : public ReactionEnsemble {
   public:
     using ReactionEnsemble::calculate_acceptance_probability;
+    using ReactionEnsemble::generic_oneway_reaction;
     using ReactionEnsemble::ReactionEnsemble;
   };
   constexpr double tol = 100 * std::numeric_limits<double>::epsilon();
 
-  ReactionEnsembleTest r_algo(42);
-  r_algo.volume = 10.;
-  r_algo.kT = 20.;
+  // check basic interface
+  {
+    ReactionEnsembleTest r_algo(42);
+    r_algo.volume = 10.;
+    r_algo.kT = 20.;
 
-  // exception if no reaction was added
-  BOOST_CHECK_THROW(r_algo.check_reaction_method(), std::runtime_error);
+    // exception if no reaction was added
+    BOOST_CHECK_THROW(r_algo.check_reaction_method(), std::runtime_error);
 
-  // create a reaction A -> 3 B + 4 C
-  int const type_A = 0;
-  int const type_B = 1;
-  int const type_C = 2;
-  SingleReaction const reaction(2., {type_A}, {1}, {type_B, type_C}, {3, 4});
+    // create a reaction A -> 3 B + 4 C
+    int const type_A = 0;
+    int const type_B = 1;
+    int const type_C = 2;
+    SingleReaction const reaction(2., {type_A}, {1}, {type_B, type_C}, {3, 4});
 
-  // check acceptance probability
-  constexpr auto g = factorial_Ni0_divided_by_factorial_Ni0_plus_nu_i;
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      for (int k = 0; k < 3; ++k) {
-        // system contains i x A, j x B, and k x C
-        auto const p_numbers =
-            std::map<int, int>{{type_A, i}, {type_B, j}, {type_C, k}};
-        auto const energy = static_cast<double>(i + 1);
-        auto const f_expr = calculate_factorial_expression(reaction, p_numbers);
-        // acceptance = V^{nu_bar} * gamma * f_expr * exp(- E / T)
-        auto const acceptance_ref = std::pow(r_algo.volume, reaction.nu_bar) *
-                                    reaction.gamma * f_expr *
-                                    std::exp(energy / r_algo.kT);
-        auto const acceptance = r_algo.calculate_acceptance_probability(
-            reaction, energy, 0., p_numbers);
-        BOOST_CHECK_CLOSE(acceptance, acceptance_ref, 5 * tol);
+    // check acceptance probability
+    constexpr auto g = factorial_Ni0_divided_by_factorial_Ni0_plus_nu_i;
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        for (int k = 0; k < 3; ++k) {
+          // system contains i x A, j x B, and k x C
+          auto const p_numbers =
+              std::map<int, int>{{type_A, i}, {type_B, j}, {type_C, k}};
+          auto const energy = static_cast<double>(i + 1);
+          auto const f_expr =
+              calculate_factorial_expression(reaction, p_numbers);
+          // acceptance = V^{nu_bar} * gamma * f_expr * exp(- E / T)
+          auto const acceptance_ref = std::pow(r_algo.volume, reaction.nu_bar) *
+                                      reaction.gamma * f_expr *
+                                      std::exp(energy / r_algo.kT);
+          auto const acceptance = r_algo.calculate_acceptance_probability(
+              reaction, energy, 0., p_numbers);
+          BOOST_CHECK_CLOSE(acceptance, acceptance_ref, 5 * tol);
+        }
       }
     }
+  }
+
+  // check that the system energy is updated after a succesful reaction
+  {
+    ReactionEnsembleTest test_reaction(42);
+    test_reaction.volume = 1.;
+    test_reaction.kT = 1.;
+    test_reaction.exclusion_radius = 0;
+
+    // create a generic identity exchange reaction D <-> E
+    int const type_D = 0;
+    int const type_E = 1;
+
+    test_reaction.charges_of_types[type_D] = 0;
+    test_reaction.charges_of_types[type_E] = 0;
+
+    // track particles
+    init_type_map(type_D);
+    init_type_map(type_E);
+
+    auto const gamma = 1e100; // reaction completly shifted to product creation
+    ReactionMethods::SingleReaction reaction(gamma, {type_D}, {1}, {type_E},
+                                             {1});
+
+    // resize system box
+    auto const box_l = Utils::Vector3d{0.5, 0.4, 0.7};
+    espresso::system->set_box_l(box_l);
+
+    // create a D particle in the system
+    auto const pid = 0;
+    auto const ref_position = Utils::Vector3d{0.1, 0.2, 0.3};
+    place_particle(pid, ref_position);
+    set_particle_type(pid, type_D);
+
+    // sentinel value to check energies get updated
+    double energy = 1.0;
+
+    // for an ideal system with gamma ~ inf, the reaction is always accepted
+    test_reaction.generic_oneway_reaction(reaction, energy);
+
+    // the potential energy of the new state has to be 0 since it is an ideal
+    // system
+    double const energy_ref = 0.0;
+    BOOST_CHECK_CLOSE(energy, energy_ref, tol);
+
+    // the reaction was updated
+    BOOST_CHECK_EQUAL(reaction.tried_moves, 1);
+    BOOST_CHECK_EQUAL(reaction.accepted_moves, 1);
   }
 }
 
 int main(int argc, char **argv) {
   auto mpi_env = std::make_shared<boost::mpi::environment>(argc, argv);
+  espresso::system = std::make_unique<EspressoSystemStandAlone>(argc, argv);
   Communication::init(mpi_env);
 
   return boost::unit_test::unit_test_main(init_unit_test, argc, argv);

--- a/src/python/espressomd/reaction_ensemble.pxd
+++ b/src/python/espressomd/reaction_ensemble.pxd
@@ -73,4 +73,4 @@ cdef extern from "reaction_methods/WidomInsertion.hpp" namespace "ReactionMethod
 
     cdef cppclass CWidomInsertion "ReactionMethods::WidomInsertion"(CReactionAlgorithm):
         CWidomInsertion(int seed)
-        pair[double, double] measure_excess_chemical_potential(SingleReaction & current_reaction) except +
+        double calculate_particle_insertion_potential_energy(SingleReaction & current_reaction) except +

--- a/testsuite/python/widom_insertion.py
+++ b/testsuite/python/widom_insertion.py
@@ -94,19 +94,28 @@ class WidomInsertionTest(ut.TestCase):
             default_charges={self.TYPE_HA: self.CHARGE_HA})
 
     def test_widom_insertion(self):
-        num_samples = 100000
+
+        num_samples = 10000
+        particle_insertion_potential_energy_samples = []
+
         for _ in range(num_samples):
             # 0 for insertion reaction
-            self.Widom.measure_excess_chemical_potential(0)
-        mu_ex = self.Widom.measure_excess_chemical_potential(0)
-        deviation_mu_ex = abs(mu_ex[0] - self.target_mu_ex)
+            particle_insertion_potential_energy = self.Widom.calculate_particle_insertion_potential_energy(
+                0)
+            particle_insertion_potential_energy_samples.append(
+                particle_insertion_potential_energy)
+
+        mu_ex_mean, mu_ex_Delta = self.Widom.calculate_excess_chemical_potential(
+            particle_insertion_potential_energy_samples=particle_insertion_potential_energy_samples)
+
+        deviation_mu_ex = abs(np.mean(mu_ex_mean) - self.target_mu_ex)
 
         self.assertLess(
             deviation_mu_ex,
             1e-3,
             msg="\nExcess chemical potential for single LJ-particle computed via Widom insertion is wrong.\n"
-            + f"  average mu_ex: {mu_ex[0]:.4f}"
-            + f"   mu_ex_std_err: {mu_ex[1]:.5f}"
+            + f"  average mu_ex: {np.mean(mu_ex_mean):.4f}"
+            + f"   mu_ex_std_err: {np.std(mu_ex_Delta):.5f}"
             + f"  target_mu_ex: {self.target_mu_ex:.4f}"
         )
 


### PR DESCRIPTION
Description of changes:
-  `WidomInsertion.measure_excess_chemical_potential()` was replaced by `WidomInsertion.calculate_excess_chemical_potential()` which returns the instantaneous value of the excess chemical potential instead of the accumulated mean and std. The mean value and std of the excess chemical potential must be now be calculated by the user elsewhere. An example of how to do it is given in `samples/widom_insertion.py`.
- `ReactionAlgorithm::do_reaction()` now only computes the potential energy of the old state at the begininng of the reaction loop. This value is updated after each successful reaction trial move.