### PR TITLE
Make CellStructureType an enum class.

### DIFF
--- a/src/core/CellStructure.cpp
+++ b/src/core/CellStructure.cpp
@@ -242,15 +242,18 @@ void CellStructure::resort_particles(int global_flag) {
 }
 
 void CellStructure::set_atom_decomposition(boost::mpi::communicator const &comm,
-                                           BoxGeometry const &box) {
+                                           BoxGeometry const &box,
+                                           LocalBox<double> &local_geo) {
   set_particle_decomposition(std::make_unique<AtomDecomposition>(comm, box));
   m_type = CellStructureType::CELL_STRUCTURE_NSQUARE;
+  local_geo.set_cell_structure_type(m_type);
 }
 
 void CellStructure::set_regular_decomposition(
     boost::mpi::communicator const &comm, double range, BoxGeometry const &box,
-    LocalBox<double> const &local_geo) {
+    LocalBox<double> &local_geo) {
   set_particle_decomposition(
       std::make_unique<RegularDecomposition>(comm, range, box, local_geo));
   m_type = CellStructureType::CELL_STRUCTURE_REGULAR;
+  local_geo.set_cell_structure_type(m_type);
 }

--- a/src/core/CellStructure.cpp
+++ b/src/core/CellStructure.cpp
@@ -22,6 +22,7 @@
 #include "CellStructure.hpp"
 
 #include "AtomDecomposition.hpp"
+#include "CellStructureType.hpp"
 #include "RegularDecomposition.hpp"
 
 #include <utils/contains.hpp>
