### PR TITLE
Put CMake targets in a namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,22 +328,25 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTDIR}/espressomd")
 # drop 'lib' prefix from all libraries
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
-add_library(coverage_interface INTERFACE)
+add_library(Espresso_coverage_flags INTERFACE)
+add_library(Espresso::coverage_flags ALIAS Espresso_coverage_flags)
 if(WITH_COVERAGE)
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(
-      coverage_interface INTERFACE -g -fprofile-instr-generate
-                                   -fcoverage-mapping)
+      Espresso_coverage_flags INTERFACE -g -fprofile-instr-generate
+                                        -fcoverage-mapping)
   else()
     target_compile_options(
-      coverage_interface INTERFACE -g --coverage -fprofile-arcs -ftest-coverage)
-    target_link_libraries(coverage_interface INTERFACE gcov)
+      Espresso_coverage_flags INTERFACE -g --coverage -fprofile-arcs
+                                        -ftest-coverage)
+    target_link_libraries(Espresso_coverage_flags INTERFACE gcov)
   endif()
 endif()
 
-add_library(cxx_interface INTERFACE)
+add_library(Espresso_cpp_flags INTERFACE)
+add_library(Espresso::cpp_flags ALIAS Espresso_cpp_flags)
 target_compile_options(
-  cxx_interface
+  Espresso_cpp_flags
   INTERFACE -Wall
             -Wextra
             $<$<BOOL:${WARNINGS_ARE_ERRORS}>:-Werror>
@@ -361,56 +364,58 @@ target_compile_options(
 # disable more warnings from -Wextra
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_PROCESSOR MATCHES
                                             "arm")
-  target_compile_options(cxx_interface INTERFACE -Wno-psabi)
+  target_compile_options(Espresso_cpp_flags INTERFACE -Wno-psabi)
 endif()
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel"
    AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
                                                      VERSION_LESS "7.0.0"))
-  target_compile_options(cxx_interface INTERFACE -Wno-implicit-fallthrough)
+  target_compile_options(Espresso_cpp_flags INTERFACE -Wno-implicit-fallthrough)
 endif()
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID
                                                 STREQUAL "Intel")
-  target_compile_options(cxx_interface INTERFACE -Wno-unused-private-field)
+  target_compile_options(Espresso_cpp_flags INTERFACE -Wno-unused-private-field)
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(cxx_interface
+  target_compile_options(Espresso_cpp_flags
                          INTERFACE -Wno-gnu-zero-variadic-macro-arguments)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "8.0.0")
-    target_compile_options(cxx_interface INTERFACE -Wimplicit-float-conversion)
+    target_compile_options(Espresso_cpp_flags
+                           INTERFACE -Wimplicit-float-conversion)
   endif()
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
      AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0")
-    target_compile_options(cxx_interface INTERFACE -Wnon-c-typedef-for-linkage)
+    target_compile_options(Espresso_cpp_flags
+                           INTERFACE -Wnon-c-typedef-for-linkage)
   endif()
 endif()
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION
                                                VERSION_GREATER "4.8.5")
   # older GCC versions don't support -Wno-pedantic which we need in src/python
-  target_compile_options(cxx_interface INTERFACE -pedantic)
+  target_compile_options(Espresso_cpp_flags INTERFACE -pedantic)
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
                                             VERSION_GREATER_EQUAL "8.1.0")
-  target_compile_options(cxx_interface INTERFACE -Wno-cast-function-type)
+  target_compile_options(Espresso_cpp_flags INTERFACE -Wno-cast-function-type)
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND CMAKE_CXX_COMPILER_VERSION
                                               VERSION_LESS "16.0")
   # workaround for compiler crash related to decltype() and variadic template
   # usage inside Boost
-  target_compile_options(cxx_interface
+  target_compile_options(Espresso_cpp_flags
                          INTERFACE -DBOOST_NO_CXX11_VARIADIC_TEMPLATES)
 endif()
 
 # prevent 80-bit arithmetic on old Intel processors
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SIZEOF_VOID_P EQUAL 4
    AND CMAKE_SYSTEM_PROCESSOR MATCHES "[xX]86")
-  target_compile_options(cxx_interface INTERFACE -ffloat-store)
+  target_compile_options(Espresso_cpp_flags INTERFACE -ffloat-store)
 endif()
 
 # enable boost::variant with more than 20 types
 target_compile_options(
-  cxx_interface INTERFACE -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
-                          -DBOOST_MPL_LIMIT_LIST_SIZE=30)
+  Espresso_cpp_flags INTERFACE -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+                               -DBOOST_MPL_LIMIT_LIST_SIZE=30)
 
 set(CMAKE_MACOSX_RPATH TRUE)
 
@@ -425,22 +430,22 @@ if(WITH_ASAN AND WITH_MSAN)
 endif()
 if(WITH_ASAN)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g -O1")
-  target_compile_options(cxx_interface INTERFACE -fsanitize=address
-                                                 -fno-omit-frame-pointer)
-  target_link_libraries(cxx_interface INTERFACE -fsanitize=address)
+  target_compile_options(Espresso_cpp_flags INTERFACE -fsanitize=address
+                                                      -fno-omit-frame-pointer)
+  target_link_libraries(Espresso_cpp_flags INTERFACE -fsanitize=address)
 endif()
 if(WITH_MSAN)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g -O1")
-  target_compile_options(cxx_interface INTERFACE -fsanitize=memory
-                                                 -fno-omit-frame-pointer)
-  target_link_libraries(cxx_interface INTERFACE -fsanitize=memory)
+  target_compile_options(Espresso_cpp_flags INTERFACE -fsanitize=memory
+                                                      -fno-omit-frame-pointer)
+  target_link_libraries(Espresso_cpp_flags INTERFACE -fsanitize=memory)
 endif()
 if(WITH_UBSAN)
-  target_compile_options(cxx_interface INTERFACE -fsanitize=undefined)
-  target_link_libraries(cxx_interface INTERFACE -fsanitize=undefined)
+  target_compile_options(Espresso_cpp_flags INTERFACE -fsanitize=undefined)
+  target_link_libraries(Espresso_cpp_flags INTERFACE -fsanitize=undefined)
 endif()
 
-target_link_libraries(cxx_interface INTERFACE coverage_interface)
+target_link_libraries(Espresso_cpp_flags INTERFACE Espresso::coverage_flags)
 
 #
 # Static analysis

--- a/cmake/unit_test.cmake
+++ b/cmake/unit_test.cmake
@@ -9,7 +9,7 @@ function(UNIT_TEST)
     target_link_libraries(${TEST_NAME} PRIVATE ${TEST_DEPENDS})
   endif()
   target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src/core)
-  target_link_libraries(${TEST_NAME} PRIVATE EspressoConfig cxx_interface)
+  target_link_libraries(${TEST_NAME} PRIVATE Espresso::config Espresso::cpp_flags)
 
   # If NUM_PROC is given, set up MPI parallel test case
   if(TEST_NUM_PROC)

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -3,7 +3,8 @@ if(DOXYGEN_FOUND)
   add_custom_command(
     OUTPUT doxy-features
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_doxyconfig.py
-            ${CMAKE_SOURCE_DIR}/src/config doxy-features DEPENDS EspressoConfig)
+            ${CMAKE_SOURCE_DIR}/src/config doxy-features
+    DEPENDS Espresso::config)
 
   set(DOXYGEN_BIB_IN ${CMAKE_SOURCE_DIR}/doc/bibliography.bib)
   set(DOXYGEN_BIB_OUT ${CMAKE_CURRENT_BINARY_DIR}/bibliography.bib)

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -761,12 +761,12 @@ The build type is controlled by ``-D CMAKE_BUILD_TYPE=<type>`` where
 * ``Coverage``: for code coverage
 
 Cluster users and HPC developers may be interested in manually editing the
