### PR TITLE
Remove distutils dependency

### DIFF
--- a/cmake/FindPythonHeaders.cmake
+++ b/cmake/FindPythonHeaders.cmake
@@ -19,14 +19,14 @@
 # find the Python C++ headers
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} -c
-          "import distutils.sysconfig as cg; print(cg.get_python_inc())"
+          "import sysconfig; print(sysconfig.get_path('include'))"
   OUTPUT_VARIABLE PYTHON_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
 # find Python installation directory
 if(NOT PYTHON_INSTDIR)
   execute_process(
     COMMAND
       ${PYTHON_EXECUTABLE} -c
-      "import distutils.sysconfig as cg; print(cg.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True, standard_lib=False).replace('${CMAKE_INSTALL_PREFIX}/', '', 1))"
+      "import sysconfig; print(sysconfig.get_path('purelib', vars={'base': ''}).lstrip('/'))"
     OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif(NOT PYTHON_INSTDIR)
 


### PR DESCRIPTION
Description of changes:
- CMake no longer prints a warning about deprecated package `distutils`
