### PR TITLE
Code maintenance

### DIFF
--- a/.github/actions/build_and_check/action.yml
+++ b/.github/actions/build_and_check/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: 'Whether to build with undefined behavior sanitizer'
     required: true
     default: 'false'
-  check_skip_long:  # id of input
-    description: 'Whether to skip long python tests'
-    required: true
-    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -22,7 +18,7 @@ runs:
        pip3 install numpy cython h5py scipy
       shell: bash
     - run: |
-        export myconfig=maxset with_cuda=false test_timeout=800 with_asan=${{ inputs.asan }} with_ubsan=${{ inputs.ubsan }} check_skip_long=${{ inputs.check_skip_long }}
+        export myconfig=maxset with_cuda=false test_timeout=800 with_asan=${{ inputs.asan }} with_ubsan=${{ inputs.ubsan }} check_skip_long=true
         bash maintainer/CI/build_cmake.sh
       shell: bash
       # This is a workaround for the unfortunate interaction of MacOS and OpenMPI 4

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           asan: false
           ubsan: false
-          check_skip_long: false
 
   sanitizer_check:
     runs-on: macos-latest
@@ -39,7 +38,6 @@ jobs:
         with:
           asan: true
           ubsan: true
-          check_skip_long: true
       - name: Setting job link variable
         if: ${{ failure() }}
         run: |

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -105,20 +105,23 @@ CUDA SDK to make use of GPU computation:
 
     sudo apt install nvidia-cuda-toolkit
 
+Later in the installation instructions, you will see CMake commands of the
+form ``cmake ..`` with optional arguments, such as ``cmake .. -D WITH_CUDA=ON``
+to activate CUDA. These commands may need to be adapted depending on which
+operating system and CUDA version you are using.
+
 On Ubuntu 22.04, the default GCC compiler is too recent for nvcc and will fail
 to compile sources that rely on ``std::function``. You can either use GCC 10:
 
 .. code-block:: bash
 
     CC=gcc-10 CXX=g++-10 cmake .. -D WITH_CUDA=ON
-    make -j
 
 or alternatively install Clang 12 as a replacement for nvcc and GCC:
 
 .. code-block:: bash
 
     CC=clang-12 CXX=clang++-12 cmake .. -D WITH_CUDA=ON -D WITH_CUDA_COMPILER=clang
-    make -j
 
 On Ubuntu 20.04, the default GCC compiler is also too recent for nvcc and will
 generate compiler errors. You can either install an older version of GCC and
@@ -133,7 +136,6 @@ specific one by providing custom paths to the compiler and toolkit:
 
     CUDACXX=/usr/local/cuda-11.0/bin/nvcc \
       cmake .. -D WITH_CUDA=ON -D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-11.0
-    make -j
 
 Alternatively for Clang:
 
@@ -141,7 +143,6 @@ Alternatively for Clang:
 
     CC=clang-12 CXX=clang++-12 CUDACXX=clang++-12 CUDAToolkit_ROOT=/usr/local/cuda-11.0 \
       cmake .. -DWITH_CUDA=ON -DWITH_CUDA_COMPILER=clang -DCMAKE_CXX_FLAGS=--cuda-path=/usr/local/cuda-11.0
-    make -j
 
 .. _Requirements for building the documentation:
 

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -44,14 +44,12 @@ Tabulated interaction
 
     Feature ``TABULATED`` required.
 
-
 The interface for tabulated interactions are implemented in the
 :class:`~espressomd.interactions.TabulatedNonBonded` class. They can be configured
 via the following syntax::
 
   system.non_bonded_inter[type1, type2].tabulated.set_params(
       min='min', max='max', energy='energy', force='force')
-
 
 This defines an interaction between particles of the types ``type1`` and
 ``type2`` according to an arbitrary tabulated pair potential by linear interpolation.
@@ -646,19 +644,6 @@ and involved types.
 
 The samples folder contains the script :file:`/samples/drude_bmimpf6.py` with a
 fully polarizable, coarse grained ionic liquid where this approach is applied.
-To use the script, compile espresso with the following features:
-
-.. code-block:: c++
-
-    #define EXTERNAL_FORCES
-    #define MASS
-    #define THERMOSTAT_PER_PARTICLE
-    #define ROTATION
-    #define ROTATIONAL_INERTIA
-    #define ELECTROSTATICS
-    #define VIRTUAL_SITES_RELATIVE
-    #define LENNARD_JONES
-    #define THOLE
 
 .. _Anisotropic non-bonded interactions:
 

--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -492,8 +492,10 @@ public:
   auto &torque() { return f.torque; }
   auto const &omega() const { return m.omega; }
   auto &omega() { return m.omega; }
+#ifdef EXTERNAL_FORCES
   auto const &ext_torque() const { return p.ext_torque; }
   auto &ext_torque() { return p.ext_torque; }
+#endif // EXTERNAL_FORCES
   auto calc_director() const { return r.calc_director(); }
 #else  // ROTATION
   bool can_rotate() const { return false; }
@@ -556,7 +558,6 @@ public:
   }
   auto const &ext_force() const { return p.ext_force; }
   auto &ext_force() { return p.ext_force; }
-
 #else  // EXTERNAL_FORCES
   constexpr bool has_fixed_coordinates() const { return false; }
   constexpr bool is_fixed_along(int const) const { return false; }