-``cxx_interface`` variable in the top-level ``CMakeLists.txt`` file for
+``Espresso_cpp_flags`` target in the top-level ``CMakeLists.txt`` file for
 finer control over compiler flags. The variable declaration is followed
 by a series of conditionals to enable or disable compiler-specific flags.
 Compiler flags passed to CMake via the ``-DCMAKE_CXX_FLAGS`` option
 (such as ``cmake . -DCMAKE_CXX_FLAGS="-ffast-math -fno-finite-math-only"``)
-will appear in the compiler command before the flags in ``cxx_interface``,
+will appear in the compiler command before the flags in ``Espresso_cpp_flags``,
 and will therefore have lower precedence.
 
 Be aware that fast-math mode can break |es|. It is incompatible with the

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -28,12 +28,14 @@ execute_process(
           ${CMAKE_CURRENT_SOURCE_DIR}/features.def
   OUTPUT_FILE ${CMAKE_BINARY_DIR}/myconfig-sample.hpp)
 
-add_library(EspressoConfig SHARED config-features.cpp)
-add_dependencies(EspressoConfig myconfig check_myconfig
+add_library(Espresso_config SHARED config-features.cpp)
+add_library(Espresso::config ALIAS Espresso_config)
+add_dependencies(Espresso_config myconfig check_myconfig
                  generate_config_features)
-install(TARGETS EspressoConfig LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
-target_include_directories(EspressoConfig PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                                 ${CMAKE_CURRENT_BINARY_DIR})
+install(TARGETS Espresso_config
+        LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
+target_include_directories(Espresso_config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+                                                  ${CMAKE_CURRENT_BINARY_DIR})
 
 find_package(Git)
 # Parse repository info from git if available Run this at build time to avoid
@@ -47,4 +49,4 @@ add_custom_target(
     ${PROJECT_SOURCE_DIR}/cmake/version.cmake)
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES version.hpp
                                        version.hpp.tmp)
-add_dependencies(EspressoConfig version)
+add_dependencies(Espresso_config version)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(EspressoCore_SRC
+set(Espresso_core_SRC
     accumulators.cpp
     bond_error.cpp
     cells.cpp
@@ -42,48 +42,51 @@ set(EspressoCore_SRC
     PartCfg.cpp
     EspressoSystemStandAlone.cpp)
 
+set(Espresso_cuda_SRC
+    cuda_common_cuda.cu
+    cuda_init.cpp
+    cuda_init_cuda.cu
+    cuda_interface.cpp
+    CudaHostAllocator.cu
+    magnetostatics/barnes_hut_gpu_cuda.cu
+    magnetostatics/dds_gpu_cuda.cu
+    electrostatics/mmm1d_gpu_cuda.cu
+    electrostatics/p3m_gpu_cuda.cu
+    electrostatics/p3m_gpu_error_cuda.cu
+    EspressoSystemInterface_cuda.cu
+    grid_based_algorithms/electrokinetics_cuda.cu
+    grid_based_algorithms/lbgpu_cuda.cu
+    grid_based_algorithms/fd-electrostatics_cuda.cu
+    grid_based_algorithms/electrokinetics.cpp
+    grid_based_algorithms/lbgpu.cpp
+    virtual_sites/lb_inertialess_tracers_cuda.cu)
+
 if(CUDA)
-  set(EspressoCuda_SRC
-      cuda_common_cuda.cu
-      cuda_init.cpp
-      cuda_init_cuda.cu
-      cuda_interface.cpp
-      CudaHostAllocator.cu
-      magnetostatics/barnes_hut_gpu_cuda.cu
-      magnetostatics/dds_gpu_cuda.cu
-      electrostatics/mmm1d_gpu_cuda.cu
-      electrostatics/p3m_gpu_cuda.cu
-      electrostatics/p3m_gpu_error_cuda.cu
-      EspressoSystemInterface_cuda.cu
-      grid_based_algorithms/electrokinetics_cuda.cu
-      grid_based_algorithms/lbgpu_cuda.cu
-      grid_based_algorithms/fd-electrostatics_cuda.cu
-      grid_based_algorithms/electrokinetics.cpp
-      grid_based_algorithms/lbgpu.cpp
-      virtual_sites/lb_inertialess_tracers_cuda.cu)
+  add_gpu_library(Espresso_core SHARED ${Espresso_core_SRC}
+                  ${Espresso_cuda_SRC})
+else()
+  add_library(Espresso_core SHARED ${Espresso_core_SRC})
+endif()
+add_library(Espresso::core ALIAS Espresso_core)
 
-  add_gpu_library(EspressoCore SHARED ${EspressoCore_SRC} ${EspressoCuda_SRC})
-else(CUDA)
-  add_library(EspressoCore SHARED ${EspressoCore_SRC})
-endif(CUDA)
-
-install(TARGETS EspressoCore LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
+install(TARGETS Espresso_core LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 target_link_libraries(
-  EspressoCore PRIVATE EspressoConfig EspressoShapes Profiler
-                       $<$<BOOL:${SCAFACOS}>:EspressoScafacos> cxx_interface
-  PUBLIC EspressoUtils MPI::MPI_CXX Random123 EspressoParticleObservables
+  Espresso_core
+  PRIVATE Espresso::config Espresso::shapes Espresso::profiler
+          $<$<BOOL:${SCAFACOS}>:Espresso::scafacos> Espresso::cpp_flags
+  PUBLIC Espresso::utils MPI::MPI_CXX Random123 Espresso::particle_observables
          Boost::serialization Boost::mpi "$<$<BOOL:${H5MD}>:${HDF5_LIBRARIES}>"
          $<$<BOOL:${H5MD}>:Boost::filesystem> $<$<BOOL:${H5MD}>:h5xx>
-         "$<$<BOOL:${FFTW3_FOUND}>:FFTW3::FFTW3>")
+         $<$<BOOL:${FFTW3_FOUND}>:FFTW3::FFTW3>)
 
 target_include_directories(
-  EspressoCore
+  Espresso_core
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
          "$<$<BOOL:${H5MD}>:${CMAKE_CURRRENT_SOURCE_DIR}/io/writer>"
          "$<$<BOOL:${H5MD}>:${HDF5_INCLUDE_DIRS}>")
 
-target_compile_definitions(EspressoCore PUBLIC $<$<BOOL:${H5MD}>:H5XX_USE_MPI>)
+target_compile_definitions(Espresso_core PUBLIC $<$<BOOL:${H5MD}>:H5XX_USE_MPI>)
 
 add_subdirectory(accumulators)
 add_subdirectory(bond_breakage)
@@ -111,5 +114,5 @@ endif(WITH_TESTS)
 
 if(STOKESIAN_DYNAMICS)
   add_subdirectory(stokesian_dynamics)
-  target_link_libraries(EspressoCore PRIVATE StokesianDynamics::sd_cpu)
+  target_link_libraries(Espresso_core PRIVATE StokesianDynamics::sd_cpu)
 endif()

--- a/src/core/accumulators/CMakeLists.txt
+++ b/src/core/accumulators/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Correlator.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/MeanVarianceCalculator.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/TimeSeries.cpp)

--- a/src/core/bond_breakage/CMakeLists.txt
+++ b/src/core/bond_breakage/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(EspressoCore
+target_sources(Espresso_core
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bond_breakage.cpp)

--- a/src/core/bonded_interactions/CMakeLists.txt
+++ b/src/core/bonded_interactions/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/angle_cosine.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/angle_cossquare.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/bonded_interaction_data.cpp

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -132,9 +132,9 @@
  *      @code
  *      # enable boost::variant with more than 20 types
  *      target_compile_options(
- *      cxx_interface INTERFACE -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- *                              -DBOOST_MPL_LIMIT_LIST_SIZE=40)
-        @endcode
+ *        EspressoCppFlags INTERFACE -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+ *                                   -DBOOST_MPL_LIMIT_LIST_SIZE=40)
+ *      @endcode
  *  * In forces_inline.hpp:
  *    - A call to the new bond's force calculation needs to be placed in either
  *      of the functions @ref calc_bond_pair_force(), @ref

--- a/src/core/cell_system/CMakeLists.txt
+++ b/src/core/cell_system/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/AtomDecomposition.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/CellStructure.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/HybridDecomposition.cpp

--- a/src/core/cluster_analysis/CMakeLists.txt
+++ b/src/core/cluster_analysis/CMakeLists.txt
@@ -1,11 +1,7 @@
-set(cluster_analysis_SRC Cluster.cpp ClusterStructure.cpp)
-add_library(core_cluster_analysis SHARED ${cluster_analysis_SRC})
-install(TARGETS core_cluster_analysis
-        LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
-set_target_properties(core_cluster_analysis PROPERTIES MACOSX_RPATH TRUE)
-target_link_libraries(core_cluster_analysis PUBLIC EspressoCore
-                      PRIVATE EspressoConfig cxx_interface)
+target_sources(
+  EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Cluster.cpp
+                       ${CMAKE_CURRENT_SOURCE_DIR}/ClusterStructure.cpp)
 
 if(GSL)
-  target_link_libraries(core_cluster_analysis PRIVATE GSL::gsl GSL::gslcblas)
+  target_link_libraries(EspressoCore PRIVATE GSL::gsl GSL::gslcblas)
 endif()

--- a/src/core/cluster_analysis/CMakeLists.txt
+++ b/src/core/cluster_analysis/CMakeLists.txt
@@ -1,7 +1,7 @@
 target_sources(
-  EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Cluster.cpp
-                       ${CMAKE_CURRENT_SOURCE_DIR}/ClusterStructure.cpp)
+  Espresso_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Cluster.cpp
+                        ${CMAKE_CURRENT_SOURCE_DIR}/ClusterStructure.cpp)
 
 if(GSL)
-  target_link_libraries(EspressoCore PRIVATE GSL::gsl GSL::gslcblas)
+  target_link_libraries(Espresso_core PRIVATE GSL::gsl GSL::gslcblas)
 endif()

--- a/src/core/constraints/CMakeLists.txt
+++ b/src/core/constraints/CMakeLists.txt
@@ -1,3 +1,3 @@
 target_sources(
-  EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/HomogeneousMagneticField.cpp
-                       ${CMAKE_CURRENT_SOURCE_DIR}/ShapeBasedConstraint.cpp)
+  Espresso_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/HomogeneousMagneticField.cpp
+                        ${CMAKE_CURRENT_SOURCE_DIR}/ShapeBasedConstraint.cpp)

--- a/src/core/electrostatics/CMakeLists.txt
+++ b/src/core/electrostatics/CMakeLists.txt
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/coulomb.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/elc.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/icc.cpp

--- a/src/core/grid_based_algorithms/CMakeLists.txt
+++ b/src/core/grid_based_algorithms/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/halo.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/lattice.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/lb_boundaries.cpp

--- a/src/core/immersed_boundary/CMakeLists.txt
+++ b/src/core/immersed_boundary/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ibm_tribend.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ibm_triel.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ibm_volcons.cpp

--- a/src/core/integrators/CMakeLists.txt
+++ b/src/core/integrators/CMakeLists.txt
@@ -1,3 +1,3 @@
 target_sources(
-  EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/velocity_verlet_npt.cpp
-                       ${CMAKE_CURRENT_SOURCE_DIR}/steepest_descent.cpp)
+  Espresso_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/velocity_verlet_npt.cpp
+                        ${CMAKE_CURRENT_SOURCE_DIR}/steepest_descent.cpp)

--- a/src/core/io/mpiio/CMakeLists.txt
+++ b/src/core/io/mpiio/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/mpiio.cpp)
+target_sources(Espresso_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/mpiio.cpp)

--- a/src/core/io/mpiio/CMakeLists.txt
+++ b/src/core/io/mpiio/CMakeLists.txt
@@ -1,5 +1,1 @@
-add_library(mpiio SHARED mpiio.cpp)
-target_include_directories(mpiio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(mpiio PRIVATE EspressoConfig EspressoCore MPI::MPI_CXX
-                                    cxx_interface)
-install(TARGETS mpiio LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
+target_sources(EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/mpiio.cpp)

--- a/src/core/io/writer/CMakeLists.txt
+++ b/src/core/io/writer/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(H5MD)
   target_sources(
-    EspressoCore PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/h5md_core.cpp"
-    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/h5md_specification.cpp")
+    EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/h5md_core.cpp
+                         ${CMAKE_CURRENT_SOURCE_DIR}/h5md_specification.cpp)
 endif(H5MD)

--- a/src/core/io/writer/CMakeLists.txt
+++ b/src/core/io/writer/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(H5MD)
   target_sources(
-    EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/h5md_core.cpp
-                         ${CMAKE_CURRENT_SOURCE_DIR}/h5md_specification.cpp)
+    Espresso_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/h5md_core.cpp
+                          ${CMAKE_CURRENT_SOURCE_DIR}/h5md_specification.cpp)
 endif(H5MD)

--- a/src/core/magnetostatics/CMakeLists.txt
+++ b/src/core/magnetostatics/CMakeLists.txt
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dipoles.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/barnes_hut_gpu.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/dds.cpp

--- a/src/core/nonbonded_interactions/CMakeLists.txt
+++ b/src/core/nonbonded_interactions/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bmhtf-nacl.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/buckingham.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/gaussian.cpp

--- a/src/core/object-in-fluid/CMakeLists.txt
+++ b/src/core/object-in-fluid/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(EspressoCore
+target_sources(Espresso_core
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/oif_global_forces.cpp)

--- a/src/core/observables/CMakeLists.txt
+++ b/src/core/observables/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/CylindricalLBFluxDensityProfileAtParticlePositions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CylindricalLBVelocityProfileAtParticlePositions.cpp

--- a/src/core/p3m/CMakeLists.txt
+++ b/src/core/p3m/CMakeLists.txt
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/TuningAlgorithm.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/send_mesh.cpp

--- a/src/core/reaction_methods/CMakeLists.txt
+++ b/src/core/reaction_methods/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ReactionAlgorithm.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ReactionEnsemble.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ConstantpHEnsemble.cpp

--- a/src/core/reaction_methods/tests/CMakeLists.txt
+++ b/src/core/reaction_methods/tests/CMakeLists.txt
@@ -18,14 +18,14 @@
 include(unit_test)
 
 unit_test(NAME SingleReaction_test SRC SingleReaction_test.cpp DEPENDS
-          EspressoCore)
+          Espresso::core)
 unit_test(NAME ConstantpHEnsemble_test SRC ConstantpHEnsemble_test.cpp DEPENDS
-          EspressoCore Boost::mpi MPI::MPI_CXX)
+          Espresso::core Boost::mpi MPI::MPI_CXX)
 unit_test(NAME ReactionAlgorithm_test SRC ReactionAlgorithm_test.cpp DEPENDS
-          EspressoCore Boost::mpi MPI::MPI_CXX)
+          Espresso::core Boost::mpi MPI::MPI_CXX)
 unit_test(NAME ReactionEnsemble_test SRC ReactionEnsemble_test.cpp DEPENDS
-          EspressoCore Boost::mpi MPI::MPI_CXX)
+          Espresso::core Boost::mpi MPI::MPI_CXX)
 unit_test(NAME particle_tracking_test SRC particle_tracking_test.cpp DEPENDS
-          EspressoCore Boost::mpi MPI::MPI_CXX)
+          Espresso::core Boost::mpi MPI::MPI_CXX)
 unit_test(NAME reaction_methods_utils_test SRC reaction_methods_utils_test.cpp
-          DEPENDS EspressoCore)
+          DEPENDS Espresso::core)

