### PR TITLE
Store absolute paths in h5md files

### DIFF
--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -17,6 +17,7 @@
 #
 
 import sys
+import pathlib
 
 from ...script_interface import script_interface_register, ScriptInterfaceHelper  # pylint: disable=import
 from ...__init__ import assert_features
@@ -127,9 +128,13 @@ class H5md(ScriptInterfaceHelper):
         fields = [fields] if isinstance(fields, str) else list(fields)
         params["fields"] = fields
         self.validate_params(params)
+        script_path = ""
+        if sys.argv and sys.argv[0]:
+            script_path = str(pathlib.Path(sys.argv[0]).resolve())
+        file_path = str(pathlib.Path(params["file_path"]).resolve())
         super().__init__(
-            file_path=params["file_path"],
-            script_path=sys.argv[0],
+            file_path=file_path,
+            script_path=script_path,
             fields=fields,
             mass_unit=unit_system.mass,
             length_unit=unit_system.length,

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -81,7 +81,7 @@ class H5mdTests(ut.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.temp_dir = tempfile.TemporaryDirectory()
-        cls.temp_path = pathlib.Path(cls.temp_dir.name)
+        cls.temp_path = pathlib.Path(cls.temp_dir.name).resolve()
         cls.temp_file = cls.temp_path / 'test.h5'
         h5_units = espressomd.io.writer.h5md.UnitSystem(
             time='ps', mass='u', length='m', charge='e')


### PR DESCRIPTION
Description of changes:
- resolve relative paths and symlinks when writing h5md file paths to avoid discrepancies when reloading from a checkpoint
