### PR TITLE
Refactor checkpointing feature

### DIFF
--- a/doc/sphinx/constraints.rst
+++ b/doc/sphinx/constraints.rst
@@ -471,6 +471,7 @@ Union
 A meta-shape which is the union of given shapes. Note that only the regions where
 all shapes have a "positive distance" (see :ref:`Available options`) can be used for the
 union. The distance to the union is defined as the minimum distance to any contained shape.
+This shape cannot be checkpointed when multiple MPI ranks are used.
 
 
 .. _Available options:

--- a/doc/sphinx/reaction_methods.rst
+++ b/doc/sphinx/reaction_methods.rst
@@ -24,6 +24,9 @@ Please keep in mind the following remarks:
   contiguously. Particle slices returned by ``system.part`` are still iterable,
   but the indices no longer match the particle ids.
 
+* Checkpointing is not supported, since the state of the Mersenne Twister
+  random number generator cannot be serialized.
+
 * For improved performance, you can set the type of invalidated particles with
   :meth:`~espressomd.reaction_methods.ReactionAlgorithm.set_non_interacting_type`
   in all reaction method classes.

--- a/src/core/grid_based_algorithms/lb_interface.cpp
+++ b/src/core/grid_based_algorithms/lb_interface.cpp
@@ -622,7 +622,7 @@ void lb_lbfluid_print_boundary(const std::string &filename) {
     }
 #endif //  CUDA
   } else {
-    auto constexpr shift = Vector3d{0.5, 0.5, 0.5};
+    auto const shift = Vector3d{{0.5, 0.5, 0.5}};
     auto const agrid = lb_lbfluid_get_agrid();
     auto const grid_size = lb_lbfluid_get_shape();
     Utils::Vector3i pos;
@@ -667,7 +667,7 @@ void lb_lbfluid_print_velocity(const std::string &filename) {
     }
 #endif //  CUDA
   } else {
-    auto constexpr shift = Vector3d{0.5, 0.5, 0.5};
+    auto const shift = Vector3d{{0.5, 0.5, 0.5}};
     auto const agrid = lb_lbfluid_get_agrid();
     auto const grid_size = lb_lbfluid_get_shape();
     auto const lattice_speed = lb_lbfluid_get_lattice_speed();

--- a/src/core/observables/CylindricalLBProfileObservable.hpp
+++ b/src/core/observables/CylindricalLBProfileObservable.hpp
@@ -57,7 +57,7 @@ public:
       auto p_cart = Utils::transform_coordinate_cylinder_to_cartesian(p);
       // We have to rotate the coordinates since the utils function assumes
       // z-axis symmetry.
-      constexpr Utils::Vector3d z_axis{{0.0, 0.0, 1.0}};
+      auto const z_axis = Utils::Vector3d{{0.0, 0.0, 1.0}};
       auto const theta = Utils::angle_between(z_axis, transform_params->axis());
       auto const rot_axis =
           Utils::vector_product(z_axis, transform_params->axis()).normalize();

--- a/src/python/espressomd/accumulators.py
+++ b/src/python/espressomd/accumulators.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from .script_interface import ScriptObjectRegistry, ScriptInterfaceHelper, script_interface_register
+from .script_interface import ScriptObjectList, ScriptInterfaceHelper, script_interface_register
 import numpy as np
 
 
@@ -299,7 +299,7 @@ class Correlator(ScriptInterfaceHelper):
 
 
 @script_interface_register
-class AutoUpdateAccumulators(ScriptObjectRegistry):
+class AutoUpdateAccumulators(ScriptObjectList):
 
     """
     Class for handling the auto-update of accumulators used by

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -120,12 +120,12 @@ cdef class CellSystem:
         return s
 
     def __getstate__(self):
-        s = {"use_verlet_list": cell_structure.use_verlet_list}
+        s = {"use_verlet_lists": type(True)(cell_structure.use_verlet_list)}
 
         if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_REGULAR:
             s["type"] = "regular_decomposition"
         if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_NSQUARE:
-            s["type"] = "nsquare"
+            s["type"] = "n_square"
         if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_HYBRID:
             s["type"] = "hybrid_decomposition"
 
@@ -139,12 +139,12 @@ cdef class CellSystem:
         if 'type' in d:
             if d['type'] == "regular_decomposition":
                 self.set_regular_decomposition(
-                    use_verlet_lists=d['use_verlet_list'])
-            elif d['type'] == "nsquare":
-                self.set_n_square(use_verlet_lists=d['use_verlet_list'])
+                    use_verlet_lists=d['use_verlet_lists'])
+            elif d['type'] == "n_square":
+                self.set_n_square(use_verlet_lists=d['use_verlet_lists'])
             elif d['type'] == "hybrid_decomposition":
                 self.set_hybrid_decomposition(
-                    use_verlet_lists=d['use_verlet_list'])
+                    use_verlet_lists=d['use_verlet_lists'])
 
     def get_pairs(self, distance, types='all'):
         """

--- a/src/python/espressomd/cellsystem.pyx
+++ b/src/python/espressomd/cellsystem.pyx
@@ -89,62 +89,58 @@ cdef class CellSystem:
         return True
 
     def get_state(self):
-        s = self.__getstate__()
+        state = self.__getstate__()
 
         if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_REGULAR:
             rd = get_regular_decomposition()
-            s["cell_grid"] = np.array(
+            state["cell_grid"] = np.array(
                 [rd.cell_grid[0], rd.cell_grid[1], rd.cell_grid[2]])
-            s["cell_size"] = np.array(
+            state["cell_size"] = np.array(
                 [rd.cell_size[0], rd.cell_size[1], rd.cell_size[2]])
         elif cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_HYBRID:
             hd = get_hybrid_decomposition()
             cell_grid = hd.get_cell_grid()
             cell_size = hd.get_cell_size()
-            s["cell_grid"] = np.array([cell_grid[d] for d in range(3)])
-            s["cell_size"] = np.array([cell_size[d] for d in range(3)])
-            s["n_square_types"] = hd.get_n_square_types()
-            s["cutoff_regular"] = hd.get_cutoff_regular()
+            state["cell_grid"] = np.array([cell_grid[d] for d in range(3)])
+            state["cell_size"] = np.array([cell_size[d] for d in range(3)])
             # manually trigger resort to make sure that particles end up
             # in their respective child decomposition before querying
             self.resort()
             n_regular, n_n_square = hybrid_parts_per_decomposition()
-            s["parts_per_decomposition"] = {
+            state["parts_per_decomposition"] = {
                 "regular": n_regular,
                 "n_square": n_n_square
             }
 
-        s["verlet_reuse"] = get_verlet_reuse()
-        s["n_nodes"] = n_nodes
+        state["verlet_reuse"] = get_verlet_reuse()
+        state["n_nodes"] = n_nodes
 
-        return s
+        return state
 
     def __getstate__(self):
-        s = {"use_verlet_lists": type(True)(cell_structure.use_verlet_list)}
+        state = {
+            "use_verlet_lists": type(True)(cell_structure.use_verlet_list),
+            "skin": self.skin, "node_grid": self.node_grid
+        }
 
         if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_REGULAR:
-            s["type"] = "regular_decomposition"
+            state["type"] = "regular_decomposition"
         if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_NSQUARE:
-            s["type"] = "n_square"
+            state["type"] = "n_square"
         if cell_structure.decomposition_type() == CellStructureType.CELL_STRUCTURE_HYBRID:
-            s["type"] = "hybrid_decomposition"
+            state["type"] = "hybrid_decomposition"
+            hd = get_hybrid_decomposition()
+            state["n_square_types"] = hd.get_n_square_types()
+            state["cutoff_regular"] = hd.get_cutoff_regular()
 
-        s["skin"] = skin
-        s["node_grid"] = np.array([node_grid[0], node_grid[1], node_grid[2]])
-        return s
+        return state
 
-    def __setstate__(self, d):
-        self.skin = d['skin']
-        self.node_grid = d['node_grid']
-        if 'type' in d:
-            if d['type'] == "regular_decomposition":
-                self.set_regular_decomposition(
-                    use_verlet_lists=d['use_verlet_lists'])
-            elif d['type'] == "n_square":
-                self.set_n_square(use_verlet_lists=d['use_verlet_lists'])
-            elif d['type'] == "hybrid_decomposition":
-                self.set_hybrid_decomposition(
-                    use_verlet_lists=d['use_verlet_lists'])
+    def __setstate__(self, state):
+        self.skin = state.pop("skin")
+        self.node_grid = state.pop("node_grid")
+        if "type" in state:
+            setter = getattr(self, f"set_{state.pop('type')}")
+            setter(**state)
 
     def get_pairs(self, distance, types='all'):
         """

--- a/src/python/espressomd/constraints.py
+++ b/src/python/espressomd/constraints.py
@@ -14,13 +14,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from .script_interface import ScriptObjectRegistry, ScriptInterfaceHelper, script_interface_register
+from .script_interface import ScriptObjectList, ScriptInterfaceHelper, script_interface_register
 import numpy as np
 import itertools
 
 
 @script_interface_register
-class Constraints(ScriptObjectRegistry):
+class Constraints(ScriptObjectList):
 
     """
     List of active constraints. Add a :class:`espressomd.constraints.Constraint`

--- a/src/python/espressomd/lbboundaries.py
+++ b/src/python/espressomd/lbboundaries.py
@@ -14,13 +14,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from .script_interface import ScriptObjectRegistry, ScriptInterfaceHelper, script_interface_register
+from .script_interface import ScriptObjectList, ScriptInterfaceHelper, script_interface_register
 from .__init__ import has_features
 
 
 if any(has_features(i) for i in ["LB_BOUNDARIES", "LB_BOUNDARIES_GPU"]):
     @script_interface_register
-    class LBBoundaries(ScriptObjectRegistry):
+    class LBBoundaries(ScriptObjectList):
 
         """
         Creates a set of lattice-Boltzmann boundaries.

--- a/src/python/espressomd/shapes.py
+++ b/src/python/espressomd/shapes.py
@@ -17,7 +17,7 @@
 
 import collections.abc
 
-from .script_interface import ScriptInterfaceHelper, script_interface_register, ScriptObjectRegistry
+from .script_interface import ScriptInterfaceHelper, script_interface_register, ScriptObjectList
 
 
 class Shape:
@@ -254,7 +254,7 @@ class HollowConicalFrustum(Shape, ScriptInterfaceHelper):
 
 
 @script_interface_register
-class Union(Shape, ScriptObjectRegistry):
+class Union(Shape, ScriptObjectList):
     """A union of shapes.
 
     This shape represents a union of shapes where the distance to the union

--- a/src/script_interface/accumulators/AutoUpdateAccumulators.hpp
+++ b/src/script_interface/accumulators/AutoUpdateAccumulators.hpp
@@ -37,6 +37,11 @@ class AutoUpdateAccumulators : public ObjectList<AccumulatorBase> {
   remove_in_core(std::shared_ptr<AccumulatorBase> const &obj_ptr) override {
     ::Accumulators::auto_update_remove(obj_ptr->accumulator().get());
   }
+
+private:
+  // disable serialization: pickling done by the python interface
+  std::string get_internal_state() const override { return {}; }
+  void set_internal_state(std::string const &state) override {}
 };
 } /* namespace Accumulators */
 } /* namespace ScriptInterface */

--- a/src/script_interface/constraints/Constraints.hpp
+++ b/src/script_interface/constraints/Constraints.hpp
@@ -38,6 +38,11 @@ class Constraints : public ObjectList<Constraint> {
   void remove_in_core(std::shared_ptr<Constraint> const &obj_ptr) override {
     ::Constraints::constraints.remove(obj_ptr->constraint());
   }
+
+private:
+  // disable serialization: pickling done by the python interface
+  std::string get_internal_state() const override { return {}; }
+  void set_internal_state(std::string const &state) override {}
 };
 } /* namespace Constraints */
 } /* namespace ScriptInterface */

