### PR TITLE
Remove code duplication in actors

### DIFF
--- a/src/python/espressomd/electrokinetics.pyx
+++ b/src/python/espressomd/electrokinetics.pyx
@@ -394,34 +394,24 @@ IF ELECTROKINETICS:
         def __init__(self, **kwargs):
             Species.py_number_of_species += 1
             self.id = Species.py_number_of_species
+            utils.check_required_keys(self.required_keys(), kwargs.keys())
+            utils.check_valid_keys(self.valid_keys(), kwargs.keys())
             self._params = self.default_params()
-
-            # Check if all required keys are given
-            for k in self.required_keys():
-                if k not in kwargs:
-                    raise ValueError(
-                        "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__() + " got " + kwargs.__str__())
-                self._params[k] = kwargs[k]
-
-            for k in kwargs:
-                if k in self.valid_keys():
-                    self._params[k] = kwargs[k]
-                else:
-                    raise KeyError(f"{k} is not a valid key")
+            self._params.update(kwargs)
 
         def valid_keys(self):
             """
             Returns the valid keys for the species.
 
             """
-            return "density", "D", "valency", "ext_force_density"
+            return {"density", "D", "valency", "ext_force_density"}
 
         def required_keys(self):
             """
             Returns the required keys for the species.
 
             """
-            return ["density", "D", "valency"]
+            return {"density", "D", "valency"}
 
         def default_params(self):
             """

--- a/src/python/espressomd/electrostatics.pyx
+++ b/src/python/espressomd/electrostatics.pyx
@@ -25,6 +25,7 @@ import numpy as np
 IF SCAFACOS == 1:
     from .scafacos import ScafacosConnector
     from . cimport scafacos
+from . import utils
 from .utils import is_valid_type, check_type_or_throw_except, handle_errors
 from .analyze cimport partCfg, PartCfg
 from .particle_data cimport particle
@@ -64,13 +65,9 @@ IF ELECTROSTATICS == 1:
             deactivate_method()
             handle_errors("Coulomb method deactivation")
 
-        def tune(self, **tune_params_subset):
-            if tune_params_subset is not None:
-                if all(k in self.valid_keys() for k in tune_params_subset):
-                    self._params.update(tune_params_subset)
-                else:
-                    raise ValueError(
-                        "Invalid parameter given to tune function.")
+        def tune(self, **tune_params):
+            utils.check_valid_keys(self.valid_keys(), tune_params.keys())
+            self._params.update(tune_params)
             self._tune()
 
 
@@ -95,10 +92,10 @@ IF ELECTROSTATICS:
             pass
 
         def valid_keys(self):
-            return ["prefactor", "kappa", "r_cut", "check_neutrality"]
+            return {"prefactor", "kappa", "r_cut", "check_neutrality"}
 
         def required_keys(self):
-            return ["prefactor", "kappa", "r_cut"]
+            return {"prefactor", "kappa", "r_cut"}
 
         def _set_params_in_es_core(self):
             set_prefactor(self._params["prefactor"])
@@ -144,11 +141,11 @@ IF ELECTROSTATICS:
             pass
 
         def valid_keys(self):
-            return ["prefactor", "kappa", "epsilon1", "epsilon2", "r_cut",
-                    "check_neutrality"]
+            return {"prefactor", "kappa", "epsilon1", "epsilon2", "r_cut",
+                    "check_neutrality"}
 
         def required_keys(self):
-            return ["prefactor", "kappa", "epsilon1", "epsilon2", "r_cut"]
+            return {"prefactor", "kappa", "epsilon1", "epsilon2", "r_cut"}
 
         def _set_params_in_es_core(self):
             set_prefactor(self._params["prefactor"])
@@ -190,12 +187,12 @@ IF P3M == 1:
                 mesh[i] = pmesh[i]
 
         def valid_keys(self):
-            return ["mesh", "cao", "accuracy", "epsilon", "alpha", "r_cut",
+            return {"mesh", "cao", "accuracy", "epsilon", "alpha", "r_cut",
                     "prefactor", "tune", "check_neutrality", "timings",
-                    "verbose", "mesh_off"]
+                    "verbose", "mesh_off"}
 
         def required_keys(self):
-            return ["prefactor", "accuracy"]
+            return {"prefactor", "accuracy"}
 
         def default_params(self):
             return {"cao": 0,
@@ -477,12 +474,12 @@ IF P3M == 1:
                 "neutralize has to be a bool")
 
         def valid_keys(self):
-            return ["p3m_actor", "maxPWerror", "gap_size", "far_cut",
+            return {"p3m_actor", "maxPWerror", "gap_size", "far_cut",
                     "neutralize", "delta_mid_top", "delta_mid_bot",
-                    "const_pot", "pot_diff", "check_neutrality"]
+                    "const_pot", "pot_diff", "check_neutrality"}
 
         def required_keys(self):
-            return ["p3m_actor", "maxPWerror", "gap_size"]
+            return {"p3m_actor", "maxPWerror", "gap_size"}
 
         def default_params(self):
             return {"maxPWerror": -1,
@@ -576,12 +573,12 @@ IF ELECTROSTATICS:
                     "verbose": True}
 
         def valid_keys(self):
-            return ["prefactor", "maxPWerror", "far_switch_radius",
+            return {"prefactor", "maxPWerror", "far_switch_radius",
                     "bessel_cutoff", "tune", "check_neutrality", "timings",
-                    "verbose"]
+                    "verbose"}
 
         def required_keys(self):
-            return ["prefactor", "maxPWerror"]
+            return {"prefactor", "maxPWerror"}
 
         def _get_params_from_es_core(self):
             params = {}
@@ -662,11 +659,11 @@ IF ELECTROSTATICS and MMM1D_GPU:
                     "check_neutrality": True}
 
         def valid_keys(self):
-            return ["prefactor", "maxPWerror", "far_switch_radius",
-                    "bessel_cutoff", "tune", "check_neutrality"]
+            return {"prefactor", "maxPWerror", "far_switch_radius",
+                    "bessel_cutoff", "tune", "check_neutrality"}
 
         def required_keys(self):
-            return ["prefactor", "maxPWerror"]
+            return {"prefactor", "maxPWerror"}
 
         def _get_params_from_es_core(self):
             params = {}

--- a/src/python/espressomd/integrate.pyx
+++ b/src/python/espressomd/integrate.pyx
@@ -20,6 +20,7 @@ from cpython.exc cimport PyErr_CheckSignals, PyErr_SetInterrupt
 include "myconfig.pxi"
 from .utils cimport check_type_or_throw_except
 from .utils import handle_errors
+from . import utils
 from . cimport integrate
 
 cdef class IntegratorHandle:
@@ -158,13 +159,7 @@ cdef class Integrator:
         return self.__getstate__()
 
     def __init__(self, *args, **kwargs):
-
-        # Check if all required keys are given
-        for k in self.required_keys():
-            if k not in kwargs:
-                raise ValueError(
-                    "At least the following keys have to be given as keyword arguments: " + self.required_keys().__str__())
-
+        utils.check_required_keys(self.required_keys(), kwargs.keys())
         self._params = self.default_params()
         self._params.update(kwargs)
         self.validate_params()
@@ -322,13 +317,13 @@ cdef class VelocityVerlet(Integrator):
         """All parameters that can be set.
 
         """
-        return {}
+        return set()
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return {}
+        return set()
 
     def validate_params(self):
         return True
@@ -411,13 +406,13 @@ cdef class BrownianDynamics(Integrator):
         """All parameters that can be set.
 
         """
-        return {}
+        return set()
 
     def required_keys(self):
         """Parameters that have to be set.
 
         """
-        return {}
+        return set()
 
     def validate_params(self):
         return True

--- a/src/python/espressomd/magnetostatics.pyx
+++ b/src/python/espressomd/magnetostatics.pyx
@@ -131,12 +131,12 @@ IF DP3M == 1:
                 raise ValueError("DipolarP3M timings must be > 0")
 
         def valid_keys(self):
-            return ["prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off",
+            return {"prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off",
                     "cao", "accuracy", "epsilon", "cao_cut", "a", "ai",
-                    "alpha", "r_cut", "cao3", "tune", "timings", "verbose"]
+                    "alpha", "r_cut", "cao3", "tune", "timings", "verbose"}
 
         def required_keys(self):
-            return ["accuracy", ]
+            return {"accuracy"}
 
         def default_params(self):
             return {"cao": -1,
@@ -218,10 +218,10 @@ IF DIPOLES == 1:
             return {}
 
         def required_keys(self):
-            return ()
+            return set()
 
         def valid_keys(self):
-            return ("prefactor",)
+            return {"prefactor"}
 
         def _get_params_from_es_core(self):
             return {"prefactor": self.get_magnetostatics_prefactor()}
@@ -256,10 +256,10 @@ IF DIPOLES == 1:
             return {}
 
         def required_keys(self):
-            return ("n_replica",)
+            return {"n_replica"}
 
         def valid_keys(self):
-            return ("prefactor", "n_replica")
+            return {"prefactor", "n_replica"}
 
         def _get_params_from_es_core(self):
             return {"prefactor": self.get_magnetostatics_prefactor(),
@@ -341,10 +341,10 @@ IF DIPOLES == 1:
                 return {}
 
             def required_keys(self):
-                return ()
+                return set()
 
             def valid_keys(self):
-                return ("prefactor",)
+                return {"prefactor"}
 
             def _get_params_from_es_core(self):
                 return {"prefactor": self.get_magnetostatics_prefactor()}
@@ -382,10 +382,10 @@ IF DIPOLES == 1:
                         "itolsq": 4.0}
 
             def required_keys(self):
-                return ()
+                return set()
 
             def valid_keys(self):
-                return ("prefactor", "epssq", "itolsq")
+                return {"prefactor", "epssq", "itolsq"}
 
             def _get_params_from_es_core(self):
                 return {"prefactor": self.get_magnetostatics_prefactor()}

--- a/src/python/espressomd/polymer.pyx
+++ b/src/python/espressomd/polymer.pyx
@@ -19,6 +19,7 @@
 
 include "myconfig.pxi"
 from . cimport polymer
+from . import utils
 import numpy as np
 from .system import System
 from .interactions import BondedInteraction
@@ -130,17 +131,9 @@ def linear_polymer_positions(**kwargs):
 
     required_keys = ["n_polymers", "beads_per_chain", "bond_length", "seed"]
 
-    for k in kwargs:
-        if k not in valid_keys:
-            raise ValueError(f"Unknown parameter '{k}'")
-        params[k] = kwargs[k]
-
-    for k in required_keys:
-        if k not in kwargs:
-            print(k)
-            raise ValueError(
-                "At least the following keys have to be given as keyword arguments: " + required_keys.__str__())
-
+    utils.check_required_keys(required_keys, kwargs.keys())
+    utils.check_valid_keys(valid_keys, kwargs.keys())
+    params.update(kwargs)
     validate_params(params, default_params)
 
     cdef vector[Vector3d] start_positions

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -315,3 +315,21 @@ def requires_experimental_features(reason):
     ELSE:
         # Return original class
         return lambda x: x
+
+
+def check_required_keys(required_keys, obtained_keys):
+    a = required_keys
+    b = obtained_keys
+    if not set(a).issubset(b):
+        raise ValueError(
+            "The following keys have to be given as keyword arguments: "
+            f"{sorted(a)}, got {sorted(b)} (missing {sorted(a - b)})")
+
+
+def check_valid_keys(valid_keys, obtained_keys):
+    a = valid_keys
+    b = obtained_keys
+    if not set(b).issubset(a):
+        raise ValueError(
+            "Only the following keys can be given as keyword arguments: "
+            f"{sorted(a)}, got {sorted(b)} (unknown {sorted(b - a)})")

--- a/testsuite/python/actor.py
+++ b/testsuite/python/actor.py
@@ -44,10 +44,10 @@ class TestActor(espressomd.actors.Actor):
         self._core_args = self._params
 
     def valid_keys(self):
-        return "a", "b", "c"
+        return {"a", "b", "c"}
 
     def required_keys(self):
-        return "a", "c"
+        return {"a", "c"}
 
     def default_params(self):
         return {"a": False, "b": False, "c": False}
@@ -107,6 +107,21 @@ class ActorTest(ut.TestCase):
         self.assertEqual(params["a"], True)
         self.assertEqual(params["b"], False)
         self.assertEqual(params["c"], True)
+
+    def test_exception(self):
+        error_msg_valid = (r"Only the following keys can be given as keyword arguments: "
+                           r"\['a', 'b', 'c'\], got \['a', 'c', 'd'\] \(unknown \['d'\]\)")
+        error_msg_required = (r"The following keys have to be given as keyword arguments: "
+                              r"\['a', 'c'\], got \['a'\] \(missing \['c'\]\)")
+        with self.assertRaisesRegex(ValueError, error_msg_valid):
+            TestActor(a=True, c=True, d=True)
+        with self.assertRaisesRegex(ValueError, error_msg_required):
+            TestActor(a=True)
+        valid_actor = TestActor(a=True, c=True)
+        with self.assertRaisesRegex(ValueError, error_msg_valid):
+            valid_actor.set_params(a=True, c=True, d=True)
+        with self.assertRaisesRegex(ValueError, error_msg_required):
+            valid_actor.set_params(a=True)
 
 
 class ActorsTest(ut.TestCase):

--- a/testsuite/python/ek_charged_plate.py
+++ b/testsuite/python/ek_charged_plate.py
@@ -164,10 +164,17 @@ class ek_charged_plate(ut.TestCase):
                 negative_ions[i, j, 30].density = 0.0
 
         # Test error when trying to change ekin parameters after initialisation
-        ek._params.update({'agrid': 3,
-                           'T': 0.01})
         with self.assertRaises(RuntimeError):
+            ek._params.update({'agrid': 3, 'T': 0.01})
             ek._set_params_in_es_core()
+
+        # Check errors from the constructor
+        with self.assertRaisesRegex(ValueError, r"The following keys have to be given as keyword arguments: "
+                                                r"\[.+\], got \[.+\] \(missing \['D'\]\)"):
+            espressomd.electrokinetics.Species(density=0, valency=1)
+        with self.assertRaisesRegex(ValueError, r"Only the following keys can be given as keyword arguments: "
+                                                r"\[.+\], got \[.+\] \(unknown \['U'\]\)"):
+            espressomd.electrokinetics.Species(density=0, valency=1, D=0, U=1)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/electrostaticInteractions.py
+++ b/testsuite/python/electrostaticInteractions.py
@@ -242,6 +242,14 @@ class ElectrostaticInteractionsTests(ut.TestCase):
                 self.system.actors.add(rf)
             self.system.actors.clear()
 
+        valid_actor = espressomd.electrostatics.ReactionField(
+            **params, prefactor=1.0)
+        with self.assertRaisesRegex(Exception, "chosen method does not support tuning"):
+            valid_actor.tune()
+        with self.assertRaisesRegex(ValueError, r"Only the following keys can be given as keyword arguments: "
+                                                r"\[.+\], got \[.+\] \(unknown \['coulomb_prefactor'\]\)"):
+            valid_actor.tune(coulomb_prefactor=1.0)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/integrator_exceptions.py
+++ b/testsuite/python/integrator_exceptions.py
@@ -65,6 +65,11 @@ class Integrator_test(ut.TestCase):
             self.system.integrator.run(0)
 
     def test_steepest_descent_integrator(self):
+        with self.assertRaisesRegex(ValueError, r"The following keys have to be given as keyword arguments: "
+                                                r"\['f_max', 'gamma', 'max_displacement'\], got "
+                                                r"\['f_max', 'gamma', 'max_d'\] \(missing \['max_displacement'\]\)"):
+            self.system.integrator.set_steepest_descent(
+                f_max=0, gamma=0.1, max_d=5)
         self.system.thermostat.set_langevin(kT=1.0, gamma=1.0, seed=42)
         self.system.integrator.set_steepest_descent(
             f_max=0, gamma=0.1, max_displacement=0.1)

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -253,6 +253,10 @@ class BondedInteractions(ut.TestCase):
         # sanity checks during bond construction
         with self.assertRaisesRegex(RuntimeError, "Parameter 'r_0' is missing"):
             espressomd.interactions.HarmonicBond(k=1.)
+        with self.assertRaisesRegex(ValueError, r"Only the following keys can be given as keyword arguments: "
+                                                r"\['k', 'r_0', 'r_cut'\], got \['k', 'r_0', 'rcut'\] "
+                                                r"\(unknown \['rcut'\]\)"):
+            espressomd.interactions.HarmonicBond(k=1., r_0=1., rcut=2.)
         with self.assertRaisesRegex(ValueError, "Unknown refShape: 'Unknown'"):
             espressomd.interactions.IBM_Tribend(
                 ind1=0, ind2=1, ind3=2, ind4=3, kb=1.1, refShape='Unknown')

--- a/testsuite/python/interactions_non-bonded_interface.py
+++ b/testsuite/python/interactions_non-bonded_interface.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import unittest as ut
+import unittest_decorators as utx
 import tests_common
 
 import espressomd
@@ -155,6 +156,27 @@ class Non_bonded_interactionsTests(ut.TestCase):
             {"eps": 1.0, "sig": 1.0, "cut": 4.0, "k1": 3.0,
              "k2": 5.0, "mu": 2.0, "nu": 1.0},
             "gay_berne")
+
+    @utx.skipIfMissingFeatures("LENNARD_JONES")
+    def test_exceptions(self):
+        err_msg_required = (r"The following keys have to be given as keyword arguments: "
+                            r"\['cutoff', 'epsilon', 'shift', 'sigma'\], got "
+                            r"\['epsilon', 'sigma'\] \(missing \['cutoff', 'shift'\]\)")
+        err_msg_valid = (r"Only the following keys can be given as keyword arguments: "
+                         r"\['cutoff', 'epsilon', 'min', 'offset', 'shift', 'sigma'\], got "
+                         r"\['cutoff', 'epsilon', 'shift', 'sigma', 'unknown'\] \(unknown \['unknown'\]\)")
+        with self.assertRaisesRegex(ValueError, err_msg_required):
+            espressomd.interactions.LennardJonesInteraction(
+                epsilon=1., sigma=2.)
+        with self.assertRaisesRegex(ValueError, err_msg_required):
+            self.system.non_bonded_inter[0, 0].lennard_jones.set_params(
+                epsilon=1., sigma=2.)
+        with self.assertRaisesRegex(ValueError, err_msg_valid):
+            espressomd.interactions.LennardJonesInteraction(
+                epsilon=1., sigma=2., cutoff=3., shift=4., unknown=5.)
+        with self.assertRaisesRegex(ValueError, err_msg_valid):
+            self.system.non_bonded_inter[0, 0].lennard_jones.set_params(
+                epsilon=1., sigma=2., cutoff=3., shift=4., unknown=5.)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/polymer_linear.py
+++ b/testsuite/python/polymer_linear.py
@@ -198,11 +198,20 @@ class LinearPolymerPositions(ut.TestCase):
                 respect_constraints=True, seed=self.seed)
         self.system.constraints.remove(wall_constraint)
 
-    def test_failure(self):
+    def test_exceptions(self):
         """
-        Check the runtime error message.
+        Check runtime error messages.
 
         """
+        with self.assertRaisesRegex(ValueError, r"The following keys have to be given as keyword arguments: "
+                                                r"\[.+\], got \[.+\] \(missing \['seed'\]\)"):
+            espressomd.polymer.linear_polymer_positions(
+                n_polymers=1, beads_per_chain=10, bond_length=0.1)
+        with self.assertRaisesRegex(ValueError, r"Only the following keys can be given as keyword arguments: "
+                                                r"\[.+\], got \[.+\] \(unknown \['bondangle'\]\)"):
+            espressomd.polymer.linear_polymer_positions(
+                n_polymers=1, beads_per_chain=10, bond_length=0.1, seed=10,
+                bondangle=0.1)
         with self.assertRaisesRegex(Exception, 'Failed to create polymer positions.'):
             espressomd.polymer.linear_polymer_positions(
                 n_polymers=1, beads_per_chain=10,


### PR DESCRIPTION
Description of changes:
- actors should check for parameter values, while `espressomd.utils` should check for parameter names and pretty-print error messages (single responsibility principle)
