### PR TITLE
Add short range neighbor methods

### DIFF
--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -56,6 +56,8 @@
 
 #include "Particle.hpp"
 
+#include <boost/optional.hpp>
+
 #include <utility>
 #include <vector>
 
@@ -115,6 +117,15 @@ get_pairs_of_types(double distance, std::vector<int> const &types);
 
 /** Check if a particle resorting is required. */
 void check_resort_particles();
+
+/**
+ * @brief Get ids of particles that are within a certain distance
+ * of another particle.
+ */
+std::vector<int> mpi_get_short_range_neighbors(int pid, double distance);
+boost::optional<std::vector<int>>
+mpi_get_short_range_neighbors_local(int pid, double distance,
+                                    bool run_sanity_checks);
 
 /**
  * @brief Find the cell in which a particle is stored.

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -128,3 +128,36 @@ double observable_compute_energy() {
   auto const obs_energy = calculate_energy();
   return obs_energy->accumulate(0);
 }
+
+double particle_short_range_energy_contribution_local(int pid) {
+  double ret = 0.0;
+
+  if (cell_structure.get_resort_particles()) {
+    cells_update_ghosts(global_ghost_flags());
+  }
+
+  auto const p = cell_structure.get_local_particle(pid);
+
+  if (p) {
+    auto kernel = [&ret](Particle const &p, Particle const &p1,
+                         Utils::Vector3d const &vec) {
+#ifdef EXCLUSIONS
+      if (not do_nonbonded(p, p1))
+        return;
+#endif
+      auto const &ia_params = *get_ia_param(p.type(), p1.type());
+      // Add energy for current particle pair to result
+      ret += calc_non_bonded_pair_energy(p, p1, ia_params, vec, vec.norm());
+    };
+    cell_structure.run_on_particle_short_range_neighbors(*p, kernel);
+  }
+  return ret;
+}
+
+REGISTER_CALLBACK_REDUCTION(particle_short_range_energy_contribution_local,
+                            std::plus<double>())
+
+double particle_short_range_energy_contribution(int pid) {
+  return mpi_call(Communication::Result::reduction, std::plus<double>(),
+                  particle_short_range_energy_contribution_local, pid);
+}

--- a/src/core/energy.hpp
+++ b/src/core/energy.hpp
@@ -42,4 +42,15 @@ double calculate_current_potential_energy_of_system();
 /** Helper function for @ref Observables::Energy. */
 double observable_compute_energy();
 
+/**
+ * @brief Compute short-range energy of a particle.
+ *
+ * Iterates through particles inside cell and neighboring cells and computes
+ * energy contribution for a specificparticle.
+ *
+ * @param pid    Particle id
+ * @return Non-bonded energy of the particle.
+ */
+double particle_short_range_energy_contribution(int pid);
+
 #endif

--- a/src/python/espressomd/analyze.pxd
+++ b/src/python/espressomd/analyze.pxd
@@ -40,6 +40,10 @@ cdef extern from "<array>" namespace "std" nogil:
         array2() except+
         double & operator[](size_t)
 
+cdef extern from "particle_data.hpp":
+    ctypedef struct particle "Particle"
+    const particle & get_particle_data(int pid) except +
+
 cdef extern from "PartCfg.hpp":
     cppclass PartCfg:
         pass
@@ -92,6 +96,7 @@ cdef extern from "pressure.hpp":
 cdef extern from "energy.hpp":
     cdef shared_ptr[Observable_stat] calculate_energy()
     double calculate_current_potential_energy_of_system()
+    double particle_short_range_energy_contribution(int pid)
 
 cdef extern from "dpd.hpp":
     Vector9d dpd_stress()

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -29,6 +29,7 @@ from .utils cimport Vector3i, Vector3d, Vector9d
 from .utils cimport make_Vector3d
 from .utils cimport make_array_locked
 from .utils cimport create_nparray_from_double_array
+from .particle_data cimport particle, ParticleHandle
 
 
 def autocorrelation(time_series):
@@ -343,6 +344,24 @@ class Analysis:
         obs = analyze.get_energy()
         utils.handle_errors("calculate_energy() failed")
         return obs
+
+    def particle_energy(self, particle):
+        """
+        Calculate the non-bonded energy of a single given particle.
+
+        Parameters
+        ----------
+        particle : :class:`~espressomd.particle_data.ParticleHandle`
+
+        Returns
+        -------
+        :obj: `float`
+            non-bonded energy of that particle
+
+        """
+        energy_contribution = particle_short_range_energy_contribution(
+            particle.id)
+        return energy_contribution
 
     def calc_re(self, chain_start=None, number_of_chains=None,
                 chain_length=None):

