### PR TITLE
Python maintenance

### DIFF
--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Check without sanitizer
         uses: ./.github/actions/build_and_check
         with:
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Check with sanitizer
         uses: ./.github/actions/build_and_check
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,9 @@ stages:
   timeout: 40m
   interruptible: false
   tags:
-    - linux
+    - docker
+    - espresso
+    - no-cuda
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
@@ -44,7 +46,8 @@ style:
     - sh maintainer/CI/fix_style.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
   variables:
     GIT_SUBMODULE_STRATEGY: none
   artifacts:
@@ -65,7 +68,8 @@ style_doxygen:
     - sh ../maintainer/CI/dox_warnings.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
 
 ### Builds without CUDA
 
@@ -85,7 +89,8 @@ default:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
 
 maxset:
   <<: *global_job_definition
@@ -105,7 +110,9 @@ maxset:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
+    - numa
 
 no_rotation:
   <<: *global_job_definition
@@ -122,7 +129,9 @@ no_rotation:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
+    - numa
 
 ubuntu:wo-dependencies:
   <<: *global_job_definition
@@ -138,7 +147,8 @@ ubuntu:wo-dependencies:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
 
 ### Builds with different distributions
 
@@ -155,7 +165,8 @@ debian:10:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
 
 fedora:34:
   <<: *global_job_definition
@@ -170,7 +181,8 @@ fedora:34:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
 
 ### Builds with CUDA
 
@@ -195,8 +207,9 @@ clang-sanitizer:
   timeout: 2h
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
+    - numa
 
 fast_math:
   <<: *global_job_definition
@@ -215,7 +228,7 @@ fast_math:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
   when: manual
 
@@ -238,8 +251,9 @@ cuda11-maxset:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
+    - numa
 
 cuda10-maxset:
   <<: *global_job_definition
@@ -263,8 +277,9 @@ cuda10-maxset:
     expire_in: 1 week
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
+    - numa
 
 tutorials-samples-maxset:
   <<: *global_job_definition
@@ -287,7 +302,7 @@ tutorials-samples-maxset:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
 
 tutorials-samples-default:
@@ -310,7 +325,7 @@ tutorials-samples-default:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
   only:
     - schedules
@@ -336,7 +351,7 @@ tutorials-samples-empty:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
   only:
     - schedules
@@ -362,7 +377,8 @@ tutorials-samples-no-gpu:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
   only:
     - schedules
 
@@ -397,7 +413,7 @@ installation:
     - make -j2 check_tutorials
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
   when: manual
 
@@ -417,8 +433,9 @@ empty:
     - bash maintainer/CI/build_cmake.sh
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
+    - numa
 
 check_sphinx:
   <<: *global_job_definition
@@ -440,8 +457,9 @@ check_sphinx:
     expire_in: 1 week
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
+    - numa
 
 run_tutorials:
   <<: *global_job_definition
@@ -464,8 +482,9 @@ run_tutorials:
     expire_in: 1 week
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
+    - numa
   only:
     - schedules
 
@@ -486,7 +505,9 @@ run_doxygen:
     expire_in: 1 week
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
+    - numa
 
 maxset_no_gpu:
   <<: *global_job_definition
@@ -500,7 +521,9 @@ maxset_no_gpu:
     - make -t && make check
   tags:
     - docker
-    - linux
+    - espresso
+    - no-cuda
+    - numa
 
 maxset_3_cores:
   <<: *global_job_definition
@@ -514,8 +537,9 @@ maxset_3_cores:
     - make -t && make check_unit_tests && make check_python_parallel_odd
   tags:
     - docker
-    - linux
+    - espresso
     - cuda
+    - numa
 
 status_success:
   <<: *notification_job_definition

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(WITH_CUDA)
   endif()
 endif(WITH_CUDA)
 
-find_package(PythonInterp 3.7 REQUIRED)
+find_package(PythonInterp 3.8 REQUIRED)
 
 if(WITH_PYTHON)
   find_package(Cython 0.29.14 REQUIRED)

--- a/doc/sphinx/inter_bonded.rst
+++ b/doc/sphinx/inter_bonded.rst
@@ -399,6 +399,9 @@ angle between the planes defined by the particle triples :math:`p_1`,
 Together with appropriate Lennard-Jones interactions, this potential can
 mimic a large number of atomic torsion potentials.
 
+Note that there is a singularity in the forces, but not in the energy, when
+:math:`\phi = 0` and :math:`\phi = \pi`.
+
 
 Tabulated dihedral potential
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -414,6 +417,8 @@ A tabulated dihedral interaction can be instantiated via
 The energy and force tables must be sampled from :math:`0` to :math:`2\pi`.
 For details of the interpolation, see :ref:`Tabulated interaction`.
 
+Note that there is a singularity in the forces, but not in the energy, when
+:math:`\phi = 0` and :math:`\phi = \pi`.
 
 .. _Immersed Boundary Method interactions:
 

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -158,7 +158,7 @@ Lees--Edwards boundary conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Lees--Edwards boundary conditions (LEbc) are special periodic boundary
-conditions to simulation systems under shear stress :cite:`lees72a`.
+conditions to simulate systems under shear stress :cite:`lees72a`.
 Periodic images of particles across the shear boundary appear with a
 time-dependent position offset. When a particle crosses the shear boundary,
 it appears to the opposite side of the simulation box with a position offset
@@ -227,13 +227,13 @@ The properties of the cell system can be accessed by
 
 * :py:attr:`~espressomd.cellsystem.CellSystem.node_grid`
 