--- a/src/core/analysis/statistics.cpp
+++ b/src/core/analysis/statistics.cpp
@@ -87,8 +87,8 @@ static Utils::Vector3d mpi_particle_momentum_local() {
 REGISTER_CALLBACK_REDUCTION(mpi_particle_momentum_local,
                             std::plus<Utils::Vector3d>())
 
-Utils::Vector3d calc_linear_momentum(int include_particles,
-                                     int include_lbfluid) {
+Utils::Vector3d calc_linear_momentum(bool include_particles,
+                                     bool include_lbfluid) {
   Utils::Vector3d linear_momentum{};
   if (include_particles) {
     linear_momentum +=

--- a/src/core/analysis/statistics.hpp
+++ b/src/core/analysis/statistics.hpp
@@ -116,11 +116,10 @@ Utils::Vector3d angular_momentum(PartCfg &partCfg, int p_type);
 Utils::Vector9d moment_of_inertia_matrix(PartCfg &partCfg, int p_type);
 
 /** Calculate total momentum of the system (particles & LB fluid).
- *  Inputs are bools to include particles and fluid in the linear momentum
- *  calculation
- *  @return Result for this processor
+ *  @param include_particles   Add particles momentum
+ *  @param include_lbfluid     Add LB fluid momentum
  */
-Utils::Vector3d calc_linear_momentum(int include_particles,
-                                     int include_lbfluid);
+Utils::Vector3d calc_linear_momentum(bool include_particles,
+                                     bool include_lbfluid);
 
 #endif

--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -41,29 +41,29 @@ public:
 
 private:
   void reset_forces() const {
-    for (auto const &c : *this) {
-      c->reset_force();
+    for (auto const &constraint : *this) {
+      constraint->reset_force();
     }
   }
 
   container_type m_constraints;
 
 public:
-  void add(std::shared_ptr<Constraint> const &c) {
-    if (not c->fits_in_box(box_geo.length())) {
+  void add(std::shared_ptr<Constraint> const &constraint) {
+    if (not constraint->fits_in_box(box_geo.length())) {
       throw std::runtime_error("Constraint not compatible with box size.");
     }
-    assert(std::find(m_constraints.begin(), m_constraints.end(), c) ==
+    assert(std::find(m_constraints.begin(), m_constraints.end(), constraint) ==
            m_constraints.end());
 
-    m_constraints.emplace_back(c);
+    m_constraints.emplace_back(constraint);
     on_constraint_change();
   }
-  void remove(std::shared_ptr<Constraint> const &c) {
-    assert(std::find(m_constraints.begin(), m_constraints.end(), c) !=
+  void remove(std::shared_ptr<Constraint> const &constraint) {
+    assert(std::find(m_constraints.begin(), m_constraints.end(), constraint) !=
            m_constraints.end());
     m_constraints.erase(
-        std::remove(m_constraints.begin(), m_constraints.end(), c),
+        std::remove(m_constraints.begin(), m_constraints.end(), constraint),
         m_constraints.end());
     on_constraint_change();
   }
@@ -82,8 +82,8 @@ public:
     for (auto &p : particles) {
       auto const pos = folded_position(p.pos(), box_geo);
       ParticleForce force{};
-      for (auto const &c : *this) {
-        force += c->force(p, pos, t);
+      for (auto const &constraint : *this) {
+        force += constraint->force(p, pos, t);
       }
 
       p.f += force;

--- a/src/core/constraints/HomogeneousMagneticField.cpp
+++ b/src/core/constraints/HomogeneousMagneticField.cpp
@@ -28,7 +28,7 @@ namespace Constraints {
 
 ParticleForce HomogeneousMagneticField::force(const Particle &p,
                                               const Utils::Vector3d &, double) {
-#if defined(ROTATION) && defined(DIPOLES)
+#ifdef DIPOLES
   return {{}, vector_product(p.calc_dip(), m_field)};
 #else
   return {};

--- a/src/core/electrostatics/mmm1d.cpp
+++ b/src/core/electrostatics/mmm1d.cpp
@@ -123,10 +123,19 @@ CoulombMMM1D::CoulombMMM1D(double prefactor, double maxPWerror,
     : maxPWerror{maxPWerror}, far_switch_radius{switch_rad},
       tune_timings{tune_timings}, tune_verbose{tune_verbose}, m_is_tuned{false},
       far_switch_radius_sq{-1.}, uz2{0.}, prefuz2{0.}, prefL3_i{0.} {
+  set_prefactor(prefactor);
+  if (maxPWerror <= 0.) {
+    throw std::domain_error("Parameter 'maxPWerror' must be > 0");
+  }
+  if (far_switch_radius <= 0. and far_switch_radius != -1.) {
+    throw std::domain_error("Parameter 'far_switch_radius' must be > 0");
+  }
   if (far_switch_radius > 0.) {
     far_switch_radius_sq = Utils::sqr(far_switch_radius);
   }
-  set_prefactor(prefactor);
+  if (tune_timings <= 0) {
+    throw std::domain_error("Parameter 'timings' must be > 0");
+  }
 }
 
 void CoulombMMM1D::sanity_checks_periodicity() const {

--- a/src/core/electrostatics/mmm1d_gpu.cpp
+++ b/src/core/electrostatics/mmm1d_gpu.cpp
@@ -36,11 +36,19 @@ CoulombMMM1DGpu::CoulombMMM1DGpu(double prefactor, double maxPWerror,
     : maxPWerror{maxPWerror}, far_switch_radius{far_switch_radius},
       far_switch_radius_sq{-1.}, bessel_cutoff{bessel_cutoff}, m_is_tuned{
                                                                    false} {
-
   set_prefactor(prefactor);
-  if (far_switch_radius >= 0. and far_switch_radius > box_geo.length()[2]) {
+  if (maxPWerror <= 0.) {
+    throw std::domain_error("Parameter 'maxPWerror' must be > 0");
+  }
+  if (far_switch_radius <= 0. and far_switch_radius != -1.) {
+    throw std::domain_error("Parameter 'far_switch_radius' must be > 0");
+  }
+  if (far_switch_radius > 0. and far_switch_radius > box_geo.length()[2]) {
     throw std::domain_error(
-        "switching radius must not be larger than box length");
+        "Parameter 'far_switch_radius' must not be larger than box length");
+  }
+  if (bessel_cutoff < 0 and bessel_cutoff != -1) {
+    throw std::domain_error("Parameter 'bessel_cutoff' must be > 0");
   }
 
   auto &system = EspressoSystemInterface::Instance();

--- a/src/core/electrostatics/p3m.cpp
+++ b/src/core/electrostatics/p3m.cpp
@@ -276,6 +276,9 @@ CoulombP3M::CoulombP3M(P3MParameters &&parameters, double prefactor,
       tune_verbose{tune_verbose}, check_complex_residuals{
                                       check_complex_residuals} {
 
+  if (tune_timings <= 0) {
+    throw std::domain_error("Parameter 'timings' must be > 0");
+  }
   m_is_tuned = !p3m.params.tuning;
   p3m.params.tuning = false;
   set_prefactor(prefactor);

--- a/src/core/electrostatics/p3m.cpp
+++ b/src/core/electrostatics/p3m.cpp
@@ -270,9 +270,11 @@ void CoulombP3M::init() {
 }
 
 CoulombP3M::CoulombP3M(P3MParameters &&parameters, double prefactor,
-                       int tune_timings, bool tune_verbose)
+                       int tune_timings, bool tune_verbose,
+                       bool check_complex_residuals)
     : p3m{std::move(parameters)}, tune_timings{tune_timings},
-      tune_verbose{tune_verbose} {
+      tune_verbose{tune_verbose}, check_complex_residuals{
+                                      check_complex_residuals} {
 
   m_is_tuned = !p3m.params.tuning;
   p3m.params.tuning = false;
@@ -490,7 +492,7 @@ double CoulombP3M::long_range_kernel(bool force_flag, bool energy_flag,
     }
 
     /* Back FFT force component mesh */
-    auto const check_complex = !p3m.params.tuning;
+    auto const check_complex = !p3m.params.tuning and check_complex_residuals;
     for (int d = 0; d < 3; d++) {
       fft_perform_back(p3m.E_mesh[d].data(), check_complex, p3m.fft, comm_cart);
     }

--- a/src/core/electrostatics/p3m.hpp
+++ b/src/core/electrostatics/p3m.hpp
@@ -89,13 +89,14 @@ struct CoulombP3M : public Coulomb::Actor<CoulombP3M> {
 
   int tune_timings;
   bool tune_verbose;
+  bool check_complex_residuals;
 
 private:
   bool m_is_tuned;
 
 public:
   CoulombP3M(P3MParameters &&parameters, double prefactor, int tune_timings,
-             bool tune_verbose);
+             bool tune_verbose, bool check_complex_residuals);
 
   bool is_tuned() const { return m_is_tuned; }
 

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -154,8 +154,7 @@ inline double calc_non_bonded_pair_energy(
 
 #ifdef GAY_BERNE
   /* Gay-Berne */
-  ret += gb_pair_energy(p1.calc_director(), p2.calc_director(), ia_params, d,
-                        dist);
+  ret += gb_pair_energy(p1.quat(), p2.quat(), ia_params, d, dist);
 #endif
 
   return ret;

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -143,11 +143,7 @@ inline ParticleForce calc_non_bonded_pair_force(
 #endif
 /* Gay-Berne */
 #ifdef GAY_BERNE
-  // The gb force function isn't inlined, probably due to its size
-  if (dist < ia_params.gay_berne.cut) {
-    pf += gb_pair_force(p1.calc_director(), p2.calc_director(), ia_params, d,
-                        dist);
-  }
+  pf += gb_pair_force(p1.quat(), p2.quat(), ia_params, d, dist);
 #endif
   pf.f += force_factor * d;
   return pf;

--- a/src/core/grid_based_algorithms/lb_boundaries.cpp
+++ b/src/core/grid_based_algorithms/lb_boundaries.cpp
@@ -171,6 +171,7 @@ void lb_init_boundaries() {
     if (this_node != 0) {
       return;
     }
+#if defined(CUDA)
 #if defined(LB_BOUNDARIES_GPU)
 #if defined(EK_BOUNDARIES)
     ek_init_boundaries();
@@ -233,6 +234,7 @@ void lb_init_boundaries() {
              "compiled in. Activate in myconfig.hpp.";
     }
 #endif // defined (LB_BOUNDARIES_GPU)
+#endif // defined (CUDA)
   } else if (lattice_switch == ActiveLB::CPU) {
 #if defined(LB_BOUNDARIES)
     using Utils::get_linear_index;

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -23,9 +23,10 @@
 
 #include "BoxGeometry.hpp"
 #include "Particle.hpp"
-#include "config/version.hpp"
 #include "h5md_specification.hpp"
 #include "lees_edwards/LeesEdwardsBC.hpp"
+
+#include "config/version.hpp"
 
 #include <utils/Vector.hpp>
 

--- a/src/core/magnetostatics/barnes_hut_gpu.cpp
+++ b/src/core/magnetostatics/barnes_hut_gpu.cpp
@@ -33,6 +33,15 @@
 DipolarBarnesHutGpu::DipolarBarnesHutGpu(double prefactor, double epssq,
                                          double itolsq)
     : prefactor{prefactor}, m_epssq{epssq}, m_itolsq{itolsq} {
+  if (prefactor <= 0.) {
+    throw std::domain_error("Parameter 'prefactor' must be > 0");
+  }
+  if (m_itolsq <= 0.) {
+    throw std::domain_error("Parameter 'itolsq' must be > 0");
+  }
+  if (m_epssq <= 0.) {
+    throw std::domain_error("Parameter 'epssq' must be > 0");
+  }
   auto &system = EspressoSystemInterface::Instance();
   system.requestFGpu();
   system.requestTorqueGpu();

--- a/src/core/magnetostatics/barnes_hut_gpu_cuda.cu
+++ b/src/core/magnetostatics/barnes_hut_gpu_cuda.cu
@@ -709,12 +709,12 @@ __global__ __launch_bounds__(THREADS5, FACTOR5) void forceCalculationKernel(
     // calculated within the array dq[i], which will
     // be compared later with squared distance between the particle
     // and the cell depending on a cell level.
-    // Original tree box edge (2*radiusd) should be divided *0.5
+    // Original tree box edge (2*radiusd) should be halved
     // as much as the tree depth takes place.
     dq[0] = radiusd * radiusd * *itolsqd;
     for (i = 1; i < maxdepthd; i++) {
-      dq[i] = dq[i - 1] * 0.25f;
-      dq[i - 1] += *epssqd;
+      dq[i] = dq[i - 1] * 0.25f; // halving of the squared distance
+      dq[i - 1] += *epssqd;      // increase thickness of previous cell
     }
     dq[i - 1] += *epssqd;
 
@@ -820,7 +820,7 @@ __global__ __launch_bounds__(THREADS5, FACTOR5) void forceCalculationKernel(
 #endif
               if (n != i) {
 
-                auto const d1 = sqrtf(tmp /*, 0.5f*/);
+                auto const d1 = sqrtf(tmp);
                 auto const dd5 = __fdividef(1.0f, tmp * tmp * d1);
                 auto b = 0.0f;
                 auto b2 = 0.0f;
@@ -891,7 +891,7 @@ __global__ __launch_bounds__(THREADS5, FACTOR5) void forceCalculationKernel(
 __global__ __launch_bounds__(THREADS5, FACTOR5) void energyCalculationKernel(
     float pf, float *energySum) {
   // NOTE: the algorithm of this kernel is almost identical to
-  // forceCalculationKernel. See comments there.
+  // @ref forceCalculationKernel. See comments there.
 
   int i, n, t;
   float dr[3], h[3], u[3], uc[3];
@@ -962,20 +962,16 @@ __global__ __launch_bounds__(THREADS5, FACTOR5) void energyCalculationKernel(
               dr[l] = -bhpara->r[3 * n + l] + bhpara->r[3 * i + l];
               tmp += dr[l] * dr[l];
             }
+            // check if all threads agree that cell is far enough away
+            // (or is a body)
 #if defined(__CUDACC__) && CUDA_VERSION >= 9000
             if ((n < bhpara->nbodies) ||
-                __all_sync(
-                    __activemask(),
-                    tmp >= dq[depth])) { // check if all threads agree that cell
-                                         // is far enough away (or is a body)
+                __all_sync(__activemask(), tmp >= dq[depth])) {
 #else
-            if ((n < bhpara->nbodies) ||
-                __all(tmp >=
-                      dq[depth])) { // check if all threads agree that cell
-                                    // is far enough away (or is a body)
+            if ((n < bhpara->nbodies) || __all(tmp >= dq[depth])) {
 #endif
               if (n != i) {
-                auto const d1 = sqrtf(tmp /*, 0.5f*/);
+                auto const d1 = sqrtf(tmp);
                 auto const dd5 = __fdividef(1.0f, tmp * tmp * d1);
                 auto b = 0.0f;
                 for (int l = 0; l < 3; l++) {
@@ -1275,4 +1271,4 @@ void fill_bh_data(float const *r, float const *dip, BHData const *bh_data) {
   cuda_safe_mem(cudaMemcpy(bh_data->u, dip, size, cudaMemcpyDeviceToDevice));
 }
 
-#endif // BARNES_HUT
+#endif // DIPOLAR_BARNES_HUT

--- a/src/core/magnetostatics/dds_gpu_cuda.cu
+++ b/src/core/magnetostatics/dds_gpu_cuda.cu
@@ -152,7 +152,7 @@ __global__ void DipolarDirectSum_kernel_force(float pf, unsigned int n,
   // There is one thread per particle. Each thread computes interactions
   // with particles whose id is smaller than the thread id.
   // The force and torque of all the interaction partners of the current thread
-  // is atomically added to global results ad once.
+  // is atomically added to global results at once.
   // The result for the particle id equal to the thread id is atomically added
   // to global memory at the end.
 

--- a/src/core/magnetostatics/dipoles_inline.hpp
+++ b/src/core/magnetostatics/dipoles_inline.hpp
@@ -51,7 +51,7 @@ struct ShortRangeForceKernel
     return {};
   }
 
-#ifdef P3M
+#ifdef DP3M
   result_type operator()(std::shared_ptr<DipolarP3M> const &ptr) const {
     auto const &actor = *ptr;
     return kernel_type{[&actor](Particle const &p1, Particle const &p2,
@@ -60,7 +60,7 @@ struct ShortRangeForceKernel
       return actor.pair_force(p1, p2, d, dist2, dist);
     }};
   }
-#endif // P3M
+#endif // DP3M
 
   result_type
   operator()(std::shared_ptr<DipolarLayerCorrection> const &ptr) const {
@@ -82,7 +82,7 @@ struct ShortRangeEnergyKernel
     return {};
   }
 
-#ifdef P3M
+#ifdef DP3M
   result_type operator()(std::shared_ptr<DipolarP3M> const &ptr) const {
     auto const &actor = *ptr;
     return kernel_type{[&actor](Particle const &p1, Particle const &p2,
@@ -91,7 +91,7 @@ struct ShortRangeEnergyKernel
       return actor.pair_energy(p1, p2, d, dist2, dist);
     }};
   }
-#endif // P3M
+#endif // DP3M
 
   result_type
   operator()(std::shared_ptr<DipolarLayerCorrection> const &ptr) const {

--- a/src/core/magnetostatics/dp3m.cpp
+++ b/src/core/magnetostatics/dp3m.cpp
@@ -154,6 +154,9 @@ DipolarP3M::DipolarP3M(P3MParameters &&parameters, double prefactor,
   if (prefactor <= 0.) {
     throw std::domain_error("Parameter 'prefactor' must be > 0");
   }
+  if (tune_timings <= 0) {
+    throw std::domain_error("Parameter 'timings' must be > 0");
+  }
 
   if (dp3m.params.mesh != Utils::Vector3i::broadcast(dp3m.params.mesh[0])) {
     throw std::domain_error("DipolarP3M requires a cubic mesh");

--- a/src/core/nonbonded_interactions/gay_berne.hpp
+++ b/src/core/nonbonded_interactions/gay_berne.hpp
@@ -41,6 +41,7 @@
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
 #include <utils/math/sqr.hpp>
+#include <utils/quaternion.hpp>
 
 #include <cmath>
 
@@ -49,8 +50,8 @@ int gay_berne_set_params(int part_type_a, int part_type_b, double eps,
                          double mu, double nu);
 
 /** Calculate Gay-Berne force and torques */
-inline ParticleForce gb_pair_force(Utils::Vector3d const &ui,
-                                   Utils::Vector3d const &uj,
+inline ParticleForce gb_pair_force(Utils::Quaternion<double> const &qi,
+                                   Utils::Quaternion<double> const &qj,
                                    IA_parameters const &ia_params,
                                    Utils::Vector3d const &d, double dist) {
   using Utils::int_pow;
@@ -60,6 +61,8 @@ inline ParticleForce gb_pair_force(Utils::Vector3d const &ui,
     return {};
   }
 
+  auto const ui = Utils::convert_quaternion_to_director(qi);
+  auto const uj = Utils::convert_quaternion_to_director(qj);
   auto const e0 = ia_params.gay_berne.eps;
   auto const s0 = ia_params.gay_berne.sig;
   auto const chi1 = ia_params.gay_berne.chi1;
@@ -132,8 +135,8 @@ inline ParticleForce gb_pair_force(Utils::Vector3d const &ui,
 }
 
 /** Calculate Gay-Berne energy */
-inline double gb_pair_energy(Utils::Vector3d const &ui,
-                             Utils::Vector3d const &uj,
+inline double gb_pair_energy(Utils::Quaternion<double> const &qi,
+                             Utils::Quaternion<double> const &qj,
                              IA_parameters const &ia_params,
                              Utils::Vector3d const &d, double dist) {
   using Utils::int_pow;
@@ -143,6 +146,8 @@ inline double gb_pair_energy(Utils::Vector3d const &ui,
     return 0.0;
   }
 
+  auto const ui = Utils::convert_quaternion_to_director(qi);
+  auto const uj = Utils::convert_quaternion_to_director(qj);
   auto const e0 = ia_params.gay_berne.eps;
   auto const s0 = ia_params.gay_berne.sig;
   auto const chi1 = ia_params.gay_berne.chi1;

--- a/src/core/observables/ParticleTraits.hpp
+++ b/src/core/observables/ParticleTraits.hpp
@@ -43,7 +43,7 @@ template <> struct traits<Particle> {
   }
   auto charge(Particle const &p) const { return p.q(); }
   auto dipole_moment(Particle const &p) const {
-#if defined(ROTATION) && defined(DIPOLES)
+#ifdef DIPOLES
     return p.calc_dip();
 #else
     return Utils::Vector3d{};

--- a/src/core/p3m/common.hpp
+++ b/src/core/p3m/common.hpp
@@ -39,6 +39,9 @@
 
 #include <utils/Vector.hpp>
 
+#include <array>
+#include <vector>
+
 /** This value indicates metallic boundary conditions. */
 auto constexpr P3M_EPSILON_METALLIC = 0.0;
 
@@ -46,10 +49,8 @@ auto constexpr P3M_EPSILON_METALLIC = 0.0;
 
 #include "LocalBox.hpp"
 
-#include <array>
 #include <cstddef>
 #include <stdexcept>
-#include <vector>
 
 namespace detail {
 /** @brief Index helpers for direct and reciprocal space.

--- a/src/core/p3m/fft.cpp
+++ b/src/core/p3m/fft.cpp
@@ -738,7 +738,7 @@ void fft_perform_back(double *data, bool check_complex, fft_data_struct &fft,
   for (int i = 0; i < fft.plan[1].new_size; i++) {
     fft.data_buf[i] = data[2 * i]; /* real value */
     // Vincent:
-    if (check_complex && (data[2 * i + 1] > 1e-5)) {
+    if (check_complex and std::abs(data[2 * i + 1]) > 1e-5) {
       printf("Complex value is not zero (i=%d,data=%g)!!!\n", i,
              data[2 * i + 1]);
       if (i > 100)

--- a/src/core/particle_data.cpp
+++ b/src/core/particle_data.cpp
@@ -24,13 +24,14 @@
 #include "Particle.hpp"
 #include "cells.hpp"
 #include "communication.hpp"
-#include "config/config.hpp"
 #include "event.hpp"
 #include "exclusions.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "partCfg_global.hpp"
 #include "particle_node.hpp"
 #include "rotation.hpp"
+
+#include "config/config.hpp"
 
 #include <utils/Span.hpp>
 #include <utils/Vector.hpp>

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -29,18 +29,17 @@
 #include "bonded_interactions/bonded_interaction_data.hpp"
 #include "cells.hpp"
 #include "communication.hpp"
-#include "config/config.hpp"
+#include "electrostatics/coulomb.hpp"
 #include "event.hpp"
 #include "grid.hpp"
 #include "interactions.hpp"
+#include "magnetostatics/dipoles.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "pressure_inline.hpp"
+#include "short_range_loop.hpp"
 #include "virtual_sites.hpp"
 
-#include "short_range_loop.hpp"
-
-#include "electrostatics/coulomb.hpp"
-#include "magnetostatics/dipoles.hpp"
+#include "config/config.hpp"
 
 #include <utils/Span.hpp>
 #include <utils/Vector.hpp>

--- a/src/core/unit_tests/EspressoSystemInterface_test.cpp
+++ b/src/core/unit_tests/EspressoSystemInterface_test.cpp
@@ -25,11 +25,12 @@
 
 #include "EspressoSystemInterface.hpp"
 #include "communication.hpp"
-#include "config/config.hpp"
 #include "particle_data.hpp"
 #include "particle_node.hpp"
 #include "virtual_sites.hpp"
 #include "virtual_sites/VirtualSitesOff.hpp"
+
+#include "config/config.hpp"
 
 #include <boost/mpi.hpp>
 

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -115,7 +115,7 @@ static void mpi_set_tuned_p3m_local(double prefactor) {
                            0.654,
                            1e-3};
   auto solver =
-      std::make_shared<CoulombP3M>(std::move(p3m), prefactor, 1, false);
+      std::make_shared<CoulombP3M>(std::move(p3m), prefactor, 1, false, true);
   ::Coulomb::add_actor(solver);
 }
 

--- a/src/core/unit_tests/energy_test.cpp
+++ b/src/core/unit_tests/energy_test.cpp
@@ -24,7 +24,7 @@
 #include "Particle.hpp"
 #include "energy_inline.hpp"
 
-#include "utils/Vector.hpp"
+#include <utils/Vector.hpp>
 
 BOOST_AUTO_TEST_CASE(translational_kinetic_energy_) {
   // real particle

--- a/src/core/virtual_sites/VirtualSitesInertialessTracers.cpp
+++ b/src/core/virtual_sites/VirtualSitesInertialessTracers.cpp
@@ -27,6 +27,7 @@
 #include "errorhandling.hpp"
 #include "grid_based_algorithms/lb_interface.hpp"
 #include "virtual_sites/lb_inertialess_tracers.hpp"
+
 #include <algorithm>
 
 void VirtualSitesInertialessTracers::after_force_calc() {
@@ -51,9 +52,7 @@ void VirtualSitesInertialessTracers::after_force_calc() {
 }
 
 void VirtualSitesInertialessTracers::after_lb_propagation(double time_step) {
-#ifdef VIRTUAL_SITES_INERTIALESS_TRACERS
   IBM_UpdateParticlePositions(cell_structure.local_particles(), time_step,
                               this_node);
-#endif
 }
-#endif
+#endif // VIRTUAL_SITES_INERTIALESS_TRACERS

--- a/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
+++ b/src/core/virtual_sites/VirtualSitesInertialessTracers.hpp
@@ -20,10 +20,11 @@
 #define VIRTUAL_SITES_VIRTUAL_SITES_INERTIALESS_TRACERS_HPP
 
 #include "config/config.hpp"
-#ifdef VIRTUAL_SITES
-#include "VirtualSites.hpp"
 
 #ifdef VIRTUAL_SITES_INERTIALESS_TRACERS
+
+#include "VirtualSites.hpp"
+
 /** @brief Virtual sites which are advected with an lb fluid. Forces on them are
  * instantaneously transferred to the fluid
  */
@@ -32,6 +33,5 @@ class VirtualSitesInertialessTracers : public VirtualSites {
   void after_lb_propagation(double time_step) override;
 };
 
-#endif
-#endif
+#endif // VIRTUAL_SITES_INERTIALESS_TRACERS
 #endif

--- a/src/core/virtual_sites/lb_inertialess_tracers.cpp
+++ b/src/core/virtual_sites/lb_inertialess_tracers.cpp
@@ -306,4 +306,4 @@ void ParticleVelocitiesFromLB_CPU() {
     }
   }
 }
-#endif
+#endif // VIRTUAL_SITES_INERTIALESS_TRACERS

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -81,13 +81,16 @@ class DrudeHelpers:
         k = harmonic_bond.params["k"]
         q_drude = -1.0 * pow(k * alpha / coulomb_prefactor, 0.5)
 
-        if has_features("PARTICLE_ANISOTROPY"):
-            gamma_off = [0.0, 0.0, 0.0]
-        else:
-            gamma_off = 0.0
+        if has_features("THERMOSTAT_PER_PARTICLE"):
+            if has_features("PARTICLE_ANISOTROPY"):
+                gamma_off = [0.0, 0.0, 0.0]
+            else:
+                gamma_off = 0.0
 
         drude_part = system.part.add(pos=p_core.pos, type=type_drude,
-                                     q=q_drude, mass=mass_drude, gamma=gamma_off)
+                                     q=q_drude, mass=mass_drude)
+        if has_features("THERMOSTAT_PER_PARTICLE"):
+            drude_part.gamma = gamma_off
         id_drude = drude_part.id
 
         if verbose:
@@ -98,8 +101,8 @@ class DrudeHelpers:
         p_core.mass -= mass_drude
         p_core.add_bond((harmonic_bond, id_drude))
         p_core.add_bond((thermalized_bond, id_drude))
-
-        p_core.gamma = gamma_off
+        if has_features("THERMOSTAT_PER_PARTICLE"):
+            p_core.gamma = gamma_off
 
         if type_drude in self.drude_dict and not (
                 self.drude_dict[type_drude]["q"] == q_drude and

--- a/src/python/espressomd/electrostatics.py
+++ b/src/python/espressomd/electrostatics.py
@@ -38,10 +38,17 @@ class ElectrostaticInteraction(ScriptInterfaceHelper):
         self._check_required_features()
 
         if 'sip' not in kwargs:
+            for key in self.required_keys():
+                if key not in kwargs:
+                    raise RuntimeError(f"Parameter '{key}' is missing")
             params = self.default_params()
             params.update(kwargs)
             self.validate_params(params)
             super().__init__(**params)
+            for key in params:
+                if key not in self._valid_parameters():
+                    raise RuntimeError(
+                        f"Parameter '{key}' is not a valid parameter")
         else:
             super().__init__(**kwargs)
 
@@ -53,12 +60,9 @@ class ElectrostaticInteraction(ScriptInterfaceHelper):
         """Check validity of given parameters.
         """
         utils.check_type_or_throw_except(
-            params["prefactor"], 1, float, "prefactor should be a double")
+            params["prefactor"], 1, float, "Parameter 'prefactor' should be a float")
 
     def default_params(self):
-        raise NotImplementedError("Derived classes must implement this method")
-
-    def valid_keys(self):
         raise NotImplementedError("Derived classes must implement this method")
 
     def required_keys(self):
@@ -93,9 +97,6 @@ class DH(ElectrostaticInteraction):
     _so_name = "Coulomb::DebyeHueckel"
     _so_creation_policy = "GLOBAL"
 
-    def valid_keys(self):
-        return {"prefactor", "kappa", "r_cut", "check_neutrality"}
-
     def required_keys(self):
         return {"prefactor", "kappa", "r_cut"}
 
@@ -126,10 +127,6 @@ class ReactionField(ElectrostaticInteraction):
     _so_name = "Coulomb::ReactionField"
     _so_creation_policy = "GLOBAL"
 
-    def valid_keys(self):
-        return {"prefactor", "kappa", "epsilon1", "epsilon2", "r_cut",
-                "check_neutrality"}
-
     def required_keys(self):
         return {"prefactor", "kappa", "epsilon1", "epsilon2", "r_cut"}
 
@@ -138,10 +135,6 @@ class ReactionField(ElectrostaticInteraction):
 
 
 class _P3MBase(ElectrostaticInteraction):
-    def valid_keys(self):
-        return {"mesh", "cao", "accuracy", "epsilon", "alpha", "r_cut",
-                "prefactor", "tune", "check_neutrality", "timings",
-                "verbose", "mesh_off"}
 
     def required_keys(self):
         return {"prefactor", "accuracy"}
@@ -165,8 +158,9 @@ class _P3MBase(ElectrostaticInteraction):
 
         if utils.is_valid_type(params["mesh"], int):
             params["mesh"] = 3 * [params["mesh"]]
-        utils.check_type_or_throw_except(params["mesh"], 3, int,
-                                         "P3M mesh has to be an integer or integer list of length 3")
+        utils.check_type_or_throw_except(
+            params["mesh"], 3, int,
+            "Parameter 'mesh' has to be an integer or integer list of length 3")
         if (params["mesh"][0] % 2 != 0 and params["mesh"][0] != -1) or \
            (params["mesh"][1] % 2 != 0 and params["mesh"][1] != -1) or \
            (params["mesh"][2] % 2 != 0 and params["mesh"][2] != -1):
@@ -178,18 +172,16 @@ class _P3MBase(ElectrostaticInteraction):
 
         utils.check_type_or_throw_except(
             params["epsilon"], 1, float,
-            "epsilon should be a double or 'metallic'")
+            "Parameter 'epsilon' has to be a float or 'metallic'")
 
         utils.check_type_or_throw_except(
             params["mesh_off"], 3, float,
-            "mesh_off should be a (3,) array_like of values between 0 and 1")
+            "Parameter 'mesh_off' has to be a (3,) array_like of values between 0.0 and 1.0")
 
         if not utils.is_valid_type(params["timings"], int):
-            raise TypeError("P3M timings has to be an integer")
-        if params["timings"] <= 0:
-            raise ValueError("P3M timings must be > 0")
+            raise TypeError("Parameter 'timings' has to be an integer")
         if not utils.is_valid_type(params["tune"], bool):
-            raise TypeError("P3M tune has to be a boolean")
+            raise TypeError("Parameter 'tune' has to be a boolean")
 
 
 @script_interface_register
@@ -371,11 +363,6 @@ class ELC(ElectrostaticInteraction):
         utils.check_type_or_throw_except(
             params["neutralize"], 1, bool, "neutralize has to be a bool")
 
-    def valid_keys(self):
-        return {"actor", "maxPWerror", "gap_size", "far_cut",
-                "neutralize", "delta_mid_top", "delta_mid_bot",
-                "const_pot", "pot_diff", "check_neutrality"}
-
     def required_keys(self):
         return {"actor", "maxPWerror", "gap_size"}
 
@@ -413,25 +400,11 @@ class MMM1D(ElectrostaticInteraction):
     _so_name = "Coulomb::CoulombMMM1D"
     _so_creation_policy = "GLOBAL"
 
-    def validate_params(self, params):
-        default_params = self.default_params()
-        if params["prefactor"] <= 0:
-            raise ValueError("prefactor should be a positive float")
-        if params["maxPWerror"] < 0 and params["maxPWerror"] != default_params["maxPWerror"]:
-            raise ValueError("maxPWerror should be a positive double")
-        if params["far_switch_radius"] < 0 and params["far_switch_radius"] != default_params["far_switch_radius"]:
-            raise ValueError("switch radius should be a positive double")
-
     def default_params(self):
         return {"far_switch_radius": -1.,
                 "verbose": True,
                 "timings": 15,
-                "tune": True,
                 "check_neutrality": True}
-
-    def valid_keys(self):
-        return {"prefactor", "maxPWerror", "far_switch_radius",
-                "verbose", "timings", "tune", "check_neutrality"}
 
     def required_keys(self):
         return {"prefactor", "maxPWerror"}
@@ -462,26 +435,10 @@ class MMM1DGPU(ElectrostaticInteraction):
         if not has_features("MMM1D_GPU"):
             raise NotImplementedError("Feature MMM1D_GPU not compiled in")
 
-    def validate_params(self, params):
-        default_params = self.default_params()
-        if params["prefactor"] <= 0:
-            raise ValueError("prefactor should be a positive float")
-        if params["maxPWerror"] < 0 and params["maxPWerror"] != default_params["maxPWerror"]:
-            raise ValueError("maxPWerror should be a positive double")
-        if params["far_switch_radius"] < 0 and params["far_switch_radius"] != default_params["far_switch_radius"]:
-            raise ValueError("switch radius should be a positive double")
-        if params["bessel_cutoff"] < 0 and params["bessel_cutoff"] != default_params["bessel_cutoff"]:
-            raise ValueError("bessel_cutoff should be a positive integer")
-
     def default_params(self):
         return {"far_switch_radius": -1.,
                 "bessel_cutoff": -1,
-                "tune": True,
                 "check_neutrality": True}
-
-    def valid_keys(self):
-        return {"prefactor", "maxPWerror", "far_switch_radius",
-                "bessel_cutoff", "tune", "check_neutrality"}
 
     def required_keys(self):
         return {"prefactor", "maxPWerror"}
@@ -542,15 +499,8 @@ class Scafacos(ElectrostaticInteraction):
         if not has_features("SCAFACOS"):
             raise NotImplementedError("Feature SCAFACOS not compiled in")
 
-    def validate_params(self, params):
-        pass
-
     def default_params(self):
         return {"check_neutrality": True}
-
-    def valid_keys(self):
-        return {"method_name", "method_params",
-                "prefactor", "check_neutrality"}
 
     def required_keys(self):
         return {"method_name", "method_params", "prefactor"}

--- a/src/python/espressomd/electrostatics.py
+++ b/src/python/espressomd/electrostatics.py
@@ -155,6 +155,7 @@ class _P3MBase(ElectrostaticInteraction):
                 "mesh_off": [-1., -1., -1.],
                 "prefactor": 0.,
                 "check_neutrality": True,
+                "check_complex_residuals": True,
                 "tune": True,
                 "timings": 10,
                 "verbose": True}
@@ -231,6 +232,9 @@ class P3M(_P3MBase):
     check_neutrality : :obj:`bool`, optional
         Raise a warning if the system is not electrically neutral when
         set to ``True`` (default).
+    check_complex_residuals: :obj:`bool`, optional
+        Raise a warning if the backward Fourier transform has non-zero
+        complex residuals when set to ``True`` (default).
 
     """
     _so_name = "Coulomb::CoulombP3M"
@@ -281,6 +285,9 @@ class P3MGPU(_P3MBase):
     check_neutrality : :obj:`bool`, optional
         Raise a warning if the system is not electrically neutral when
         set to ``True`` (default).
+    check_complex_residuals: :obj:`bool`, optional
+        Raise a warning if the backward Fourier transform has non-zero
+        complex residuals when set to ``True`` (default).
 
     """
     _so_name = "Coulomb::CoulombP3MGPU"

--- a/src/python/espressomd/magnetostatics.py
+++ b/src/python/espressomd/magnetostatics.py
@@ -38,10 +38,18 @@ class MagnetostaticInteraction(ScriptInterfaceHelper):
         self._check_required_features()
 
         if 'sip' not in kwargs:
+            for key in self.required_keys():
+                if key not in kwargs:
+                    raise RuntimeError(f"Parameter '{key}' is missing")
+            utils.check_required_keys(self.required_keys(), kwargs.keys())
             params = self.default_params()
             params.update(kwargs)
             self.validate_params(params)
             super().__init__(**params)
+            for key in params:
+                if key not in self._valid_parameters():
+                    raise RuntimeError(
+                        f"Parameter '{key}' is not a valid parameter")
         else:
             super().__init__(**kwargs)
 
@@ -53,12 +61,9 @@ class MagnetostaticInteraction(ScriptInterfaceHelper):
         """Check validity of given parameters.
         """
         utils.check_type_or_throw_except(
-            params["prefactor"], 1, float, "prefactor should be a double")
+            params["prefactor"], 1, float, "Parameter 'prefactor' should be a float")
 
     def default_params(self):
-        raise NotImplementedError("Derived classes must implement this method")
-
-    def valid_keys(self):
         raise NotImplementedError("Derived classes must implement this method")
 
     def required_keys(self):
@@ -125,30 +130,25 @@ class DipolarP3M(MagnetostaticInteraction):
         if utils.is_valid_type(params["mesh"], int):
             params["mesh"] = 3 * [params["mesh"]]
         else:
-            utils.check_type_or_throw_except(params["mesh"], 3, int,
-                                             "DipolarP3M mesh has to be an integer or integer list of length 3")
+            utils.check_type_or_throw_except(
+                params["mesh"], 3, int,
+                "Parameter 'mesh' has to be an integer or integer list of length 3")
 
         if params["epsilon"] == "metallic":
             params["epsilon"] = 0.0
 
         utils.check_type_or_throw_except(
             params["epsilon"], 1, float,
-            "epsilon should be a double or 'metallic'")
+            "Parameter 'epsilon' has to be a float or 'metallic'")
 
-        utils.check_type_or_throw_except(params["mesh_off"], 3, float,
-                                         "mesh_off should be a (3,) array_like of values between 0.0 and 1.0")
+        utils.check_type_or_throw_except(
+            params["mesh_off"], 3, float,
+            "Parameter 'mesh_off' has to be a (3,) array_like of values between 0.0 and 1.0")
 
         if not utils.is_valid_type(params["timings"], int):
-            raise TypeError("DipolarP3M timings has to be an integer")
-        if params["timings"] <= 0:
-            raise ValueError("DipolarP3M timings must be > 0")
+            raise TypeError("Parameter 'timings' has to be an integer")
         if not utils.is_valid_type(params["tune"], bool):
-            raise TypeError("DipolarP3M tune has to be a boolean")
-
-    def valid_keys(self):
-        return {"prefactor", "alpha_L", "r_cut_iL", "mesh", "mesh_off",
-                "cao", "accuracy", "epsilon", "cao_cut", "a", "ai",
-                "alpha", "r_cut", "cao3", "tune", "timings", "verbose"}
+            raise TypeError("Parameter 'tune' has to be a boolean")
 
     def required_keys(self):
         return {"accuracy"}
@@ -190,9 +190,6 @@ class DipolarDirectSumCpu(MagnetostaticInteraction):
     def required_keys(self):
         return set()
 
-    def valid_keys(self):
-        return {"prefactor"}
-
 
 @script_interface_register
 class DipolarDirectSumWithReplicaCpu(MagnetostaticInteraction):
@@ -218,9 +215,6 @@ class DipolarDirectSumWithReplicaCpu(MagnetostaticInteraction):
 
     def required_keys(self):
         return {"n_replica"}
-
-    def valid_keys(self):
-        return {"prefactor", "n_replica"}
 
 
 @script_interface_register
@@ -260,14 +254,8 @@ class Scafacos(MagnetostaticInteraction):
             raise NotImplementedError(
                 "Feature SCAFACOS_DIPOLES not compiled in")
 
-    def validate_params(self, params):
-        pass
-
     def default_params(self):
         return {}
-
-    def valid_keys(self):
-        return {"method_name", "method_params", "prefactor"}
 
     def required_keys(self):
         return {"method_name", "method_params", "prefactor"}
@@ -306,9 +294,6 @@ class DipolarDirectSumGpu(MagnetostaticInteraction):
         return {}
 
     def required_keys(self):
-        return set()
-
-    def valid_keys(self):
         return {"prefactor"}
 
 
@@ -325,6 +310,13 @@ class DipolarBarnesHutGpu(MagnetostaticInteraction):
     Requires feature ``DIPOLAR_BARNES_HUT``, which depends on
     ``DIPOLES`` and ``CUDA``.
 
+    Parameters
+    ----------
+    epssq : :obj:`float`, optional
+        Squared skin of the octant cells.
+    itolsq : :obj:`float`, optional
+        Squared inverse fraction of the octant cells.
+
     """
     _so_name = "Dipoles::DipolarBarnesHutGpu"
     _so_creation_policy = "GLOBAL"
@@ -338,10 +330,7 @@ class DipolarBarnesHutGpu(MagnetostaticInteraction):
         return {"epssq": 100.0, "itolsq": 4.0}
 
     def required_keys(self):
-        return set()
-
-    def valid_keys(self):
-        return {"prefactor", "epssq", "itolsq"}
+        return {"prefactor"}
 
 
 @script_interface_register
@@ -375,17 +364,17 @@ class DLC(MagnetostaticInteraction):
 
     def validate_params(self, params):
         utils.check_type_or_throw_except(
-            params["maxPWerror"], 1, float, "maxPWerror has to be a float")
+            params["maxPWerror"], 1, float,
+            "Parameter 'maxPWerror' has to be a float")
         utils.check_type_or_throw_except(
-            params["gap_size"], 1, float, "gap_size has to be a float")
+            params["gap_size"], 1, float,
+            "Parameter 'gap_size' has to be a float")
         utils.check_type_or_throw_except(
-            params["far_cut"], 1, float, "far_cut has to be a float")
+            params["far_cut"], 1, float,
+            "Parameter 'far_cut' has to be a float")
 
     def default_params(self):
         return {"far_cut": -1.}
-
-    def valid_keys(self):
-        return {"actor", "maxPWerror", "gap_size", "far_cut"}
 
     def required_keys(self):
         return {"actor", "maxPWerror", "gap_size"}

--- a/src/script_interface/electrostatics/CoulombP3M.hpp
+++ b/src/script_interface/electrostatics/CoulombP3M.hpp
@@ -69,6 +69,8 @@ public:
         {"timings", AutoParameter::read_only,
          [this]() { return actor()->tune_timings; }},
         {"tune", AutoParameter::read_only, [this]() { return m_tune; }},
+        {"check_complex_residuals", AutoParameter::read_only,
+         [this]() { return actor()->check_complex_residuals; }},
     });
   }
 
@@ -85,8 +87,8 @@ public:
                                get_value<double>(params, "accuracy")};
       m_actor = std::make_shared<CoreActorClass>(
           std::move(p3m), get_value<double>(params, "prefactor"),
-          get_value<int>(params, "timings"),
-          get_value<bool>(params, "verbose"));
+          get_value<int>(params, "timings"), get_value<bool>(params, "verbose"),
+          get_value<bool>(params, "check_complex_residuals"));
     });
     set_charge_neutrality_tolerance(params);
   }

--- a/src/script_interface/electrostatics/CoulombP3MGPU.hpp
+++ b/src/script_interface/electrostatics/CoulombP3MGPU.hpp
@@ -70,6 +70,8 @@ public:
         {"timings", AutoParameter::read_only,
          [this]() { return actor()->tune_timings; }},
         {"tune", AutoParameter::read_only, [this]() { return m_tune; }},
+        {"check_complex_residuals", AutoParameter::read_only,
+         [this]() { return actor()->check_complex_residuals; }},
     });
   }
 
@@ -86,8 +88,8 @@ public:
                                get_value<double>(params, "accuracy")};
       m_actor = std::make_shared<CoreActorClass>(
           std::move(p3m), get_value<double>(params, "prefactor"),
-          get_value<int>(params, "timings"),
-          get_value<bool>(params, "verbose"));
+          get_value<int>(params, "timings"), get_value<bool>(params, "verbose"),
+          get_value<bool>(params, "check_complex_residuals"));
     });
     m_actor->request_gpu();
     set_charge_neutrality_tolerance(params);

--- a/src/script_interface/electrostatics/ICCStar.hpp
+++ b/src/script_interface/electrostatics/ICCStar.hpp
@@ -41,7 +41,7 @@
 namespace ScriptInterface {
 namespace Coulomb {
 
-class ICCStar : public AutoParameters<::ICCStar> {
+class ICCStar : public AutoParameters<ICCStar> {
   using CoreActorClass = ::ICCStar;
   std::shared_ptr<CoreActorClass> m_actor;
 

--- a/src/script_interface/magnetostatics/DipolarBarnesHutGpu.hpp
+++ b/src/script_interface/magnetostatics/DipolarBarnesHutGpu.hpp
@@ -49,10 +49,12 @@ public:
   }
 
   void do_construct(VariantMap const &params) override {
-    m_actor =
-        std::make_shared<CoreActorClass>(get_value<double>(params, "prefactor"),
-                                         get_value<double>(params, "epssq"),
-                                         get_value<double>(params, "itolsq"));
+    context()->parallel_try_catch([&]() {
+      m_actor = std::make_shared<CoreActorClass>(
+          get_value<double>(params, "prefactor"),
+          get_value<double>(params, "epssq"),
+          get_value<double>(params, "itolsq"));
+    });
   }
 };
 

--- a/src/script_interface/tests/GlobalContext_test.cpp
+++ b/src/script_interface/tests/GlobalContext_test.cpp
@@ -28,6 +28,7 @@
 #include <boost/mpi/communicator.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -49,7 +50,7 @@ struct Dummy : si::ObjectHandle {
     static const boost::string_ref parameter_names[] = {"id", "object_param"};
 
     return Utils::make_const_span(parameter_names,
-                                  std::min(params.size(), 2lu));
+                                  std::min(params.size(), std::size_t{2u}));
   }
 };
 

--- a/src/script_interface/tests/LocalContext_test.cpp
+++ b/src/script_interface/tests/LocalContext_test.cpp
@@ -28,6 +28,7 @@
 #include <boost/mpi/communicator.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -49,7 +50,7 @@ struct Dummy : si::ObjectHandle {
     static const boost::string_ref parameter_names[] = {"id", "object_param"};
 
     return Utils::make_const_span(parameter_names,
-                                  std::min(params.size(), 2lu));
+                                  std::min(params.size(), std::size_t{2u}));
   }
 };
 

--- a/src/shapes/include/shapes/Union.hpp
+++ b/src/shapes/include/shapes/Union.hpp
@@ -35,12 +35,12 @@ namespace Shapes {
 
 class Union : public Shape {
 public:
-  void add(std::shared_ptr<Shapes::Shape> const &s) {
-    m_shapes.emplace_back(s);
+  void add(std::shared_ptr<Shapes::Shape> const &shape) {
+    m_shapes.emplace_back(shape);
   }
 
-  void remove(std::shared_ptr<Shapes::Shape> const &s) {
-    m_shapes.erase(std::remove(m_shapes.begin(), m_shapes.end(), s),
+  void remove(std::shared_ptr<Shapes::Shape> const &shape) {
+    m_shapes.erase(std::remove(m_shapes.begin(), m_shapes.end(), shape),
                    m_shapes.end());
   }
 
@@ -55,10 +55,10 @@ public:
   void calculate_dist(Utils::Vector3d const &pos, double &dist,
                       Utils::Vector3d &vec) const override {
     auto dist_compare = [&pos](std::pair<double, Utils::Vector3d> const &res,
-                               std::shared_ptr<Shapes::Shape> const &s) {
+                               std::shared_ptr<Shapes::Shape> const &shape) {
       double d;
       Utils::Vector3d vec;
-      (*s).calculate_dist(pos, d, vec);
+      shape->calculate_dist(pos, d, vec);
       if (d < 0.0)
         throw std::domain_error(
             "Distance to Union not well-defined for given position!");
@@ -76,7 +76,7 @@ public:
 
   bool is_inside(Utils::Vector3d const &pos) const override {
     return boost::algorithm::any_of(
-        m_shapes, [&pos](auto const &s) { return s->is_inside(pos); });
+        m_shapes, [&pos](auto const &shape) { return shape->is_inside(pos); });
   }
 
 private:

--- a/src/utils/include/utils/u32_to_u64.hpp
+++ b/src/utils/include/utils/u32_to_u64.hpp
@@ -33,4 +33,4 @@ constexpr inline std::pair<uint32_t, uint32_t> u64_to_u32(uint64_t in) {
 
 } // namespace Utils
 
-#endif // ESPRESSO_U32_TO_U64_HPP
+#endif

--- a/src/utils/include/utils/u32_to_u64.hpp
+++ b/src/utils/include/utils/u32_to_u64.hpp
@@ -19,7 +19,7 @@
 #ifndef UTILS_U32_TO_U64_HPP
 #define UTILS_U32_TO_U64_HPP
 
-#include <cinttypes>
+#include <cstdint>
 #include <utility>
 
 namespace Utils {

--- a/src/utils/tests/gatherv_test.cpp
+++ b/src/utils/tests/gatherv_test.cpp
@@ -30,20 +30,16 @@
 #include <string>
 #include <vector>
 
-using Utils::Mpi::gatherv;
-
-namespace mpi = boost::mpi;
-
 /*
  * Check that implementation behaves
- * like MPI_Gatherv with an mpi datatype.
- * To test this we gather the rank from
+ * like @c MPI_Gatherv with an mpi datatype.
+ * To test this, we gather the rank from
  * every rank to one rank and then check
  * that the value was written to the
  * correct position in the output array.
  */
 BOOST_AUTO_TEST_CASE(mpi_type) {
-  mpi::communicator world;
+  boost::mpi::communicator world;
   auto const rank = world.rank();
   auto const size = world.size();
   auto const root = world.size() - 1;
@@ -54,10 +50,10 @@ BOOST_AUTO_TEST_CASE(mpi_type) {
       std::vector<int> out(size, -1);
       std::vector<int> sizes(size, 1);
 
-      gatherv(world, &rank, 1, out.data(), sizes.data(), root);
+      Utils::Mpi::gatherv(world, &rank, 1, out.data(), sizes.data(), root);
 
       for (int i = 0; i < size; i++) {
-        BOOST_CHECK_EQUAL(i, out.at(i));
+        BOOST_CHECK_EQUAL(out.at(i), i);
       }
     } else {
       Utils::Mpi::gatherv(world, &rank, 1, root);
@@ -71,10 +67,10 @@ BOOST_AUTO_TEST_CASE(mpi_type) {
       out[rank] = rank;
       std::vector<int> sizes(size, 1);
 
-      gatherv(world, out.data(), 1, out.data(), sizes.data(), root);
+      Utils::Mpi::gatherv(world, out.data(), 1, out.data(), sizes.data(), root);
 
       for (int i = 0; i < size; i++) {
-        BOOST_CHECK_EQUAL(i, out.at(i));
+        BOOST_CHECK_EQUAL(out.at(i), i);
       }
     } else {
       Utils::Mpi::gatherv(world, &rank, 1, root);
@@ -84,14 +80,14 @@ BOOST_AUTO_TEST_CASE(mpi_type) {
 
 /*
  * Check that implementation behaves
- * like MPI_Gatherv with an non-mpi datatype.
- * To test this we gather a string containing the rank from
+ * like @c MPI_Gatherv with a non-mpi datatype.
+ * To test this, we gather a string containing the rank from
  * every rank to one rank and then check
  * that the value was written to the
  * correct position in the output array.
  */
 BOOST_AUTO_TEST_CASE(non_mpi_type) {
-  mpi::communicator world;
+  boost::mpi::communicator world;
   auto const rank = world.rank();
   auto const size = world.size();
   auto const root = world.size() - 1;
@@ -103,10 +99,10 @@ BOOST_AUTO_TEST_CASE(non_mpi_type) {
       std::vector<std::string> out(size);
       std::vector<int> sizes(size, 1);
 
-      gatherv(world, &in, 1, out.data(), sizes.data(), root);
+      Utils::Mpi::gatherv(world, &in, 1, out.data(), sizes.data(), root);
 
       for (int i = 0; i < size; i++) {
-        BOOST_CHECK_EQUAL(std::to_string(i), out.at(i));
+        BOOST_CHECK_EQUAL(out.at(i), std::to_string(i));
       }
     } else {
       Utils::Mpi::gatherv(world, &in, 1, root);
@@ -120,10 +116,10 @@ BOOST_AUTO_TEST_CASE(non_mpi_type) {
       out[rank] = in;
       std::vector<int> sizes(size, 1);
 
-      gatherv(world, out.data(), 1, out.data(), sizes.data(), root);
+      Utils::Mpi::gatherv(world, out.data(), 1, out.data(), sizes.data(), root);
 
       for (int i = 0; i < size; i++) {
-        BOOST_CHECK_EQUAL(std::to_string(i), out.at(i));
+        BOOST_CHECK_EQUAL(out.at(i), std::to_string(i));
       }
     } else {
       Utils::Mpi::gatherv(world, &in, 1, root);
@@ -132,7 +128,7 @@ BOOST_AUTO_TEST_CASE(non_mpi_type) {
 }
 
 int main(int argc, char **argv) {
-  mpi::environment mpi_env(argc, argv);
+  boost::mpi::environment mpi_env(argc, argv);
 
   return boost::unit_test::unit_test_main(init_unit_test, argc, argv);
 }

--- a/src/utils/tests/u32_to_u64_test.cpp
+++ b/src/utils/tests/u32_to_u64_test.cpp
@@ -25,7 +25,7 @@
 #include <utility>
 
 BOOST_AUTO_TEST_CASE(u32_to_u64) {
-  constexpr const uint64_t expected = (4ul << 32) | (11ul);
+  constexpr const uint64_t expected = (uint64_t{4ul} << 32) | (11ul);
   BOOST_CHECK(expected == Utils::u32_to_u64(4u, 11u));
 }
 

--- a/testsuite/python/bond_breakage.py
+++ b/testsuite/python/bond_breakage.py
@@ -216,6 +216,7 @@ class NetworkBreakage(BondBreakageCommon, ut.TestCase):
         self.system.bonded_inter.clear()
         self.system.thermostat.turn_off()
 
+    @utx.skipIfMissingFeatures(["COLLISION_DETECTION"])
     def test_center_bonds(self):
 
         harm = espressomd.interactions.HarmonicBond(k=1.0, r_0=0.0, r_cut=5)
@@ -244,7 +245,8 @@ class NetworkBreakage(BondBreakageCommon, ut.TestCase):
         bonds_count = self.count_bonds(pairs)
         np.testing.assert_equal(bonds_dist, bonds_count)
 
-    @utx.skipIfMissingFeatures("VIRTUAL_SITES_RELATIVE")
+    @utx.skipIfMissingFeatures(
+        ["VIRTUAL_SITES_RELATIVE", "COLLISION_DETECTION"])
     def test_vs_bonds(self):
 
         harm = espressomd.interactions.HarmonicBond(k=1.0, r_0=0.0, r_cut=5)

--- a/testsuite/python/collision_detection.py
+++ b/testsuite/python/collision_detection.py
@@ -464,7 +464,7 @@ class CollisionDetection(ut.TestCase):
         self.run_test_glue_to_surface_for_pos(
             np.array((0.2, 0, 0)), np.array((0.95, 0, 0)), np.array((0.7, 0, 0)))
 
-    @utx.skipIfMissingFeatures("VIRTUAL_SITES_RELATIVE")
+    @utx.skipIfMissingFeatures(["LENNARD_JONES", "VIRTUAL_SITES_RELATIVE"])
     def test_glue_to_surface_random(self):
         """Integrate lj liquid and check that no double bonds are formed
            and the number of bonds fits the number of virtual sites

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -30,7 +30,7 @@ import espressomd.shapes
 import tests_common
 
 
-@utx.skipIfMissingFeatures(["LENNARD_JONES_GENERIC"])
+@utx.skipIfMissingFeatures(["LENNARD_JONES", "LENNARD_JONES_GENERIC"])
 class ShapeBasedConstraintTest(ut.TestCase):
 
     box_l = 30.

--- a/testsuite/python/coulomb_interface.py
+++ b/testsuite/python/coulomb_interface.py
@@ -59,7 +59,8 @@ class Test(ut.TestCase):
             system, espressomd.electrostatics.P3M,
             dict(prefactor=2., epsilon=0., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,
                  cao=2, mesh=[8, 10, 8], alpha=12., accuracy=0.01, tune=False,
-                 check_neutrality=True, charge_neutrality_tolerance=7e-12))
+                 check_neutrality=True, charge_neutrality_tolerance=7e-12,
+                 check_complex_residuals=False))
         test_p3m_cpu_non_metallic = tests_common.generate_test_for_actor_class(
             system, espressomd.electrostatics.P3M,
             dict(prefactor=2., epsilon=3., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,
@@ -78,7 +79,8 @@ class Test(ut.TestCase):
             system, espressomd.electrostatics.P3MGPU,
             dict(prefactor=2., epsilon=0., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,
                  cao=2, mesh=[8, 10, 8], alpha=12., accuracy=0.01, tune=False,
-                 check_neutrality=True, charge_neutrality_tolerance=7e-12))
+                 check_neutrality=True, charge_neutrality_tolerance=7e-12,
+                 check_complex_residuals=False))
         test_p3m_gpu_non_metallic = tests_common.generate_test_for_actor_class(
             system, espressomd.electrostatics.P3MGPU,
             dict(prefactor=2., epsilon=3., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,

--- a/testsuite/python/dawaanr-and-bh-gpu.py
+++ b/testsuite/python/dawaanr-and-bh-gpu.py
@@ -49,7 +49,7 @@ class BHGPUTest(ut.TestCase):
         pf_dawaanr = 3.524
         ratio_dawaanr_bh_gpu = pf_dawaanr / pf_bh_gpu
         system = self.system
-        system.box_l = 3 * [15]
+        system.box_l = [15., 15., 15.]
         system.periodicity = [False, False, False]
         system.time_step = 1E-4
         system.cell_system.skin = 0.1

--- a/testsuite/python/dawaanr-and-dds-gpu.py
+++ b/testsuite/python/dawaanr-and-dds-gpu.py
@@ -41,7 +41,7 @@ class DDSGPUTest(ut.TestCase):
         pf_dds_gpu = 2.34
         pf_dawaanr = 3.524
         ratio_dawaanr_dds_gpu = pf_dawaanr / pf_dds_gpu
-        self.system.box_l = 3 * [15]
+        self.system.box_l = [15., 15., 15.]
         self.system.periodicity = [False, False, False]
         self.system.time_step = 1E-4
         self.system.cell_system.skin = 0.1

--- a/testsuite/python/dds-and-bh-gpu.py
+++ b/testsuite/python/dds-and-bh-gpu.py
@@ -45,9 +45,8 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
         pf_bh_gpu = 2.34
         pf_dds_gpu = 3.524
         ratio_dawaanr_bh_gpu = pf_dds_gpu / pf_bh_gpu
-        l = 15
         system = self.system
-        system.box_l = 3 * [l]
+        system.box_l = [15., 15., 15.]
         system.periodicity = 3 * [False]
         system.time_step = 1E-4
         system.cell_system.skin = 0.1
@@ -56,7 +55,7 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
 
         for n in [128, 541]:
             dipole_modulus = 1.3
-            part_pos = np.random.random((n, 3)) * l
+            part_pos = np.random.random((n, 3)) * system.box_l[0]
             part_dip = dipole_modulus * tests_common.random_dipoles(n)
             system.part.add(pos=part_pos, dip=part_dip,
                             v=n * [(0, 0, 0)], omega_body=n * [(0, 0, 0)])

--- a/testsuite/python/dipolar_direct_summation.py
+++ b/testsuite/python/dipolar_direct_summation.py
@@ -121,6 +121,7 @@ class dds(ut.TestCase):
 
     @ut.skipIf(system.cell_system.get_state()["n_nodes"] > 1,
                "Skipping test: only runs for n_nodes == 1")
+    @utx.skipIfMissingFeatures(["LENNARD_JONES"])
     def test_gen_reference_data(self):
         filepaths = ('dipolar_direct_summation_energy.npy',
                      'dipolar_direct_summation_arrays.npy')

--- a/testsuite/python/dipolar_interface.py
+++ b/testsuite/python/dipolar_interface.py
@@ -166,6 +166,9 @@ class Test(ut.TestCase):
         with self.assertRaisesRegex(ValueError, "Parameter 'prefactor' must be > 0"):
             espressomd.magnetostatics.DipolarP3M(
                 **{**dp3m_params, 'prefactor': -2.})
+        with self.assertRaisesRegex(ValueError, "Parameter 'timings' must be > 0"):
+            espressomd.magnetostatics.DipolarP3M(
+                **{**dp3m_params, 'timings': -2})
         with self.assertRaisesRegex(ValueError, "Parameter 'mesh' has to be an integer or integer list of length 3"):
             espressomd.magnetostatics.DipolarP3M(
                 **{**dp3m_params, 'mesh': [49, 49]})

--- a/testsuite/python/dipolar_interface.py
+++ b/testsuite/python/dipolar_interface.py
@@ -166,13 +166,25 @@ class Test(ut.TestCase):
         with self.assertRaisesRegex(ValueError, "Parameter 'prefactor' must be > 0"):
             espressomd.magnetostatics.DipolarP3M(
                 **{**dp3m_params, 'prefactor': -2.})
-        with self.assertRaisesRegex(ValueError, "DipolarP3M mesh has to be an integer or integer list of length 3"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'mesh' has to be an integer or integer list of length 3"):
             espressomd.magnetostatics.DipolarP3M(
                 **{**dp3m_params, 'mesh': [49, 49]})
         dp3m = DP3M(**dp3m_params)
         mdlc = MDLC(gap_size=2., maxPWerror=0.1, actor=dp3m)
         with self.assertRaisesRegex(ValueError, "Parameter 'actor' of type Dipoles::DipolarLayerCorrection isn't supported by DLC"):
             MDLC(gap_size=2., maxPWerror=0.1, actor=mdlc)
+        with self.assertRaisesRegex(RuntimeError, "Parameter 'accuracy' is not a valid parameter"):
+            MDLC(gap_size=2., maxPWerror=0.1, actor=dp3m, accuracy=1e-3)
+
+    @utx.skipIfMissingGPU()
+    @utx.skipIfMissingFeatures(["DIPOLAR_BARNES_HUT"])
+    def test_exceptions_barnes_hut(self):
+        valid_params = dict(prefactor=2., epssq=200., itolsq=8.)
+        for key in valid_params.keys():
+            invalid_params = valid_params.copy()
+            invalid_params[key] = -1.
+            with self.assertRaisesRegex(ValueError, f"Parameter '{key}' must be > 0"):
+                espressomd.magnetostatics.DipolarBarnesHutGpu(**invalid_params)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
+++ b/testsuite/python/dipolar_mdlc_p3m_scafacos_p2nfft.py
@@ -33,7 +33,7 @@ DIPOLAR_PREFACTOR = 1.1
 
 
 @utx.skipIfMissingFeatures(["DIPOLES", "FFTW"])
-class Dipolar_p3m_mdlc_p2nfft(ut.TestCase):
+class Test(ut.TestCase):
 
     """Tests mdlc (2d)  as well as dipolar p3m and dipolar p2nfft (3d) against
        stored data. Validity of the stored data:

--- a/testsuite/python/electrostatic_interactions.py
+++ b/testsuite/python/electrostatic_interactions.py
@@ -246,7 +246,7 @@ class ElectrostaticInteractionsTests(ut.TestCase):
             r_cut=1.0)
         for key in params:
             invalid_params = {**params, key: -1.0}
-            with self.assertRaisesRegex(ValueError, f"'{key}' must be >=? 0"):
+            with self.assertRaisesRegex(ValueError, f"Parameter '{key}' must be >=? 0"):
                 espressomd.electrostatics.ReactionField(**invalid_params)
 
 

--- a/testsuite/python/integrator_npt.py
+++ b/testsuite/python/integrator_npt.py
@@ -71,7 +71,7 @@ class IntegratorNPT(ut.TestCase):
         # get the equilibrium box length for the chosen NpT parameters
         system.integrator.run(500)
         # catch unstable simulation early (when the DP3M test case ran first)
-        assert system.box_l[0] < 20.
+        assert system.box_l[0] < 20., "NpT simulation is unstable"
         system.integrator.run(1500)
         box_l_ref = system.box_l[0]
 

--- a/testsuite/python/lees_edwards.py
+++ b/testsuite/python/lees_edwards.py
@@ -343,7 +343,7 @@ class LeesEdwards(ut.TestCase):
                 np.copy(system.velocity_difference(p1, p2)),
                 np.copy(p2.v - p1.v) - system.lees_edwards.shear_velocity * shear_axis)
 
-    @utx.skipIfMissingFeatures("EXTERNAL_FORCES")
+    @utx.skipIfMissingFeatures(["EXTERNAL_FORCES", "SOFT_SPHERE"])
     def test_interactions(self):
         """
         We place two particles crossing a boundary and connect them with an
@@ -449,7 +449,7 @@ class LeesEdwards(ut.TestCase):
         np.testing.assert_allclose(
             np.copy(p1.torque_lab), [0, 0, -2], atol=tol)
 
-    @utx.skipIfMissingFeatures(["VIRTUAL_SITES_RELATIVE", "ROTATION"])
+    @utx.skipIfMissingFeatures(["VIRTUAL_SITES_RELATIVE", "ROTATION", "DPD"])
     def test_virt_sites_interaction(self):
         """
         A virtual site interacts with a real particle via a DPD interaction

--- a/testsuite/python/long_range_actors.py
+++ b/testsuite/python/long_range_actors.py
@@ -284,13 +284,13 @@ class Test(ut.TestCase):
         self.assertFalse(p3m.is_tuned)
         self.assertEqual(len(self.system.actors), 0)
 
-    @utx.skipIfMissingFeatures(["P3M"])
+    @utx.skipIfMissingFeatures(["P3M", "NPT"])
     def test_p3m_cpu_tuning_errors(self):
         self.add_charged_particles()
         p3m = espressomd.electrostatics.P3M(prefactor=1., accuracy=1e-3)
         self.check_p3m_tuning_errors(p3m)
 
-    @utx.skipIfMissingFeatures(["DP3M"])
+    @utx.skipIfMissingFeatures(["DP3M", "NPT"])
     def test_dp3m_cpu_tuning_errors(self):
         self.add_magnetic_particles()
         dp3m = espressomd.magnetostatics.DipolarP3M(

--- a/testsuite/python/long_range_actors.py
+++ b/testsuite/python/long_range_actors.py
@@ -331,7 +331,7 @@ class Test(ut.TestCase):
         self.system.periodicity = (False, False, True)
         self.check_mmm1d_exceptions(espressomd.electrostatics.MMM1DGPU)
 
-        with self.assertRaisesRegex(ValueError, "switching radius must not be larger than box length"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'far_switch_radius' must not be larger than box length"):
             espressomd.electrostatics.MMM1DGPU(
                 prefactor=1., maxPWerror=1e-2,
                 far_switch_radius=2. * self.system.box_l[2])

--- a/testsuite/python/mmm1d.py
+++ b/testsuite/python/mmm1d.py
@@ -111,14 +111,10 @@ class ElectrostaticInteractionsTests:
     def test_infinite_wire(self):
         """
         For an infinite wire, the energy per ion is :math:`MC\\frac{q}{a}`
-        with :math:`M = - \\ln{2}` the 1D Madelung constant, :math:`C`
+        with :math:`M = - 2\\ln{2}` the 1D Madelung constant, :math:`C`
         the electrostatics prefactor, :math:`q` the ion charge and
-        :math:`a` the lattice constant. Likewise, the pressure for
-        one ion can be derived as :math:`MC\\frac{q}{aV}` with
-        :math:`V` the simulation box volume. For more details, see
-        Orion Ciftja, "Equivalence of an infinite one-dimensional ionic
-        crystal to a simple electrostatic model", Results in Physics,
-        Volume 13, 2019, 102325, doi:10.1016/j.rinp.2019.102325
+        :math:`a` the lattice constant. See user guide sections
+        :ref:`Madelung electrostatics` for more details.
         """
         n_pairs = 128
         n_part = 2 * n_pairs
@@ -131,9 +127,8 @@ class ElectrostaticInteractionsTests:
         energy = self.system.analysis.energy()["coulomb"]
         p_scalar = self.system.analysis.pressure()["coulomb"]
         p_tensor = self.system.analysis.pressure_tensor()["coulomb"]
-        ref_energy = -np.log(2.)
-        np.testing.assert_allclose(energy / n_part, ref_energy,
-                                   atol=0., rtol=5e-7)
+        ref_energy = -np.log(2.) * n_part
+        np.testing.assert_allclose(energy, ref_energy, atol=0., rtol=5e-7)
         np.testing.assert_allclose(p_scalar, 0., atol=1e-12)
         np.testing.assert_allclose(p_tensor, 0., atol=1e-12)
 

--- a/testsuite/python/p3m_madelung.py
+++ b/testsuite/python/p3m_madelung.py
@@ -79,7 +79,7 @@ class Test(ut.TestCase):
             self.system.part.add(pos=spacing * pos, dip=[1., 0., 0.])
 
         dp3m_params = dict(prefactor=1., accuracy=1e-9, mesh=48, r_cut=28.,
-                           cao=6, tuning=False)
+                           cao=6, alpha=0.137582516, tune=False)
         mdlc_params = {'maxPWerror': 1e-9, 'gap_size': 16.}
 
         def check():
@@ -123,7 +123,7 @@ class Test(ut.TestCase):
             self.system.part.add(pos=spacing * pos, dip=[0., 0., 1.])
 
         dp3m_params = dict(prefactor=1., accuracy=1e-9, mesh=48, r_cut=33.6,
-                           cao=7, tuning=False)
+                           cao=7, alpha=0.1186918, tune=False)
         mdlc_params = {'maxPWerror': 1e-9, 'gap_size': 16.}
 
         def check():
@@ -167,7 +167,8 @@ class Test(ut.TestCase):
             self.system.part.add(pos=spacing * pos, dip=[0., 0., 1.])
 
         dp3m_params = dict(
-            prefactor=1., accuracy=5e-8, mesh=64, r_cut=8.2, cao=7, tuning=False)
+            prefactor=1., accuracy=5e-8, mesh=64, r_cut=8.2, cao=7,
+            alpha=0.5091135, tune=False)
 
         def check():
             # minimal energy configuration
@@ -198,7 +199,7 @@ class Test(ut.TestCase):
         base = [0., 0., 1.]
         ref_energy, ref_pressure = self.get_reference_obs_per_ion(mc, base)
         p3m_params = dict(prefactor=1., accuracy=1e-8, mesh=32, r_cut=14.,
-                          cao=7, tuning=False)
+                          cao=7, alpha=0.27362958, tune=False)
 
         def check():
             energy, p_scalar, p_tensor = self.get_normalized_obs_per_ion()
@@ -228,7 +229,7 @@ class Test(ut.TestCase):
         base = [1., 1., 0.]
         ref_energy, ref_pressure = self.get_reference_obs_per_ion(mc, base)
         p3m_params = dict(prefactor=1., accuracy=1e-8, mesh=48, r_cut=22.,
-                          cao=7, tuning=False)
+                          cao=7, alpha=0.179719, tune=False)
         elc_params = dict(maxPWerror=1e-6, gap_size=16)
 
         def check(pressure=True):
@@ -261,7 +262,7 @@ class Test(ut.TestCase):
 
     @utx.skipIfMissingFeatures(["P3M"])
     def test_infinite_ionic_cube(self):
-        n_pairs = 8
+        n_pairs = 6
         self.system.box_l = 3 * [2 * n_pairs]
         for j, k, l in itertools.product(range(2 * n_pairs), repeat=3):
             self.system.part.add(pos=[j, k, l], q=(-1)**(j + k + l))
@@ -269,8 +270,8 @@ class Test(ut.TestCase):
         mc = -1.74756459463318219
         base = [1., 1., 1.]
         ref_energy, ref_pressure = self.get_reference_obs_per_ion(mc, base)
-        p3m_params = dict(prefactor=1., accuracy=3e-7, mesh=44, r_cut=7., cao=7,
-                          tuning=False)
+        p3m_params = dict(prefactor=1., accuracy=3e-7, mesh=52, r_cut=4.4, cao=7,
+                          alpha=0.8895166, tune=False)
 
         def check():
             energy, p_scalar, p_tensor = self.get_normalized_obs_per_ion()
@@ -285,6 +286,8 @@ class Test(ut.TestCase):
         check()
         if espressomd.has_features("CUDA") and espressomd.gpu_available():
             self.system.actors.clear()
+            p3m_params = dict(prefactor=1., accuracy=3e-7, mesh=42, r_cut=5.5,
+                              cao=7, alpha=0.709017, tune=False)
             p3m = espressomd.electrostatics.P3MGPU(**p3m_params)
             self.system.actors.add(p3m)
             check()

--- a/testsuite/python/random_pairs.py
+++ b/testsuite/python/random_pairs.py
@@ -20,6 +20,7 @@
 import unittest as ut
 import espressomd
 import numpy as np
+import scipy.spatial
 import itertools
 import collections
 import tests_common
@@ -38,23 +39,31 @@ class RandomPairTest(ut.TestCase):
     system = espressomd.System(box_l=[10., 15., 15.])
 
     def setUp(self):
-        s = self.system
-        s.time_step = .1
-        s.cell_system.skin = 0.0
-        s.min_global_cut = 1.5
-        n_part = 500
+        system = self.system
+        system.time_step = .1
+        system.cell_system.skin = 0.0
+        system.min_global_cut = 1.5
+        n_part = 400
 
         np.random.seed(2)
 
-        s.part.add(pos=s.box_l * np.random.random((n_part, 3)))
+        positions = system.box_l * np.random.random((n_part, 3))
+        system.part.add(pos=positions)
         self.all_pairs = []
 
-        dist_func = self.system.distance
-        for pair in self.system.part.pairs():
-            if dist_func(pair[0], pair[1]) < 1.5:
-                self.all_pairs.append((pair[0].id, pair[1].id))
+        def euclidean_pbc(a, b, box_l):
+            vec = np.fmod(a - b + box_l, box_l)
+            for i in range(3):
+                if vec[i] > box_l[i] / 2.:
+                    vec[i] -= box_l[i]
+            return np.linalg.norm(vec)
 
-        self.all_pairs = set(self.all_pairs)
+        dist_mat = scipy.spatial.distance.cdist(
+            positions, positions, metric=euclidean_pbc,
+            box_l=np.copy(system.box_l))
+        diag_mask = np.logical_not(np.eye(n_part, dtype=bool))
+        dist_crit = (dist_mat < 1.5) * diag_mask
+        self.all_pairs = list(zip(*np.nonzero(np.triu(dist_crit))))
         self.assertGreater(len(self.all_pairs), 0)
 
     def tearDown(self):

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -125,6 +125,7 @@ if espressomd.has_features('P3M') and ('P3M' in modes or 'ELC' in modes):
         cao=1,
         alpha=1.0,
         r_cut=1.0,
+        check_complex_residuals=False,
         timings=15,
         tune=False)
     if 'ELC' in modes:

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -76,8 +76,10 @@ if 'INT.NPT' not in modes:
 lbf_actor = None
 if 'LB.CPU' in modes:
     lbf_actor = espressomd.lb.LBFluid
+    has_lbb = espressomd.has_features("LB_BOUNDARIES")
 elif 'LB.GPU' in modes and espressomd.gpu_available():
     lbf_actor = espressomd.lb.LBFluidGPU
+    has_lbb = espressomd.has_features("LB_BOUNDARIES_GPU")
 if lbf_actor:
     lbf_cpt_mode = 0 if 'LB.ASCII' in modes else 1
     lbf = lbf_actor(agrid=0.5, visc=1.3, dens=1.5, tau=0.01, gamma_odd=0.2,
@@ -85,8 +87,7 @@ if lbf_actor:
     system.actors.add(lbf)
     if 'THERM.LB' in modes:
         system.thermostat.set_lb(LB_fluid=lbf, seed=23, gamma=2.0)
-    if (espressomd.has_features(
-            "LB_BOUNDARIES") or espressomd.has_features("LB_BOUNDARIES_GPU")):
+    if has_lbb:
         system.lbboundaries.add(espressomd.lbboundaries.LBBoundary(
             shape=espressomd.shapes.Wall(normal=(1, 0, 0), dist=0.5), velocity=(1e-4, 1e-4, 0)))
         system.lbboundaries.add(espressomd.lbboundaries.LBBoundary(

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -44,6 +44,9 @@ is_gpu_available = espressomd.gpu_available()
 modes = config.get_modes()
 has_lb_mode = 'LB.CPU' in modes or 'LB.GPU' in modes and is_gpu_available
 has_p3m_mode = 'P3M.CPU' in modes or 'P3M.GPU' in modes and is_gpu_available
+has_lbb = ('LB.CPU' in modes and espressomd.has_features("LB_BOUNDARIES") or
+           'LB.GPU' in modes and espressomd.has_features("LB_BOUNDARIES_GPU")
+           and espressomd.gpu_available())
 
 
 class CheckpointTest(ut.TestCase):
@@ -589,9 +592,7 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(list(system.part.by_id(1).exclusions), [2])
         self.assertEqual(list(system.part.by_id(2).exclusions), [0, 1])
 
-    @ut.skipIf(not has_lb_mode or not (espressomd.has_features("LB_BOUNDARIES")
-                                       or espressomd.has_features("LB_BOUNDARIES_GPU")),
-               "Missing features")
+    @ut.skipIf(not has_lbb, "Missing features")
     def test_lb_boundaries(self):
         # check boundary objects
         self.assertEqual(len(system.lbboundaries), 2)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -504,6 +504,7 @@ class CheckpointTest(ut.TestCase):
         reference = {'prefactor': 1.0, 'accuracy': 0.1, 'mesh': 3 * [10],
                      'cao': 1, 'alpha': 1.0, 'r_cut': 1.0, 'tune': False,
                      'timings': 15, 'check_neutrality': True,
+                     'check_complex_residuals': False,
                      'charge_neutrality_tolerance': 1e-12}
         for key in reference:
             self.assertIn(key, state)
@@ -519,6 +520,7 @@ class CheckpointTest(ut.TestCase):
         p3m_reference = {'prefactor': 1.0, 'accuracy': 0.1, 'mesh': 3 * [10],
                          'cao': 1, 'alpha': 1.0, 'r_cut': 1.0, 'tune': False,
                          'timings': 15, 'check_neutrality': True,
+                         'check_complex_residuals': False,
                          'charge_neutrality_tolerance': 7e-12}
         elc_reference = {'gap_size': 6.0, 'maxPWerror': 0.1,
                          'delta_mid_top': 0.9, 'delta_mid_bot': 0.1,

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -668,6 +668,7 @@ class CheckpointTest(ut.TestCase):
         if self.n_nodes == 1:
             union = c[7].shape
             self.assertIsInstance(union, espressomd.shapes.Union)
+            self.assertEqual(c[7].particle_type, 2)
             self.assertEqual(len(union), 2)
             wall1, wall2 = union.call_method('get_elements')
             self.assertIsInstance(wall1, espressomd.shapes.Wall)


### PR DESCRIPTION
Description of changes:
- fix non-critical regressions in the testsuite introduced in 4.3-dev
- reduce runtime of tests that scale with O(N^2) by using slightly less particles or using faster numpy operations
- skip statistical tests in the macOS CI job to reduce runtime from 1h30 to 1h
- fix FFT complex residuals check and add an option to disable them to stop the ICC interface test from randomly failing  (fixes #4567)
- fix parameter range checks in electrostatics and magnetostatic methods, unknown parameters now raise an exception
- cleanup header includes and feature guards (fixes #4560)
- let Gay-Berne kernels take quaternions (fixes #3922)