--- a/src/python/espressomd/cell_system.py
+++ b/src/python/espressomd/cell_system.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from . import utils
+from . import particle_data
 from .script_interface import ScriptInterfaceHelper, script_interface_register
 
 
@@ -176,6 +177,38 @@ class CellSystem(ScriptInterfaceHelper):
             raise ValueError("Argument 'types' must be an iterable")
         pairs = self.call_method("get_pairs", distance=distance, types=types)
         return [tuple(pair) for pair in pairs]
+
+    def get_neighbors(self, particle, distance):
+        """
+        Get neighbors of a given particle up to a certain distance.
+
+        The choice of :ref:`cell systems <Cell systems>` has an impact on
+        how far the algorithm can detect particle pairs:
+
+        * N-square: no restriction on the search distance, no double counting
+          if search distance is larger than the box size
+        * regular decomposition: the search distance is bounded by half
+          the local cell geometry
+        * hybrid decomposition: not supported
+
+        Parameters
+        ----------
+        particle : :class:`~espressomd.particle_data.ParticleHandle`
+        distance : :obj:`float`
+            Pairs of particles closer than ``distance`` are found.
+
+        Returns
+        -------
+        (N,) array_like of :obj:`int`
+            The list of neighbor particles surrounding the particle
+
+        """
+        utils.check_type_or_throw_except(
+            particle, 1, particle_data.ParticleHandle, "Parameter 'particle' must be a particle")
+        utils.check_type_or_throw_except(
+            distance, 1, float, "Parameter 'distance' must be a float")
+        return self.call_method(
+            "get_neighbors", distance=distance, pid=particle.id)
 
     def non_bonded_loop_trace(self):
         pairs = self.call_method("non_bonded_loop_trace")

--- a/src/python/espressomd/reaction_methods.py
+++ b/src/python/espressomd/reaction_methods.py
@@ -72,6 +72,13 @@ class ReactionAlgorithm(ScriptInterfaceHelper):
         Initial counter value (or seed) of the Mersenne Twister RNG.
     exclusion_radius_per_type : :obj:`dict`, optional
          Mapping of particle types to exclusion radii.
+    search_algorithm : :obj:`str`
+        Pair search algorithm. Default is ``"order_n"``, which evaluates the
+        distance between the inserted particle and all other particles in the
+        system, which scales with O(N). For MPI-parallel simulations, the
+        ``"parallel"`` method is faster. The ``"parallel"`` method is not
+        recommended for simulations on 1 MPI rank, since it comes with the
+        overhead of a ghost particle update.
 
     Methods
     -------
@@ -286,7 +293,8 @@ class ReactionAlgorithm(ScriptInterfaceHelper):
             utils.check_valid_keys(self.valid_keys(), kwargs.keys())
 
     def valid_keys(self):
-        return {"kT", "exclusion_range", "seed", "exclusion_radius_per_type"}
+        return {"kT", "exclusion_range", "seed",
+                "exclusion_radius_per_type", "search_algorithm"}
 
     def required_keys(self):
         return {"kT", "exclusion_range", "seed"}
@@ -409,7 +417,7 @@ class ConstantpHEnsemble(ReactionAlgorithm):
 
     def valid_keys(self):
         return {"kT", "exclusion_range", "seed",
-                "constant_pH", "exclusion_radius_per_type"}
+                "constant_pH", "exclusion_radius_per_type", "search_algorithm"}
 
     def required_keys(self):
         return {"kT", "exclusion_range", "seed", "constant_pH"}

--- a/src/script_interface/reaction_methods/ConstantpHEnsemble.hpp
+++ b/src/script_interface/reaction_methods/ConstantpHEnsemble.hpp
@@ -56,6 +56,9 @@ public:
         get_value<double>(params, "constant_pH"),
         get_value_or<std::unordered_map<int, double>>(
             params, "exclusion_radius_per_type", {}));
+    do_set_parameter("search_algorithm",
+                     Variant{get_value_or<std::string>(
+                         params, "search_algorithm", "order_n")});
   }
 
 private:

--- a/src/script_interface/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/script_interface/reaction_methods/ReactionAlgorithm.hpp
@@ -67,6 +67,24 @@ public:
             return out;
           }},
          {"kT", AutoParameter::read_only, [this]() { return RE()->get_kT(); }},