-  (int[3]) 3D node grid for real space domain decomposition (optional, if
+  3D node grid for real space domain decomposition (optional, if
   unset an optimal set is chosen automatically). The domain decomposition
   can be visualized with :file:`samples/visualization_cellsystem.py`.
 
 * :py:attr:`~espressomd.cellsystem.CellSystem.skin`
 
-  (float) Skin for the Verlet list. This value has to be set, otherwise the simulation will not start.
+  Skin for the Verlet list. This value has to be set, otherwise the simulation will not start.
 
 Details about the cell system can be obtained by :meth:`espressomd.system.System.cell_system.get_state() <espressomd.cellsystem.CellSystem.get_state>`:
 

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -72,6 +72,12 @@ set_default_value() {
     fi
 }
 
+# the number of available processors depends on the CI runner
+if grep -q "i7-3820" /proc/cpuinfo; then
+   ci_procs=2
+else
+   ci_procs=4
+fi
 
 # handle environment variables
 set_default_value srcdir "$(pwd)"
@@ -82,7 +88,7 @@ set_default_value with_ubsan false
 set_default_value with_asan false
 set_default_value with_static_analysis false
 set_default_value myconfig "default"
-set_default_value build_procs 2
+set_default_value build_procs ${ci_procs}
 set_default_value check_procs ${build_procs}
 set_default_value check_odd_only false
 set_default_value check_gpu_only false

--- a/maintainer/CI/deploy_tutorials.py
+++ b/maintainer/CI/deploy_tutorials.py
@@ -20,20 +20,18 @@
 
 """List all tutorial files to deploy (PDF, HTML and figures)"""
 
-import os
-import glob
+import pathlib
 import lxml.html
 
-deploy_list = glob.glob('*/*.pdf')
-for filepath in glob.glob('*/*.html'):
+deploy_list = list(pathlib.Path().glob('*/*.pdf'))
+for filepath in pathlib.Path().glob('*/*.html'):
     deploy_list.append(filepath)
     # extract all figures
-    dirname = os.path.dirname(filepath)
     with open(filepath, encoding='utf-8') as f:
         html = lxml.html.parse(f)
     figures = filter(lambda src: not src.startswith('data:image'),
                      html.xpath('//img/@src'))
-    deploy_list += list(map(lambda src: os.path.join(dirname, src), figures))
+    deploy_list += list(map(lambda src: filepath.parent / src, figures))
 
 with open('deploy_list.txt', 'w') as f:
-    f.write('\n'.join(deploy_list))
+    f.write('\n'.join(map(str, deploy_list)))

--- a/maintainer/CI/dox_warnings.py
+++ b/maintainer/CI/dox_warnings.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import re
-import os
+import pathlib
 
 # collect list of Doxygen warnings
 with open('doc/doxygen/warnings.log') as f:
@@ -38,7 +38,7 @@ if content:
     for line in content.strip().split('\n'):
         m = re.search(r'^(.+):(\d+):[\s\*]*([@\\]t?param).*\s(\S+)\s*$', line)
         filepath, lineno, paramtype, varname = m.groups()
-        ext = os.path.splitext(filepath)[1]
+        ext = pathlib.Path(filepath).suffix
         if ext.lower() not in source_code_ext:
             continue
         warning = (f'argument \'{varname}\' of {paramtype} has no description,'

--- a/maintainer/benchmarks/benchmarks.py
+++ b/maintainer/benchmarks/benchmarks.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import os
 import sys
 import time
+import pathlib
 import numpy as np
 
 
@@ -127,12 +127,12 @@ def write_report(filepath, n_proc, timings, n_steps, label=''):
         Label to distinguish e.g. MD from MC or LB steps.
 
     '''
-    script = os.path.basename(sys.argv[0])
+    script = pathlib.Path(sys.argv[0]).name
     cmd = " ".join(x for x in sys.argv[1:] if not x.startswith("--output"))
     avg, ci = get_average_time(timings)
     header = '"script","arguments","cores","mean","ci","nsteps","duration","label"\n'
     report = f'"{script}","{cmd}",{n_proc},{avg:.3e},{ci:.3e},{n_steps},{np.sum(timings):.1f},"{label}"\n'
-    if os.path.isfile(filepath):
+    if pathlib.Path(filepath).is_file():
         header = ''
     with open(filepath, "a") as f:
         f.write(header + report)

--- a/src/core/bonded_interactions/bonded_tab.hpp
+++ b/src/core/bonded_interactions/bonded_tab.hpp
@@ -203,7 +203,6 @@ inline double TabulatedAngleBond::energy(Utils::Vector3d const &r_mid,
 }
 
 /** Compute the four-body dihedral interaction force.
- *  This function is not tested yet.
  *  The forces have a singularity at @f$ \phi = 0 @f$ and @f$ \phi = \pi @f$
  *  (see @cite swope92a page 592).
  *
@@ -254,7 +253,6 @@ TabulatedDihedralBond::forces(Utils::Vector3d const &r1,
 }
 
 /** Compute the four-body dihedral interaction energy.
- *  This function is not tested yet.
  *  The energy doesn't have any singularity if the angle phi is well-defined.
  *
  *  @param[in]  r1        Position of the first particle.

--- a/src/core/lees_edwards/protocols.hpp
+++ b/src/core/lees_edwards/protocols.hpp
@@ -37,7 +37,8 @@ struct Off {
 
 /** Lees-Edwards protocol for linear shearing */
 struct LinearShear {
-  LinearShear() : m_initial_pos_offset{0}, m_shear_velocity{0}, m_time_0{0} {}
+  LinearShear()
+      : m_initial_pos_offset{0.}, m_shear_velocity{0.}, m_time_0{0.} {}
   LinearShear(double initial_offset, double shear_velocity, double time_0)
       : m_initial_pos_offset{initial_offset},
         m_shear_velocity{shear_velocity}, m_time_0{time_0} {}
@@ -52,15 +53,20 @@ struct LinearShear {
 
 /** Lees-Edwards protocol for oscillatory shearing */
 struct OscillatoryShear {
-  OscillatoryShear() : m_amplitude{0}, m_omega{0}, m_time_0{0} {}
-  OscillatoryShear(double amplitude, double omega, double time_0)
-      : m_amplitude{amplitude}, m_omega{omega}, m_time_0{time_0} {}
+  OscillatoryShear()
+      : m_initial_pos_offset{0.}, m_amplitude{0.}, m_omega{0.}, m_time_0{0.} {}
+  OscillatoryShear(double initial_offset, double amplitude, double omega,
+                   double time_0)
+      : m_initial_pos_offset{initial_offset},
+        m_amplitude{amplitude}, m_omega{omega}, m_time_0{time_0} {}
   double pos_offset(double time) const {
-    return m_amplitude * std::sin(m_omega * (time - m_time_0));
+    return m_initial_pos_offset +
+           m_amplitude * std::sin(m_omega * (time - m_time_0));
   }
   double shear_velocity(double time) const {
     return m_omega * m_amplitude * std::cos(m_omega * (time - m_time_0));
   }
+  double m_initial_pos_offset;
   double m_amplitude;
   double m_omega;
   double m_time_0;

--- a/src/core/unit_tests/lees_edwards_test.cpp
+++ b/src/core/unit_tests/lees_edwards_test.cpp
@@ -132,10 +132,12 @@ BOOST_AUTO_TEST_CASE(protocol_lin) {
 
 BOOST_AUTO_TEST_CASE(protocol_osc) {
   auto const t0 = 1.2;
+  auto const x0 = 0.1;
   auto const a = 3.1;
   auto const o = 2.1;
-  auto osc = OscillatoryShear(a, o, t0);
-  BOOST_CHECK_CLOSE(get_pos_offset(3.3, osc), a * sin(o * (3.3 - t0)), tol);
+  auto osc = OscillatoryShear(x0, a, o, t0);
+  BOOST_CHECK_CLOSE(get_pos_offset(3.3, osc), x0 + a * sin(o * (3.3 - t0)),
+                    tol);
   BOOST_CHECK_CLOSE(get_shear_velocity(3.3, osc), a * o * cos(o * (3.3 - t0)),
                     tol);
 }

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -374,10 +374,7 @@ class Analysis:
 
         """
         self.check_topology(chain_start, number_of_chains, chain_length)
-        re = analyze.calc_re(
-            chain_start,
-            number_of_chains,
-            chain_length)
+        re = analyze.calc_re(chain_start, number_of_chains, chain_length)
         return np.array([re[0], re[1], re[2], re[3]])
 
     def calc_rg(self, chain_start=None, number_of_chains=None,
@@ -410,10 +407,7 @@ class Analysis:
 
         """
         self.check_topology(chain_start, number_of_chains, chain_length)
-        rg = analyze.calc_rg(
-            chain_start,
-            number_of_chains,
-            chain_length)
+        rg = analyze.calc_rg(chain_start, number_of_chains, chain_length)
         return np.array([rg[0], rg[1], rg[2], rg[3]])
 
     def calc_rh(self, chain_start=None, number_of_chains=None,
@@ -445,10 +439,7 @@ class Analysis:
         """
 
         self.check_topology(chain_start, number_of_chains, chain_length)
-        rh = analyze.calc_rh(
-            chain_start,
-            number_of_chains,
-            chain_length)
+        rh = analyze.calc_rh(chain_start, number_of_chains, chain_length)
         return np.array([rh[0], rh[1]])
 
     def check_topology(self, chain_start=None, number_of_chains=None,

--- a/src/python/espressomd/lees_edwards.py
+++ b/src/python/espressomd/lees_edwards.py
@@ -75,6 +75,8 @@ class OscillatoryShear(ScriptInterfaceHelper):
 
     Parameters
     ----------
+    initial_pos_offset : :obj:`float`
+       Positional offset at the Lees--Edwards boundary at t=0.
     amplitude : :obj:`float`
        Maximum amplitude of the positional offset at the Lees--Edwards boundary.
     omega : :obj:`float`

--- a/src/python/espressomd/lees_edwards.py
+++ b/src/python/espressomd/lees_edwards.py
@@ -22,9 +22,23 @@ from .script_interface import ScriptInterfaceHelper, script_interface_register
 @script_interface_register
 class LeesEdwards(ScriptInterfaceHelper):
 
-    """Interface to the Lees-Edwards boundary conditions.
+    """
+    Interface to the :ref:`Lees-Edwards boundary conditions`.
 
-       See documentation.
+    Attributes
+    ----------
+    protocol : :obj:`object`
+        Lees--Edwards protocol.
+    shear_velocity: :obj:`float`
+        Current shear velocity.
+    pos_offset : :obj:`float`
+        Current position offset
+    shear_direction : :obj:`int`
+        Shear direction: 0 for the *x*-axis, 1 for the *y*-axis,
+        2 for the *z*-axis.
+    shear_plane_normal : :obj:`int`
+        Shear plane normal: 0 for the *x*-axis, 1 for the *y*-axis,
+        2 for the *z*-axis.
 
     """
 
@@ -34,25 +48,21 @@ class LeesEdwards(ScriptInterfaceHelper):
 @script_interface_register
 class Off(ScriptInterfaceHelper):
 
-    """Lees-Edwards protocol resulting in un-shifted boundaries."""
+    """Lees--Edwards protocol resulting in un-shifted boundaries."""
     _so_name = "LeesEdwards::Off"
 
 
 @script_interface_register
 class LinearShear(ScriptInterfaceHelper):
 
-    """Lees-Edwards protocol for linear shear.
+    """Lees--Edwards protocol for linear shear.
 
     Parameters
     ----------
-    shear_direction
-       Cartesian coordinate of the shear direction (0=x, 1=y, 2=z)
-    shear_plane_normal
-       Cartesian coordinate of the shear plane normal
-    initial_pos_offset
-       Positional offset at the Lees-Edwards boundary at t=0
-    shear_velocity
-       Shear velocity (velocity jump) across the Lees-Edwards boundary
+    initial_pos_offset : :obj:`float`
+       Positional offset at the Lees--Edwards boundary at t=0.
+    shear_velocity : :obj:`float`
+       Shear velocity (velocity jump) across the Lees--Edwards boundary.
 
     """
     _so_name = "LeesEdwards::LinearShear"
@@ -61,21 +71,16 @@ class LinearShear(ScriptInterfaceHelper):
 @script_interface_register
 class OscillatoryShear(ScriptInterfaceHelper):
 
-    """Lees-Edwards protocol for oscillatory shear.
+    """Lees--Edwards protocol for oscillatory shear.
 
     Parameters
     ----------
-    shear_direction
-       Cartesian coordinate of the shear direction (0=x, 1=y, 2=z)
-    shear_plane_normal
-       Cartesian coordinate of the shear plane normal
-    amplitude
-       Maximum amplitude of the positional offset at the Lees-Edwards boundary
-    frequency
-       Frequency of the shear
-    time_0
-       Time offset of the oscillation
-
+    amplitude : :obj:`float`
+       Maximum amplitude of the positional offset at the Lees--Edwards boundary.
+    omega : :obj:`float`
+       Radian frequency of the oscillation.
+    time_0 : :obj:`float`
+       Time offset of the oscillation.
 
     """
     _so_name = "LeesEdwards::OscillatoryShear"

--- a/src/script_interface/lees_edwards/OscillatoryShear.hpp
+++ b/src/script_interface/lees_edwards/OscillatoryShear.hpp
@@ -37,7 +37,10 @@ public:
       : m_protocol{std::make_shared<::LeesEdwards::ActiveProtocol>(
             ::LeesEdwards::OscillatoryShear())} {
     add_parameters(
-        {{"amplitude",
+        {{"initial_pos_offset",
+          boost::get<::LeesEdwards::OscillatoryShear>(*m_protocol)
+              .m_initial_pos_offset},
+         {"amplitude",
           boost::get<::LeesEdwards::OscillatoryShear>(*m_protocol).m_amplitude},
          {"omega",
           boost::get<::LeesEdwards::OscillatoryShear>(*m_protocol).m_omega},

--- a/testsuite/python/analyze_chains.py
+++ b/testsuite/python/analyze_chains.py
@@ -133,6 +133,16 @@ class AnalyzeChain(ut.TestCase):
         self.system.box_l = self.system.box_l / 2.
         all_partcls.pos = old_pos
 
+    def test_exceptions(self):
+        err_msg = """particle with id 10 does not exist
+cannot perform analysis on the range chain_start=0, number_of_chains=2, chain_length=10
+please provide a contiguous range of particle ids"""
+        analysis = self.system.analysis
+        for method in (analysis.calc_re, analysis.calc_rg, analysis.calc_rh):
+            with self.assertRaisesRegex(ValueError, err_msg):
+                method(chain_start=0, number_of_chains=self.num_poly,
+                       chain_length=2 * self.num_mono)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/cluster_analysis.py
+++ b/testsuite/python/cluster_analysis.py
@@ -149,28 +149,26 @@ class ClusterAnalysis(ut.TestCase):
         # Unknown method should return None
         self.assertIsNone(c.call_method("unknown"))
 
-        # Fractal dimension calc require gsl
-        if not espressomd.has_features("GSL"):
-            print("Skipping fractal dimension tests due to missing GSL dependency")
-            return
+        # Fractal dimension calculation requires gsl
+        if espressomd.has_features("GSL"):
+            # The fractal dimension of a line should be 1
+            dr = 0.
+            self.assertAlmostEqual(
+                c.fractal_dimension(dr=dr)[0], 1, delta=0.05)
 
-        # The fractal dimension of a line should be 1
-        dr = 0.
-        self.assertAlmostEqual(c.fractal_dimension(dr=dr)[0], 1, delta=0.05)
-
-        # The fractal dimension of a disk should be close to 2
-        self.system.part.clear()
-        center = np.array((0.1, .02, 0.15))
-        for _ in range(3000):
-            r_inv, phi = np.random.random(2) * np.array((0.2, 2 * np.pi))
-            r = 1 / r_inv
-            self.system.part.add(
-                pos=center + r * np.array((np.sin(phi), np.cos(phi), 0)))
-        self.cs.clear()
-        self.cs.run_for_all_pairs()
-        cid = self.cs.cluster_ids()[0]
-        df = self.cs.clusters[cid].fractal_dimension(dr=0.001)
-        self.assertAlmostEqual(df[0], 2, delta=0.08)
+            # The fractal dimension of a disk should be close to 2
+            self.system.part.clear()
+            center = np.array((0.1, .02, 0.15))
+            for _ in range(3000):
+                r_inv, phi = np.random.random(2) * np.array((0.2, 2 * np.pi))
+                r = 1 / r_inv
+                self.system.part.add(
+                    pos=center + r * np.array((np.sin(phi), np.cos(phi), 0)))
+            self.cs.clear()
+            self.cs.run_for_all_pairs()
+            cid = self.cs.cluster_ids()[0]
+            df = self.cs.clusters[cid].fractal_dimension(dr=0.001)
+            self.assertAlmostEqual(df[0], 2, delta=0.08)
 
     def test_analysis_for_bonded_particles(self):
         self.set_two_clusters()

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -36,8 +36,8 @@ class CoulombCloudWall(ut.TestCase):
     """
 
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])
-    data = np.genfromtxt(tests_common.abspath(
-        "data/coulomb_cloud_wall_system.data"))
+    data = np.genfromtxt(tests_common.data_path(
+        "coulomb_cloud_wall_system.data"))
 
     tolerance = 1E-3
 

--- a/testsuite/python/coulomb_cloud_wall_duplicated.py
+++ b/testsuite/python/coulomb_cloud_wall_duplicated.py
@@ -35,7 +35,7 @@ class CoulombCloudWall(ut.TestCase):
     system.time_step = 0.01
     system.cell_system.skin = 0.4
     data = np.genfromtxt(
-        tests_common.abspath("data/coulomb_cloud_wall_duplicated_system.data"))
+        tests_common.data_path("coulomb_cloud_wall_duplicated_system.data"))
 
     tolerance = 1E-3
 

--- a/testsuite/python/coulomb_mixed_periodicity.py
+++ b/testsuite/python/coulomb_mixed_periodicity.py
@@ -31,8 +31,8 @@ class CoulombMixedPeriodicity(ut.TestCase):
     """Test mixed periodicity electrostatics"""
 
     system = espressomd.System(box_l=[10, 10, 10])
-    data = np.genfromtxt(tests_common.abspath(
-        "data/coulomb_mixed_periodicity_system.data"))
+    data = np.genfromtxt(tests_common.data_path(
+        "coulomb_mixed_periodicity_system.data"))
 
     tolerance_force = 5E-4
     tolerance_energy = 1.8E-3

--- a/testsuite/python/coulomb_tuning.py
+++ b/testsuite/python/coulomb_tuning.py
@@ -39,7 +39,7 @@ class CoulombCloudWallTune(ut.TestCase):
         self.system.time_step = 0.01
         self.system.cell_system.skin = 0.4
 
-        data = np.load(tests_common.abspath("data/coulomb_tuning_system.npz"))
+        data = np.load(tests_common.data_path("coulomb_tuning_system.npz"))
         self.forces = data['forces']
         self.system.part.add(pos=data['pos'], q=data['charges'])
 

--- a/testsuite/python/decorators.py
+++ b/testsuite/python/decorators.py
@@ -54,6 +54,9 @@ class Tests(ut.TestCase):
         decorator = utx.skipIfMissingModules(['numpy___', 'scipy___'])
         args = self.get_skip_reason(decorator)
         self.assertEqual(args, (err_msg + 'modules numpy___, scipy___',))
+        decorator = utx.skipIfMissingModules(['espressomd'])
+        args = self.get_skip_reason(decorator)
+        self.assertIsNone(args)
 
     def test_missing_gpu(self):
         espressomd.gpu_available = lambda: False

--- a/testsuite/python/dipolar_direct_summation.py
+++ b/testsuite/python/dipolar_direct_summation.py
@@ -19,15 +19,15 @@
 import espressomd
 import espressomd.magnetostatics
 import espressomd.magnetostatic_extensions
-import os
+import pathlib
 import numpy as np
 import unittest as ut
 import unittest_decorators as utx
 import tests_common
-OPEN_BOUNDARIES_REF_ENERGY = tests_common.abspath(
-    "data/dipolar_open_boundaries_energy.npy")
-OPEN_BOUNDARIES_REF_ARRAYS = tests_common.abspath(
-    "data/dipolar_open_boundaries_arrays.npy")
+OPEN_BOUNDARIES_REF_ENERGY = tests_common.data_path(
+    "dipolar_open_boundaries_energy.npy")
+OPEN_BOUNDARIES_REF_ARRAYS = tests_common.data_path(
+    "dipolar_open_boundaries_arrays.npy")
 
 
 @utx.skipIfMissingFeatures(["DIPOLES"])
@@ -114,12 +114,11 @@ class dds(ut.TestCase):
         filepaths = ('dipolar_direct_summation_energy.npy',
                      'dipolar_direct_summation_arrays.npy')
         for filepath in filepaths:
-            if os.path.isfile(filepath):
-                os.remove(filepath)
+            pathlib.Path(filepath).unlink(missing_ok=True)
 
         self.gen_reference_data(filepaths[0], filepaths[1])
         for filepath in filepaths:
-            self.assertTrue(os.path.isfile(filepath))
+            self.assertTrue(pathlib.Path(filepath).is_file())
 
     def gen_reference_data(self, filepath_energy=OPEN_BOUNDARIES_REF_ENERGY,
                            filepath_arrays=OPEN_BOUNDARIES_REF_ARRAYS):

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -62,14 +62,14 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         particle_radius = 0.5
         box_l = np.cbrt(4 * n_particle * np.pi / (3 * rho)) * particle_radius
         s.box_l = 3 * [box_l]
-        ref_E_path = tests_common.abspath(
-            "data/mdlc_reference_data_energy.dat")
+        ref_E_path = tests_common.data_path(
+            "mdlc_reference_data_energy.dat")
         ref_E = float(np.genfromtxt(ref_E_path)) * DIPOLAR_PREFACTOR
         gap_size = 2.0
 
         # Particles
         data = np.genfromtxt(
-            tests_common.abspath("data/mdlc_reference_data_forces_torques.dat"))
+            tests_common.data_path("mdlc_reference_data_forces_torques.dat"))
         partcls = s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
         partcls.rotation = 3 * [True]
 
@@ -126,7 +126,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
 
         # Particles
         data = np.genfromtxt(
-            tests_common.abspath("data/p3m_magnetostatics_system.data"))
+            tests_common.data_path("p3m_magnetostatics_system.data"))
         partcls = s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
         partcls.rotation = 3 * [True]
 
@@ -135,7 +135,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         s.actors.add(p3m)
         s.integrator.run(0)
         expected = np.genfromtxt(
-            tests_common.abspath("data/p3m_magnetostatics_expected.data"))[:, 1:]
+            tests_common.data_path("p3m_magnetostatics_expected.data"))[:, 1:]
         err_f = self.vector_error(
             partcls.f, expected[:, 0:3] * DIPOLAR_PREFACTOR)
         err_t = self.vector_error(
@@ -166,7 +166,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
 
         # Particles
         data = np.genfromtxt(
-            tests_common.abspath("data/p3m_magnetostatics_system.data"))
+            tests_common.data_path("p3m_magnetostatics_system.data"))
         partcls = s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
         partcls.rotation = 3 * [True]
 
@@ -186,7 +186,7 @@ class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
         s.actors.add(scafacos)
         s.integrator.run(0)
         expected = np.genfromtxt(
-            tests_common.abspath("data/p3m_magnetostatics_expected.data"))[:, 1:]
+            tests_common.data_path("p3m_magnetostatics_expected.data"))[:, 1:]
         err_f = self.vector_error(
             partcls.f, expected[:, 0:3] * DIPOLAR_PREFACTOR)
         err_t = self.vector_error(

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -31,19 +31,17 @@ import espressomd.io.writer
 import espressomd.lees_edwards
 import espressomd.version
 import tempfile
-try:
+import contextlib
+
+with contextlib.suppress(ImportError):
     import h5py  # h5py has to be imported *after* espressomd (MPI)
-    skipIfMissingPythonPackage = utx.no_skip
-except ImportError:
-    skipIfMissingPythonPackage = ut.skip(
-        "Python module h5py not available, skipping test!")
 
 
 N_PART = 26
 
 
 @utx.skipIfMissingFeatures(['H5MD'])
-@skipIfMissingPythonPackage
+@utx.skipIfMissingModules("h5py")
 class H5mdTests(ut.TestCase):
     """
     Test the core implementation of writing hdf5 files.

--- a/testsuite/python/integrator_npt.py
+++ b/testsuite/python/integrator_npt.py
@@ -154,10 +154,8 @@ class IntegratorNPT(ut.TestCase):
             self.run_with_p3m(
                 dp3m, cubic_box=False, direction=(False, True, True))
         self.tearDown()
-        try:
-            self.run_with_p3m(dp3m)
-        except Exception as err:
-            self.fail(f'integrator raised ValueError("{err}")')
+        # should not raise an exception
+        self.run_with_p3m(dp3m)
 
     @utx.skipIfMissingFeatures(["P3M"])
     def test_p3m_exception(self):
@@ -170,10 +168,8 @@ class IntegratorNPT(ut.TestCase):
             self.run_with_p3m(
                 p3m, cubic_box=False, direction=(False, True, True))
         self.tearDown()
-        try:
-            self.run_with_p3m(p3m)
-        except Exception as err:
-            self.fail(f'integrator raised ValueError("{err}")')
+        # should not raise an exception
+        self.run_with_p3m(p3m)
 
     @utx.skipIfMissingGPU()
     @utx.skipIfMissingFeatures(["P3M"])

--- a/testsuite/python/integrator_npt_stats.py
+++ b/testsuite/python/integrator_npt_stats.py
@@ -44,7 +44,7 @@ class IntegratorNPT(ut.TestCase):
         system = self.system
         system.box_l = [5.86326165] * 3
 
-        data = np.genfromtxt(tests_common.abspath("data/npt_lj_system.data"))
+        data = np.genfromtxt(tests_common.data_path("npt_lj_system.data"))
         p_ext = 2.0
 
         system.part.add(pos=data[:, :3], v=data[:, 3:])

--- a/testsuite/python/lb_vtk.py
+++ b/testsuite/python/lb_vtk.py
@@ -19,7 +19,8 @@
 import unittest as ut
 import unittest_decorators as utx
 
-import os
+import pathlib
+import tempfile
 import numpy as np
 
 try:
@@ -61,7 +62,7 @@ class TestLBWrite:
 
     def parse_vtk(self, filepath, name, shape):
         reader = vtk.vtkStructuredPointsReader()
-        reader.SetFileName(filepath)
+        reader.SetFileName(str(filepath))
         reader.ReadAllVectorsOn()
         reader.ReadAllScalarsOn()
         reader.Update()
@@ -76,136 +77,121 @@ class TestLBWrite:
         Check VTK files.
         '''
 
-        os.makedirs('vtk_out', exist_ok=True)
-        filepaths = ['vtk_out/boundary.vtk', 'vtk_out/velocity.vtk',
-                     'vtk_out/velocity_bb.vtk']
+        with tempfile.TemporaryDirectory() as tmp_directory:
+            path_vtk_root = pathlib.Path(tmp_directory)
+            path_vtk_boundary = path_vtk_root / 'boundary.vtk'
+            path_vtk_velocity = path_vtk_root / 'velocity.vtk'
+            path_vtk_velocity_bb = path_vtk_root / 'velocity_bb.vtk'
+            path_vtk_skip = path_vtk_root / 'skip.vtk'
+            path_vtk_invalid = path_vtk_root / 'non_existent_folder' / 'file'
 
-        # cleanup action
-        for filepath in filepaths:
-            if os.path.exists(filepath):
-                os.remove(filepath)
+            shape = [10, 11, 12]
+            lbf = self.set_lbf()
+            self.system.integrator.run(100)
 
-        shape = [10, 11, 12]
-        lbf = self.set_lbf()
-        self.system.integrator.run(100)
+            # write VTK files
+            with self.assertRaises(RuntimeError):
+                lbf.write_vtk_velocity(str(path_vtk_invalid))
+            with self.assertRaises(RuntimeError):
+                lbf.write_vtk_boundary(str(path_vtk_invalid))
+            lbf.write_vtk_boundary(str(path_vtk_boundary))
+            lbf.write_vtk_velocity(str(path_vtk_velocity))
+            with self.assertRaises(ValueError):
+                lbf.write_vtk_velocity(str(path_vtk_skip), 3 * [0], None)
+            with self.assertRaises(ValueError):
+                lbf.write_vtk_velocity(str(path_vtk_skip), None, 3 * [0])
+            with self.assertRaises(RuntimeError):
+                lbf.write_vtk_velocity(str(path_vtk_skip), [-2, 1, 1], 3 * [1])
+            with self.assertRaises(RuntimeError):
+                lbf.write_vtk_velocity(str(path_vtk_skip), 3 * [0], [1, 2, 16])
+            with self.assertRaises(ValueError):
+                lbf.write_vtk_velocity(str(path_vtk_skip), [1, 1], 3 * [1])
+            with self.assertRaises(ValueError):
+                lbf.write_vtk_velocity(
+                    str(path_vtk_skip), 3 * [1], np.array([2, 3]))
+            bb1, bb2 = ([1, 2, 3], [9, 10, 11])
+            lbf.write_vtk_velocity(str(path_vtk_velocity_bb), bb1, bb2)
 
-        # write VTK files
-        with self.assertRaises(RuntimeError):
-            lbf.write_vtk_velocity('non_existent_folder/file')
-        with self.assertRaises(RuntimeError):
-            lbf.write_vtk_boundary('non_existent_folder/file')
-        lbf.write_vtk_boundary('vtk_out/boundary.vtk')
-        lbf.write_vtk_velocity('vtk_out/velocity.vtk')
-        with self.assertRaises(ValueError):
-            lbf.write_vtk_velocity('vtk_out/delme', 3 * [0], None)
-        with self.assertRaises(ValueError):
-            lbf.write_vtk_velocity('vtk_out/delme', None, 3 * [0])
-        with self.assertRaises(RuntimeError):
-            lbf.write_vtk_velocity('vtk_out/delme', [-2, 1, 1], 3 * [1])
-        with self.assertRaises(RuntimeError):
-            lbf.write_vtk_velocity('vtk_out/delme', 3 * [0], [1, 2, 16])
-        with self.assertRaises(ValueError):
-            lbf.write_vtk_velocity('vtk_out/delme', [1, 1], 3 * [1])
-        with self.assertRaises(ValueError):
-            lbf.write_vtk_velocity('vtk_out/delme', 3 * [1], np.array([2, 3]))
-        bb1, bb2 = ([1, 2, 3], [9, 10, 11])
-        lbf.write_vtk_velocity('vtk_out/velocity_bb.vtk', bb1, bb2)
+            # check VTK values match node values
+            node_velocity = np.zeros(shape + [3])
+            node_boundary = np.zeros(shape, dtype=int)
+            for i in range(shape[0]):
+                for j in range(shape[1]):
+                    for k in range(shape[2]):
+                        node = lbf[i, j, k]
+                        node_velocity[i, j, k] = node.velocity
+                        node_boundary[i, j, k] = node.boundary
+            node_velocity_bb = node_velocity[bb1[0]:bb2[0],
+                                             bb1[1]:bb2[1],
+                                             bb1[2]:bb2[2]]
 
-        # check VTK files exist
-        for filepath in filepaths:
-            self.assertTrue(
-                os.path.exists(filepath),
-                f'VTK file "{filepath}" not written to disk')
+            vtk_velocity = self.parse_vtk(path_vtk_velocity, 'velocity',
+                                          node_velocity.shape)
+            np.testing.assert_allclose(vtk_velocity, node_velocity, atol=5e-7)
 
-        # check VTK values match node values
-        node_velocity = np.zeros(shape + [3])
-        node_boundary = np.zeros(shape, dtype=int)
-        for i in range(shape[0]):
-            for j in range(shape[1]):
-                for k in range(shape[2]):
-                    node = lbf[i, j, k]
-                    node_velocity[i, j, k] = node.velocity
-                    node_boundary[i, j, k] = node.boundary
-        node_velocity_bb = node_velocity[bb1[0]:bb2[0],
-                                         bb1[1]:bb2[1],
-                                         bb1[2]:bb2[2]]
+            vtk_velocity_bb = self.parse_vtk(path_vtk_velocity_bb, 'velocity',
+                                             node_velocity_bb.shape)
+            np.testing.assert_allclose(
+                vtk_velocity_bb, node_velocity_bb, atol=5e-7)
 
-        vtk_velocity = self.parse_vtk('vtk_out/velocity.vtk', 'velocity',
-                                      node_velocity.shape)
-        np.testing.assert_allclose(vtk_velocity, node_velocity, atol=5e-7)
-
-        vtk_velocity_bb = self.parse_vtk('vtk_out/velocity_bb.vtk', 'velocity',
-                                         node_velocity_bb.shape)
-        np.testing.assert_allclose(
-            vtk_velocity_bb, node_velocity_bb, atol=5e-7)
-
-        vtk_boundary = self.parse_vtk(
-            'vtk_out/boundary.vtk', 'boundary', shape)
-        np.testing.assert_equal(vtk_boundary, node_boundary.astype(int))
-        if self.system.lbboundaries is None:
-            np.testing.assert_equal(np.sum(node_boundary), 0.)
+            vtk_boundary = self.parse_vtk(path_vtk_boundary, 'boundary', shape)
+            np.testing.assert_equal(vtk_boundary, node_boundary.astype(int))
+            if self.system.lbboundaries is None:
+                np.testing.assert_equal(np.sum(node_boundary), 0.)
 
     def test_print(self):
         '''
         Check data files.
         '''
 
-        os.makedirs('vtk_out', exist_ok=True)
-        filepaths = ['vtk_out/boundary.dat', 'vtk_out/velocity.dat']
+        with tempfile.TemporaryDirectory() as tmp_directory:
+            path_dat_root = pathlib.Path(tmp_directory)
+            path_dat_boundary = path_dat_root / 'boundary.vtk'
+            path_dat_velocity = path_dat_root / 'velocity.vtk'
+            path_dat_invalid = path_dat_root / 'non_existent_folder' / 'file'
 
-        # cleanup action
-        for filepath in filepaths:
-            if os.path.exists(filepath):
-                os.remove(filepath)
+            shape = [10, 11, 12]
+            lbf = self.set_lbf()
+            self.system.integrator.run(100)
 
-        shape = [10, 11, 12]
-        lbf = self.set_lbf()
-        self.system.integrator.run(100)
+            # write data files
+            with self.assertRaises(RuntimeError):
+                lbf.write_velocity(str(path_dat_invalid))
+            with self.assertRaises(RuntimeError):
+                lbf.write_boundary(str(path_dat_invalid))
+            lbf.write_boundary(str(path_dat_boundary))
+            lbf.write_velocity(str(path_dat_velocity))
 
-        # write data files
-        with self.assertRaises(RuntimeError):
-            lbf.write_velocity('non_existent_folder/file')
-        with self.assertRaises(RuntimeError):
-            lbf.write_boundary('non_existent_folder/file')
-        lbf.write_boundary('vtk_out/boundary.dat')
-        lbf.write_velocity('vtk_out/velocity.dat')
+            # check data values match node values
+            node_velocity = np.zeros(shape + [3])
+            node_boundary = np.zeros(shape, dtype=int)
+            for i in range(shape[0]):
+                for j in range(shape[1]):
+                    for k in range(shape[2]):
+                        node = lbf[i, j, k]
+                        node_velocity[i, j, k] = node.velocity
+                        node_boundary[i, j, k] = node.boundary
 
-        # check data files exist
-        for filepath in filepaths:
-            self.assertTrue(
-                os.path.exists(filepath),
-                f'data file "{filepath}" not written to disk')
+            ref_coord = np.array([
+                np.tile(np.arange(shape[0]), shape[1] * shape[2]),
+                np.tile(np.repeat(np.arange(shape[1]), shape[0]), shape[2]),
+                np.repeat(np.arange(shape[2]), shape[0] * shape[1])]).T
 
-        # check data values match node values
-        node_velocity = np.zeros(shape + [3])
-        node_boundary = np.zeros(shape, dtype=int)
-        for i in range(shape[0]):
-            for j in range(shape[1]):
-                for k in range(shape[2]):
-                    node = lbf[i, j, k]
-                    node_velocity[i, j, k] = node.velocity
-                    node_boundary[i, j, k] = node.boundary
+            dat_velocity = np.loadtxt(path_dat_velocity)
+            dat_coord = (dat_velocity[:, 0:3] - 0.5).astype(int)
+            np.testing.assert_equal(dat_coord, ref_coord)
+            dat_vel = dat_velocity[:, 3:]
+            ref_vel = np.swapaxes(node_velocity, 0, 2).reshape((-1, 3))
+            np.testing.assert_allclose(dat_vel, ref_vel, atol=5e-7)
 
-        ref_coord = np.array([
-            np.tile(np.arange(shape[0]), shape[1] * shape[2]),
-            np.tile(np.repeat(np.arange(shape[1]), shape[0]), shape[2]),
-            np.repeat(np.arange(shape[2]), shape[0] * shape[1])]).T
-
-        dat_velocity = np.loadtxt('vtk_out/velocity.dat')
-        dat_coord = (dat_velocity[:, 0:3] - 0.5).astype(int)
-        np.testing.assert_equal(dat_coord, ref_coord)
-        dat_vel = dat_velocity[:, 3:]
-        ref_vel = np.swapaxes(node_velocity, 0, 2).reshape((-1, 3))
-        np.testing.assert_allclose(dat_vel, ref_vel, atol=5e-7)
-
-        dat_boundary = np.loadtxt('vtk_out/boundary.dat')
-        dat_coord = (dat_boundary[:, 0:3] - 0.5).astype(int)
-        np.testing.assert_equal(dat_coord, ref_coord)
-        dat_bound = dat_boundary[:, 3].astype(int)
-        ref_bound = np.swapaxes(node_boundary, 0, 2).reshape(-1)
-        if isinstance(lbf, espressomd.lb.LBFluid):
-            ref_bound = (ref_bound != 0).astype(int)
-        np.testing.assert_equal(dat_bound, ref_bound)
+            dat_boundary = np.loadtxt(path_dat_boundary)
+            dat_coord = (dat_boundary[:, 0:3] - 0.5).astype(int)
+            np.testing.assert_equal(dat_coord, ref_coord)
+            dat_bound = dat_boundary[:, 3].astype(int)
+            ref_bound = np.swapaxes(node_boundary, 0, 2).reshape(-1)
+            if isinstance(lbf, espressomd.lb.LBFluid):
+                ref_bound = (ref_bound != 0).astype(int)
+            np.testing.assert_equal(dat_bound, ref_bound)
 
 
 @skipIfMissingPythonPackage

--- a/testsuite/python/lees_edwards.py
+++ b/testsuite/python/lees_edwards.py
@@ -30,8 +30,9 @@ import itertools
 
 
 np.random.seed(42)
-params_lin = {'shear_velocity': 1.2, 'initial_pos_offset': 0.1, 'time_0': 0.1}
-params_osc = {'amplitude': 2.3, 'omega': 2.51, 'time_0': -2.1}
+params_lin = {'initial_pos_offset': 0.1, 'time_0': 0.1, 'shear_velocity': 1.2}
+params_osc = {'initial_pos_offset': 0.1, 'time_0': -2.1, 'amplitude': 2.3,
+              'omega': 2.51}
 lin_protocol = espressomd.lees_edwards.LinearShear(**params_lin)
 osc_protocol = espressomd.lees_edwards.OscillatoryShear(**params_osc)
 off_protocol = espressomd.lees_edwards.Off()
@@ -113,7 +114,7 @@ class LeesEdwards(ut.TestCase):
         # check that LE offsets are recalculated on simulation time change
         for time in [0., 2.3]:
             system.time = time
-            expected_pos = params_osc['amplitude'] * \
+            expected_pos = params_osc['initial_pos_offset'] + params_osc['amplitude'] * \
                 np.sin(params_osc['omega'] * (time - params_osc['time_0']))
             expected_vel = params_osc['amplitude'] * params_osc['omega'] * \
                 np.cos(params_osc['omega'] * (time - params_osc['time_0']))
@@ -124,7 +125,7 @@ class LeesEdwards(ut.TestCase):
         # Check that time change during integration updates offsets
         system.integrator.run(1)
         time = system.time
-        expected_pos = params_osc['amplitude'] * \
+        expected_pos = params_osc['initial_pos_offset'] + params_osc['amplitude'] * \
             np.sin(params_osc['omega'] * (time - params_osc['time_0']))
         expected_vel = params_osc['amplitude'] * params_osc['omega'] * \
             np.cos(params_osc['omega'] * (time - params_osc['time_0']))

--- a/testsuite/python/lj.py
+++ b/testsuite/python/lj.py
@@ -26,7 +26,7 @@ import tests_common
 @utx.skipIfMissingFeatures(["LENNARD_JONES"])
 class LennardJonesTest(ut.TestCase):
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])
-    data = np.loadtxt(tests_common.abspath('data/lj_system.dat'))
+    data = np.loadtxt(tests_common.data_path('lj_system.dat'))
     pos = data[:, 1:4]
     forces = data[:, 4:7]
 

