### PR TITLE
Hide particle struct layout

### DIFF
--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -467,6 +467,7 @@ public:
   constexpr auto &mass() const { return p.mass; }
 #endif
 #ifdef ROTATION
+  auto &rotation() { return p.rotation; }
   auto rotation() const { return p.rotation; }
   bool can_rotate() const { return static_cast<bool>(p.rotation); }
   bool can_rotate_around(int const axis) const {
@@ -520,6 +521,7 @@ public:
   auto &mu_E() { return p.mu_E; }
 #endif
 #ifdef VIRTUAL_SITES
+  bool &virtual_flag() { return p.is_virtual; }
   bool is_virtual() const { return p.is_virtual; }
   void set_virtual(bool const virt_flag) { p.is_virtual = virt_flag; }
 #ifdef VIRTUAL_SITES_RELATIVE
@@ -538,6 +540,7 @@ public:
 #endif // ROTATION
 #endif // THERMOSTAT_PER_PARTICLE
 #ifdef EXTERNAL_FORCES
+  auto &fixed() { return p.ext_flag; }
   bool has_fixed_coordinates() const { return static_cast<bool>(p.ext_flag); }
   bool is_fixed_along(int const axis) const {
     detail::check_axis_idx_valid(axis);
@@ -567,6 +570,8 @@ public:
   auto &pos_last_time_step() { return r.p_last_timestep; }
   auto const &rattle_params() const { return rattle; }
   auto &rattle_params() { return rattle; }
+  auto const &rattle_correction() const { return rattle.correction; }
+  auto &rattle_correction() { return rattle.correction; }
 #endif
 
 #ifdef EXCLUSIONS

--- a/src/core/observables/ParticleAngularVelocities.hpp
+++ b/src/core/observables/ParticleAngularVelocities.hpp
@@ -20,38 +20,11 @@
 #define OBSERVABLES_PARTICLEANGULARVELOCITIES_HPP
 
 #include "PidObservable.hpp"
-#include "rotation.hpp"
-
-#include <utils/Span.hpp>
-
-#include <cstddef>
-#include <vector>
 
 namespace Observables {
 
-class ParticleAngularVelocities : public PidObservable {
-public:
-  using PidObservable::PidObservable;
+using ParticleAngularVelocities =
+    ParticleObservable<ParticleObservables::AngularVelocities>;
 
-  std::vector<double>
-  evaluate(ParticleReferenceRange particles,
-           const ParticleObservables::traits<Particle> &) const override {
-    std::vector<double> res(n_values());
-#ifdef ROTATION
-    std::size_t i = 0;
-    for (auto const &p : particles) {
-      auto const omega = convert_vector_body_to_space(p.get(), p.get().omega());
-      res[3 * i + 0] = omega[0];
-      res[3 * i + 1] = omega[1];
-      res[3 * i + 2] = omega[2];
-      i++;
-    }
-#endif
-    return res;
-  }
-
-  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
-};
-
-} // Namespace Observables
+} // namespace Observables
 #endif

--- a/src/core/observables/ParticleBodyAngularVelocities.hpp
+++ b/src/core/observables/ParticleBodyAngularVelocities.hpp
@@ -21,36 +21,10 @@
 
 #include "PidObservable.hpp"
 
-#include <utils/Span.hpp>
-
-#include <cstddef>
-#include <vector>
-
 namespace Observables {
 
-class ParticleBodyAngularVelocities : public PidObservable {
-public:
-  using PidObservable::PidObservable;
+using ParticleBodyAngularVelocities =
+    ParticleObservable<ParticleObservables::BodyAngularVelocities>;
 
-  std::vector<double>
-  evaluate(ParticleReferenceRange particles,
-           const ParticleObservables::traits<Particle> &) const override {
-    std::vector<double> res(n_values());
-#ifdef ROTATION
-    std::size_t i = 0;
-    for (auto const &p : particles) {
-      auto const &omega = p.get().omega();
-      res[3 * i + 0] = omega[0];
-      res[3 * i + 1] = omega[1];
-      res[3 * i + 2] = omega[2];
-      i++;
-    }
-#endif
-    return res;
-  }
-
-  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
-};
-
-} // Namespace Observables
+} // namespace Observables
 #endif

--- a/src/core/observables/ParticleBodyVelocities.hpp
+++ b/src/core/observables/ParticleBodyVelocities.hpp
@@ -21,37 +21,10 @@
 
 #include "PidObservable.hpp"
 
