### PR TITLE
Remove time count in every iteration of sim run

### DIFF
--- a/samples/visualization_ljliquid.py
+++ b/samples/visualization_ljliquid.py
@@ -142,7 +142,6 @@ plt.show(block=False)
 
 def main_loop():
     global energies
-    print(f"run at time={system.time:.2f}")
 
     system.integrator.run(int_steps)
     visualizer.update()


### PR DESCRIPTION
Bloats the terminal and doesn't add any context to the simulation