### PR TITLE
Always overwrite values in std::unordered_map objects

### DIFF
--- a/src/core/PartCfg.hpp
+++ b/src/core/PartCfg.hpp
@@ -29,12 +29,11 @@
  *
  * This class implements cached access to all particles in a
  * particle range on the head node.
- * This implementation fetches all particles to
- * the head node on first access. Updates of the particle data are
- * triggered automatically on access. The data in the cache
- * is invalidated automatically on_particle_change, and then
+ * This implementation fetches all particles to the head node on first access,
+ * which invalidates all existing particle pointers. Updates of the particle
+ * data are triggered automatically on access. The data in the cache
+ * is invalidated automatically by @ref on_particle_change, and then
  * updated on the next access.
- *
  */
 class PartCfg {
   /** The particle data */

--- a/src/core/bond_breakage/bond_breakage.cpp
+++ b/src/core/bond_breakage/bond_breakage.cpp
@@ -43,7 +43,7 @@ namespace BondBreakage {
 static std::unordered_map<int, std::shared_ptr<BreakageSpec>> breakage_specs;
 
 void insert_spec(int key, std::shared_ptr<BreakageSpec> obj) {
-  breakage_specs.insert({key, std::move(obj)});
+  breakage_specs[key] = std::move(obj);
 }
 
 void erase_spec(int key) { breakage_specs.erase(key); }

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -188,13 +188,12 @@ std::vector<int> nbhood(PartCfg &partCfg, const Utils::Vector3d &pos,
   return ids;
 }
 
-double distto(PartCfg &partCfg, const Utils::Vector3d &pos, int pid) {
+double distto(PartCfg &partCfg, const Utils::Vector3d pos, int pid) {
   auto mindist = std::numeric_limits<double>::infinity();
 
   for (auto const &part : partCfg) {
     if (pid != part.id()) {
-      auto const d =
-          box_geo.get_mi_vector({pos[0], pos[1], pos[2]}, part.pos());
+      auto const d = box_geo.get_mi_vector(pos, part.pos());
       mindist = std::min(mindist, d.norm2());
     }
   }

--- a/src/core/statistics.hpp
+++ b/src/core/statistics.hpp
@@ -52,14 +52,15 @@ std::vector<int> nbhood(PartCfg &partCfg, const Utils::Vector3d &pos,
                         double r_catch, const Utils::Vector3i &planedims);
 
 /** Calculate minimal distance to point.
+ *  Note: Particle handles may be invalided!
  *  @param partCfg particle selection
- *  @param pos  point
+ *  @param pos  point (must be a copy to avoid use-after-free errors)
  *  @param pid  if a valid particle id, this particle is omitted from
  *              minimization (this is a good idea if @p pos is the
  *              position of a particle).
  *  @return the minimal distance of a particle to coordinates @p pos
  */
-double distto(PartCfg &partCfg, const Utils::Vector3d &pos, int pid = -1);
+double distto(PartCfg &partCfg, Utils::Vector3d pos, int pid = -1);
 
 /** Calculate the distribution of particles around others.
  *

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -147,7 +147,6 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory,
     mpi_kill_particle_motion(0);
     for (int i = 0; i < 5; ++i) {
       set_particle_v(pid2, {static_cast<double>(i), 0., 0.});
-      auto const &p = get_particle_data(pid2);
 
       acc.update();
       auto const time_series = acc.time_series();
@@ -155,6 +154,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory,
 
       auto const acc_value = time_series.back();
       auto const obs_value = (*obs)();
+      auto const &p = get_particle_data(pid2);
       BOOST_TEST(obs_value == p.v(), boost::test_tools::per_element());
       BOOST_TEST(acc_value == p.v(), boost::test_tools::per_element());
     }

--- a/src/script_interface/GlobalContext.cpp
+++ b/src/script_interface/GlobalContext.cpp
@@ -49,7 +49,7 @@ void GlobalContext::make_handle(ObjectId id, const std::string &name,
     ObjectRef so = m_node_local_context->make_shared(
         name, unpack(parameters, m_local_objects));
 
-    m_local_objects.emplace(std::make_pair(id, std::move(so)));
+    m_local_objects[id] = std::move(so);
   } catch (Exception const &) {
   }
 }

--- a/src/script_interface/auto_parameters/AutoParameters.hpp
+++ b/src/script_interface/auto_parameters/AutoParameters.hpp
@@ -112,7 +112,10 @@ protected:
 
   void add_parameters(std::vector<AutoParameter> &&params) {
     for (auto const &p : params) {
-      m_parameters.emplace(std::make_pair(p.name, p));
+      if (m_parameters.count(p.name)) {
+        m_parameters.erase(p.name);
+      }
+      m_parameters.emplace(std::make_pair(p.name, std::move(p)));
     }
   }
 

--- a/src/script_interface/tests/AutoParameters_test.cpp
+++ b/src/script_interface/tests/AutoParameters_test.cpp
@@ -52,16 +52,25 @@ BOOST_AUTO_TEST_CASE(basic) {
 }
 
 struct B : public A {
-  B(int i_, int j_, int k_) : A(i_, j_), k(k_) { add_parameters({{"k", k}}); }
+  B(int i_, int j_, int k_, int l_) : A(i_, j_), k(k_), l(l_) {
+    add_parameters({{"k", k}, {"i", l} /* override i accessor */});
+  }
   int k;
+  int l;
 };
 
 BOOST_AUTO_TEST_CASE(add_parameters) {
-  B b{1, 2, 3};
+  B b{1, 2, 3, 4};
+  A &a = b;
 
-  BOOST_CHECK(3 == boost::get<int>(b.get_parameter("k")));
+  BOOST_CHECK_EQUAL(a.i, 1);
+  BOOST_CHECK_EQUAL(b.i, 1);
+  BOOST_CHECK_EQUAL(boost::get<int>(b.get_parameter("j")), 2);
+  BOOST_CHECK_EQUAL(boost::get<int>(b.get_parameter("k")), 3);
+  BOOST_CHECK_EQUAL(boost::get<int>(b.get_parameter("i")), 4);
+  BOOST_CHECK_EQUAL(boost::get<int>(a.get_parameter("i")), 4);
   b.set_parameter("k", 12);
-  BOOST_CHECK(12 == boost::get<int>(b.get_parameter("k")));
+  BOOST_CHECK_EQUAL(boost::get<int>(b.get_parameter("k")), 12);
 }
 
 BOOST_AUTO_TEST_CASE(exceptions) {

--- a/src/utils/include/utils/Cache.hpp
+++ b/src/utils/include/utils/Cache.hpp
@@ -110,11 +110,19 @@ public:
    * maximal size, a random element is removed before
    * putting the new one. */
   template <typename ValueRef> Value const *put(Key const &k, ValueRef &&v) {
+    auto check_for_k = true;
+
     /* If there already is a value for k, overwriting it
      * will not increase the size, so we don't have to
      * make room. */
-    if ((m_cache.size() >= m_max_size) && !has(k))
+    if ((m_cache.size() >= m_max_size) && !has(k)) {
       drop_random_element();
+      check_for_k = false;
+    }
+
+    if (check_for_k && has(k)) {
+      m_cache.erase(k);
+    }
 
     typename map_type::const_iterator it;
     std::tie(it, std::ignore) = m_cache.emplace(k, std::forward<ValueRef>(v));

--- a/src/utils/include/utils/Factory.hpp
+++ b/src/utils/include/utils/Factory.hpp
@@ -111,8 +111,8 @@ public:
    * @param name Given name for the type, has to be unique in this Factory<T>.
    */
   template <typename Derived> void register_new(const std::string &name) {
-    m_map.insert({name, []() { return pointer_type(new Derived()); }});
-    m_type_map.insert({typeid(Derived), name});
+    m_map[name] = []() { return pointer_type(new Derived()); };
+    m_type_map[typeid(Derived)] = name;
   }
 
   /**

--- a/src/utils/include/utils/NumeratedContainer.hpp
+++ b/src/utils/include/utils/NumeratedContainer.hpp
@@ -57,7 +57,7 @@ public:
   explicit NumeratedContainer(std::initializer_list<value_type> l)
       : NumeratedContainer() {
     for (auto const &e : l) {
-      m_container.insert(e);
+      m_container[e.first] = e.second;
       /* Remove the index from the index set if it exists. */
       m_free_indices.erase(m_free_indices.find(e.first), m_free_indices.end());
     }
@@ -79,14 +79,14 @@ public:
    */
   index_type add(const T &c) {
     const index_type ind = get_index();
-    m_container.emplace(std::make_pair(ind, c));
+    m_container[ind] = c;
     return ind;
   }
 
   /** @overload */
   index_type add(T &&c) {
     const index_type ind = get_index();
-    m_container.emplace(std::make_pair(ind, std::move(c)));
+    m_container[ind] = std::move(c);
     return ind;
   }
 


### PR DESCRIPTION
Fixes #4448

Affected code (all ESPResSo versions since 4.0.0):
- `Utils::Cache` (used for particle caches)
- `Utils::Factory` (used in the script interface registry)
- `Utils::NumeratedContainer` (used in MPI callbacks)
- `ScriptInterface::AutoParameters` (multiple parameter definitions didn't overwrite each other)
- `ScriptInterface::GlobalContext` (risk of stale references being stored in MPI ranks >=1)
- `bond_breakage` (multiple specifications didn't overwrite each other)