### PR TITLE
Add Sphinx toggleprompt plugin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: docker.pkg.github.com/espressomd/docker/ubuntu-20.04:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
+image: docker.pkg.github.com/espressomd/docker/ubuntu-20.04:254edd4a9c6e4d7b557be73158e400f5794e4f99
 
 stages:
   - prepare

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: docker.pkg.github.com/espressomd/docker/ubuntu-20.04:738c3dfe015626632d16bcd816ad4aa670955c21
+image: docker.pkg.github.com/espressomd/docker/ubuntu-20.04:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
 
 stages:
   - prepare
@@ -127,7 +127,7 @@ no_rotation:
 ubuntu:wo-dependencies:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/ubuntu-wo-dependencies:738c3dfe015626632d16bcd816ad4aa670955c21
+  image: docker.pkg.github.com/espressomd/docker/ubuntu-wo-dependencies:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
   variables:
      myconfig: 'maxset'
      with_cuda: 'false'
@@ -145,7 +145,7 @@ ubuntu:wo-dependencies:
 debian:10:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/debian:08d67d67a4d3c3279cacee975b68c02ec89b2a21
+  image: docker.pkg.github.com/espressomd/docker/debian:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
   variables:
      with_cuda: 'false'
      myconfig: 'maxset'
@@ -157,10 +157,10 @@ debian:10:
     - docker
     - linux
 
-fedora:32:
+fedora:34:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/fedora:08d67d67a4d3c3279cacee975b68c02ec89b2a21
+  image: docker.pkg.github.com/espressomd/docker/fedora:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
   variables:
      with_cuda: 'false'
      myconfig: 'maxset'
@@ -171,21 +171,6 @@ fedora:32:
   tags:
     - docker
     - linux
-
-fedora:latest:
-  <<: *global_job_definition
-  stage: build
-  image: docker.pkg.github.com/espressomd/docker/fedora:latest_base
-  variables:
-     with_cuda: 'false'
-     myconfig: 'maxset'
-     make_check_python: 'false'
-  script:
-    - bash maintainer/CI/build_cmake.sh
-  tags:
-    - docker
-    - linux
-  when: manual
 
 ### Builds with CUDA
 
@@ -216,7 +201,7 @@ clang-sanitizer:
 fast_math:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/cuda:738c3dfe015626632d16bcd816ad4aa670955c21
+  image: docker.pkg.github.com/espressomd/docker/cuda:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'
@@ -237,7 +222,7 @@ fast_math:
 cuda11-maxset:
   <<: *global_job_definition
   stage: build
-  image: docker.pkg.github.com/espressomd/docker/cuda:738c3dfe015626632d16bcd816ad4aa670955c21
+  image: docker.pkg.github.com/espressomd/docker/cuda:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.doctest',
     'sphinxcontrib.bibtex',
+    'sphinx_toggleprompt',
     'sphinx.ext.napoleon'
 ]
 

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -24,7 +24,7 @@ sys.path.insert(0, '@CMAKE_BINARY_DIR@/src/python')
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '2.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -120,7 +120,6 @@ required to compile |es| on other Linux distributions:
 
 * `Fedora <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-fedora>`_
 * `Debian <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-debian>`_
-* `OpenSUSE <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-opensuse>`_
 
 .. _Installing requirements on Windows via WSL:
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -88,7 +88,7 @@ are required:
 .. code-block:: bash
 
     sudo apt install python3-matplotlib python3-pint python3-tqdm ipython3 jupyter-notebook
-    pip3 install --user 'jupyter_contrib_nbextensions==0.5.1' 'MDAnalysis>=1.0.0' \
+    pip3 install --user 'jupyter_contrib_nbextensions==0.5.1' 'MDAnalysis>=1.0.0,<2.0.0' \
                         'sphinx>=2.3.0,!=3.0.0' 'sphinxcontrib-bibtex>=0.3.5' 'sphinx-toggleprompt==0.0.5'
     jupyter contrib nbextension install --user
     jupyter nbextension enable rubberband/main

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -89,7 +89,7 @@ are required:
 
     sudo apt install python3-matplotlib python3-pint python3-tqdm ipython3 jupyter-notebook
     pip3 install --user 'jupyter_contrib_nbextensions==0.5.1' 'MDAnalysis>=1.0.0' \
-                        'sphinx>=2.3.0,!=3.0.0' 'sphinxcontrib-bibtex>=0.3.5'
+                        'sphinx>=2.3.0,!=3.0.0' 'sphinxcontrib-bibtex>=0.3.5' 'sphinx-toggleprompt==0.0.5'
     jupyter contrib nbextension install --user
     jupyter nbextension enable rubberband/main
     jupyter nbextension enable exercise2/main

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ requests>=2.18.4 # to post on GitHub as espresso-ci
 lxml>=4.2.1 # to deploy tutorials
 # sphinx and its dependencies
 sphinx>=2.3.0,!=3.0.0
+sphinx-toggleprompt==0.0.5
 sphinxcontrib-bibtex>=0.3.5
 # jupyter dependencies
 jupyter_contrib_nbextensions==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.17.4
 h5py>=2.7.1
 # optional scientific packages
 scipy>=1.4.0
-MDAnalysis>=1.0.0
+MDAnalysis>=1.0.0,<2.0.0
 pint>=0.10.1
 # optional packages for graphics and external devices
 matplotlib>=3.1.2

--- a/src/python/espressomd/MDA_ESP/__init__.py
+++ b/src/python/espressomd/MDA_ESP/__init__.py
@@ -50,7 +50,9 @@ except ImportError:
 import numpy as np
 import MDAnalysis
 
-from distutils.version import LooseVersion
+import setuptools
+assert setuptools.version.pkg_resources.packaging.specifiers.SpecifierSet('>=1.0.0,<2.0.0').contains(MDAnalysis.__version__), \
+    f'MDAnalysis version {MDAnalysis.__version__} is not supported'
 
 from MDAnalysis.lib import util
 from MDAnalysis.coordinates.core import triclinic_box


### PR DESCRIPTION
Description of changes:
- update docker images and remove unused rolling image (`fedora-latest`)
- add a button to hide output and prompt symbols in python code examples
- require a compatible MDAnalysis version when using `espressomd.MDA_ESP`