--- a/src/core/scafacos/CMakeLists.txt
+++ b/src/core/scafacos/CMakeLists.txt
@@ -1,3 +1,3 @@
 target_sources(
-  EspressoCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ScafacosContext.cpp
-                       ${CMAKE_CURRENT_SOURCE_DIR}/ScafacosContextBase.cpp)
+  Espresso_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ScafacosContext.cpp
+                        ${CMAKE_CURRENT_SOURCE_DIR}/ScafacosContextBase.cpp)

--- a/src/core/stokesian_dynamics/CMakeLists.txt
+++ b/src/core/stokesian_dynamics/CMakeLists.txt
@@ -17,10 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-target_include_directories(EspressoCore SYSTEM
+target_include_directories(Espresso_core SYSTEM
                            PRIVATE ${stokesian_dynamics_SOURCE_DIR}/include)
 target_include_directories(
-  EspressoCore PRIVATE ${CMAKE_SOURCE_DIR}/src/core/stokesian_dynamics)
+  Espresso_core PRIVATE ${CMAKE_SOURCE_DIR}/src/core/stokesian_dynamics)
 
-target_sources(EspressoCore
+target_sources(Espresso_core
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/sd_interface.cpp)

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -23,46 +23,48 @@ include(unit_test)
 unit_test(NAME RuntimeError_test SRC RuntimeError_test.cpp DEPENDS
           Boost::serialization)
 unit_test(NAME RuntimeErrorCollector_test SRC RuntimeErrorCollector_test.cpp
-          DEPENDS EspressoCore Boost::mpi MPI::MPI_CXX NUM_PROC 2)
+          DEPENDS Espresso::core Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME EspressoSystemStandAlone_test SRC
-          EspressoSystemStandAlone_test.cpp DEPENDS EspressoCore Boost::mpi
+          EspressoSystemStandAlone_test.cpp DEPENDS Espresso::core Boost::mpi
           MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME EspressoSystemInterface_test SRC
-          EspressoSystemInterface_test.cpp DEPENDS EspressoCore Boost::mpi)
+          EspressoSystemInterface_test.cpp DEPENDS Espresso::core Boost::mpi)
 unit_test(NAME MpiCallbacks_test SRC MpiCallbacks_test.cpp DEPENDS
-          EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 2)
+          Espresso::utils Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME ParticleIterator_test SRC ParticleIterator_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME p3m_test SRC p3m_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME link_cell_test SRC link_cell_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME Particle_test SRC Particle_test.cpp DEPENDS EspressoUtils
+          Espresso::utils)
+unit_test(NAME p3m_test SRC p3m_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME link_cell_test SRC link_cell_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME Particle_test SRC Particle_test.cpp DEPENDS Espresso::utils
           Boost::serialization)
 unit_test(NAME Particle_serialization_test SRC Particle_serialization_test.cpp
-          DEPENDS EspressoUtils Boost::serialization)
-unit_test(NAME rotation_test SRC rotation_test.cpp DEPENDS EspressoUtils
-          EspressoCore)
+          DEPENDS Espresso::utils Boost::serialization)
+unit_test(NAME rotation_test SRC rotation_test.cpp DEPENDS Espresso::utils
+          Espresso::core)
 unit_test(NAME field_coupling_couplings SRC field_coupling_couplings_test.cpp
-          DEPENDS EspressoUtils)
+          DEPENDS Espresso::utils)
 unit_test(NAME field_coupling_fields SRC field_coupling_fields_test.cpp DEPENDS
-          EspressoUtils)
+          Espresso::utils)
 unit_test(NAME field_coupling_force_field SRC
-          field_coupling_force_field_test.cpp DEPENDS EspressoUtils)
+          field_coupling_force_field_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME periodic_fold_test SRC periodic_fold_test.cpp)
-unit_test(NAME grid_test SRC grid_test.cpp DEPENDS EspressoCore)
-unit_test(NAME lees_edwards_test SRC lees_edwards_test.cpp DEPENDS EspressoCore)
-unit_test(NAME BoxGeometry_test SRC BoxGeometry_test.cpp DEPENDS EspressoCore)
-unit_test(NAME LocalBox_test SRC LocalBox_test.cpp DEPENDS EspressoCore)
-unit_test(NAME Lattice_test SRC Lattice_test.cpp DEPENDS EspressoCore)
-unit_test(NAME lb_exceptions SRC lb_exceptions.cpp DEPENDS EspressoCore)
-unit_test(NAME Verlet_list_test SRC Verlet_list_test.cpp DEPENDS EspressoCore
+unit_test(NAME grid_test SRC grid_test.cpp DEPENDS Espresso::core)
+unit_test(NAME lees_edwards_test SRC lees_edwards_test.cpp DEPENDS
+          Espresso::core)
+unit_test(NAME BoxGeometry_test SRC BoxGeometry_test.cpp DEPENDS Espresso::core)
+unit_test(NAME LocalBox_test SRC LocalBox_test.cpp DEPENDS Espresso::core)
+unit_test(NAME Lattice_test SRC Lattice_test.cpp DEPENDS Espresso::core)
+unit_test(NAME lb_exceptions SRC lb_exceptions.cpp DEPENDS Espresso::core)
+unit_test(NAME Verlet_list_test SRC Verlet_list_test.cpp DEPENDS Espresso::core
           NUM_PROC 4)
 unit_test(NAME VerletCriterion_test SRC VerletCriterion_test.cpp DEPENDS
-          EspressoCore)
-unit_test(NAME thermostats_test SRC thermostats_test.cpp DEPENDS EspressoCore)
-unit_test(NAME random_test SRC random_test.cpp DEPENDS EspressoUtils Random123)
-unit_test(NAME BondList_test SRC BondList_test.cpp DEPENDS EspressoCore)
-unit_test(NAME energy_test SRC energy_test.cpp DEPENDS EspressoCore)
+          Espresso::core)
+unit_test(NAME thermostats_test SRC thermostats_test.cpp DEPENDS Espresso::core)
+unit_test(NAME random_test SRC random_test.cpp DEPENDS Espresso::utils
+          Random123)
+unit_test(NAME BondList_test SRC BondList_test.cpp DEPENDS Espresso::core)
+unit_test(NAME energy_test SRC energy_test.cpp DEPENDS Espresso::core)
 unit_test(NAME bonded_interactions_map_test SRC
-          bonded_interactions_map_test.cpp DEPENDS EspressoCore)
+          bonded_interactions_map_test.cpp DEPENDS Espresso::core)
 unit_test(NAME bond_breakage_test SRC bond_breakage_test.cpp DEPENDS
-          EspressoCore)
+          Espresso::core)