-#include "rotation.hpp"
-
-#include <utils/Span.hpp>
-
-#include <cstddef>
-#include <vector>
-
 namespace Observables {
 
-class ParticleBodyVelocities : public PidObservable {
-public:
-  using PidObservable::PidObservable;
+using ParticleBodyVelocities =
+    ParticleObservable<ParticleObservables::BodyVelocities>;
 
-  std::vector<double>
-  evaluate(ParticleReferenceRange particles,
-           const ParticleObservables::traits<Particle> &traits) const override {
-    std::vector<double> res(n_values());
-    for (std::size_t i = 0; i < particles.size(); i++) {
-#ifdef ROTATION
-      const Utils::Vector3d vel_body = convert_vector_space_to_body(
-          particles[i].get(), traits.velocity(particles[i]));
-
-      res[3 * i + 0] = vel_body[0];
-      res[3 * i + 1] = vel_body[1];
-      res[3 * i + 2] = vel_body[2];
-#endif
-    }
-    return res;
-  }
-  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
-};
-
-} // Namespace Observables
+} // namespace Observables
 #endif

--- a/src/core/observables/ParticleDistances.hpp
+++ b/src/core/observables/ParticleDistances.hpp
@@ -23,9 +23,6 @@
 #include "PidObservable.hpp"
 #include "grid.hpp"
 
-#include <utils/Span.hpp>
-#include <utils/Vector.hpp>
-
 #include <cassert>
 #include <cstddef>
 #include <stdexcept>
@@ -65,6 +62,6 @@ public:
   }
 };
 
-} // Namespace Observables
+} // namespace Observables
 
 #endif

--- a/src/core/observables/ParticleForces.hpp
+++ b/src/core/observables/ParticleForces.hpp
@@ -19,11 +19,7 @@
 #ifndef OBSERVABLES_PARTICLEFORCES_HPP
 #define OBSERVABLES_PARTICLEFORCES_HPP
 
-#include "Particle.hpp"
 #include "PidObservable.hpp"
-
-#include <cstddef>
-#include <vector>
 
 namespace Observables {
 
@@ -31,26 +27,7 @@ namespace Observables {
  *  For \f$n\f$ particles, return \f$3 n\f$ forces ordered as
  *  \f$(f_x^1, f_y^1, f_z^1, \dots, f_x^n, f_y^n, f_z^n)\f$.
  */
-class ParticleForces : public PidObservable {
-public:
-  using PidObservable::PidObservable;
+using ParticleForces = ParticleObservable<ParticleObservables::Forces>;
 
-  std::vector<double>
-  evaluate(ParticleReferenceRange particles,
-           const ParticleObservables::traits<Particle> &) const override {
-    std::vector<double> res(n_values());
-    std::size_t i = 0;
-    for (auto const &p : particles) {
-      auto const &f = p.get().f.f;
-      res[3 * i + 0] = f[0];
-      res[3 * i + 1] = f[1];
-      res[3 * i + 2] = f[2];
-      i++;
-    }
-    return res;
-  };
-  std::vector<std::size_t> shape() const override { return {ids().size(), 3}; }
-};
-
-} // Namespace Observables
+} // namespace Observables
 #endif

--- a/src/core/observables/ParticlePositions.hpp
+++ b/src/core/observables/ParticlePositions.hpp
@@ -21,8 +21,6 @@
 
 #include "PidObservable.hpp"
 
-#include <vector>
-
 namespace Observables {
 
 /** Extract particle positions.
@@ -30,5 +28,6 @@ namespace Observables {
  *  \f$(x_1, y_1, z_1, \dots, x_n, y_n, z_n)\f$.
  */
 using ParticlePositions = ParticleObservable<ParticleObservables::Positions>;
+
 } // namespace Observables
 #endif

--- a/src/core/observables/ParticleTraits.hpp
+++ b/src/core/observables/ParticleTraits.hpp
@@ -21,6 +21,7 @@
 
 #include "Particle.hpp"
 #include "config.hpp"
