### PR TITLE
Support recent Linux distributions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/espressomd/docker/ubuntu-20.04:285fee33c6cdc3b617745a75bd28aec331a53365
+image: ghcr.io/espressomd/docker/ubuntu-20.04:7ec021ab4af6f89d65121db2eb24acb1ed452e02
 
 stages:
   - prepare
@@ -26,7 +26,6 @@ stages:
   timeout: 40m
   interruptible: false
   tags:
-    - docker
     - espresso
     - no-cuda
 
@@ -51,7 +50,6 @@ style:
   script:
     - sh maintainer/CI/fix_style.sh
   tags:
-    - docker
     - espresso
     - no-cuda
   variables:
@@ -73,7 +71,6 @@ style_doxygen:
     - cmake .. -DWITH_CUDA=ON -DWITH_SCAFACOS=ON
     - sh ../maintainer/CI/dox_warnings.sh
   tags:
-    - docker
     - espresso
     - no-cuda
 
@@ -94,7 +91,6 @@ default:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - no-cuda
 
@@ -115,7 +111,6 @@ maxset:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - no-cuda
     - numa
@@ -134,7 +129,6 @@ no_rotation:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - no-cuda
     - numa
@@ -142,7 +136,7 @@ no_rotation:
 ubuntu:wo-dependencies:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:285fee33c6cdc3b617745a75bd28aec331a53365
+  image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:7ec021ab4af6f89d65121db2eb24acb1ed452e02
   variables:
      myconfig: 'maxset'
      with_cuda: 'false'
@@ -152,7 +146,6 @@ ubuntu:wo-dependencies:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - no-cuda
 
@@ -161,7 +154,7 @@ ubuntu:wo-dependencies:
 debian:10:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/debian:285fee33c6cdc3b617745a75bd28aec331a53365
+  image: ghcr.io/espressomd/docker/debian:7ec021ab4af6f89d65121db2eb24acb1ed452e02
   variables:
      with_cuda: 'false'
      myconfig: 'maxset'
@@ -170,14 +163,13 @@ debian:10:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - no-cuda
 
-fedora:34:
+fedora:36:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/fedora:285fee33c6cdc3b617745a75bd28aec331a53365
+  image: ghcr.io/espressomd/docker/fedora:7ec021ab4af6f89d65121db2eb24acb1ed452e02
   variables:
      with_cuda: 'false'
      myconfig: 'maxset'
@@ -186,7 +178,6 @@ fedora:34:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - no-cuda
 
@@ -212,7 +203,6 @@ clang-sanitizer:
     - bash maintainer/CI/build_cmake.sh
   timeout: 2h
   tags:
-    - docker
     - espresso
     - cuda
     - numa
@@ -220,7 +210,7 @@ clang-sanitizer:
 fast_math:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/cuda:285fee33c6cdc3b617745a75bd28aec331a53365
+  image: ghcr.io/espressomd/docker/cuda:7ec021ab4af6f89d65121db2eb24acb1ed452e02
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'
@@ -233,15 +223,14 @@ fast_math:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - cuda
   when: manual
 
-cuda11-maxset:
+cuda11-maxset-ubuntu20.04:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/cuda:285fee33c6cdc3b617745a75bd28aec331a53365
+  image: ghcr.io/espressomd/docker/cuda:7ec021ab4af6f89d65121db2eb24acb1ed452e02
   variables:
      CC: 'gcc-9'
      CXX: 'g++-9'
@@ -250,13 +239,32 @@ cuda11-maxset:
      with_cuda: 'true'
      with_coverage: 'true'
      check_skip_long: 'true'
-     srcdir: '${CI_PROJECT_DIR}'
      with_scafacos: 'true'
      with_stokesian_dynamics: 'true'
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
+    - espresso
+    - cuda
+    - numa
+
+cuda11-maxset-ubuntu22.04:
+  <<: *global_job_definition
+  stage: build
+  image: ghcr.io/espressomd/docker/ubuntu-22.04:7ec021ab4af6f89d65121db2eb24acb1ed452e02
+  variables:
+     CC: 'gcc-10'
+     CXX: 'g++-10'
+     GCOV: 'gcov-10'
+     myconfig: 'maxset'
+     with_cuda: 'true'
+     with_coverage: 'true'
+     check_skip_long: 'true'
+     with_scafacos: 'true'
+     with_stokesian_dynamics: 'true'
+  script:
+    - bash maintainer/CI/build_cmake.sh
+  tags:
     - espresso
     - cuda
     - numa