--- a/testsuite/python/mdanalysis.py
+++ b/testsuite/python/mdanalysis.py
@@ -25,16 +25,14 @@ import espressomd.interactions
 import numpy as np
 import unittest as ut
 import unittest_decorators as utx
-try:
-    import MDAnalysis as mda
+import contextlib
+
+with contextlib.suppress(ImportError):
+    import MDAnalysis
     import espressomd.MDA_ESP
-    skipIfMissingPythonPackage = utx.no_skip
-except ImportError:
-    skipIfMissingPythonPackage = ut.skip(
-        "Python module MDAnalysis not available, skipping test!")
 
 
-@skipIfMissingPythonPackage
+@utx.skipIfMissingModules("MDAnalysis")
 class TestMDAnalysis(ut.TestCase):
     system = espressomd.System(box_l=[10.0, 10.0, 10.0])
     system.time_step = 0.001
@@ -58,7 +56,7 @@ class TestMDAnalysis(ut.TestCase):
         system = self.system
         partcls = system.part.all()
         eos = espressomd.MDA_ESP.Stream(system)
-        u = mda.Universe(eos.topology, eos.trajectory)
+        u = MDAnalysis.Universe(eos.topology, eos.trajectory)
         # check atoms
         self.assertEqual(len(u.atoms), 10)
         np.testing.assert_equal(u.atoms.ids, np.arange(10) + 1)

