### PR TITLE
Skip short-range non-bonded loop when no IA is active

### DIFF
--- a/src/core/short_range_loop.hpp
+++ b/src/core/short_range_loop.hpp
@@ -48,7 +48,8 @@ void short_range_loop(BondKernel bond_kernel, PairKernel pair_kernel,
     cell_structure.bond_loop(bond_kernel);
   }
 
-  if (pair_cutoff >= 0.)
+  if (pair_cutoff > 0.) {
     cell_structure.non_bonded_loop(pair_kernel, verlet_criterion);
+  }
 }
 #endif


### PR DESCRIPTION
Fixes #4293