+         {"search_algorithm",
+          [this](Variant const &v) {
+            auto const key = get_value<std::string>(v);
+            if (key == "order_n") {
+              RE()->neighbor_search_order_n = true;
+            } else if (key == "parallel") {
+              RE()->neighbor_search_order_n = false;
+            } else {
+              throw std::invalid_argument("Unknown search algorithm '" + key +
+                                          "'");
+            }
+          },
+          [this]() {
+            if (RE()->neighbor_search_order_n) {
+              return std::string("order_n");
+            }
+            return std::string("parallel");
+          }},
          {"exclusion_range", AutoParameter::read_only,
           [this]() { return RE()->get_exclusion_range(); }},
          {"exclusion_radius_per_type",

--- a/src/script_interface/reaction_methods/ReactionEnsemble.hpp
+++ b/src/script_interface/reaction_methods/ReactionEnsemble.hpp
@@ -45,6 +45,9 @@ public:
         get_value<double>(params, "exclusion_range"),
         get_value_or<std::unordered_map<int, double>>(
             params, "exclusion_radius_per_type", {}));
+    do_set_parameter("search_algorithm",
+                     Variant{get_value_or<std::string>(
+                         params, "search_algorithm", "order_n")});
   }
 
 private:

--- a/src/script_interface/reaction_methods/WidomInsertion.hpp
+++ b/src/script_interface/reaction_methods/WidomInsertion.hpp
@@ -40,6 +40,15 @@ public:
     return m_re;
   }
 