--- a/testsuite/python/mmm1d.py
+++ b/testsuite/python/mmm1d.py
@@ -35,7 +35,7 @@ class ElectrostaticInteractionsTests:
     system.cell_system.set_n_square()
     system.thermostat.set_langevin(kT=0, gamma=1, seed=8)
 
-    data = np.loadtxt(tests_common.abspath("data/mmm1d_data.txt"))
+    data = np.loadtxt(tests_common.data_path("mmm1d_data.txt"))
     p_pos = data[:, 1:4]
     p_q = data[:, 4]
     forces_target = data[:, 5:8]

--- a/testsuite/python/npt_thermostat.py
+++ b/testsuite/python/npt_thermostat.py
@@ -117,7 +117,7 @@ class NPTThermostat(ut.TestCase):
     def test_02__direction(self):
         """Test for NpT constrained in one direction."""
 
-        data = np.genfromtxt(tests_common.abspath("data/npt_lj_system.data"))
+        data = np.genfromtxt(tests_common.data_path("npt_lj_system.data"))
         ref_box_l = 1.01 * np.max(data[:, 0:3])
 
         system = self.system

--- a/testsuite/python/oif_volume_conservation.py
+++ b/testsuite/python/oif_volume_conservation.py
@@ -37,8 +37,9 @@ class OifVolumeConservation(ut.TestCase):
 
         # creating the template for OIF object
         cell_type = oif.OifCellType(
-            nodes_file=tests_common.abspath("data/sphere393nodes.dat"),
-            triangles_file=tests_common.abspath("data/sphere393triangles.dat"),
+            nodes_file=str(tests_common.data_path("sphere393nodes.dat")),
+            triangles_file=str(
+                tests_common.data_path("sphere393triangles.dat")),
             system=system, ks=1.0, kb=1.0, kal=1.0, kag=0.1, kv=0.1,
             check_orientation=False, resize=(3.0, 3.0, 3.0))
 