+#include "rotation.hpp"
 
 namespace ParticleObservables {
 /**
@@ -31,6 +32,7 @@ namespace ParticleObservables {
 template <> struct traits<Particle> {
   auto position(Particle const &p) const { return p.pos(); }
   auto velocity(Particle const &p) const { return p.v(); }
+  auto force(Particle const &p) const { return p.force(); }
   auto mass(Particle const &p) const {
 #ifdef VIRTUAL_SITES
     // we exclude virtual particles since their mass does not have a meaning
@@ -43,6 +45,27 @@ template <> struct traits<Particle> {
   auto dipole_moment(Particle const &p) const {
 #if defined(ROTATION) && defined(DIPOLES)
     return p.calc_dip();
+#else
+    return Utils::Vector3d{};
+#endif
+  }
+  auto velocity_body(Particle const &p) const {
+#ifdef ROTATION
+    return convert_vector_space_to_body(p, p.v());
+#else
+    return Utils::Vector3d{};
+#endif
+  }
+  auto angular_velocity(Particle const &p) const {
+#ifdef ROTATION
+    return convert_vector_body_to_space(p, p.omega());
+#else
+    return Utils::Vector3d{};
+#endif
+  }
+  auto angular_velocity_body(Particle const &p) const {
+#ifdef ROTATION
+    return p.omega();
 #else
     return Utils::Vector3d{};
 #endif

--- a/src/core/observables/ParticleVelocities.hpp
+++ b/src/core/observables/ParticleVelocities.hpp
@@ -21,8 +21,6 @@
 
 #include "PidObservable.hpp"
 
-#include <vector>
-
 namespace Observables {
 
 /** Extract particle velocities.

--- a/src/particle_observables/include/particle_observables/observable.hpp
+++ b/src/particle_observables/include/particle_observables/observable.hpp
@@ -50,8 +50,12 @@ using Momentum = Product<Mass, Velocity>;
 using AverageMomentum = Average<Momentum>;
 using CenterOfMassPosition = WeightedAverage<Position, Mass>;
 using CenterOfMassVelocity = WeightedAverage<Velocity, Mass>;
+using Forces = Map<Force>;
 using Positions = Map<Position>;
 using Velocities = Map<Velocity>;
+using BodyVelocities = Map<BodyVelocity>;
+using AngularVelocities = Map<AngularVelocity>;
+using BodyAngularVelocities = Map<BodyAngularVelocity>;
 } // namespace ParticleObservables
 
 #endif // SRC_PARTICLE_OBSERVABLES_OBSERVABLE_HPP

--- a/src/particle_observables/include/particle_observables/properties.hpp
+++ b/src/particle_observables/include/particle_observables/properties.hpp
@@ -39,6 +39,14 @@ template <class T> using decay_t = typename decay<T>::type;
 template <class Particle>
 using default_traits = traits<detail::decay_t<Particle>>;
 
+struct Force {
+  template <class Particle, class Traits = default_traits<Particle>>
+  decltype(auto) operator()(Particle const &p,
+                            Traits particle_traits = {}) const {
+    return particle_traits.force(p);
+  }
+};
+
 struct Position {
   template <class Particle, class Traits = default_traits<Particle>>
   decltype(auto) operator()(Particle const &p,
@@ -52,6 +60,30 @@ struct Velocity {
   decltype(auto) operator()(Particle const &p,
                             Traits particle_traits = {}) const {
     return particle_traits.velocity(p);
+  }
+};
+
+struct BodyVelocity {
+  template <class Particle, class Traits = default_traits<Particle>>
+  decltype(auto) operator()(Particle const &p,
+                            Traits particle_traits = {}) const {
+    return particle_traits.velocity_body(p);
+  }
+};
+
+struct AngularVelocity {
+  template <class Particle, class Traits = default_traits<Particle>>
+  decltype(auto) operator()(Particle const &p,
+                            Traits particle_traits = {}) const {
+    return particle_traits.angular_velocity(p);
+  }
+};
+
+struct BodyAngularVelocity {
+  template <class Particle, class Traits = default_traits<Particle>>
+  decltype(auto) operator()(Particle const &p,
+                            Traits particle_traits = {}) const {
+    return particle_traits.angular_velocity_body(p);
   }
 };
 


### PR DESCRIPTION
Description of changes:
- reduce complexity of the particle observables and rely on `Particle` getters instead of directly accessing member variables
- rewrite ghost communication serialization to make it independent of the way `Particle` member variables are ordered
   - no measurable performance impact on a LJ simulation on 8 cores with 10'000 particles per core at 0.5 volume fraction