--- a/src/core/virtual_sites/CMakeLists.txt
+++ b/src/core/virtual_sites/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
-  EspressoCore
+  Espresso_core
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lb_inertialess_tracers.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/lb_inertialess_tracers_cuda_interface.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/VirtualSitesInertialessTracers.cpp

--- a/src/particle_observables/CMakeLists.txt
+++ b/src/particle_observables/CMakeLists.txt
@@ -1,10 +1,11 @@
-add_library(EspressoParticleObservables INTERFACE)
+add_library(Espresso_particle_observables INTERFACE)
+add_library(Espresso::particle_observables ALIAS Espresso_particle_observables)
 target_include_directories(
-  EspressoParticleObservables SYSTEM
+  Espresso_particle_observables SYSTEM
   INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>)
 
-install(TARGETS EspressoParticleObservables
+install(TARGETS Espresso_particle_observables
         LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 if(WITH_TESTS)

--- a/src/particle_observables/tests/CMakeLists.txt
+++ b/src/particle_observables/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 include(unit_test)
 
 unit_test(NAME properties_test SRC properties.cpp DEPENDS
-          EspressoParticleObservables)
+          Espresso::particle_observables)
 unit_test(NAME algorithms_test SRC algorithms.cpp DEPENDS
-          EspressoParticleObservables)
+          Espresso::particle_observables)
 unit_test(NAME observables_test SRC observables.cpp DEPENDS
-          EspressoParticleObservables)
+          Espresso::particle_observables)