--- a/testsuite/python/p3m_electrostatic_pressure.py
+++ b/testsuite/python/p3m_electrostatic_pressure.py
@@ -105,10 +105,14 @@ class VirialPressureConsistency(ut.TestCase):
             max_displacement=0.01)
 
         # warmup
-        while self.system.analysis.energy()["total"] > 10 * num_part:
-            print("minimization: {:.1f}".format(
-                self.system.analysis.energy()["total"]))
+        energy = self.system.analysis.energy()["total"]
+        print(f"minimization: {energy:.1f}")
+        for _ in range(10):
             self.system.integrator.run(10)
+            energy = self.system.analysis.energy()["total"]
+            print(f"minimization: {energy:.1f}")
+            if energy < 2 * num_part:
+                break
         self.system.integrator.set_vv()
         self.system.thermostat.set_langevin(kT=self.kT, gamma=1.0, seed=41)
 
@@ -121,8 +125,9 @@ class VirialPressureConsistency(ut.TestCase):
             cao=6,
             r_cut=1.4941e-01 * self.system.box_l[0])
         self.system.actors.add(p3m)
-        print("Tune skin: {}".format(self.system.cell_system.tune_skin(
-            min_skin=0.0, max_skin=2.5, tol=0.05, int_steps=100)))
+        skin = self.system.cell_system.tune_skin(
+            min_skin=0.0, max_skin=2.5, tol=0.05, int_steps=100)
+        print(f"Tuned skin: {skin}")
 
         num_samples = 25
         pressure_via_volume_scaling = pressureViaVolumeScaling(

--- a/testsuite/python/scafacos_dipoles_1d_2d.py
+++ b/testsuite/python/scafacos_dipoles_1d_2d.py
@@ -62,19 +62,19 @@ class Scafacos1d2d(ut.TestCase):
 
             # Read reference data
             if dim == 2:
-                file_prefix = "data/mdlc"
+                file_prefix = "mdlc"
                 s.periodicity = [1, 1, 0]
             else:
                 s.periodicity = [1, 0, 0]
-                file_prefix = "data/scafacos_dipoles_1d"
+                file_prefix = "scafacos_dipoles_1d"
 
-            ref_E_path = tests_common.abspath(
-                file_prefix + "_reference_data_energy.dat")
+            ref_E_path = tests_common.data_path(
+                f"{file_prefix}_reference_data_energy.dat")
             ref_E = float(np.genfromtxt(ref_E_path))
 
             # Particles
-            data = np.genfromtxt(tests_common.abspath(
-                file_prefix + "_reference_data_forces_torques.dat"))
+            data = np.genfromtxt(tests_common.data_path(
+                f"{file_prefix}_reference_data_forces_torques.dat"))
             s.part.add(pos=data[:, 1:4], dip=data[:, 4:7])
             s.part.all().rotation = 3 * [True]
 

--- a/testsuite/python/script_interface.py
+++ b/testsuite/python/script_interface.py
@@ -105,8 +105,6 @@ class ScriptInterface(ut.TestCase):
             espressomd.constraints.ShapeBasedConstraint(shape=ut)
         with self.assertRaisesRegex(TypeError, "No conversion from type 'module' to 'Variant'"):
             constraint.set_params(shape=ut)
-        with self.assertRaisesRegex(TypeError, "No conversion from type 'module' to 'Variant'"):
-            constraint.call_method('unknown', unknown=ut)
         # check restrictions on the dict type
         with self.assertRaisesRegex(TypeError, r"No conversion from type 'dict_item\(\[\(str, int\)\]\)' to 'Variant\[std::(__1::)?unordered_map<int, Variant>\]'"):
             constraint.shape = {'1': 2}

--- a/testsuite/python/script_interface.py
+++ b/testsuite/python/script_interface.py
@@ -102,7 +102,7 @@ class ScriptInterface(ut.TestCase):
         constraint = espressomd.constraints.ShapeBasedConstraint()
         # check conversion of unsupported types
         with self.assertRaisesRegex(TypeError, "No conversion from type 'module' to 'Variant'"):
-            espressomd.constraints.ShapeBasedConstraint(unknown=ut)
+            espressomd.constraints.ShapeBasedConstraint(shape=ut)
         with self.assertRaisesRegex(TypeError, "No conversion from type 'module' to 'Variant'"):
             constraint.set_params(shape=ut)
         with self.assertRaisesRegex(TypeError, "No conversion from type 'module' to 'Variant'"):

--- a/testsuite/python/sigint.py
+++ b/testsuite/python/sigint.py
@@ -21,13 +21,13 @@ import signal
 import subprocess
 import time
 import sys
-import os
+import pathlib
 
 
 class SigintTest(ut.TestCase):
 
     def setUp(self):
-        script = os.path.join(os.path.dirname(__file__), 'sigint_child.py')
+        script = str(pathlib.Path(__file__).parent / 'sigint_child.py')
         self.process = subprocess.Popen([sys.executable, script])
 
     def test_signal_handling(self):

--- a/testsuite/python/stokesian_dynamics.py
+++ b/testsuite/python/stokesian_dynamics.py
@@ -35,7 +35,7 @@ class StokesianDynamicsTest(ut.TestCase):
     # Digitized reference data of Figure 5b from
     # Durlofsky et al., J. Fluid Mech. 180, 21 (1987)
     # https://doi.org/10.1017/S002211208700171X
-    data = np.loadtxt(tests_common.abspath('data/dancing.txt'))
+    data = np.loadtxt(tests_common.data_path('dancing.txt'))
 
     def setUp(self):
         self.system.box_l = [10] * 3

--- a/testsuite/python/tests_common.py
+++ b/testsuite/python/tests_common.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import os
+import pathlib
 import numpy as np
 
 
@@ -128,8 +128,11 @@ def verify_lj_forces(system, tolerance, ids_to_skip=()):
             err_msg=f"LJ force verification failed on particle {p.id}.")
 
 
