### PR TITLE
Cell system refactor

### DIFF
--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -187,8 +187,8 @@ Example::
     le_protocol = espressomd.lees_edwards.LinearShear(
         shear_velocity=-0.1, initial_pos_offset=0.0, time_0=-0.1)
     system.lees_edwards.set_boundary_conditions(
-        shear_direction=1, # shear along y-axis
-        shear_plane_normal=0, # shear when crossing the x-boundary
+        shear_direction="y", # shear along y-axis
+        shear_plane_normal="x", # shift when crossing the x-boundary
         protocol=le_protocol)
     p = system.part.add(pos=[4.9, 0.0, 0.0], v=[0.1, 0.0, 0.0])
     system.integrator.run(20)

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -186,9 +186,10 @@ Example::
     system.cell_system.set_n_square(use_verlet_lists=True)
     le_protocol = espressomd.lees_edwards.LinearShear(
         shear_velocity=-0.1, initial_pos_offset=0.0, time_0=-0.1)
-    system.lees_edwards.protocol = le_protocol
-    system.lees_edwards.shear_direction = 1 # shear along y-axis
-    system.lees_edwards.shear_plane_normal = 0 # shear when crossing the x-boundary
+    system.lees_edwards.set_boundary_conditions(
+        shear_direction=1, # shear along y-axis
+        shear_plane_normal=0, # shear when crossing the x-boundary
+        protocol=le_protocol)
     p = system.part.add(pos=[4.9, 0.0, 0.0], v=[0.1, 0.0, 0.0])
     system.integrator.run(20)
     print(f"pos        = {p.pos}")
@@ -209,6 +210,14 @@ Particles inserted outside the box boundaries will be wrapped around
 using the normal periodic boundary rules, i.e. they will not be sheared,
 even though their :attr:`~espressomd.particle_data.ParticleHandle.image_box`
 is *not* zero.
+
+Once a valid tuple ``(shear_direction, shear_plane_normal, protocol)`` has been
+set via :meth:`~espressomd.lees_edwards.LeesEdwards.set_boundary_conditions`,
+one can update the protocol via a simple assignment of the form
+``system.lees_edwards.protocol = new_le_protocol``, in which case
+the shear direction and shear normal are left unchanged. The method
+:meth:`~espressomd.lees_edwards.LeesEdwards.set_boundary_conditions`
+is the only way to modify the shear direction and shear normal.
 
 
 .. _Cell systems:

--- a/samples/h5md_trajectory.py
+++ b/samples/h5md_trajectory.py
@@ -37,7 +37,7 @@ system = espressomd.System(box_l=[6, 7, 8], periodicity=[True, True, False])
 system.time_step = 0.1
 system.cell_system.skin = 0.0
 system.lees_edwards.set_boundary_conditions(
-    shear_direction=0, shear_plane_normal=1,
+    shear_direction="x", shear_plane_normal="y",
     protocol=espressomd.lees_edwards.Off())
 for i in range(12):
     p = system.part.add(pos=3 * [float(i - 4)], v=[0., 1., 0.])

--- a/samples/h5md_trajectory.py
+++ b/samples/h5md_trajectory.py
@@ -36,8 +36,9 @@ import tempfile
 system = espressomd.System(box_l=[6, 7, 8], periodicity=[True, True, False])
 system.time_step = 0.1
 system.cell_system.skin = 0.0
-system.lees_edwards.shear_direction = 0
-system.lees_edwards.shear_plane_normal = 1
+system.lees_edwards.set_boundary_conditions(
+    shear_direction=0, shear_plane_normal=1,
+    protocol=espressomd.lees_edwards.Off())
 for i in range(12):
     p = system.part.add(pos=3 * [float(i - 4)], v=[0., 1., 0.])
 

--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -198,9 +198,18 @@ public:
   BoxType type() const { return m_type; }
   void set_type(BoxType type) { m_type = type; }
 
-  LeesEdwardsBC &lees_edwards_bc() { return m_lees_edwards_bc; }
   LeesEdwardsBC const &lees_edwards_bc() const { return m_lees_edwards_bc; }
   void set_lees_edwards_bc(LeesEdwardsBC bc) { m_lees_edwards_bc = bc; }