+  WidomInsertion() {
+    add_parameters({{"search_algorithm",
+                     [](Variant const &) {
+                       throw std::runtime_error(
+                           "No search algorithm for WidomInsertion");
+                     },
+                     []() { return none; }}});
+  }
+
   void do_construct(VariantMap const &params) override {
     m_re = std::make_shared<::ReactionMethods::WidomInsertion>(
         get_value<int>(params, "seed"), get_value<double>(params, "kT"), 0.,

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -107,6 +107,8 @@ checkpoint_test(MODES therm_sdm__int_sdm)
 
 python_test(FILE bond_breakage.py MAX_NUM_PROC 4)
 python_test(FILE cell_system.py MAX_NUM_PROC 4)
+python_test(FILE get_neighbors.py MAX_NUM_PROC 4)
+python_test(FILE get_neighbors.py MAX_NUM_PROC 3 SUFFIX 3_cores)
 python_test(FILE tune_skin.py MAX_NUM_PROC 1)
 python_test(FILE constraint_homogeneous_magnetic_field.py MAX_NUM_PROC 4)
 python_test(FILE cutoffs.py MAX_NUM_PROC 4)

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -81,6 +81,9 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["kinetic"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
+        # Test the single particle energy function
+        self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
+            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
         # add another pair of particles
         self.system.part.add(pos=[3, 2, 2], type=1)
         self.system.part.add(pos=[4, 2, 2], type=1)
@@ -93,6 +96,9 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["non_bonded", 0, 0]
                                + energy["non_bonded", 0, 1]
                                + energy["non_bonded", 1, 1], energy["total"], delta=1e-7)
+        # Test the single particle energy function
+        self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
+            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
 
     def test_bonded(self):
         p0, p1 = self.system.part.all()
@@ -134,6 +140,8 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["kinetic"], 50., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 3. / 2., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
+        self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
+            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
         # two bonds
         p1.add_bond((self.harmonic, p0))
         energy = self.system.analysis.energy()
@@ -141,6 +149,8 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["kinetic"], 50., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 3., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
+        self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
+            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
         # add another pair of particles
         self.system.part.add(pos=[1, 5, 5], type=1)
         self.system.part.add(pos=[2, 5, 5], type=1)
@@ -150,6 +160,8 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["kinetic"], 50., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 3., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1. + 1., delta=1e-7)
+        self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
+            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
 
     @utx.skipIfMissingFeatures(["ELECTROSTATICS", "P3M"])
     def test_electrostatics(self):

--- a/testsuite/python/get_neighbors.py
+++ b/testsuite/python/get_neighbors.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2022 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest as ut
+import numpy as np
+import espressomd
+import espressomd.lees_edwards
+
+
+class Test(ut.TestCase):
+    system = espressomd.System(box_l=[1., 1., 1.])
+    system.cell_system.skin = 0.01
+    system.time_step = 0.01
+    n_nodes = system.cell_system.get_state()["n_nodes"]
+    node_grid = system.cell_system.node_grid
+
+    def setUp(self):
+        self.system.cell_system.set_regular_decomposition()
+        self.system.cell_system.node_grid = self.node_grid
+        self.system.periodicity = [True, True, True]
+
+    def tearDown(self):
+        self.system.part.clear()
+        self.system.lees_edwards.protocol = None
+
+    def get_neighbors_list(self, p1, dist):
+        result = []
+        for p2 in self.system.part.all():
+            if p1.id != p2.id and self.system.distance(p1, p2) <= dist:
+                result.append(p2.id)
+        return result
+
+    def check_neighbors(self, dist):
+        for p in self.system.part.all():
+            list_ref = np.sort(self.get_neighbors_list(p, dist))
+            list_core = np.sort(self.system.cell_system.get_neighbors(p, dist))
+            np.testing.assert_array_equal(list_core, list_ref)
+
+    @ut.skipIf(n_nodes == 1, "only runs for 2 or more MPI ranks")
+    def test_get_neighbors_different_domains(self):
+        system = self.system
+        get_neighbors = system.cell_system.get_neighbors
+        pos_red = system.box_l - 0.01
+        pos_black = np.array(3 * [0.01])
+        with self.subTest(msg='no ghost update required'):
+            # check particles on neighboring nodes
+            p1, p2 = system.part.add(id=[1, 2], pos=[pos_black, pos_red])
+            assert p1.node != p2.node
+            np.testing.assert_array_equal(get_neighbors(p1, 0.1), [2])
+            np.testing.assert_array_equal(get_neighbors(p2, 0.1), [1])
+        system.part.clear()
+        with self.subTest(msg='ghost update required'):
+            # check particles on the same node
+            p1, p2 = system.part.add(id=[1, 2], pos=[pos_black, pos_black])
+            assert p1.node == p2.node
+            np.testing.assert_array_equal(get_neighbors(p1, 0.1), [2])
+            np.testing.assert_array_equal(get_neighbors(p2, 0.1), [1])
+            # check after move to the same node
+            p2.pos = pos_black + [0.12, 0., 0.]
+            assert p1.node == p2.node
+            np.testing.assert_array_equal(get_neighbors(p1, 0.1), [])
+            np.testing.assert_array_equal(get_neighbors(p2, 0.1), [])
+            # check after move to a neighboring node (ghost update required)
+            p2.pos = pos_red
+            assert p1.node == p2.node  # ghosts not updated yet
+            np.testing.assert_array_equal(get_neighbors(p1, 0.1), [2])
+            np.testing.assert_array_equal(get_neighbors(p2, 0.1), [1])
+            # check after move to a neighboring node + forced ghost update
+            system.integrator.run(0, recalc_forces=False)
+            assert p1.node != p2.node
+            np.testing.assert_array_equal(get_neighbors(p1, 0.1), [2])
+            np.testing.assert_array_equal(get_neighbors(p2, 0.1), [1])
+
+    @ut.skipIf(n_nodes == 3, "Only runs if number of MPI cores is not 3")
+    def test_get_neighbors_random_positions(self):
+        system = self.system
+        system.part.add(pos=np.random.random((20, 3)) * system.box_l)
+        for _ in range(10):
+            system.part.all().pos = np.random.random((20, 3)) * system.box_l
+            self.check_neighbors(0.2)
+        system.part.clear()
+
+    def test_n_square(self):
+        """
+        Check the N-square system is supported. The search distance is not
+        bounded by the box size. No double counting occurs.
+        """
+        system = self.system
+        system.cell_system.set_n_square()
+        p1 = system.part.add(pos=[0., 0., 0.])
+        p2 = system.part.add(pos=[0., 0., 0.49])
+        self.assertEqual(system.cell_system.get_neighbors(p1, 0.5), [p2.id])
+        self.assertEqual(system.cell_system.get_neighbors(p1, 50.), [p2.id])
+
+    @ut.skipIf(n_nodes == 1, "Only runs if number of MPI cores is 2 or more")
+    def test_domain_decomposition(self):
+        """
+        Check the neighbor search distance is bounded by the regular
+        decomposition maximal range and that aperiodic systems are supported.
+        """
+        system = self.system
+        get_neighbors = system.cell_system.get_neighbors
+        local_box_l = np.copy(system.box_l / system.cell_system.node_grid)
+        max_range = np.min(local_box_l) / 2.
+        pos = np.array([0.01, 0.01, 0.01])
+        p1, p2 = system.part.add(pos=[pos, -pos])
+        self.check_neighbors(0.9999 * max_range)
+        with np.testing.assert_raises_regex(ValueError, "pair search distance .* bigger than the decomposition range"):
+            get_neighbors(p1, 1.0001 * max_range)
+
+        # change periodicity
+        pair_dist = np.linalg.norm(system.distance_vec(p1, p2))
+        self.assertEqual(get_neighbors(p1, 1.1 * pair_dist), [p2.id])
+        system.periodicity = [False, True, True]
+        self.assertEqual(get_neighbors(p1, 1.1 * pair_dist), [])
+
+    def test_hybrid_decomposition(self):
+        """
+        Set up colloids in a N-square cell system coupled to ions on a
+        regular decomposition cell system.
+        """
+        system = self.system
+        system.cell_system.set_hybrid_decomposition(
+            n_square_types={1}, cutoff_regular=0.1)
+        p_ion = system.part.add(pos=[0., 0., 0.], type=0)
+        p_colloid = system.part.add(pos=[0., 0., 0.], type=1)
+
+        msg = "Cannot search for neighbors in the hybrid decomposition cell system"
+        with np.testing.assert_raises_regex(RuntimeError, msg):
+            system.cell_system.get_neighbors(p_ion, 0.05)
+        with np.testing.assert_raises_regex(RuntimeError, msg):
+            system.cell_system.get_neighbors(p_colloid, 0.05)
+
+    def test_lees_edwards(self):
+        """
+        Check the Lees-Edwards position offset is taken into account
+        in the distance calculation.
+        """
+        system = self.system
+        system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+            initial_pos_offset=0.1, time_0=0., shear_velocity=1.0)
+        system.lees_edwards.shear_direction = 0
+        system.lees_edwards.shear_plane_normal = 2
+        p1 = system.part.add(pos=[0., 0., 0.])
+        p2 = system.part.add(pos=[0., 0., 0.99])
+        self.assertEqual(system.cell_system.get_neighbors(p1, 0.10), [])
+        self.assertEqual(system.cell_system.get_neighbors(p1, 0.15), [p2.id])
+
+
+if __name__ == "__main__":
+    ut.main()

