### PR TITLE
throw if lb boundaries do not fit lb algorithm

### DIFF
--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -170,10 +170,11 @@ void ek_init_boundaries() {
 /** Initialize boundary conditions for all constraints in the system. */
 void lb_init_boundaries() {
   if (lattice_switch == ActiveLB::GPU) {
-#if defined(CUDA) && defined(LB_BOUNDARIES_GPU)
     if (this_node != 0) {
       return;
     }
+#if defined(CUDA)
+#if defined(LB_BOUNDARIES_GPU)
     ek_init_boundaries();
     unsigned number_of_boundnodes = 0;
     std::vector<int> host_boundary_node_list;
@@ -228,7 +229,14 @@ void lb_init_boundaries() {
                            host_boundary_index_list.data(),
                            boundary_velocity.data());
 
-#endif /* defined (CUDA) && defined (LB_BOUNDARIES_GPU) */
+#else  // defined (LB_BOUNDARIES_GPU)
+    if (not lbboundaries.empty()) {
+      runtimeErrorMsg()
+          << "LB boundaries not empty for GPU LB but LB_BOUNDARIES_GPU not "
+             "compiled in. Activate in myconfig.hpp.";
+    }
+#endif // defined (LB_BOUNDARIES_GPU)
+#endif // defined (CUDA)
   } else if (lattice_switch == ActiveLB::CPU) {
 #if defined(LB_BOUNDARIES)
     boost::for_each(lbfields, [](auto &f) { f.boundary = 0; });
@@ -260,7 +268,13 @@ void lb_init_boundaries() {
         }
       }
     }
-#endif
+#else  // defined(LB_BOUNDARIES)
+    if (not lbboundaries.empty()) {
+      runtimeErrorMsg()
+          << "LB boundaries not empty for CPU LB but LB_BOUNDARIES not "
+             "compiled in. Activate in myconfig.hpp.";
+    }
+#endif // defined(LB_BOUNDARIES)
   }
 }
 


### PR DESCRIPTION
Fixes #4467 

Test this by setting up a ``myconfig.hpp`` with ``LB_BOUNDARIES`` xor ``LB_BOUNDARIES_GPU`` and running

```python 
import unittest as ut
from espressomd import System, lb, lbboundaries, shapes
import espressomd


class TestBoundaryFeatureCombo(ut.TestCase):
    system = System(box_l=3 * [10])
    system.time_step = 1
    lb_bound = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[1, 0, 0], dist=3))
    lb_params = {'agrid': 1.,
                 'dens': 1.,
                 'visc': 1.,
                 'tau': system.time_step}

    def test_errors(self):
        if espressomd.has_features(["CUDA", "LB_BOUNDARIES"]) and espressomd.missing_features(["LB_BOUNDARIES_GPU"]):
            lbf = lb.LBFluidGPU(**self.lb_params)
            self.system.actors.add(lbf)
            with self.assertRaises(Exception):
                self.system.lbboundaries.add(self.lb_bound)
        if espressomd.has_features(["LB_BOUNDARIES_GPU"]) and espressomd.missing_features(["LB_BOUNDARIES"]):
            lbf = lb.LBFluid(**self.lb_params)
            self.system.actors.add(lbf)
            with self.assertRaises(Exception):
                self.system.lbboundaries.add(self.lb_bound)

if __name__ == '__main__':
    ut.main()
```