@@ -282,7 +290,6 @@ cuda10-maxset:
     - build/
     expire_in: 1 week
   tags:
-    - docker
     - espresso
     - cuda
     - numa
@@ -307,7 +314,6 @@ tutorials-samples-maxset:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - cuda
 
@@ -330,7 +336,6 @@ tutorials-samples-default:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - cuda
   only:
@@ -356,7 +361,6 @@ tutorials-samples-empty:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - cuda
   only:
@@ -382,7 +386,6 @@ tutorials-samples-no-gpu:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - no-cuda
   only:
@@ -410,15 +413,15 @@ installation:
     # get path of installed files
     - CI_INSTALL_DIR="/tmp/espresso-unit-tests"
     - CI_INSTALL_PYTHON_PATH=$(dirname $(find "${CI_INSTALL_DIR}/lib" -name espressomd))
+    - CI_CORES=$(cmake -L . | grep CTEST_ARGS | grep --color=never -Po '(?<=-j)[0-9]+')
     # deploy object-in-fluid module
     - cp -r "src/python/object_in_fluid" "${CI_INSTALL_PYTHON_PATH}/object_in_fluid"
     # run all tests with the installed files
     - sed -i "s|$(pwd)/pypresso|${CI_INSTALL_DIR}/bin/pypresso|" testsuite/{python,scripts/samples,scripts/tutorials}/CTestTestfile.cmake
-    - make -j2 check_python
-    - make -j2 check_samples
-    - make -j2 check_tutorials
+    - make -j ${CI_CORES} check_python_skip_long
+    - make -j ${CI_CORES} check_samples
+    - make -j 2 check_tutorials
   tags:
-    - docker
     - espresso
     - cuda
   when: manual
@@ -438,7 +441,6 @@ empty:
   script:
     - bash maintainer/CI/build_cmake.sh
   tags:
-    - docker
     - espresso
     - cuda
     - numa
@@ -461,7 +463,6 @@ check_sphinx:
     - build/doc/sphinx
     expire_in: 1 week
   tags:
-    - docker
     - espresso
     - cuda
     - numa
@@ -486,7 +487,6 @@ run_tutorials:
     - build/doc/tutorials
     expire_in: 1 week
   tags:
-    - docker
     - espresso
     - cuda
     - numa
@@ -509,7 +509,6 @@ run_doxygen:
     - build/doc/doxygen
     expire_in: 1 week
   tags:
-    - docker
     - espresso
     - no-cuda
     - numa
@@ -525,7 +524,6 @@ maxset_no_gpu:
     - cd ${CI_PROJECT_DIR}/build
     - make -t && make check
   tags:
-    - docker
     - espresso
     - no-cuda
     - numa
@@ -541,7 +539,6 @@ maxset_3_cores:
     - cmake -DTEST_NP=3 .
     - make -t && make check_unit_tests && make check_python_parallel_odd
   tags:
-    - docker
     - espresso
     - cuda
     - numa

--- a/cmake/FindCUDACompilerClang.cmake
+++ b/cmake/FindCUDACompilerClang.cmake
@@ -64,6 +64,12 @@ set(gpu_interface_flags "${CUDA_NVCC_FLAGS} ${CUDA_NVCC_FLAGS_${CMAKE_BUILD_TYPE
 if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11)
   set(gpu_interface_flags "${gpu_interface_flags} --cuda-gpu-arch=sm_30")
 endif()
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.0.0" AND
+   CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "13.0.0" AND
+   CUDA_VERSION VERSION_GREATER_EQUAL "11.0" AND
+   CUDA_VERSION VERSION_LESS "12.0")
+  set(gpu_interface_flags "${gpu_interface_flags} -Wno-unknown-cuda-version")
+endif()
 
 function(find_gpu_library)
   cmake_parse_arguments(LIBRARY "REQUIRED" "NAMES;VARNAME" "" ${ARGN})

--- a/doc/sphinx/_static/custom.css
+++ b/doc/sphinx/_static/custom.css
@@ -1,4 +1,6 @@
+/*****************************************/
 /* customization for the alabaster theme */