-def abspath(path):
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
+def data_path(filename):
+    """
+    Resolve abosulte path to a resource.
+    """
+    return pathlib.Path(__file__).resolve().parent / "data" / filename
 
 
 def transform_pos_from_cartesian_to_polar_coordinates(pos):

--- a/testsuite/python/unittest_generator.py
+++ b/testsuite/python/unittest_generator.py
@@ -17,9 +17,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
 import sys
 import inspect
+import pathlib
 
 
 class TestGenerator:
@@ -141,4 +141,4 @@ class TestGenerator:
         Generate parameters to instantiate an ESPResSo checkpoint file.
         """
         return {"checkpoint_id": f"checkpoint_{self.test_idx}",
-                "checkpoint_path": os.path.dirname(__file__)}
+                "checkpoint_path": str(pathlib.Path(__file__).parent)}

--- a/testsuite/scripts/importlib_wrapper.py
+++ b/testsuite/scripts/importlib_wrapper.py
@@ -90,11 +90,8 @@ def configure_and_import(filepath,
         return module, skipIfMissingGPU
     filepath = os.path.abspath(filepath)
     # load original script
-    # read in binary mode, then decode as UTF-8 to avoid this python3.5 error:
-    # UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 915:
-    #                      ordinal not in range(128)
-    with open(filepath, "rb") as f:
-        code = f.read().decode(encoding="utf-8")
+    with open(filepath, "r") as f:
+        code = f.read()
     # custom substitutions
     code = substitutions(code)
     assert code.strip()

--- a/testsuite/scripts/importlib_wrapper.py
+++ b/testsuite/scripts/importlib_wrapper.py
@@ -52,23 +52,23 @@ def configure_and_import(filepath,
 
     Parameters
     ----------
-    filepath : str
+    filepath : :obj:`str`
         python script to import
-    gpu : bool
+    gpu : :obj:`bool`
         whether GPU is necessary or not
-    substitutions : function
+    substitutions : :obj:`function`
         custom text replacement operation (useful to edit out calls to the
         OpenGL or Mayavi visualizers' ``run()`` method)
-    cmd_arguments : list
+    cmd_arguments : :obj:`list`
         command line arguments, i.e. sys.argv without the script path
-    script_suffix : str
+    script_suffix : :obj:`str`
         suffix to append to the configured script (useful when a single
         module is being tested by multiple tests in parallel)
-    mock_visualizers : bool
-        if ``True``, substitute ES visualizers with `Mock()` classes in case
-        of `ImportError()` (use ``False`` if an `ImportError()` is relevant
+    mock_visualizers : :obj:`bool`
+        if ``True``, substitute ES visualizers with ``Mock`` classes in case
+        of ``ImportError`` (use ``False`` if an ``ImportError`` is relevant
         to your test)
-    move_to_script_dir : bool
+    move_to_script_dir : :obj:`bool`
         if ``True``, move to the script's directory (useful when the script
         needs to load files hardcoded as relative paths, or when files are
         generated and need cleanup); this is enabled by default
@@ -203,12 +203,12 @@ def substitute_variable_values(code, strings_as_is=False, keep_original=True,
 
     Parameters
     ----------
-    code : str
+    code : :obj:`str`
         Source code to edit.
-    strings_as_is : bool
+    strings_as_is : :obj:`bool`
         If ``True``, consider all values in \*\*parameters are strings and
         substitute them in-place without formatting by ``repr()``.
-    keep_original : bool
+    keep_original : :obj:`bool`
         Keep the original value (e.g. ``N = 10; _N__original = 1000``), helps
         with debugging.
     \*\*parameters :
@@ -569,9 +569,9 @@ class GetEspressomdVisualizerImports(ast.NodeVisitor):
 
 def mock_es_visualization(code):
     """
-    Replace ``import espressomd.visualization_<backend>`` by a ``MagicMock()``
+    Replace ``import espressomd.visualization_<backend>`` by a ``MagicMock``
     when the visualization module is unavailable, by catching the
-    ``ImportError()`` exception. Please note that ``espressomd.visualization``
+    ``ImportError`` exception. Please note that ``espressomd.visualization``
     is deferring the exception, thus requiring additional checks.
 
     Import aliases are supported, however please don't use

--- a/testsuite/scripts/importlib_wrapper.py
+++ b/testsuite/scripts/importlib_wrapper.py
@@ -23,6 +23,7 @@ import ast
 import tokenize
 import unittest
 import importlib
+import pathlib
 import espressomd
 from unittest.mock import MagicMock
 
@@ -40,7 +41,7 @@ def configure_and_import(filepath,
                          gpu=False,
                          substitutions=lambda x: x,
                          cmd_arguments=None,
-                         script_suffix=None,
+                         script_suffix="",
                          move_to_script_dir=True,
                          mock_visualizers=True,
                          **parameters):