--- a/src/profiler/CMakeLists.txt
+++ b/src/profiler/CMakeLists.txt
@@ -1,9 +1,10 @@
-add_library(Profiler INTERFACE)
-target_include_directories(Profiler INTERFACE "include")
+add_library(Espresso_profiler INTERFACE)
+add_library(Espresso::profiler ALIAS Espresso_profiler)
+target_include_directories(Espresso_profiler INTERFACE "include")
 
 if(WITH_PROFILER)
   find_package(caliper REQUIRED)
 
-  target_link_libraries(Profiler INTERFACE caliper-mpi)
-  target_compile_definitions(Profiler INTERFACE HAVE_CALIPER)
+  target_link_libraries(Espresso_profiler INTERFACE caliper-mpi)
+  target_compile_definitions(Espresso_profiler INTERFACE HAVE_CALIPER)
 endif()

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -26,7 +26,7 @@ add_custom_command(
   DEPENDS ${CMAKE_SOURCE_DIR}/src/config/features.def)
 
 add_executable(gen_pxiconfig gen_pxiconfig.cpp)
-target_link_libraries(gen_pxiconfig EspressoConfig)
+target_link_libraries(gen_pxiconfig Espresso::config)
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/myconfig.pxi
@@ -59,24 +59,25 @@ add_subdirectory(io)
 list(APPEND cython_SRC ${CMAKE_CURRENT_BINARY_DIR}/code_info.pyx)
 list(REMOVE_DUPLICATES cython_SRC)
 
-add_library(pyx_interface INTERFACE)
+add_library(Espresso_pyx_flags INTERFACE)
+add_library(Espresso::pyx_flags ALIAS Espresso_pyx_flags)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(
-    pyx_interface
+    Espresso_pyx_flags
     INTERFACE -Wno-pedantic -Wno-cpp -Wno-strict-aliasing
               -Wno-maybe-uninitialized -Wno-unused-variable
               -Wno-deprecated-declarations)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL
                                                  "AppleClang")
   target_compile_options(
-    pyx_interface
+    Espresso_pyx_flags
     INTERFACE -Wno-pedantic -Wno-\#warnings -Wno-sometimes-uninitialized
               -Wno-unused-variable -Wno-deprecated-declarations)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  target_compile_options(pyx_interface INTERFACE -wd1224)
+  target_compile_options(Espresso_pyx_flags INTERFACE -wd1224)
 else()
-  target_compile_options(pyx_interface INTERFACE -Wno-pedantic
-                                                 -Wno-unused-variable)
+  target_compile_options(Espresso_pyx_flags INTERFACE -Wno-pedantic
+                                                      -Wno-unused-variable)
 endif()
 
 # Configure, compile and install Cython files
@@ -120,10 +121,10 @@ foreach(cython_file ${cython_SRC})
                                           "-undefined dynamic_lookup")
     endif()
     set_target_properties(${target} PROPERTIES CXX_CLANG_TIDY "")
-    target_link_libraries(${target} PRIVATE EspressoConfig EspressoCore
-                                            ScriptInterface)
-    target_link_libraries(${target} PRIVATE cxx_interface)
-    target_link_libraries(${target} PRIVATE pyx_interface)
+    target_link_libraries(${target} PRIVATE Espresso::config Espresso::core
+                                            Espresso::script_interface)
+    target_link_libraries(${target} PRIVATE Espresso::cpp_flags)
+    target_link_libraries(${target} PRIVATE Espresso::pyx_flags)
     target_include_directories(${target} SYSTEM PRIVATE ${PYTHON_INCLUDE_DIRS}
                                                         ${NUMPY_INCLUDE_DIR})
     add_dependencies(espressomd ${target})
@@ -131,7 +132,7 @@ foreach(cython_file ${cython_SRC})
   endif()
 endforeach()
 
-target_link_libraries(espressomd_profiler PRIVATE Profiler)
+target_link_libraries(espressomd_profiler PRIVATE Espresso::profiler)
 
 # Configure Python files
 foreach(auxfile ${cython_AUX})

--- a/src/scafacos/CMakeLists.txt
+++ b/src/scafacos/CMakeLists.txt
@@ -1,14 +1,16 @@
 set(SOURCE_FILES src/Scafacos.cpp src/Coulomb.cpp src/Dipoles.cpp)
 