--- a/testsuite/python/reaction_ensemble.py
+++ b/testsuite/python/reaction_ensemble.py
@@ -58,7 +58,7 @@ class ReactionEnsembleTest(ut.TestCase):
     product_types = [types["A-"], types["H+"]]
     product_coefficients = [1, 1]
     nubar = 1
-    system = espressomd.System(box_l=np.ones(3) * (N0 / c0)**(1.0 / 3.0))
+    system = espressomd.System(box_l=np.ones(3) * np.cbrt(N0 / c0))
     np.random.seed(69)  # make reaction code fully deterministic
     system.cell_system.skin = 0.4
     volume = system.volume()
@@ -68,8 +68,8 @@ class ReactionEnsembleTest(ut.TestCase):
     # degree of dissociation alpha = N_A / N_HA = N_H / N_0
     gamma = target_alpha**2 / (1. - target_alpha) * N0 / (volume**nubar)
     RE = espressomd.reaction_methods.ReactionEnsemble(
-        kT=temperature,
-        exclusion_range=exclusion_range, seed=12)
+        seed=12, kT=temperature,
+        exclusion_range=exclusion_range, search_algorithm="parallel")
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixes #4399, fixes #4438

Description of changes:
- `CellStructure.cpp`: Added the `CellStructure::run_on_particle_short_range_neighbors()` method which runs a kernel function over all particles inside the cell and its neighbors of a given particle
- `cells.hpp`: Added the `mpi_get_short_range_neighbors()` function to execute a parallel search
   - can be called from the Python interface via `system.cell_system.get_neighbors.get_neighbors(p, distance)`
- `energy.hpp`: Added the `compute_non_bonded_pair_energy()` function which returns both the short-range Coulomb interactions plus the non-bonded energy contributions  of two particles
   - can be called from the Python interface via `system.analysis.particle_energy(p)`
- Reaction methods can use the new neighbor search algorithm with constructor argument `search_algorithm="parallel"` (default is `search_algorithm="order_n"`); on 1 MPI rank the original order N algorithm is faster since the parallel algorithm introduces some overhead due to the ghost update (this overhead is negligible with 2 or more MPI ranks)