### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 7 * * *'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   deploy_docs:
     runs-on: ubuntu-20.04

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   regular_check:
     runs-on: macos-latest
@@ -24,6 +27,10 @@ jobs:
           ubsan: false
 
   sanitizer_check:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      issues: write # to create an issue
+
     runs-on: macos-latest
     if: (github.event_name == 'schedule' && github.repository == 'espressomd/espresso')
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.