### PR TITLE
Fix OpenGL visualizer for polymers

### DIFF
--- a/src/python/espressomd/visualization.py
+++ b/src/python/espressomd/visualization.py
@@ -908,7 +908,7 @@ class openGLLive():
                 for bond in particle.bonds:
                     # input data:
                     # bond[0]: bond type, bond[1:] bond partners
-                    bond_type = bond[0].type_number()
+                    bond_type = bond[0]._type_number
                     if len(bond) == 4:
                         self.bonds.append([particle.id, bond[1], bond_type])
                         self.bonds.append([particle.id, bond[2], bond_type])


### PR DESCRIPTION
Description of changes:
- fix a regression introduced in 4.3-dev by 283e0c8e412608d in #4558 that crashes the visualizer when drawing bonds between particles