+
+  /**
+   * @brief Update the Lees-Edwards parameters of the box geometry
+   * for the current simulation time.
+   */
+  void lees_edwards_update(double pos_offset, double shear_velocity) {
+    assert(type() == BoxType::LEES_EDWARDS);
+    m_lees_edwards_bc.pos_offset = pos_offset;
+    m_lees_edwards_bc.shear_velocity = shear_velocity;
+  }
 
   /** Calculate the velocity difference including the Lees-Edwards velocity */
   Utils::Vector3d velocity_difference(Utils::Vector3d const &x,

--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -240,6 +240,7 @@ inline std::pair<double, int> fold_coordinate(double pos, int image_box,
 }
 
 /** @brief Fold particle coordinates to primary simulation box.
+ *  Lees-Edwards offset is ignored.
  *  @param[in,out] pos        coordinate to fold
  *  @param[in,out] image_box  image box offset
  *  @param[in] box            box parameters (side lengths, periodicity)

--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -162,7 +162,7 @@ struct ParticleProperties {
    */
   struct VirtualSitesRelativeParameters {
     int to_particle_id = 0;
-    double distance = 0;
+    double distance = 0.;
     /** Relative position of the virtual site. */
     Utils::Quaternion<double> rel_orientation =
         Utils::Quaternion<double>::identity();
@@ -197,10 +197,10 @@ struct ParticleProperties {
 
 #ifdef EXTERNAL_FORCES
   /** External force. */
-  Utils::Vector3d ext_force = {0, 0, 0};
+  Utils::Vector3d ext_force = {0., 0., 0.};
 #ifdef ROTATION
   /** External torque. */
-  Utils::Vector3d ext_torque = {0, 0, 0};
+  Utils::Vector3d ext_torque = {0., 0., 0.};
 #endif // ROTATION
 #endif // EXTERNAL_FORCES
 
@@ -264,7 +264,7 @@ struct ParticleProperties {
  */
 struct ParticlePosition {
   /** periodically folded position. */
-  Utils::Vector3d p = {0, 0, 0};
+  Utils::Vector3d p = {0., 0., 0.};
 
 #ifdef ROTATION
   /** quaternion to define particle orientation */
@@ -272,7 +272,7 @@ struct ParticlePosition {
   /** unit director calculated from the quaternion */
   Utils::Vector3d calc_director() const {
     return Utils::convert_quaternion_to_director(quat);
-  };
+  }
 #endif
 
 #ifdef BOND_CONSTRAINT
@@ -366,7 +366,7 @@ struct ParticleLocal {
   /** index of the simulation box image where the particle really sits. */
   Utils::Vector3i i = {0, 0, 0};
   /** position from the last Verlet list update. */
-  Utils::Vector3d p_old = {0, 0, 0};
+  Utils::Vector3d p_old = {0., 0., 0.};
   /** Accumulated applied Lees-Edwards offset. */
   double lees_edwards_offset = 0.;
 
@@ -382,7 +382,7 @@ struct ParticleLocal {
 #ifdef BOND_CONSTRAINT
 struct ParticleRattle {
   /** position/velocity correction */
-  Utils::Vector3d correction = {0, 0, 0};
+  Utils::Vector3d correction = {0., 0., 0.};
 
   friend ParticleRattle operator+(ParticleRattle const &lhs,
                                   ParticleRattle const &rhs) {
@@ -401,36 +401,23 @@ struct ParticleRattle {
 
 /** Struct holding all information for one particle. */
 struct Particle { // NOLINT(bugprone-exception-escape)
-  int &identity() { return p.identity; }
-  int const &identity() const { return p.identity; }
-
-  bool operator==(Particle const &rhs) const {
-    return identity() == rhs.identity();
-  }
-
-  bool operator!=(Particle const &rhs) const {
-    return identity() != rhs.identity();
-  }
-
   ///
   ParticleProperties p;
   ///
   ParticlePosition r;
-#ifdef DIPOLES
-  Utils::Vector3d calc_dip() const { return r.calc_director() * p.dipm; }
-#endif
   ///
   ParticleMomentum m;
   ///
   ParticleForce f;
   ///
   ParticleLocal l;
+
+private:
 #ifdef BOND_CONSTRAINT
   ///
   ParticleRattle rattle;
 #endif
 
-private:
   BondList bl;
 
 #ifdef EXCLUSIONS
@@ -447,6 +434,10 @@ public:
   auto &mol_id() { return p.mol_id; }
   auto const &type() const { return p.type; }
   auto &type() { return p.type; }
+
+  bool operator==(Particle const &rhs) const { return id() == rhs.id(); }
+
+  bool operator!=(Particle const &rhs) const { return id() != rhs.id(); }
 
   auto const &bonds() const { return bl; }
   auto &bonds() { return bl; }
@@ -476,6 +467,7 @@ public:
   constexpr auto &mass() const { return p.mass; }
 #endif
 #ifdef ROTATION
+  auto rotation() const { return p.rotation; }
   bool can_rotate() const { return static_cast<bool>(p.rotation); }
   bool can_rotate_around(int const axis) const {
     detail::check_axis_idx_valid(axis);
@@ -509,6 +501,7 @@ public:
 #ifdef DIPOLES
   auto const &dipm() const { return p.dipm; }
   auto &dipm() { return p.dipm; }
+  auto calc_dip() const { return calc_director() * dipm(); }
 #endif
 #ifdef ROTATIONAL_INERTIA
   auto const &rinertia() const { return p.rinertia; }

--- a/src/core/bond_breakage/bond_breakage.cpp
+++ b/src/core/bond_breakage/bond_breakage.cpp
@@ -127,10 +127,10 @@ ActionSet actions_for_breakage(QueueEntry const &e) {
     // between which the bond broke.
     auto p1 = cell_structure.get_local_particle(e.particle_id);
     auto p2 = cell_structure.get_local_particle(e.bond_partner_id);
-    if (!p1 || !p2)
+    if (not p1 or not p2)
       return {}; // particles not on this mpi rank
 
-    if (!p1->p.is_virtual || !p2->p.is_virtual) {
+    if (not p1->is_virtual() or not p2->is_virtual()) {
       runtimeErrorMsg() << "The REVERT_BIND_AT_POINT_OF_COLLISION bond "
                            "breakage action has to be configured for the "
                            "bond on the virtual site. Encountered a particle "
@@ -143,10 +143,10 @@ ActionSet actions_for_breakage(QueueEntry const &e) {
         DeleteBond{e.particle_id, e.bond_partner_id, e.bond_type},
         // Bond between base particles. We do not know, on which of the two
         // the bond is defined, since bonds are stored only on one partner
-        DeleteAllBonds{p1->p.vs_relative.to_particle_id,
-                       p2->p.vs_relative.to_particle_id},
-        DeleteAllBonds{p2->p.vs_relative.to_particle_id,
-                       p1->p.vs_relative.to_particle_id},
+        DeleteAllBonds{p1->vs_relative().to_particle_id,
+                       p2->vs_relative().to_particle_id},
+        DeleteAllBonds{p2->vs_relative().to_particle_id,
+                       p1->vs_relative().to_particle_id},
     };
   }
 #endif // VIRTUAL_SITES_RELATIVE

--- a/src/core/bonded_interactions/bonded_interaction_utils.hpp
+++ b/src/core/bonded_interactions/bonded_interaction_utils.hpp
@@ -38,7 +38,7 @@ template <typename BondType>
 inline bool pair_bond_enum_exists_on(Particle const &p,
                                      Particle const &p_partner) {
   return boost::algorithm::any_of(
-      p.bonds(), [partner_id = p_partner.identity()](BondView const &bond) {
+      p.bonds(), [partner_id = p_partner.id()](BondView const &bond) {
         auto const &bond_ptr = bonded_ia_params.at(bond.bond_id());
         return (boost::get<BondType>(bond_ptr.get()) != nullptr) and
                (bond.partner_ids()[0] == partner_id);

--- a/src/core/bonded_interactions/thermalized_bond_kernel.hpp
+++ b/src/core/bonded_interactions/thermalized_bond_kernel.hpp
@@ -49,19 +49,19 @@ ThermalizedBond::forces(Particle const &p1, Particle const &p2,
     return {};
   }
 
-  auto const mass_tot = p1.p.mass + p2.p.mass;
+  auto const mass_tot = p1.mass() + p2.mass();
   auto const mass_tot_inv = 1.0 / mass_tot;
   auto const sqrt_mass_tot = sqrt(mass_tot);
-  auto const sqrt_mass_red = sqrt(p1.p.mass * p2.p.mass / mass_tot);
-  auto const com_vel = mass_tot_inv * (p1.p.mass * p1.m.v + p2.p.mass * p2.m.v);
-  auto const dist_vel = p2.m.v - p1.m.v;
+  auto const sqrt_mass_red = sqrt(p1.mass() * p2.mass() / mass_tot);
+  auto const com_vel = mass_tot_inv * (p1.mass() * p1.v() + p2.mass() * p2.v());
+  auto const dist_vel = p2.v() - p1.v();
 
   extern ThermalizedBondThermostat thermalized_bond;
   Utils::Vector3d force1{};
   Utils::Vector3d force2{};
   auto const noise = Random::noise_uniform<RNGSalt::THERMALIZED_BOND>(
-      thermalized_bond.rng_counter(), thermalized_bond.rng_seed(),
-      p1.p.identity, p2.p.identity);
+      thermalized_bond.rng_counter(), thermalized_bond.rng_seed(), p1.id(),
+      p2.id());
 
   for (int i = 0; i < 3; i++) {
     double force_lv_com, force_lv_dist;
@@ -82,8 +82,8 @@ ThermalizedBond::forces(Particle const &p1, Particle const &p2,
       force_lv_dist = -pref1_dist * dist_vel[i];
     }
     // Add forces
-    force1[i] = p1.p.mass * mass_tot_inv * force_lv_com - force_lv_dist;
-    force2[i] = p2.p.mass * mass_tot_inv * force_lv_com + force_lv_dist;
+    force1[i] = p1.mass() * mass_tot_inv * force_lv_com - force_lv_dist;
+    force2[i] = p2.mass() * mass_tot_inv * force_lv_com + force_lv_dist;
   }
 
   return std::make_tuple(force1, force2);

--- a/src/core/cell_system/AtomDecomposition.cpp
+++ b/src/core/cell_system/AtomDecomposition.cpp
@@ -116,9 +116,9 @@ void AtomDecomposition::resort(bool global_flag,
   std::vector<std::vector<Particle>> send_buf(m_comm.size());
   for (auto it = local().particles().begin();
        it != local().particles().end();) {
-    auto const target_node = id_to_rank(it->identity());
+    auto const target_node = id_to_rank(it->id());
     if (target_node != m_comm.rank()) {
-      diff.emplace_back(RemovedParticle{it->identity()});
+      diff.emplace_back(RemovedParticle{it->id()});
       send_buf.at(target_node).emplace_back(std::move(*it));
       it = local().particles().erase(it);
     } else {

--- a/src/core/cell_system/AtomDecomposition.cpp
+++ b/src/core/cell_system/AtomDecomposition.cpp
@@ -139,6 +139,9 @@ void AtomDecomposition::resort(bool global_flag,
   }
 }
 
+AtomDecomposition::AtomDecomposition(BoxGeometry const &box_geo)
+    : m_box(box_geo) {}
+
 AtomDecomposition::AtomDecomposition(const boost::mpi::communicator &comm,
                                      BoxGeometry const &box_geo)
     : comm(comm), cells(comm.size()), m_box(box_geo) {

--- a/src/core/cell_system/AtomDecomposition.hpp
+++ b/src/core/cell_system/AtomDecomposition.hpp
@@ -96,7 +96,7 @@ public:
    * @return Pointer to cell or nullptr if not local.
    */
   Cell *particle_to_cell(Particle const &p) override {
-    return id_to_cell(p.identity());
+    return id_to_cell(p.id());
   }
 
   Utils::Vector3d max_cutoff() const override;

--- a/src/core/cell_system/AtomDecomposition.hpp
+++ b/src/core/cell_system/AtomDecomposition.hpp
@@ -61,10 +61,10 @@ class AtomDecomposition : public ParticleDecomposition {
   GhostCommunicator m_exchange_ghosts_comm;
   GhostCommunicator m_collect_ghost_force_comm;
 
-  BoxGeometry m_box;
+  BoxGeometry const &m_box;
 
 public:
-  AtomDecomposition() = default;
+  AtomDecomposition(BoxGeometry const &m_box);
   AtomDecomposition(boost::mpi::communicator const &comm,
                     BoxGeometry const &box_geo);
 
@@ -109,7 +109,7 @@ public:
     return m_box;
   }
 
-  BoxGeometry box() const override { return m_box; };
+  BoxGeometry const &box() const override { return m_box; };
 
 private:
   /**

--- a/src/core/cell_system/AtomDecomposition.hpp
+++ b/src/core/cell_system/AtomDecomposition.hpp
@@ -52,7 +52,7 @@
  * For a more detailed discussion please see @cite plimpton95a.
  */
 class AtomDecomposition : public ParticleDecomposition {
-  boost::mpi::communicator comm;
+  boost::mpi::communicator m_comm;
   std::vector<Cell> cells;
 
   std::vector<Cell *> m_local_cells;
@@ -65,8 +65,7 @@ class AtomDecomposition : public ParticleDecomposition {
 
 public:
   AtomDecomposition(BoxGeometry const &m_box);
-  AtomDecomposition(boost::mpi::communicator const &comm,
-                    BoxGeometry const &box_geo);
+  AtomDecomposition(boost::mpi::communicator comm, BoxGeometry const &box_geo);
 
   void resort(bool global_flag, std::vector<ParticleChange> &diff) override;
 
@@ -75,7 +74,7 @@ public:
   }
   GhostCommunicator const &collect_ghost_force_comm() const override {
     return m_collect_ghost_force_comm;
-  };
+  }
 
   Utils::Span<Cell *> local_cells() override {
     return Utils::make_span(m_local_cells);
@@ -118,13 +117,14 @@ private:
    * @return Cell for id.
    */
   Cell *id_to_cell(int id) {
-    return (id_to_rank(id) == comm.rank()) ? std::addressof(local()) : nullptr;
+    return (id_to_rank(id) == m_comm.rank()) ? std::addressof(local())
+                                             : nullptr;
   }
 
   /**
    * @brief Get the local cell.
    */
-  Cell &local() { return cells.at(comm.rank()); }
+  Cell &local() { return cells.at(m_comm.rank()); }
 
   void configure_neighbors();
   GhostCommunicator prepare_comm();
@@ -142,7 +142,7 @@ private:
   /**
    * @brief Determine which rank owns a particle id.
    */
-  int id_to_rank(int id) const { return id % comm.size(); }
+  int id_to_rank(int id) const { return id % m_comm.size(); }
 };
 
 #endif

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -44,6 +44,9 @@
 #include <utility>
 #include <vector>
 
+CellStructure::CellStructure(BoxGeometry const &box)
+    : m_decomposition{std::make_unique<AtomDecomposition>(box)} {}
+
 void CellStructure::check_particle_index() {
   auto const max_id = get_max_local_particle_id();
 

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -51,7 +51,7 @@ void CellStructure::check_particle_index() {
   auto const max_id = get_max_local_particle_id();
 
   for (auto const &p : local_particles()) {
-    auto const id = p.identity();
+    auto const id = p.id();
 
     if (id < 0 || id > max_id) {
       throw std::runtime_error("Particle id out of bounds.");
@@ -67,7 +67,7 @@ void CellStructure::check_particle_index() {
   for (int n = 0; n < get_max_local_particle_id() + 1; n++) {
     if (get_local_particle(n) != nullptr) {
       local_part_cnt++;
-      if (get_local_particle(n)->p.identity != n) {
+      if (get_local_particle(n)->id() != n) {
         throw std::runtime_error("local_particles part has corrupted id.");
       }
     }
@@ -85,7 +85,7 @@ void CellStructure::check_particle_sorting() {
     for (auto const &p : cell->particles()) {
       if (particle_to_cell(p) != cell) {
         throw std::runtime_error("misplaced particle with id " +
-                                 std::to_string(p.identity()));
+                                 std::to_string(p.id()));
       }
     }
   }
@@ -110,7 +110,7 @@ void CellStructure::remove_particle(int id) {
     auto &parts = c->particles();
 
     for (auto it = parts.begin(); it != parts.end();) {
-      if (it->identity() == id) {
+      if (it->id() == id) {
         it = parts.erase(it);
         update_particle_index(id, nullptr);
         update_particle_index(parts);
@@ -151,7 +151,7 @@ int CellStructure::get_max_local_particle_id() const {
   auto it = std::find_if(m_particle_index.rbegin(), m_particle_index.rend(),
                          [](const Particle *p) { return p != nullptr; });
 
-  return (it != m_particle_index.rend()) ? (*it)->identity() : -1;
+  return (it != m_particle_index.rend()) ? (*it)->id() : -1;
 }
 
 void CellStructure::remove_all_particles() {

--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -109,7 +109,7 @@ struct Distance {
 };
 namespace detail {
 struct MinimalImageDistance {
-  const BoxGeometry box;
+  BoxGeometry const box;
 
   Distance operator()(Particle const &p1, Particle const &p2) const {
     return Distance(box.get_mi_vector(p1.r.p, p2.r.p));
@@ -512,7 +512,7 @@ private:
 
 public:
   /**
-   * @brief Set the particle decomposition to AtomDecomposition.
+   * @brief Set the particle decomposition to @ref AtomDecomposition.
    *
    * @param comm Communicator to use.
    * @param box Box Geometry.
@@ -523,7 +523,7 @@ public:
                               LocalBox<double> &local_geo);
 
   /**
-   * @brief Set the particle decomposition to RegularDecomposition.
+   * @brief Set the particle decomposition to @ref RegularDecomposition.
    *
    * @param comm Cartesian communicator to use.
    * @param range Interaction range.
@@ -535,7 +535,7 @@ public:
                                  LocalBox<double> &local_geo);
 
   /**
-   * @brief Set the particle decomposition to HybridDecomposition.
+   * @brief Set the particle decomposition to @ref HybridDecomposition.
    *
    * @param comm Communicator to use.
    * @param cutoff_regular Interaction cutoff_regular.

--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -112,13 +112,13 @@ struct MinimalImageDistance {
   BoxGeometry const box;
 
   Distance operator()(Particle const &p1, Particle const &p2) const {
-    return Distance(box.get_mi_vector(p1.r.p, p2.r.p));
+    return Distance(box.get_mi_vector(p1.pos(), p2.pos()));
   }
 };
 
 struct EuclidianDistance {
   Distance operator()(Particle const &p1, Particle const &p2) const {
-    return Distance(p1.r.p - p2.r.p);
+    return Distance(p1.pos() - p2.pos());
   }
 };
 } // namespace detail
@@ -162,7 +162,7 @@ public:
   void update_particle_index(int id, Particle *p) {
     assert(id >= 0);
     // cppcheck-suppress assertWithSideEffect
-    assert(not p or id == p->identity());
+    assert(not p or p->id() == id);
 
     if (id >= m_particle_index.size())
       m_particle_index.resize(id + 1);
@@ -179,7 +179,7 @@ public:
    * @param p Pointer to the particle.
    */
   void update_particle_index(Particle &p) {
-    update_particle_index(p.identity(), std::addressof(p));
+    update_particle_index(p.id(), std::addressof(p));
   }
 
   /**
@@ -189,7 +189,7 @@ public:
    */
   void update_particle_index(ParticleList &pl) {
     for (auto &p : pl) {
-      update_particle_index(p.identity(), std::addressof(p));
+      update_particle_index(p.id(), std::addressof(p));
     }
   }
 
@@ -469,10 +469,10 @@ private:
             handler(p, bond.bond_id(), Utils::make_span(partners));
 
         if (bond_broken) {
-          bond_broken_error(p.identity(), partner_ids);
+          bond_broken_error(p.id(), partner_ids);
         }
       } catch (const BondResolutionError &) {
-        bond_broken_error(p.identity(), partner_ids);
+        bond_broken_error(p.id(), partner_ids);
       }
     }
   }
@@ -483,8 +483,8 @@ private:
    */
   void invalidate_ghosts() {
     for (auto const &p : ghost_particles()) {
-      if (get_local_particle(p.identity()) == &p) {
-        update_particle_index(p.identity(), nullptr);
+      if (get_local_particle(p.id()) == &p) {
+        update_particle_index(p.id(), nullptr);
       }
     }
   }

--- a/src/core/cell_system/HybridDecomposition.cpp
+++ b/src/core/cell_system/HybridDecomposition.cpp
@@ -41,8 +41,8 @@
 
 HybridDecomposition::HybridDecomposition(boost::mpi::communicator comm,
                                          double cutoff_regular,
-                                         const BoxGeometry &box_geo,
-                                         const LocalBox<double> &local_box,
+                                         BoxGeometry const &box_geo,
+                                         LocalBox<double> const &local_box,
                                          std::set<int> n_square_types)
     : m_comm(std::move(comm)), m_box(box_geo), m_cutoff_regular(cutoff_regular),
       m_regular_decomposition(RegularDecomposition(

--- a/src/core/cell_system/HybridDecomposition.cpp
+++ b/src/core/cell_system/HybridDecomposition.cpp
@@ -100,7 +100,7 @@ void HybridDecomposition::resort(bool global,
   for (auto &c : m_regular_decomposition.local_cells()) {
     for (auto it = c->particles().begin(); it != c->particles().end();) {
       /* Particle is in the right decomposition, i.e. has no n_square type */
-      if (not is_n_square_type(it->p.type)) {
+      if (not is_n_square_type(it->type())) {
         std::advance(it, 1);
         continue;
       }
@@ -109,7 +109,7 @@ void HybridDecomposition::resort(bool global,
       auto p = std::move(*it);
       it = c->particles().erase(it);
       diff.emplace_back(ModifiedList{c->particles()});
-      diff.emplace_back(RemovedParticle{p.identity()});
+      diff.emplace_back(RemovedParticle{p.id()});
 
       /* ... and insert into a n_square cell */
       auto const first_local_cell = m_n_square.get_local_cells()[0];
@@ -121,7 +121,7 @@ void HybridDecomposition::resort(bool global,
     for (auto &c : m_n_square.local_cells()) {
       for (auto it = c->particles().begin(); it != c->particles().end();) {
         /* Particle is of n_square type */
-        if (is_n_square_type(it->p.type)) {
+        if (is_n_square_type(it->type())) {
           std::advance(it, 1);
           continue;
         }
@@ -130,7 +130,7 @@ void HybridDecomposition::resort(bool global,
         auto p = std::move(*it);
         it = c->particles().erase(it);
         diff.emplace_back(ModifiedList{c->particles()});
-        diff.emplace_back(RemovedParticle{p.identity()});
+        diff.emplace_back(RemovedParticle{p.id()});
 
         /* ... and insert in regular decomposition */
         auto const target_cell = particle_to_cell(p);

--- a/src/core/cell_system/HybridDecomposition.hpp
+++ b/src/core/cell_system/HybridDecomposition.hpp
@@ -112,7 +112,7 @@ public:
   }
 
   Cell *particle_to_cell(Particle const &p) override {
-    if (is_n_square_type(p.p.type)) {
+    if (is_n_square_type(p.type())) {
       return m_n_square.particle_to_cell(p);
     }
     return m_regular_decomposition.particle_to_cell(p);

--- a/src/core/cell_system/HybridDecomposition.hpp
+++ b/src/core/cell_system/HybridDecomposition.hpp
@@ -129,7 +129,18 @@ public:
 
   BoxGeometry const &box() const override { return m_box; };
 
-  Utils::Vector<std::size_t, 2> parts_per_decomposition_local() const;
+  /** @brief Count particles in child regular decompositions. */
+  std::size_t count_particles_in_regular() const {
+    return count_particles(m_regular_decomposition.get_local_cells());
+  }
+
+  /** @brief Count particles in child N-square decompositions. */
+  std::size_t count_particles_in_n_square() const {
+    return count_particles(m_n_square.get_local_cells());
+  }
+
+private:
+  std::size_t count_particles(std::vector<Cell *> const &local_cells) const;
 };
 
 #endif

--- a/src/core/cell_system/HybridDecomposition.hpp
+++ b/src/core/cell_system/HybridDecomposition.hpp
@@ -77,8 +77,8 @@ class HybridDecomposition : public ParticleDecomposition {
 
 public:
   HybridDecomposition(boost::mpi::communicator comm, double cutoff_regular,
-                      const BoxGeometry &box_geo,
-                      const LocalBox<double> &local_box,
+                      BoxGeometry const &box_geo,
+                      LocalBox<double> const &local_box,
                       std::set<int> n_square_types);
 
   Utils::Vector3i get_cell_grid() const {

--- a/src/core/cell_system/HybridDecomposition.hpp
+++ b/src/core/cell_system/HybridDecomposition.hpp
@@ -56,7 +56,7 @@
  */
 class HybridDecomposition : public ParticleDecomposition {
   boost::mpi::communicator m_comm;
-  BoxGeometry m_box;
+  BoxGeometry const &m_box;
   double m_cutoff_regular;
   std::vector<Cell *> m_local_cells;
   std::vector<Cell *> m_ghost_cells;
@@ -127,7 +127,7 @@ public:
     return m_box;
   }
 
-  BoxGeometry box() const override { return m_box; }
+  BoxGeometry const &box() const override { return m_box; };
 
   Utils::Vector<std::size_t, 2> parts_per_decomposition_local() const;
 };

--- a/src/core/cell_system/ParticleDecomposition.hpp
+++ b/src/core/cell_system/ParticleDecomposition.hpp
@@ -129,7 +129,7 @@ public:
    */
   virtual boost::optional<BoxGeometry> minimum_image_distance() const = 0;
 
-  virtual BoxGeometry box() const = 0;
+  virtual BoxGeometry const &box() const = 0;
 
   virtual ~ParticleDecomposition() = default;
 };

--- a/src/core/cell_system/RegularDecomposition.cpp
+++ b/src/core/cell_system/RegularDecomposition.cpp
@@ -48,7 +48,7 @@
 #include <vector>
 
 /** Returns pointer to the cell which corresponds to the position if the
- *  position is in the nodes spatial domain otherwise a nullptr pointer.
+ *  position is in the node's spatial domain otherwise a nullptr.
  */
 Cell *RegularDecomposition::position_to_cell(const Utils::Vector3d &pos) {
   Utils::Vector3i cpos;
@@ -256,8 +256,8 @@ void RegularDecomposition::mark_cells() {
 }
 
 void RegularDecomposition::fill_comm_cell_lists(ParticleList **part_lists,
-                                                const Utils::Vector3i &lc,
-                                                const Utils::Vector3i &hc) {
+                                                Utils::Vector3i const &lc,
+                                                Utils::Vector3i const &hc) {
   for (int o = lc[0]; o <= hc[0]; o++)
     for (int n = lc[1]; n <= hc[1]; n++)
       for (int m = lc[2]; m <= hc[2]; m++) {
@@ -631,8 +631,8 @@ GhostCommunicator RegularDecomposition::prepare_comm() {
 
 RegularDecomposition::RegularDecomposition(boost::mpi::communicator comm,
                                            double range,
-                                           const BoxGeometry &box_geo,
-                                           const LocalBox<double> &local_geo)
+                                           BoxGeometry const &box_geo,
+                                           LocalBox<double> const &local_geo)
     : m_comm(std::move(comm)), m_box(box_geo), m_local_box(local_geo) {
   /* set up new regular decomposition cell structure */
   create_cell_grid(range);

--- a/src/core/cell_system/RegularDecomposition.cpp
+++ b/src/core/cell_system/RegularDecomposition.cpp
@@ -103,12 +103,12 @@ void RegularDecomposition::move_left_or_right(ParticleList &src,
                                               ParticleList &right,
                                               int dir) const {
   for (auto it = src.begin(); it != src.end();) {
-    if ((m_box.get_mi_coord(it->r.p[dir], m_local_box.my_left()[dir], dir) <
+    if ((m_box.get_mi_coord(it->pos()[dir], m_local_box.my_left()[dir], dir) <
          0.0) and
         (m_box.periodic(dir) || (m_local_box.boundary()[2 * dir] == 0))) {
       left.insert(std::move(*it));
       it = src.erase(it);
-    } else if ((m_box.get_mi_coord(it->r.p[dir], m_local_box.my_right()[dir],
+    } else if ((m_box.get_mi_coord(it->pos()[dir], m_local_box.my_right()[dir],
                                    dir) >= 0.0) and
                (m_box.periodic(dir) ||
                 (m_local_box.boundary()[2 * dir + 1] == 0))) {
@@ -195,7 +195,7 @@ void RegularDecomposition::resort(bool global,
 
       /* Particle is not local */
       if (target_cell == nullptr) {
-        diff.emplace_back(RemovedParticle{p.identity()});
+        diff.emplace_back(RemovedParticle{p.id()});
         displaced_parts.insert(std::move(p));
       }
       /* Particle belongs on this node but is in the wrong cell. */
@@ -230,7 +230,7 @@ void RegularDecomposition::resort(bool global,
     auto sort_cell = local_cells()[0];
 
     for (auto &part : displaced_parts) {
-      runtimeErrorMsg() << "Particle " << part.identity() << " moved more "
+      runtimeErrorMsg() << "Particle " << part.id() << " moved more "
                         << "than one local box length in one timestep";
       sort_cell->particles().insert(std::move(part));
 

--- a/src/core/cell_system/RegularDecomposition.hpp
+++ b/src/core/cell_system/RegularDecomposition.hpp
@@ -88,8 +88,8 @@ struct RegularDecomposition : public ParticleDecomposition {
 
 public:
   RegularDecomposition(boost::mpi::communicator comm, double range,
-                       const BoxGeometry &box_geo,
-                       const LocalBox<double> &local_geo);
+                       BoxGeometry const &box_geo,
+                       LocalBox<double> const &local_geo);
 
   GhostCommunicator const &exchange_ghosts_comm() const override {
     return m_exchange_ghosts_comm;

--- a/src/core/cell_system/RegularDecomposition.hpp
+++ b/src/core/cell_system/RegularDecomposition.hpp
@@ -78,7 +78,7 @@ struct RegularDecomposition : public ParticleDecomposition {
   Utils::Vector3d inv_cell_size = {};
 
   boost::mpi::communicator m_comm;
-  BoxGeometry m_box;
+  BoxGeometry const &m_box;
   LocalBox<double> m_local_box;
   std::vector<Cell> cells;
   std::vector<Cell *> m_local_cells;
@@ -120,7 +120,8 @@ public:
   boost::optional<BoxGeometry> minimum_image_distance() const override {
     return {m_box};
   }
-  BoxGeometry box() const override { return m_box; }
+
+  BoxGeometry const &box() const override { return m_box; };
 
 private:
   /** Fill @c m_local_cells list and @c m_ghost_cells list for use with regular

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -275,6 +275,6 @@ void cells_update_ghosts(unsigned data_parts) {
   }
 }
 
-Cell *find_current_cell(const Particle &p) {
+Cell *find_current_cell(Particle const &p) {
   return cell_structure.find_current_cell(p);
 }

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -53,7 +53,7 @@
 #include <vector>
 
 /** Type of cell structure in use */
-CellStructure cell_structure;
+CellStructure cell_structure{box_geo};
 
 /**
  * @brief Get pairs of particles that are closer than a distance and fulfill a

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -261,9 +261,9 @@ void cells_update_ghosts(unsigned data_parts) {
 
     /* Add the ghost particles to the index if we don't already
      * have them. */
-    for (auto &part : cell_structure.ghost_particles()) {
-      if (cell_structure.get_local_particle(part.id()) == nullptr) {
-        cell_structure.update_particle_index(part.identity(), &part);
+    for (auto &p : cell_structure.ghost_particles()) {
+      if (cell_structure.get_local_particle(p.id()) == nullptr) {
+        cell_structure.update_particle_index(p.id(), &p);
       }
     }
 

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -53,6 +53,7 @@
 #include "cell_system/Cell.hpp"
 #include "cell_system/CellStructure.hpp"
 #include "cell_system/CellStructureType.hpp"
+#include "cell_system/HybridDecomposition.hpp"
 
 #include "Particle.hpp"
 

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -53,7 +53,6 @@
 #include "cell_system/Cell.hpp"
 #include "cell_system/CellStructure.hpp"
 #include "cell_system/CellStructureType.hpp"
-#include "cell_system/HybridDecomposition.hpp"
 
 #include "Particle.hpp"
 
@@ -76,20 +75,12 @@ enum {
 /** Type of cell structure in use. */
 extern CellStructure cell_structure;
 
-/** Initialize cell structure HybridDecomposition
+/** Initialize cell structure @ref HybridDecomposition
  *  @param n_square_types   Types of particles to place in the N-square cells.
  *  @param cutoff_regular   Cutoff for the regular decomposition.
  */
 void set_hybrid_decomposition(std::set<int> n_square_types,
                               double cutoff_regular);
-
-/**
- * @brief Count particles in child decompositions of a HybridDecomposition.
- *
- * @return Number of particles in regular decomposition resp. N-square.
- */
-std::pair<std::size_t, std::size_t>
-hybrid_parts_per_decomposition(HybridDecomposition const &hd);
 
 /** Reinitialize the cell structures.
  *  @param new_cs The new topology to use afterwards.

--- a/src/core/cells.hpp
+++ b/src/core/cells.hpp
@@ -136,7 +136,7 @@ mpi_get_short_range_neighbors_local(int pid, double distance,
  *
  * @return pointer to the cell or nullptr if the particle is not on the node
  */
-Cell *find_current_cell(const Particle &p);
+Cell *find_current_cell(Particle const &p);
 
 class PairInfo {
 public:

--- a/src/core/cluster_analysis/Cluster.hpp
+++ b/src/core/cluster_analysis/Cluster.hpp
@@ -35,7 +35,7 @@ public:
   /** @brief Ids of the particles in the cluster */
   std::vector<int> particles;
   /** @brief add a particle to the cluster */
-  void add_particle(const Particle &p) { particles.push_back(p.identity()); }
+  void add_particle(const Particle &p) { particles.push_back(p.id()); }
   /** @brief Calculate the center of mass of the cluster */
   Utils::Vector3d
   center_of_mass_subcluster(std::vector<int> const &particle_ids);

--- a/src/core/cluster_analysis/ClusterStructure.cpp
+++ b/src/core/cluster_analysis/ClusterStructure.cpp
@@ -42,7 +42,7 @@ void ClusterStructure::clear() {
 }
 
 inline bool ClusterStructure::part_of_cluster(const Particle &p) {
-  return cluster_id.find(p.identity()) != cluster_id.end();
+  return cluster_id.find(p.id()) != cluster_id.end();
 }
 
 // Analyze the cluster structure of the given particles
@@ -93,24 +93,24 @@ void ClusterStructure::add_pair(const Particle &p1, const Particle &p2) {
       const int cid = get_next_free_cluster_id();
 
       // assign the cluster_ids
-      cluster_id[p1.p.identity] = cid;
-      cluster_id[p2.p.identity] = cid;
+      cluster_id[p1.id()] = cid;
+      cluster_id[p2.id()] = cid;
     } else if // p2 belongs to a cluster but p1 doesn't
         (part_of_cluster(p2) && !part_of_cluster(p1)) {
       // Give p1 the same cluster id as p2
-      cluster_id[p1.p.identity] = find_id_for(cluster_id.at(p2.p.identity));
+      cluster_id[p1.id()] = find_id_for(cluster_id.at(p2.id()));
     } else if // i belongs to a cluster but j doesn't
         (part_of_cluster(p1) && !part_of_cluster(p2)) {
       // give p2 the cluster id from p1
-      cluster_id[p2.p.identity] = find_id_for(cluster_id.at(p1.p.identity));
+      cluster_id[p2.id()] = find_id_for(cluster_id.at(p1.id()));
     } else if // Both belong to different clusters
         (part_of_cluster(p1) && part_of_cluster(p2) &&
-         cluster_id.at(p1.p.identity) != cluster_id.at(p2.p.identity)) {
+         cluster_id.at(p1.id()) != cluster_id.at(p2.id())) {
       // Clusters of p1 and p2 are one and the same. Add an identity to the list
       // The higher number must be inserted as first value of the pair
       // because the substitutions later have to be done in descending order
-      const int cid1 = find_id_for(cluster_id.at(p1.p.identity));
-      const int cid2 = find_id_for(cluster_id.at(p2.p.identity));
+      const int cid1 = find_id_for(cluster_id.at(p1.id()));
+      const int cid2 = find_id_for(cluster_id.at(p2.id()));
       if (cid1 > cid2) {
         m_cluster_identities[cid1] = cid2;
       } else if (cid1 < cid2) {

--- a/src/core/collision.cpp
+++ b/src/core/collision.cpp
@@ -302,8 +302,8 @@ void coldet_do_three_particle_bond(Particle &p, Particle const &p1,
                 collision_params.three_particle_angle_resolution);
   };
   /* Check if the bond is between the particles we are currently considering */
-  auto has_same_partners = [id1 = p1.identity(),
-                            id2 = p2.identity()](BondView const &bond) {
+  auto has_same_partners = [id1 = p1.id(),
+                            id2 = p2.id()](BondView const &bond) {
     auto const partner_ids = bond.partner_ids();
 
     return ((partner_ids[0] == id1) && (partner_ids[1] == id2)) ||
@@ -354,7 +354,7 @@ void place_vs_and_relate_to_particle(const int current_vs_pid,
 
   local_vs_relate_to(*p_vs, get_part(relate_to));
 
-  p_vs->p.is_virtual = true;
+  p_vs->set_virtual(true);
   p_vs->type() = collision_params.vs_particle_type;
 }
 
@@ -558,8 +558,7 @@ void handle_collisions() {
 
           auto handle_particle = [&](Particle *p, Utils::Vector3d const &pos) {
             if (not p->is_ghost()) {
-              place_vs_and_relate_to_particle(current_vs_pid, pos,
-                                              p->identity());
+              place_vs_and_relate_to_particle(current_vs_pid, pos, p->id());
               // Particle storage locations may have changed due to
               // added particle
               p1 = cell_structure.get_local_particle(c.pp1);
@@ -618,7 +617,7 @@ void handle_collisions() {
           // Vs placement happens on the node that has p1
           if (!attach_vs_to.is_ghost()) {
             place_vs_and_relate_to_particle(current_vs_pid, pos,
-                                            attach_vs_to.identity());
+                                            attach_vs_to.id());
             // Particle storage locations may have changed due to
             // added particle
             p1 = cell_structure.get_local_particle(c.pp1);

--- a/src/core/collision.hpp
+++ b/src/core/collision.hpp
@@ -116,8 +116,8 @@ inline bool glue_to_surface_criterion(Particle const &p1, Particle const &p2) {
 
 /** @brief Detect (and queue) a collision between the given particles. */
 inline void detect_collision(Particle const &p1, Particle const &p2,
-                             const double &dist_betw_part2) {
-  if (dist_betw_part2 > collision_params.distance2)
+                             double const dist2) {
+  if (dist2 > collision_params.distance2)
     return;
 
   // If we are in the glue to surface mode, check that the particles

--- a/src/core/collision.hpp
+++ b/src/core/collision.hpp
@@ -108,10 +108,10 @@ void queue_collision(int part1, int part2);
 
 /** @brief Check additional criteria for the glue_to_surface collision mode */
 inline bool glue_to_surface_criterion(Particle const &p1, Particle const &p2) {
-  return (((p1.p.type == collision_params.part_type_to_be_glued) &&
-           (p2.p.type == collision_params.part_type_to_attach_vs_to)) ||
-          ((p2.p.type == collision_params.part_type_to_be_glued) &&
-           (p1.p.type == collision_params.part_type_to_attach_vs_to)));
+  return (((p1.type() == collision_params.part_type_to_be_glued) &&
+           (p2.type() == collision_params.part_type_to_attach_vs_to)) ||
+          ((p2.type() == collision_params.part_type_to_be_glued) &&
+           (p1.type() == collision_params.part_type_to_attach_vs_to)));
 }
 
 /** @brief Detect (and queue) a collision between the given particles. */
@@ -127,26 +127,24 @@ inline void detect_collision(Particle const &p1, Particle const &p2,
       return;
 
   // Ignore virtual particles
-  if ((p1.p.is_virtual) || (p2.p.is_virtual))
+  if (p1.is_virtual() or p2.is_virtual())
     return;
 
   // Check, if there's already a bond between the particles
-  if (pair_bond_exists_on(p1.bonds(), p2.identity(),
-                          collision_params.bond_centers))
+  if (pair_bond_exists_on(p1.bonds(), p2.id(), collision_params.bond_centers))
     return;
 
-  if (pair_bond_exists_on(p2.bonds(), p1.identity(),
-                          collision_params.bond_centers))
+  if (pair_bond_exists_on(p2.bonds(), p1.id(), collision_params.bond_centers))
     return;
 
   /* If we're still here, there is no previous bond between the particles,
      we have a new collision */
 
   // do not create bond between ghost particles
-  if (p1.l.ghost && p2.l.ghost) {
+  if (p1.is_ghost() and p2.is_ghost()) {
     return;
   }
-  queue_collision(p1.p.identity, p2.p.identity);
+  queue_collision(p1.id(), p2.id());
 }
 
 #endif // COLLISION_DETECTION

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -43,7 +43,7 @@ static void pack_particles(ParticleRange particles,
     buffer[i].p = static_cast<Vector3f>(folded_position(part.pos(), box_geo));
 
     buffer[i].identity = part.id();
-    buffer[i].v = static_cast<Vector3f>(part.m.v);
+    buffer[i].v = static_cast<Vector3f>(part.v());
 #ifdef VIRTUAL_SITES
     buffer[i].is_virtual = part.is_virtual();
 #endif
@@ -116,11 +116,11 @@ static void add_forces_and_torques(ParticleRange particles,
                                    Utils::Span<const float> forces,
                                    Utils::Span<const float> torques) {
   int i = 0;
-  for (auto &part : particles) {
+  for (auto &p : particles) {
     for (int j = 0; j < 3; j++) {
-      part.f.f[j] += forces[3 * i + j];
+      p.force()[j] += forces[3 * i + j];
 #ifdef ROTATION
-      part.torque()[j] += torques[3 * i + j];
+      p.torque()[j] += torques[3 * i + j];
 #endif
     }
     i++;

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -120,10 +120,11 @@ Utils::Vector3d dpd_pair_force(Particle const &p1, Particle const &p2,
     return {};
   }
 
-  auto const v21 = box_geo.velocity_difference(p1.r.p, p2.r.p, p1.m.v, p2.m.v);
+  auto const v21 =
+      box_geo.velocity_difference(p1.pos(), p2.pos(), p1.v(), p2.v());
   auto const noise_vec =
       (ia_params.dpd_radial.pref > 0.0 || ia_params.dpd_trans.pref > 0.0)
-          ? dpd_noise(p1.p.identity, p2.p.identity)
+          ? dpd_noise(p1.id(), p2.id())
           : Vector3d{};
 
   auto const f_r = dpd_pair_force(ia_params.dpd_radial, v21, dist, noise_vec);
@@ -144,9 +145,9 @@ static auto dpd_viscous_stress_local() {
   cell_structure.non_bonded_loop(
       [&stress](const Particle &p1, const Particle &p2, Distance const &d) {
         auto const v21 =
-            box_geo.velocity_difference(p1.r.p, p2.r.p, p1.m.v, p2.m.v);
+            box_geo.velocity_difference(p1.pos(), p2.pos(), p1.v(), p2.v());
 
-        IA_parameters const &ia_params = *get_ia_param(p1.p.type, p2.p.type);
+        IA_parameters const &ia_params = *get_ia_param(p1.type(), p2.type());
         auto const dist = std::sqrt(d.dist2);
 
         auto const f_r = dpd_pair_force(ia_params.dpd_radial, v21, dist, {});

--- a/src/core/electrostatics/elc.cpp
+++ b/src/core/electrostatics/elc.cpp
@@ -280,7 +280,7 @@ double ElectrostaticLayerCorrection::dipole_energy(
   gblcblk[5] = 0.; // sum q_i (z_i - L/2)^2 boundary layers
   gblcblk[6] = 0.; // sum q_i z_i           primary box
 
-  for (auto &p : particles) {
+  for (auto const &p : particles) {
     check_gap(p);
     auto const q = p.q();
     auto const z = p.pos()[2];
@@ -367,7 +367,7 @@ ElectrostaticLayerCorrection::z_energy(ParticleRange const &particles) const {
   if (elc.dielectric_contrast_on) {
     if (elc.const_pot) {
       clear_vec(gblcblk, size);
-      for (auto &p : particles) {
+      for (auto const &p : particles) {
         auto const z = p.pos()[2];
         auto const q = p.q();
         gblcblk[0] += q;
@@ -385,7 +385,7 @@ ElectrostaticLayerCorrection::z_energy(ParticleRange const &particles) const {
       // metallic boundaries
       clear_vec(gblcblk, size);
       auto const h = elc.box_h;
-      for (auto &p : particles) {
+      for (auto const &p : particles) {
         auto const z = p.pos()[2];
         auto const q = p.q();
         gblcblk[0] += q;
@@ -438,7 +438,7 @@ void ElectrostaticLayerCorrection::add_z_force(
     if (elc.const_pot) {
       clear_vec(gblcblk, size);
       /* just counter the 2 pi |z| contribution stemming from P3M */
-      for (auto &p : particles) {
+      for (auto const &p : particles) {
         auto const z = p.pos()[2];
         auto const q = p.q();
         if (z < elc.space_layer)
@@ -448,7 +448,7 @@ void ElectrostaticLayerCorrection::add_z_force(
       }
     } else {
       clear_vec(gblcblk, size);
-      for (auto &p : particles) {
+      for (auto const &p : particles) {
         auto const z = p.pos()[2];
         auto const q = p.q();
         if (z < elc.space_layer) {
@@ -507,7 +507,7 @@ void setup_PoQ(elc_data const &elc, double prefactor, std::size_t index,
 
   std::size_t ic = 0;
   auto const o = (index - 1) * particles.size();
-  for (auto &p : particles) {
+  for (auto const &p : particles) {
     auto const z = p.pos()[2];
     auto const q = p.q();
     auto e = exp(omega * z);

--- a/src/core/electrostatics/elc.cpp
+++ b/src/core/electrostatics/elc.cpp
@@ -113,8 +113,8 @@ static std::vector<SCCache> calc_sc_cache(ParticleRange const &particles,
     auto const pref = c_2pi * u * static_cast<double>(freq);
 
     std::size_t o = (freq - 1) * n_part;
-    for (auto const &part : particles) {
-      auto const arg = pref * part.r.p[dir];
+    for (auto const &p : particles) {
+      auto const arg = pref * p.pos()[dir];
       ret[o++] = {sin(arg), cos(arg)};
     }
   }

--- a/src/core/electrostatics/icc.cpp
+++ b/src/core/electrostatics/icc.cpp
@@ -129,7 +129,7 @@ void ICCStar::iteration(CellStructure &cell_structure,
     for (auto &p : particles) {
       auto const pid = p.id();
       if (pid >= icc_cfg.first_id and pid < icc_cfg.n_icc + icc_cfg.first_id) {
-        auto const id = p.identity() - icc_cfg.first_id;
+        auto const id = p.id() - icc_cfg.first_id;
         /* the dielectric-related prefactor: */
         auto const eps_in = icc_cfg.epsilons[id];
         auto const eps_out = icc_cfg.eps_out;

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -154,8 +154,8 @@ inline double calc_non_bonded_pair_energy(
 
 #ifdef GAY_BERNE
   /* Gay-Berne */
-  ret += gb_pair_energy(p1.r.calc_director(), p2.r.calc_director(), ia_params,
-                        d, dist);
+  ret += gb_pair_energy(p1.calc_director(), p2.calc_director(), ia_params, d,
+                        dist);
 #endif
 
   return ret;

--- a/src/core/exclusions.hpp
+++ b/src/core/exclusions.hpp
@@ -36,7 +36,7 @@ inline bool do_nonbonded(Particle const &p1, Particle const &p2) {
   /* check for particle 2 in particle 1's exclusion list. The exclusion list is
    * symmetric, so this is sufficient. */
   return std::none_of(p1.exclusions().begin(), p1.exclusions().end(),
-                      [&p2](int id) { return p2.p.identity == id; });
+                      [&p2](int id) { return p2.id() == id; });
 }
 
 /** Remove exclusion from particle if possible */

--- a/src/core/field_coupling/couplings/Scaled.hpp
+++ b/src/core/field_coupling/couplings/Scaled.hpp
@@ -43,7 +43,7 @@ public:
 
 private:
   template <typename Particle> double scale(Particle const &p) const {
-    auto const &val = m_scales.find(p.identity());
+    auto const &val = m_scales.find(p.id());
     if (val != m_scales.end())
       return val->second;
 

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -27,6 +27,7 @@
 #include "EspressoSystemInterface.hpp"
 
 #include "bond_breakage/bond_breakage.hpp"
+#include "cell_system/CellStructure.hpp"
 #include "cells.hpp"
 #include "collision.hpp"
 #include "comfixed_global.hpp"

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -421,9 +421,9 @@ add_bonded_force(Particle &p1, int bond_id, Utils::Span<Particle *> partners,
 
   // Consider for bond breakage
   if (partners.size() == 1) {
-    auto d = box_geo.get_mi_vector(p1.r.p, partners[0]->r.p).norm();
-    if (BondBreakage::check_and_handle_breakage(
-            p1.p.identity, partners[0]->p.identity, bond_id, d))
+    auto d = box_geo.get_mi_vector(p1.pos(), partners[0]->pos()).norm();
+    if (BondBreakage::check_and_handle_breakage(p1.id(), partners[0]->id(),
+                                                bond_id, d))
       return false;
   }
 

--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -220,7 +220,7 @@ std::vector<Utils::Vector3d> positions_in_halo(Utils::Vector3d pos,
 /** @brief Return if locally there exists a physical particle
  ** for a given (ghost) particle */
 bool is_ghost_for_local_particle(const Particle &p) {
-  return !cell_structure.get_local_particle(p.identity())->is_ghost();
+  return !cell_structure.get_local_particle(p.id())->is_ghost();
 }
 
 /** @brief Determine if a given particle should be coupled.
@@ -236,9 +236,8 @@ bool should_be_coupled(const Particle &p,
   // for ghosts check that we don't have the physical particle and
   // that a ghost for the same particle has not yet been coupled
   if ((not is_ghost_for_local_particle(p)) and
-      (coupled_ghost_particles.find(p.identity()) ==
-       coupled_ghost_particles.end())) {
-    coupled_ghost_particles.insert(p.identity());
+      (coupled_ghost_particles.find(p.id()) == coupled_ghost_particles.end())) {
+    coupled_ghost_particles.insert(p.id());
     return true;
   }
   return false;
@@ -326,8 +325,8 @@ void lb_lbcoupling_calc_particle_lattice_ia(bool couple_virtual,
           Utils::Vector3d force = {};
           for (auto pos : positions_in_halo(p.pos(), box_geo)) {
             if (in_local_halo(pos)) {
-              force = lb_viscous_coupling(
-                  p, pos, noise_amplitude * f_random(p.identity()));
+              force = lb_viscous_coupling(p, pos,
+                                          noise_amplitude * f_random(p.id()));
               break;
             }
           }

--- a/src/core/immersed_boundary/ImmersedBoundaries.cpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.cpp
@@ -21,6 +21,7 @@
 
 #include "BoxGeometry.hpp"
 #include "Particle.hpp"
+#include "cell_system/CellStructure.hpp"
 #include "communication.hpp"
 #include "grid.hpp"
 #include "ibm_volcons.hpp"

--- a/src/core/immersed_boundary/ImmersedBoundaries.cpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.cpp
@@ -196,9 +196,9 @@ void ImmersedBoundaries::calc_volume_force(CellStructure &cs) {
       auto const nHat = n / ln;
       auto const force = -fact * A * nHat;
 
-      p1.f.f += force;
-      p2.f.f += force;
-      p3.f.f += force;
+      p1.force() += force;
+      p2.force() += force;
+      p3.force() += force;
     }
     return false;
   });

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -110,11 +110,11 @@ static std::shared_ptr<ActiveProtocol> protocol = nullptr;
  * @brief Update the Lees-Edwards parameters of the box geometry
  * for the current simulation time.
  */
-inline void update_box_params() {
+static void update_box_params() {
   if (box_geo.type() == BoxType::LEES_EDWARDS) {
     assert(protocol != nullptr);
-    update_pos_offset(*protocol, box_geo, sim_time);
-    update_shear_velocity(*protocol, box_geo, sim_time);
+    box_geo.lees_edwards_update(get_pos_offset(sim_time, *protocol),
+                                get_shear_velocity(sim_time, *protocol));
   }
 }
 
@@ -122,14 +122,14 @@ void set_protocol(std::shared_ptr<ActiveProtocol> new_protocol) {
   box_geo.set_type(BoxType::LEES_EDWARDS);
   protocol = std::move(new_protocol);
   LeesEdwards::update_box_params();
+  ::recalc_forces = true;
   cell_structure.set_resort_particles(Cells::RESORT_LOCAL);
 }
 
 void unset_protocol() {
   protocol = nullptr;
-  box_geo.lees_edwards_bc().shear_velocity = 0;
-  box_geo.lees_edwards_bc().pos_offset = 0;
   box_geo.set_type(BoxType::CUBOID);
+  ::recalc_forces = true;
   cell_structure.set_resort_particles(Cells::RESORT_LOCAL);
 }
 

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -51,7 +51,7 @@ void velocity_verlet_npt_propagate_vel_final(const ParticleRange &particles,
     // Virtual sites are not propagated during integration
     if (p.is_virtual())
       continue;
-    auto const noise = friction_therm0_nptiso<2>(npt_iso, p.v(), p.identity());
+    auto const noise = friction_therm0_nptiso<2>(npt_iso, p.v(), p.id());
     for (int j = 0; j < 3; j++) {
       if (!p.is_fixed_along(j)) {
         if (nptiso.geometry & nptiso.nptgeom_dir[j]) {
@@ -172,8 +172,7 @@ void velocity_verlet_npt_propagate_vel(const ParticleRange &particles,
       continue;
     for (int j = 0; j < 3; j++) {
       if (!p.is_fixed_along(j)) {
-        auto const noise =
-            friction_therm0_nptiso<1>(npt_iso, p.v(), p.identity());
+        auto const noise = friction_therm0_nptiso<1>(npt_iso, p.v(), p.id());
         if (integ_switch == INTEG_METHOD_NPT_ISO &&
             (nptiso.geometry & nptiso.nptgeom_dir[j])) {
           p.v()[j] += (p.force()[j] * time_step / 2.0 + noise[j]) / p.mass();

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -380,7 +380,7 @@ void File::write(const ParticleRange &particles, double time, int step,
 
   write_td_particle_property<2>(
       prefix, n_part_global, particles, datasets["particles/atoms/id/value"],
-      [](auto const &p) { return Utils::Vector<int, 1>{p.identity()}; });
+      [](auto const &p) { return Utils::Vector<int, 1>{p.id()}; });
 
   {
     h5xx::dataset &dataset = datasets["particles/atoms/id/value"];
@@ -446,7 +446,7 @@ void File::write_connectivity(const ParticleRange &particles) {
       auto const partner_ids = b.partner_ids();
       if (partner_ids.size() == 1) {
         bond.resize(boost::extents[1][nbonds_local + 1][2]);
-        bond[0][nbonds_local][0] = p.identity();
+        bond[0][nbonds_local][0] = p.id();
         bond[0][nbonds_local][1] = partner_ids[0];
         nbonds_local++;
       }

--- a/src/core/lees_edwards/LeesEdwardsBC.hpp
+++ b/src/core/lees_edwards/LeesEdwardsBC.hpp
@@ -22,21 +22,17 @@
 #include <utils/Vector.hpp>
 
 #include <bitset>
-#include <cassert>
 #include <cmath>
 
 struct LeesEdwardsBC {
   double pos_offset = 0.;
   double shear_velocity = 0.;
-  int shear_direction = 0;
-  int shear_plane_normal = 0;
-  Utils::Vector3d distance(const Utils::Vector3d &d, const Utils::Vector3d &l,
-                           const Utils::Vector3d &hal_l,
-                           const Utils::Vector3d &l_inv,
-                           const std::bitset<3> periodic) const {
-    assert(shear_plane_normal != shear_direction);
-    assert(shear_direction >= 0 and shear_direction <= 2);
-    assert(shear_plane_normal >= 0 and shear_plane_normal <= 2);
+  int shear_direction = -1;
+  int shear_plane_normal = -1;
+  Utils::Vector3d distance(Utils::Vector3d const &d, Utils::Vector3d const &l,
+                           Utils::Vector3d const &hal_l,
+                           Utils::Vector3d const &l_inv,
+                           std::bitset<3> const periodic) const {
 
     Utils::Vector3d n_jumps{};
     Utils::Vector3d res = d;

--- a/src/core/lees_edwards/lees_edwards.hpp
+++ b/src/core/lees_edwards/lees_edwards.hpp
@@ -86,18 +86,6 @@ inline Utils::Vector3d shear_direction(BoxGeometry const &box) {
   return Utils::unit_vector<double>(box.lees_edwards_bc().shear_direction);
 }
 
-inline void update_pos_offset(ActiveProtocol const &protocol, BoxGeometry &box,
-                              double time) {
-  assert(box.type() == BoxType::LEES_EDWARDS);
-  box.lees_edwards_bc().pos_offset = get_pos_offset(time, protocol);
-}
-
-inline void update_shear_velocity(ActiveProtocol const &protocol,
-                                  BoxGeometry &box, double time) {
-  assert(box.type() == BoxType::LEES_EDWARDS);
-  box.lees_edwards_bc().shear_velocity = get_shear_velocity(time, protocol);
-}
-
 inline Utils::Vector3d verlet_list_offset(BoxGeometry const &box,
                                           double pos_offset_at_last_resort) {
   if (box.type() == BoxType::LEES_EDWARDS) {

--- a/src/core/magnetostatics/dds.cpp
+++ b/src/core/magnetostatics/dds.cpp
@@ -55,7 +55,7 @@ double DipolarDirectSum::calc_dipole_dipole_ia(Particle &p1,
   auto const dip2 = p2.calc_dip();
 
   // Distance between particles
-  auto const dr = box_geo.get_mi_vector(p1.r.p, p2.r.p);
+  auto const dr = box_geo.get_mi_vector(p1.pos(), p2.pos());
 
   // Powers of distance
   auto const r2 = dr.norm2();

--- a/src/core/magnetostatics/dds_replica.cpp
+++ b/src/core/magnetostatics/dds_replica.cpp
@@ -88,7 +88,7 @@ DipolarDirectSumWithReplica::kernel(bool force_flag, bool energy_flag,
       mz[dip_particles] = dip[2];
 
       /* here we wish the coordinates to be folded into the primary box */
-      auto const ppos = folded_position(p.r.p, box_geo);
+      auto const ppos = folded_position(p.pos(), box_geo);
       x[dip_particles] = ppos[0];
       y[dip_particles] = ppos[1];
       z[dip_particles] = ppos[2];

--- a/src/core/magnetostatics/dp3m.hpp
+++ b/src/core/magnetostatics/dp3m.hpp
@@ -179,7 +179,7 @@ struct DipolarP3M {
   inline ParticleForce pair_force(Particle const &p1, Particle const &p2,
                                   Utils::Vector3d const &d, double dist2,
                                   double dist) const {
-    if ((p1.p.dipm == 0.) || (p2.p.dipm == 0.) || dist >= dp3m.params.r_cut ||
+    if ((p1.dipm() == 0.) || (p2.dipm() == 0.) || dist >= dp3m.params.r_cut ||
         dist <= 0.)
       return {};
 
@@ -223,9 +223,9 @@ struct DipolarP3M {
     auto const torque = prefactor * (-mixmj * B_r + mixr * (mjr * C_r));
 #ifdef NPT
 #if USE_ERFC_APPROXIMATION
-    auto const fac = prefactor * p1.p.dipm * p2.p.dipm * exp_adist2;
+    auto const fac = prefactor * p1.dipm() * p2.dipm() * exp_adist2;
 #else
-    auto const fac = prefactor * p1.p.dipm * p2.p.dipm;
+    auto const fac = prefactor * p1.dipm() * p2.dipm();
 #endif
     auto const energy = fac * (mimj * B_r - mir * mjr * C_r);
     npt_add_virial_magnetic_contribution(energy);
@@ -237,7 +237,7 @@ struct DipolarP3M {
   inline double pair_energy(Particle const &p1, Particle const &p2,
                             Utils::Vector3d const &d, double dist2,
                             double dist) const {
-    if ((p1.p.dipm == 0.) || (p2.p.dipm == 0.) || dist >= dp3m.params.r_cut ||
+    if ((p1.dipm() == 0.) || (p2.dipm() == 0.) || dist >= dp3m.params.r_cut ||
         dist <= 0.)
       return {};
 

--- a/src/core/nonbonded_interactions/VerletCriterion.hpp
+++ b/src/core/nonbonded_interactions/VerletCriterion.hpp
@@ -85,7 +85,7 @@ public:
 #endif
 
     // Within short-range distance (including dpd and the like)
-    auto const ia_cut = get_nonbonded_cutoff(p1.p.type, p2.p.type);
+    auto const ia_cut = get_nonbonded_cutoff(p1.type(), p2.type());
     return (ia_cut != INACTIVE_CUTOFF) &&
            (dist2 <= Utils::sqr(ia_cut + m_skin));
   }

--- a/src/core/object-in-fluid/oif_global_forces.cpp
+++ b/src/core/object-in-fluid/oif_global_forces.cpp
@@ -56,8 +56,8 @@ Utils::Vector2d calc_oif_global(int molType, CellStructure &cs) {
       // remaining neighbors fetched
       auto const p11 =
           unfolded_position(p1.pos(), p1.image_box(), box_geo.length());
-      auto const p22 = p11 + box_geo.get_mi_vector(partners[0]->r.p, p11);
-      auto const p33 = p11 + box_geo.get_mi_vector(partners[1]->r.p, p11);
+      auto const p22 = p11 + box_geo.get_mi_vector(partners[0]->pos(), p11);
+      auto const p33 = p11 + box_geo.get_mi_vector(partners[1]->pos(), p11);
 
       // unfolded positions correct
       auto const VOL_A = area_triangle(p11, p22, p33);
@@ -91,8 +91,8 @@ void add_oif_global_forces(Utils::Vector2d const &area_volume, int molType,
             bonded_ia_params.at(bond_id).get())) {
       auto const p11 =
           unfolded_position(p1.pos(), p1.image_box(), box_geo.length());
-      auto const p22 = p11 + box_geo.get_mi_vector(partners[0]->r.p, p11);
-      auto const p33 = p11 + box_geo.get_mi_vector(partners[1]->r.p, p11);
+      auto const p22 = p11 + box_geo.get_mi_vector(partners[0]->pos(), p11);
+      auto const p33 = p11 + box_geo.get_mi_vector(partners[1]->pos(), p11);
 
       // unfolded positions correct
       // starting code from volume force
@@ -120,8 +120,8 @@ void add_oif_global_forces(Utils::Vector2d const &area_volume, int molType,
                         m3_length * m3_length);
 
       p1.force() += fac * m1 + VOL_force;
-      partners[0]->f.f += fac * m2 + VOL_force;
-      partners[1]->f.f += fac * m3 + VOL_force;
+      partners[0]->force() += fac * m2 + VOL_force;
+      partners[1]->force() += fac * m3 + VOL_force;
     }
 
     return false;

--- a/src/core/observables/ParticleAngularVelocities.hpp
+++ b/src/core/observables/ParticleAngularVelocities.hpp
@@ -40,7 +40,7 @@ public:
 #ifdef ROTATION
     std::size_t i = 0;
     for (auto const &p : particles) {
-      auto const omega = convert_vector_body_to_space(p.get(), p.get().m.omega);
+      auto const omega = convert_vector_body_to_space(p.get(), p.get().omega());
       res[3 * i + 0] = omega[0];
       res[3 * i + 1] = omega[1];
       res[3 * i + 2] = omega[2];

--- a/src/core/observables/ParticleBodyAngularVelocities.hpp
+++ b/src/core/observables/ParticleBodyAngularVelocities.hpp
@@ -39,7 +39,7 @@ public:
 #ifdef ROTATION
     std::size_t i = 0;
     for (auto const &p : particles) {
-      auto const &omega = p.get().m.omega;
+      auto const &omega = p.get().omega();
       res[3 * i + 0] = omega[0];
       res[3 * i + 1] = omega[1];
       res[3 * i + 2] = omega[2];

--- a/src/core/observables/RDF.cpp
+++ b/src/core/observables/RDF.cpp
@@ -62,7 +62,7 @@ RDF::evaluate(Utils::Span<const Particle *const> particles1,
   long int cnt = 0;
   auto op = [=, &cnt, &res](const Particle *const p1,
                             const Particle *const p2) {
-    auto const dist = box_geo.get_mi_vector(p1->r.p, p2->r.p).norm();
+    auto const dist = box_geo.get_mi_vector(p1->pos(), p2->pos()).norm();
     if (dist > min_r && dist < max_r) {
       auto const ind =
           static_cast<int>(std::floor((dist - min_r) * inv_bin_width));

--- a/src/core/observables/TotalForce.hpp
+++ b/src/core/observables/TotalForce.hpp
@@ -35,9 +35,9 @@ public:
            const ParticleObservables::traits<Particle> &) const override {
     Utils::Vector3d res{};
     for (auto const &p : particles) {
-      if (p.get().p.is_virtual)
+      if (p.get().is_virtual())
         continue;
-      res += p.get().f.f;
+      res += p.get().force();
     }
     return res.as_vector();
   }

--- a/src/core/pair_criteria/BondCriterion.hpp
+++ b/src/core/pair_criteria/BondCriterion.hpp
@@ -28,8 +28,8 @@ namespace PairCriteria {
 class BondCriterion : public PairCriterion {
 public:
   bool decide(Particle const &p1, Particle const &p2) const override {
-    return pair_bond_exists_on(p1.bonds(), p2.identity(), m_bond_type) ||
-           pair_bond_exists_on(p2.bonds(), p1.identity(), m_bond_type);
+    return pair_bond_exists_on(p1.bonds(), p2.id(), m_bond_type) ||
+           pair_bond_exists_on(p2.bonds(), p1.id(), m_bond_type);
   }
   int get_bond_type() { return m_bond_type; }
   void set_bond_type(int t) { m_bond_type = t; }

--- a/src/core/reaction_methods/ReactionAlgorithm.cpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.cpp
@@ -397,7 +397,7 @@ void ReactionAlgorithm::check_exclusion_range(int inserted_particle_id) {
                                    inserted_particle_id),
                        particle_ids.end());
   } else {
-    particle_ids = mpi_get_short_range_neighbors(inserted_particle.identity(),
+    particle_ids = mpi_get_short_range_neighbors(inserted_particle.id(),
                                                  m_max_exclusion_range);
   }
 

--- a/src/core/rotation.cpp
+++ b/src/core/rotation.cpp
@@ -132,7 +132,7 @@ void propagate_omega_quat_particle(Particle &p, double time_step) {
   Utils::Vector3d S{}, Wd{};
 
   // Clear rotational velocity for blocked rotation axes.
-  p.omega() = Utils::mask(p.p.rotation, p.omega());
+  p.omega() = Utils::mask(p.rotation(), p.omega());
 
   define_Qdd(p, Qd, Qdd, S, Wd);
 

--- a/src/core/rotation.hpp
+++ b/src/core/rotation.hpp
@@ -114,7 +114,7 @@ local_rotate_particle_body(Particle const &p,
     return p.quat();
   if (std::abs(phi) > std::numeric_limits<double>::epsilon())
     return p.quat() *
-           boost::qvm::rot_quat(mask(p.p.rotation, axis_body_frame), phi);
+           boost::qvm::rot_quat(mask(p.rotation(), axis_body_frame), phi);
   return p.quat();
 }
 
@@ -132,7 +132,7 @@ inline void local_rotate_particle(Particle &p,
 
 inline void convert_torque_to_body_frame_apply_fix(Particle &p) {
   auto const torque = convert_vector_space_to_body(p, p.torque());
-  p.torque() = mask(p.p.rotation, torque);
+  p.torque() = mask(p.rotation(), torque);
 }
 
 #endif // ROTATION

--- a/src/core/statistics.cpp
+++ b/src/core/statistics.cpp
@@ -191,7 +191,7 @@ void calc_part_distribution(PartCfg &partCfg, std::vector<int> const &p1_types,
   for (int i = 0; i < r_bins; i++)
     dist[i] = 0.0;
   if (log_flag)
-    inv_bin_width = (double)r_bins / (log(r_max) - log(r_min));
+    inv_bin_width = (double)r_bins / (log(r_max / r_min));
   else
     inv_bin_width = (double)r_bins / (r_max - r_min);
 
@@ -219,7 +219,7 @@ void calc_part_distribution(PartCfg &partCfg, std::vector<int> const &p1_types,
           if (min_dist >= r_min) {
             /* calculate bin index */
             if (log_flag)
-              ind = (int)((log(min_dist) - log(r_min)) * inv_bin_width);
+              ind = (int)((log(min_dist / r_min)) * inv_bin_width);
             else
               ind = (int)((min_dist - r_min) * inv_bin_width);
             if (ind >= 0 && ind < r_bins) {

--- a/src/core/thermostats/brownian_inline.hpp
+++ b/src/core/thermostats/brownian_inline.hpp
@@ -170,7 +170,7 @@ inline Utils::Vector3d bd_random_walk(BrownianThermostat const &brownian,
   // magnitude defined in the second eq. (14.38), schlick10a.
   Utils::Vector3d delta_pos_body{};
   auto const noise = Random::noise_gaussian<RNGSalt::BROWNIAN_WALK>(
-      brownian.rng_counter(), brownian.rng_seed(), p.identity());
+      brownian.rng_counter(), brownian.rng_seed(), p.id());
   for (int j = 0; j < 3; j++) {
     if (!p.is_fixed_along(j)) {
 #ifndef PARTICLE_ANISOTROPY
@@ -224,7 +224,7 @@ inline Utils::Vector3d bd_random_walk_vel(BrownianThermostat const &brownian,
     return {};
 
   auto const noise = Random::noise_gaussian<RNGSalt::BROWNIAN_INC>(
-      brownian.rng_counter(), brownian.rng_seed(), p.identity());
+      brownian.rng_counter(), brownian.rng_seed(), p.id());
   Utils::Vector3d velocity = {};
   for (int j = 0; j < 3; j++) {
     if (!p.is_fixed_along(j)) {
@@ -274,7 +274,7 @@ bd_drag_rot(Thermostat::GammaType const &brownian_gamma_rotation, Particle &p,
 #endif // PARTICLE_ANISOTROPY
     }
   }
-  dphi = mask(p.p.rotation, dphi);
+  dphi = mask(p.rotation(), dphi);
   double dphi_m = dphi.norm();
   if (dphi_m != 0.) {
     auto const dphi_u = dphi / dphi_m;
@@ -313,7 +313,7 @@ bd_drag_vel_rot(Thermostat::GammaType const &brownian_gamma_rotation,
 #endif // PARTICLE_ANISOTROPY
     }
   }
-  return mask(p.p.rotation, omega);
+  return mask(p.rotation(), omega);
 }
 
 /** Determine the quaternions: random walk part.
@@ -341,7 +341,7 @@ bd_random_walk_rot(BrownianThermostat const &brownian, Particle const &p,
 
   Utils::Vector3d dphi = {};
   auto const noise = Random::noise_gaussian<RNGSalt::BROWNIAN_ROT_INC>(
-      brownian.rng_counter(), brownian.rng_seed(), p.identity());
+      brownian.rng_counter(), brownian.rng_seed(), p.id());
   for (int j = 0; j < 3; j++) {
     if (!p.is_fixed_along(j)) {
 #ifndef PARTICLE_ANISOTROPY
@@ -355,7 +355,7 @@ bd_random_walk_rot(BrownianThermostat const &brownian, Particle const &p,
 #endif // PARTICLE_ANISOTROPY
     }
   }
-  dphi = mask(p.p.rotation, dphi);
+  dphi = mask(p.rotation(), dphi);
   // making the algorithm independent of the order of the rotations
   double dphi_m = dphi.norm();
   if (dphi_m != 0) {
@@ -376,13 +376,13 @@ bd_random_walk_vel_rot(BrownianThermostat const &brownian, Particle const &p) {
 
   Utils::Vector3d domega{};
   auto const noise = Random::noise_gaussian<RNGSalt::BROWNIAN_ROT_WALK>(
-      brownian.rng_counter(), brownian.rng_seed(), p.identity());
+      brownian.rng_counter(), brownian.rng_seed(), p.id());
   for (int j = 0; j < 3; j++) {
     if (!p.is_fixed_along(j)) {
       domega[j] = sigma_vel * noise[j] / sqrt(p.rinertia()[j]);
     }
   }
-  return mask(p.p.rotation, domega);
+  return mask(p.rotation(), domega);
 }
 #endif // ROTATION
 

--- a/src/core/thermostats/langevin_inline.hpp
+++ b/src/core/thermostats/langevin_inline.hpp
@@ -88,9 +88,8 @@ friction_thermo_langevin(LangevinThermostat const &langevin, Particle const &p,
 #endif // PARTICLE_ANISOTROPY
 
   return friction_op * velocity +
-         noise_op *
-             Random::noise_uniform<RNGSalt::LANGEVIN>(
-                 langevin.rng_counter(), langevin.rng_seed(), p.identity());
+         noise_op * Random::noise_uniform<RNGSalt::LANGEVIN>(
+                        langevin.rng_counter(), langevin.rng_seed(), p.id());
 }
 
 #ifdef ROTATION
@@ -123,7 +122,7 @@ friction_thermo_langevin_rotation(LangevinThermostat const &langevin,
 #endif // THERMOSTAT_PER_PARTICLE
 
   auto const noise = Random::noise_uniform<RNGSalt::LANGEVIN_ROT>(
-      langevin.rng_counter(), langevin.rng_seed(), p.identity());
+      langevin.rng_counter(), langevin.rng_seed(), p.id());
   return hadamard_product(pref_friction, p.omega()) +
          hadamard_product(pref_noise, noise);
 }

--- a/src/core/unit_tests/ParticleIterator_test.cpp
+++ b/src/core/unit_tests/ParticleIterator_test.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(completeness) {
 
   /* Iterator over parts and count occurrence */
   for (; begin != end; ++begin) {
-    counts[begin->identity()]++;
+    counts[begin->id()]++;
   }
 
   /* Every particle should be visited exactly once. */
@@ -80,9 +80,9 @@ BOOST_AUTO_TEST_CASE(skip_empty) {
 
   auto begin = iterator(cells.begin(), cells.end());
 
-  BOOST_CHECK(begin->identity() == 0);
+  BOOST_CHECK(begin->id() == 0);
   ++begin;
-  BOOST_CHECK(begin->identity() == 1);
+  BOOST_CHECK(begin->id() == 1);
 }
 
 BOOST_AUTO_TEST_CASE(order) {
@@ -103,11 +103,11 @@ BOOST_AUTO_TEST_CASE(order) {
   std::vector<Particle> id_diff(n_cells, Particle{0});
   std::adjacent_difference(begin, end, id_diff.begin(),
                            [](Particle const &a, Particle const &b) {
-                             return Particle{a.identity() - b.identity()};
+                             return Particle{a.id() - b.id()};
                            });
 
   BOOST_CHECK(std::all_of(id_diff.begin() + 1, id_diff.end(),
-                          [](Particle const &p) { return p.identity() == 1; }));
+                          [](Particle const &p) { return p.id() == 1; }));
 }
 
 BOOST_AUTO_TEST_CASE(distance_overload) {

--- a/src/core/unit_tests/Particle_test.cpp
+++ b/src/core/unit_tests/Particle_test.cpp
@@ -42,8 +42,8 @@ BOOST_AUTO_TEST_CASE(comparison) {
   {
     Particle p, q;
 
-    p.identity() = 1;
-    q.identity() = 2;
+    p.id() = 1;
+    q.id() = 2;
 
     BOOST_CHECK(p != q);
     BOOST_CHECK(not(p == q));
@@ -52,8 +52,8 @@ BOOST_AUTO_TEST_CASE(comparison) {
   {
     Particle p, q;
 
-    p.identity() = 2;
-    q.identity() = 2;
+    p.id() = 2;
+    q.id() = 2;
 
     BOOST_CHECK(not(p != q));
     BOOST_CHECK(p == q);

--- a/src/core/unit_tests/field_coupling_couplings_test.cpp
+++ b/src/core/unit_tests/field_coupling_couplings_test.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(scaled) {
     struct Particle {
       Particle(int id) : m_id(id) {}
 
-      int identity() const { return m_id; };
+      int id() const { return m_id; };
 
       const int m_id;
     };

--- a/src/core/unit_tests/grid_test.cpp
+++ b/src/core/unit_tests/grid_test.cpp
@@ -143,9 +143,7 @@ BOOST_AUTO_TEST_CASE(lees_edwards_mi_vector) {
   box.set_length(box_l);
   box.set_periodic(1, false);
   box.set_type(BoxType::LEES_EDWARDS);
-  LeesEdwardsBC le;
-  le.shear_direction = 2;
-  le.shear_plane_normal = 0;
+  LeesEdwardsBC le{0., 0., 2, 0};
   box.set_lees_edwards_bc(le);
 
   // No pos offset -> behave like normal get_mi_vector
@@ -200,9 +198,7 @@ BOOST_AUTO_TEST_CASE(lees_edwards_mi_vector) {
   box.set_periodic(1, true);
   box.set_periodic(2, true);
   box.set_length(Vector3d{5, 5, 5});
-  box.lees_edwards_bc().pos_offset = 2.98;
-  box.lees_edwards_bc().shear_direction = 0;
-  box.lees_edwards_bc().shear_plane_normal = 1;
+  box.set_lees_edwards_bc(LeesEdwardsBC{2.98, 0., 0, 1});
   auto const result =
       box.get_mi_vector(Vector3d{2.5, 1., 2.5}, Vector3d{4.52, 4., 2.5});
   BOOST_CHECK_SMALL(std::fabs(result[0]), box.length_half()[0]);
@@ -220,7 +216,7 @@ BOOST_AUTO_TEST_CASE(image_shift_test) {
 }
 
 BOOST_AUTO_TEST_CASE(unfolded_position_test) {
-  Utils::Vector3d pos{5., 6, 7.};
+  Utils::Vector3d pos{5., 6., 7.};
   Utils::Vector3i img{1, -2, 3};
   Utils::Vector3d box{1., 2., 3.};
 

--- a/src/core/unit_tests/lees_edwards_test.cpp
+++ b/src/core/unit_tests/lees_edwards_test.cpp
@@ -40,11 +40,10 @@ auto constexpr eps = std::numeric_limits<double>::epsilon();
 auto constexpr tol = 100. * eps;
 
 BOOST_AUTO_TEST_CASE(test_shear_direction) {
-  LeesEdwardsBC le;
-  le.shear_direction = 1;
+  LeesEdwardsBC le{0., 0., 1, 0};
   BoxGeometry box;
   box.set_lees_edwards_bc(le);
-  auto const expected_direction = Utils::Vector3d{{0, 1, 0}};
+  auto const expected_direction = Utils::Vector3d{{0., 1., 0.}};
   BOOST_CHECK_SMALL((shear_direction(box) - expected_direction).norm(), eps);
 }
 
@@ -53,10 +52,7 @@ BOOST_AUTO_TEST_CASE(test_update_offset) {
   p.image_box() = {2, 4, -1};
   p.lees_edwards_offset() = 1.5;
 
-  LeesEdwardsBC le;
-  le.shear_direction = 1;
-  le.shear_plane_normal = 2;
-  le.shear_velocity = 3.5;
+  LeesEdwardsBC le{0., 3.5, 1, 2};
   BoxGeometry box;
   box.set_lees_edwards_bc(le);
   UpdateOffset(box, 3.5)(p);
@@ -81,11 +77,7 @@ BOOST_AUTO_TEST_CASE(test_push) {
   p.image_box() = {2, 4, -1};
   p.lees_edwards_offset() = old_offset;
 
-  LeesEdwardsBC le;
-  le.shear_direction = 2;
-  le.shear_plane_normal = 1;
-  le.pos_offset = 2.5;
-  le.shear_velocity = -3.1;
+  LeesEdwardsBC le{2.5, -3.1, 2, 1};
 
   BoxGeometry box;
   box.set_type(BoxType::LEES_EDWARDS);

--- a/src/core/unit_tests/mock/Particle.hpp
+++ b/src/core/unit_tests/mock/Particle.hpp
@@ -28,7 +28,7 @@ public:
   Particle() : m_id(-1) {}
   explicit Particle(int id) : m_id(id) {}
 
-  int identity() const { return m_id; }
+  int id() const { return m_id; }
 
   int m_id;
 };

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -130,7 +130,7 @@ calculate_vs_relate_to_params(Particle const &p_current,
 void local_vs_relate_to(Particle &p_current, Particle const &p_relate_to) {
   // Set the particle id of the particle we want to relate to, the distance
   // and the relative orientation
-  p_current.vs_relative().to_particle_id = p_relate_to.identity();
+  p_current.vs_relative().to_particle_id = p_relate_to.id();
   std::tie(p_current.vs_relative().rel_orientation,
            p_current.vs_relative().distance) =
       calculate_vs_relate_to_params(p_current, p_relate_to);

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -82,7 +82,7 @@ static Particle *get_reference_particle(Particle const &p) {
   auto p_ref_ptr = cell_structure.get_local_particle(vs_rel.to_particle_id);
   if (!p_ref_ptr) {
     runtimeErrorMsg() << "No real particle with id " << vs_rel.to_particle_id
-                      << " for virtual site with id " << p.identity();
+                      << " for virtual site with id " << p.id();
   }
   return p_ref_ptr;
 }

--- a/src/python/espressomd/analyze.pyx
+++ b/src/python/espressomd/analyze.pyx
@@ -605,7 +605,7 @@ class Analysis:
         r = np.zeros(r_bins)
 
         if log_flag:
-            log_fac = (float(r_max) / r_min)**(1.0 / r_bins)
+            log_fac = (r_max / r_min)**(1.0 / r_bins)
             r[0] = r_min * np.sqrt(log_fac)
             for i in xrange(1, r_bins):
                 r[i] = r[i - 1] * log_fac

--- a/src/python/espressomd/lb.pyx
+++ b/src/python/espressomd/lb.pyx
@@ -86,12 +86,7 @@ cdef class FluidActor:
         Check if the data stored in this instance still matches the
         corresponding data in the core.
         """
-        temp_params = self._get_params_from_es_core()
-        if self._params != temp_params:
-            return False
-
-        # If we're still here, the instance is valid
-        return True
+        return self._params == self._get_params_from_es_core()
 
     def get_params(self):
         """Get interaction parameters"""

--- a/src/python/espressomd/lees_edwards.py
+++ b/src/python/espressomd/lees_edwards.py
@@ -24,6 +24,9 @@ class LeesEdwards(ScriptInterfaceHelper):
 
     """
     Interface to the :ref:`Lees-Edwards boundary conditions`.
+    When writing H5MD files, the shear direction and shear plane normals
+    are written as integers instead of characters, with 0 = *x*-axis,
+    1 = *y*-axis, 2 = *z*-axis.
 
     Attributes
     ----------
@@ -33,12 +36,10 @@ class LeesEdwards(ScriptInterfaceHelper):
         Current shear velocity.
     pos_offset : :obj:`float`
         Current position offset
-    shear_direction : :obj:`int`
-        Shear direction: 0 for the *x*-axis, 1 for the *y*-axis,
-        2 for the *z*-axis.
-    shear_plane_normal : :obj:`int`
-        Shear plane normal: 0 for the *x*-axis, 1 for the *y*-axis,
-        2 for the *z*-axis.
+    shear_direction : :obj:`str`, \{'x', 'y', 'z'\}
+        Shear direction.
+    shear_plane_normal : :obj:`str`, \{'x', 'y', 'z'\}
+        Shear plane normal.
 
     Methods
     -------
@@ -48,8 +49,8 @@ class LeesEdwards(ScriptInterfaceHelper):
         Parameters
         ----------
         protocol : :obj:`object`
-        shear_direction : :obj:`int`
-        shear_plane_normal : :obj:`int`
+        shear_direction : :obj:`str`, \{'x', 'y', 'z'\}
+        shear_plane_normal : :obj:`str`, \{'x', 'y', 'z'\}
 
     """
 

--- a/src/python/espressomd/lees_edwards.py
+++ b/src/python/espressomd/lees_edwards.py
@@ -40,9 +40,21 @@ class LeesEdwards(ScriptInterfaceHelper):
         Shear plane normal: 0 for the *x*-axis, 1 for the *y*-axis,
         2 for the *z*-axis.
 
+    Methods
+    -------
+    set_boundary_conditions()
+        Set a protocol, the shear direction and shear normal.
+
+        Parameters
+        ----------
+        protocol : :obj:`object`
+        shear_direction : :obj:`int`
+        shear_plane_normal : :obj:`int`
+
     """
 
     _so_name = "LeesEdwards::LeesEdwards"
+    _so_bind_methods = ("set_boundary_conditions",)
 
 
 @script_interface_register

--- a/src/python/espressomd/particle_data.pxd
+++ b/src/python/espressomd/particle_data.pxd
@@ -46,7 +46,7 @@ cdef extern from "Particle.hpp":
     ctypedef struct particle "Particle":
         Vector3d calc_dip()
         int type()
-        int identity()
+        int id()
         double mass()
         int mol_id()
         Vector3d pos()

--- a/src/python/espressomd/particle_data.pyx
+++ b/src/python/espressomd/particle_data.pyx
@@ -104,7 +104,7 @@ cdef class ParticleHandle:
 
         def __get__(self):
             self.update_particle_data()
-            return self.particle_data.identity()
+            return self.particle_data.id()
 
     # The individual attributes of a particle are implemented as properties.
 

--- a/src/python/espressomd/system.pyx
+++ b/src/python/espressomd/system.pyx
@@ -212,9 +212,10 @@ cdef class System:
         if has_features("VIRTUAL_SITES"):
             checkpointable_properties.append("_active_virtual_sites_handle")
         checkpointable_properties += [
-            "non_bonded_inter", "bonded_inter", "cell_system", "part", "actors",
-            "analysis", "auto_update_accumulators", "comfixed", "constraints",
-            "galilei", "thermostat", "bond_breakage", "max_oif_objects"
+            "non_bonded_inter", "bonded_inter", "cell_system", "lees_edwards",
+            "part", "actors", "analysis", "auto_update_accumulators",
+            "comfixed", "constraints", "galilei", "thermostat",
+            "bond_breakage", "max_oif_objects"
         ]
         if has_features("LB_BOUNDARIES") or has_features("LB_BOUNDARIES_GPU"):
             checkpointable_properties.append("lbboundaries")

--- a/src/script_interface/cell_system/CellSystem.hpp
+++ b/src/script_interface/cell_system/CellSystem.hpp
@@ -23,6 +23,8 @@
 #include "script_interface/ScriptInterface.hpp"
 
 #include "core/bonded_interactions/bonded_interaction_data.hpp"
+#include "core/cell_system/HybridDecomposition.hpp"
+#include "core/cell_system/RegularDecomposition.hpp"
 #include "core/cells.hpp"
 #include "core/communication.hpp"
 #include "core/event.hpp"
@@ -191,11 +193,10 @@ public:
         state["cell_grid"] = pack_vector(hd.get_cell_grid());
         state["cell_size"] = Variant{hd.get_cell_size()};
         mpi_resort_particles(true); // needed to get correct particle counts
-        auto const n_particles = hybrid_parts_per_decomposition(hd);
         state["parts_per_decomposition"] =
             Variant{std::unordered_map<std::string, Variant>{
-                {"regular", n_particles.first},
-                {"n_square", n_particles.second}}};
+                {"regular", hd.count_particles_in_regular()},
+                {"n_square", hd.count_particles_in_n_square()}}};
       }
       state["verlet_reuse"] = get_verlet_reuse();
       state["n_nodes"] = ::n_nodes;

--- a/src/script_interface/lees_edwards/LeesEdwards.hpp
+++ b/src/script_interface/lees_edwards/LeesEdwards.hpp
@@ -102,6 +102,12 @@ public:
     return {};
   }
 
+  void do_construct(VariantMap const &params) override {
+    if (not params.empty()) {
+      do_call_method("set_boundary_conditions", params);
+    }
+  }
+
 private:
   int get_shear_axis(VariantMap const &params, std::string name) {
     auto const value = get_value<std::string>(params, name);

--- a/src/script_interface/lees_edwards/LeesEdwards.hpp
+++ b/src/script_interface/lees_edwards/LeesEdwards.hpp
@@ -70,9 +70,9 @@ public:
          {"pos_offset", AutoParameter::read_only,
           [this]() { return m_lebc.pos_offset; }},
          {"shear_direction", AutoParameter::read_only,
-          [this]() { return m_lebc.shear_direction; }},
+          [this]() { return get_shear_name(m_lebc.shear_direction); }},
          {"shear_plane_normal", AutoParameter::read_only,
-          [this]() { return m_lebc.shear_plane_normal; }}});
+          [this]() { return get_shear_name(m_lebc.shear_plane_normal); }}});
   }
 
   Variant do_call_method(std::string const &name,
@@ -86,16 +86,9 @@ public:
         }
         // check input arguments
         m_protocol = get_value<std::shared_ptr<Protocol>>(protocol);
-        auto const shear_direction = get_value<int>(params, "shear_direction");
+        auto const shear_direction = get_shear_axis(params, "shear_direction");
         auto const shear_plane_normal =
-            get_value<int>(params, "shear_plane_normal");
-        if (shear_direction < 0 or shear_direction > 2) {
-          throw std::invalid_argument("Parameter 'shear_direction' is invalid");
-        }
-        if (shear_plane_normal < 0 or shear_plane_normal > 2) {
-          throw std::invalid_argument(
-              "Parameter 'shear_plane_normal' is invalid");
-        }
+            get_shear_axis(params, "shear_plane_normal");
         if (shear_plane_normal == shear_direction) {
           throw std::invalid_argument("Parameters 'shear_direction' and "
                                       "'shear_plane_normal' must differ");
@@ -107,6 +100,34 @@ public:
       });
     }
     return {};
+  }
+
+private:
+  int get_shear_axis(VariantMap const &params, std::string name) {
+    auto const value = get_value<std::string>(params, name);
+    if (value == "x") {
+      return 0;
+    }
+    if (value == "y") {
+      return 1;
+    }
+    if (value == "z") {
+      return 2;
+    }
+    throw std::invalid_argument("Parameter '" + name + "' is invalid");
+  }
+
+  Variant get_shear_name(int axis) {
+    if (axis == 0) {
+      return {std::string("x")};
+    }
+    if (axis == 1) {
+      return {std::string("y")};
+    }
+    if (axis == 2) {
+      return {std::string("z")};
+    }
+    return {none};
   }
 };
 

--- a/testsuite/python/analyze_distance.py
+++ b/testsuite/python/analyze_distance.py
@@ -81,10 +81,14 @@ class AnalyzeDistance(ut.TestCase):
             self.assertAlmostEqual(self.system.analysis.min_dist(),
                                    self.min_dist(),
                                    delta=1e-7)
-
-    def test_min_dist_empty(self):
+        # without particles
         self.system.part.clear()
         self.assertEqual(self.system.analysis.min_dist(), float("inf"))
+        # with specific types
+        self.system.part.add(pos=[[0., 0., 0.], [1., 0., 0.], [2., 0., 0.]],
+                             type=[0, 1, 2])
+        self.assertAlmostEqual(
+            self.system.analysis.min_dist([0], [2]), 2., delta=1e-12)
 
     def test_nbhood(self):
         # try five times

--- a/testsuite/python/get_neighbors.py
+++ b/testsuite/python/get_neighbors.py
@@ -150,10 +150,10 @@ class Test(ut.TestCase):
         in the distance calculation.
         """
         system = self.system
-        system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+        protocol = espressomd.lees_edwards.LinearShear(
             initial_pos_offset=0.1, time_0=0., shear_velocity=1.0)
-        system.lees_edwards.shear_direction = 0
-        system.lees_edwards.shear_plane_normal = 2
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=2, protocol=protocol)
         p1 = system.part.add(pos=[0., 0., 0.])
         p2 = system.part.add(pos=[0., 0., 0.99])
         self.assertEqual(system.cell_system.get_neighbors(p1, 0.10), [])

--- a/testsuite/python/get_neighbors.py
+++ b/testsuite/python/get_neighbors.py
@@ -153,7 +153,7 @@ class Test(ut.TestCase):
         protocol = espressomd.lees_edwards.LinearShear(
             initial_pos_offset=0.1, time_0=0., shear_velocity=1.0)
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=2, protocol=protocol)
+            shear_direction="x", shear_plane_normal="z", protocol=protocol)
         p1 = system.part.add(pos=[0., 0., 0.])
         p2 = system.part.add(pos=[0., 0., 0.99])
         self.assertEqual(system.cell_system.get_neighbors(p1, 0.10), [])

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -72,10 +72,10 @@ class H5mdTests(ut.TestCase):
 
     system.integrator.run(steps=0)
     system.time = 12.3
-    system.lees_edwards.shear_direction = 0
-    system.lees_edwards.shear_plane_normal = 1
-    system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+    protocol = espressomd.lees_edwards.LinearShear(
         shear_velocity=1.5, initial_pos_offset=0.5, time_0=-0.3)
+    system.lees_edwards.set_boundary_conditions(
+        shear_direction=0, shear_plane_normal=1, protocol=protocol)
     n_nodes = system.cell_system.get_state()["n_nodes"]
 
     @classmethod

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -75,7 +75,7 @@ class H5mdTests(ut.TestCase):
     protocol = espressomd.lees_edwards.LinearShear(
         shear_velocity=1.5, initial_pos_offset=0.5, time_0=-0.3)
     system.lees_edwards.set_boundary_conditions(
-        shear_direction=0, shear_plane_normal=1, protocol=protocol)
+        shear_direction="x", shear_plane_normal="y", protocol=protocol)
     n_nodes = system.cell_system.get_state()["n_nodes"]
 
     @classmethod
@@ -209,8 +209,9 @@ class H5mdTests(ut.TestCase):
         le_offset = protocol.initial_pos_offset + protocol.shear_velocity * (
             self.system.time - protocol.time_0)
         np.testing.assert_allclose(self.py_le_offset, le_offset)
-        self.assertEqual(self.py_le_direction, le_bc.shear_direction)
-        self.assertEqual(self.py_le_normal, le_bc.shear_plane_normal)
+        conv = {0: "x", 1: "y", 2: "z"}
+        self.assertEqual(conv[self.py_le_direction[0]], le_bc.shear_direction)
+        self.assertEqual(conv[self.py_le_normal[0]], le_bc.shear_plane_normal)
 
     def test_metadata(self):
         """Test if the H5MD metadata has been written properly."""

--- a/testsuite/python/integrator_exceptions.py
+++ b/testsuite/python/integrator_exceptions.py
@@ -88,13 +88,17 @@ class Integrator_test(ut.TestCase):
             self.system.integrator.run(0)
         self.system.thermostat.turn_off()
         self.system.thermostat.set_npt(kT=1.0, gamma0=2., gammav=0.04, seed=42)
+        protocol = espressomd.lees_edwards.LinearShear(
+            shear_velocity=1., initial_pos_offset=0., time_0=0.)
         with self.assertRaisesRegex(Exception, self.msg + 'The NpT integrator cannot use Lees-Edwards'):
-            self.system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
-                shear_velocity=1., initial_pos_offset=0., time_0=0.)
+            self.system.lees_edwards.set_boundary_conditions(
+                shear_direction=0, shear_plane_normal=1, protocol=protocol)
             self.system.integrator.run(0)
         with self.assertRaisesRegex(Exception, self.msg + 'The NpT integrator cannot use Lees-Edwards'):
             self.system.lees_edwards.protocol = espressomd.lees_edwards.Off()
             self.system.integrator.run(0)
+        self.system.lees_edwards.protocol = None
+        self.system.integrator.run(0)
 
     @utx.skipIfMissingFeatures("STOKESIAN_DYNAMICS")
     def test_stokesian_integrator(self):

--- a/testsuite/python/integrator_exceptions.py
+++ b/testsuite/python/integrator_exceptions.py
@@ -92,7 +92,7 @@ class Integrator_test(ut.TestCase):
             shear_velocity=1., initial_pos_offset=0., time_0=0.)
         with self.assertRaisesRegex(Exception, self.msg + 'The NpT integrator cannot use Lees-Edwards'):
             self.system.lees_edwards.set_boundary_conditions(
-                shear_direction=0, shear_plane_normal=1, protocol=protocol)
+                shear_direction="x", shear_plane_normal="y", protocol=protocol)
             self.system.integrator.run(0)
         with self.assertRaisesRegex(Exception, self.msg + 'The NpT integrator cannot use Lees-Edwards'):
             self.system.lees_edwards.protocol = espressomd.lees_edwards.Off()

--- a/testsuite/python/lees_edwards.py
+++ b/testsuite/python/lees_edwards.py
@@ -41,7 +41,8 @@ off_protocol = espressomd.lees_edwards.Off()
 def axis(coord):
     """Return Cartesian axis from coordinate index"""
     res = np.zeros(3)
-    res[coord] = 1
+    mapping = {"x": 0, "y": 1, "z": 2}
+    res[mapping[coord]] = 1
     return res
 
 
@@ -53,7 +54,7 @@ class LeesEdwards(ut.TestCase):
 
     time_step = 0.5
     system.time_step = time_step
-    direction_permutations = list(itertools.permutations([0, 1, 2], 2))
+    direction_permutations = list(itertools.permutations(["x", "y", "z"], 2))
 
     def setUp(self):
         self.system.time = 0.0
@@ -73,8 +74,8 @@ class LeesEdwards(ut.TestCase):
 
         # Protocol should be off by default
         self.assertIsNone(system.lees_edwards.protocol)
-        self.assertEqual(system.lees_edwards.shear_direction, -1)
-        self.assertEqual(system.lees_edwards.shear_plane_normal, -1)
+        self.assertIsNone(system.lees_edwards.shear_direction)
+        self.assertIsNone(system.lees_edwards.shear_plane_normal)
         self.assertEqual(system.lees_edwards.shear_velocity, 0.)
         self.assertEqual(system.lees_edwards.pos_offset, 0.)
 
@@ -85,7 +86,7 @@ class LeesEdwards(ut.TestCase):
         system = self.system
         system.time = 3.15
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=1, protocol=lin_protocol)
+            shear_direction="x", shear_plane_normal="y", protocol=lin_protocol)
 
         # check protocol assignment
         self.assertEqual(system.lees_edwards.protocol, lin_protocol)
@@ -141,18 +142,18 @@ class LeesEdwards(ut.TestCase):
 
         # Check that LE is disabled correctly via parameter
         system.lees_edwards.protocol = None
-        self.assertEqual(system.lees_edwards.shear_direction, -1)
-        self.assertEqual(system.lees_edwards.shear_plane_normal, -1)
+        self.assertIsNone(system.lees_edwards.shear_direction)
+        self.assertIsNone(system.lees_edwards.shear_plane_normal)
         self.assertEqual(system.lees_edwards.shear_velocity, 0.)
         self.assertEqual(system.lees_edwards.pos_offset, 0.)
 
         # Check that LE is disabled correctly via boundary conditions setter
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=1, protocol=lin_protocol)
+            shear_direction="z", shear_plane_normal="y", protocol=lin_protocol)
         system.lees_edwards.set_boundary_conditions(
             shear_direction=99, shear_plane_normal=99, protocol=None)
-        self.assertEqual(system.lees_edwards.shear_direction, -1)
-        self.assertEqual(system.lees_edwards.shear_plane_normal, -1)
+        self.assertIsNone(system.lees_edwards.shear_direction)
+        self.assertIsNone(system.lees_edwards.shear_plane_normal)
         self.assertEqual(system.lees_edwards.shear_velocity, 0.)
         self.assertEqual(system.lees_edwards.pos_offset, 0.)
 
@@ -163,16 +164,16 @@ class LeesEdwards(ut.TestCase):
             system.lees_edwards.protocol = lin_protocol
 
         # Check assertions
-        for invalid in (-2, -1, 3):
+        for invalid in ("xy", "t"):
             with self.assertRaisesRegex(ValueError, "Parameter 'shear_direction' is invalid"):
                 system.lees_edwards.set_boundary_conditions(
-                    shear_direction=invalid, shear_plane_normal=0,
+                    shear_direction=invalid, shear_plane_normal="x",
                     protocol=lin_protocol)
             with self.assertRaisesRegex(ValueError, "Parameter 'shear_plane_normal' is invalid"):
                 system.lees_edwards.set_boundary_conditions(
-                    shear_direction=0, shear_plane_normal=invalid,
+                    shear_direction="x", shear_plane_normal=invalid,
                     protocol=lin_protocol)
-        for valid in (0, 1, 2):
+        for valid in "xyz":
             with self.assertRaisesRegex(ValueError, "Parameters 'shear_direction' and 'shear_plane_normal' must differ"):
                 system.lees_edwards.set_boundary_conditions(
                     shear_direction=valid, shear_plane_normal=valid,
@@ -279,7 +280,7 @@ class LeesEdwards(ut.TestCase):
         protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=1., initial_pos_offset=0.0, time_0=0.0)
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=1, protocol=protocol)
+            shear_direction="x", shear_plane_normal="y", protocol=protocol)
 
         pos = system.box_l - 0.01
         vel = np.array([0, 1, 0])
@@ -420,7 +421,7 @@ class LeesEdwards(ut.TestCase):
         system.integrator.run(1)
 
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=1, protocol=lin_protocol)
+            shear_direction="x", shear_plane_normal="y", protocol=lin_protocol)
         system.integrator.run(1)
         np.testing.assert_allclose(
             np.copy(system.distance_vec(p3, p2)), [0, 2, 0], atol=tol)
@@ -462,7 +463,7 @@ class LeesEdwards(ut.TestCase):
         protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=2.0, initial_pos_offset=0.0)
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=1, protocol=protocol)
+            shear_direction="x", shear_plane_normal="y", protocol=protocol)
         p1 = system.part.add(
             pos=[2.5, 2.5, 2.5], rotation=(1, 1, 1), type=10, v=(0.0, -0.1, -0.25))
         p2 = system.part.add(pos=(2.5, 3.5, 2.5), type=11)
@@ -522,7 +523,7 @@ class LeesEdwards(ut.TestCase):
         protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=-1.0, initial_pos_offset=0.0)
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=1, protocol=protocol)
+            shear_direction="x", shear_plane_normal="y", protocol=protocol)
 
         col_part1 = system.part.add(
             pos=(2.5, 4.5, 2.5), type=30, fix=[True, True, True])
@@ -611,7 +612,7 @@ class LeesEdwards(ut.TestCase):
         protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=-1.0, initial_pos_offset=0.0)
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=0, shear_plane_normal=1, protocol=protocol)
+            shear_direction="x", shear_plane_normal="y", protocol=protocol)
 
         harm = espressomd.interactions.HarmonicBond(
             k=1.0, r_0=0.0, r_cut=np.sqrt(2.))
@@ -711,7 +712,7 @@ class LeesEdwards(ut.TestCase):
         protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=0.3, initial_pos_offset=0.01)
         system.lees_edwards.set_boundary_conditions(
-            shear_direction=2, shear_plane_normal=0, protocol=protocol)
+            shear_direction="z", shear_plane_normal="x", protocol=protocol)
         system.integrator.run(1, recalc_forces=True)
         tests_common.check_non_bonded_loop_trace(self, system)
 

--- a/testsuite/python/lees_edwards.py
+++ b/testsuite/python/lees_edwards.py
@@ -73,8 +73,10 @@ class LeesEdwards(ut.TestCase):
 
         # Protocol should be off by default
         self.assertIsNone(system.lees_edwards.protocol)
-        self.assertEqual(system.lees_edwards.shear_velocity, 0)
-        self.assertEqual(system.lees_edwards.pos_offset, 0)
+        self.assertEqual(system.lees_edwards.shear_direction, -1)
+        self.assertEqual(system.lees_edwards.shear_plane_normal, -1)
+        self.assertEqual(system.lees_edwards.shear_velocity, 0.)
+        self.assertEqual(system.lees_edwards.pos_offset, 0.)
 
     def test_protocols(self):
         """Test shear velocity and pos offset vs protocol and time"""
@@ -82,7 +84,8 @@ class LeesEdwards(ut.TestCase):
         # Linear shear
         system = self.system
         system.time = 3.15
-        system.lees_edwards.protocol = lin_protocol
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=1, protocol=lin_protocol)
 
         # check protocol assignment
         self.assertEqual(system.lees_edwards.protocol, lin_protocol)
@@ -122,6 +125,7 @@ class LeesEdwards(ut.TestCase):
                 system.lees_edwards.shear_velocity, expected_vel)
             self.assertAlmostEqual(
                 system.lees_edwards.pos_offset, expected_pos)
+
         # Check that time change during integration updates offsets
         system.integrator.run(1)
         time = system.time
@@ -135,10 +139,44 @@ class LeesEdwards(ut.TestCase):
         self.assertAlmostEqual(
             system.lees_edwards.pos_offset, expected_pos)
 
-        # Check that LE is disabled correctly
+        # Check that LE is disabled correctly via parameter
         system.lees_edwards.protocol = None
-        self.assertEqual(system.lees_edwards.shear_velocity, 0)
-        self.assertEqual(system.lees_edwards.pos_offset, 0)
+        self.assertEqual(system.lees_edwards.shear_direction, -1)
+        self.assertEqual(system.lees_edwards.shear_plane_normal, -1)
+        self.assertEqual(system.lees_edwards.shear_velocity, 0.)
+        self.assertEqual(system.lees_edwards.pos_offset, 0.)
+
+        # Check that LE is disabled correctly via boundary conditions setter
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=1, protocol=lin_protocol)
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=99, shear_plane_normal=99, protocol=None)
+        self.assertEqual(system.lees_edwards.shear_direction, -1)
+        self.assertEqual(system.lees_edwards.shear_plane_normal, -1)
+        self.assertEqual(system.lees_edwards.shear_velocity, 0.)
+        self.assertEqual(system.lees_edwards.pos_offset, 0.)
+
+        # Check that when LE is disabled, protocols can only be
+        # initialized via boundary conditions setter, because the
+        # shear direction and shear normal must be known
+        with self.assertRaisesRegex(RuntimeError, "must be initialized together with 'protocol' on first activation"):
+            system.lees_edwards.protocol = lin_protocol
+
+        # Check assertions
+        for invalid in (-2, -1, 3):
+            with self.assertRaisesRegex(ValueError, "Parameter 'shear_direction' is invalid"):
+                system.lees_edwards.set_boundary_conditions(
+                    shear_direction=invalid, shear_plane_normal=0,
+                    protocol=lin_protocol)
+            with self.assertRaisesRegex(ValueError, "Parameter 'shear_plane_normal' is invalid"):
+                system.lees_edwards.set_boundary_conditions(
+                    shear_direction=0, shear_plane_normal=invalid,
+                    protocol=lin_protocol)
+        for valid in (0, 1, 2):
+            with self.assertRaisesRegex(ValueError, "Parameters 'shear_direction' and 'shear_plane_normal' must differ"):
+                system.lees_edwards.set_boundary_conditions(
+                    shear_direction=valid, shear_plane_normal=valid,
+                    protocol=lin_protocol)
 
     def test_boundary_crossing_lin(self):
         """
@@ -148,13 +186,13 @@ class LeesEdwards(ut.TestCase):
 
         system = self.system
 
-        system.lees_edwards.protocol = lin_protocol
         box_l = np.copy(system.box_l)
         tol = 1e-10
 
         for shear_direction, shear_plane_normal in self.direction_permutations:
-            system.lees_edwards.shear_direction = shear_direction
-            system.lees_edwards.shear_plane_normal = shear_plane_normal
+            system.lees_edwards.set_boundary_conditions(
+                shear_direction=shear_direction,
+                shear_plane_normal=shear_plane_normal, protocol=lin_protocol)
 
             system.time = 0.0
             shear_axis = axis(shear_direction)
@@ -207,13 +245,13 @@ class LeesEdwards(ut.TestCase):
         """
 
         system = self.system
-        system.lees_edwards.protocol = off_protocol
         box_l = np.copy(system.box_l)
         tol = 1e-10
 
         for shear_direction, shear_plane_normal in self.direction_permutations:
-            system.lees_edwards.shear_direction = shear_direction
-            system.lees_edwards.shear_plane_normal = shear_plane_normal
+            system.lees_edwards.set_boundary_conditions(
+                shear_direction=shear_direction,
+                shear_plane_normal=shear_plane_normal, protocol=off_protocol)
 
             system.time = 0.0
             pos = box_l - 0.01
@@ -238,10 +276,10 @@ class LeesEdwards(ut.TestCase):
     def test_trajectory_reconstruction(self):
         system = self.system
 
-        system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+        protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=1., initial_pos_offset=0.0, time_0=0.0)
-        system.lees_edwards.shear_direction = 0
-        system.lees_edwards.shear_plane_normal = 1
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=1, protocol=protocol)
 
         pos = system.box_l - 0.01
         vel = np.array([0, 1, 0])
@@ -269,15 +307,14 @@ class LeesEdwards(ut.TestCase):
         """
 
         system = self.system
-        system.lees_edwards.protocol = lin_protocol
         epsilon = 0.01
 
         for shear_direction, shear_plane_normal in self.direction_permutations:
-            system.lees_edwards.shear_direction = shear_direction
-            system.lees_edwards.shear_plane_normal = shear_plane_normal
-            shear_axis = axis(shear_direction)
+            system.lees_edwards.set_boundary_conditions(
+                shear_direction=shear_direction,
+                shear_plane_normal=shear_plane_normal, protocol=lin_protocol)
 
-            system.lees_edwards.protocol = lin_protocol
+            shear_axis = axis(shear_direction)
             p1 = system.part.add(
                 pos=[epsilon] * 3, v=np.random.random(3), fix=[True] * 3)
             p2 = system.part.add(
@@ -306,14 +343,13 @@ class LeesEdwards(ut.TestCase):
         """
 
         system = self.system
-        system.lees_edwards.protocol = lin_protocol
         epsilon = 0.01
 
         for shear_direction, shear_plane_normal in self.direction_permutations:
-            system.lees_edwards.shear_direction = shear_direction
-            system.lees_edwards.shear_plane_normal = shear_plane_normal
+            system.lees_edwards.set_boundary_conditions(
+                shear_direction=shear_direction,
+                shear_plane_normal=shear_plane_normal, protocol=lin_protocol)
 
-            system.lees_edwards.protocol = lin_protocol
             p1 = system.part.add(pos=[epsilon] * 3, fix=[True] * 3)
             p2 = system.part.add(pos=system.box_l - epsilon, fix=[True] * 3)
 
@@ -383,9 +419,8 @@ class LeesEdwards(ut.TestCase):
         p3.vs_auto_relate_to(p1)
         system.integrator.run(1)
 
-        system.lees_edwards.protocol = lin_protocol
-        system.lees_edwards.shear_direction = 0
-        system.lees_edwards.shear_plane_normal = 1
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=1, protocol=lin_protocol)
         system.integrator.run(1)
         np.testing.assert_allclose(
             np.copy(system.distance_vec(p3, p2)), [0, 2, 0], atol=tol)
@@ -424,10 +459,10 @@ class LeesEdwards(ut.TestCase):
             weight_function=0, gamma=1.75, r_cut=2.,
             trans_weight_function=0, trans_gamma=1.5, trans_r_cut=2.0)
 
-        system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+        protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=2.0, initial_pos_offset=0.0)
-        system.lees_edwards.shear_direction = 0
-        system.lees_edwards.shear_plane_normal = 1
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=1, protocol=protocol)
         p1 = system.part.add(
             pos=[2.5, 2.5, 2.5], rotation=(1, 1, 1), type=10, v=(0.0, -0.1, -0.25))
         p2 = system.part.add(pos=(2.5, 3.5, 2.5), type=11)
@@ -484,10 +519,10 @@ class LeesEdwards(ut.TestCase):
         system = self.system
         system.min_global_cut = 1.0
         system.time = 0
-        system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+        protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=-1.0, initial_pos_offset=0.0)
-        system.lees_edwards.shear_direction = 0
-        system.lees_edwards.shear_plane_normal = 1
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=1, protocol=protocol)
 
         col_part1 = system.part.add(
             pos=(2.5, 4.5, 2.5), type=30, fix=[True, True, True])
@@ -573,10 +608,10 @@ class LeesEdwards(ut.TestCase):
         system = self.system
         system.min_global_cut = 1.0
         system.virtual_sites = espressomd.virtual_sites.VirtualSitesRelative()
-        system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+        protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=-1.0, initial_pos_offset=0.0)
-        system.lees_edwards.shear_direction = 0
-        system.lees_edwards.shear_plane_normal = 1
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=0, shear_plane_normal=1, protocol=protocol)
 
         harm = espressomd.interactions.HarmonicBond(
             k=1.0, r_0=0.0, r_cut=np.sqrt(2.))
@@ -673,10 +708,10 @@ class LeesEdwards(ut.TestCase):
         """
         system = self.system
         self.setup_lj_liquid()
-        system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+        protocol = espressomd.lees_edwards.LinearShear(
             shear_velocity=0.3, initial_pos_offset=0.01)
-        system.lees_edwards.shear_direction = 2
-        system.lees_edwards.shear_plane_normal = 0
+        system.lees_edwards.set_boundary_conditions(
+            shear_direction=2, shear_plane_normal=0, protocol=protocol)
         system.integrator.run(1, recalc_forces=True)
         tests_common.check_non_bonded_loop_trace(self, system)
 

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -25,6 +25,7 @@ import espressomd.code_info
 import espressomd.electrostatics
 import espressomd.magnetostatics
 import espressomd.interactions
+import espressomd.lees_edwards
 import espressomd.drude_helpers
 import espressomd.virtual_sites
 import espressomd.accumulators
@@ -61,6 +62,13 @@ for filepath in path_cpt_root.iterdir():
     filepath.unlink(missing_ok=True)
 
 n_nodes = system.cell_system.get_state()["n_nodes"]
+
+# Lees-Edwards boundary conditions
+if 'INT.NPT' not in modes:
+    protocol = espressomd.lees_edwards.LinearShear(
+        initial_pos_offset=0.1, time_0=0.2, shear_velocity=1.2)
+    system.lees_edwards.set_boundary_conditions(
+        shear_direction="x", shear_plane_normal="y", protocol=protocol)
 
 lbf_actor = None
 if 'LB.CPU' in modes:

--- a/testsuite/python/tabulated.py
+++ b/testsuite/python/tabulated.py
@@ -29,15 +29,11 @@ class TabulatedTest(ut.TestCase):
     system.cell_system.skin = 0.4
 
     def setUp(self):
-        self.force = np.zeros((100,))
-        self.energy = np.zeros((100,))
         self.min_ = 1.
         self.max_ = 2.
-
         self.dx = (self.max_ - self.min_) / 99.
-        for i in range(0, 100):
-            self.force[i] = 5 + i * 2.3 * self.dx
-            self.energy[i] = 5 - i * 2.3 * self.dx
+        self.force = 5 + np.arange(0, 100) * 2.3 * self.dx
+        self.energy = 5 - np.arange(0, 100) * 2.3 * self.dx
 
         self.system.part.add(type=0, pos=[5., 5., 5.0])
         self.system.part.add(type=0, pos=[5., 5., 5.5])
@@ -89,6 +85,21 @@ class TabulatedTest(ut.TestCase):
         p0, p1 = self.system.part.all()
         p0.add_bond((tb, p1))
         self.check()
+
+        # make bond too short: potential becomes constant
+        for z in np.linspace(0.1, 1., 9, endpoint=False):
+            p1.pos = [5., 5., 5. + z]
+            self.system.integrator.run(0)
+            np.testing.assert_allclose(np.copy(p0.f), [0., 0., -5.])
+            np.testing.assert_allclose(np.copy(p0.f), -np.copy(p1.f))
+            self.assertAlmostEqual(self.system.analysis.energy()['total'], 5.)
+
+        # break bond
+        p1.pos = [5., 5., 6. + self.max_ + 0.1]
+        with self.assertRaisesRegex(Exception, "bond broken between particles 0, 1"):
+            self.system.analysis.energy()
+        with self.assertRaisesRegex(Exception, "bond broken between particles 0, 1"):
+            self.system.integrator.run(0)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -28,6 +28,7 @@ import espressomd.checkpointing
 import espressomd.electrostatics
 import espressomd.magnetostatics
 import espressomd.io.writer  # pylint: disable=unused-import
+import espressomd.lees_edwards
 import espressomd.virtual_sites
 import espressomd.integrate
 import espressomd.shapes
@@ -139,6 +140,17 @@ class CheckpointTest(ut.TestCase):
         np.testing.assert_allclose(np.copy(system.box_l), self.ref_box_l)
         np.testing.assert_array_equal(
             np.copy(system.periodicity), self.ref_periodicity)
+
+    @ut.skipIf('INT.NPT' in modes, 'Lees-Edwards not compatible with NPT')
+    def test_lees_edwards(self):
+        lebc = system.lees_edwards
+        protocol = lebc.protocol
+        self.assertEqual(lebc.shear_direction, "x")
+        self.assertEqual(lebc.shear_plane_normal, "y")
+        self.assertIsInstance(protocol, espressomd.lees_edwards.LinearShear)
+        self.assertAlmostEqual(protocol.initial_pos_offset, 0.1, delta=1e-10)
+        self.assertAlmostEqual(protocol.time_0, 0.2, delta=1e-10)
+        self.assertAlmostEqual(protocol.shear_velocity, 1.2, delta=1e-10)
 
     def test_part(self):
         p1, p2 = system.part.by_ids([0, 1])


### PR DESCRIPTION
Description of changes:
- separation of concerns: hide regular/N-square/hybrid implementation details from `CellStructure` and from most of the core
- cell systems now access the `box_geo` global via const reference instead of maintaining a local copy (that can diverge)
- roll out the new `Particle` struct interface in the core
   - ghost communication and force reduction still need access to the particle substructs
- Lees-Edwards changes:
   - checkpointing is now possible
   - changing the protocol now invalidates forces
   - the shear direction and shear plane normal are now labeled as "x", "y", "z" instead of 0, 1, 2
   - the shear direction and shear plane normal must now be changed together (otherwise the system would be temporarily left in an invalid state when swapping the direction and normal)