--- a/src/script_interface/interactions/BondedInteractions.hpp
+++ b/src/script_interface/interactions/BondedInteractions.hpp
@@ -100,7 +100,7 @@ public:
   }
 
 private:
-  // disable serialization: bonded interactions have their own pickling logic
+  // disable serialization: pickling done by the python interface
   std::string get_internal_state() const override { return {}; }
   void set_internal_state(std::string const &state) override {}
   container_type m_bonds;

--- a/src/script_interface/lbboundaries/LBBoundaries.hpp
+++ b/src/script_interface/lbboundaries/LBBoundaries.hpp
@@ -43,6 +43,11 @@ class LBBoundaries : public ObjectList<LBBoundary> {
     ::LBBoundaries::remove(obj_ptr->lbboundary());
 #endif
   }
+
+private:
+  // disable serialization: pickling done by the python interface
+  std::string get_internal_state() const override { return {}; }
+  void set_internal_state(std::string const &state) override {}
 };
 } /* namespace LBBoundaries */
 } /* namespace ScriptInterface */

--- a/src/script_interface/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/script_interface/reaction_methods/ReactionAlgorithm.hpp
@@ -149,6 +149,10 @@ private:
     m_reactions.erase(m_reactions.begin() + reaction_id);
     RE()->delete_reaction(reaction_id);
   }