+/*****************************************/
 
 /* color links to python objects */
 div.bodywrapper a.reference.internal code {
@@ -30,4 +32,16 @@ div.admonition p {
 /* center main text by shifting it to the left by the width of the sidebar */
 div.document {
   padding-right: 260px;
+}
+
+/*************************************/
+/* customization for the basic theme */
+/*************************************/
+
+/* remove automatic hyphenation */
+div.body p, div.body dd, div.body li, div.body blockquote {
+    -moz-hyphens: manual;
+    -ms-hyphens: manual;
+    -webkit-hyphens: manual;
+    hyphens: manual;
 }

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -75,7 +75,7 @@ release = '@PROJECT_VERSION@'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -73,14 +73,13 @@ are required to be able to compile and use |es|:
 Installing requirements on Ubuntu Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To compile |es| on Ubuntu 20.04 LTS, install the following dependencies:
+To compile |es| on Ubuntu 22.04 LTS, install the following dependencies:
 
 .. code-block:: bash
 
     sudo apt install build-essential cmake cython3 python3-pip python3-numpy \
       libboost-all-dev openmpi-common fftw3-dev libhdf5-dev libhdf5-openmpi-dev \
-      python3-opengl libgsl-dev
-    pip3 install --user 'scipy>=1.4.0'
+      python3-scipy python3-opengl libgsl-dev
 
 Optionally the ccmake utility can be installed for easier configuration:
 
@@ -100,11 +99,26 @@ CUDA SDK to make use of GPU computation:
 
     sudo apt install nvidia-cuda-toolkit
 
-On Ubuntu 20.04, the default GCC compiler is too recent for nvcc, which will
+On Ubuntu 22.04, the default GCC compiler is too recent for nvcc and will fail
+to compile sources that rely on ``std::function``. You can either use GCC 10:
+
+.. code-block:: bash
+
+    CC=gcc-10 CXX=g++-10 cmake .. -D WITH_CUDA=ON
+    make -j
+
+or alternatively install Clang 12 as a replacement for nvcc and GCC:
+
+.. code-block:: bash
+
+    CC=clang-12 CXX=clang++-12 cmake .. -D WITH_CUDA=ON -D WITH_CUDA_COMPILER=clang
+    make -j
+
+On Ubuntu 20.04, the default GCC compiler is also too recent for nvcc and will
 generate compiler errors. You can either install an older version of GCC and
 select it with environment variables ``CC`` and ``CXX`` when building |es|,
 or edit the system header files as shown in the following
-`patch for Ubuntu 20.04 <https://github.com/espressomd/espresso/issues/3654#issuecomment-612165048>`_.
+`patch for Ubuntu 20.04 <https://github.com/espressomd/espresso/issues/3654#issuecomment-612165048>`__.
 
 .. _Requirements for building the documentation:
 
@@ -115,7 +129,7 @@ To generate the Sphinx documentation, install the following packages:
 
 .. code-block:: bash
 
-    pip3 install --user --constraint\
+    pip3 install --user \
         'sphinx>=2.3.0,!=3.0.0' \
         'sphinxcontrib-bibtex>=2.4.1' \
         'sphinx-toggleprompt==0.0.5'
@@ -181,8 +195,8 @@ Installing requirements on other Linux distributions
 Please refer to the following Dockerfiles to find the minimum set of packages
 required to compile |es| on other Linux distributions:
 
-* `Fedora <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-fedora>`_
-* `Debian <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-debian>`_
+* `Fedora <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-fedora>`__
+* `Debian <https://github.com/espressomd/docker/blob/master/docker/Dockerfile-debian>`__
 
 .. _Installing requirements on Windows via WSL:
 
@@ -199,18 +213,17 @@ To run |es| on Windows, use the Linux subsystem. For that you need to
   to set up CUDA.
 * follow the instructions for :ref:`Installing requirements on Ubuntu Linux`
 
-.. _Installing requirements on Mac OS X:
+.. _Installing requirements on macOS:
 
-Installing requirements on Mac OS X
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing requirements on macOS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Preparation
-"""""""""""
+To build |es| on macOS 10.15 or higher, you need to install its dependencies.
+There are two possibilities for this, MacPorts and Homebrew. We strongly
+recommend Homebrew, but if you already have MacPorts installed, you can use
+that too, although we do not provide MacPorts installation instructions.
 
-To make |es| run on Mac OS X 10.9 or higher, you need to install its
-dependencies. There are two possibilities for this, MacPorts and Homebrew.
-We recommend MacPorts, but if you already have Homebrew installed, you can use
-that too. To check whether you already have one or the other installed, run the
+To check whether you already have one or the other installed, run the
 following commands:
 
 .. code-block:: bash
@@ -218,20 +231,16 @@ following commands:
     test -e /opt/local/bin/port && echo "MacPorts is installed"
     test -e /usr/local/bin/brew && echo "Homebrew is installed"
 
-If both are installed, you need to remove one of the two. To do that, run one
-of the following two commands:
-
-.. code-block:: bash
-
-    sudo port -f uninstall installed && rm -r /opt/local
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
-
 If Homebrew is already installed, you should resolve any problems reported by
 the command
 
 .. code-block:: bash
 
     brew doctor
+
+If you want to install Homebrew, follow the installation instructions at
+https://docs.brew.sh/Installation, but bear in mind that MacPorts and Homebrew
+may conflict with one another.
 
 If Anaconda Python or the Python from www.python.org are installed, you
 will likely not be able to run |es|. Therefore, please uninstall them
@@ -241,31 +250,6 @@ using the following commands:
 
     sudo rm -r ~/anaconda[23]
     sudo rm -r /Library/Python
-
-If you want to install MacPorts, download the installer package
-appropriate for your Mac OS X version from
-https://www.macports.org/install.php and follow their
-installation instructions.
-
-If you want to install Homebrew, follow the installation
-instructions at https://docs.brew.sh/Installation.
-
-Installing packages using MacPorts
-""""""""""""""""""""""""""""""""""
-
-Run the following commands:
-
-.. code-block:: bash
-
-    sudo port selfupdate
-    sudo port install cmake python37 py37-cython py37-numpy py37-scipy \
-      openmpi-default fftw-3 +openmpi boost +openmpi +python37 \
-      doxygen py37-opengl py37-sphinx gsl hdf5 +openmpi \
-      py37-matplotlib py37-ipython py37-jupyter
-    sudo port select --set cython cython37
-    sudo port select --set python3 python37
-    sudo port select --set mpi openmpi-mp-fortran
-
 
 Installing packages using Homebrew
 """"""""""""""""""""""""""""""""""
@@ -651,24 +635,24 @@ each variant having different activated features, and for as many
 platforms as you want.
 
 Once you've run ``ccmake``, you can list the configured variables with
-``cmake -LAH -N .. | less`` (uses a pager) or with ``ccmake ..`` and pressing
-key ``t`` to toggle the advanced mode on (uses the curses interface).
+``cmake -LAH -N . | less`` (uses a pager) or with ``ccmake ..`` and pressing
+key ``t`` to toggle the advanced mode on (uses the ``curses`` interface).
 
 **Example:**
 
 When the source directory is :file:`srcdir` (the files where unpacked to this
 directory), then the user can create a build directory :file:`build` below that
-path by calling :file:`mkdir srcdir/build`. In the build directory ``cmake`` is to be
-executed, followed by a call to make. None of the files in the source directory
+path by calling ``mkdir srcdir/build``. In the build directory ``cmake`` is to be
+executed, followed by a call to ``make``. None of the files in the source directory
 are ever modified by the build process.
 
 .. code-block:: bash
 
     cd build
     cmake ..
-    make
+    make -j
 
-Afterwards |es| can be run via calling :file:`./pypresso` from the command line.
+Afterwards |es| can be run via calling ``./pypresso`` from the command line.
 
 
 .. _ccmake:
@@ -788,7 +772,7 @@ external libraries that are downloaded automatically by CMake. When a
 network connection cannot be established due to firewall restrictions,
 the CMake logic needs editing:
 
-* ``WITH_HDF5``: when cloning |es|, the :file:`/libs/h5xx` folder will be
+* ``WITH_HDF5``: when cloning |es|, the :file:`libs/h5xx` folder will be
   a git submodule containing a :file:`.git` subfolder. To prevent CMake from
   updating this submodule with git, delete the corresponding command with:
 
@@ -800,7 +784,7 @@ the CMake logic needs editing:
   is needed for HDF5.
 
 * ``WITH_STOKESIAN_DYNAMICS``: this library is installed using `FetchContent
-  <https://cmake.org/cmake/help/latest/module/FetchContent.html>`_.
+  <https://cmake.org/cmake/help/latest/module/FetchContent.html>`__.
   The repository URL can be found in the ``GIT_REPOSITORY`` field of the
   corresponding ``FetchContent_Declare()`` command. The ``GIT_TAG`` field
   provides the commit. Clone this repository locally next to the |es|
@@ -877,7 +861,7 @@ Troubleshooting
 ---------------
 
 If you encounter issues when building |es| or running it for the first time,
-please have a look at the `Installation FAQ <https://github.com/espressomd/espresso/wiki/Installation-FAQ>`_
+please have a look at the `Installation FAQ <https://github.com/espressomd/espresso/wiki/Installation-FAQ>`__
 on the wiki. If you still didn't find an answer, see :ref:`Community support`.
 
 Many algorithms require parameters that must be provided within valid ranges.

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -230,7 +230,11 @@ else
     fi
 fi
 
-cmake ${cmake_params} "${cmake_param_protected}" "${srcdir}" || exit 1
+if [ -z "${cmake_param_protected}" ]; then
+  cmake "${srcdir}" ${cmake_params} || exit 1
+else
+  cmake "${srcdir}" ${cmake_params} "${cmake_param_protected}" || exit 1
+fi
 end "CONFIGURE"
 
 # BUILD

--- a/src/core/accumulators/Correlator.cpp
+++ b/src/core/accumulators/Correlator.cpp
@@ -273,6 +273,8 @@ void Correlator::initialize() {
                                 compressB_name + "' for second observable");
   }
 
+  using index_type = decltype(result)::index;
+
   A.resize(std::array<int, 2>{{m_hierarchy_depth, m_tau_lin + 1}});
   std::fill_n(A.data(), A.num_elements(), std::vector<double>(dim_A, 0));
   B.resize(std::array<int, 2>{{m_hierarchy_depth, m_tau_lin + 1}});
@@ -287,11 +289,9 @@ void Correlator::initialize() {
   n_vals = std::vector<long>(m_hierarchy_depth, 0);
 
   result.resize(std::array<std::size_t, 2>{{n_result, m_dim_corr}});
-
-  for (std::size_t i = 0; i < n_result; i++) {
-    for (std::size_t j = 0; j < m_dim_corr; j++) {
-      // and initialize the values
-      result[i][j] = 0;
+  for (index_type i = 0; i < static_cast<index_type>(n_result); i++) {
+    for (index_type j = 0; j < static_cast<index_type>(m_dim_corr); j++) {
+      result[i][j] = 0.;
     }
   }
 
@@ -377,6 +377,7 @@ void Correlator::update() {
     B_accumulated_average[k] += B[0][newest[0]][k];
   }
 
+  using index_type = decltype(result)::index;
   // Now update the lowest level correlation estimates
   for (long j = 0; j < min(m_tau_lin + 1, n_vals[0]); j++) {
     auto const index_new = newest[0];
@@ -386,7 +387,7 @@ void Correlator::update() {
     assert(temp.size() == m_dim_corr);
 
     n_sweeps[j]++;
-    for (std::size_t k = 0; k < m_dim_corr; k++) {
+    for (index_type k = 0; k < static_cast<index_type>(m_dim_corr); k++) {
       result[j][k] += temp[k];
     }
   }
@@ -403,7 +404,7 @@ void Correlator::update() {
       assert(temp.size() == m_dim_corr);
 
       n_sweeps[index_res]++;
-      for (std::size_t k = 0; k < m_dim_corr; k++) {
+      for (index_type k = 0; k < static_cast<index_type>(m_dim_corr); k++) {
         result[index_res][k] += temp[k];
       }
     }
@@ -411,6 +412,7 @@ void Correlator::update() {
 }
 
 int Correlator::finalize() {
+  using index_type = decltype(result)::index;
   if (finalized) {
     throw std::runtime_error("Correlator::finalize() can only be called once.");
   }
@@ -479,7 +481,7 @@ int Correlator::finalize() {
           assert(temp.size() == m_dim_corr);
 
           n_sweeps[index_res]++;
-          for (std::size_t k = 0; k < m_dim_corr; k++) {
+          for (index_type k = 0; k < static_cast<index_type>(m_dim_corr); k++) {
             result[index_res][k] += temp[k];
           }
         }
@@ -490,14 +492,16 @@ int Correlator::finalize() {
 }
 
 std::vector<double> Correlator::get_correlation() {
+  using index_type = decltype(result)::index;
   auto const n_result = n_values();
   std::vector<double> res(n_result * m_dim_corr);
 
   for (std::size_t i = 0; i < n_result; i++) {
-    auto const index = m_dim_corr * i;
-    for (std::size_t k = 0; k < m_dim_corr; k++) {
+    auto const index = static_cast<index_type>(m_dim_corr * i);
+    for (index_type k = 0; k < static_cast<index_type>(m_dim_corr); k++) {
       if (n_sweeps[i]) {
-        res[index + k] = result[i][k] / static_cast<double>(n_sweeps[i]);
+        res[index + k] = result[static_cast<index_type>(i)][k] /
+                         static_cast<double>(n_sweeps[i]);
       }
     }
   }

--- a/src/core/accumulators/Correlator.hpp
+++ b/src/core/accumulators/Correlator.hpp
@@ -234,6 +234,8 @@ private:
   double m_tau_max;       ///< maximum time for which the correlation should be
                           ///< calculated
 
+  using multi_array_index_type = boost::multi_array<double, 2>::index;
+
   std::string compressA_name;
   std::string compressB_name;
   std::string corr_operation_name; ///< Name of the correlation operator

--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -107,7 +107,9 @@ struct Distance {
   Utils::Vector3d vec21;
   double dist2;
 };
+
 namespace detail {
+// NOLINTNEXTLINE(bugprone-exception-escape)
 struct MinimalImageDistance {
   BoxGeometry const box;
 

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -174,6 +174,7 @@ get_pairs_of_types(double const distance, std::vector<int> const &types) {
   detail::search_distance_sanity_check(distance);
   auto pairs = get_pairs_filtered(distance, [types](Particle const &p) {
     return std::any_of(types.begin(), types.end(),
+                       // NOLINTNEXTLINE(bugprone-exception-escape)
                        [p](int const type) { return p.type() == type; });
   });
   Utils::Mpi::gather_buffer(pairs, comm_cart);

--- a/src/core/cuda_interface.cpp
+++ b/src/core/cuda_interface.cpp
@@ -130,16 +130,18 @@ static void add_forces_and_torques(ParticleRange particles,
 void cuda_mpi_send_forces(const ParticleRange &particles,
                           Utils::Span<float> host_forces,
                           Utils::Span<float> host_torques) {
-  auto const n_elements = 3 * particles.size();
+
+  auto const size = 3 * particles.size();
+  auto const n_elements = static_cast<int>(size);
 
   if (this_node > 0) {
     static std::vector<float> buffer_forces;
     static std::vector<float> buffer_torques;
 
-    buffer_forces.resize(n_elements);
+    buffer_forces.resize(size);
     Utils::Mpi::scatter_buffer(buffer_forces.data(), n_elements, comm_cart);
 #ifdef ROTATION
-    buffer_torques.resize(n_elements);
+    buffer_torques.resize(size);
     Utils::Mpi::scatter_buffer(buffer_torques.data(), n_elements, comm_cart);
 #endif
     add_forces_and_torques(particles, buffer_forces, buffer_torques);

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -114,6 +114,7 @@ static std::shared_ptr<Observable_stat> calculate_energy_local() {
 
   obs_energy.mpi_reduce();
   return obs_energy_ptr;
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
 REGISTER_CALLBACK_MAIN_RANK(calculate_energy_local)

--- a/src/core/grid_based_algorithms/electrokinetics_cuda.cu
+++ b/src/core/grid_based_algorithms/electrokinetics_cuda.cu
@@ -3612,10 +3612,10 @@ void ek_print_lbpar() {
   printf("    float agrid = %f;\n", lbpar_gpu.agrid);
   printf("    float tau = %f;\n", lbpar_gpu.tau);
   printf("    float bulk_viscosity = %f;\n", lbpar_gpu.bulk_viscosity);
-  printf("    unsigned int dim_x = %d;\n", lbpar_gpu.dim[0]);
-  printf("    unsigned int dim_y = %d;\n", lbpar_gpu.dim[1]);
-  printf("    unsigned int dim_z = %d;\n", lbpar_gpu.dim[2]);
-  printf("    unsigned int number_of_nodes = %d;\n", lbpar_gpu.number_of_nodes);
+  printf("    unsigned int dim_x = %u;\n", lbpar_gpu.dim[0]);
+  printf("    unsigned int dim_y = %u;\n", lbpar_gpu.dim[1]);
+  printf("    unsigned int dim_z = %u;\n", lbpar_gpu.dim[2]);
+  printf("    unsigned int number_of_nodes = %u;\n", lbpar_gpu.number_of_nodes);
   printf("    bool external_force_density = %d;\n",
          static_cast<int>(lbpar_gpu.external_force_density));
   printf("    float ext_force_density[3] = {%f, %f, %f};\n",

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -181,9 +181,9 @@ void lb_init_boundaries() {
     std::vector<int> host_boundary_index_list;
     std::size_t size_of_index;
 
-    for (int z = 0; z < int(lbpar_gpu.dim[2]); z++) {
-      for (int y = 0; y < int(lbpar_gpu.dim[1]); y++) {
-        for (int x = 0; x < int(lbpar_gpu.dim[0]); x++) {
+    for (unsigned z = 0; z < lbpar_gpu.dim[2]; z++) {
+      for (unsigned y = 0; y < lbpar_gpu.dim[1]; y++) {
+        for (unsigned x = 0; x < lbpar_gpu.dim[0]; x++) {
           auto const pos = static_cast<double>(lbpar_gpu.agrid) *
                            (Utils::Vector3d{1. * x, 1. * y, 1. * z} +
                             Utils::Vector3d::broadcast(0.5));
@@ -198,12 +198,10 @@ void lb_init_boundaries() {
             host_boundary_node_list.resize(size_of_index);
             host_boundary_index_list.resize(size_of_index);
             host_boundary_node_list[number_of_boundnodes] =
-                x + lbpar_gpu.dim[0] * y +
-                lbpar_gpu.dim[0] * lbpar_gpu.dim[1] * z;
-            auto const boundary_number =
-                std::distance(lbboundaries.begin(), boundary.base()) - 1;
-            host_boundary_index_list[number_of_boundnodes] =
-                boundary_number + 1;
+                static_cast<int>(x + lbpar_gpu.dim[0] * y +
+                                 lbpar_gpu.dim[0] * lbpar_gpu.dim[1] * z);
+            host_boundary_index_list[number_of_boundnodes] = static_cast<int>(
+                std::distance(lbboundaries.begin(), boundary.base()));
             number_of_boundnodes++;
           }
         }
@@ -257,10 +255,9 @@ void lb_init_boundaries() {
               [&pos](auto const lbb) { return lbb->shape().is_inside(pos); });
           auto const index = get_linear_index(x, y, z, lblattice.halo_grid);
           if (boundary != boost::rend(lbboundaries)) {
-            auto const boundary_number =
-                std::distance(lbboundaries.begin(), boundary.base()) - 1;
             auto &node = lbfields[index];
-            node.boundary = static_cast<int>(boundary_number) + 1;
+            node.boundary = static_cast<int>(
+                std::distance(lbboundaries.begin(), boundary.base()));
             node.slip_velocity = (*boundary)->velocity() * vel_conv;
           } else {
             lbfields[index].boundary = 0;

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -368,7 +368,7 @@ void File::write(const ParticleRange &particles, double time, int step,
                     datasets["particles/atoms/lees_edwards/normal/value"]);
   }
 
-  int const n_part_local = particles.size();
+  auto const n_part_local = static_cast<int>(particles.size());
   // calculate count and offset
   int prefix = 0;
   // calculate prefix for write of the current process
@@ -441,7 +441,7 @@ void File::write_connectivity(const ParticleRange &particles) {
   MultiArray3i bond(boost::extents[0][0][0]);
   int particle_index = 0;
   for (auto const &p : particles) {
-    int nbonds_local = bond.shape()[1];
+    auto nbonds_local = static_cast<decltype(bond)::index>(bond.shape()[1]);
     for (auto const b : p.bonds()) {
       auto const partner_ids = b.partner_ids();
       if (partner_ids.size() == 1) {
@@ -454,7 +454,7 @@ void File::write_connectivity(const ParticleRange &particles) {
     particle_index++;
   }
 
-  int n_bonds_local = bond.shape()[1];
+  auto const n_bonds_local = static_cast<int>(bond.shape()[1]);
   int prefix_bonds = 0;
   BOOST_MPI_CHECK_RESULT(
       MPI_Exscan, (&n_bonds_local, &prefix_bonds, 1, MPI_INT, MPI_SUM, m_comm));

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -314,7 +314,7 @@ def is_valid_type(value, t):
             float_types.append(np.float128)
         return isinstance(value, tuple(float_types))
     elif t == bool:
-        return isinstance(value, (bool, np.bool, np.bool_))
+        return isinstance(value, (bool, np.bool_))
     else:
         return isinstance(value, t)
 

--- a/src/script_interface/GlobalContext.hpp
+++ b/src/script_interface/GlobalContext.hpp
@@ -90,6 +90,7 @@ public:
                 std::shared_ptr<LocalContext> node_local_context)
       : m_local_objects(), m_node_local_context(std::move(node_local_context)),
         m_is_head_node(callbacks.comm().rank() == 0),
+        // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
         m_parallel_exception_handler(callbacks.comm()),
         cb_make_handle(&callbacks,
                        [this](ObjectId id, const std::string &name,

--- a/src/script_interface/LocalContext.hpp
+++ b/src/script_interface/LocalContext.hpp
@@ -49,6 +49,7 @@ public:
   LocalContext(Utils::Factory<ObjectHandle> factory,
                boost::mpi::communicator const &comm)
       : m_factory(std::move(factory)), m_is_head_node(comm.rank() == 0),
+        // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
         m_parallel_exception_handler(comm) {}
 
   const Utils::Factory<ObjectHandle> &factory() const { return m_factory; }

--- a/src/script_interface/tests/ParallelExceptionHandler_test.cpp
+++ b/src/script_interface/tests/ParallelExceptionHandler_test.cpp
@@ -20,7 +20,22 @@
 #define BOOST_TEST_NO_MAIN
 #define BOOST_TEST_MODULE ScriptInterface::ParallelExceptionHandler test
 #define BOOST_TEST_DYN_LINK
+
+/* Guard against a GCC 12 diagnostic for Boost versions <= 1.79.
+ * More details in https://github.com/boostorg/function/issues/42
+ */
+#include <boost/serialization/version.hpp>
+#if BOOST_VERSION <= 107900 and defined(BOOST_GCC) and (BOOST_GCC >= 120000)
+#define BOOST_HAS_GCC_12_UNINITIALIZED_DIAGNOSTIC
+#endif
+#if defined(BOOST_HAS_GCC_12_UNINITIALIZED_DIAGNOSTIC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 #include <boost/test/unit_test.hpp>
+#if defined(BOOST_HAS_GCC_12_UNINITIALIZED_DIAGNOSTIC)
+#pragma GCC diagnostic pop
+#endif
 
 #include "script_interface/Exception.hpp"
 #include "script_interface/ParallelExceptionHandler.hpp"

--- a/src/shapes/src/Rhomboid.cpp
+++ b/src/shapes/src/Rhomboid.cpp
@@ -57,7 +57,7 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double &dist,
     auto const A = a * d;
     auto const B = b * d;
     auto const C = c * d;
-    if (op1(A, 0) & op2(B, 0) & op3(C, 0)) {
+    if (op1(A, 0) and op2(B, 0) and op3(C, 0)) {
       vec = d;
       dist = m_direction * vec.norm();
       return true;
@@ -92,7 +92,7 @@ void Rhomboid::calculate_dist(const Utils::Vector3d &pos, double &dist,
                                      Utils::Vector3d const &edge) {
     auto const A = (d * axis1) / dir1_dot_axis1;
     auto const B = (d * axis2) / dir2_dot_axis2;
-    if (op1(A, 0) & op2(B, 0)) {
+    if (op1(A, 0) and op2(B, 0)) {
       auto const tmp = (d * edge) / edge.norm2();
       vec = d - edge * tmp;
       dist = m_direction * vec.norm();

--- a/src/utils/tests/serialization_test.cpp
+++ b/src/utils/tests/serialization_test.cpp
@@ -137,7 +137,9 @@ auto to_vector(std::stringstream &buffer_in) {
   std::vector<std::stringstream::char_type> buffer_out;
   buffer_in.seekg(0);
   while (!buffer_in.eof()) {
-    buffer_out.push_back(buffer_in.get());
+    std::stringstream::char_type c = '\0';
+    buffer_in.get(c);
+    buffer_out.push_back(c);
   }
   return buffer_out;
 }
@@ -241,7 +243,8 @@ BOOST_AUTO_TEST_CASE(serialization_level_test) {
   for (std::size_t i = 0; i < Testing::N; ++i) {
     auto constexpr N = sizeof(Testing::T);
     auto const offset = sizeof(std::size_t) + i * N;
-    auto const array_data = sorted_view<N>(buffer.begin() + offset);
+    auto const array_data =
+        sorted_view<N>(buffer.begin() + static_cast<long>(offset));
     auto const array_data_ref = std::array<Testing::Serial_T, N>{
         {static_cast<Testing::Serial_T>(Testing::values[i])}};
     BOOST_TEST(array_data == array_data_ref, boost::test_tools::per_element());

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -118,6 +118,8 @@ class H5mdTests(ut.TestCase):
         h5 = espressomd.io.writer.h5md.H5md(file_path=str(self.temp_file))
         h5.close()
 
+    # doesn't alway work in parallel: https://github.com/h5py/h5py/issues/736
+    @ut.skipIf(n_nodes > 1, "only runs for 1 MPI rank")
     def test_appending(self):
         # write one frame to the file
         temp_file = self.temp_path / 'appending.h5'


### PR DESCRIPTION
Description of changes:
- fix compiler warnings and diagnostics from recent GCC/Clang releases
- fix CMake 3.22 warnings and Python 3.10 numpy warnings
- update installation instructions for Ubuntu 22.04 and macOS
- check Fedora 36 and Ubuntu 22.04 in CI
- add support for Sphinx 5.0.0