### PR TITLE
Script interface maintenance

### DIFF
--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -125,6 +125,10 @@ cmake_params="-DCMAKE_BUILD_TYPE=${build_type} -DCMAKE_CXX_STANDARD=${with_cxx_s
 cmake_params="${cmake_params} -DCMAKE_INSTALL_PREFIX=/tmp/espresso-unit-tests"
 cmake_params="${cmake_params} -DCTEST_ARGS=-j${check_procs} -DTEST_TIMEOUT=${test_timeout}"
 
+if [ "${make_check_benchmarks}" = true ]; then
+    cmake_params="${cmake_params} -DWITH_BENCHMARKS=ON"
+fi
+
 if [ "${with_ccache}" = true ]; then
     cmake_params="${cmake_params} -DWITH_CCACHE=ON"
 fi

--- a/maintainer/benchmarks/CMakeLists.txt
+++ b/maintainer/benchmarks/CMakeLists.txt
@@ -82,7 +82,7 @@ python_benchmark(FILE lj.py ARGUMENTS
                  "--particles_per_core=10000;--volume_fraction=0.50")
 python_benchmark(FILE lj.py ARGUMENTS
                  "--particles_per_core=10000;--volume_fraction=0.02")
-python_benchmark(FILE MC-acid-base-reservoir.py ARGUMENTS
+python_benchmark(FILE mc_acid_base_reservoir.py ARGUMENTS
                  "--particles_per_core=500;--mode=benchmark")
 python_benchmark(
   FILE lj.py ARGUMENTS

--- a/src/python/espressomd/collision_detection.pyx
+++ b/src/python/espressomd/collision_detection.pyx
@@ -173,7 +173,7 @@ class CollisionDetection(ScriptInterfaceHelper):
         if name == "mode":
             res = self._str_mode(value)
 
-        # Convert bond parameters from bond ids to into BondedInteractions
+        # Get bonded interaction
         if name in ["bond_centers", "bond_vs", "bond_three_particle_binding"]:
             if value == -1:  # Not defined
                 res = None

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -1911,6 +1911,7 @@ class HarmonicBond(BondedInteraction):
 
 if ELECTROSTATICS:
 
+    @script_interface_register
     class BondedCoulomb(BondedInteraction):
 
         """
@@ -1971,6 +1972,7 @@ if ELECTROSTATICS:
             return {}
 
 
+@script_interface_register
 class ThermalizedBond(BondedInteraction):
 
     """
@@ -2100,6 +2102,7 @@ IF THOLE:
 
 IF BOND_CONSTRAINT == 1:
 
+    @script_interface_register
     class RigidBond(BondedInteraction):
 
         """
@@ -2142,6 +2145,7 @@ ELSE:
         name = "RIGID"
 
 
+@script_interface_register
 class Dihedral(BondedInteraction):
 
     """
@@ -2223,6 +2227,7 @@ IF TABULATED:
             """
             return {}
 
+    @script_interface_register
     class TabulatedDistance(_TabulatedBase):
 
         """
@@ -2256,6 +2261,7 @@ IF TABULATED:
             """
             return "TABULATED_DISTANCE"
 
+    @script_interface_register
     class TabulatedAngle(_TabulatedBase):
 
         """
@@ -2298,6 +2304,7 @@ IF TABULATED:
                 raise ValueError(f"Tabulated angle expects forces/energies "
                                  f"within the range [0, pi], got {phi}")
 
+    @script_interface_register
     class TabulatedDihedral(_TabulatedBase):
 
         """
@@ -2419,6 +2426,7 @@ IF TABULATED:
                 return True
 
 
+@script_interface_register
 class Virtual(BondedInteraction):
 
     """
@@ -2446,6 +2454,7 @@ class Virtual(BondedInteraction):
         return {}
 
 
+@script_interface_register
 class AngleHarmonic(BondedInteraction):
 
     """
@@ -2478,6 +2487,7 @@ class AngleHarmonic(BondedInteraction):
         return {}
 
 
+@script_interface_register
 class AngleCosine(BondedInteraction):
 
     """
@@ -2510,6 +2520,7 @@ class AngleCosine(BondedInteraction):
         return {}
 
 
+@script_interface_register
 class AngleCossquare(BondedInteraction):
 
     """
@@ -2542,6 +2553,7 @@ class AngleCossquare(BondedInteraction):
         return {}
 
 
+@script_interface_register
 class IBM_Triel(BondedInteraction):
 
     """
@@ -2600,6 +2612,7 @@ class IBM_Triel(BondedInteraction):
              "elasticLaw": self.elasticLaw}
 
 
+@script_interface_register
 class IBM_Tribend(BondedInteraction):
 
     """
@@ -2650,6 +2663,7 @@ class IBM_Tribend(BondedInteraction):
         return {"kb": self.kb, "theta0": self.theta0}
 
 
+@script_interface_register
 class IBM_VolCons(BondedInteraction):
 
     """
@@ -2694,6 +2708,7 @@ class IBM_VolCons(BondedInteraction):
         return immersed_boundaries.get_current_volume(self.softID)
 
 
+@script_interface_register
 class OifGlobalForces(BondedInteraction):
 
     """
@@ -2733,6 +2748,7 @@ class OifGlobalForces(BondedInteraction):
         return {}
 
 
+@script_interface_register
 class OifLocalForces(BondedInteraction):
 
     """
@@ -2781,6 +2797,7 @@ class OifLocalForces(BondedInteraction):
         return {}
 
 
+@script_interface_register
 class QuarticBond(BondedInteraction):
 
     """

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -1735,7 +1735,7 @@ class BondedInteraction(ScriptInterfaceHelper):
 
     @params.setter
     def params(self, p):
-        raise Exception("Bonds are immutable.")
+        raise RuntimeError("Bond parameters are immutable.")
 
     def validate_params(self, params):
         """Check that parameters are valid.

--- a/src/python/espressomd/interactions.pyx
+++ b/src/python/espressomd/interactions.pyx
@@ -3001,7 +3001,7 @@ class BondedInteractions(ScriptObjectRegistry):
         return bond_id
 
     def __len__(self):
-        return bonded_ia_params_size()
+        return self.call_method('get_size')
 
     # Support iteration over active bonded interactions
     def __iter__(self):

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -1276,7 +1276,7 @@ cdef class ParticleHandle:
         # Validity of the numeric id
         if not bonded_ia_params_zero_based_type(bond[0]._bond_id):
             raise ValueError(
-                f"The bond type f{bond[0]._bond_id} does not exist.")
+                f"The bond type {bond[0]._bond_id} does not exist.")
 
         # Number of partners
         expected_num_partners = bond[0].call_method('get_num_partners')

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -334,7 +334,13 @@ class ScriptInterfaceHelper(PScriptInterface):
         if attr in self._valid_parameters():
             self.set_params(**{attr: value})
         else:
-            self.__dict__[attr] = value
+            super().__setattr__(attr, value)
+
+    def __delattr__(self, attr):
+        if attr in self._valid_parameters():
+            raise RuntimeError(f"Parameter '{attr}' is read-only")
+        else:
+            super().__delattr__(attr)
 
     def generate_caller(self, method_name):
         def template_method(**kwargs):

--- a/src/script_interface/Context.hpp
+++ b/src/script_interface/Context.hpp
@@ -97,6 +97,8 @@ public:
    */
   virtual boost::string_ref name(const ObjectHandle *o) const = 0;
 
+  virtual bool is_head_node() const = 0;
+
   virtual ~Context() = default;
 };
 } // namespace ScriptInterface

--- a/src/script_interface/ContextManager.cpp
+++ b/src/script_interface/ContextManager.cpp
@@ -55,7 +55,8 @@ std::string ContextManager::serialize(const ObjectHandle *o) const {
 
 ContextManager::ContextManager(Communication::MpiCallbacks &callbacks,
                                const Utils::Factory<ObjectHandle> &factory) {
-  auto local_context = std::make_shared<LocalContext>(factory);
+  auto const mpi_rank = callbacks.comm().rank();
+  auto local_context = std::make_shared<LocalContext>(factory, mpi_rank);
 
   /* If there is only one node, we can treat all objects as local, and thus
    * never invoke any callback. */

--- a/src/script_interface/GlobalContext.hpp
+++ b/src/script_interface/GlobalContext.hpp
@@ -68,6 +68,8 @@ private:
 
   std::shared_ptr<LocalContext> m_node_local_context;
 
+  bool m_is_head_node;
+
 private:
   Communication::CallbackHandle<ObjectId, const std::string &,
                                 const PackedMap &>
@@ -83,7 +85,8 @@ private:
 public:
   GlobalContext(Communication::MpiCallbacks &callbacks,
                 std::shared_ptr<LocalContext> node_local_context)
-      : m_node_local_context(std::move(node_local_context)),
+      : m_local_objects(), m_node_local_context(std::move(node_local_context)),
+        m_is_head_node(callbacks.comm().rank() == 0),
         cb_make_handle(&callbacks,
                        [this](ObjectId id, const std::string &name,
                               const PackedMap &parameters) {
@@ -157,6 +160,8 @@ public:
   make_shared(std::string const &name, const VariantMap &parameters) override;
 
   boost::string_ref name(const ObjectHandle *o) const override;
+
+  bool is_head_node() const override { return m_is_head_node; };
 };
 } // namespace ScriptInterface
 

--- a/src/script_interface/LocalContext.hpp
+++ b/src/script_interface/LocalContext.hpp
@@ -39,10 +39,11 @@ namespace ScriptInterface {
  */
 class LocalContext : public Context {
   Utils::Factory<ObjectHandle> m_factory;
+  bool m_is_head_node;
 
 public:
-  explicit LocalContext(Utils::Factory<ObjectHandle> factory)
-      : m_factory(std::move(factory)) {}
+  explicit LocalContext(Utils::Factory<ObjectHandle> factory, int mpi_rank)
+      : m_factory(std::move(factory)), m_is_head_node(mpi_rank == 0) {}
 
   const Utils::Factory<ObjectHandle> &factory() const { return m_factory; }
 
@@ -66,6 +67,8 @@ public:
 
     return factory().type_name(*o);
   }
+
+  bool is_head_node() const override { return m_is_head_node; };
 };
 } // namespace ScriptInterface
 

--- a/src/script_interface/interactions/BondedInteractions.hpp
+++ b/src/script_interface/interactions/BondedInteractions.hpp
@@ -67,6 +67,10 @@ public:
 
   Variant do_call_method(std::string const &name,
                          VariantMap const &params) override {
+    if (name == "get_size") {
+      return {static_cast<int>(::bonded_ia_params.size())};
+    }
+
     if (name == "get_bond_ids") {
       std::vector<int> bond_ids;
       for (auto const &kv : ::bonded_ia_params)

--- a/src/script_interface/interactions/BondedInteractions.hpp
+++ b/src/script_interface/interactions/BondedInteractions.hpp
@@ -22,7 +22,6 @@
 
 #include "BondedInteraction.hpp"
 
-#include "core/communication.hpp"
 #include "core/bonded_interactions/bonded_interaction_data.hpp"
 
 #include "script_interface/ObjectMap.hpp"
@@ -87,7 +86,7 @@ public:
       auto const bond_id = get_value<int>(params, "bond_id");
       // core and script interface must agree
       assert(m_bonds.count(bond_id) == ::bonded_ia_params.count(bond_id));
-      if (this_node != 0)
+      if (not context()->is_head_node())
         return {};
       // bond must exist
       if (m_bonds.count(bond_id) == 0) {

--- a/src/script_interface/interactions/bonded.hpp
+++ b/src/script_interface/interactions/bonded.hpp
@@ -35,9 +35,6 @@ inline int bonded_ia_params_zero_based_type(int bond_id) {
   return 0;
 }
 
-/** Return the total number of bonds. */
-inline int bonded_ia_params_size() { return bonded_ia_params.size(); }
-
 /** Return the next key. */
 inline int bonded_ia_params_next_key() {
   return bonded_ia_params.get_next_key();

--- a/src/script_interface/lbboundaries/LBBoundary.hpp
+++ b/src/script_interface/lbboundaries/LBBoundary.hpp
@@ -21,7 +21,6 @@
 
 #include "config.hpp"
 
-#include "core/communication.hpp"
 #include "core/grid_based_algorithms/lb_interface.hpp"
 #include "core/grid_based_algorithms/lbboundaries/LBBoundary.hpp"
 #include "script_interface/ScriptInterface.hpp"
@@ -69,7 +68,7 @@ public:
   Variant do_call_method(const std::string &name, const VariantMap &) override {
     if (name == "get_force") {
       // The get force method uses mpi callbacks on lb cpu
-      if (this_node == 0) {
+      if (context()->is_head_node()) {
         const auto agrid = lb_lbfluid_get_agrid();
         const auto tau = lb_lbfluid_get_tau();
         const double unit_conversion = agrid / tau / tau;

--- a/src/script_interface/object_container_mpi_guard.hpp
+++ b/src/script_interface/object_container_mpi_guard.hpp
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef ESPRESSO_OBJECT_CONTAINER_MPI_GUARD__HPP
+#define ESPRESSO_OBJECT_CONTAINER_MPI_GUARD__HPP
 
 #include <boost/utility/string_ref.hpp>
 
@@ -40,3 +42,5 @@
  */
 void object_container_mpi_guard(boost::string_ref const &name,
                                 std::size_t n_elements);
+
+#endif

--- a/src/script_interface/tests/GlobalContext_test.cpp
+++ b/src/script_interface/tests/GlobalContext_test.cpp
@@ -57,7 +57,7 @@ auto make_global_context(Communication::MpiCallbacks &cb) {
   factory.register_new<Dummy>("Dummy");
 
   return std::make_shared<si::GlobalContext>(
-      cb, std::make_shared<si::LocalContext>(factory));
+      cb, std::make_shared<si::LocalContext>(factory, 0));
 }
 
 BOOST_AUTO_TEST_CASE(GlobalContext_make_shared) {

--- a/src/script_interface/tests/LocalContext_test.cpp
+++ b/src/script_interface/tests/LocalContext_test.cpp
@@ -57,7 +57,7 @@ auto factory = []() {
 }();
 
 BOOST_AUTO_TEST_CASE(LocalContext_make_shared) {
-  auto ctx = std::make_shared<si::LocalContext>(factory);
+  auto ctx = std::make_shared<si::LocalContext>(factory, 0);
 
   auto res = ctx->make_shared("Dummy", {});
   BOOST_REQUIRE(res != nullptr);
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(LocalContext_make_shared) {
 }
 
 BOOST_AUTO_TEST_CASE(LocalContext_serialization) {
-  auto ctx = std::make_shared<si::LocalContext>(factory);
+  auto ctx = std::make_shared<si::LocalContext>(factory, 0);
 
   auto const serialized = [&]() {
     auto d1 = ctx->make_shared("Dummy", {});

--- a/src/script_interface/tests/ObjectHandle_test.cpp
+++ b/src/script_interface/tests/ObjectHandle_test.cpp
@@ -163,6 +163,8 @@ struct LogContext : public Context {
   boost::string_ref name(const ObjectHandle *o) const override {
     return "Dummy";
   }
+
+  bool is_head_node() const override { return true; };
 };
 
 /*

--- a/src/script_interface/tests/ObjectList_test.cpp
+++ b/src/script_interface/tests/ObjectList_test.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(serialization) {
   Utils::Factory<ObjectHandle> f;
   f.register_new<ObjectHandle>("ObjectHandle");
   f.register_new<ObjectListImpl>("ObjectList");
-  auto ctx = std::make_shared<LocalContext>(f);
+  auto ctx = std::make_shared<LocalContext>(f, 0);
   // A list of some elements
   auto list = std::dynamic_pointer_cast<ObjectListImpl>(
       ctx->make_shared("ObjectList", {}));

--- a/src/script_interface/tests/ObjectMap_test.cpp
+++ b/src/script_interface/tests/ObjectMap_test.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(serialization) {
   Utils::Factory<ObjectHandle> f;
   f.register_new<ObjectHandle>("ObjectHandle");
   f.register_new<ObjectMapImpl>("ObjectMap");
-  auto ctx = std::make_shared<LocalContext>(f);
+  auto ctx = std::make_shared<LocalContext>(f, 0);
   // A list of some elements
   auto map = std::dynamic_pointer_cast<ObjectMapImpl>(
       ctx->make_shared("ObjectMap", {}));

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -59,22 +59,24 @@ class BondedInteractions(ut.TestCase):
         classname = bondObject.__class__.__name__
         valid_keys = bondObject.valid_keys()
         required_keys = bondObject.required_keys()
+        old_params = bondObject.params.copy()
         default_keys = set(bondObject.get_default_params())
         self.assertIsInstance(valid_keys, set,
-                              "{}.valid_keys() must return a set".format(
-                                  classname))
+                              f"{classname}.valid_keys() must return a set")
         self.assertIsInstance(required_keys, set,
-                              "{}.required_keys() must return a set".format(
-                                  classname))
+                              f"{classname}.required_keys() must return a set")
         self.assertTrue(default_keys.issubset(valid_keys),
-                        "{}.get_default_params() has unknown parameters: {}".format(
-            classname, default_keys.difference(valid_keys)))
+                        f"{classname}.get_default_params() has unknown "
+                        f"parameters: {default_keys.difference(valid_keys)}")
         self.assertTrue(default_keys.isdisjoint(required_keys),
-                        "{}.get_default_params() has extra parameters: {}".format(
-            classname, default_keys.intersection(required_keys)))
+                        f"{classname}.get_default_params() has extra "
+                        f"parameters: {default_keys.intersection(required_keys)}")
         self.assertSetEqual(default_keys, valid_keys - required_keys,
-                            "{}.get_default_params() should have keys: {}, got: {}".format(
-                                classname, valid_keys - required_keys, default_keys))
+                            f"{classname}.get_default_params() should have keys: "
+                            f"{valid_keys - required_keys}, got: {default_keys}")
+        with self.assertRaisesRegex(RuntimeError, "Bond parameters are immutable"):
+            bondObject.params = {}
+        self.assertEqual(bondObject.params, old_params)
 
     def generateTestForBondParams(_bondId, _bondClass, _params, _refs=None):
         """Generates test cases for checking bond parameters set and gotten

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -220,11 +220,16 @@ class BondedInteractions(ut.TestCase):
             0, espressomd.interactions.BondedCoulombSRBond, params)(self)
 
     def test_exceptions(self):
+        error_msg_not_yet_defined = 'The bond with id 0 is not yet defined'
         bond_type = espressomd.interactions.get_bonded_interaction_type_from_es_core(
             5000)
         self.assertEqual(bond_type, 0)
-        with self.assertRaisesRegex(ValueError, 'The bonded interaction with the id 0 is not yet defined'):
+        has_bond = self.system.bonded_inter.call_method('has_bond', bond_id=0)
+        self.assertFalse(has_bond)
+        with self.assertRaisesRegex(ValueError, error_msg_not_yet_defined):
             self.system.bonded_inter[0]
+        with self.assertRaisesRegex(IndexError, error_msg_not_yet_defined):
+            self.system.bonded_inter.call_method('get_bond', bond_id=0)
 
         # bonds can only be overwritten by bonds of the same type
         harm_bond1 = espressomd.interactions.HarmonicBond(r_0=1., k=1.)
@@ -254,18 +259,17 @@ class BondedInteractions(ut.TestCase):
 
         # sanity checks when removing bonds
         self.system.bonded_inter.clear()
-        error_msg = 'The bonded interaction with the id 0 is not yet defined'
-        with self.assertRaisesRegex(ValueError, error_msg):
+        with self.assertRaisesRegex(ValueError, error_msg_not_yet_defined):
             self.system.bonded_inter[0]
         self.system.bonded_inter[0] = harm_bond1
         self.system.bonded_inter[0]
         self.system.bonded_inter.remove(0)
-        with self.assertRaisesRegex(ValueError, error_msg):
+        with self.assertRaisesRegex(ValueError, error_msg_not_yet_defined):
             self.system.bonded_inter[0]
         self.system.bonded_inter[0] = harm_bond1
         self.system.bonded_inter[0]
         del self.system.bonded_inter[0]
-        with self.assertRaisesRegex(ValueError, error_msg):
+        with self.assertRaisesRegex(ValueError, error_msg_not_yet_defined):
             self.system.bonded_inter[0]
 
 

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -59,9 +59,7 @@ class BondedInteractions(ut.TestCase):
         classname = bondObject.__class__.__name__
         valid_keys = bondObject.valid_keys()
         required_keys = bondObject.required_keys()
-        old_params = dict(bondObject.params)
         default_keys = set(bondObject.get_default_params())
-        bondObject.params = old_params
         self.assertIsInstance(valid_keys, set,
                               "{}.valid_keys() must return a set".format(
                                   classname))

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -308,6 +308,10 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(params2, reference2)
 
     def test_bonded_inter(self):
+        # check the ObjectHandle was correctly initialized (including MPI)
+        bond_ids = system.bonded_inter.call_method('get_bond_ids')
+        self.assertEqual(len(bond_ids), len(system.bonded_inter))
+        # check bonded interactions
         state = system.part[1].bonds[0][0].params
         reference = {'r_0': 0.0, 'k': 1.0, 'r_cut': 0.0}
         self.assertEqual(state, reference)
@@ -328,6 +332,11 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(
             ibm_triel_bond.params,
             {'k1': 1.1, 'k2': 1.2, 'maxDist': 1.6, 'elasticLaw': 'NeoHookean'})
+        # check new bonds can be added
+        new_harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0.2, k=1.)
+        system.bonded_inter.add(new_harmonic_bond)
+        bond_ids = system.bonded_inter.call_method('get_bond_ids')
+        self.assertEqual(len(bond_ids), len(system.bonded_inter))
 
     @ut.skipIf('THERM.LB' in modes, 'LB thermostat in modes')
     @utx.skipIfMissingFeatures(['ELECTROSTATICS', 'MASS', 'ROTATION'])


### PR DESCRIPTION
Description of changes:
- allow `@property`-setters in `ScriptInterfaceHelper` classes instead of silently skipping them
- unit test the `ScriptInterfaceHelper` class in python
- re-enable benchmark tests
- fix regressions introduced by #4350
- store bond objects in the ObjectMap (see https://github.com/espressomd/espresso/issues/4391#issuecomment-968664361)
- stop using the core global variable `this_node` in the script interface