+
+  std::string get_internal_state() const override {
+    throw std::runtime_error("Reaction methods do not support checkpointing");
+  }
 };
 } /* namespace ReactionMethods */
 } /* namespace ScriptInterface */

--- a/testsuite/python/cellsystem.py
+++ b/testsuite/python/cellsystem.py
@@ -29,17 +29,17 @@ class CellSystem(ut.TestCase):
     def test_cell_system(self):
         self.system.cell_system.set_n_square(use_verlet_lists=False)
         s = self.system.cell_system.get_state()
-        self.assertEqual([s['use_verlet_list'], s['type']], [0, "nsquare"])
+        self.assertEqual([s['use_verlet_lists'], s['type']], [0, "n_square"])
         self.system.cell_system.set_regular_decomposition(
             use_verlet_lists=True)
         s = self.system.cell_system.get_state()
         self.assertEqual(
-            [s['use_verlet_list'], s['type']], [1, "regular_decomposition"])
+            [s['use_verlet_lists'], s['type']], [1, "regular_decomposition"])
         self.system.cell_system.set_hybrid_decomposition(
             use_verlet_lists=False, n_square_types={1, 3, 5}, cutoff_regular=1.27)
         s = self.system.cell_system.get_state()
         self.assertEqual(
-            [s['use_verlet_list'], s['type'],
+            [s['use_verlet_lists'], s['type'],
                 s['n_square_types'], s['cutoff_regular']],
             [0, "hybrid_decomposition", {1, 3, 5}, 1.27])
 

--- a/testsuite/python/cellsystem.py
+++ b/testsuite/python/cellsystem.py
@@ -19,6 +19,7 @@
 import unittest as ut
 import espressomd
 import numpy as np
+import tests_common
 
 
 class CellSystem(ut.TestCase):
@@ -27,21 +28,21 @@ class CellSystem(ut.TestCase):
     n_nodes = system.cell_system.get_state()['n_nodes']
 
     def test_cell_system(self):
-        self.system.cell_system.set_n_square(use_verlet_lists=False)
-        s = self.system.cell_system.get_state()
-        self.assertEqual([s['use_verlet_lists'], s['type']], [0, "n_square"])
-        self.system.cell_system.set_regular_decomposition(
-            use_verlet_lists=True)
-        s = self.system.cell_system.get_state()
-        self.assertEqual(
-            [s['use_verlet_lists'], s['type']], [1, "regular_decomposition"])
-        self.system.cell_system.set_hybrid_decomposition(
-            use_verlet_lists=False, n_square_types={1, 3, 5}, cutoff_regular=1.27)
-        s = self.system.cell_system.get_state()
-        self.assertEqual(
-            [s['use_verlet_lists'], s['type'],
-                s['n_square_types'], s['cutoff_regular']],
-            [0, "hybrid_decomposition", {1, 3, 5}, 1.27])
+        parameters = {
+            "n_square": {"use_verlet_lists": False},
+            "regular_decomposition": {"use_verlet_lists": True},
+            "hybrid_decomposition": {"use_verlet_lists": False,
+                                     "n_square_types": {1, 3, 5},
+                                     "cutoff_regular": 1.27},
+        }
+        for cell_system, params_in in parameters.items():
+            setter = getattr(self.system.cell_system, f"set_{cell_system}")
+            setter(**params_in)
+            params_in["type"] = cell_system
+            params_out = self.system.cell_system.get_state()
+            tests_common.assert_params_match(self, params_in, params_out)
+            params_out = self.system.cell_system.__getstate__()
+            tests_common.assert_params_match(self, params_in, params_out)
 
     @ut.skipIf(n_nodes == 1, "Skipping test: only runs for n_nodes >= 2")
     def check_node_grid(self):

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -73,7 +73,7 @@ if lbf_actor:
     system.actors.add(lbf)
     if 'THERM.LB' in modes:
         system.thermostat.set_lb(LB_fluid=lbf, seed=23, gamma=2.0)
-    if n_nodes == 1 and (espressomd.has_features(
+    if (espressomd.has_features(
             "LB_BOUNDARIES") or espressomd.has_features("LB_BOUNDARIES_GPU")):
         system.lbboundaries.add(espressomd.lbboundaries.LBBoundary(
             shape=espressomd.shapes.Wall(normal=(1, 0, 0), dist=0.5), velocity=(1e-4, 1e-4, 0)))
@@ -138,37 +138,40 @@ acc_mean_variance.update()
 acc_time_series.update()
 acc_correlator.update()
 
-if n_nodes == 1:
-    system.auto_update_accumulators.add(acc_mean_variance)
-    system.auto_update_accumulators.add(acc_time_series)
-    system.auto_update_accumulators.add(acc_correlator)
+system.auto_update_accumulators.add(acc_mean_variance)
+system.auto_update_accumulators.add(acc_time_series)
+system.auto_update_accumulators.add(acc_correlator)
 
 # constraints
+system.constraints.add(shape=espressomd.shapes.Sphere(center=system.box_l / 2, radius=0.1),
+                       particle_type=17)
+system.constraints.add(
+    shape=espressomd.shapes.Wall(
+        normal=[1. / np.sqrt(3)] * 3, dist=0.5))
+system.constraints.add(espressomd.constraints.Gravity(g=[1., 2., 3.]))
+system.constraints.add(
+    espressomd.constraints.HomogeneousMagneticField(H=[1., 2., 3.]))
+system.constraints.add(
+    espressomd.constraints.HomogeneousFlowField(u=[1., 2., 3.], gamma=2.3))
+pot_field_data = espressomd.constraints.ElectricPotential.field_from_fn(
+    system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
+checkpoint.register("pot_field_data")
+system.constraints.add(espressomd.constraints.PotentialField(
+    field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6,
+    particle_scales={5: 6.0}))
+vec_field_data = espressomd.constraints.ForceField.field_from_fn(
+    system.box_l, np.ones(3), lambda x: 10 * np.ones(3) - x)
+checkpoint.register("vec_field_data")
+system.constraints.add(espressomd.constraints.ForceField(
+    field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4))
+union = espressomd.shapes.Union()
+union.add([espressomd.shapes.Wall(normal=[1., 0., 0.], dist=0.5),
+           espressomd.shapes.Wall(normal=[0., 1., 0.], dist=1.5)])
 if n_nodes == 1:
-    system.constraints.add(shape=espressomd.shapes.Sphere(center=system.box_l / 2, radius=0.1),
-                           particle_type=17)
-    system.constraints.add(
-        shape=espressomd.shapes.Wall(
-            normal=[1. / np.sqrt(3)] * 3, dist=0.5))
-    system.constraints.add(espressomd.constraints.Gravity(g=[1., 2., 3.]))
-    system.constraints.add(
-        espressomd.constraints.HomogeneousMagneticField(H=[1., 2., 3.]))
-    system.constraints.add(
-        espressomd.constraints.HomogeneousFlowField(u=[1., 2., 3.], gamma=2.3))
-    pot_field_data = espressomd.constraints.ElectricPotential.field_from_fn(
-        system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
-    checkpoint.register("pot_field_data")
-    system.constraints.add(espressomd.constraints.PotentialField(
-        field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6,
-        particle_scales={5: 6.0}))
-    vec_field_data = espressomd.constraints.ForceField.field_from_fn(
-        system.box_l, np.ones(3), lambda x: 10 * np.ones(3) - x)
-    checkpoint.register("vec_field_data")
-    system.constraints.add(espressomd.constraints.ForceField(
-        field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4))
-    if espressomd.has_features("ELECTROSTATICS"):
-        system.constraints.add(espressomd.constraints.ElectricPlaneWave(
-            E0=[1., -2., 3.], k=[-.1, .2, .3], omega=5., phi=1.4))
+    system.constraints.add(shape=union, particle_type=2)
+if espressomd.has_features("ELECTROSTATICS"):
+    system.constraints.add(espressomd.constraints.ElectricPlaneWave(
+        E0=[1., -2., 3.], k=[-.1, .2, .3], omega=5., phi=1.4))
 
 if 'LB' not in modes:
     # set thermostat

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -34,6 +34,7 @@ import espressomd.lbboundaries
 import espressomd.shapes
 import espressomd.constraints
 import espressomd.bond_breakage
+import espressomd.reaction_methods
 
 config = utg.TestGenerator()
 modes = config.get_modes()
@@ -385,6 +386,11 @@ class TestCheckpoint(ut.TestCase):
             # write checkpoint file with different box dimensions
             with open(cpt_path.format("-wrong-boxdim"), "wb") as f:
                 f.write(b"2" + boxsize + b"\n" + data)
+
+    def test_reaction_methods_sanity_check(self):
+        with self.assertRaisesRegex(RuntimeError, "Reaction methods do not support checkpointing"):
+            widom = espressomd.reaction_methods.WidomInsertion(kT=1, seed=1)
+            widom._serialize()
 
 
 if __name__ == '__main__':

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -130,7 +130,7 @@ class CheckpointTest(ut.TestCase):
 
     def test_system_variables(self):
         cell_system_params = system.cell_system.get_state()
-        self.assertTrue(cell_system_params['use_verlet_list'])
+        self.assertTrue(cell_system_params['use_verlet_lists'])
         self.assertAlmostEqual(system.cell_system.skin, 0.1, delta=1E-10)
         self.assertAlmostEqual(system.time_step, 0.01, delta=1E-10)
         self.assertAlmostEqual(system.time, 1.5, delta=1E-10)


### PR DESCRIPTION
Description of changes:
- Intel 19.0.x  compiler errors in the LB code were addressed (reported by @pm-blanco)
- reaction methods now generate a clear error message when an attempt is made to checkpoint them (reported by @mebrito)
- the cell system now properly serializes its state during checkpointing, including the `HybridDecomposition` cell system
- restore checkpointing of constraints, LB boundaries and auto-update accumulators when using 2 or more MPI ranks