### PR TITLE
throw error for bonded interactions if particles are at the same posi…

### DIFF
--- a/src/core/bonded_interactions/fene.hpp
+++ b/src/core/bonded_interactions/fene.hpp
@@ -27,6 +27,7 @@
  */
 
 #include "config.hpp"
+#include "errorhandling.hpp"
 
 #include <utils/Vector.hpp>
 
@@ -84,7 +85,10 @@ FeneBond::force(Utils::Vector3d const &dx) const {
   if (len > ROUND_ERROR_PREC) {
     fac /= len;
   } else {
-    fac = 0.0;
+    if (r0 > 0.) {
+      runtimeErrorMsg() << "FENE bond: Particles have zero distance. "
+                           "This is most likely an error in the system setup.";
+    }
   }
 
   return fac * dx;

--- a/src/core/bonded_interactions/harmonic.hpp
+++ b/src/core/bonded_interactions/harmonic.hpp
@@ -25,6 +25,7 @@
  */
 
 #include "config.hpp"
+#include "errorhandling.hpp"
 
 #include <utils/Vector.hpp>
 #include <utils/math/sqr.hpp>
@@ -79,7 +80,10 @@ HarmonicBond::force(Utils::Vector3d const &dx) const {
   if (dist > ROUND_ERROR_PREC) { /* Regular case */
     fac /= dist;
   } else {
-    fac = 0;
+    if (r > 0.) {
+      runtimeErrorMsg() << "Harmonic bond: Particles have zero distance. "
+                           "This is most likely an error in the system setup.";
+    }
   }
   return fac * dx;
 }

--- a/src/core/bonded_interactions/quartic.hpp
+++ b/src/core/bonded_interactions/quartic.hpp
@@ -24,6 +24,7 @@
  *  Routines to calculate the quartic potential between particle pairs.
  */
 
+#include "errorhandling.hpp"
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
 #include <utils/math/sqr.hpp>
@@ -73,7 +74,16 @@ QuarticBond::force(Utils::Vector3d const &dx) const {
   }
 
   auto const dr = dist - r;
-  auto const fac = (k0 * dr + k1 * Utils::int_pow<3>(dr)) / dist;
+  auto fac = (k0 * dr + k1 * Utils::int_pow<3>(dr));
+
+  if (dist > ROUND_ERROR_PREC) { /* Regular case */
+    fac /= dist;
+  } else {
+    if (r > 0.) {
+      runtimeErrorMsg() << "Quartic bond: Particles have zero distance. "
+                           "This is most likely an error in the system setup.";
+    }
+  }
   return -fac * dx;
 }
 

--- a/testsuite/python/interactions_bonded.py
+++ b/testsuite/python/interactions_bonded.py
@@ -63,7 +63,7 @@ class InteractionsBondedTest(ut.TestCase):
                           scalar_r=r, k=hb_k, r_0=hb_r_0),
                       lambda r: tests_common.harmonic_potential(
                           scalar_r=r, k=hb_k, r_0=hb_r_0),
-                      0.01, hb_r_cut, True)
+                      0.01, hb_r_cut, True, test_same_pos_exception=True)
 
     # Test Fene Bond
     def test_fene(self):
@@ -78,7 +78,7 @@ class InteractionsBondedTest(ut.TestCase):
                           scalar_r=r, k=fene_k, d_r_max=fene_d_r_max, r_0=fene_r_0),
                       lambda r: tests_common.fene_potential(
                           scalar_r=r, k=fene_k, d_r_max=fene_d_r_max, r_0=fene_r_0),
-                      0.01, fene_r_0 + fene_d_r_max, True)
+                      0.01, fene_r_0 + fene_d_r_max, True, test_same_pos_exception=True)
 
     def test_virtual_bond(self):
         # add sentinel harmonic bond, otherwise short-range loop is skipped
@@ -167,10 +167,10 @@ class InteractionsBondedTest(ut.TestCase):
                           k0=quartic_k0, k1=quartic_k1, r=quartic_r, r_cut=quartic_r_cut, scalar_r=r),
                       lambda r: tests_common.quartic_potential(
                           k0=quartic_k0, k1=quartic_k1, r=quartic_r, r_cut=quartic_r_cut, scalar_r=r),
-                      0.01, quartic_r_cut, True)
+                      0.01, quartic_r_cut, True, test_same_pos_exception=True)
 
     def run_test(self, bond_instance, force_func, energy_func, min_dist,
-                 cutoff, test_breakage=False):
+                 cutoff, test_breakage=False, test_same_pos_exception=False):
         self.system.bonded_inter.add(bond_instance)
         p1, p2 = self.system.part.all()
         p1.bonds = ((bond_instance, p2),)
@@ -216,6 +216,10 @@ class InteractionsBondedTest(ut.TestCase):
         if test_breakage:
             p2.pos = p1.pos + self.axis * cutoff * 1.01
             with self.assertRaisesRegex(Exception, "Encountered errors during integrate"):
+                self.system.integrator.run(recalc_forces=True, steps=0)
+        if test_same_pos_exception:
+            p2.pos = p1.pos
+            with self.assertRaises(Exception):
                 self.system.integrator.run(recalc_forces=True, steps=0)
 
 


### PR DESCRIPTION
…tion

Fixes #4453 

Description of changes:
- if particle dist is 0 and the equilibrium extension of the bond is nonzero, throw error (because direction of the force cannot be determined)
- affects FENE, harmonic and quartic bond
