### PR TITLE
Bump cmake-format requirements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/espressomd/docker/ubuntu-20.04:254edd4a9c6e4d7b557be73158e400f5794e4f99
+image: ghcr.io/espressomd/docker/ubuntu-20.04:285fee33c6cdc3b617745a75bd28aec331a53365
 
 stages:
   - prepare
@@ -136,7 +136,7 @@ no_rotation:
 ubuntu:wo-dependencies:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
+  image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:285fee33c6cdc3b617745a75bd28aec331a53365
   variables:
      myconfig: 'maxset'
      with_cuda: 'false'
@@ -155,7 +155,7 @@ ubuntu:wo-dependencies:
 debian:10:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/debian:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
+  image: ghcr.io/espressomd/docker/debian:285fee33c6cdc3b617745a75bd28aec331a53365
   variables:
      with_cuda: 'false'
      myconfig: 'maxset'
@@ -171,7 +171,7 @@ debian:10:
 fedora:34:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/fedora:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
+  image: ghcr.io/espressomd/docker/fedora:285fee33c6cdc3b617745a75bd28aec331a53365
   variables:
      with_cuda: 'false'
      myconfig: 'maxset'
@@ -214,7 +214,7 @@ clang-sanitizer:
 fast_math:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/cuda:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
+  image: ghcr.io/espressomd/docker/cuda:285fee33c6cdc3b617745a75bd28aec331a53365
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'
@@ -235,7 +235,7 @@ fast_math:
 cuda11-maxset:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/cuda:9ef2166b82d4c0eb258d17f5ec29f7bc39991f5d
+  image: ghcr.io/espressomd/docker/cuda:285fee33c6cdc3b617745a75bd28aec331a53365
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,9 @@ stages:
   except:
     - staging.tmp
     - trying.tmp
+  before_script:
+    - git config --global --add safe.directory ${CI_PROJECT_DIR}
+    - git config --global --add safe.directory ${CI_PROJECT_DIR}/libs/h5xx
   timeout: 1h
   interruptible: true
 
@@ -17,6 +20,8 @@ stages:
   <<: *global_job_definition
   variables:
     GIT_SUBMODULE_STRATEGY: none
+  before_script:
+    - git config --global --add safe.directory ${CI_PROJECT_DIR}
   dependencies: []
   timeout: 40m
   interruptible: false
@@ -41,6 +46,7 @@ style:
   stage: prepare
   dependencies: []
   before_script:
+    - git config --global --add safe.directory ${CI_PROJECT_DIR}
     - git submodule deinit .
   script:
     - sh maintainer/CI/fix_style.sh

--- a/maintainer/format/cmake-format.sh
+++ b/maintainer/format/cmake-format.sh
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-CMAKE_FORMAT_VER=0.6.11
-python3 -m cmake_format 2>&1 > /dev/null
+CMAKE_FORMAT_VER=0.6.13
+python3 -m cmakelang.format 2>&1 > /dev/null
 if [ "$?" = "0" ]; then
-    CMAKE_FORMAT="python3 -m cmake_format"
+    CMAKE_FORMAT="python3 -m cmakelang.format"
 else
     echo "No cmake-format found."
     exit 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ astroid>=2.3.3
 isort>=4.3.4
 setuptools>=39.0.1
 pre-commit>=2.2.0
-cmake-format==0.6.11
+cmakelang==0.6.13

--- a/testsuite/python/mmm1d_gpu.py
+++ b/testsuite/python/mmm1d_gpu.py
@@ -26,6 +26,8 @@ import espressomd.electrostatics
 @utx.skipIfMissingGPU()
 class MMM1D_GPU_Test(mmm1d.ElectrostaticInteractionsTests, ut.TestCase):
 
+    allowed_error = 1e-4
+
     def setUp(self):
         self.MMM1D = espressomd.electrostatics.MMM1DGPU
         super().setUp()


### PR DESCRIPTION
Fixes #4500, fixes #4499, fixes #4495

Description of changes:
- replace deprecated Python package `cmake-format`, which is not packaged in Ubuntu, by `cmakelang`, which is packaged in Ubuntu 21.04 and later versions; `cmakelang` provides `cmake-format` as a backward-compatible sub-command
- fix git fatal error "unsafe repository is owned by someone else" on recent git versions that addressed CVE-2022-24765
- fix flaky MMM1D GPU test on that randomly failed in CI