-add_library(EspressoScafacos SHARED ${SOURCE_FILES})
-target_link_libraries(EspressoScafacos PRIVATE ${SCAFACOS_LDFLAGS})
-target_link_libraries(EspressoScafacos PUBLIC MPI::MPI_CXX
-                      PRIVATE cxx_interface)
+add_library(Espresso_scafacos SHARED ${SOURCE_FILES})
+add_library(Espresso::scafacos ALIAS Espresso_scafacos)
+target_link_libraries(Espresso_scafacos PRIVATE ${SCAFACOS_LDFLAGS})
+target_link_libraries(Espresso_scafacos PUBLIC MPI::MPI_CXX
+                      PRIVATE Espresso::cpp_flags)
 
 target_include_directories(
-  EspressoScafacos PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                          $<INSTALL_INTERFACE:include>)
-target_include_directories(EspressoScafacos SYSTEM
+  Espresso_scafacos
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+target_include_directories(Espresso_scafacos SYSTEM
                            PUBLIC ${SCAFACOS_INCLUDE_DIRS})
 
-install(TARGETS EspressoScafacos DESTINATION ${PYTHON_INSTDIR}/espressomd)
+install(TARGETS Espresso_scafacos DESTINATION ${PYTHON_INSTDIR}/espressomd)

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -28,8 +28,7 @@ install(TARGETS ScriptInterface
 
 target_link_libraries(
   ScriptInterface PRIVATE EspressoConfig EspressoCore
-  PUBLIC mpiio EspressoUtils MPI::MPI_CXX EspressoShapes core_cluster_analysis
-  PRIVATE cxx_interface)
+  PUBLIC EspressoUtils MPI::MPI_CXX EspressoShapes PRIVATE cxx_interface)
 
 target_include_directories(ScriptInterface PUBLIC ${CMAKE_SOURCE_DIR}/src)
 

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(
-  ScriptInterface SHARED
+  Espresso_script_interface SHARED
   initialize.cpp ObjectHandle.cpp object_container_mpi_guard.cpp
   GlobalContext.cpp ContextManager.cpp ParallelExceptionHandler.cpp)
+add_library(Espresso::script_interface ALIAS Espresso_script_interface)
 
 add_subdirectory(accumulators)
 add_subdirectory(bond_breakage)
@@ -23,13 +24,15 @@ add_subdirectory(shapes)
 add_subdirectory(h5md)
 add_subdirectory(reaction_methods)
 
-install(TARGETS ScriptInterface
+install(TARGETS Espresso_script_interface
         LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 target_link_libraries(
-  ScriptInterface PRIVATE EspressoConfig EspressoCore
-  PUBLIC EspressoUtils MPI::MPI_CXX EspressoShapes PRIVATE cxx_interface)
+  Espresso_script_interface PRIVATE Espresso::config Espresso::core
+  PUBLIC Espresso::utils MPI::MPI_CXX Espresso::shapes
+  PRIVATE Espresso::cpp_flags)
 
-target_include_directories(ScriptInterface PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(Espresso_script_interface
+                           PUBLIC ${CMAKE_SOURCE_DIR}/src)
 
 add_subdirectory(tests)

--- a/src/script_interface/accumulators/CMakeLists.txt
+++ b/src/script_interface/accumulators/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/bond_breakage/CMakeLists.txt
+++ b/src/script_interface/bond_breakage/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/cell_system/CMakeLists.txt
+++ b/src/script_interface/cell_system/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/cluster_analysis/CMakeLists.txt
+++ b/src/script_interface/cluster_analysis/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/collision_detection/CMakeLists.txt
+++ b/src/script_interface/collision_detection/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/constraints/CMakeLists.txt
+++ b/src/script_interface/constraints/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/electrostatics/CMakeLists.txt
+++ b/src/script_interface/electrostatics/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/h5md/CMakeLists.txt
+++ b/src/script_interface/h5md/CMakeLists.txt
@@ -1,4 +1,4 @@
 target_sources(
-  ScriptInterface
+  Espresso_script_interface
   PRIVATE $<$<BOOL:H5MD>:${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp>
           $<$<BOOL:H5MD>:${CMAKE_CURRENT_SOURCE_DIR}/h5md.cpp>)

--- a/src/script_interface/interactions/CMakeLists.txt
+++ b/src/script_interface/interactions/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/lbboundaries/CMakeLists.txt
+++ b/src/script_interface/lbboundaries/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/lees_edwards/CMakeLists.txt
+++ b/src/script_interface/lees_edwards/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/magnetostatics/CMakeLists.txt
+++ b/src/script_interface/magnetostatics/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/mpiio/CMakeLists.txt
+++ b/src/script_interface/mpiio/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/observables/CMakeLists.txt
+++ b/src/script_interface/observables/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/pair_criteria/CMakeLists.txt
+++ b/src/script_interface/pair_criteria/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/reaction_methods/CMakeLists.txt
+++ b/src/script_interface/reaction_methods/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/scafacos/CMakeLists.txt
+++ b/src/script_interface/scafacos/CMakeLists.txt
@@ -1,1 +1,2 @@
-target_sources(ScriptInterface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/scafacos.cpp)
+target_sources(Espresso_script_interface
+               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/scafacos.cpp)

--- a/src/script_interface/shapes/CMakeLists.txt
+++ b/src/script_interface/shapes/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/script_interface/tests/CMakeLists.txt
+++ b/src/script_interface/tests/CMakeLists.txt
@@ -34,17 +34,20 @@ unit_test(NAME GlobalContext_test SRC GlobalContext_test.cpp DEPENDS
           ScriptInterface Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME Exception_test SRC Exception_test.cpp DEPENDS ScriptInterface)
 unit_test(NAME ParallelExceptionHandler_test SRC
-          ParallelExceptionHandler_test.cpp DEPENDS ScriptInterface Boost::mpi
-          MPI::MPI_CXX NUM_PROC 2)
+          ParallelExceptionHandler_test.cpp DEPENDS ScriptInterface
+          EspressoCore Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME packed_variant_test SRC packed_variant_test.cpp DEPENDS
           ScriptInterface)
-unit_test(NAME ObjectList_test SRC ObjectList_test.cpp DEPENDS ScriptInterface)
-unit_test(NAME ObjectMap_test SRC ObjectMap_test.cpp DEPENDS ScriptInterface)
+unit_test(NAME ObjectList_test SRC ObjectList_test.cpp DEPENDS ScriptInterface
+          EspressoCore)
+unit_test(NAME ObjectMap_test SRC ObjectMap_test.cpp DEPENDS ScriptInterface
+          EspressoCore)
 unit_test(NAME serialization_mpi_guard_test SRC
           serialization_mpi_guard_test.cpp DEPENDS ScriptInterface Boost::mpi
           MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME Accumulators_test SRC Accumulators_test.cpp DEPENDS
-          ScriptInterface)
+          ScriptInterface EspressoCore)
 unit_test(NAME Constraints_test SRC Constraints_test.cpp DEPENDS
-          ScriptInterface)
-unit_test(NAME Actors_test SRC Actors_test.cpp DEPENDS ScriptInterface)
+          ScriptInterface EspressoCore)
+unit_test(NAME Actors_test SRC Actors_test.cpp DEPENDS ScriptInterface
+          EspressoCore)

--- a/src/script_interface/tests/CMakeLists.txt
+++ b/src/script_interface/tests/CMakeLists.txt
@@ -20,34 +20,37 @@
 include(unit_test)
 
 unit_test(NAME ObjectHandle_test SRC ObjectHandle_test.cpp DEPENDS
-          ScriptInterface)
+          Espresso::script_interface)
 unit_test(NAME AutoParameters_test SRC AutoParameters_test.cpp DEPENDS
-          ScriptInterface)
+          Espresso::script_interface)
 unit_test(NAME AutoParameter_test SRC AutoParameter_test.cpp DEPENDS
-          ScriptInterface)
-unit_test(NAME Variant_test SRC Variant_test.cpp DEPENDS ScriptInterface)
-unit_test(NAME get_value_test SRC get_value_test.cpp DEPENDS ScriptInterface)
-unit_test(NAME None_test SRC None_test.cpp DEPENDS ScriptInterface)
+          Espresso::script_interface)
+unit_test(NAME Variant_test SRC Variant_test.cpp DEPENDS
+          Espresso::script_interface)
+unit_test(NAME get_value_test SRC get_value_test.cpp DEPENDS
+          Espresso::script_interface)
+unit_test(NAME None_test SRC None_test.cpp DEPENDS Espresso::script_interface)
 unit_test(NAME LocalContext_test SRC LocalContext_test.cpp DEPENDS
-          ScriptInterface)
+          Espresso::script_interface)
 unit_test(NAME GlobalContext_test SRC GlobalContext_test.cpp DEPENDS
-          ScriptInterface Boost::mpi MPI::MPI_CXX NUM_PROC 2)
-unit_test(NAME Exception_test SRC Exception_test.cpp DEPENDS ScriptInterface)
+          Espresso::script_interface Boost::mpi MPI::MPI_CXX NUM_PROC 2)
+unit_test(NAME Exception_test SRC Exception_test.cpp DEPENDS
+          Espresso::script_interface)
 unit_test(NAME ParallelExceptionHandler_test SRC
-          ParallelExceptionHandler_test.cpp DEPENDS ScriptInterface
-          EspressoCore Boost::mpi MPI::MPI_CXX NUM_PROC 2)
+          ParallelExceptionHandler_test.cpp DEPENDS Espresso::script_interface
+          Espresso::core Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME packed_variant_test SRC packed_variant_test.cpp DEPENDS
-          ScriptInterface)
-unit_test(NAME ObjectList_test SRC ObjectList_test.cpp DEPENDS ScriptInterface
-          EspressoCore)
-unit_test(NAME ObjectMap_test SRC ObjectMap_test.cpp DEPENDS ScriptInterface
-          EspressoCore)
+          Espresso::script_interface)
+unit_test(NAME ObjectList_test SRC ObjectList_test.cpp DEPENDS
+          Espresso::script_interface Espresso::core)
+unit_test(NAME ObjectMap_test SRC ObjectMap_test.cpp DEPENDS
+          Espresso::script_interface Espresso::core)
 unit_test(NAME serialization_mpi_guard_test SRC
-          serialization_mpi_guard_test.cpp DEPENDS ScriptInterface Boost::mpi
-          MPI::MPI_CXX NUM_PROC 2)
+          serialization_mpi_guard_test.cpp DEPENDS Espresso::script_interface
+          Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 unit_test(NAME Accumulators_test SRC Accumulators_test.cpp DEPENDS
-          ScriptInterface EspressoCore)
+          Espresso::script_interface Espresso::core)
 unit_test(NAME Constraints_test SRC Constraints_test.cpp DEPENDS
-          ScriptInterface EspressoCore)
-unit_test(NAME Actors_test SRC Actors_test.cpp DEPENDS ScriptInterface
-          EspressoCore)
+          Espresso::script_interface Espresso::core)
+unit_test(NAME Actors_test SRC Actors_test.cpp DEPENDS
+          Espresso::script_interface Espresso::core)