@@ -79,6 +80,7 @@ def configure_and_import(filepath,
         global variables to replace
 
     """
+    filepath = pathlib.Path(filepath).resolve()
     if skip_future_imports:
         module = MagicMock()
         skipIfMissingImport = skip_future_imports_dependency(filepath)
@@ -88,10 +90,8 @@ def configure_and_import(filepath,
         skipIfMissingGPU = unittest.skip("gpu not available, skipping test!")
         module = MagicMock()
         return module, skipIfMissingGPU
-    filepath = os.path.abspath(filepath)
     # load original script
-    with open(filepath, "r") as f:
-        code = f.read()
+    code = filepath.read_text()
     # custom substitutions
     code = substitutions(code)
     assert code.strip()
@@ -106,23 +106,17 @@ def configure_and_import(filepath,
     if mock_visualizers:
         code = mock_es_visualization(code)
     # save changes to a new file
-    if script_suffix:
-        if script_suffix[0] != "_":
-            script_suffix = "_" + script_suffix
-    else:
-        script_suffix = ""
-    script_suffix += "_processed.py"
-    output_filepath = os.path.splitext(filepath)[0] + script_suffix
-    assert os.path.isfile(output_filepath) is False, \
+    output_filepath = filepath.parent / \
+        f"{filepath.stem}_{script_suffix}_processed.py"
+    assert not output_filepath.exists(), \
         f"File {output_filepath} already processed, cannot overwrite"
-    with open(output_filepath, "wb") as f:
-        f.write(code.encode(encoding="utf-8"))
+    output_filepath.write_bytes(code.encode(encoding="utf-8"))
     # import
-    dirname, basename = os.path.split(output_filepath)
+    dirname = output_filepath.parent
     if move_to_script_dir:
         os.chdir(dirname)
-    sys.path.insert(0, dirname)
-    module_name = os.path.splitext(basename)[0]
+    sys.path.insert(0, str(dirname))
+    module_name = output_filepath.stem
     try:
         module = importlib.import_module(module_name)
     except espressomd.FeaturesError as err:
@@ -162,7 +156,7 @@ def set_cmd(code, filepath, cmd_arguments):
     """
     assert isinstance(cmd_arguments, (list, tuple))
     sys_argv = list(map(str, cmd_arguments))
-    sys_argv.insert(0, os.path.basename(filepath))
+    sys_argv.insert(0, filepath.name)
     visitor = GetSysArgparseImports()
     visitor.visit(ast.parse(protect_ipython_magics(code)))
     assert visitor.linenos, "module sys (or argparse) is not imported"
@@ -636,7 +630,7 @@ def skip_future_imports_dependency(filepath):
     """
     global skip_future_imports
     if not skip_future_imports:
-        module_name = os.path.splitext(os.path.basename(filepath))[0]
+        module_name = filepath.stem
         assert module_name != ""
         skip_future_imports = module_name
     return unittest.skip(

--- a/testsuite/scripts/samples/test_ekboundaries.py
+++ b/testsuite/scripts/samples/test_ekboundaries.py
@@ -17,7 +17,7 @@
 
 import unittest as ut
 import importlib_wrapper
-import os
+import pathlib
 
 sample, skipIfMissingFeatures = importlib_wrapper.configure_and_import(
     "@SAMPLES_DIR@/ekboundaries.py", gpu=True, n_int_cycles=50)
@@ -28,13 +28,12 @@ class Sample(ut.TestCase):
     system = sample.system
 
     def test_file_generation(self):
-        # test .checkpoint files exist
+        # test .vtk files exist
+        path_vtk_root = pathlib.Path("ek")
         for basename in ["pos_dens_0.vtk", "pos_flux_0.vtk", "ekv_0.vtk",
                          "neg_dens_0.vtk", "neg_flux_0.vtk", "ekb_0.vtk"]:
-            filepath = os.path.join("ek", basename)
-            self.assertTrue(
-                os.path.isfile(filepath),
-                filepath + " not created")
+            filepath = path_vtk_root / basename
+            self.assertTrue(filepath.is_file(), f"File {filepath} not created")
 
 
 if __name__ == "__main__":

--- a/testsuite/scripts/samples/test_immersed_boundary.py
+++ b/testsuite/scripts/samples/test_immersed_boundary.py
@@ -17,7 +17,7 @@
 
 import unittest as ut
 import importlib_wrapper
-import os
+import pathlib
 
 sample, skipIfMissingFeatures = importlib_wrapper.configure_and_import(
     "@SAMPLES_DIR@/immersed_boundary/sampleImmersedBoundary.py",
@@ -31,10 +31,8 @@ class Sample(ut.TestCase):
     def test_file_generation(self):
         # test .vtk files exist
         for i in range(sample.numSteps + 1):
-            filepath = os.path.join("outputVolParaCUDA", "cell_%i.vtk" % i)
-            self.assertTrue(
-                os.path.isfile(filepath),
-                filepath + " not created")
+            filepath = pathlib.Path("outputVolParaCUDA") / f"cell_{i}.vtk"
+            self.assertTrue(filepath.is_file(), f"File {filepath} not created")
 
 
 if __name__ == "__main__":

--- a/testsuite/scripts/samples/test_object_in_fluid__motivation.py
+++ b/testsuite/scripts/samples/test_object_in_fluid__motivation.py
@@ -18,6 +18,7 @@
 import unittest as ut
 import importlib_wrapper
 import os
+import pathlib
 
 os.chdir("@SAMPLES_DIR@/object_in_fluid")
 sample, skipIfMissingFeatures = importlib_wrapper.configure_and_import(
@@ -39,13 +40,13 @@ class Sample(ut.TestCase):
             "wallFront.vtk"]
         for i in [0, 1]:
             for j in range(sample.maxCycle):
-                basenames.append("cell{}_{}.vtk".format(i, j))
+                basenames.append(f"cell{i}_{j}.vtk")
+
         # test .vtk files exist
+        path_vtk_root = pathlib.Path("output")
         for name in basenames:
-            filepath = os.path.join("output", "sim0", name)
-            self.assertTrue(
-                os.path.isfile(filepath),
-                filepath + " not created")
+            filepath = path_vtk_root / "sim0" / name
+            self.assertTrue(filepath.is_file(), f"File {filepath} not created")
 
 
 if __name__ == "__main__":

--- a/testsuite/scripts/samples/test_save_checkpoint.py
+++ b/testsuite/scripts/samples/test_save_checkpoint.py
@@ -17,7 +17,7 @@
 
 import unittest as ut
 import importlib_wrapper
-import os
+import pathlib
 
 sample, skipIfMissingFeatures = importlib_wrapper.configure_and_import(
     "@SAMPLES_DIR@/save_checkpoint.py")
@@ -29,8 +29,8 @@ class Sample(ut.TestCase):
 
     def test_file_generation(self):
         # test .checkpoint files exist
-        filepath = os.path.join("mycheckpoint", "0.checkpoint")
-        self.assertTrue(os.path.isfile(filepath), filepath + " not created")
+        filepath = pathlib.Path("mycheckpoint") / "0.checkpoint"
+        self.assertTrue(filepath.exists(), f"File {filepath} not created")
 
 
 if __name__ == "__main__":

--- a/testsuite/scripts/test_importlib_wrapper.py
+++ b/testsuite/scripts/test_importlib_wrapper.py
@@ -20,21 +20,24 @@ import importlib_wrapper as iw
 import sys
 import ast
 import pathlib
+import tempfile
+import espressomd
 
 
 class importlib_wrapper(ut.TestCase):
 
     def test_substitute_variable_values(self):
-        str_inp = "n_steps=5000\nnsteps == 5\n"
-        str_exp = "n_steps = 10; _n_steps__original=5000\nnsteps == 5\n"
+        str_inp = "n_steps=(\n5000)\nnsteps == 5\n"
+        str_exp = "n_steps = 10; _n_steps__original=(\n5000)\nnsteps == 5\n"
         str_out = iw.substitute_variable_values(str_inp, n_steps=10)
         self.assertEqual(str_out, str_exp)
         str_out = iw.substitute_variable_values(str_inp, n_steps='10',
                                                 strings_as_is=True)
         self.assertEqual(str_out, str_exp)
-        str_inp = "N=5000\nnsteps == 5\n"
-        str_exp = "N = 10\nnsteps == 5\n"
-        str_out = iw.substitute_variable_values(str_inp, N=10, keep_original=0)
+        str_inp = "N=(\n5000)\nnsteps == 5\n"
+        str_exp = "N = 10\n\nnsteps == 5\n"
+        str_out = iw.substitute_variable_values(str_inp, N=10,
+                                                keep_original=False)
         self.assertEqual(str_out, str_exp)
         # test exceptions
         str_inp = "n_steps=5000\nnsteps == 5\n"
@@ -93,9 +96,9 @@ try:
        hasattr(espressomd.visualization.openGLLive, 'deferred_ImportError'):
         raise ImportError()
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    espressomd.visualization = MagicMock()
+    espressomd.visualization = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -107,9 +110,9 @@ try:
        hasattr(test.openGLLive, 'deferred_ImportError'):
         raise ImportError()
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    test = MagicMock()
+    test = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -121,18 +124,18 @@ try:
        hasattr(espressomd.visualization.openGLLive, 'deferred_ImportError'):
         raise ImportError()
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    espressomd.visualization = MagicMock()
+    espressomd.visualization = unittest.mock.MagicMock()
 try:
     import espressomd.visualization as test
     if hasattr(test.mayaviLive, 'deferred_ImportError') or \\
        hasattr(test.openGLLive, 'deferred_ImportError'):
         raise ImportError()
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    test = MagicMock()
+    test = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -144,9 +147,9 @@ try:
        hasattr(visualization.openGLLive, 'deferred_ImportError'):
         raise ImportError()
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    visualization = MagicMock()
+    visualization = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -158,9 +161,9 @@ try:
        hasattr(test.openGLLive, 'deferred_ImportError'):
         raise ImportError()
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    test = MagicMock()
+    test = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -169,9 +172,9 @@ except ImportError:
 try:
     from espressomd import visualization_mayavi
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    visualization_mayavi = MagicMock()
+    visualization_mayavi = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -180,9 +183,9 @@ except ImportError:
 try:
     from espressomd import visualization_mayavi as test
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    test = MagicMock()
+    test = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -191,9 +194,9 @@ except ImportError:
 try:
     from espressomd.visualization_mayavi import mayaviLive
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    mayaviLive = MagicMock()
+    mayaviLive = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -202,9 +205,9 @@ except ImportError:
 try:
     from espressomd.visualization_mayavi import mayaviLive as test
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    test = MagicMock()
+    test = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -213,15 +216,15 @@ except ImportError:
 try:
     from espressomd.visualization_mayavi import a as b
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    b = MagicMock()
+    b = unittest.mock.MagicMock()
 try:
     from espressomd.visualization_mayavi import mayaviLive
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    mayaviLive = MagicMock()
+    mayaviLive = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -232,9 +235,9 @@ try:
     if hasattr(openGLLive, 'deferred_ImportError'):
         raise openGLLive.deferred_ImportError
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    openGLLive = MagicMock()
+    openGLLive = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -245,9 +248,9 @@ try:
     if hasattr(test, 'deferred_ImportError'):
         raise test.deferred_ImportError
 except ImportError:
-    from unittest.mock import MagicMock
+    import unittest.mock
     import espressomd
-    test = MagicMock()
+    test = unittest.mock.MagicMock()
 """
         self.assertEqual(iw.mock_es_visualization(statement), expected[1:])
 
@@ -313,6 +316,7 @@ except ImportError:
             'import espressomd.System as s1, espressomd.system.System as s2',
             'from espressomd import System as s3, electrostatics',
             'from espressomd.system import System as s4',
+            'from espressomd import system as es5',
             'sys1 = es1.System()',
             'sys2 = es1.system.System()',
             'sys3 = es2.System()',
@@ -320,6 +324,7 @@ except ImportError:
             'sys5 = s2()',
             'sys6 = s3()',
             'sys7 = s4()',
+            'sys8 = es5.System()',
             'import numpy as np',
             'import numpy.random as npr1',
             'from numpy import random as npr2',
@@ -332,13 +337,14 @@ except ImportError:
         v.visit(tree)
         # find all aliases for espressomd.system.System
         expected_es_sys_aliases = {'es1.System', 'es1.system.System',
-                                   'es2.System', 's1', 's2', 's3', 's4'}
+                                   'es2.System', 's1', 's2', 's3', 's4',
+                                   'es5.System'}
         self.assertEqual(v.es_system_aliases, expected_es_sys_aliases)
         # find all variables of type espressomd.system.System
-        expected_es_sys_objs = set(f'sys{i}' for i in range(1, 8))
+        expected_es_sys_objs = set(f'sys{i}' for i in range(1, 9))
         self.assertEqual(v.variable_system_aliases, expected_es_sys_objs)
         # find all seeds setup
