### PR TITLE
New particle access syntax

### DIFF
--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -41,7 +41,7 @@ Note that alternatively to particle handles, the particle's ids can be
 used to setup bonded interactions. For example, to create a bond between the
 particles with the ids 12 and 43::
 
-    system.part[12].add_bond((fene, 43))
+    system.part.by_id(12).add_bond((fene, 43))
 
 .. _Distance-dependent bonds:
 
@@ -492,7 +492,7 @@ where ``softID`` identifies the soft particle and ``kappaV`` is a volumetric
 spring constant. Note that this ``volCons`` bond does not have a bond partner.
 It is added to a particle as follows::
 
-    system.part[0].add_bond((volCons,))
+    system.part.by_id(0).add_bond((volCons,))
 
 The comma is needed to create a tuple containing a single item.
 

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -182,21 +182,21 @@ particles>` over all particles::
 
 Internally, each particle is automatically assigned a unique numerical id by |es|.
 Note that in principle it is possible to explicitly set this particle id (if not in use already) on particle creation.
-Using the id in square brackets, the respective particle can be accessed from the particle list::
+Using the id, the respective particle can be accessed from the particle list::
 
     >>> system.part.add(id=3, pos=[2.1, 1.2, 3.3], type=0)
-    >>> system.part[3].pos = [1.0, 1.0, 2.0]
-    >>> print(system.part[3])
+    >>> system.part.by_id(3).pos = [1.0, 1.0, 2.0]
+    >>> print(system.part.by_id(3).pos)
     [1.0, 1.0, 2.0]
 
 For larger simulation setups, explicit handling of numerical ids can quickly
 become confusing and is thus error-prone. We therefore highly recommend using
 :class:`~espressomd.particle_data.ParticleHandle` instead wherever possible.
 
-:ref:`Properties of several particles<Interacting with groups of particles>`
-can be accessed by using Python slices: ::
+:ref:`Properties of all particles<Interacting with groups of particles>`
+can be accessed via: ::
 
-    positions = system.part[:].pos
+    positions = system.part.all().pos
 
 .. rubric:: Interactions
 

--- a/doc/sphinx/io.rst
+++ b/doc/sphinx/io.rst
@@ -442,7 +442,7 @@ To read a PDB file containing a single frame::
     # create particles and add bonds between them
     system.part.add(pos=np.array(chainA.positions, dtype=float))
     for i in range(0, len(chainA) - 1):
-        system.part[i].add_bond((system.bonded_inter[0], system.part[i + 1].id))
+        system.part.by_id(i).add_bond((system.bonded_inter[0], i + 1))
     # visualize protein in 3D
     import espressomd.visualization
     visualizer = espressomd.visualization.openGLLive(system, bond_type_radius=[0.2])

--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -55,7 +55,7 @@ automatically. Alternatively, you can assign an id manually when adding them to 
 The id provides an alternative way to access particles in the system. To
 retrieve the handle of the particle with id ``INDEX``, call::
 
-    p = system.part[<INDEX>]
+    p = system.part.by_id(<INDEX>)
 
 .. _Accessing particle properties:
 
@@ -134,11 +134,11 @@ Exclusions do not apply to the short range part of electrostatics and magnetosta
 
 To create exclusions for particles pairs 0 and 1::
 
-    system.part[0].add_exclusion(1)
+    system.part.by_id(0).add_exclusion(1)
 
 To delete the exclusion::
 
-    system.part[0].delete_exclusion(1)
+    system.part.by_id(0).delete_exclusion(1)
 
 See :attr:`espressomd.particle_data.ParticleHandle.exclusions`
 
@@ -346,30 +346,19 @@ to retrieve a particle slice:
   When adding several particles at once, a particle slice is returned instead
   of a particle handle.
 
-- By slicing :py:attr:`espressomd.system.System.part`
+- By calling :meth:`espressomd.particle_data.ParticleList.by_ids`
 
-  The :class:`~espressomd.particle_data.ParticleList` supports slicing
-  similarly to lists and NumPy arrays, however with the distinction that
-  particle slices can have gaps.
+  It is also possible to get a slice containing particles of specific ids, e.g.::
 
-  Using a colon returns a slice containing all particles::
-
-      print(system.part[:])
-
-  To access particles with ids ranging from 0 to 9, use::
-
-      system.part[0:10]
-
-  Note that, like in other cases in Python, the lower bound is inclusive and
-  the upper bound is non-inclusive. The length of the slice does not have to
-  be 10, it can be for example 2 if there are only 2 particles in the system
-  with an id between 0 and 9.
-
-  It is also possible to get a slice containing particles of specific ids::
-
-      system.part[[1, 4, 3]]
+      system.part.by_ids([1, 4, 3])
 
   would contain the particles with ids 1, 4, and 3 in that specific order.
+  
+- By calling :meth:`espressomd.particle_data.ParticleList.all`
+
+  You can get a slice containing all particles using::
+
+      system.part.all()
 
 - By calling :meth:`espressomd.particle_data.ParticleList.select`
 
@@ -381,7 +370,7 @@ to retrieve a particle slice:
 Properties of particle slices can be accessed just like with single particles.
 A list of all values is returned::
 
-    print(system.part[:].q)
+    print(system.part.all().q)
 
 A particle slice can be iterated over, see :ref:`Iterating over particles and pairs of particles`.
 
@@ -389,27 +378,27 @@ Setting properties of slices can be done by
 
 - supplying a *single value* that is assigned to each entry of the slice, e.g.::
 
-      system.part[0:10].ext_force = [1, 0, 0]
+      system.part.by_ids(range(10)).ext_force = [1, 0, 0]
 
 - supplying an *array of values* that matches the length of the slice which sets each entry individually, e.g.::
 
-      system.part[0:3].ext_force = [[1, 0, 0], [2, 0, 0], [3, 0, 0]]
+      system.partby_ids(range(3)).ext_force = [[1, 0, 0], [2, 0, 0], [3, 0, 0]]
 
 For list properties that have no fixed length like ``exclusions`` or ``bonds``, some care has to be taken.
 There, *single value* assignment also accepts lists/tuples just like setting the property of an individual particle. For example::
 
-    system.part[0].exclusions = [1, 2]
+    system.part.by_id(0).exclusions = [1, 2]
 
 would both exclude short-range interactions of the particle pairs ``0 <-> 1`` and ``0 <-> 2``.
 Similarly, a list can also be assigned to each entry of the slice::
 
-    system.part[2:4].exclusions = [0, 1]
+    system.part.by_ids(range(2,4)).exclusions = [0, 1]
 
 This would exclude interactions between ``2 <-> 0``, ``2 <-> 1``, ``3 <-> 0`` and ``3 <-> 1``.
 Now when it is desired to supply an *array of values* with individual values for each slice entry, the distinction can no longer be done
 by the length of the input, as slice length and input length can be equal. Here, the nesting level of the input is the distinctive criterion::
 
-    system.part[2:4].exclusions = [[0, 1], [0, 1]]
+    system.part.by_ids(range(2,4)).exclusions = [[0, 1], [0, 1]]
 
 The above code snippet would lead to the same exclusions as the one before.
 The same accounts for the ``bonds`` property by interchanging the integer entries of the exclusion list with

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -258,7 +258,7 @@ force/torque observable used in the custom convergence criterion. Since these
 two properties can be cast to boolean values, they can be used as masks to
 remove forces/torques that are ignored by the integrator::
 
-    particles = system.part[:]
+    particles = system.part.all()
     max_force = np.max(np.linalg.norm(particles.f * np.logical_not(particles.fix), axis=1))
     max_torque = np.max(np.linalg.norm(particles.torque_lab * np.logical_not(particles.rotation), axis=1))
 
@@ -273,7 +273,7 @@ The correct forces need to be re-calculated after running the integration::
     p2 = system.part.add(pos=[0, 0, 0.1], type=1)
     p2.vs_auto_relate_to(p1)
     system.integrator.set_steepest_descent(f_max=800, gamma=1.0, max_displacement=0.01)
-    while convergence_criterion(system.part[:].f):
+    while convergence_criterion(system.part.all().f):
         system.integrator.run(10)
         system.integrator.run(0, recalc_forces=True)  # re-calculate forces from virtual sites
     system.integrator.set_vv()

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -73,7 +73,7 @@ Some variables like or are no longer directly available as attributes.
 In these cases they can be easily derived from the corresponding Python
 objects like::
 
-    n_part = len(system.part[:].pos)
+    n_part = len(system.part)
 
 or by calling the corresponding ``get_state()`` methods like::
 

--- a/doc/tutorials/charged_system/charged_system.ipynb
+++ b/doc/tutorials/charged_system/charged_system.ipynb
@@ -223,7 +223,7 @@
     "                          ROD_CHARGE_DENS, N_rod_beads, ROD_TYPE)\n",
     "\n",
     "# check that the particle setup was done correctly\n",
-    "assert abs(sum(system.part[:].q)) < 1e-10\n",
+    "assert abs(sum(system.part.all().q)) < 1e-10\n",
     "assert np.all(system.part.select(type=ROD_TYPE).fix)"
    ]
   },
@@ -303,7 +303,7 @@
     "\n",
     "    # Initialize integrator to obtain initial forces\n",
     "    system.integrator.run(0)\n",
-    "    maxforce = np.max(np.linalg.norm(system.part[:].f, axis=1))\n",
+    "    maxforce = np.max(np.linalg.norm(system.part.all().f, axis=1))\n",
     "    energy = system.analysis.energy()['total']\n",
     "\n",
     "    i = 0\n",
@@ -311,7 +311,7 @@
     "        prev_maxforce = maxforce\n",
     "        prev_energy = energy\n",
     "        system.integrator.run(sd_params['emstep'])\n",
-    "        maxforce = np.max(np.linalg.norm(system.part[:].f, axis=1))\n",
+    "        maxforce = np.max(np.linalg.norm(system.part.all().f, axis=1))\n",
     "        relforce = np.abs((maxforce - prev_maxforce) / prev_maxforce)\n",
     "        energy = system.analysis.energy()['total']\n",
     "        relener = np.abs((energy - prev_energy) / prev_energy)\n",
@@ -944,7 +944,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/ferrofluid/ferrofluid_part1.ipynb
+++ b/doc/tutorials/ferrofluid/ferrofluid_part1.ipynb
@@ -714,7 +714,7 @@
     "    system.integrator.run(100)\n",
     "\n",
     "    # Save current system state as a plot\n",
-    "    x_data, y_data = system.part[:].pos_folded[:, 0], system.part[:].pos_folded[:, 1]\n",
+    "    x_data, y_data = system.part.all().pos_folded[:, 0], system.part.all().pos_folded[:, 1]\n",
     "    ax.figure.canvas.draw()\n",
     "    part.set_data(x_data, y_data)\n",
     "    print(\"progress: {:3.0f}%\".format((i + 1) * 100. / LOOPS), end=\"\\r\")\n",
@@ -905,7 +905,7 @@
     "plt.ylim(0, BOX_SIZE)\n",
     "plt.xlabel('x-position', fontsize=20)\n",
     "plt.ylabel('y-position', fontsize=20)\n",
-    "plt.plot(system.part[:].pos_folded[:, 0], system.part[:].pos_folded[:, 1], 'o')\n",
+    "plt.plot(system.part.all().pos_folded[:, 0], system.part.all().pos_folded[:, 1], 'o')\n",
     "plt.show()"
    ]
   },
@@ -1026,7 +1026,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/ferrofluid/ferrofluid_part2.ipynb
+++ b/doc/tutorials/ferrofluid/ferrofluid_part2.ipynb
@@ -152,7 +152,7 @@
     "pos = box_size * np.hstack((np.random.random((N_PART, 2)), np.zeros((N_PART, 1))))\n",
     "\n",
     "# Add particles\n",
-    "system.part.add(pos=pos, rotation=N_PART * [(1, 1, 1)], dip=dip, fix=N_PART * [(0, 0, 1)])\n",
+    "particles = system.part.add(pos=pos, rotation=N_PART * [(True, True, True)], dip=dip, fix=N_PART * [(False, False, True)])\n",
     "\n",
     "# Remove overlap between particles by means of the steepest descent method\n",
     "system.integrator.set_steepest_descent(\n",
@@ -289,7 +289,7 @@
     "plt.ylim(0, box_size)\n",
     "plt.xlabel('x-position', fontsize=20)\n",
     "plt.ylabel('y-position', fontsize=20)\n",
-    "plt.plot(system.part[:].pos_folded[:, 0], system.part[:].pos_folded[:, 1], 'o')\n",
+    "plt.plot(particles.pos_folded[:, 0], particles.pos_folded[:, 1], 'o')\n",
     "plt.show()"
    ]
   },
@@ -351,7 +351,7 @@
     "    system.integrator.run(50)\n",
     "\n",
     "    # Save current system state as a plot\n",
-    "    xdata, ydata = system.part[:].pos_folded[:, 0], system.part[:].pos_folded[:, 1]\n",
+    "    xdata, ydata = particles.pos_folded[:, 0], particles.pos_folded[:, 1]\n",
     "    ax.figure.canvas.draw()\n",
     "    part.set_data(xdata, ydata)\n",
     "    print(\"progress: {:3.0f}%\".format(i + 1), end=\"\\r\")\n",
@@ -498,7 +498,7 @@
    "outputs": [],
    "source": [
     "# remove all particles\n",
-    "system.part[:].remove()\n",
+    "system.part.clear()\n",
     "system.thermostat.turn_off()\n",
     "\n",
     "# Random dipole moments\n",
@@ -514,7 +514,7 @@
     "pos = box_size * np.hstack((np.random.random((N_PART, 2)), np.zeros((N_PART, 1))))\n",
     "\n",
     "# Add particles\n",
-    "system.part.add(pos=pos, rotation=N_PART * [(1, 1, 1)], dip=dip, fix=N_PART * [(0, 0, 1)])\n",
+    "particles = system.part.add(pos=pos, rotation=N_PART * [(True, True, True)], dip=dip, fix=N_PART * [(False, False, True)])\n",
     "\n",
     "# Remove overlap between particles by means of the steepest descent method\n",
     "system.integrator.set_steepest_descent(f_max=0, gamma=0.1, max_displacement=0.05)\n",
@@ -570,7 +570,7 @@
    "source": [
     "```python\n",
     "import espressomd.observables\n",
-    "dipm_tot = espressomd.observables.MagneticDipoleMoment(ids=system.part[:].id)\n",
+    "dipm_tot = espressomd.observables.MagneticDipoleMoment(ids=particles.id)\n",
     "```"
    ]
   },
@@ -1041,7 +1041,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/ferrofluid/ferrofluid_part3.ipynb
+++ b/doc/tutorials/ferrofluid/ferrofluid_part3.ipynb
@@ -215,7 +215,7 @@
     "pos = box_size * np.random.random((N, 3))\n",
     "\n",
     "# Add particles\n",
-    "system.part.add(pos=pos, rotation=N * [(1, 1, 1)], dip=dip)\n",
+    "particles = system.part.add(pos=pos, rotation=N * [(True, True, True)], dip=dip)\n",
     "\n",
     "# Remove overlap between particles by means of the steepest descent method\n",
     "system.integrator.set_steepest_descent(\n",
@@ -275,7 +275,7 @@
    "outputs": [],
    "source": [
     "import espressomd.observables\n",
-    "dipm_tot_calc = espressomd.observables.MagneticDipoleMoment(ids=system.part[:].id)"
+    "dipm_tot_calc = espressomd.observables.MagneticDipoleMoment(ids=particles.id)"
    ]
   },
   {
@@ -670,7 +670,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/lennard_jones/lennard_jones.ipynb
+++ b/doc/tutorials/lennard_jones/lennard_jones.ipynb
@@ -311,7 +311,7 @@
     "\n",
     "### Placing and accessing particles\n",
     "\n",
-    "Particles in the simulation can be added and accessed via the <tt>part</tt> property of the System class. Individual  particles  are  referred  to  by  an  integer  id, e.g., <tt>system.part[0]</tt>. If <tt>id</tt> is unspecified, an unused particle id is automatically assigned. It  is  also possible to use common python iterators and slicing operations to add or access several particles at once.\n",
+    "Particles in the simulation can be added and accessed via the <tt>part</tt> property of the System class. Individual  particles should be referred to by the particle handle returned upon creation. You can also retrieve them by an integer id, e.g. <tt>system.part.by_id(0)</tt>. If <tt>id</tt> is unspecified when creating a particle, an unused particle id is automatically assigned. It  is  also possible to use common python iterators and slicing operations to add or access several particles at once.\n",
     "\n",
     "Particles can be grouped into several types, so that, e.g., a binary fluid can be simulated. Particle types are identified by integer ids, which are set via the particles' <tt>type</tt> attribute. If it is not specified, zero is implied."
    ]
@@ -325,11 +325,11 @@
    "source": [
     "<!-- **Exercise:** -->\n",
     "\n",
-    "* Create <tt>N_PART</tt> particles at random positions.\n",
+    "* Create <tt>N_PART</tt> particles at random positions, store their handles in a variable called ``particles``.\n",
     "\n",
     "  Use [system.part.add()](https://espressomd.github.io/doc/espressomd.html#espressomd.particle_data.ParticleList).\n",
     "  \n",
-    "  Either write a loop or use an (<tt>N_PART</tt> x 3) array for positions.\n",
+    "  Use an (<tt>N_PART</tt> x 3) array for positions.\n",
     "  Use <tt>np.random.random()</tt> to generate random numbers."
    ]
   },
@@ -340,7 +340,7 @@
    },
    "source": [
     "```python\n",
-    "system.part.add(type=[0] * N_PART, pos=np.random.random((N_PART, 3)) * system.box_l)\n",
+    "particles = system.part.add(type=[0] * N_PART, pos=np.random.random((N_PART, 3)) * system.box_l)\n",
     "```"
    ]
   },