--- a/src/script_interface/virtual_sites/CMakeLists.txt
+++ b/src/script_interface/virtual_sites/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(ScriptInterface
+target_sources(Espresso_script_interface
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp)

--- a/src/shapes/CMakeLists.txt
+++ b/src/shapes/CMakeLists.txt
@@ -1,16 +1,18 @@
-set(SOURCE_FILES
-    src/HollowConicalFrustum.cpp src/Cylinder.cpp src/Ellipsoid.cpp
-    src/Rhomboid.cpp src/SimplePore.cpp src/Slitpore.cpp src/Sphere.cpp
-    src/SpheroCylinder.cpp src/Torus.cpp src/Wall.cpp)
+add_library(
+  Espresso_shapes SHARED
+  src/HollowConicalFrustum.cpp src/Cylinder.cpp src/Ellipsoid.cpp
+  src/Rhomboid.cpp src/SimplePore.cpp src/Slitpore.cpp src/Sphere.cpp
+  src/SpheroCylinder.cpp src/Torus.cpp src/Wall.cpp)
+add_library(Espresso::shapes ALIAS Espresso_shapes)
 
-add_library(EspressoShapes SHARED ${SOURCE_FILES})
-target_link_libraries(EspressoShapes PUBLIC EspressoUtils PRIVATE Boost::boost
-                                                                  cxx_interface)
+target_link_libraries(Espresso_shapes PUBLIC Espresso::utils
+                      PRIVATE Boost::boost Espresso::cpp_flags)
 target_include_directories(
-  EspressoShapes PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                        $<INSTALL_INTERFACE:include>)
+  Espresso_shapes PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                         $<INSTALL_INTERFACE:include>)
 
-install(TARGETS EspressoShapes LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
+install(TARGETS Espresso_shapes
+        LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 if(WITH_TESTS)
   add_subdirectory(unit_tests)

--- a/src/shapes/unit_tests/CMakeLists.txt
+++ b/src/shapes/unit_tests/CMakeLists.txt
@@ -1,12 +1,13 @@
 include(unit_test)
-unit_test(NAME Wall_test SRC Wall_test.cpp DEPENDS EspressoShapes EspressoUtils)
+unit_test(NAME Wall_test SRC Wall_test.cpp DEPENDS Espresso::shapes
+          Espresso::utils)
 unit_test(NAME HollowConicalFrustum_test SRC HollowConicalFrustum_test.cpp
-          DEPENDS EspressoShapes EspressoUtils)
-unit_test(NAME Union_test SRC Union_test.cpp DEPENDS EspressoShapes
-          EspressoUtils)
-unit_test(NAME Ellipsoid_test SRC Ellipsoid_test.cpp DEPENDS EspressoShapes
-          EspressoUtils)
-unit_test(NAME Sphere_test SRC Sphere_test.cpp DEPENDS EspressoShapes
-          EspressoUtils)
-unit_test(NAME NoWhere_test SRC NoWhere_test.cpp DEPENDS EspressoShapes
-          EspressoUtils)
+          DEPENDS Espresso::shapes Espresso::utils)
+unit_test(NAME Union_test SRC Union_test.cpp DEPENDS Espresso::shapes
+          Espresso::utils)
+unit_test(NAME Ellipsoid_test SRC Ellipsoid_test.cpp DEPENDS Espresso::shapes
+          Espresso::utils)
+unit_test(NAME Sphere_test SRC Sphere_test.cpp DEPENDS Espresso::shapes
+          Espresso::utils)
+unit_test(NAME NoWhere_test SRC NoWhere_test.cpp DEPENDS Espresso::shapes
+          Espresso::utils)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,11 +1,13 @@
-add_library(EspressoUtils INTERFACE)
+add_library(Espresso_utils INTERFACE)
+add_library(Espresso::utils ALIAS Espresso_utils)
 target_include_directories(
-  EspressoUtils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                          $<INSTALL_INTERFACE:include>)
-target_link_libraries(EspressoUtils INTERFACE Boost::serialization Boost::mpi
-                                              MPI::MPI_CXX)
+  Espresso_utils
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>)
+target_link_libraries(Espresso_utils INTERFACE Boost::serialization Boost::mpi
+                                               MPI::MPI_CXX)
 