-        self.assertEqual(v.numpy_seeds, [17, 18, 19])
+        self.assertEqual(v.numpy_seeds, [19, 20, 21])
         # test exceptions
         str_es_sys_list = [
             'import espressomd.System',
@@ -396,6 +402,49 @@ except ImportError:
         self.assertEqual(code_protected, code_protected_ref)
         code_deprotected = iw.deprotect_ipython_magics(code_protected)
         self.assertEqual(code_deprotected, code)
+
+    def test_configure_and_import(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path_in = pathlib.Path(temp_dir) / "sample.py"
+            path_out = pathlib.Path(temp_dir) / "sample_test_processed.py"
+            path_features = pathlib.Path(temp_dir) / "sample_impossible.py"
+
+            # test importing a simple sample
+            sys.argv.append("42")
+            sys_argv_ref = list(sys.argv)
+            path_in.write_text("""
+import sys
+from argparse import ArgumentParser
+value = 42
+argv = list(sys.argv)
+import espressomd.visualization_opengl
+""")
+            sample, _ = iw.configure_and_import(
+                path_in, move_to_script_dir=False, cmd_arguments=["TestCase"],
+                gpu=False, script_suffix="test", value=43)
+            self.assertEqual(sys.argv, sys_argv_ref)
+            self.assertEqual(sample.argv, [path_in.name, "TestCase"])
+            self.assertTrue(path_out.exists(), f"File {path_out} not found")
+            self.assertEqual(sample.value, 43)
+            self.assertIn(
+                "espressomd.visualization_opengl = unittest.mock.MagicMock()",
+                path_out.read_text())
+
+            # test importing a sample that relies on features not compiled in
+            inactive_features = espressomd.all_features() - set(espressomd.features())
+            if inactive_features:
+                path_features.write_text(f"""
+import espressomd
+espressomd.assert_features({list(inactive_features)})
+""")
+                module, _ = iw.configure_and_import(path_features)
+                self.assertIsInstance(module, ut.mock.MagicMock)
+
+                # importing a valid sample is impossible after a failed import
+                sample, _ = iw.configure_and_import(
+                    path_in, move_to_script_dir=True, script_suffix="test",
+                    cmd_arguments=["TestCase"], gpu=False, value=43)
+                self.assertIsInstance(sample, ut.mock.MagicMock)
 
 
 if __name__ == "__main__":

--- a/testsuite/scripts/test_importlib_wrapper.py
+++ b/testsuite/scripts/test_importlib_wrapper.py
@@ -19,6 +19,7 @@ import unittest as ut
 import importlib_wrapper as iw
 import sys
 import ast
+import pathlib
 
 
 class importlib_wrapper(ut.TestCase):
@@ -49,20 +50,21 @@ class importlib_wrapper(ut.TestCase):
     def test_set_cmd(self):
         original_sys_argv = list(sys.argv)
         sys.argv = [0, "test"]
+        path = pathlib.Path("a.py")
         # test substitutions
         str_inp = "import sys\nimport argparse"
-        str_exp = "import sys;sys.argv = ['a.py', '1', '2'];" + str_inp
-        str_out, sys_argv = iw.set_cmd(str_inp, "a.py", (1, 2))
+        str_exp = f"import sys;sys.argv = ['{path.name}', '1', '2'];" + str_inp
+        str_out, sys_argv = iw.set_cmd(str_inp, path, (1, 2))
         self.assertEqual(str_out, str_exp)
         self.assertEqual(sys_argv, [0, "test"])
         str_inp = "import argparse"
-        str_exp = "import sys;sys.argv = ['a.py', '1', '2'];" + str_inp
-        str_out, sys_argv = iw.set_cmd(str_inp, "a.py", ["1", 2])
+        str_exp = f"import sys;sys.argv = ['{path.name}', '1', '2'];" + str_inp
+        str_out, sys_argv = iw.set_cmd(str_inp, path, ["1", 2])
         self.assertEqual(str_out, str_exp)
         self.assertEqual(sys_argv, [0, "test"])
         # test exceptions
         str_inp = "import re"
-        self.assertRaises(AssertionError, iw.set_cmd, str_inp, "a.py", (1, 2))
+        self.assertRaises(AssertionError, iw.set_cmd, str_inp, path, (1, 2))
         # restore sys.argv
         sys.argv = original_sys_argv
 

--- a/testsuite/scripts/tutorials/test_convert.py
+++ b/testsuite/scripts/tutorials/test_convert.py
@@ -16,10 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest as ut
-import os
 import sys
 import nbformat
 import traceback
+import pathlib
 
 sys.path.insert(0, '@CMAKE_BINARY_DIR@/doc/tutorials')
 import convert
@@ -96,17 +96,16 @@ plt.show()
             traceback.print_exc()
             self.fail(error_msg)
         if output is not None:
-            self.assertTrue(os.path.isfile(output), f"{output} not created")
+            self.assertTrue(output.exists(), f"File {output} not created")
 
     def test_html_wrapper(self):
-        f_input = '@CMAKE_CURRENT_BINARY_DIR@/test_convert_notebook.ipynb'
-        f_output = '@CMAKE_CURRENT_BINARY_DIR@/test_convert_notebook.run.ipynb'
-        f_script = '@CMAKE_CURRENT_BINARY_DIR@/test_convert_script.py'
+        root = pathlib.Path("@CMAKE_CURRENT_BINARY_DIR@")
+        f_input = root / "test_convert_notebook.ipynb"
+        f_output = root / "test_convert_notebook.run.ipynb"
+        f_script = root / "test_convert_script.py"
         # setup
-        if os.path.isfile(f_output):
-            os.remove(f_output)
-        with open(f_script, 'w') as f:
-            f.write('global_var = 5')
+        f_output.unlink(missing_ok=True)
+        f_script.write_text('global_var = 5')
         with open(f_input, 'w', encoding='utf-8') as f:
             nb = nbformat.v4.new_notebook(metadata=self.nb_metadata)
             cell_md = nbformat.v4.new_markdown_cell(source=self.cell_md_src)
@@ -116,9 +115,9 @@ plt.show()
             nbformat.write(nb, f)
         # run command and check for errors
         cmd = ['ci',
-               '--input', f_input,
-               '--output', f_output,
-               '--scripts', f_script,
+               '--input', str(f_input),
+               '--output', str(f_output),
+               '--scripts', str(f_script),
                '--substitutions', 'global_var=20',
                '--execute']
         self.run_command(cmd, f_output)
@@ -155,11 +154,11 @@ plt.show()
         self.assertEqual(nb_output['cells'][4]['source'], 'global_var = 20')
 
     def test_exercise2_plugin(self):
-        f_input = '@CMAKE_CURRENT_BINARY_DIR@/test_convert_exercise2.ipynb'
-        f_output = '@CMAKE_CURRENT_BINARY_DIR@/test_convert_exercise2.run.ipynb'
+        root = pathlib.Path("@CMAKE_CURRENT_BINARY_DIR@")
+        f_input = root / "test_convert_exercise2.ipynb"
+        f_output = root / "test_convert_exercise2.run.ipynb"
         # setup
-        if os.path.isfile(f_output):
-            os.remove(f_output)
+        f_output.unlink(missing_ok=True)
         with open(f_input, 'w', encoding='utf-8') as f:
             nb = nbformat.v4.new_notebook(metadata=self.nb_metadata)
             # question with 2 answers and an empty cell
@@ -191,8 +190,8 @@ plt.show()
             nbformat.write(nb, f)
         # run command and check for errors
         cmd = ['ci',
-               '--input', f_input,
-               '--output', f_output,
+               '--input', str(f_input),
+               '--output', str(f_output),
                '--substitutions', 'global_var=20',
                '--exercise2', '--remove-empty-cells']
         self.run_command(cmd, f_output)
@@ -226,7 +225,8 @@ plt.show()
         self.assertEqual(next(cells, 'EOF'), 'EOF')
 
     def test_exercise2_conversion(self):
-        f_input = '@CMAKE_CURRENT_BINARY_DIR@/test_convert_exercise2_conversion.ipynb'
+        root = pathlib.Path("@CMAKE_CURRENT_BINARY_DIR@")
+        f_input = root / "test_convert_exercise2_conversion.ipynb"
         # setup
         with open(f_input, 'w', encoding='utf-8') as f:
             nb = nbformat.v4.new_notebook(metadata=self.nb_metadata)
@@ -242,7 +242,7 @@ plt.show()
             nb['cells'].append(cell_md)
             nbformat.write(nb, f)
         # run command and check for errors
-        cmd = ['exercise2', '--to-py', f_input]
+        cmd = ['exercise2', '--to-py', str(f_input)]
         self.run_command(cmd, f_input)
         # read processed notebook
         with open(f_input, encoding='utf-8') as f:
@@ -259,7 +259,7 @@ plt.show()
         self.assertEqual(cell['metadata']['key'], 'value')
         self.assertEqual(next(cells, 'EOF'), 'EOF')
         # run command and check for errors
-        cmd = ['exercise2', '--to-md', f_input]
+        cmd = ['exercise2', '--to-md', str(f_input)]
         self.run_command(cmd, f_input)
         # read processed notebook
         with open(f_input, encoding='utf-8') as f:
@@ -278,7 +278,8 @@ plt.show()
 
     @skipIfMissingModules
     def test_exercise2_autopep8(self):
-        f_input = '@CMAKE_CURRENT_BINARY_DIR@/test_convert_exercise2_autopep8.ipynb'
+        root = pathlib.Path("@CMAKE_CURRENT_BINARY_DIR@")
+        f_input = root / "test_convert_exercise2_autopep8.ipynb"
         # setup
         with open(f_input, 'w', encoding='utf-8') as f:
             nb = nbformat.v4.new_notebook(metadata=self.nb_metadata)
@@ -293,7 +294,7 @@ plt.show()
             nb['cells'].append(cell_md)
             nbformat.write(nb, f)
         # run command and check for errors
-        cmd = ['exercise2', '--pep8', f_input]
+        cmd = ['exercise2', '--pep8', str(f_input)]
         self.run_command(cmd)
         # read processed notebook
         with open(f_input, encoding='utf-8') as f:


### PR DESCRIPTION
Fixes #4488, fixes  #4490, fixes #4491, fixes #4477

Description of changes:
- require Python 3.8+ (as per #3421)
- use `contextlib` in the testsuite to better handle `ImportError` from missing dependencies
- use `pathlib` in the testsuite and scripts for portability on non-Posix environments
- modernize python testsuite, fix broken test cases, improve code coverage
- implement initial position offset for LEbc protocol `OscillatoryShear`
- use new CI infrastructure: run jobs on 4 cores (reduce test runtime by 30%), update labels to better utilize GPU runners