@@ -243,7 +244,7 @@ void CellStructure::resort_particles(int global_flag) {
 void CellStructure::set_atom_decomposition(boost::mpi::communicator const &comm,
                                            BoxGeometry const &box) {
   set_particle_decomposition(std::make_unique<AtomDecomposition>(comm, box));
-  m_type = CELL_STRUCTURE_NSQUARE;
+  m_type = CellStructureType::CELL_STRUCTURE_NSQUARE;
 }
 
 void CellStructure::set_regular_decomposition(
@@ -251,5 +252,5 @@ void CellStructure::set_regular_decomposition(
     LocalBox<double> const &local_geo) {
   set_particle_decomposition(
       std::make_unique<RegularDecomposition>(comm, range, box, local_geo));
-  m_type = CELL_STRUCTURE_REGULAR;
+  m_type = CellStructureType::CELL_STRUCTURE_REGULAR;
 }

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -490,22 +490,24 @@ public:
    * @brief Set the particle decomposition to AtomDecomposition.
    *
    * @param comm Communicator to use.
-   * @param box Box Geometry
+   * @param box Box Geometry.
+   * @param local_geo Geometry of the local box (holds cell structure type).
    */
   void set_atom_decomposition(boost::mpi::communicator const &comm,
-                              BoxGeometry const &box);
+                              BoxGeometry const &box,
+                              LocalBox<double> &local_geo);
 
   /**
    * @brief Set the particle decomposition to RegularDecomposition.
    *
    * @param comm Cartesian communicator to use.
    * @param range Interaction range.
-   * @param box Box Geometry
+   * @param box Box Geometry.
    * @param local_geo Geometry of the local box.
    */
   void set_regular_decomposition(boost::mpi::communicator const &comm,
                                  double range, BoxGeometry const &box,
-                                 LocalBox<double> const &local_geo);
+                                 LocalBox<double> &local_geo);
 
 public:
   template <class BondKernel> void bond_loop(BondKernel const &bond_kernel) {

--- a/src/core/CellStructure.hpp
+++ b/src/core/CellStructure.hpp
@@ -25,6 +25,7 @@
 #include "AtomDecomposition.hpp"
 #include "BoxGeometry.hpp"
 #include "Cell.hpp"
+#include "CellStructureType.hpp"
 #include "LocalBox.hpp"
 #include "Particle.hpp"
 #include "ParticleDecomposition.hpp"
@@ -47,14 +48,6 @@
 #include <memory>
 #include <utility>
 #include <vector>
-
-/** Cell Structure */
-enum CellStructureType : int {
-  /** cell structure regular decomposition */
-  CELL_STRUCTURE_REGULAR = 1,
-  /** cell structure n square */
-  CELL_STRUCTURE_NSQUARE = 2
-};
 
 namespace Cells {
 enum Resort : unsigned {
@@ -132,7 +125,7 @@ private:
   std::unique_ptr<ParticleDecomposition> m_decomposition =
       std::make_unique<AtomDecomposition>();
   /** Active type in m_decomposition */
-  int m_type = CELL_STRUCTURE_NSQUARE;
+  CellStructureType m_type = CellStructureType::CELL_STRUCTURE_NSQUARE;
   /** One of @ref Cells::Resort, announces the level of resort needed.
    */
   unsigned m_resort_particles = Cells::RESORT_NONE;
@@ -247,7 +240,7 @@ public:
   }
 
 public:
-  int decomposition_type() const { return m_type; }
+  CellStructureType decomposition_type() const { return m_type; }
 
   /** Maximal cutoff supported by current cell system. */
   Utils::Vector3d max_cutoff() const;

--- a/src/core/CellStructureType.hpp
+++ b/src/core/CellStructureType.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2010-2020 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ESPRESSO_CELLSTRUCTURETYPE_HPP
+#define ESPRESSO_CELLSTRUCTURETYPE_HPP
+
+/** Cell structure */
+enum class CellStructureType : int {
+  /** cell structure regular decomposition */
+  CELL_STRUCTURE_REGULAR = 1,
+  /** cell structure n square */
+  CELL_STRUCTURE_NSQUARE = 2
+};
+
+#endif // ESPRESSO_CELLSTRUCTURETYPE_HPP

--- a/src/core/LocalBox.hpp
+++ b/src/core/LocalBox.hpp
@@ -19,6 +19,7 @@
 #ifndef ESPRESSO_LOCALBOX_HPP
 #define ESPRESSO_LOCALBOX_HPP
 
+#include "CellStructureType.hpp"
 #include <utils/Vector.hpp>
 
 template <class T> class LocalBox {
@@ -26,15 +27,17 @@ template <class T> class LocalBox {
   Utils::Vector<T, 3> m_lower_corner = {0, 0, 0};
   Utils::Vector<T, 3> m_upper_corner = {1, 1, 1};
   Utils::Array<int, 6> m_boundaries = {};
+  CellStructureType m_cell_structure_type;
 
 public:
   LocalBox() = default;
   LocalBox(Utils::Vector<T, 3> const &lower_corner,
            Utils::Vector<T, 3> const &local_box_length,
-           Utils::Array<int, 6> const &boundaries)
+           Utils::Array<int, 6> const &boundaries,
+           CellStructureType const cell_structure_type)
       : m_local_box_l(local_box_length), m_lower_corner(lower_corner),
         m_upper_corner(lower_corner + local_box_length),
-        m_boundaries(boundaries) {}
+        m_boundaries(boundaries), m_cell_structure_type(cell_structure_type) {}
 
   /** Left (bottom, front) corner of this nodes local box. */
   Utils::Vector<T, 3> const &my_left() const { return m_lower_corner; }
@@ -52,6 +55,16 @@ public:
    * @return Array with boundary information.
    */
   Utils::Array<int, 6> const &boundary() const { return m_boundaries; }
+
+  /** Return cell structure type. */
+  CellStructureType const &cell_structure_type() const {
+    return m_cell_structure_type;
+  }
+
+  /** Set cell structure type. */
+  void set_cell_structure_type(CellStructureType cell_structure_type) {
+    m_cell_structure_type = cell_structure_type;
+  }
 };
 
 #endif

--- a/src/core/actor/Mmm1dgpuForce.cpp
+++ b/src/core/actor/Mmm1dgpuForce.cpp
@@ -26,7 +26,6 @@
 #include "electrostatics_magnetostatics/coulomb.hpp"
 
 #include "CellStructureType.hpp"
-#include "cells.hpp"
 #include "energy.hpp"
 #include "forces.hpp"
 #include "grid.hpp"
@@ -42,7 +41,7 @@ Mmm1dgpuForce::Mmm1dgpuForce(SystemInterface &s) {
   if (box_geo.periodic(0) || box_geo.periodic(1) || !box_geo.periodic(2)) {
     throw std::runtime_error("MMM1D requires periodicity (0, 0, 1)");
   }
-  if (cell_structure.decomposition_type() !=
+  if (local_geo.cell_structure_type() !=
       CellStructureType::CELL_STRUCTURE_NSQUARE) {
     throw std::runtime_error("MMM1D requires the N-square cellsystem");
   }

--- a/src/core/actor/Mmm1dgpuForce.cpp
+++ b/src/core/actor/Mmm1dgpuForce.cpp
@@ -25,6 +25,7 @@
 #include "electrostatics_magnetostatics/common.hpp"
 #include "electrostatics_magnetostatics/coulomb.hpp"
 
+#include "CellStructureType.hpp"
 #include "cells.hpp"
 #include "energy.hpp"
 #include "forces.hpp"
@@ -41,7 +42,8 @@ Mmm1dgpuForce::Mmm1dgpuForce(SystemInterface &s) {
   if (box_geo.periodic(0) || box_geo.periodic(1) || !box_geo.periodic(2)) {
     throw std::runtime_error("MMM1D requires periodicity (0, 0, 1)");
   }
-  if (cell_structure.decomposition_type() != CELL_STRUCTURE_NSQUARE) {
+  if (cell_structure.decomposition_type() !=
+      CellStructureType::CELL_STRUCTURE_NSQUARE) {
     throw std::runtime_error("MMM1D requires the N-square cellsystem");
   }
 

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -195,13 +195,13 @@ std::vector<int> mpi_resort_particles(int global_flag) {
   return n_parts;
 }
 
-void cells_re_init(int new_cs) {
+void cells_re_init(CellStructureType new_cs) {
   switch (new_cs) {
-  case CELL_STRUCTURE_REGULAR:
+  case CellStructureType::CELL_STRUCTURE_REGULAR:
     cell_structure.set_regular_decomposition(comm_cart, interaction_range(),
                                              box_geo, local_geo);
     break;
-  case CELL_STRUCTURE_NSQUARE:
+  case CellStructureType::CELL_STRUCTURE_NSQUARE:
     cell_structure.set_atom_decomposition(comm_cart, box_geo);
     break;
   default:
@@ -213,7 +213,9 @@ void cells_re_init(int new_cs) {
 
 REGISTER_CALLBACK(cells_re_init)
 
-void mpi_bcast_cell_structure(int cs) { mpi_call_all(cells_re_init, cs); }
+void mpi_bcast_cell_structure(CellStructureType cs) {
+  mpi_call_all(cells_re_init, cs);
+}
 
 void check_resort_particles() {
   auto const level = (cell_structure.check_resort_required(

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -202,7 +202,7 @@ void cells_re_init(CellStructureType new_cs) {
                                              box_geo, local_geo);
     break;
   case CellStructureType::CELL_STRUCTURE_NSQUARE:
-    cell_structure.set_atom_decomposition(comm_cart, box_geo);
+    cell_structure.set_atom_decomposition(comm_cart, box_geo, local_geo);
     break;
   default:
     throw std::runtime_error("Unknown cell system type");

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -40,6 +40,7 @@
 
 #include "Cell.hpp"
 #include "CellStructure.hpp"
+#include "CellStructureType.hpp"
 #include "Particle.hpp"
 #include "RegularDecomposition.hpp"
 
@@ -63,10 +64,10 @@ extern CellStructure cell_structure;
 /** Reinitialize the cell structures.
  *  @param new_cs The new topology to use afterwards.
  */
-void cells_re_init(int new_cs);
+void cells_re_init(CellStructureType new_cs);
 
 /** Change the cell structure on all nodes. */
-void mpi_bcast_cell_structure(int cs);
+void mpi_bcast_cell_structure(CellStructureType cs);
 
 /**
  * @brief Set @ref CellStructure::use_verlet_list

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -35,6 +35,7 @@
 #include "electrostatics_magnetostatics/mmm-common.hpp"
 #include "electrostatics_magnetostatics/mmm-modpsi.hpp"
 
+#include "CellStructureType.hpp"
 #include "cells.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
@@ -152,7 +153,8 @@ bool MMM1D_sanity_checks() {
     runtimeErrorMsg() << "MMM1D requires periodicity (0, 0, 1)";
     return true;
   }
-  if (cell_structure.decomposition_type() != CELL_STRUCTURE_NSQUARE) {
+  if (cell_structure.decomposition_type() !=
+      CellStructureType::CELL_STRUCTURE_NSQUARE) {
     runtimeErrorMsg() << "MMM1D requires the N-square cellsystem";
     return true;
   }

--- a/src/core/electrostatics_magnetostatics/mmm1d.cpp
+++ b/src/core/electrostatics_magnetostatics/mmm1d.cpp
@@ -36,7 +36,6 @@
 #include "electrostatics_magnetostatics/mmm-modpsi.hpp"
 
 #include "CellStructureType.hpp"
-#include "cells.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
 #include "specfunc.hpp"
@@ -153,7 +152,7 @@ bool MMM1D_sanity_checks() {
     runtimeErrorMsg() << "MMM1D requires periodicity (0, 0, 1)";
     return true;
   }
-  if (cell_structure.decomposition_type() !=
+  if (local_geo.cell_structure_type() !=
       CellStructureType::CELL_STRUCTURE_NSQUARE) {
     runtimeErrorMsg() << "MMM1D requires the N-square cellsystem";
     return true;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -45,6 +45,7 @@
 #include "electrostatics_magnetostatics/p3m_interpolation.hpp"
 #include "electrostatics_magnetostatics/p3m_send_mesh.hpp"
 
+#include "CellStructureType.hpp"
 #include "Particle.hpp"
 #include "ParticleRange.hpp"
 #include "cells.hpp"
@@ -1421,7 +1422,8 @@ bool dp3m_sanity_checks(const Utils::Vector3i &grid) {
     ret = true;
   }
 
-  if (cell_structure.decomposition_type() != CELL_STRUCTURE_REGULAR) {
+  if (cell_structure.decomposition_type() !=
+      CellStructureType::CELL_STRUCTURE_REGULAR) {
     runtimeErrorMsg() << "dipolar P3M requires the regular decomposition "
                          "cell system";
     ret = true;

--- a/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m-dipolar.cpp
@@ -1422,7 +1422,7 @@ bool dp3m_sanity_checks(const Utils::Vector3i &grid) {
     ret = true;
   }
 
-  if (cell_structure.decomposition_type() !=
+  if (local_geo.cell_structure_type() !=
       CellStructureType::CELL_STRUCTURE_REGULAR) {
     runtimeErrorMsg() << "dipolar P3M requires the regular decomposition "
                          "cell system";

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -1287,7 +1287,7 @@ bool p3m_sanity_checks_system(const Utils::Vector3i &grid) {
     ret = true;
   }
 
-  if (cell_structure.decomposition_type() !=
+  if (local_geo.cell_structure_type() !=
       CellStructureType::CELL_STRUCTURE_REGULAR) {
     runtimeErrorMsg() << "P3M requires the regular decomposition cell system";
     ret = true;

--- a/src/core/electrostatics_magnetostatics/p3m.cpp
+++ b/src/core/electrostatics_magnetostatics/p3m.cpp
@@ -31,6 +31,7 @@
 #include "electrostatics_magnetostatics/elc.hpp"
 #include "electrostatics_magnetostatics/p3m_influence_function.hpp"
 
+#include "CellStructureType.hpp"
 #include "Particle.hpp"
 #include "ParticleRange.hpp"
 #include "cells.hpp"
@@ -1286,7 +1287,8 @@ bool p3m_sanity_checks_system(const Utils::Vector3i &grid) {
     ret = true;
   }
 
-  if (cell_structure.decomposition_type() != CELL_STRUCTURE_REGULAR) {
+  if (cell_structure.decomposition_type() !=
+      CellStructureType::CELL_STRUCTURE_REGULAR) {
     runtimeErrorMsg() << "P3M requires the regular decomposition cell system";
     ret = true;
   }

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -25,6 +25,7 @@
  */
 #include "event.hpp"
 
+#include "CellStructureType.hpp"
 #include "bonded_interactions/thermalized_bond.hpp"
 #include "cells.hpp"
 #include "collision.hpp"
@@ -90,7 +91,7 @@ void on_program_start() {
   init_node_grid();
 
   /* initially go for regular decomposition */
-  cells_re_init(CELL_STRUCTURE_REGULAR);
+  cells_re_init(CellStructureType::CELL_STRUCTURE_REGULAR);
 
   if (this_node == 0) {
     /* make sure interaction 0<->0 always exists */

--- a/src/core/grid.cpp
+++ b/src/core/grid.cpp
@@ -87,7 +87,8 @@ LocalBox<double> regular_decomposition(const BoxGeometry &box,
     boundaries[2 * dir + 1] = -(node_pos[dir] == node_grid_par[dir] - 1);
   }
 
-  return {my_left, local_length, boundaries};
+  return {my_left, local_length, boundaries,
+          CellStructureType::CELL_STRUCTURE_REGULAR};
 }
 
 void grid_changed_box_l(const BoxGeometry &box) {

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -30,7 +30,6 @@
 #include "grid_based_algorithms/lb.hpp"
 
 #include "CellStructureType.hpp"
-#include "cells.hpp"
 #include "communication.hpp"
 #include "errorhandling.hpp"
 #include "grid.hpp"
@@ -51,6 +50,7 @@
 #include <boost/mpi/collectives/reduce.hpp>
 #include <boost/multi_array.hpp>
 #include <boost/optional.hpp>
+#include <boost/range/algorithm.hpp>
 #include <boost/range/numeric.hpp>
 #include <profiler/profiler.hpp>
 
@@ -614,7 +614,7 @@ void lb_sanity_checks(const LB_Parameters &lb_parameters) {
   if (lb_parameters.viscosity <= 0.0) {
     runtimeErrorMsg() << "Lattice Boltzmann fluid viscosity not set";
   }
-  if (cell_structure.decomposition_type() !=
+  if (local_geo.cell_structure_type() !=
       CellStructureType::CELL_STRUCTURE_REGULAR) {
     runtimeErrorMsg() << "LB requires regular-decomposition cellsystem";
   }

--- a/src/core/grid_based_algorithms/lb.cpp
+++ b/src/core/grid_based_algorithms/lb.cpp
@@ -29,6 +29,7 @@
 
 #include "grid_based_algorithms/lb.hpp"
 
+#include "CellStructureType.hpp"
 #include "cells.hpp"
 #include "communication.hpp"
 #include "errorhandling.hpp"
@@ -613,7 +614,8 @@ void lb_sanity_checks(const LB_Parameters &lb_parameters) {
   if (lb_parameters.viscosity <= 0.0) {
     runtimeErrorMsg() << "Lattice Boltzmann fluid viscosity not set";
   }
-  if (cell_structure.decomposition_type() != CELL_STRUCTURE_REGULAR) {
+  if (cell_structure.decomposition_type() !=
+      CellStructureType::CELL_STRUCTURE_REGULAR) {
     runtimeErrorMsg() << "LB requires regular-decomposition cellsystem";
   }
 }

--- a/src/core/unit_tests/LocalBox_test.cpp
+++ b/src/core/unit_tests/LocalBox_test.cpp
@@ -21,6 +21,7 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
+#include "CellStructureType.hpp"
 #include "LocalBox.hpp"
 
 #include <utils/Array.hpp>
@@ -53,13 +54,15 @@ BOOST_AUTO_TEST_CASE(constructors) {
     Utils::Vector<double, 3> const lower_corner = {1., 2., 3.};
     Utils::Vector<double, 3> const local_box_length = {4., 5., 6.};
     Utils::Array<int, 6> const boundaries = {{{-1, 0, 1, 1, 0, -1}}};
+    CellStructureType const type = CellStructureType::CELL_STRUCTURE_REGULAR;
 
     auto const box =
-        LocalBox<double>(lower_corner, local_box_length, boundaries);
+        LocalBox<double>(lower_corner, local_box_length, boundaries, type);
 
     BOOST_CHECK(box.my_left() == lower_corner);
     BOOST_CHECK(box.length() == local_box_length);
     BOOST_CHECK(boost::equal(boundaries, box.boundary()));
+    BOOST_CHECK(box.cell_structure_type() == type);
     check_length(box);
   }
 }

--- a/src/python/espressomd/cellsystem.pxd
+++ b/src/python/espressomd/cellsystem.pxd
@@ -35,12 +35,14 @@ cdef extern from "cells.hpp":
 cdef extern from "communication.hpp":
     int n_nodes
 
-cdef extern from "cells.hpp":
-    int CELL_STRUCTURE_REGULAR
-    int CELL_STRUCTURE_NSQUARE
+cdef extern from "CellStructureType.hpp":
+    ctypedef enum CellStructureType:
+        CELL_STRUCTURE_REGULAR "CellStructureType::CELL_STRUCTURE_REGULAR"
+        CELL_STRUCTURE_NSQUARE "CellStructureType::CELL_STRUCTURE_NSQUARE"
 
+cdef extern from "cells.hpp":
     ctypedef struct CellStructure:
-        int decomposition_type()
+        CellStructureType decomposition_type()
         bool use_verlet_list
 
     CellStructure cell_structure

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -42,7 +42,7 @@ cdef class CellSystem:
 
         """
         mpi_set_use_verlet_lists(use_verlet_lists)
-        mpi_bcast_cell_structure(CELL_STRUCTURE_REGULAR)
+        mpi_bcast_cell_structure(CellStructureType.CELL_STRUCTURE_REGULAR)
 
         handle_errors("Error while initializing the cell system.")
         return True
@@ -59,14 +59,14 @@ cdef class CellSystem:
 
         """
         mpi_set_use_verlet_lists(use_verlet_lists)
-        mpi_bcast_cell_structure(CELL_STRUCTURE_NSQUARE)
+        mpi_bcast_cell_structure(CellStructureType.CELL_STRUCTURE_NSQUARE)
 
         return True
 
     def get_state(self):
         s = self.__getstate__()
 
-        if cell_structure.decomposition_type() == CELL_STRUCTURE_REGULAR:
+        if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_REGULAR:
             rd = get_regular_decomposition()
             s["cell_grid"] = np.array(
                 [rd.cell_grid[0], rd.cell_grid[1], rd.cell_grid[2]])
@@ -81,9 +81,9 @@ cdef class CellSystem:
     def __getstate__(self):
         s = {"use_verlet_list": cell_structure.use_verlet_list}
 
-        if cell_structure.decomposition_type() == CELL_STRUCTURE_REGULAR:
+        if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_REGULAR:
             s["type"] = "regular_decomposition"
-        if cell_structure.decomposition_type() == CELL_STRUCTURE_NSQUARE:
+        if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_NSQUARE:
             s["type"] = "nsquare"
 
         s["skin"] = skin


### PR DESCRIPTION
Partial fix for #4428

Description of changes:
- `CellStructureType` is now an `enum class`.
- Removed access to the cell system in several files by storing the information about the current `CellStructureType` in the global variable `LocalBox<double> local_geo`.