### PR TITLE
Safe exception handling during type conversion

### DIFF
--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -185,7 +185,7 @@ cdef class PScriptInterface:
 
         return odict
 
-cdef Variant python_object_to_variant(value) except +:
+cdef Variant python_object_to_variant(value) except *:
     """Convert Python objects to C++ Variant objects."""
 
     cdef vector[Variant] vec

--- a/testsuite/python/script_interface.py
+++ b/testsuite/python/script_interface.py
@@ -101,10 +101,15 @@ class ScriptInterface(ut.TestCase):
         """Check AutoParameters framework"""
         constraint = espressomd.constraints.ShapeBasedConstraint()
         # check conversion of unsupported types
-        with self.assertRaisesRegex(TypeError, "No conversion from type 'module' to 'Variant'"):
+        err_msg = "No conversion from type 'module' to 'Variant'"
+        with self.assertRaisesRegex(TypeError, err_msg):
             espressomd.constraints.ShapeBasedConstraint(shape=ut)
-        with self.assertRaisesRegex(TypeError, "No conversion from type 'module' to 'Variant'"):
+        with self.assertRaisesRegex(TypeError, err_msg):
+            espressomd.constraints.ShapeBasedConstraint(unknown=ut)
+        with self.assertRaisesRegex(TypeError, err_msg):
             constraint.set_params(shape=ut)
+        with self.assertRaisesRegex(TypeError, err_msg):
+            constraint.call_method('unknown', unknown=ut)
         # check restrictions on the dict type
         with self.assertRaisesRegex(TypeError, r"No conversion from type 'dict_item\(\[\(str, int\)\]\)' to 'Variant\[std::(__1::)?unordered_map<int, Variant>\]'"):
             constraint.shape = {'1': 2}


### PR DESCRIPTION
Fix a regression introduced in #4387 that would randomly block the propagation of a `TypeError` when converting an unsupported Python type to a C++ variant. Please refer to cython/cython#4720 for the details. Restore the corresponding `TypeError` checks in the testsuite.