@@ -375,16 +375,23 @@
    "outputs": [],
    "source": [
     "# Access position of a single particle\n",
-    "print(\"position of particle with id 0:\", system.part[0].pos)\n",
+    "print(\"position of particle with id 0:\", system.part.by_id(0).pos)\n",
     "\n",
     "# Iterate over the first five particles for the purpose of demonstration.\n",
-    "# For accessing all particles, use a slice: system.part[:]\n",
-    "for i in range(5):\n",
-    "    print(\"id\", i, \"position:\", system.part[i].pos)\n",
-    "    print(\"id\", i, \"velocity:\", system.part[i].v)\n",
+    "first_five = system.part.by_ids(range(5))\n",
+    "for p in first_five:\n",
+    "    print(\"id\", p.id, \"position:\", p.pos)\n",
+    "    print(\"id\", p.id, \"velocity:\", p.v)\n",
     "\n",
-    "# Obtain all particle positions\n",
-    "cur_pos = system.part[:].pos"
+    "# Obtain particle positions for the particles created until now\n",
+    "cur_pos = particles.pos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also get all particles using ``system.part.all()``, but ``particles`` already contains all particles that are in the simulation so far."
    ]
   },
   {
@@ -400,7 +407,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(system.part[0])"
+    "print(system.part.by_id(0))"
    ]
   },
   {
@@ -540,12 +547,12 @@
     "\n",
     "# Initialize integrator to obtain initial forces\n",
     "system.integrator.run(0)\n",
-    "old_force = np.max(np.linalg.norm(system.part[:].f, axis=1))\n",
+    "old_force = np.max(np.linalg.norm(system.part.all().f, axis=1))\n",
     "\n",
     "\n",
     "while system.time / system.time_step < MAX_STEPS:\n",
     "    system.integrator.run(EM_STEP)\n",
-    "    force = np.max(np.linalg.norm(system.part[:].f, axis=1))\n",
+    "    force = np.max(np.linalg.norm(system.part.all().f, axis=1))\n",
     "    rel_force = np.abs((force - old_force) / old_force)\n",
     "    print(f'rel. force change: {rel_force:.2e}')\n",
     "    if rel_force < F_TOL:\n",
@@ -983,7 +990,7 @@
    },
    "source": [
     "```python\n",
-    "rdf_obs = espressomd.observables.RDF(ids1=system.part[:].id, min_r=R_MIN, max_r=R_MAX, n_r_bins=N_BINS)\n",
+    "rdf_obs = espressomd.observables.RDF(ids1=system.part.all().id, min_r=R_MIN, max_r=R_MAX, n_r_bins=N_BINS)\n",
     "rdf_acc = espressomd.accumulators.MeanVarianceCalculator(obs=rdf_obs, delta_N=steps_per_subsample)\n",
     "system.auto_update_accumulators.add(rdf_acc)\n",
     "```"
@@ -1211,7 +1218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/doc/tutorials/raspberry_electrophoresis/raspberry_electrophoresis.ipynb
+++ b/doc/tutorials/raspberry_electrophoresis/raspberry_electrophoresis.ipynb
@@ -283,7 +283,7 @@
     "for _ in range(100):\n",
     "    system.integrator.run(50)\n",
     "    constrain_surface_particles()\n",
-    "    force_max = np.max(np.linalg.norm(system.part[:].f, axis=1))\n",
+    "    force_max = np.max(np.linalg.norm(system.part.all().f, axis=1))\n",
     "    logging.info(f\"maximal force: {force_max:.1f}\")\n",
     "    if force_max < 10.:\n",
     "        break\n",
@@ -385,7 +385,7 @@
    "source": [
     "```python\n",
     "# Calculate the center of mass position (com) and the moment of inertia (momI) of the colloid\n",
-    "com = np.average(surface_parts.pos, 0)  # system.part[:].pos returns an n-by-3 array\n",
+    "com = np.average(surface_parts.pos, 0)  # surface_parts.pos returns an n-by-3 array\n",
     "momI = 0\n",
     "for p in surface_parts:\n",
     "    momI += np.power(np.linalg.norm(com - p.pos), 2)\n",
@@ -474,7 +474,7 @@
    "outputs": [],
    "source": [
     "# Check charge neutrality\n",
-    "assert np.abs(np.sum(system.part[:].q)) < 1E-10"
+    "assert np.abs(np.sum(system.part.all().q)) < 1E-10"
    ]
   },
   {
@@ -620,7 +620,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system.part[:].v = (0, 0, 0)"
+    "system.part.all().v = (0, 0, 0)"
    ]
   },
   {

--- a/samples/chamber_game.py
+++ b/samples/chamber_game.py
@@ -266,7 +266,7 @@ while n < bubbles_n:
         new_part.remove()
         n -= 1
 
-p_bubbles = np.where(system.part[:].type == bubble_type)[0]
+p_bubbles = system.part.select(type=bubble_type)
 
 # TEMP CHANGE PARTICLES
 bpos = [np.random.random() * (pore_xl - snake_head_sigma * 4) +
@@ -291,7 +291,7 @@ system.integrator.set_steepest_descent(f_max=100, gamma=30.0,
                                        max_displacement=0.01)
 system.integrator.run(10000)
 system.integrator.set_vv()
-p_startpos = system.part[:].pos
+p_startpos = system.part.all().pos
 
 # THERMOSTAT
 system.thermostat.set_langevin(kT=temperature, gamma=gamma, seed=42)
@@ -344,7 +344,7 @@ def set_particle_force():
 
 
 def restart():
-    system.part[:].pos = p_startpos
+    system.part.all().pos = p_startpos
     system.galilei.kill_particle_motion()
     system.galilei.kill_particle_forces()
 
@@ -358,7 +358,7 @@ def explode():
     if not exploding:
         exploding = True
         expl_time = time.time()
-        for p in system.part[p_bubbles]:
+        for p in p_bubbles:
             dv = p.pos - p_head.pos
             lv = np.linalg.norm(dv)
             if lv < expl_range:
@@ -478,14 +478,14 @@ def main():
                 temp_r -= dtemp
                 if temp_r < 0:
                     temp_r = 0.0
-                for p in system.part[p_bubbles]:
+                for p in p_bubbles:
                     if p.pos[0] > pore_xr:
                         p.v = [0, 0, 0]
             else:
                 temp_l -= dtemp
                 if temp_l < 0:
                     temp_l = 0.0
-                for p in system.part[p_bubbles]:
+                for p in p_bubbles:
                     if p.pos[0] < pore_xl:
                         p.v = [0, 0, 0]
 

--- a/samples/dancing.py
+++ b/samples/dancing.py
@@ -59,7 +59,7 @@ system.part.add(pos=[7, 0, 0], rotation=[1, 1, 1])
 gravity = espressomd.constraints.Gravity(g=[0, -1, 0])
 system.constraints.add(gravity)
 
-obs = espressomd.observables.ParticlePositions(ids=system.part[:].id)
+obs = espressomd.observables.ParticlePositions(ids=system.part.all().id)
 acc = espressomd.accumulators.TimeSeries(obs=obs, delta_N=1)
 system.auto_update_accumulators.add(acc)
 acc.update()

--- a/samples/electrophoresis.py
+++ b/samples/electrophoresis.py
@@ -111,8 +111,9 @@ system.part.add(pos=np.random.random((N_IONS, 3)) * system.box_l,
                 q=np.resize((1, -1), N_IONS),
                 type=np.resize((1, 2), N_IONS))
 
-logging.info(f"particle types: {system.part[:].type}\n")
-logging.info(f"total charge: {np.sum(system.part[:].q)}")
+all_partcls = system.part.all()
+logging.info(f"particle types: {all_partcls.type}\n")
+logging.info(f"total charge: {np.sum(all_partcls.q)}")
 
 # warm-up integration
 ###############################################################
@@ -138,8 +139,8 @@ system.actors.add(p3m)
 # apply external force (external electric field)
 #############################################################
 n_part = len(system.part)
-system.part[:].ext_force = np.dstack(
-    (system.part[:].q * np.ones(n_part) * E_FIELD, np.zeros(n_part), np.zeros(n_part)))[0]
+all_partcls.ext_force = np.dstack(
+    (all_partcls.q * np.ones(n_part) * E_FIELD, np.zeros(n_part), np.zeros(n_part)))[0]
 
 # equilibration
 #############################################################
@@ -169,7 +170,7 @@ for i in range(N_SAMPLES):
     if i % 100 == 0:
         logging.info(f"\rsampling: {i:4d}")
     system.integrator.run(N_INT_STEPS)
-    pos[i] = system.part[:N_MONOMERS].pos
+    pos[i] = system.part.by_ids(range(N_MONOMERS)).pos
 
 logging.info("\nsampling finished!\n")
 

--- a/samples/gibbs_ensemble/gibbs_ensemble.py
+++ b/samples/gibbs_ensemble/gibbs_ensemble.py
@@ -61,7 +61,8 @@ class Client(Process):
 
     @property
     def density(self):
-        return len(self.system.part[:].id) / float(np.prod(self.system.box_l))
+        return len(self.system.part.all().id) / \
+            float(np.prod(self.system.box_l))
 
     @property
     def energy(self):
@@ -76,12 +77,12 @@ class Client(Process):
 
     def send_info(self):
         self.pipe.send([MessageID.INFO, self.system.box_l[0],
-                        len(self.system.part[:].id)])
+                        len(self.system.part.all().id)])
 
     def move_particle(self, DX_MAX):
         """ Move random particle inside the box """
-        random_particle_id = np.random.choice(self.system.part[:].id)
-        self.old_particle = self.system.part[random_particle_id]
+        random_particle_id = np.random.choice(self.system.part.all().id)
+        self.old_particle = self.system.part.by_id(random_particle_id)
         self.old_pos = self.old_particle.pos
         self.old_particle.pos = self.old_pos + \
             (0.5 - np.random.random(size=3)) * DX_MAX
@@ -105,9 +106,10 @@ class Client(Process):
 
     def remove_particle(self):
         """ Remove a random particle """
-        random_particle_id = np.random.choice(self.system.part[:].id)
-        self.old_particle = self.system.part[random_particle_id].to_dict()
-        self.system.part[self.old_particle["id"]].remove()
+        random_particle_id = np.random.choice(self.system.part.all().id)
+        self.old_particle = self.system.part.by_id(
+            random_particle_id).to_dict()
+        self.system.part.by_id(self.old_particle["id"]).remove()
         self.send_energy()
 
     def revert_remove_particle(self):

--- a/samples/immersed_boundary/addBending.py
+++ b/samples/immersed_boundary/addBending.py
@@ -35,4 +35,4 @@ def AddBending(system, kb):
             tribend = espressomd.interactions.IBM_Tribend(
                 ind1=id1, ind2=id2, ind3=id3, ind4=id4, kb=kb, refShape="Initial")
             system.bonded_inter.add(tribend)
-            system.part[id1].add_bond((tribend, id2, id3, id4))
+            system.part.by_id(id1).add_bond((tribend, id2, id3, id4))

--- a/samples/immersed_boundary/addSoft.py
+++ b/samples/immersed_boundary/addSoft.py
@@ -48,4 +48,4 @@ def AddSoft(system, comX, comY, comZ, k1, k2):
                 ind1=id1, ind2=id2, ind3=id3, elasticLaw="Skalak", maxDist=5,
                 k1=k1, k2=k2)
             system.bonded_inter.add(tri)
-            system.part[id1].add_bond((tri, id2, id3))
+            system.part.by_id(id1).add_bond((tri, id2, id3))

--- a/samples/immersed_boundary/addVolCons.py
+++ b/samples/immersed_boundary/addVolCons.py
@@ -26,5 +26,5 @@ def AddVolCons(system, kV):
     system.bonded_inter.add(volCons)
 
     # loop over particles and add
-    for i in range(len(system.part)):
-        system.part[i].add_bond((volCons,))
+    for p in system.part:
+        p.add_bond((volCons,))

--- a/samples/immersed_boundary/writeVTK.py
+++ b/samples/immersed_boundary/writeVTK.py
@@ -31,5 +31,5 @@ def WriteVTK(system, outFile):
         fp.write(f"POINTS {numPoints} floats\n")
 
         # points, positions
-        for i in range(0, len(system.part)):
-            fp.write(f"{' '.join(map(str, system.part[i].pos_folded))}\n")
+        for p in system.part:
+            fp.write(f"{' '.join(map(str, p.pos_folded))}\n")

--- a/samples/lj-demo.py
+++ b/samples/lj-demo.py
@@ -453,9 +453,8 @@ def main_loop():
 
         new_box = np.ones(3) * controls.volume**(1. / 3.)
         if np.any(np.array(system.box_l) != new_box):
-            for i in range(len(system.part)):
-                system.part[i].pos = system.part[i].pos * \
-                    new_box / system.box_l[0]
+            for p in system.part:
+                p.pos *= new_box / system.box_l[0]
             print("volume changed")
             system.force_cap = lj_cap
         system.box_l = new_box
@@ -468,7 +467,7 @@ def main_loop():
         system.force_cap = lj_cap
     elif new_part < len(system.part):
         for i in range(new_part, len(system.part)):
-            system.part[i].remove()
+            system.part.by_id(i).remove()
         print("particles removed")
 
     plt1_x_data = plot1.get_xdata()

--- a/samples/load_checkpoint.py
+++ b/samples/load_checkpoint.py
@@ -55,7 +55,7 @@ print(
 
 # test "system.part"
 print("\n### system.part test ###")
-print(f"system.part[:].pos = {system.part[:].pos}")
+print(f"system.part.all().pos = {system.part.all().pos}")
 
 # test "system.thermostat"
 print("\n### system.thermostat test ###")

--- a/samples/rigid_body.py
+++ b/samples/rigid_body.py
@@ -60,7 +60,7 @@ for direction in np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]):
                         type=ParticleTypes.BRANCH.value)
         system.part.add(pos=center - (n + 1) * direction,
                         type=ParticleTypes.BRANCH.value)
-
+all_partcls = system.part.all()
 
 center_of_mass = system.analysis.center_of_mass(
     p_type=ParticleTypes.BRANCH.value)
@@ -68,12 +68,12 @@ print("Center of mass:", center_of_mass)
 
 # if using multiple nodes, we need to change min_global_cut to the largest
 # separation
-max_inter = np.max(np.linalg.norm(system.part[:].pos - center_of_mass, axis=1))
+max_inter = np.max(np.linalg.norm(all_partcls.pos - center_of_mass, axis=1))
 system.min_global_cut = max_inter
 
 
 principal_moments, principal_axes = espressomd.rotation.diagonalized_inertia_tensor(
-    system.part[:].pos, system.part[:].mass)
+    all_partcls.pos, all_partcls.mass)
 # in this simple case, the cluster has principal axes aligned with the box
 print(f"Principal moments: {principal_moments}")
 print(f"Principal axes tensor:\n{principal_axes}")
@@ -94,7 +94,7 @@ for p in system.part:
 
 
 principal_moments, principal_axes = espressomd.rotation.diagonalized_inertia_tensor(
-    system.part[:].pos, system.part[:].mass)
+    all_partcls.pos, all_partcls.mass)
 # after rotating the whole object the principal axes changed
 print("After rotating:")
 print(f"Principal moments: {principal_moments}")

--- a/samples/slice_input.py
+++ b/samples/slice_input.py
@@ -57,32 +57,33 @@ id_list = np.arange(n_part)
 pos_list = np.random.random((n_part, 3)) * system.box_l
 type_list = np.ones(n_part, dtype=int)
 
-system.part.add(id=id_list, pos=pos_list, type=type_list)
+partcls = system.part.add(id=id_list, pos=pos_list, type=type_list)
+p0p1 = system.part.by_ids([0, 1])
 
+print("TYPE\n%s" % partcls.type)
+p0p1.type = [3, 3]
+print("TYPE_NEW\n%s" % partcls.type)
 
-print("TYPE\n%s" % system.part[:].type)
-system.part[0:2].type = [3, 3]
-print("TYPE_NEW\n%s" % system.part[:].type)
+print("POS\n%s" % partcls.pos)
+system.part.by_ids(range(5)).pos = [[1, 1, 1], [2, 2, 2], [
+    3, 3, 3], [4, 4, 4], [5, 5, 5]]
+print("POS_NEW\n%s" % partcls.pos)
 
-print("POS\n%s" % system.part[:].pos)
-system.part[:5].pos = [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5, 5]]
-print("POS_NEW\n%s" % system.part[:].pos)
+print("V\n%s" % partcls.v)
+p0p1.v = [[1, 2, 3], [2, 3, 4]]
+print("V_NEW\n%s" % partcls.v)
 
-print("V\n%s" % system.part[:].v)
-system.part[:2].v = [[1, 2, 3], [2, 3, 4]]
-print("V_NEW\n%s" % system.part[:].v)
-
-print("F\n%s" % system.part[:].f)
-system.part[:2].f = [[3, 4, 5], [4, 5, 6]]
-print("F_NEW\n%s" % system.part[:].f)
+print("F\n%s" % partcls.f)
+p0p1.f = [[3, 4, 5], [4, 5, 6]]
+print("F_NEW\n%s" % partcls.f)
 
 if espressomd.has_features(["MASS"]):
-    print("MASS\n%s" % system.part[:].mass)
-    system.part[:2].mass = [2, 3]
-    print("MASS_NEW\n%s" % system.part[:].mass)
+    print("MASS\n%s" % partcls.mass)
+    p0p1.mass = [2, 3]
+    print("MASS_NEW\n%s" % partcls.mass)
 
 if espressomd.has_features(["ELECTROSTATICS"]):
