### PR TITLE
Missing guard ext torque

### DIFF
--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -492,8 +492,10 @@ public:
   auto &torque() { return f.torque; }
   auto const &omega() const { return m.omega; }
   auto &omega() { return m.omega; }
+#ifdef EXTERNAL_FORCES
   auto const &ext_torque() const { return p.ext_torque; }
   auto &ext_torque() { return p.ext_torque; }
+#endif // EXTERNAL_FORCES
   auto calc_director() const { return r.calc_director(); }
 #else  // ROTATION
   bool can_rotate() const { return false; }

--- a/testsuite/python/bond_breakage.py
+++ b/testsuite/python/bond_breakage.py
@@ -162,7 +162,7 @@ class BondBreakage(BondBreakageCommon, ut.TestCase):
             system.integrator.run(1)
 
 
-@utx.skipIfMissingFeatures("LENNARD_JONES")
+@utx.skipIfMissingFeatures(["LENNARD_JONES", "COLLISION_DETECTION"])
 class NetworkBreakage(BondBreakageCommon, ut.TestCase):
 
     @classmethod

--- a/testsuite/python/lees_edwards.py
+++ b/testsuite/python/lees_edwards.py
@@ -449,7 +449,7 @@ class LeesEdwards(ut.TestCase):
         np.testing.assert_allclose(
             np.copy(p1.torque_lab), [0, 0, -2], atol=tol)
 
-    @utx.skipIfMissingFeatures(["VIRTUAL_SITES_RELATIVE", "ROTATION"])
+    @utx.skipIfMissingFeatures(["VIRTUAL_SITES_RELATIVE", "ROTATION", "DPD"])
     def test_virt_sites_interaction(self):
         """
         A virtual site interacts with a real particle via a DPD interaction


### PR DESCRIPTION
Partial fix for #4560 

Add missing `EXTERNAL_FORCES` guard for `ext_torque()`; revealed by the following `myconfig.hpp`:
```c++
#define ROTATION
#define ROTATIONAL_INERTIA
#define MASS
#define THERMOSTAT_PER_PARTICLE
#define LENNARD_JONES
#define VIRTUAL_SITES_RELATIVE
```
The second commit adds missing guards to fix tests that failed with the feature configuration given above.