-install(TARGETS EspressoUtils LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
+install(TARGETS Espresso_utils LIBRARY DESTINATION ${PYTHON_INSTDIR}/espressomd)
 
 if(WITH_TESTS)
   add_subdirectory(tests)

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -1,86 +1,89 @@
 include(unit_test)
 
-unit_test(NAME abs_test SRC abs_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME Vector_test SRC Vector_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME Factory_test SRC Factory_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME abs_test SRC abs_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME Vector_test SRC Vector_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME Factory_test SRC Factory_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME NumeratedContainer_test SRC NumeratedContainer_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME keys_test SRC keys_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME Cache_test SRC Cache_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME histogram SRC histogram.cpp DEPENDS EspressoUtils)
-unit_test(NAME accumulator SRC accumulator.cpp DEPENDS EspressoUtils
+          Espresso::utils)
+unit_test(NAME keys_test SRC keys_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME Cache_test SRC Cache_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME histogram SRC histogram.cpp DEPENDS Espresso::utils)
+unit_test(NAME accumulator SRC accumulator.cpp DEPENDS Espresso::utils
           Boost::serialization)
-unit_test(NAME int_pow SRC int_pow_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME sgn SRC sgn_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME AS_erfc_part SRC AS_erfc_part_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME sinc SRC sinc_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME as_const SRC as_const_test.cpp DEPENDS EspressoUtils)
+unit_test(NAME int_pow SRC int_pow_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME sgn SRC sgn_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME AS_erfc_part SRC AS_erfc_part_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME sinc SRC sinc_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME as_const SRC as_const_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME permute_ifield_test SRC permute_ifield_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME vec_rotate SRC vec_rotate_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME tensor_product SRC tensor_product_test.cpp DEPENDS EspressoUtils)
+          Espresso::utils)
+unit_test(NAME vec_rotate SRC vec_rotate_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME tensor_product SRC tensor_product_test.cpp DEPENDS
+          Espresso::utils)
 unit_test(NAME linear_interpolation SRC linear_interpolation_test.cpp DEPENDS
-          EspressoUtils)
+          Espresso::utils)
 unit_test(NAME interpolation_gradient SRC interpolation_gradient_test.cpp
-          DEPENDS EspressoUtils)
-unit_test(NAME interpolation SRC interpolation_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME bspline_test SRC bspline_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME Span_test SRC Span_test.cpp DEPENDS EspressoUtils)
+          DEPENDS Espresso::utils)
+unit_test(NAME interpolation SRC interpolation_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME bspline_test SRC bspline_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME Span_test SRC Span_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME matrix_vector_product SRC matrix_vector_product.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME index_test SRC index_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME tuple_test SRC tuple_test.cpp DEPENDS EspressoUtils)
+          Espresso::utils)
+unit_test(NAME index_test SRC index_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME tuple_test SRC tuple_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME Array_test SRC Array_test.cpp DEPENDS Boost::serialization
-          EspressoUtils)
-unit_test(NAME contains_test SRC contains_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME Counter_test SRC Counter_test.cpp DEPENDS EspressoUtils
+          Espresso::utils)
+unit_test(NAME contains_test SRC contains_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME Counter_test SRC Counter_test.cpp DEPENDS Espresso::utils
           Boost::serialization)
 unit_test(NAME RunningAverage_test SRC RunningAverage_test.cpp DEPENDS
-          EspressoUtils)
+          Espresso::utils)
 unit_test(NAME for_each_pair_test SRC for_each_pair_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME raster_test SRC raster_test.cpp DEPENDS EspressoUtils)
+          Espresso::utils)
+unit_test(NAME raster_test SRC raster_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME make_lin_space_test SRC make_lin_space_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME sampling_test SRC sampling_test.cpp DEPENDS EspressoUtils)
+          Espresso::utils)
+unit_test(NAME sampling_test SRC sampling_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME coordinate_transformation_test SRC coordinate_transformation.cpp
-          DEPENDS EspressoUtils)
+          DEPENDS Espresso::utils)
 unit_test(NAME cylindrical_transformation_test SRC
-          cylindrical_transformation.cpp DEPENDS EspressoUtils)
+          cylindrical_transformation.cpp DEPENDS Espresso::utils)
 unit_test(NAME rotation_matrix_test SRC rotation_matrix_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME quaternion_test SRC quaternion_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME mask_test SRC mask_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME type_traits_test SRC type_traits_test.cpp DEPENDS EspressoUtils)
-unit_test(NAME uniform_test SRC uniform_test.cpp DEPENDS EspressoUtils)
+          Espresso::utils)
+unit_test(NAME quaternion_test SRC quaternion_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME mask_test SRC mask_test.cpp DEPENDS Espresso::utils)
+unit_test(NAME type_traits_test SRC type_traits_test.cpp DEPENDS
+          Espresso::utils)
+unit_test(NAME uniform_test SRC uniform_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME memcpy_archive_test SRC memcpy_archive_test.cpp DEPENDS
-          EspressoUtils)
+          Espresso::utils)
 unit_test(NAME triangle_functions_test SRC triangle_functions_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME Bag_test SRC Bag_test.cpp DEPENDS EspressoUtils
+          Espresso::utils)
+unit_test(NAME Bag_test SRC Bag_test.cpp DEPENDS Espresso::utils
           Boost::serialization)
 unit_test(NAME integral_parameter_test SRC integral_parameter_test.cpp DEPENDS
-          EspressoUtils)
-unit_test(NAME flatten_test SRC flatten_test.cpp DEPENDS EspressoUtils)
+          Espresso::utils)
+unit_test(NAME flatten_test SRC flatten_test.cpp DEPENDS Espresso::utils)
 unit_test(NAME pack_test SRC pack_test.cpp DEPENDS Boost::serialization
-          EspressoUtils)
+          Espresso::utils)
 unit_test(NAME unordered_map_test SRC unordered_map_test.cpp DEPENDS
-          Boost::serialization EspressoUtils)
-unit_test(NAME u32_to_u64_test SRC u32_to_u64_test.cpp DEPENDS EspressoUtils
+          Boost::serialization Espresso::utils)
+unit_test(NAME u32_to_u64_test SRC u32_to_u64_test.cpp DEPENDS Espresso::utils
           NUM_PROC 1)
 unit_test(NAME gather_buffer_test SRC gather_buffer_test.cpp DEPENDS
-          EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
+          Espresso::utils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
 unit_test(NAME scatter_buffer_test SRC scatter_buffer_test.cpp DEPENDS
-          EspressoUtils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
-unit_test(NAME all_compare_test SRC all_compare_test.cpp DEPENDS EspressoUtils
+          Espresso::utils Boost::mpi MPI::MPI_CXX NUM_PROC 4)
+unit_test(NAME all_compare_test SRC all_compare_test.cpp DEPENDS
+          Espresso::utils Boost::mpi MPI::MPI_CXX NUM_PROC 3)
+unit_test(NAME gatherv_test SRC gatherv_test.cpp DEPENDS Espresso::utils
           Boost::mpi MPI::MPI_CXX NUM_PROC 3)
-unit_test(NAME gatherv_test SRC gatherv_test.cpp DEPENDS EspressoUtils
-          Boost::mpi MPI::MPI_CXX NUM_PROC 3)
-unit_test(NAME sendrecv_test SRC sendrecv_test.cpp DEPENDS EspressoUtils
-          Boost::mpi MPI::MPI_CXX EspressoUtils NUM_PROC 3)
+unit_test(NAME sendrecv_test SRC sendrecv_test.cpp DEPENDS Espresso::utils
+          Boost::mpi MPI::MPI_CXX Espresso::utils NUM_PROC 3)
 unit_test(NAME serialization_test SRC serialization_test.cpp DEPENDS
-          EspressoUtils Boost::serialization Boost::mpi MPI::MPI_CXX NUM_PROC 1)
-unit_test(NAME matrix_test SRC matrix_test.cpp DEPENDS EspressoUtils
+          Espresso::utils Boost::serialization Boost::mpi MPI::MPI_CXX NUM_PROC
+          1)
+unit_test(NAME matrix_test SRC matrix_test.cpp DEPENDS Espresso::utils
           Boost::serialization NUM_PROC 1)
 unit_test(NAME orthonormal_vec_test SRC orthonormal_vec_test.cpp DEPENDS
-          EspressoUtils Boost::serialization NUM_PROC 1)
+          Espresso::utils Boost::serialization NUM_PROC 1)

--- a/testsuite/cmake/test_install.sh
+++ b/testsuite/cmake/test_install.sh
@@ -23,7 +23,7 @@ source BashUnitTests.sh
 function test_install() {
   # check Python files were installed in espressomd
   local -r filepaths=("@CMAKE_INSTALL_FULL_BINDIR@/pypresso" \
-                      "@PYTHON_DIR@/espressomd/EspressoCore.so" \
+                      "@PYTHON_DIR@/espressomd/Espresso_core.so" \
                       "@PYTHON_DIR@/espressomd/_init.so" \
                       "@PYTHON_DIR@/espressomd/__init__.py"
                      )


### PR DESCRIPTION
Fixes #4524

Description of changes:
- put binary CMake targets in a namespace
- fix cyclic dependencies in CMake targets
- remove unnecessary CMake targets