-    print("Q\n%s" % system.part[:].q)
-    system.part[::2].q = np.ones(n_part // 2)
-    system.part[1::2].q = -np.ones(n_part // 2)
-    print("Q_NEW\n%s" % system.part[:].q)
+    print("Q\n%s" % partcls.q)
+    system.part.by_ids(range(0, n_part, 2)).q = np.ones(n_part // 2)
+    system.part.by_ids(range(1, n_part, 2)).q = -np.ones(n_part // 2)
+    print("Q_NEW\n%s" % partcls.q)

--- a/samples/visualization_elc.py
+++ b/samples/visualization_elc.py
@@ -46,13 +46,12 @@ visualizer = espressomd.visualization.openGLLive(
 
 system.time_step = 0.02
 system.cell_system.skin = 0.4
-system.periodicity = [1, 1, 1]
+system.periodicity = 3 * [True]
 
 qion = 1
 for i in range(300):
     rpos = np.random.random(3) * box_l
-    system.part.add(pos=rpos, type=0, q=qion)
-    qion *= -1
+    system.part.add(pos=rpos, type=0, q=(-1)**i * qion)
 
 system.constraints.add(shape=espressomd.shapes.Wall(
     dist=0, normal=[0, 0, 1]), particle_type=1)

--- a/samples/visualization_interactive.py
+++ b/samples/visualization_interactive.py
@@ -38,8 +38,7 @@ system.time_step = 0.00001
 system.cell_system.skin = 3.0
 
 N = 50
-for i in range(N):
-    system.part.add(pos=[0, 0, 0])
+partcls = system.part.add(pos=N * [[0, 0, 0]])
 
 system.thermostat.set_langevin(kT=1.0, gamma=1.0, seed=42)
 
@@ -47,9 +46,9 @@ system.thermostat.set_langevin(kT=1.0, gamma=1.0, seed=42)
 
 
 def spin():
-    system.part[:].pos = [[box_l * 0.5, box_l * (i + 1) / (N + 2), box_l * 0.5]
-                          for i in range(N)]
-    system.part[:].v = [
+    partcls.pos = [[box_l * 0.5, box_l * (i + 1) / (N + 2), box_l * 0.5]
+                   for i in range(N)]
+    partcls.v = [
         [np.sin(10.0 * i / N) * 20, 0, np.cos(10.0 * i / N) * 20] for i in range(N)]
 
 

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -232,8 +232,8 @@ class DrudeHelpers:
 
         for drude_id in self.drude_id_list:
             core_id = self.core_id_from_drude_id[drude_id]
-            pd = system.part[drude_id]
-            pc = system.part[core_id]
+            pd = system.part.by_id(drude_id)
+            pc = system.part.by_id(core_id)
             bond = self.drude_dict[pd.type]["subtr_sr_bonds_drude-core"]
             pc.add_bond((bond, drude_id))
             if verbose:

--- a/src/python/espressomd/io/writer/vtf.py
+++ b/src/python/espressomd/io/writer/vtf.py
@@ -66,12 +66,14 @@ def writevsf(system, fp, types='all'):
     fp.write(f"unitcell {' '.join(map(str, system.box_l))}\n")
 
     for pid, vtf_id, in vtf_index.items():
+        partcl = system.part.by_id(pid)
         fp.write(
-            f"atom {vtf_id} radius 1 name {system.part[pid].type} type {system.part[pid].type} \n")
+            f"atom {vtf_id} radius 1 name {partcl.type} type {partcl.type} \n")
     for pid, vtf_id, in vtf_index.items():
-        for b in system.part[pid].bonds:
-            if system.part[b[1]].id in vtf_index:
-                fp.write(f"bond {vtf_id}:{vtf_index[system.part[b[1]].id]}\n")
+        for b in system.part.by_id(pid).bonds:
+            if system.part.by_id(b[1]).id in vtf_index:
+                fp.write(
+                    f"bond {vtf_id}:{vtf_index[system.part.by_id(b[1]).id]}\n")
 
 
 def writevcf(system, fp, types='all'):
@@ -91,4 +93,4 @@ def writevcf(system, fp, types='all'):
     vtf_index = vtf_pid_map(system, types)
     fp.write("\ntimestep indexed\n")
     for pid, vtf_id, in vtf_index.items():
-        fp.write(f"{vtf_id} {' '.join(map(str, system.part[pid].pos))}\n")
+        fp.write(f"{vtf_id} {' '.join(map(str, system.part.by_id(pid).pos))}\n")

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -289,12 +289,12 @@ def setup_diamond_polymer(system=None, bond=None, MPC=0,
                 # add bonds along the chain
                 if not no_bonds:
                     if j == 1:
-                        system.part[node_ids[start_node]].add_bond(
+                        system.part.by_id(node_ids[start_node]).add_bond(
                             (bond, current_id))
                     else:
-                        system.part[current_id].add_bond(
+                        system.part.by_id(current_id).add_bond(
                             (bond, current_id - 1))
                     if j == MPC:
-                        system.part[node_ids[end_node]].add_bond(
+                        system.part.by_id(node_ids[end_node]).add_bond(
                             (bond, current_id))
                 current_id += 1

--- a/src/python/object_in_fluid/oif_classes.py
+++ b/src/python/object_in_fluid/oif_classes.py
@@ -489,7 +489,7 @@ class Mesh:
             new_part_id = len(self.system.part)
             self.system.part.add(
                 pos=tmp_pos, type=particle_type, mass=particle_mass, mol_id=particle_type)
-            new_part = self.system.part[new_part_id]
+            new_part = self.system.part.by_id(new_part_id)
             new_part_point = PartPoint(new_part, len(mesh.points), new_part_id)
             mesh.points.append(new_part_point)
         for edge in self.edges:

--- a/testsuite/python/accumulator_mean_variance.py
+++ b/testsuite/python/accumulator_mean_variance.py
@@ -58,7 +58,7 @@ class MeanVarianceCalculatorTest(ut.TestCase):
         positions = np.copy(system.box_l) * np.random.random((10, N_PART, 3))
 
         for pos in positions:
-            system.part[:].pos = pos
+            system.part.all().pos = pos
             acc.update()
 
         self.assertEqual(acc.get_params()['obs'], obs)

--- a/testsuite/python/accumulator_time_series.py
+++ b/testsuite/python/accumulator_time_series.py
@@ -58,7 +58,7 @@ class TimeSeriesTest(ut.TestCase):
         positions = np.copy(system.box_l) * np.random.random((10, N_PART, 3))
 
         for pos in positions:
-            system.part[:].pos = pos
+            system.part.all().pos = pos
             acc.update()
 
         self.assertEqual(acc.get_params()['obs'], obs)

--- a/testsuite/python/analyze_distribution.py
+++ b/testsuite/python/analyze_distribution.py
@@ -32,7 +32,7 @@ class AnalyzeDistributions(ut.TestCase):
         # start with a small box
         cls.system.box_l = np.array([box_l, box_l, box_l])
         cls.system.cell_system.set_n_square(use_verlet_lists=False)
-        cls.system.part.add(
+        cls.partcls = cls.system.part.add(
             pos=np.outer(np.random.random(cls.num_part), cls.system.box_l))
 
     def calc_min_distribution(self, bins):
@@ -46,9 +46,9 @@ class AnalyzeDistributions(ut.TestCase):
     # test system.analysis.distribution(), all the same particle types
     def test_distribution_lin(self):
         # increase PBC to remove mirror images
-        old_pos = self.system.part[:].pos.copy()
+        old_pos = self.partcls.pos.copy()
         self.system.box_l = self.system.box_l * 2.
-        self.system.part[:].pos = old_pos
+        self.partcls.pos = old_pos
         r_min = 0.0
         r_max = 100.0
         r_bins = 100

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -53,7 +53,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.system.part.clear()
 
     def test_kinetic(self):
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         p0.pos = [1, 2, 2]
         p1.pos = [5, 2, 2]
         # single moving particle
@@ -73,7 +73,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["non_bonded"], 0., delta=1e-7)
 
     def test_non_bonded(self):
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         p0.pos = [1, 2, 2]
         p1.pos = [2, 2, 2]
         energy = self.system.analysis.energy()
@@ -95,7 +95,7 @@ class AnalyzeEnergy(ut.TestCase):
                                + energy["non_bonded", 1, 1], energy["total"], delta=1e-7)
 
     def test_bonded(self):
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         p0.pos = [1, 2, 2]
         p1.pos = [3, 2, 2]
         # single bond
@@ -122,7 +122,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["non_bonded"], 0., delta=1e-7)
 
     def test_all(self):
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         p0.pos = [1, 2, 2]
         p1.pos = [2, 2, 2]
         p0.v = [3, 4, 5]
@@ -153,7 +153,7 @@ class AnalyzeEnergy(ut.TestCase):
 
     @utx.skipIfMissingFeatures(["ELECTROSTATICS", "P3M"])
     def test_electrostatics(self):
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         p0.pos = [1, 2, 2]
         p1.pos = [3, 2, 2]
         p0.q = 1

--- a/testsuite/python/analyze_gyration_tensor.py
+++ b/testsuite/python/analyze_gyration_tensor.py
@@ -60,7 +60,7 @@ class AnalyzeGyration(ut.TestCase):
         res = self.system.analysis.gyration_tensor(
             p_type=[self.type_stick, self.type_cube])
         rg = self.system.analysis.calc_rg(
-            chain_start=0, number_of_chains=1, chain_length=len(self.system.part[:]))[0]
+            chain_start=0, number_of_chains=1, chain_length=len(self.system.part.all()))[0]
         # check eigenvectors
         np.testing.assert_allclose(
             np.abs(res['eva0'][1]), [0., 0., 1.], atol=1e-6)

--- a/testsuite/python/analyze_mass_related.py
+++ b/testsuite/python/analyze_mass_related.py
@@ -44,14 +44,15 @@ class AnalyzeMassRelated(ut.TestCase):
         if espressomd.has_features("VIRTUAL_SITES"):
             cls.system.part.add(
                 pos=np.random.random((10, 3)) * cls.box_l, type=[0] * 10, virtual=[True] * 10)
-        cls.system.part[:].v = np.random.random(
-            (len(cls.system.part), 3)) + 0.1
+        all_partcls = cls.system.part.all()
+        all_partcls.v = np.random.random(
+            (len(all_partcls), 3)) + 0.1
         if espressomd.has_features("MASS"):
-            cls.system.part[:].mass = 0.5 + \
-                np.random.random(len(cls.system.part))
+            all_partcls.mass = 0.5 + \
+                np.random.random(len(all_partcls))
 
     def i_tensor(self, ids):
-        pslice = self.system.part[ids]
+        pslice = self.system.part.by_ids(ids)
 
         I = np.zeros((3, 3))
 

--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -99,7 +99,7 @@ class ArrayPropertyTest(ArrayCommon):
     system.box_l = [12.0, 12.0, 12.0]
     system.time_step = 0.01
     system.cell_system.skin = 0.01
-    system.part.add(pos=[0, 0, 0])
+    partcl = system.part.add(pos=[0, 0, 0])
 
     def setUp(self):
         self.system.box_l = [12.0, 12.0, 12.0]
@@ -112,77 +112,77 @@ class ArrayPropertyTest(ArrayCommon):
         self.assertTrue(cpy.flags.writeable)
 
     def test_common(self):
-        self.assert_operator_usage_raises(self.system.part[0].pos)
-        self.assert_operator_usage_raises(self.system.part[0].v)
-        self.assert_operator_usage_raises(self.system.part[0].f)
-        self.assert_operator_usage_raises(self.system.part[0].pos_folded)
+        self.assert_operator_usage_raises(self.partcl.pos)
+        self.assert_operator_usage_raises(self.partcl.v)
+        self.assert_operator_usage_raises(self.partcl.f)
+        self.assert_operator_usage_raises(self.partcl.pos_folded)
 
         self.assert_operator_usage_raises(self.system.box_l)
 
-        check_array_writable(self.system.part[0].pos)
-        check_array_writable(self.system.part[0].v)
-        check_array_writable(self.system.part[0].f)
+        check_array_writable(self.partcl.pos)
+        check_array_writable(self.partcl.v)
+        check_array_writable(self.partcl.f)
         check_array_writable(self.system.box_l)
 
-        self.assert_copy_is_writable(self.system.part[0].pos)
-        self.assert_copy_is_writable(self.system.part[0].v)
-        self.assert_copy_is_writable(self.system.part[0].f)
-        self.assert_copy_is_writable(self.system.part[0].pos_folded)
+        self.assert_copy_is_writable(self.partcl.pos)
+        self.assert_copy_is_writable(self.partcl.v)
+        self.assert_copy_is_writable(self.partcl.f)
+        self.assert_copy_is_writable(self.partcl.pos_folded)
 
         self.assert_copy_is_writable(self.system.box_l)
 
     @utx.skipIfMissingFeatures(["ROTATION"])
     def test_rotation(self):
-        self.assert_operator_usage_raises(self.system.part[0].omega_lab)
-        self.assert_operator_usage_raises(self.system.part[0].quat)
-        self.assert_operator_usage_raises(self.system.part[0].rotation)
-        self.assert_operator_usage_raises(self.system.part[0].omega_body)
-        self.assert_operator_usage_raises(self.system.part[0].torque_lab)
+        self.assert_operator_usage_raises(self.partcl.omega_lab)
+        self.assert_operator_usage_raises(self.partcl.quat)
+        self.assert_operator_usage_raises(self.partcl.rotation)
+        self.assert_operator_usage_raises(self.partcl.omega_body)
+        self.assert_operator_usage_raises(self.partcl.torque_lab)
         if espressomd.has_features("EXTERNAL_FORCES"):
-            self.assert_operator_usage_raises(self.system.part[0].ext_torque)
+            self.assert_operator_usage_raises(self.partcl.ext_torque)
 
-        check_array_writable(self.system.part[0].quat)
-        check_array_writable(self.system.part[0].omega_lab)
-        check_array_writable(self.system.part[0].rotation)
-        check_array_writable(self.system.part[0].omega_body)
-        check_array_writable(self.system.part[0].torque_lab)
+        check_array_writable(self.partcl.quat)
+        check_array_writable(self.partcl.omega_lab)
+        check_array_writable(self.partcl.rotation)
+        check_array_writable(self.partcl.omega_body)
+        check_array_writable(self.partcl.torque_lab)
 
         if espressomd.has_features("EXTERNAL_FORCES"):
-            check_array_writable(self.system.part[0].ext_torque)
+            check_array_writable(self.partcl.ext_torque)
 
-        self.assert_copy_is_writable(self.system.part[0].omega_lab)
-        self.assert_copy_is_writable(self.system.part[0].quat)
-        self.assert_copy_is_writable(self.system.part[0].rotation)
-        self.assert_copy_is_writable(self.system.part[0].omega_body)
-        self.assert_copy_is_writable(self.system.part[0].torque_lab)
+        self.assert_copy_is_writable(self.partcl.omega_lab)
+        self.assert_copy_is_writable(self.partcl.quat)
+        self.assert_copy_is_writable(self.partcl.rotation)
+        self.assert_copy_is_writable(self.partcl.omega_body)
+        self.assert_copy_is_writable(self.partcl.torque_lab)
         if espressomd.has_features("EXTERNAL_FORCES"):
-            self.assert_copy_is_writable(self.system.part[0].ext_torque)
+            self.assert_copy_is_writable(self.partcl.ext_torque)
 
     @utx.skipIfMissingFeatures(["ROTATIONAL_INERTIA"])
     def test_rotational_inertia(self):
-        self.assert_operator_usage_raises(self.system.part[0].rinertia)
-        check_array_writable(self.system.part[0].rinertia)
-        self.assert_copy_is_writable(self.system.part[0].rinertia)
+        self.assert_operator_usage_raises(self.partcl.rinertia)
+        check_array_writable(self.partcl.rinertia)
+        self.assert_copy_is_writable(self.partcl.rinertia)
 
     @utx.skipIfMissingFeatures(["EXTERNAL_FORCES"])
     def test_external_forces(self):
-        self.assert_operator_usage_raises(self.system.part[0].ext_force)
-        self.assert_operator_usage_raises(self.system.part[0].fix)
+        self.assert_operator_usage_raises(self.partcl.ext_force)
+        self.assert_operator_usage_raises(self.partcl.fix)
 
-        check_array_writable(self.system.part[0].ext_force)
-        check_array_writable(self.system.part[0].fix)
+        check_array_writable(self.partcl.ext_force)
+        check_array_writable(self.partcl.fix)
 
-        self.assert_copy_is_writable(self.system.part[0].ext_force)
-        self.assert_copy_is_writable(self.system.part[0].fix)
+        self.assert_copy_is_writable(self.partcl.ext_force)
+        self.assert_copy_is_writable(self.partcl.fix)
 
     @utx.skipIfMissingFeatures(["ROTATION", "THERMOSTAT_PER_PARTICLE",
                                 "PARTICLE_ANISOTROPY"])
     def test_rot_aniso(self):
-        self.assert_operator_usage_raises(self.system.part[0].gamma_rot)
+        self.assert_operator_usage_raises(self.partcl.gamma_rot)
 
-        check_array_writable(self.system.part[0].gamma_rot)
+        check_array_writable(self.partcl.gamma_rot)
 
-        self.assert_copy_is_writable(self.system.part[0].gamma_rot)
+        self.assert_copy_is_writable(self.partcl.gamma_rot)
 
     def test_lb(self):
         lbf = espressomd.lb.LBFluid(agrid=0.5, dens=1, visc=1, tau=0.01)
@@ -196,23 +196,23 @@ class ArrayPropertyTest(ArrayCommon):
     @utx.skipIfMissingFeatures(["THERMOSTAT_PER_PARTICLE",
                                 "PARTICLE_ANISOTROPY"])
     def test_thermostat_per_particle_aniso(self):
-        self.assert_operator_usage_raises(self.system.part[0].gamma)
+        self.assert_operator_usage_raises(self.partcl.gamma)
 
-        check_array_writable(self.system.part[0].gamma)
+        check_array_writable(self.partcl.gamma)
 
-        self.assert_copy_is_writable(self.system.part[0].gamma)
+        self.assert_copy_is_writable(self.partcl.gamma)
 
     @utx.skipIfMissingFeatures(["DIPOLES"])
     def test_dipoles(self):
-        self.assert_operator_usage_raises(self.system.part[0].dip)
+        self.assert_operator_usage_raises(self.partcl.dip)
 
-        check_array_writable(self.system.part[0].dip)
+        check_array_writable(self.partcl.dip)
 
-        self.assert_copy_is_writable(self.system.part[0].dip)
+        self.assert_copy_is_writable(self.partcl.dip)
 
     @utx.skipIfMissingFeatures(["EXCLUSIONS"])
     def test_exclusions(self):
-        self.assert_operator_usage_raises(self.system.part[0].exclusions)
+        self.assert_operator_usage_raises(self.partcl.exclusions)
 
     def test_partial_periodic(self):
         self.assert_operator_usage_raises(self.system.periodicity)

--- a/testsuite/python/auto_exclusions.py
+++ b/testsuite/python/auto_exclusions.py
@@ -38,21 +38,21 @@ class AutoExclusions(ut.TestCase):
             s.part.add(id=i, pos=[0, 0, 0])
 
         for i in range(9):
-            s.part[i].add_bond((bond, i + 1))
+            s.part.by_id(i).add_bond((bond, i + 1))
 
         s.auto_exclusions(1)
 
         for p in range(1, 9):
-            excl = s.part[p].exclusions
+            excl = s.part.by_id(p).exclusions
             self.assertEqual(len(excl), 2)
             self.assertIn(p - 1, excl)
             self.assertIn(p + 1, excl)
 
-        excl = s.part[0].exclusions
+        excl = s.part.by_id(0).exclusions
         self.assertEqual(len(excl), 1)
         self.assertIn(1, excl)
 
-        excl = s.part[9].exclusions
+        excl = s.part.by_id(9).exclusions
         self.assertEqual(len(excl), 1)
         self.assertIn(8, excl)
 
@@ -65,12 +65,12 @@ class AutoExclusions(ut.TestCase):
             s.part.add(id=i, pos=[0, 0, 0])
 
         for i in range(10):
-            s.part[i].add_bond((bond, (i + 1) % 10))
+            s.part.by_id(i).add_bond((bond, (i + 1) % 10))
 
         s.auto_exclusions(2)
 
         for p in range(10):
-            excl = s.part[p].exclusions
+            excl = s.part.by_id(p).exclusions
             self.assertEqual(len(excl), 4)
             for i in range(1, 3):
                 self.assertIn((p - i) % 10, excl)

--- a/testsuite/python/cluster_analysis.py
+++ b/testsuite/python/cluster_analysis.py
@@ -134,12 +134,12 @@ class ClusterAnalysis(ut.TestCase):
 
         # Longest distance
         ref_dist = self.system.distance(
-            self.system.part[0], self.system.part[len(self.system.part) - 1])
+            self.system.part.by_id(0), self.system.part.by_id(len(self.system.part) - 1))
         self.assertAlmostEqual(c.longest_distance(), ref_dist, delta=1E-8)
 
         # Radius of gyration
         rg = 0.
-        com_particle = self.system.part[len(self.system.part) // 2]
+        com_particle = self.system.part.by_id(len(self.system.part) // 2)
         for p in c.particles():
             rg += self.system.distance(p, com_particle)**2
         rg /= len(self.system.part)
@@ -187,7 +187,7 @@ class ClusterAnalysis(ut.TestCase):
         # Check particle to cluster id mapping, once by ParticleHandle, once by
         # id
         self.assertEqual(self.cs.cid_for_particle(
-            self.system.part[0]), self.cs.cluster_ids()[0])
+            self.system.part.by_id(0)), self.cs.cluster_ids()[0])
         self.assertEqual(self.cs.cid_for_particle(1), self.cs.cluster_ids()[0])
 
         # Unknown method should return None

--- a/testsuite/python/comfixed.py
+++ b/testsuite/python/comfixed.py
@@ -43,12 +43,13 @@ class ComFixed(ut.TestCase):
             v = 3 * [0.]
             # Make sure that id and type gaps work correctly
             system.part.add(id=2 * i, pos=r, v=v, type=2 * (i % 2))
+        partcls = system.part.all()
 
         if espressomd.has_features(["MASS"]):
             # Avoid masses too small for the time step
-            system.part[:].mass = 2. * (0.1 + np.random.random(100))
+            partcls.mass = 2. * (0.1 + np.random.random(100))
 
-        com_0 = self.com(system.part[:])
+        com_0 = self.com(partcls)
 
         system.comfixed.types = [0, 2]
 
@@ -56,7 +57,7 @@ class ComFixed(ut.TestCase):
         self.assertEqual(system.comfixed.types, [2, 0])
 
         for i in range(10):
-            com_i = self.com(system.part[:])
+            com_i = self.com(partcls)
 
             for j in range(3):
                 self.assertAlmostEqual(com_0[j], com_i[j], places=10)

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -612,7 +612,7 @@ class ShapeBasedConstraintTest(ut.TestCase):
             theta = 2. * i / float(N) * np.pi
             for r in radii:
                 pos = r * np.array([np.cos(theta), 0, np.sin(theta)])
-                system.part[0].pos = pos + self.box_l / 2.0
+                p.pos = pos + self.box_l / 2.0
                 system.integrator.run(recalc_forces=True, steps=0)
                 energy = system.analysis.energy()
                 self.assertAlmostEqual(energy["total"], np.abs(10. - r))

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -62,7 +62,7 @@ class CoulombCloudWall(ut.TestCase):
         # Compare forces and energy now in the system to stored ones
 
         # Force
-        force_diff = np.linalg.norm(self.system.part[:].f / prefactor - self.forces,
+        force_diff = np.linalg.norm(self.system.part.all().f / prefactor - self.forces,
                                     axis=1)
         self.assertLess(
             np.mean(force_diff), self.tolerance,

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -57,7 +57,7 @@ class CoulombCloudWall(ut.TestCase):
 
         # Force
         force_diff = np.linalg.norm(
-            self.system.part[:].f - self.forces, axis=1)
+            self.system.part.all().f - self.forces, axis=1)
         self.assertLess(
             np.mean(force_diff), self.tolerance,
             msg="Absolute force difference too large for method " + method_name)

--- a/testsuite/python/coulomb_mixed_periodicity.py
+++ b/testsuite/python/coulomb_mixed_periodicity.py
@@ -58,7 +58,7 @@ class CoulombMixedPeriodicity(ut.TestCase):
 
         # Force
         force_diff = np.linalg.norm(
-            self.system.part[:].f - self.forces, axis=1)
+            self.system.part.all().f - self.forces, axis=1)
         self.assertLessEqual(
             np.mean(force_diff), self.tolerance_force,
             "Absolute force difference too large for method " + method_name)

--- a/testsuite/python/coulomb_tuning.py
+++ b/testsuite/python/coulomb_tuning.py
@@ -50,7 +50,7 @@ class CoulombCloudWallTune(ut.TestCase):
     def compare(self, method_name):
         # Compare forces now in the system to stored ones
         difference = np.linalg.norm(
-            self.system.part[:].f - self.forces, axis=1)
+            self.system.part.all().f - self.forces, axis=1)
         self.assertLessEqual(
             np.mean(difference), self.tolerance,
             "Absolute force difference too large for method " + method_name)

--- a/testsuite/python/dawaanr-and-bh-gpu.py
+++ b/testsuite/python/dawaanr-and-bh-gpu.py
@@ -79,8 +79,8 @@ class BHGPUTest(ut.TestCase):
             self.system.actors.add(dds_cpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            dawaanr_f = np.copy(self.system.part[:].f)
-            dawaanr_t = np.copy(self.system.part[:].torque_lab)
+            dawaanr_f = np.copy(self.system.part.all().f)
+            dawaanr_t = np.copy(self.system.part.all().torque_lab)
             dawaanr_e = self.system.analysis.energy()["total"]
 
             del dds_cpu
@@ -92,8 +92,8 @@ class BHGPUTest(ut.TestCase):
             self.system.actors.add(bh_gpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            bhgpu_f = np.copy(self.system.part[:].f)
-            bhgpu_t = np.copy(self.system.part[:].torque_lab)
+            bhgpu_f = np.copy(self.system.part.all().f)
+            bhgpu_t = np.copy(self.system.part.all().torque_lab)
             bhgpu_e = self.system.analysis.energy()["total"]
 
             # compare

--- a/testsuite/python/dawaanr-and-dds-gpu.py
+++ b/testsuite/python/dawaanr-and-dds-gpu.py
@@ -75,8 +75,8 @@ class DDSGPUTest(ut.TestCase):
             self.system.actors.add(dds_cpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            dawaanr_f = np.copy(self.system.part[:].f)
-            dawaanr_t = np.copy(self.system.part[:].torque_lab)
+            dawaanr_f = np.copy(self.system.part.all().f)
+            dawaanr_t = np.copy(self.system.part.all().torque_lab)
             dawaanr_e = self.system.analysis.energy()["total"]
 
             del dds_cpu
@@ -89,8 +89,8 @@ class DDSGPUTest(ut.TestCase):
             self.system.actors.add(dds_gpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            ddsgpu_f = np.copy(self.system.part[:].f)
-            ddsgpu_t = np.copy(self.system.part[:].torque_lab)
+            ddsgpu_f = np.copy(self.system.part.all().f)
+            ddsgpu_t = np.copy(self.system.part.all().torque_lab)
             ddsgpu_e = self.system.analysis.energy()["total"]
 
             # compare

--- a/testsuite/python/dds-and-bh-gpu.py
+++ b/testsuite/python/dds-and-bh-gpu.py
@@ -43,8 +43,8 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
         pf_dds_gpu = 3.524
         ratio_dawaanr_bh_gpu = pf_dds_gpu / pf_bh_gpu
         l = 15
-        self.system.box_l = [l, l, l]
-        self.system.periodicity = [0, 0, 0]
+        self.system.box_l = 3 * [l]
+        self.system.periodicity = 3 * [False]
         self.system.time_step = 1E-4
         self.system.cell_system.skin = 0.1
 
@@ -80,8 +80,8 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
             self.system.actors.add(dds_gpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            dawaanr_f = np.copy(self.system.part[:].f)
-            dawaanr_t = np.copy(self.system.part[:].torque_lab)
+            dawaanr_f = np.copy(self.system.part.all().f)
+            dawaanr_t = np.copy(self.system.part.all().torque_lab)
             dawaanr_e = self.system.analysis.energy()["total"]
 
             del dds_gpu
@@ -93,8 +93,8 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
             self.system.actors.add(bh_gpu)
             self.system.integrator.run(steps=0, recalc_forces=True)
 
-            bhgpu_f = np.copy(self.system.part[:].f)
-            bhgpu_t = np.copy(self.system.part[:].torque_lab)
+            bhgpu_f = np.copy(self.system.part.all().f)
+            bhgpu_t = np.copy(self.system.part.all().torque_lab)
             bhgpu_e = self.system.analysis.energy()["total"]
 
             # compare

--- a/testsuite/python/dipolar_direct_summation.py
+++ b/testsuite/python/dipolar_direct_summation.py
@@ -51,8 +51,8 @@ class dds(ut.TestCase):
 
         system.integrator.run(steps=0, recalc_forces=True)
         ref_e = system.analysis.energy()["dipolar"]
-        ref_f = np.copy(system.part[:].f)
-        ref_t = np.copy(system.part[:].torque_lab)
+        ref_f = np.copy(self.particles.f)
+        ref_t = np.copy(self.particles.torque_lab)
 
         system.actors.clear()
 
@@ -66,8 +66,8 @@ class dds(ut.TestCase):
 
         system.integrator.run(steps=0, recalc_forces=True)
         ref_e = system.analysis.energy()["dipolar"]
-        ref_f = np.copy(system.part[:].f)
-        ref_t = np.copy(system.part[:].torque_lab)
+        ref_f = np.copy(self.particles.f)
+        ref_t = np.copy(self.particles.torque_lab)
 
         system.actors.clear()
 
@@ -82,8 +82,8 @@ class dds(ut.TestCase):
 
         system.integrator.run(steps=0, recalc_forces=True)
         ref_e = system.analysis.energy()["dipolar"]
-        ref_f = np.copy(system.part[:].f)
-        ref_t = np.copy(system.part[:].torque_lab)
+        ref_f = np.copy(self.particles.f)
+        ref_t = np.copy(self.particles.torque_lab)
 
         system.actors.clear()
 
@@ -101,8 +101,8 @@ class dds(ut.TestCase):
 
         system.integrator.run(0, recalc_forces=True)
         ref_e = system.analysis.energy()["dipolar"]
-        ref_f = np.copy(system.part[:].f)
-        ref_t = np.copy(system.part[:].torque_lab)
+        ref_f = np.copy(self.particles.f)
+        ref_t = np.copy(self.particles.torque_lab)
 
         system.actors.clear()
 
@@ -131,8 +131,8 @@ class dds(ut.TestCase):
         dipole_modulus = 1.3
         part_pos = np.random.random((N, 3)) * system.box_l
         part_dip = dipole_modulus * tests_common.random_dipoles(N)
-        particles = system.part.add(pos=part_pos, dip=part_dip,
-                                    rotation=N * [(1, 1, 1)])
+        self.particles = system.part.add(pos=part_pos, dip=part_dip,
+                                         rotation=N * [(1, 1, 1)])
 
         # minimize system
         system.non_bonded_inter[0, 0].lennard_jones.set_params(
@@ -154,8 +154,8 @@ class dds(ut.TestCase):
         np.save(
             filepath_arrays,
             np.hstack(
-                (particles.pos_folded,
-                 particles.dip,
+                (self.particles.pos_folded,
+                 self.particles.dip,
                  ref_f,
                  ref_t)),
             allow_pickle=False)
@@ -171,7 +171,8 @@ class dds(ut.TestCase):
         ref_f = array_data[:, 6:9]
         ref_t = array_data[:, 9:12]
 
-        system.part.add(pos=pos, dip=dip, rotation=[[1, 1, 1]] * len(pos))
+        self.particles = system.part.add(
+            pos=pos, dip=dip, rotation=[[1, 1, 1]] * len(pos))
         dds_e, dds_f, dds_t = method_func()
         self.assertAlmostEqual(dds_e, ref_e, delta=energy_tol)
         np.testing.assert_allclose(dds_f, ref_f, atol=force_tol)

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -70,8 +70,8 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         # Particles
         data = np.genfromtxt(
             tests_common.abspath("data/mdlc_reference_data_forces_torques.dat"))
-        s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
-        s.part[:].rotation = (1, 1, 1)
+        partcls = s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
+        partcls.rotation = 3 * [True]
 
         p3m = espressomd.magnetostatics.DipolarP3M(
             prefactor=DIPOLAR_PREFACTOR, mesh=32, accuracy=1E-4)
@@ -81,9 +81,9 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         s.actors.add(dlc)
         s.integrator.run(0)
         err_f = self.vector_error(
-            s.part[:].f, data[:, 7:10] * DIPOLAR_PREFACTOR)
+            partcls.f, data[:, 7:10] * DIPOLAR_PREFACTOR)
         err_t = self.vector_error(
-            s.part[:].torque_lab, data[:, 10:13] * DIPOLAR_PREFACTOR)
+            partcls.torque_lab, data[:, 10:13] * DIPOLAR_PREFACTOR)
         err_e = s.analysis.energy()["dipolar"] - ref_E
 
         tol_f = 2E-3
@@ -96,7 +96,8 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
 
         # Check if error is thrown when particles enter the MDLC gap
         # positive direction
-        s.part[0].pos = [
+        p0 = s.part.by_id(0)
+        p0.pos = [
             s.box_l[0] / 2,
             s.box_l[1] / 2,
             s.box_l[2] - gap_size / 2]
@@ -105,7 +106,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         with self.assertRaises(Exception):
             self.integrator.run(2)
         # negative direction
-        s.part[0].pos = [s.box_l[0] / 2, s.box_l[1] / 2, -gap_size / 2]
+        p0.pos = [s.box_l[0] / 2, s.box_l[1] / 2, -gap_size / 2]
         with self.assertRaises(Exception):
             self.system.analysis.energy()
         with self.assertRaises(Exception):
@@ -126,8 +127,8 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         # Particles
         data = np.genfromtxt(
             tests_common.abspath("data/p3m_magnetostatics_system.data"))
-        s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
-        s.part[:].rotation = (1, 1, 1)
+        partcls = s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
+        partcls.rotation = 3 * [True]
 
         p3m = espressomd.magnetostatics.DipolarP3M(
             prefactor=DIPOLAR_PREFACTOR, mesh=32, accuracy=1E-6, epsilon="metallic")
@@ -136,9 +137,9 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         expected = np.genfromtxt(
             tests_common.abspath("data/p3m_magnetostatics_expected.data"))[:, 1:]
         err_f = self.vector_error(
-            s.part[:].f, expected[:, 0:3] * DIPOLAR_PREFACTOR)
+            partcls.f, expected[:, 0:3] * DIPOLAR_PREFACTOR)
         err_t = self.vector_error(
-            s.part[:].torque_lab, expected[:, 3:6] * DIPOLAR_PREFACTOR)
+            partcls.torque_lab, expected[:, 3:6] * DIPOLAR_PREFACTOR)
         ref_E = 5.570 * DIPOLAR_PREFACTOR
         err_e = s.analysis.energy()["dipolar"] - ref_E
 
@@ -166,8 +167,8 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         # Particles
         data = np.genfromtxt(
             tests_common.abspath("data/p3m_magnetostatics_system.data"))
-        s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
-        s.part[:].rotation = (1, 1, 1)
+        partcls = s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
+        partcls.rotation = 3 * [True]
 
         scafacos = espressomd.magnetostatics.Scafacos(
             prefactor=DIPOLAR_PREFACTOR,
@@ -187,9 +188,9 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         expected = np.genfromtxt(
             tests_common.abspath("data/p3m_magnetostatics_expected.data"))[:, 1:]
         err_f = self.vector_error(
-            s.part[:].f, expected[:, 0:3] * DIPOLAR_PREFACTOR)
+            partcls.f, expected[:, 0:3] * DIPOLAR_PREFACTOR)
         err_t = self.vector_error(
-            s.part[:].torque_lab, expected[:, 3:6] * DIPOLAR_PREFACTOR)
+            partcls.torque_lab, expected[:, 3:6] * DIPOLAR_PREFACTOR)
         ref_E = 5.570 * DIPOLAR_PREFACTOR
         err_e = s.analysis.energy()["dipolar"] - ref_E
 

--- a/testsuite/python/dipolar_p3m.py
+++ b/testsuite/python/dipolar_p3m.py
@@ -27,12 +27,11 @@ import espressomd.magnetostatic_extensions
 
 @utx.skipIfMissingFeatures(["DP3M"])
 class MagnetostaticsP3M(ut.TestCase):
-    system = espressomd.System(box_l=[10., 10., 10.])
+    system = espressomd.System(box_l=3 * [10.])
 
     def setUp(self):
-        self.system.box_l = [10., 10., 10.]
-        self.system.part.add(pos=[4.0, 2.0, 2.0], dip=(1.3, 2.1, -6.0))
-        self.system.part.add(pos=[6.0, 2.0, 2.0], dip=(7.3, 6.1, -4.0))
+        self.partcls = self.system.part.add(pos=[[4.0, 2.0, 2.0], [6.0, 2.0, 2.0]],
+                                            dip=[(1.3, 2.1, -6.0), (7.3, 6.1, -4.0)])
 
     def tearDown(self):
         self.system.part.clear()
@@ -48,7 +47,7 @@ class MagnetostaticsP3M(ut.TestCase):
         self.system.time_step = 0.01
         prefactor = 1.1
         box_vol = self.system.volume()
-        p1, p2 = self.system.part[:]
+        p1, p2 = self.partcls
         dip = np.copy(p1.dip + p2.dip)
         dp3m_params = {'accuracy': 1e-6,
                        'mesh': [49, 49, 49],
@@ -82,7 +81,7 @@ class MagnetostaticsP3M(ut.TestCase):
 
         # keep current values as reference to check for DP3M dipole correction
         ref_dp3m_energy_metallic = self.system.analysis.energy()['dipolar']
-        ref_dp3m_forces_metallic = np.copy(self.system.part[:].f)
+        ref_dp3m_forces_metallic = np.copy(self.partcls.f)
         ref_dp3m_torque_metallic = np.array([
             p1.convert_vector_space_to_body(p1.torque_lab),
             p2.convert_vector_space_to_body(p2.torque_lab)])
@@ -94,8 +93,8 @@ class MagnetostaticsP3M(ut.TestCase):
         # keep current values as reference to check for MDLC dipole correction
         self.system.integrator.run(0, recalc_forces=True)
         ref_mdlc_energy_metallic = self.system.analysis.energy()['dipolar']
-        ref_mdlc_forces_metallic = np.copy(self.system.part[:].f)
-        ref_mdlc_torque_metallic = np.copy(self.system.part[:].torque_lab)
+        ref_mdlc_forces_metallic = np.copy(self.partcls.f)
+        ref_mdlc_torque_metallic = np.copy(self.partcls.torque_lab)
         self.system.actors.clear()
 
         # check non-metallic case
@@ -111,7 +110,7 @@ class MagnetostaticsP3M(ut.TestCase):
                 prefactor=prefactor, epsilon=epsilon, tune=False, **dp3m_params)
             self.system.actors.add(dp3m)
             self.system.integrator.run(0, recalc_forces=True)
-            dp3m_forces = np.copy(self.system.part[:].f)
+            dp3m_forces = np.copy(self.partcls.f)
             dp3m_torque = np.array([
                 p1.convert_vector_space_to_body(p1.torque_lab),
                 p2.convert_vector_space_to_body(p2.torque_lab)])
@@ -127,8 +126,8 @@ class MagnetostaticsP3M(ut.TestCase):
             mdlc = espressomd.magnetostatic_extensions.DLC(**mdlc_params)
             self.system.actors.add(mdlc)
             self.system.integrator.run(0, recalc_forces=True)
-            mdlc_forces = np.copy(self.system.part[:].f)
-            mdlc_torque = np.copy(self.system.part[:].torque_lab)
+            mdlc_forces = np.copy(self.partcls.f)
+            mdlc_torque = np.copy(self.partcls.torque_lab)
             mdlc_energy = self.system.analysis.energy()['dipolar']
             np.testing.assert_allclose(mdlc_forces, ref_mdlc_forces, atol=tol)
             np.testing.assert_allclose(mdlc_torque, ref_mdlc_torque, atol=tol)

--- a/testsuite/python/domain_decomposition.py
+++ b/testsuite/python/domain_decomposition.py
@@ -24,7 +24,7 @@ np.random.seed(42)
 
 
 class DomainDecomposition(ut.TestCase):
-    system = espressomd.System(box_l=[50.0, 50.0, 50.0])
+    system = espressomd.System(box_l=3 * [50.0])
     original_node_grid = tuple(system.cell_system.node_grid)
 
     def setUp(self):
@@ -40,10 +40,11 @@ class DomainDecomposition(ut.TestCase):
         n_part = 2351
 
         # Add the particles on node 0, so that they have to be resorted
-        self.system.part.add(pos=n_part * [(0, 0, 0)], type=n_part * [1])
+        partcls = self.system.part.add(
+            pos=n_part * [(0, 0, 0)], type=n_part * [1])
 
         # And now change their positions
-        self.system.part[:].pos = self.system.box_l * \
+        partcls.pos = self.system.box_l * \
             np.random.random((n_part, 3))
 
         # Add an interacting particle in a corner of the box
@@ -63,7 +64,7 @@ class DomainDecomposition(ut.TestCase):
         # Check that we can still access all the particles
         # This basically checks if part_node and local_particles
         # is still in a valid state after the particle exchange
-        self.assertEqual(sum(self.system.part[:].type), n_part)
+        self.assertEqual(sum(self.system.part.all().type), n_part)
 
         # Check that the system is still valid
         if espressomd.has_features(['LENNARD_JONES']):

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -125,7 +125,7 @@ class DPDThermostat(ut.TestCase):
         system.integrator.run(0)
 
         # Outside of both cutoffs, forces should be 0
-        for f in system.part[:].f:
+        for f in system.part.all().f:
             np.testing.assert_array_equal(np.copy(f), [0., 0., 0.])
 
         # Only trans
@@ -167,7 +167,7 @@ class DPDThermostat(ut.TestCase):
         system.integrator.run(0)
 
         # Outside of both cutoffs, forces should be 0
-        for f in system.part[:].f:
+        for f in system.part.all().f:
             np.testing.assert_array_equal(np.copy(f), [0., 0., 0.])
 
         # Only trans
@@ -221,7 +221,7 @@ class DPDThermostat(ut.TestCase):
         p1 = system.part.add(pos=[3, 5, 5], type=0, v=v)
 
         # Outside of both cutoffs, forces should be 0
-        for f in system.part[:].f:
+        for f in system.part.all().f:
             np.testing.assert_array_equal(np.copy(f), [0., 0., 0.])
 
         # Place the particle at different positions to test the parabolic
@@ -347,13 +347,13 @@ class DPDThermostat(ut.TestCase):
             trans_weight_function=1, trans_gamma=gamma / 2.0, trans_r_cut=r_cut)
 
         pos = system.box_l * np.random.random((n_part, 3))
-        system.part.add(pos=pos)
+        partcls = system.part.add(pos=pos)
         system.integrator.run(10)
 
         for kT in [0., 2.]:
             system.thermostat.set_dpd(kT=kT, seed=3)
             # run 1 integration step to get velocities
-            system.part[:].v = np.zeros((n_part, 3))
+            partcls.v = np.zeros((n_part, 3))
             system.integrator.run(steps=1)
 
             pairs = system.part.pairs()
@@ -383,18 +383,18 @@ class DPDThermostat(ut.TestCase):
 
         system = self.system
         system.thermostat.set_dpd(kT=1.3, seed=42)
-        system.part.add(pos=((0, 0, 0), (0.1, 0.1, 0.1), (0.1, 0, 0)),
-                        mass=(1, 2, 3))
+        partcls = system.part.add(pos=((0, 0, 0), (0.1, 0.1, 0.1), (0.1, 0, 0)),
+                                  mass=(1, 2, 3))
 
         system.non_bonded_inter[0, 0].dpd.set_params(
             weight_function=1, gamma=gamma, r_cut=r_cut,
             trans_weight_function=1, trans_gamma=gamma / 2.0, trans_r_cut=r_cut)
-        momentum = np.matmul(system.part[:].v.T, system.part[:].mass)
+        momentum = np.matmul(partcls.v.T, partcls.mass)
         for _ in range(10):
             system.integrator.run(25)
-            np.testing.assert_almost_equal(np.sum(system.part[:].f), 3 * [0.])
+            np.testing.assert_almost_equal(np.sum(partcls.f), 3 * [0.])
             np.testing.assert_allclose(
-                np.matmul(system.part[:].v.T, system.part[:].mass), momentum, atol=1E-12)
+                np.matmul(partcls.v.T, partcls.mass), momentum, atol=1E-12)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/dpd_stats.py
+++ b/testsuite/python/dpd_stats.py
@@ -42,14 +42,14 @@ class DPDThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         self.system.integrator.set_vv()
 
     def check_total_zero(self):
-        v_total = np.sum(self.system.part[:].v, axis=0)
+        v_total = np.sum(self.system.part.all().v, axis=0)
         np.testing.assert_allclose(v_total, np.zeros(3), atol=1e-11)
 
     def single(self, with_langevin=False):
         """Test velocity distribution of a dpd fluid with a single type."""
         N = 500
         system = self.system
-        system.part.add(pos=system.box_l * np.random.random((N, 3)))
+        partcls = system.part.add(pos=system.box_l * np.random.random((N, 3)))
         kT = 2.3
         gamma = 1.5
         if with_langevin:
@@ -63,7 +63,7 @@ class DPDThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             system.integrator.run(10)
-            v_stored[i] = system.part[:].v
+            v_stored[i] = partcls.v
         v_minmax = 5
         bins = 5
         error_tol = 0.01
@@ -104,7 +104,7 @@ class DPDThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             system.integrator.run(10)
-            v_stored[i] = system.part[:].v
+            v_stored[i] = system.part.all().v
         v_minmax = 5
         bins = 5
         error_tol = 0.01
@@ -116,7 +116,7 @@ class DPDThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         N = 200
         system = self.system
         system.time_step = 0.01
-        system.part.add(pos=system.box_l * np.random.random((N, 3)))
+        partcls = system.part.add(pos=system.box_l * np.random.random((N, 3)))
         kT = 2.3
         gamma = 1.5
         system.thermostat.set_dpd(kT=kT, seed=42)
@@ -129,12 +129,12 @@ class DPDThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         system.thermostat.turn_off()
 
         # Reset velocities
-        system.part[:].v = [1., 2., 3.]
+        partcls.v = [1., 2., 3.]
 
         system.integrator.run(10)
 
         # Check that there was neither noise nor friction
-        for v in system.part[:].v:
+        for v in partcls.v:
             for i in range(3):
                 self.assertEqual(v[i], float(i + 1))
 
@@ -142,7 +142,7 @@ class DPDThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         system.thermostat.set_dpd(kT=kT, seed=42)
 
         # Reset velocities for faster convergence
-        system.part[:].v = [0., 0., 0.]
+        partcls.v = [0., 0., 0.]
 
         # Equilibrate
         system.integrator.run(250)
@@ -151,7 +151,7 @@ class DPDThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             system.integrator.run(10)
-            v_stored[i] = system.part[:].v
+            v_stored[i] = partcls.v
         v_minmax = 5
         bins = 5
         error_tol = 0.012

--- a/testsuite/python/elc_vs_analytic.py
+++ b/testsuite/python/elc_vs_analytic.py
@@ -83,7 +83,7 @@ class ELC_vs_analytic(ut.TestCase):
             elc_results, analytic_results, rtol=0, atol=self.check_accuracy)
 
     def scan(self):
-        p1, p2 = self.system.part[:]
+        p1, p2 = self.system.part.all()
         result_array = np.empty((len(self.q), len(self.zPos), 2))
         for chargeIndex, charge in enumerate(self.q):
             p1.q = charge

--- a/testsuite/python/engine_langevin.py
+++ b/testsuite/python/engine_langevin.py
@@ -50,7 +50,7 @@ class SwimmerTest(ut.TestCase):
 
         p0 = system.part.add(pos=pos_0, swimming={"v_swim": v_swim})
         p1 = system.part.add(pos=pos_1, swimming={"f_swim": f_swim})
-        system.part[:].rotation = (1, 1, 1)
+        system.part.all().rotation = (1, 1, 1)
 
         system.thermostat.set_langevin(kT=temp, gamma=gamma, seed=42)
 

--- a/testsuite/python/force_cap.py
+++ b/testsuite/python/force_cap.py
@@ -36,7 +36,7 @@ class ForceCap(ut.TestCase):
     np.random.seed(42)
 
     def calc_f_max(self):
-        f = np.power(self.system.part[:].f, 2)
+        f = np.power(self.system.part.all().f, 2)
         sqr_sum = (np.sum(f, axis=1))
         f_max = np.max(sqr_sum)**0.5
         return f_max

--- a/testsuite/python/galilei.py
+++ b/testsuite/python/galilei.py
@@ -28,15 +28,15 @@ class Galilei(ut.TestCase):
 
     def setUp(self):
         N_PART = 500
-        self.system.part.add(
+        self.partcls = self.system.part.add(
             pos=self.system.box_l * np.random.random((N_PART, 3)),
             v=-5. + 10. * np.random.random((N_PART, 3)),
             f=np.random.random((N_PART, 3)))
         if espressomd.has_features("MASS"):
-            self.system.part[:].mass = 42. * np.random.random((N_PART,))
+            self.partcls.mass = 42. * np.random.random((N_PART,))
         if espressomd.has_features("ROTATION"):
-            self.system.part[:].omega_lab = -2. - np.random.random((N_PART, 3))
-            self.system.part[:].torque_lab = - \
+            self.partcls.omega_lab = -2. - np.random.random((N_PART, 3))
+            self.partcls.torque_lab = - \
                 2. - np.random.random((N_PART, 3))
 
     def tearDown(self):
@@ -46,34 +46,34 @@ class Galilei(ut.TestCase):
         g = espressomd.galilei.GalileiTransform()
         g.kill_particle_motion()
 
-        np.testing.assert_array_equal(np.copy(self.system.part[:].v), 0)
+        np.testing.assert_array_equal(np.copy(self.partcls.v), 0)
 
         if espressomd.has_features("ROTATION"):
             np.testing.assert_array_less(
-                np.copy(self.system.part[:].omega_lab), 0)
+                np.copy(self.partcls.omega_lab), 0)
 
             g.kill_particle_motion(rotation=True)
 
             np.testing.assert_array_equal(
-                np.copy(self.system.part[:].omega_lab), 0)
+                np.copy(self.partcls.omega_lab), 0)
 
     def test_kill_particle_forces(self):
         g = espressomd.galilei.GalileiTransform()
         g.kill_particle_forces()
 
-        np.testing.assert_array_equal(np.copy(self.system.part[:].f), 0)
+        np.testing.assert_array_equal(np.copy(self.partcls.f), 0)
 
         if espressomd.has_features("ROTATION"):
             np.testing.assert_array_less(
-                np.copy(self.system.part[:].torque_lab), 0)
+                np.copy(self.partcls.torque_lab), 0)
 
             g.kill_particle_forces(torque=True)
 
             np.testing.assert_array_equal(
-                np.copy(self.system.part[:].torque_lab), 0)
+                np.copy(self.partcls.torque_lab), 0)
 
     def test_cms(self):
-        parts = self.system.part[:]
+        parts = self.partcls
         g = espressomd.galilei.GalileiTransform()
 
         total_mass = np.sum(parts.mass)
@@ -83,7 +83,7 @@ class Galilei(ut.TestCase):
         np.testing.assert_allclose(np.copy(g.system_CMS()), com)
 
     def test_cms_velocity(self):
-        parts = self.system.part[:]
+        parts = self.partcls
         g = espressomd.galilei.GalileiTransform()
         total_mass = np.sum(parts.mass)
         com_v = np.sum(

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -57,20 +57,20 @@ class H5mdTests(ut.TestCase):
     system.time_step = 0.01
 
     for i in range(N_PART):
-        system.part.add(id=i, pos=np.array(3 * [i], dtype=float),
-                        v=np.array([1.0, 2.0, 3.0]), type=23)
+        p = system.part.add(id=i, pos=np.array(3 * [i], dtype=float),
+                            v=np.array([1.0, 2.0, 3.0]), type=23)
         if espressomd.has_features(['MASS']):
-            system.part[i].mass = 2.3
+            p.mass = 2.3
         if espressomd.has_features(['EXTERNAL_FORCES']):
-            system.part[i].ext_force = [0.1, 0.2, 0.3]
+            p.ext_force = [0.1, 0.2, 0.3]
         if espressomd.has_features(['ELECTROSTATICS']):
-            system.part[i].q = i
+            p.q = i
 
     vb = espressomd.interactions.Virtual()
     system.bonded_inter.add(vb)
 
     for i in range(N_PART - 1):
-        system.part[i].add_bond((vb, i + 1))
+        system.part.by_id(i).add_bond((vb, i + 1))
 
     system.integrator.run(steps=0)
     system.time = 12.3

--- a/testsuite/python/integrator_npt.py
+++ b/testsuite/python/integrator_npt.py
@@ -114,7 +114,7 @@ class IntegratorNPT(ut.TestCase):
         # the core state is unchanged
         system.integrator.run(1)
         np.testing.assert_allclose(
-            np.copy(system.part[:].pos),
+            np.copy(system.part.all().pos),
             positions_start + np.array([[-1.2e-3, 0, 0], [1.2e-3, 0, 0]]))
 
     def run_with_p3m(self, p3m, **npt_kwargs):
@@ -122,11 +122,13 @@ class IntegratorNPT(ut.TestCase):
         np.random.seed(42)
         # set up particles
         system.box_l = [6] * 3
-        system.part.add(pos=np.random.uniform(0, system.box_l[0], (11, 3)))
+        partcl = system.part.add(
+            pos=np.random.uniform(
+                0, system.box_l[0], (11, 3)))
         if espressomd.has_features("P3M"):
-            system.part[:].q = np.sign(np.arange(-5, 6))
+            partcl.q = np.sign(np.arange(-5, 6))
         if espressomd.has_features("DP3M"):
-            system.part[:].dip = tests_common.random_dipoles(11)
+            partcl.dip = tests_common.random_dipoles(11)
         system.non_bonded_inter[0, 0].lennard_jones.set_params(
             epsilon=1, sigma=1, cutoff=2**(1 / 6), shift=0.25)
         system.integrator.set_steepest_descent(

--- a/testsuite/python/interactions_bonded.py
+++ b/testsuite/python/interactions_bonded.py
@@ -83,7 +83,7 @@ class InteractionsBondedTest(ut.TestCase):
         coulomb_k = 1
         q1 = 1
         q2 = -1
-        p1, p2 = self.system.part[:]
+        p1, p2 = self.system.part.all()
         p1.q = q1
         p2.q = q2
         self.run_test(
@@ -98,7 +98,7 @@ class InteractionsBondedTest(ut.TestCase):
         # interactions
         q1 = 1.2
         q2 = -q1
-        p1, p2 = self.system.part[:]
+        p1, p2 = self.system.part.all()
         p1.q = q1
         p2.q = q2
         r_cut = 2
@@ -143,7 +143,7 @@ class InteractionsBondedTest(ut.TestCase):
     def run_test(self, bond_instance, force_func, energy_func, min_dist,
                  cutoff, test_breakage=False):
         self.system.bonded_inter.add(bond_instance)
-        p1, p2 = self.system.part[:]
+        p1, p2 = self.system.part.all()
         p1.bonds = ((bond_instance, p2),)
 
         # n+1 steps from min_dist to cut, then we remove the cut, because that

--- a/testsuite/python/interactions_dihedral.py
+++ b/testsuite/python/interactions_dihedral.py
@@ -121,7 +121,7 @@ class InteractionsBondedTest(ut.TestCase):
 
     # Test Dihedral Angle
     def test_dihedral(self):
-        p0, p1, p2, p3 = self.system.part[:]
+        p0, p1, p2, p3 = self.system.part.all()
 
         dh_k = 1
         dh_phase = np.pi / 6
@@ -161,7 +161,7 @@ class InteractionsBondedTest(ut.TestCase):
     # Test Tabulated Dihedral Angle
     @utx.skipIfMissingFeatures(["TABULATED"])
     def test_tabulated_dihedral(self):
-        p0, p1, p2, p3 = self.system.part[:]
+        p0, p1, p2, p3 = self.system.part.all()
 
         N = 111
         d_phi = 2 * np.pi / N

--- a/testsuite/python/interactions_non-bonded.py
+++ b/testsuite/python/interactions_non-bonded.py
@@ -344,7 +344,7 @@ class InteractionsNonBondedTest(ut.TestCase):
 
         setup_system(gb_params)
 
-        p1, p2 = self.system.part[:]
+        p1, p2 = self.system.part.all()
 
         delta = 1.0e-6
 
@@ -405,7 +405,7 @@ class InteractionsNonBondedTest(ut.TestCase):
 
         getattr(self.system.non_bonded_inter[0, 0], name).set_params(
             **parameters)
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         p1.pos = p0.pos + self.step * n_initial_steps
 
         force_parameters = parameters.copy()

--- a/testsuite/python/langevin_thermostat_stats.py
+++ b/testsuite/python/langevin_thermostat_stats.py
@@ -192,7 +192,7 @@ class LangevinThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
 
         # linear vel
         vel_obs = espressomd.observables.ParticleVelocities(
-            ids=system.part[:].id)
+            ids=system.part.all().id)
         corr_vel = espressomd.accumulators.Correlator(
             obs1=vel_obs, tau_lin=10, tau_max=1.4, delta_N=2,
             corr_operation="componentwise_product", compress1="discard1")
@@ -200,7 +200,7 @@ class LangevinThermostat(ut.TestCase, thermostats_common.ThermostatsCommon):
         # angular vel
         if espressomd.has_features("ROTATION"):
             omega_obs = espressomd.observables.ParticleBodyAngularVelocities(
-                ids=system.part[:].id)
+                ids=system.part.all().id)
             corr_omega = espressomd.accumulators.Correlator(
                 obs1=omega_obs, tau_lin=10, tau_max=1.5, delta_N=2,
                 corr_operation="componentwise_product", compress1="discard1")

--- a/testsuite/python/lb_get_u_at_pos.py
+++ b/testsuite/python/lb_get_u_at_pos.py
@@ -77,7 +77,7 @@ class TestLBGetUAtPos(ut.TestCase):
         numpy.testing.assert_allclose(
             self.interpolated_vels[:-1],
             self.lb_fluid.get_interpolated_fluid_velocity_at_positions(
-                self.system.part[:].pos, False)[:-1],
+                self.system.part.all().pos, False)[:-1],
             atol=1e-4)
 
 

--- a/testsuite/python/lb_stats.py
+++ b/testsuite/python/lb_stats.py
@@ -50,10 +50,10 @@ class TestLB:
 
     def test_mass_momentum_thermostat(self):
         self.n_col_part = 100
-        self.system.part.add(pos=np.random.random(
+        partcls = self.system.part.add(pos=np.random.random(
             (self.n_col_part, 3)) * self.system.box_l[0])
         if espressomd.has_features("MASS"):
-            self.system.part[:].mass = 0.1 + np.random.random(
+            partcls.mass = 0.1 + np.random.random(
                 len(self.system.part))
 
         self.system.thermostat.turn_off()

--- a/testsuite/python/lb_thermostat.py
+++ b/testsuite/python/lb_thermostat.py
@@ -66,7 +66,7 @@ class LBThermostatCommon(thermostats_common.ThermostatsCommon):
         v_stored = np.zeros((loops, N, 3))
         for i in range(loops):
             self.system.integrator.run(3)
-            v_stored[i] = self.system.part[:].v
+            v_stored[i] = self.system.part.all().v
         minmax = 5
         n_bins = 7
         error_tol = 0.01

--- a/testsuite/python/lj.py
+++ b/testsuite/python/lj.py
@@ -47,8 +47,9 @@ class LennardJonesTest(ut.TestCase):
         self.system.part.add(pos=self.pos)
 
     def check(self):
-        f_diff = np.linalg.norm(self.system.part[:].f - self.forces, axis=1)
-        max_deviation = np.max(np.abs(self.system.part[:].f - self.forces))
+        all_partcls = self.system.part.all()
+        f_diff = np.linalg.norm(all_partcls.f - self.forces, axis=1)
+        max_deviation = np.max(np.abs(all_partcls.f - self.forces))
         self.assertLess(np.mean(f_diff), 1e-7)
         self.assertLess(max_deviation, 1e-5)
 

--- a/testsuite/python/mass-and-rinertia_per_particle.py
+++ b/testsuite/python/mass-and-rinertia_per_particle.py
@@ -151,13 +151,13 @@ class ThermoTest(ut.TestCase):
         for i in range(n):
             for k in range(2):
                 ind = i + k * n
-                self.system.part.add(
+                partcl = self.system.part.add(
                     rotation=(1, 1, 1), pos=(0.0, 0.0, 0.0), id=ind)
-                self.system.part[ind].v = [1.0, 1.0, 1.0]
+                partcl.v = [1.0, 1.0, 1.0]
                 if espressomd.has_features("ROTATION"):
-                    self.system.part[ind].omega_body = [1.0, 1.0, 1.0]
-                self.system.part[ind].mass = self.mass
-                self.system.part[ind].rinertia = self.J
+                    partcl.omega_body = [1.0, 1.0, 1.0]
+                partcl.mass = self.mass
+                partcl.rinertia = self.J
 
     def fluctuation_dissipation_param_setup(self, n):
         """
@@ -214,7 +214,7 @@ class ThermoTest(ut.TestCase):
                 part_pos = np.random.random(3) * box
                 part_v = [0.0, 0.0, 0.0]
                 part_omega_body = [0.0, 0.0, 0.0]
-                self.system.part.add(
+                partcl = self.system.part.add(
                     rotation=(1, 1, 1),
                     id=ind,
                     mass=self.mass,
@@ -222,7 +222,7 @@ class ThermoTest(ut.TestCase):
                     pos=part_pos,
                     v=part_v)
                 if espressomd.has_features("ROTATION"):
-                    self.system.part[ind].omega_body = part_omega_body
+                    partcl.omega_body = part_omega_body
 
     def check_dissipation(self, n):
         """
@@ -247,13 +247,13 @@ class ThermoTest(ut.TestCase):
                         # Hence, only isotropic gamma_tran_p_validate could be
                         # tested here.
                         self.assertAlmostEqual(
-                            self.system.part[ind].v[j],
+                            self.system.part.by_id(ind).v[j],
                             math.exp(- self.gamma_tran_p_validate[k, j]
                                      * self.system.time / self.mass),
                             delta=tol)
                         if espressomd.has_features("ROTATION"):
                             self.assertAlmostEqual(
-                                self.system.part[ind].omega_body[j],
+                                self.system.part.by_id(ind).omega_body[j],
                                 math.exp(- self.gamma_rot_p_validate[k, j]
                                          * self.system.time / self.J[j]),
                                 delta=tol)
@@ -288,7 +288,7 @@ class ThermoTest(ut.TestCase):
         for p in range(n):
             for k in range(2):
                 ind = p + k * n
-                pos0[ind, :] = self.system.part[ind].pos
+                pos0[ind, :] = self.system.part.by_id(ind).pos
         dt0 = self.mass / self.gamma_tran_p_validate
 
         loops = 10
@@ -302,11 +302,12 @@ class ThermoTest(ut.TestCase):
             for p in range(n):
                 for k in range(2):
                     ind = p + k * n
-                    v = self.system.part[ind].v
+                    partcl = self.system.part.by_id(ind)
+                    v = partcl.v
                     if espressomd.has_features("ROTATION"):
-                        o = self.system.part[ind].omega_body
+                        o = partcl.omega_body
                         o2[k, :] = o2[k, :] + np.power(o[:], 2)
-                    pos = self.system.part[ind].pos
+                    pos = partcl.pos
                     v2[k, :] = v2[k, :] + np.power(v[:], 2)
                     dr2[k, :] = np.power((pos[:] - pos0[ind, :]), 2)
                     dt = (int_steps * (i + 1) + therm_steps) * \
@@ -380,9 +381,10 @@ class ThermoTest(ut.TestCase):
             self.gamma_rot_p_validate[k, :] = self.gamma_rot_p[k, :]
             for i in range(n):
                 ind = i + k * n
-                self.system.part[ind].gamma = self.gamma_tran_p[k, :]
+                partcl = self.system.part.by_id(ind)
+                partcl.gamma = self.gamma_tran_p[k, :]
                 if espressomd.has_features("ROTATION"):
-                    self.system.part[ind].gamma_rot = self.gamma_rot_p[k, :]
+                    partcl.gamma_rot = self.gamma_rot_p[k, :]
 
     def set_diffusivity_tran(self):
         """

--- a/testsuite/python/mdanalysis.py
+++ b/testsuite/python/mdanalysis.py
@@ -50,12 +50,13 @@ class TestMDAnalysis(ut.TestCase):
     system.bonded_inter.add(bond)
     system.bonded_inter.add(angle)
     system.bonded_inter.add(dihe)
-    system.part[1].add_bond((bond, 0))
-    system.part[3].add_bond((angle, 2, 4))
-    system.part[6].add_bond((dihe, 5, 7, 8))
+    system.part.by_id(1).add_bond((bond, 0))
+    system.part.by_id(3).add_bond((angle, 2, 4))
+    system.part.by_id(6).add_bond((dihe, 5, 7, 8))
 
     def test_universe(self):
         system = self.system
+        partcls = system.part.all()
         eos = espressomd.MDA_ESP.Stream(system)
         u = mda.Universe(eos.topology, eos.trajectory)
         # check atoms
@@ -63,13 +64,13 @@ class TestMDAnalysis(ut.TestCase):
         np.testing.assert_equal(u.atoms.ids, np.arange(10) + 1)
         np.testing.assert_equal(u.atoms.types, 5 * ['T0', 'T1'])
         np.testing.assert_almost_equal(
-            u.atoms.charges, system.part[:].q, decimal=6)
+            u.atoms.charges, partcls.q, decimal=6)
         np.testing.assert_almost_equal(
-            u.atoms.positions, system.part[:].pos, decimal=6)
+            u.atoms.positions, partcls.pos, decimal=6)
         np.testing.assert_almost_equal(
-            u.atoms.velocities, system.part[:].v, decimal=6)
+            u.atoms.velocities, partcls.v, decimal=6)
         np.testing.assert_almost_equal(
-            u.atoms.forces, system.part[:].f, decimal=6)
+            u.atoms.forces, partcls.f, decimal=6)
         # check bonds
         self.assertEqual(len(u.bonds), 1)
         self.assertEqual(len(u.angles), 1)

--- a/testsuite/python/mmm1d.py
+++ b/testsuite/python/mmm1d.py
@@ -55,7 +55,7 @@ class ElectrostaticInteractionsTests:
         self.system.actors.clear()
 
     def test_forces(self):
-        measured_f = np.copy(self.system.part[:].f)
+        measured_f = np.copy(self.system.part.all().f)
         np.testing.assert_allclose(measured_f, self.forces_target,
                                    atol=self.allowed_error)
 

--- a/testsuite/python/nsquare.py
+++ b/testsuite/python/nsquare.py
@@ -40,10 +40,11 @@ class NSquare(ut.TestCase):
         n_part_avg = n_part // n_nodes
 
         # Add the particles on node 0, so that they have to be resorted
-        self.system.part.add(pos=n_part * [(0, 0, 0)], type=n_part * [1])
+        partcls = self.system.part.add(
+            pos=n_part * [(0, 0, 0)], type=n_part * [1])
 
         # And now change their positions
-        self.system.part[:].pos = self.system.box_l * \
+        partcls.pos = self.system.box_l * \
             np.random.random((n_part, 3))
 
         # Add an interacting particle in a corner of the box
@@ -67,7 +68,7 @@ class NSquare(ut.TestCase):
         # Check that we can still access all the particles
         # This basically checks if part_node and local_particles
         # are still in a valid state after the particle exchange
-        self.assertEqual(sum(self.system.part[:].type), n_part)
+        self.assertEqual(sum(partcls.type), n_part)
 
         # Check that the system is still valid
         if espressomd.has_features(['LENNARD_JONES']):

--- a/testsuite/python/observable_cylindrical.py
+++ b/testsuite/python/observable_cylindrical.py
@@ -134,7 +134,7 @@ class TestCylindricalObservable(ut.TestCase):
                 self.cyl_transform_params.center)
             vel_aligned.append(self.align_with_observable_frame(vel))
         self.system.part.add(pos=pos_aligned, v=vel_aligned)
-        self.params['ids'] = self.system.part[:].id
+        self.params['ids'] = self.system.part.all().id
 
         return np_dens, np_edges
 
@@ -206,7 +206,7 @@ class TestCylindricalObservable(ut.TestCase):
         params['n_z_bins'] = 8
         self.system.part.add(pos=[0, 0, 0], type=0)
         self.system.part.add(pos=[0, 0, 0], type=1)
-        params['ids'] = self.system.part[:].id
+        params['ids'] = self.system.part.all().id
         observable = espressomd.observables.CylindricalDensityProfile(**params)
         # check pids
         np.testing.assert_array_equal(np.copy(observable.ids), params['ids'])

--- a/testsuite/python/observable_cylindricalLB.py
+++ b/testsuite/python/observable_cylindricalLB.py
@@ -138,7 +138,7 @@ class CylindricalLBObservableCommon:
                 [0.5]),
             dtype=int)
         self.system.part.add(pos=pos_aligned, v=vel_aligned)
-        self.params['ids'] = self.system.part[:].id
+        self.params['ids'] = self.system.part.all().id
 
         for node, vel in zip(node_aligned, vel_aligned):
             self.lbf[node].velocity = vel

--- a/testsuite/python/observable_profile.py
+++ b/testsuite/python/observable_profile.py
@@ -29,7 +29,7 @@ class ProfileObservablesTest(ut.TestCase):
     system.part.add(pos=[4.0, 4.0, 6.0], v=[0.0, 0.0, 1.0])
     system.part.add(pos=[4.0, 4.0, 6.0], v=[0.0, 0.0, 1.0])
     bin_volume = 5.0**3
-    kwargs = {'ids': list(system.part[:].id),
+    kwargs = {'ids': list(system.part.all().id),
               'n_x_bins': 2,
               'n_y_bins': 3,
               'n_z_bins': 4,
@@ -47,7 +47,7 @@ class ProfileObservablesTest(ut.TestCase):
         obs_bin_edges = density_profile.bin_edges()
         obs_bin_centers = density_profile.bin_centers()
         np_hist, np_edges = tests_common.get_histogram(
-            np.copy(self.system.part[:].pos), self.kwargs, 'cartesian',
+            np.copy(self.system.part.all().pos), self.kwargs, 'cartesian',
             normed=True)
         np_hist *= len(self.system.part)
         np.testing.assert_array_almost_equal(obs_data, np_hist)
@@ -69,7 +69,7 @@ class ProfileObservablesTest(ut.TestCase):
     def test_force_density_profile(self):
         density_profile = espressomd.observables.ForceDensityProfile(
             **self.kwargs)
-        self.system.part[:].ext_force = [0.0, 0.0, 1.0]
+        self.system.part.all().ext_force = [0.0, 0.0, 1.0]
         self.system.integrator.run(0)
         obs_data = density_profile.calculate()
         np.testing.assert_array_equal(
@@ -91,7 +91,7 @@ class ProfileObservablesTest(ut.TestCase):
 
     def test_pid_profile_interface(self):
         # test setters and getters
-        params = {'ids': list(self.system.part[:].id),
+        params = {'ids': list(self.system.part.all().id),
                   'n_x_bins': 4,
                   'n_y_bins': 6,
                   'n_z_bins': 8,

--- a/testsuite/python/oif_volume_conservation.py
+++ b/testsuite/python/oif_volume_conservation.py
@@ -46,27 +46,26 @@ class OifVolumeConservation(ut.TestCase):
         cell0 = oif.OifCell(
             cell_type=cell_type, particle_type=0, origin=[5.0, 5.0, 5.0])
         self.assertEqual(system.max_oif_objects, 1)
-        # cell0.output_vtk_pos_folded(file_name="cell0_0.vtk")
+        partcls = system.part.all()
 
         # fluid
-
         diameter_init = cell0.diameter()
         print(f"initial diameter = {diameter_init}")
 
         # OIF object is being stretched by factor 1.5
-        system.part[:].pos = (system.part[:].pos - 5) * 1.5 + 5
+        partcls.pos = (partcls.pos - 5) * 1.5 + 5
 
         diameter_stretched = cell0.diameter()
         print(f"stretched diameter = {diameter_stretched}")
 
         # Apply non-isotropic deformation
-        system.part[:].pos = system.part[:].pos * np.array((0.96, 1.05, 1.02))
+        partcls.pos = partcls.pos * np.array((0.96, 1.05, 1.02))
 
         # Test that restoring forces net to zero and don't produce a torque
         system.integrator.run(1)
         np.testing.assert_allclose(
             np.sum(
-                system.part[:].f, axis=0), [
+                partcls.f, axis=0), [
                 0., 0., 0.], atol=1E-12)
 
         total_torque = np.zeros(3)

--- a/testsuite/python/p3m_tuning_exceptions.py
+++ b/testsuite/python/p3m_tuning_exceptions.py
@@ -242,7 +242,7 @@ class P3M_tuning_test(ut.TestCase):
         with self.assertRaisesRegex(ValueError, "maxPWerror must be > 0"):
             self.system.actors.add(solver_elc)
 
-        self.system.part[0].q = -2
+        self.system.part.by_id(0).q = -2
 
         self.system.actors.clear()
         solver_elc = espressomd.electrostatics.ELC(
@@ -258,7 +258,7 @@ class P3M_tuning_test(ut.TestCase):
         with self.assertRaisesRegex(RuntimeError, "ELC does not work for non-neutral systems and non-metallic dielectric contrast"):
             self.system.actors.add(solver_elc)
 
-        self.system.part[0].q = -1
+        self.system.part.by_id(0).q = -1
 
         self.system.actors.clear()
         solver_elc = espressomd.electrostatics.ELC(

--- a/testsuite/python/pair_criteria.py
+++ b/testsuite/python/pair_criteria.py
@@ -45,7 +45,7 @@ class PairCriteria(ut.TestCase):
 
         # Decisions
         # Periodic system. Particles in range via minimum image convention
-        self.system.periodicity = (1, 1, 1)
+        self.system.periodicity = 3 * [True]
         self.assertTrue(dc.decide(self.p1, self.p2))
         self.assertTrue(dc.decide(self.p1.id, self.p2.id))
 
@@ -101,13 +101,13 @@ class PairCriteria(ut.TestCase):
         self.assertTrue(not bc.decide(self.p1.id, self.p2.id))
 
         # Add bond. Then the criterion should match
-        self.system.part[self.p1.id].bonds = ((bt, self.p2.id),)
+        self.p1.bonds = ((bt, self.p2.id),)
         self.assertTrue(bc.decide(self.p1, self.p2))
         self.assertTrue(bc.decide(self.p1.id, self.p2.id))
 
         # Place bond on the 2nd particle. The criterion should still match
-        self.system.part[self.p1.id].bonds = ()
-        self.system.part[self.p2.id].bonds = ((bt, self.p1.id),)
+        self.p1.bonds = ()
+        self.p2.bonds = ((bt, self.p1.id),)
         self.assertTrue(bc.decide(self.p1, self.p2))
         self.assertTrue(bc.decide(self.p1.id, self.p2.id))
 

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -43,7 +43,7 @@ class ParticleProperties(ut.TestCase):
 
     def setUp(self):
         if not self.system.part.exists(self.pid):
-            self.system.part.add(id=self.pid, pos=(0, 0, 0))
+            self.partcl = self.system.part.add(id=self.pid, pos=(0, 0, 0))
 
     def tearDown(self):
         self.system.part.clear()
@@ -62,9 +62,9 @@ class ParticleProperties(ut.TestCase):
             # This code is run at the execution of the generated function.
             # It will use the state of the variables in the outer function,
             # which was there, when the outer function was called
-            setattr(self.system.part[self.pid], propName, value)
+            setattr(self.partcl, propName, value)
             np.testing.assert_allclose(
-                np.array(getattr(self.system.part[self.pid], propName)), value,
+                np.array(getattr(self.partcl, propName)), value,
                 err_msg=propName + ": value set and value gotten back differ.",
                 atol=self.tol)
 
@@ -84,8 +84,8 @@ class ParticleProperties(ut.TestCase):
             # This code is run at the execution of the generated function.
             # It will use the state of the variables in the outer function,
             # which was there, when the outer function was called
-            setattr(self.system.part[self.pid], propName, value)
-            self.assertEqual(getattr(self.system.part[self.pid], propName),
+            setattr(self.partcl, propName, value)
+            self.assertEqual(getattr(self.partcl, propName),
                              value, propName + ": value set and value gotten back differ.")
 
         return func
@@ -129,9 +129,9 @@ class ParticleProperties(ut.TestCase):
             sample_vector_normalized = sample_vector / \
                 np.linalg.norm(sample_vector)
 
-            setattr(self.system.part[self.pid], "director", sample_vector)
+            setattr(self.partcl, "director", sample_vector)
             np.testing.assert_allclose(
-                np.array(getattr(self.system.part[self.pid], "director")),
+                np.array(getattr(self.partcl, "director")),
                 sample_vector_normalized
             )
 
@@ -141,9 +141,9 @@ class ParticleProperties(ut.TestCase):
                     "gamma", np.array([2., 9., 0.23]))
 
                 def test_gamma_single(self):
-                    self.system.part[self.pid].gamma = 17.4
+                    self.partcl.gamma = 17.4
                     np.testing.assert_array_equal(
-                        np.copy(self.system.part[self.pid].gamma),
+                        np.copy(self.partcl.gamma),
                         np.array([17.4, 17.4, 17.4]),
                         "gamma: value set and value gotten back differ.")
             else:
@@ -154,9 +154,9 @@ class ParticleProperties(ut.TestCase):
                     "gamma_rot", np.array([5., 10., 0.33]))
 
                 def test_gamma_rot_single(self):
-                    self.system.part[self.pid].gamma_rot = 15.4
+                    self.partcl.gamma_rot = 15.4
                     np.testing.assert_array_equal(
-                        np.copy(self.system.part[self.pid].gamma_rot),
+                        np.copy(self.partcl.gamma_rot),
                         np.array([15.4, 15.4, 15.4]),
                         "gamma_rot: value set and value gotten back differ.")
             else:
@@ -185,12 +185,12 @@ class ParticleProperties(ut.TestCase):
     if espressomd.has_features(["VIRTUAL_SITES_RELATIVE"]):
         def test_yy_vs_relative(self):
             self.system.part.add(id=0, pos=(0, 0, 0))
-            self.system.part.add(id=1, pos=(0, 0, 0))
-            self.system.part[1].vs_relative = (0, 5.0, (0.5, -0.5, -0.5, -0.5))
-            self.system.part[1].vs_quat = [1, 2, 3, 4]
+            p1 = self.system.part.add(id=1, pos=(0, 0, 0))
+            p1.vs_relative = (0, 5.0, (0.5, -0.5, -0.5, -0.5))
+            p1.vs_quat = [1, 2, 3, 4]
             np.testing.assert_array_equal(
-                self.system.part[1].vs_quat, [1, 2, 3, 4])
-            res = self.system.part[1].vs_relative
+                p1.vs_quat, [1, 2, 3, 4])
+            res = p1.vs_relative
             self.assertEqual(res[0], 0, "vs_relative: " + res.__str__())
             self.assertEqual(res[1], 5.0, "vs_relative: " + res.__str__())
             np.testing.assert_allclose(
@@ -198,13 +198,13 @@ class ParticleProperties(ut.TestCase):
                 err_msg="vs_relative: " + res.__str__(), atol=self.tol)
             # check exceptions
             with self.assertRaisesRegex(ValueError, "needs input in the form"):
-                self.system.part[1].vs_relative = (0, 5.0)
+                p1.vs_relative = (0, 5.0)
             with self.assertRaisesRegex(ValueError, "particle id has to be given as an int"):
-                self.system.part[1].vs_relative = ('0', 5.0, (1, 0, 0, 0))
+                p1.vs_relative = ('0', 5.0, (1, 0, 0, 0))
             with self.assertRaisesRegex(ValueError, "distance has to be given as a float"):
-                self.system.part[1].vs_relative = (0, '5', (1, 0, 0, 0))
+                p1.vs_relative = (0, '5', (1, 0, 0, 0))
             with self.assertRaisesRegex(ValueError, "quaternion has to be given as a tuple of 4 floats"):
-                self.system.part[1].vs_relative = (0, 5.0, (1, 0, 0))
+                p1.vs_relative = (0, 5.0, (1, 0, 0))
 
     @utx.skipIfMissingFeatures("DIPOLES")
     def test_contradicting_properties_dip_dipm(self):
@@ -260,20 +260,20 @@ class ParticleProperties(ut.TestCase):
 
         pos = 1.5 * s.box_l
 
-        s.part.add(pos=pos)
+        p = s.part.add(pos=pos)
 
-        np.testing.assert_equal(np.copy(s.part[0].image_box), [1, 1, 1])
+        np.testing.assert_equal(np.copy(p.image_box), [1, 1, 1])
 
     def test_accessing_invalid_id_raises(self):
         self.system.part.clear()
-        handle_to_non_existing_particle = self.system.part[42]
+        handle_to_non_existing_particle = self.system.part.by_id(42)
         with self.assertRaises(RuntimeError):
             handle_to_non_existing_particle.id
 
     def test_parallel_property_setters(self):
         s = self.system
         s.part.clear()
-        s.part.add(pos=s.box_l * np.random.random((100, 3)))
+        partcls = s.part.add(pos=s.box_l * np.random.random((100, 3)))
 
         # Copy individual properties of particle 0
         print(
@@ -282,21 +282,21 @@ class ParticleProperties(ut.TestCase):
             # Uncomment to identify guilty property
             # print( p)
 
-            assert hasattr(s.part[0], p), \
+            assert hasattr(s.part.by_id(0), p), \
                 "Inconsistency between ParticleHandle and particle_data.particle_attributes"
             try:
-                setattr(s.part[:], p, getattr(s.part[0], p))
+                setattr(partcls, p, getattr(s.part.by_id(0), p))
             except AttributeError:
                 print("Skipping read-only", p)
             # Cause a different mpi callback to uncover deadlock immediately
-            _ = getattr(s.part[:], p)
+            _ = getattr(partcls, p)
 
     def test_remove_particle(self):
         """Tests that if a particle is removed,
         it no longer exists and bonds to the removed particle are
         also removed."""
 
-        p1 = self.system.part[self.pid]
+        p1 = self.system.part.by_id(self.pid)
         p2 = self.system.part.add(pos=p1.pos, bonds=[(self.f1, p1.id)])
 
         p1.remove()
@@ -306,7 +306,7 @@ class ParticleProperties(ut.TestCase):
     def test_bonds(self):
         """Tests bond addition and removal."""
 
-        p1 = self.system.part[self.pid]
+        p1 = self.system.part.by_id(self.pid)
         p2 = self.system.part.add(pos=p1.pos)
         inactive_bond = espressomd.interactions.FeneBond(k=1, d_r_max=2)
         p2.add_bond([self.f1, p1])
@@ -329,17 +329,17 @@ class ParticleProperties(ut.TestCase):
             p2.delete_bond((self.f1, 'p1'))
 
     def test_zz_remove_all(self):
-        for pid in self.system.part[:].id:
-            self.system.part[pid].remove()
+        for p in self.system.part.all():
+            p.remove()
         self.system.part.add(
             pos=np.random.random((100, 3)) * self.system.box_l,
             id=np.arange(100, dtype=int))
-        ids = self.system.part[:].id
+        ids = self.system.part.all().id
         np.random.shuffle(ids)
         for pid in ids:
-            self.system.part[pid].remove()
+            self.system.part.by_id(pid).remove()
         with self.assertRaises(Exception):
-            self.system.part[17].remove()
+            self.system.part.by_id(17).remove()
 
     def test_coord_fold_corner_cases(self):
         system = self.system
@@ -381,11 +381,12 @@ class ParticleProperties(ut.TestCase):
 
         # Empty slice
         system.part.clear()
-        self.assertEqual(len(system.part[:]), 0)
-        self.assertEqual(len(system.part[:].pos), 0)
-        self.assertEqual(len(system.part[:].id), 0)
+        all_partcls_empty = system.part.all()
+        self.assertEqual(len(all_partcls_empty), 0)
+        self.assertEqual(len(all_partcls_empty), 0)
+        self.assertEqual(len(all_partcls_empty), 0)
         with self.assertRaises(AttributeError):
-            system.part[:].pos = ((1, 2, 3,),)
+            all_partcls_empty.pos = ((1, 2, 3,),)
 
         # Slice containing particles
         ids = [1, 4, 6, 3, 8, 9]
@@ -393,34 +394,30 @@ class ParticleProperties(ut.TestCase):
         system.part.add(id=ids, pos=pos)
 
         # All particles
-        self.assertEqual(len(system.part[:]), len(ids))
-        np.testing.assert_equal(system.part[:].id, sorted(ids))
-        np.testing.assert_equal(system.part[:].pos, pos[np.argsort(ids)])
+        all_partcls = system.part.all()
+        self.assertEqual(len(all_partcls), len(ids))
+        np.testing.assert_equal(all_partcls.id, sorted(ids))
+        np.testing.assert_equal(all_partcls.pos, pos[np.argsort(ids)])
 
         # Access via slicing
-        np.testing.assert_equal(system.part[4:9].id,
+        np.testing.assert_equal(system.part.by_ids(range(4, 9)).id,
                                 [i for i in sorted(ids) if i >= 4 and i < 9])
-        np.testing.assert_equal(system.part[9:4:-1].id,
+        np.testing.assert_equal(system.part.by_ids(range(9, 4, -1)).id,
                                 [i for i in sorted(ids, key=lambda i:-i) if i > 4 and i <= 9])
-        # Check that negative start and end on slices are not accepted
-        with self.assertRaises(IndexError):
-            system.part[-1:]
-        with self.assertRaises(IndexError):
-            system.part[:-1]
 
         # Setting particle properties on a slice
-        system.part[:5].pos = 0, 0, 0
-        np.testing.assert_equal(system.part[:].pos,
+        system.part.by_ids(range(5)).pos = 0, 0, 0
+        np.testing.assert_equal(system.part.all().pos,
                                 [pos[i] if ids[i] >= 5 else [0, 0, 0] for i in np.argsort(ids)])
 
         # Slice access via explicit list of ids
-        np.testing.assert_equal(system.part[ids[1:4]].id, ids[1:4])
+        np.testing.assert_equal(system.part.by_ids(ids[1:4]).id, ids[1:4])
         # Check that ids passed in an explicit list must exist
         with self.assertRaises(IndexError):
-            system.part[99, 3]
+            system.part.by_ids([99, 3])
         # Check that wrong types are not accepted
         with self.assertRaises(TypeError):
-            system.part[[ids[0], 1.2]]
+            system.part.by_ids([[ids[0], 1.2]])
 
     def test_to_dict(self):
         self.system.part.clear()

--- a/testsuite/python/particle_slice.py
+++ b/testsuite/python/particle_slice.py
@@ -22,80 +22,83 @@ import numpy as np
 
 class ParticleSliceTest(ut.TestCase):
 
-    state = [[0, 0, 0], [0, 0, 1]]
-    system = espressomd.System(box_l=[10, 10, 10])
+    system = espressomd.System(box_l=3 * [10])
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.system.part.clear()
-        for i in range(4):
-            self.system.part.add(pos=[0, 0, i])
+    def setUp(self):
+        self.fix_flags = [[False, False, False], [False, False, True]]
+        self.p0 = self.system.part.add(pos=[0, 0, 0])
+        self.p1 = self.system.part.add(pos=[0, 0, 1])
+        self.p2 = self.system.part.add(pos=[0, 0, 2])
+        self.p3 = self.system.part.add(pos=[0, 0, 3])
+
+        self.all_partcls = self.system.part.all()
+        self.p0p1 = self.system.part.by_ids([0, 1])
+        self.p2p3 = self.system.part.by_ids([2, 3])
 
         if espressomd.has_features(["EXTERNAL_FORCES"]):
-            self.system.part[1].fix = self.state[1]
+            self.p1.fix = self.fix_flags[1]
             np.testing.assert_array_equal(
-                np.copy(self.system.part[0].fix), self.state[0])
+                np.copy(self.p0.fix), self.fix_flags[0])
             np.testing.assert_array_equal(
-                np.copy(self.system.part[1].fix), self.state[1])
+                np.copy(self.p1.fix), self.fix_flags[1])
             np.testing.assert_array_equal(
-                np.copy(self.system.part[:2].fix), self.state)
-        xs = self.system.part[:].pos
-        for i in range(len(xs)):
-            np.testing.assert_array_equal(
-                xs[i], np.copy(self.system.part[i].pos))
+                np.copy(self.p0p1.fix), self.fix_flags)
+
+    def tearDown(self):
+        self.system.part.clear()
 
     @utx.skipIfMissingFeatures(["EXTERNAL_FORCES"])
     def test_1_set_different_values(self):
-        self.state[0] = [1, 0, 0]
-        self.state[1] = [1, 0, 0]
-        self.system.part[:2].fix = self.state
+        self.fix_flags[0] = [1, 0, 0]
+        self.fix_flags[1] = [1, 0, 0]
+        self.p0p1.fix = self.fix_flags
         np.testing.assert_array_equal(
-            np.copy(self.system.part[:2].fix), self.state)
+            np.copy(self.p0p1.fix), self.fix_flags)
 
     @utx.skipIfMissingFeatures(["EXTERNAL_FORCES"])
     def test_2_set_same_value(self):
-        self.state[0] = [0, 1, 0]
-        self.state[1] = [0, 1, 0]
-        self.system.part[:2].fix = self.state[1]
+        self.fix_flags[0] = [0, 1, 0]
+        self.fix_flags[1] = [0, 1, 0]
+        self.p0p1.fix = self.fix_flags[1]
         np.testing.assert_array_equal(
-            np.copy(self.system.part[:2].fix), self.state)
+            np.copy(self.p0p1.fix), self.fix_flags)
 
     @utx.skipIfMissingFeatures(["EXTERNAL_FORCES"])
     def test_3_set_one_value(self):
-        self.state[1] = [0, 0, 1]
-        self.system.part[1:2].fix = self.state[1]
+        self.fix_flags[1] = [0, 0, 1]
+        self.p1.fix = self.fix_flags[1]
         np.testing.assert_array_equal(
-            np.copy(self.system.part[:2].fix), self.state)
+            np.copy(self.p0p1.fix), self.fix_flags)
 
     @utx.skipIfMissingFeatures(["EXTERNAL_FORCES"])
     def test_4_str(self):
-        self.assertEqual(repr(self.system.part[0].fix),
-                         repr(np.array([0, 1, 0])))
-        self.assertEqual(repr(self.system.part[:2].fix),
-                         repr(np.array([[0, 1, 0], [0, 0, 1]])))
+        self.assertEqual(repr(self.p0.fix),
+                         repr(np.array([0, 0, 0])))
+        self.assertEqual(repr(self.p0p1.fix),
+                         repr(np.array([[0, 0, 0], [0, 0, 1]])))
 
     def test_pos_str(self):
-        self.system.part[0].pos = [0, 0, 0]
-        self.system.part[1].pos = [0, 0, 1]
-        self.assertEqual(repr(self.system.part[0].pos),
+        self.p0.pos = [0, 0, 0]
+        self.p1.pos = [0, 0, 1]
+        self.assertEqual(repr(self.p0.pos),
                          repr(np.array([0.0, 0.0, 0.0])))
-        self.assertEqual(repr(self.system.part[:2].pos),
+        self.assertEqual(repr(self.p0p1.pos),
                          repr(np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])))
 
     @utx.skipIfMissingFeatures(["ELECTROSTATICS"])
     def test_scalar(self):
-        self.system.part[:1].q = 1.3
-        self.assertEqual(self.system.part[0].q, 1.3)
-        self.system.part[:2].q = 2.0
-        self.assertEqual(self.system.part[0].q, 2)
-        self.assertEqual(self.system.part[1].q, 2)
-        self.system.part[:2].q = 3
-        self.assertEqual(self.system.part[0].q, 3)
-        self.assertEqual(self.system.part[1].q, 3)
-        self.system.part[:2].q = [-1, 1.0]
-        self.assertEqual(self.system.part[0].q, -1)
-        self.assertEqual(self.system.part[1].q, 1)
-        qs = self.system.part[:2].q
+        self.p0.q = 1.3
+        self.assertEqual(self.p0.q, 1.3)
+        self.p0p1.q = 2.0
+        self.assertEqual(self.p0.q, 2)
+        self.assertEqual(self.p1.q, 2)
+        self.p0p1.q = 3
+        self.assertEqual(self.p0.q, 3)
+        self.assertEqual(self.p1.q, 3)
+        self.p0p1.q = [-1, 1.0]
+        self.assertEqual(self.p0.q, -1)
+        self.assertEqual(self.p1.q, 1)
+        qs = self.p0p1.q
         self.assertEqual(qs[0], -1)
         self.assertEqual(qs[1], 1)
 
@@ -108,246 +111,245 @@ class ParticleSliceTest(ut.TestCase):
 
         # tuple
         b = fene, 0
-        self.system.part[2].bonds = b
-        self.assertEqual(self.system.part[:].bonds, [(), (), ((fene, 0),), ()])
+        self.p2.bonds = b
+        self.assertEqual(self.all_partcls.bonds, [(), (), ((fene, 0),), ()])
 
         # list
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [fene, 0]
-        self.system.part[2].bonds = b
-        self.assertEqual(self.system.part[:].bonds, [(), (), ((fene, 0),), ()])
+        self.p2.bonds = b
+        self.assertEqual(self.all_partcls.bonds, [(), (), ((fene, 0),), ()])
 
         # nested list single
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [[fene, 0]]
-        self.system.part[2].bonds = b
-        self.assertEqual(self.system.part[:].bonds, [(), (), ((fene, 0),), ()])
+        self.p2.bonds = b
+        self.assertEqual(self.all_partcls.bonds, [(), (), ((fene, 0),), ()])
 
         # nested list multi
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [[fene, 0], [fene, 1]]
-        self.system.part[2].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0), (fene, 1)), ()])
 
         # nested tuple single
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = ((fene, 0),)
-        self.system.part[2].bonds = b
-        self.assertEqual(self.system.part[:].bonds, [(), (), ((fene, 0),), ()])
+        self.p2.bonds = b
+        self.assertEqual(self.all_partcls.bonds, [(), (), ((fene, 0),), ()])
 
         # nested tuple multi
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = ((fene, 0), (fene, 1))
-        self.system.part[2].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0), (fene, 1)), ()])
 
         # Add/Del bonds
-        self.system.part[:].bonds = []
-        self.system.part[2].add_bond((fene, 0))
-        self.assertEqual(self.system.part[:].bonds, [(), (), ((fene, 0),), ()])
-        self.system.part[2].add_bond((fene, 1))
-        self.assertEqual(self.system.part[:].bonds,
+        self.all_partcls.bonds = []
+        self.p2.add_bond((fene, 0))
+        self.assertEqual(self.all_partcls.bonds, [(), (), ((fene, 0),), ()])
+        self.p2.add_bond((fene, 1))
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0), (fene, 1)), ()])
-        self.system.part[2].delete_bond((fene, 1))
-        self.assertEqual(self.system.part[:].bonds, [(), (), ((fene, 0),), ()])
-        self.system.part[2].delete_bond((fene, 0))
-        self.assertEqual(self.system.part[:].bonds, [(), (), (), ()])
+        self.p2.delete_bond((fene, 1))
+        self.assertEqual(self.all_partcls.bonds, [(), (), ((fene, 0),), ()])
+        self.p2.delete_bond((fene, 0))
+        self.assertEqual(self.all_partcls.bonds, [(), (), (), ()])
 
-        self.system.part[:].bonds = []
-        self.system.part[2].add_bond((fene, 0))
-        self.system.part[2].add_bond((fene, 1))
-        self.system.part[2].delete_all_bonds()
-        self.assertEqual(self.system.part[:].bonds, [(), (), (), ()])
+        self.all_partcls.bonds = []
+        self.p2.add_bond((fene, 0))
+        self.p2.add_bond((fene, 1))
+        self.p2.delete_all_bonds()
+        self.assertEqual(self.all_partcls.bonds, [(), (), (), ()])
 
         # Slices
 
         # tuple for all
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = fene, 0
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0),), ((fene, 0),)])
 
         # list for all
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [fene, 0]
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0),), ((fene, 0),)])
 
         # nested list single for all
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [[fene, 0]]
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0),), ((fene, 0),)])
 
         # nested list multi for all
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [[fene, 0], [fene, 1]]
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0), (fene, 1)), ((fene, 0), (fene, 1))])
 
         # tuples for each
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = (((fene, 0),), ((fene, 1),))
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0),), ((fene, 1),)])
 
         # lists for each
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [[[fene, 0]], [[fene, 1]]]
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0),), ((fene, 1),)])
 
         # multi tuples for each
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = (((fene, 0), (fene, 1)), ((fene, 0), (fene, 1)))
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0), (fene, 1)), ((fene, 0), (fene, 1))])
 
         # multi lists for each
-        self.system.part[:].bonds = []
+        self.all_partcls.bonds = []
         b = [[[fene, 0], [fene, 1]], [[fene, 0], [fene, 1]]]
-        self.system.part[2:].bonds = b
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.bonds = b
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0), (fene, 1)), ((fene, 0), (fene, 1))])
 
         # Add/Del bonds
-        self.system.part[:].bonds = []
-        self.system.part[2:].add_bond((fene, 0))
-        self.assertEqual(self.system.part[:].bonds,
+        self.all_partcls.bonds = []
+        self.p2p3.add_bond((fene, 0))
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0),), ((fene, 0),)])
-        self.system.part[2:].add_bond((fene, 1))
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.add_bond((fene, 1))
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0), (fene, 1)), ((fene, 0), (fene, 1))])
-        self.system.part[2:].delete_bond((fene, 1))
-        self.assertEqual(self.system.part[:].bonds,
+        self.p2p3.delete_bond((fene, 1))
+        self.assertEqual(self.all_partcls.bonds,
                          [(), (), ((fene, 0),), ((fene, 0),)])
-        self.system.part[2:].delete_bond((fene, 0))
-        self.assertEqual(self.system.part[:].bonds, [(), (), (), ()])
+        self.p2p3.delete_bond((fene, 0))
+        self.assertEqual(self.all_partcls.bonds, [(), (), (), ()])
 
         b = [[[fene, 0], [fene, 1]], [[fene, 0], [fene, 1]]]
-        self.system.part[2:].bonds = b
-        self.system.part[:].delete_all_bonds()
-        self.assertEqual(self.system.part[:].bonds, [(), (), (), ()])
+        self.p2p3.bonds = b
+        self.all_partcls.delete_all_bonds()
+        self.assertEqual(self.all_partcls.bonds, [(), (), (), ()])
 
     @utx.skipIfMissingFeatures(["EXCLUSIONS"])
     def test_exclusions(self):
 
         def assert_exclusions_equal(B):
-            A = self.system.part[:].exclusions
+            A = self.all_partcls.exclusions
             self.assertEqual([x.tolist() for x in A], B)
 
         # Setter
         # int
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = 1
-        self.system.part[2].exclusions = b
+        self.p2.exclusions = b
         assert_exclusions_equal([[], [2], [1], []])
 
         # single list
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = [1]
-        self.system.part[2].exclusions = b
+        self.p2.exclusions = b
         assert_exclusions_equal([[], [2], [1], []])
 
         # tuple
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = (0, 1)
-        self.system.part[2].exclusions = b
+        self.p2.exclusions = b
         assert_exclusions_equal([[2], [2], [0, 1], []])
 
         # list
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = [0, 1]
-        self.system.part[2].exclusions = b
+        self.p2.exclusions = b
         assert_exclusions_equal([[2], [2], [0, 1], []])
 
         # Add/Del exclusions
-        self.system.part[:].exclusions = []
-        self.system.part[2].add_exclusion(1)
+        self.all_partcls.exclusions = []
+        self.p2.add_exclusion(1)
         assert_exclusions_equal([[], [2], [1], []])
-        self.system.part[2].add_exclusion(0)
+        self.p2.add_exclusion(0)
         assert_exclusions_equal([[2], [2], [1, 0], []])
-        self.system.part[2].delete_exclusion(0)
+        self.p2.delete_exclusion(0)
         assert_exclusions_equal([[], [2], [1], []])
-        self.system.part[2].delete_exclusion(1)
+        self.p2.delete_exclusion(1)
         assert_exclusions_equal([[], [], [], []])
 
         # Slices
 
         # single list for all
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = [1]
-        self.system.part[2:].exclusions = b
+        self.p2p3.exclusions = b
         assert_exclusions_equal([[], [2, 3], [1], [1]])
 
         # list for all
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = [0, 1]
-        self.system.part[2:].exclusions = b
+        self.p2p3.exclusions = b
         assert_exclusions_equal([[2, 3], [2, 3], [0, 1], [0, 1]])
 
         # single list for each
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = [[0], [0]]
-        self.system.part[2:].exclusions = b
+        self.p2p3.exclusions = b
         assert_exclusions_equal([[2, 3], [], [0], [0]])
 
         # multi list for each
-        self.system.part[:].exclusions = []
+        self.all_partcls.exclusions = []
         b = [[0, 1], [0, 1]]
-        self.system.part[2:].exclusions = b
+        self.p2p3.exclusions = b
         assert_exclusions_equal([[2, 3], [2, 3], [0, 1], [0, 1]])
 
         # Add/Del exclusions
-        self.system.part[:].exclusions = []
-        self.system.part[2:].add_exclusion(1)
+        self.all_partcls.exclusions = []
+        self.p2p3.add_exclusion(1)
         assert_exclusions_equal([[], [2, 3], [1], [1]])
-        self.system.part[2:].add_exclusion(0)
+        self.p2p3.add_exclusion(0)
         assert_exclusions_equal([[2, 3], [2, 3], [1, 0], [1, 0]])
-        self.system.part[2:].delete_exclusion(0)
+        self.p2p3.delete_exclusion(0)
         assert_exclusions_equal([[], [2, 3], [1], [1]])
-        self.system.part[2:].delete_exclusion(1)
+        self.p2p3.delete_exclusion(1)
         assert_exclusions_equal([[], [], [], []])
 
     @utx.skipIfMissingFeatures("VIRTUAL_SITES_RELATIVE")
     def test_vs_relative(self):
 
         self.system.part.clear()
-        self.system.part.add(pos=[0, 0, 0])
-        self.system.part.add(pos=[0, 0, 0])
-        self.system.part.add(pos=[0, 0, 0])
-        self.system.part.add(pos=[0, 0, 0])
-        self.system.part[0].vs_relative = [1, 1.0, (1.0, 1.0, 1.0, 1.0)]
+        p0 = self.system.part.add(pos=[0, 0, 0])
+        self.system.part.add(pos=3 * [[0, 0, 0]])
+        p0.vs_relative = [1, 1.0, (1.0, 1.0, 1.0, 1.0)]
+        all_partcls = self.system.part.all()
 
-        self.assertEqual(repr(self.system.part[:].vs_relative),
+        self.assertEqual(repr(all_partcls.vs_relative),
                          repr([(1, 1.0, np.array([1., 1., 1., 1.])),
                                (0, 0.0, np.array([1., 0., 0., 0.])),
                                (0, 0.0, np.array([1., 0., 0., 0.])),
                                (0, 0.0, np.array([1., 0., 0., 0.]))]))
 
-        self.system.part[:].vs_relative = [1, 1.0, (1.0, 1.0, 1.0, 1.0)]
+        all_partcls.vs_relative = [1, 1.0, (1.0, 1.0, 1.0, 1.0)]
 
-        self.assertEqual(repr(self.system.part[:].vs_relative),
+        self.assertEqual(repr(all_partcls.vs_relative),
                          repr([(1, 1.0, np.array([1., 1., 1., 1.])),
                                (1, 1.0, np.array([1., 1., 1., 1.])),
                                (1, 1.0, np.array([1., 1., 1., 1.])),
                                (1, 1.0, np.array([1., 1., 1., 1.]))]))
 
-        self.system.part[:].vs_relative = [[1, 1.0, (1.0, 1.0, 1.0, 1.0)],
-                                           [1, 2.0, (1.0, 1.0, 1.0, 1.0)],
-                                           [1, 3.0, (1.0, 1.0, 1.0, 1.0)],
-                                           [1, 4.0, (1.0, 1.0, 1.0, 1.0)]]
+        all_partcls.vs_relative = [[1, 1.0, (1.0, 1.0, 1.0, 1.0)],
+                                   [1, 2.0, (1.0, 1.0, 1.0, 1.0)],
+                                   [1, 3.0, (1.0, 1.0, 1.0, 1.0)],
+                                   [1, 4.0, (1.0, 1.0, 1.0, 1.0)]]
 
-        self.assertEqual(repr(self.system.part[:].vs_relative),
+        self.assertEqual(repr(all_partcls.vs_relative),
                          repr([(1, 1.0, np.array([1., 1., 1., 1.])),
                                (1, 2.0, np.array([1., 1., 1., 1.])),
                                (1, 3.0, np.array([1., 1., 1., 1.])),
@@ -356,11 +358,12 @@ class ParticleSliceTest(ut.TestCase):
     def test_multiadd(self):
         self.system.part.clear()
         positions = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-        self.system.part.add(pos=positions)
+        partcls_multiadd = self.system.part.add(pos=positions)
         for p in positions:
             self.system.part.add(pos=p)
+        partcls_singleadd = self.system.part.by_ids(range(3, 6))
         np.testing.assert_allclose(
-            np.copy(self.system.part[:3].pos), np.copy(self.system.part[3:6].pos))
+            np.copy(partcls_multiadd.pos), np.copy(partcls_singleadd.pos))
 
         with self.assertRaises(ValueError):
             self.system.part.add(pos=([1, 1, 1], [2, 2, 2]), type=0)
@@ -368,21 +371,23 @@ class ParticleSliceTest(ut.TestCase):
             self.system.part.add(pos=([1, 1, 1], [2, 2, 2]), type=(0, 1, 2))
 
         self.system.part.clear()
-        self.system.part.add(pos=([1, 1, 1], [2, 2, 2]), type=(0, 1))
-        self.assertEqual(self.system.part[0].type, 0)
-        self.assertEqual(self.system.part[1].type, 1)
+        p0, p1 = self.system.part.add(pos=([1, 1, 1], [2, 2, 2]), type=(0, 1))
+        self.assertEqual(p0.type, 0)
+        self.assertEqual(p1.type, 1)
 
     def test_empty(self):
-        np.testing.assert_array_equal(self.system.part[0:0].pos, np.empty(0))
+        np.testing.assert_array_equal(
+            self.system.part.by_ids(
+                []).pos, np.empty(0))
 
     def test_len(self):
-        self.assertEqual(len(self.system.part[0:0]), 0)
-        self.assertEqual(len(self.system.part[0:1]), 1)
-        self.assertEqual(len(self.system.part[0:2]), 2)
+        self.assertEqual(len(self.system.part.by_ids([])), 0)
+        self.assertEqual(len(self.system.part.by_ids([0])), 1)
+        self.assertEqual(len(self.system.part.by_ids([0, 1, 2])), 3)
 
     def test_non_existing_property(self):
         with self.assertRaises(AttributeError):
-            self.system.part[:].thispropertydoesnotexist = 1.0
+            self.all_partcls.thispropertydoesnotexist = 1.0
 
 
 if __name__ == "__main__":

--- a/testsuite/python/polymer_diamond.py
+++ b/testsuite/python/polymer_diamond.py
@@ -85,7 +85,7 @@ class DiamondPolymer(ut.TestCase):
         np.testing.assert_allclose(self.charged_mono.q,
                                    len(self.charged_mono) * [self.diamond_params['val_cM']])
         # particle id
-        self.assertGreaterEqual(min(self.system.part[:].id),
+        self.assertGreaterEqual(min(self.system.part.all().id),
                                 self.diamond_params['start_id'])
 
     def test_bonds(self):
@@ -109,9 +109,10 @@ class DiamondPolymer(ut.TestCase):
         test that all particles in the polymer are connected by pushing one particle
         """
 
-        self.system.part[self.diamond_params['start_id']].ext_force = 3 * [2]
+        self.system.part.by_id(
+            self.diamond_params['start_id']).ext_force = 3 * [2]
         self.system.integrator.run(200)
-        vels = np.linalg.norm(self.system.part[:].v, axis=1)
+        vels = np.linalg.norm(self.system.part.all().v, axis=1)
         self.assertGreater(np.min(vels), 1e-6)
 
     def test_geometry(self):

--- a/testsuite/python/pressure.py
+++ b/testsuite/python/pressure.py
@@ -126,8 +126,9 @@ class PressureLJ(ut.TestCase):
         p2.v = [27.0, 23.0, 17.0]
         p3.v = [13.0, 11.0, 19.0]
 
-        pos = system.part[:].pos
-        vel = system.part[:].v
+        partcls = system.part.all()
+        pos = partcls.pos
+        vel = partcls.v
 
         sim_pressure_tensor = system.analysis.pressure_tensor()
         sim_pressure_tensor_kinetic = np.copy(sim_pressure_tensor['kinetic'])

--- a/testsuite/python/random_pairs.py
+++ b/testsuite/python/random_pairs.py
@@ -66,7 +66,8 @@ class RandomPairTest(ut.TestCase):
         pairs = []
         parts = self.system.part
         for p in self.all_pairs:
-            if self.system.distance(parts[p[0]], parts[p[1]]) <= dist:
+            if self.system.distance(parts.by_id(
+                    p[0]), parts.by_id(p[1])) <= dist:
                 pairs.append(p)
         return set(pairs)
 

--- a/testsuite/python/rdf.py
+++ b/testsuite/python/rdf.py
@@ -51,7 +51,7 @@ class RdfTest(ut.TestCase):
         r_bins = 50
         r_min = 0.5 * dx
         r_max = r_bins * dx
-        obs = espressomd.observables.RDF(ids1=system.part[:].id, min_r=r_min,
+        obs = espressomd.observables.RDF(ids1=system.part.all().id, min_r=r_min,
                                          max_r=r_max, n_r_bins=r_bins)
         rdf = obs.calculate()
         r = obs.bin_centers()
@@ -72,12 +72,13 @@ class RdfTest(ut.TestCase):
         for i in range(n_part):
             system.part.add(
                 pos=[i * dx, 0.5 * system.box_l[1], 0.5 * system.box_l[2]], type=(i % 2))
+        partcls = system.part.all()
 
         r_bins = 50
         r_min = 0.5 * dx
         r_max = r_bins * dx
-        obs = espressomd.observables.RDF(ids1=system.part[:].id[0::2],
-                                         ids2=system.part[:].id[1::2],
+        obs = espressomd.observables.RDF(ids1=partcls.id[0::2],
+                                         ids2=partcls.id[1::2],
                                          min_r=r_min, max_r=r_max,
                                          n_r_bins=r_bins)
         rdf01 = obs.calculate()
@@ -93,8 +94,8 @@ class RdfTest(ut.TestCase):
         np.testing.assert_allclose(parts_in_bin[1::2], 0.0)
 
         # Check symmetry
-        obs = espressomd.observables.RDF(ids1=system.part[:].id[1::2],
-                                         ids2=system.part[:].id[0::2],
+        obs = espressomd.observables.RDF(ids1=partcls.id[1::2],
+                                         ids2=partcls.id[0::2],
                                          min_r=r_min, max_r=r_max,
                                          n_r_bins=r_bins)
         rdf10 = obs.calculate()
@@ -104,9 +105,9 @@ class RdfTest(ut.TestCase):
     def test_rdf_interface(self):
         # test setters and getters
         system = self.system
-        system.part.add(pos=4 * [(0, 0, 0)], type=[0, 1, 0, 1])
-        pids1 = system.part[:].id[0::2]
-        pids2 = system.part[:].id[1::2]
+        partcls = system.part.add(pos=4 * [(0, 0, 0)], type=[0, 1, 0, 1])
+        pids1 = partcls.id[0::2]
+        pids2 = partcls.id[1::2]
         params = {
             'ids1': pids1,
             'ids2': pids2,
@@ -117,8 +118,8 @@ class RdfTest(ut.TestCase):
         # check pids
         np.testing.assert_array_equal(np.copy(observable.ids1), pids1)
         np.testing.assert_array_equal(np.copy(observable.ids2), pids2)
-        new_pids1 = [system.part[:].id[0]]
-        new_pids2 = [system.part[:].id[1]]
+        new_pids1 = [partcls.id[0]]
+        new_pids2 = [partcls.id[1]]
         observable = espressomd.observables.RDF(
             **{**params, 'ids1': new_pids1, 'ids2': new_pids2})
         np.testing.assert_array_equal(np.copy(observable.ids1), new_pids1)

--- a/testsuite/python/rescale.py
+++ b/testsuite/python/rescale.py
@@ -33,7 +33,11 @@ class RescaleTest(ut.TestCase):
     def setUp(self):
         N = 100
         self.system.box_l = 3 * [10]
-        self.system.part.add(pos=self.system.box_l * np.random.random((N, 3)))
+        self.partcls = self.system.part.add(
+            pos=self.system.box_l * np.random.random((N, 3)))
+
+    def tearDown(self):
+        self.system.part.clear()
 
     def test_iso(self):
         """Test 'isotropic' case (dir="xyz").
@@ -41,9 +45,9 @@ class RescaleTest(ut.TestCase):
         scale = 1.3
         new_box_l = scale * self.system.box_l[0]
 
-        old_pos = self.system.part[:].pos
+        old_pos = self.partcls.pos
         self.system.change_volume_and_rescale_particles(new_box_l)
-        new_pos = self.system.part[:].pos
+        new_pos = self.partcls.pos
 
         max_diff = np.max(np.abs(new_pos / old_pos - scale))
         self.assertAlmostEqual(0., max_diff, places=10)
@@ -54,9 +58,9 @@ class RescaleTest(ut.TestCase):
         scale = 0.7
         new_box_l = scale * self.system.box_l[dir]
 
-        old_pos = self.system.part[:].pos
+        old_pos = self.partcls.pos
         self.system.change_volume_and_rescale_particles(new_box_l, dir=dir)
-        new_pos = self.system.part[:].pos
+        new_pos = self.partcls.pos
 
         for i in range(3):
             if i == dir:

--- a/testsuite/python/rotational-diffusion-aniso.py
+++ b/testsuite/python/rotational-diffusion-aniso.py
@@ -56,10 +56,10 @@ class RotDiffAniso(ut.TestCase):
 
     def add_particles(self):
         positions = np.random.random((self.n_part, 3)) * self.system.box_l[0]
-        self.system.part.add(pos=positions, rotation=self.n_part * [(1, 1, 1)],
-                             rinertia=self.n_part * [self.J])
+        self.partcls = self.system.part.add(pos=positions, rotation=self.n_part * [(1, 1, 1)],
+                                            rinertia=self.n_part * [self.J])
         if espressomd.has_features("ROTATION"):
-            self.system.part[:].omega_body = [0.0, 0.0, 0.0]
+            self.partcls.omega_body = [0.0, 0.0, 0.0]
 
     def set_anisotropic_param(self):
         """
@@ -142,7 +142,7 @@ class RotDiffAniso(ut.TestCase):
         # The body angular velocity is rotated now, but there is only the
         # thermal velocity, hence, this does not impact the test and its
         # physical context.
-        self.system.part[:].quat = [1.0, 0.0, 0.0, 0.0]
+        self.partcls.quat = [1.0, 0.0, 0.0, 0.0]
         # Average direction cosines
         # Diagonal ones:
         dcosjj_validate = np.zeros((3))

--- a/testsuite/python/scafacos_dipoles_1d_2d.py
+++ b/testsuite/python/scafacos_dipoles_1d_2d.py
@@ -76,7 +76,7 @@ class Scafacos1d2d(ut.TestCase):
             data = np.genfromtxt(tests_common.abspath(
                 file_prefix + "_reference_data_forces_torques.dat"))
             s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
-            s.part[:].rotation = (1, 1, 1)
+            s.part.all().rotation = 3 * [True]
 
             if dim == 2:
                 scafacos = espressomd.magnetostatics.Scafacos(
@@ -122,8 +122,8 @@ class Scafacos1d2d(ut.TestCase):
 
             # Calculate errors
 
-            err_f = self.vector_error(s.part[:].f, data[:, 7:10])
-            err_t = self.vector_error(s.part[:].torque_lab, data[:, 10:13])
+            err_f = self.vector_error(s.part.all().f, data[:, 7:10])
+            err_t = self.vector_error(s.part.all().torque_lab, data[:, 10:13])
             err_e = s.analysis.energy()["dipolar"] - ref_E
 
             tol_f = 2E-3

--- a/testsuite/python/scafacos_interface.py
+++ b/testsuite/python/scafacos_interface.py
@@ -32,7 +32,7 @@ class ScafacosInterface(ut.TestCase):
     system = espressomd.System(box_l=3 * [5])
     system.time_step = 0.01
     system.cell_system.skin = 0.5
-    system.periodicity = [1, 1, 1]
+    system.periodicity = 3 * [True]
 
     def tearDown(self):
         self.system.part.clear()
@@ -153,8 +153,8 @@ class ScafacosInterface(ut.TestCase):
         system.integrator.run(0, recalc_forces=True)
         ref_E_coulomb = system.analysis.energy()["coulomb"]
         ref_E_dipoles = system.analysis.energy()["dipolar"]
-        ref_forces = np.copy(system.part[:].f)
-        ref_torques = np.copy(system.part[:].torque_lab)
+        ref_forces = np.copy(system.part.all().f)
+        ref_torques = np.copy(system.part.all().torque_lab)
 
         system.actors.clear()
 
@@ -197,8 +197,8 @@ class ScafacosInterface(ut.TestCase):
         system.integrator.run(0, recalc_forces=True)
         ref_E_coulomb = system.analysis.energy()["coulomb"]
         ref_E_dipoles = system.analysis.energy()["dipolar"]
-        ref_forces = np.copy(system.part[:].f)
-        ref_torques = np.copy(system.part[:].torque_lab)
+        ref_forces = np.copy(system.part.all().f)
+        ref_torques = np.copy(system.part.all().torque_lab)
 
         system.actors.clear()
 

--- a/testsuite/python/tabulated.py
+++ b/testsuite/python/tabulated.py
@@ -46,9 +46,9 @@ class TabulatedTest(ut.TestCase):
         self.system.part.clear()
 
     def check(self):
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         # Below cutoff
-        np.testing.assert_allclose(np.copy(self.system.part[:].f), 0.0)
+        np.testing.assert_allclose(np.copy(self.system.part.all().f), 0.0)
 
         for z in np.linspace(0, self.max_ - self.min_, 200, endpoint=False):
             p1.pos = [5., 5., 6. + z]
@@ -86,7 +86,7 @@ class TabulatedTest(ut.TestCase):
         self.assertAlmostEqual(tb.params['min'], self.min_)
         self.assertAlmostEqual(tb.params['max'], self.max_)
 
-        p0, p1 = self.system.part[:]
+        p0, p1 = self.system.part.all()
         p0.add_bond((tb, p1))
         self.check()
 

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -127,7 +127,7 @@ class CheckpointTest(ut.TestCase):
             np.copy(system.periodicity), self.ref_periodicity)
 
     def test_part(self):
-        p1, p2 = system.part[0:2]
+        p1, p2 = system.part.by_ids([0, 1])
         np.testing.assert_allclose(np.copy(p1.pos), np.array([1.0, 2.0, 3.0]))
         np.testing.assert_allclose(np.copy(p2.pos), np.array([1.0, 1.0, 2.0]))
         np.testing.assert_allclose(np.copy(p1.f), particle_force0)
@@ -139,7 +139,7 @@ class CheckpointTest(ut.TestCase):
         experience the force from a harmonic bond. The thermostat friction
         is negligible compared to the harmonic bond strength.
         '''
-        p3, p4 = system.part[3:5]
+        p3, p4 = system.part.by_ids([3, 4])
         np.testing.assert_allclose(np.copy(p3.pos), system.box_l / 2. - 1.)
         np.testing.assert_allclose(np.copy(p4.pos), system.box_l / 2. + 1.)
         np.testing.assert_allclose(np.copy(p3.f), -np.copy(p4.f), rtol=1e-4)
@@ -153,7 +153,7 @@ class CheckpointTest(ut.TestCase):
         experience the force from a shape-based constraint. The thermostat
         friction is negligible compared to the LJ force.
         '''
-        p3, p4 = system.part[3:5]
+        p3, p4 = system.part.by_ids([3, 4])
         old_force = np.copy(p3.f)
         system.constraints.remove(system.constraints[0])
         system.integrator.run(0, recalc_forces=True)
@@ -312,17 +312,18 @@ class CheckpointTest(ut.TestCase):
         bond_ids = system.bonded_inter.call_method('get_bond_ids')
         self.assertEqual(len(bond_ids), len(system.bonded_inter))
         # check bonded interactions
-        state = system.part[1].bonds[0][0].params
+        partcl_1 = system.part.by_id(1)
+        state = partcl_1.bonds[0][0].params
         reference = {'r_0': 0.0, 'k': 1.0, 'r_cut': 0.0}
         self.assertEqual(state, reference)
-        state = system.part[1].bonds[0][0].params
+        state = partcl_1.bonds[0][0].params
         self.assertEqual(state, reference)
         if 'THERM.LB' not in modes:
-            state = system.part[1].bonds[1][0].params
+            state = partcl_1.bonds[1][0].params
             reference = {'temp_com': 0., 'gamma_com': 0., 'temp_distance': 0.2,
                          'gamma_distance': 0.5, 'r_cut': 2.0, 'seed': 51}
             self.assertEqual(state, reference)
-            state = system.part[1].bonds[1][0].params
+            state = partcl_1.bonds[1][0].params
             self.assertEqual(state, reference)
         # immersed boundary bonds
         self.assertEqual(
@@ -359,7 +360,7 @@ class CheckpointTest(ut.TestCase):
 
     @utx.skipIfMissingFeatures(['VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE'])
     def test_virtual_sites(self):
-        self.assertTrue(system.part[1].virtual)
+        self.assertTrue(system.part.by_id(1).virtual)
         self.assertIsInstance(
             system.virtual_sites,
             espressomd.virtual_sites.VirtualSitesRelative)
@@ -492,9 +493,9 @@ class CheckpointTest(ut.TestCase):
 
     @utx.skipIfMissingFeatures('EXCLUSIONS')
     def test_exclusions(self):
-        self.assertEqual(list(system.part[0].exclusions), [2])
-        self.assertEqual(list(system.part[1].exclusions), [2])
-        self.assertEqual(list(system.part[2].exclusions), [0, 1])
+        self.assertEqual(list(system.part.by_id(0).exclusions), [2])
+        self.assertEqual(list(system.part.by_id(1).exclusions), [2])
+        self.assertEqual(list(system.part.by_id(2).exclusions), [0, 1])
 
     @ut.skipIf(not LB or not (espressomd.has_features("LB_BOUNDARIES")
                               or espressomd.has_features("LB_BOUNDARIES_GPU")), "Missing features")

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -89,7 +89,7 @@ def verify_lj_forces(system, tolerance, ids_to_skip=()):
 
     # Initialize dict with expected forces
     f_expected = {}
-    for pid in system.part[:].id:
+    for pid in system.part.all().id:
         f_expected[pid] = np.zeros(3)
 
     # Cache some stuff to speed up pair loop
@@ -98,7 +98,7 @@ def verify_lj_forces(system, tolerance, ids_to_skip=()):
     non_bonded_inter = system.non_bonded_inter
     # LJ parameters
     lj_params = {}
-    all_types = np.unique(system.part[:].type)
+    all_types = np.unique(system.part.all().type)
     for i in all_types:
         for j in all_types:
             lj_params[i, j] = non_bonded_inter[i, j].lennard_jones.get_params()

--- a/testsuite/python/thole.py
+++ b/testsuite/python/thole.py
@@ -43,8 +43,14 @@ class TestThole(ut.TestCase):
     def setUp(self):
         self.system.time_step = 0.01
         self.system.cell_system.skin = 0.4
-        self.system.part.add(pos=[0, 0, 0], type=0, fix=[1, 1, 1], q=self.q1)
-        self.system.part.add(pos=[2, 0, 0], type=0, fix=[1, 1, 1], q=self.q2)
+        self.p0 = self.system.part.add(
+            pos=[
+                0, 0, 0], type=0, fix=[
+                1, 1, 1], q=self.q1)
+        self.p1 = self.system.part.add(
+            pos=[
+                2, 0, 0], type=0, fix=[
+                1, 1, 1], q=self.q2)
 
         p3m = espressomd.electrostatics.P3M(
             prefactor=COULOMB_PREFACTOR, accuracy=1e-6, mesh=3 * [52], cao=4)
@@ -59,7 +65,7 @@ class TestThole(ut.TestCase):
         ns = 100
         for i in range(1, ns):
             x = 20.0 * i / ns
-            self.system.part[1].pos = [x, 0, 0]
+            self.p1.pos = [x, 0, 0]
             self.system.integrator.run(0)
 
             sd = x * self.thole_s
@@ -74,7 +80,7 @@ class TestThole(ut.TestCase):
 
             E = self.system.analysis.energy()
             E_tot = E["total"]
-            res_dForce.append(self.system.part[1].f[0] - F_calc)
+            res_dForce.append(self.p1.f[0] - F_calc)
             res_dEnergy.append(E_tot - E_calc)
 
         for f in res_dForce:

--- a/testsuite/python/writevtf.py
+++ b/testsuite/python/writevtf.py
@@ -55,9 +55,10 @@ class CommonTests(ut.TestCase):
 
     system.bonded_inter.add(
         espressomd.interactions.FeneBond(k=1., d_r_max=10.0))
-    system.part[0].add_bond((0, 1))
-    system.part[0].add_bond((0, 2))
-    system.part[0].add_bond((0, 3))
+    p0 = system.part.by_id(0)
+    p0.add_bond((0, 1))
+    p0.add_bond((0, 2))
+    p0.add_bond((0, 3))
 
     system.integrator.run(steps=0)
 
@@ -101,10 +102,9 @@ class CommonTests(ut.TestCase):
     def test_vtf_pid_map(self):
         system = self.system
         types = self.types_to_write
-        if types == 'all':
-            ids = system.part[:].id
-        else:
-            ids = system.part[:].id[np.isin(system.part[:].type, types)]
+        ids = system.part.all().id
+        if types != 'all':
+            ids = ids[np.isin(system.part.all().type, types)]
         mapping_ref = dict(zip(ids, range(len(ids))))
         mapping = espressomd.io.writer.vtf.vtf_pid_map(system, types=types)
         self.assertEqual(mapping, mapping_ref)

--- a/testsuite/scripts/samples/test_MDAnalysisIntegration.py
+++ b/testsuite/scripts/samples/test_MDAnalysisIntegration.py
@@ -36,18 +36,19 @@ class Sample(ut.TestCase):
 
     def test_universe(self):
         system = self.system
+        partcls = system.part.all()
         u = sample.u
         self.assertEqual(len(u.atoms), 10)
         np.testing.assert_equal(u.atoms.ids, np.arange(10) + 1)
         np.testing.assert_equal(u.atoms.types, sorted(5 * ['T0', 'T1']))
         np.testing.assert_almost_equal(
-            u.atoms.charges, system.part[:].q, decimal=6)
+            u.atoms.charges, partcls.q, decimal=6)
         np.testing.assert_almost_equal(
-            u.atoms.positions, system.part[:].pos, decimal=6)
+            u.atoms.positions, partcls.pos, decimal=6)
         np.testing.assert_almost_equal(
-            u.atoms.velocities, system.part[:].v, decimal=6)
+            u.atoms.velocities, partcls.v, decimal=6)
         np.testing.assert_almost_equal(
-            u.atoms.forces, system.part[:].f, decimal=6)
+            u.atoms.forces, partcls.f, decimal=6)
 
 
 if __name__ == "__main__":

--- a/testsuite/scripts/samples/test_visualization_elc.py
+++ b/testsuite/scripts/samples/test_visualization_elc.py
@@ -38,7 +38,8 @@ class Sample(ut.TestCase):
 
     def test_dipole_moment(self):
         import espressomd.observables
-        obs = espressomd.observables.DipoleMoment(ids=self.system.part[:].id)
+        obs = espressomd.observables.DipoleMoment(
+            ids=self.system.part.all().id)
         dipm = obs.calculate()
         self.assertLess(dipm[2], 0, msg="charges moved in the wrong direction")
         # the dipole moment should be the strongest along the z-axis


### PR DESCRIPTION
Fixes #4389 

Description of changes:
- The `[]`-operator on `system.part` was removed
- An individual particle can be accessed by id using `system.part.by_id(id)`, where `id` is the numerical particle id. This returns a `ParticleHandle`
- A slice of particles can be accessed via an iterable of ids with `system.part.by_ids(id_list)`, which returns a `ParticleSlice`
- `system.part.all()` returns a slice containing all particles
- The order in which particles will be provided when iterating over a slice will stay fixed, once the slice has been instanced. I.e, `for pos, vel in zip(system.part.all().pos, system.part.all().v)` will produce the expected result.
- Selection by criterion (either using `key=value` or a lambda) can be done with the existing `system.part.select()`