### PR TITLE
Refactored MC displacement move of particles

### DIFF
--- a/src/core/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.hpp
@@ -80,11 +80,11 @@ public:
   double volume;
   int non_interacting_type = 100;
 
-  int m_accepted_configurational_MC_moves = 0;
-  int m_tried_configurational_MC_moves = 0;
-  double get_acceptance_rate_configurational_moves() const {
-    return static_cast<double>(m_accepted_configurational_MC_moves) /
-           static_cast<double>(m_tried_configurational_MC_moves);
+  int N_trial_particle_displacement_MC_moves = 0;
+  int N_accepted_particle_displacement_MC_moves = 0;
+  double get_acceptance_rate_particle_displacement_MC_moves() const {
+    return static_cast<double>(N_accepted_particle_displacement_MC_moves) /
+           static_cast<double>(N_trial_particle_displacement_MC_moves);
   }
 
   auto get_kT() const { return kT; }
@@ -133,7 +133,9 @@ public:
     reactions.erase(reactions.begin() + reaction_id);
   }
 
-  bool displacement_move_for_particles_of_type(int type, int n_part);
+  void
+  do_particle_displacement_MC_move(int mc_steps,
+                                   std::vector<int> particle_types_to_move);
 
   bool particle_inside_exclusion_range_touched = false;
   bool neighbor_search_order_n = true;
@@ -164,8 +166,6 @@ protected:
   std::tuple<std::vector<StoredParticleProperty>, std::vector<int>,
              std::vector<StoredParticleProperty>>
   make_reaction_attempt(SingleReaction const &current_reaction);
-  std::vector<std::tuple<int, Utils::Vector3d, Utils::Vector3d>>
-  generate_new_particle_positions(int type, int n_particles);
   void
   restore_properties(std::vector<StoredParticleProperty> const &property_list);
   /**

--- a/src/python/espressomd/reaction_methods.py
+++ b/src/python/espressomd/reaction_methods.py
@@ -168,7 +168,7 @@ class ReactionAlgorithm(ScriptInterfaceHelper):
         Get the volume to be used in the acceptance probability of the reaction
         ensemble.
 
-    get_acceptance_rate_configurational_moves()
+    get_acceptance_rate_particle_displacement_MC_moves()
         Returns the acceptance rate for the configuration moves.
 
     get_acceptance_rate_reaction()
@@ -209,29 +209,21 @@ class ReactionAlgorithm(ScriptInterfaceHelper):
         reaction_steps : :obj:`int`, optional
             The number of reactions to be performed at once, defaults to 1.
 
-    displacement_mc_move_for_particles_of_type()
-        Performs displacement Monte Carlo moves for particles of a given type.
+    do_particle_displacement_MC_move()
+        Performs particle displacement MC moves in the canonical ensemble.
         New positions of the displaced particles are chosen from the whole box
-        with a uniform probability distribution and new velocities are
-        sampled from the Maxwell-Boltzmann distribution.
-
-        The sequence of moves is only accepted if each individual move in
-        the sequence was accepted. Particles are sampled without replacement.
-        Therefore, calling this method once for 10 particles is not equivalent
-        to calling this method 10 times for 1 particle.
+        with a uniform probability distribution. When moved, the particles preserve
+        their original velocity. By default, any particle can be selected to be moved,
+        but the particles types allowed to moved can be selected with particle_types_to_move
 
         Parameters
         ----------
-        type_mc : :obj:`int`
-            Particle type which should be moved
-        particle_number_to_be_changed : :obj:`int`
-            Number of particles to move, defaults to 1.
-            Particles are selected without replacement.
+        mc_steps : :obj:`int`
+            Number of trial MC steps
+        particle_types_to_move : :obj:`list`
+            List of particle types from which particles are selected. 
+            If empty, any particle can be chosen by default.
 
-        Returns
-        -------
-        :obj:`bool`
-            Whether all moves were accepted.
 
     delete_particle()
         Deletes the particle of the given p_id and makes sure that the particle
@@ -287,7 +279,7 @@ class ReactionAlgorithm(ScriptInterfaceHelper):
                         "set_non_interacting_type",
                         "get_non_interacting_type",
                         "reaction",
-                        "displacement_mc_move_for_particles_of_type",
+                        "do_particle_displacement_MC_move",
                         "check_reaction_method",
                         "change_reaction_constant",
                         "delete_reaction",

--- a/src/script_interface/reaction_methods/ReactionAlgorithm.hpp
+++ b/src/script_interface/reaction_methods/ReactionAlgorithm.hpp
@@ -127,10 +127,12 @@ public:
       return RE()->non_interacting_type;
     } else if (name == "reaction") {
       RE()->do_reaction(get_value_or<int>(parameters, "reaction_steps", 1));
-    } else if (name == "displacement_mc_move_for_particles_of_type") {
-      return RE()->displacement_move_for_particles_of_type(
-          get_value<int>(parameters, "type_mc"),
-          get_value_or<int>(parameters, "particle_number_to_be_changed", 1));
+    } else if (name == "do_particle_displacement_MC_move") {
+      std::vector<int> v;
+      RE()->do_particle_displacement_MC_move(
+          get_value_or<int>(parameters, "mc_steps", 1),
+          get_value_or<std::vector<int>>(parameters, "particle_types_to_move",
+                                         v));
     } else if (name == "check_reaction_method") {
       RE()->check_reaction_method();
     } else if (name == "delete_particle") {

--- a/testsuite/python/canonical_ensemble.py
+++ b/testsuite/python/canonical_ensemble.py
@@ -53,24 +53,15 @@ class Test(ut.TestCase):
 
         p = self.system.part.add(pos=[0., 0., 0.], q=1, type=0)
         obs_pos = espressomd.observables.ParticlePositions(ids=(p.id,))
-        obs_vel = espressomd.observables.ParticleVelocities(ids=(p.id,))
         acc_pos = espressomd.accumulators.TimeSeries(obs=obs_pos)
-        acc_vel = espressomd.accumulators.TimeSeries(obs=obs_vel)
 
         E = np.array([-1., 0., 0.])
         field = espressomd.constraints.LinearElectricPotential(E=E, phi0=0.)
         self.system.constraints.add(field)
 
-        for _ in range(5000):
-            accepted = method.displacement_mc_move_for_particles_of_type(
-                type_mc=0, particle_number_to_be_changed=1)
-            if accepted:
-                acc_pos.update()
-                acc_vel.update()
-                p.pos = [0., 0., 0.]
-                p.v = [0., 0., 0.]
-            else:
-                self.assertAlmostEqual(np.linalg.norm(p.v), 0., delta=1e-12)
+        for _ in range(100000):
+            method.do_particle_displacement_MC_move()
+            acc_pos.update()
 
         # the x-position should follow an exponential distribution
         # -> mean = kT, median = kT x ln(2), variance = kT^2
@@ -81,6 +72,7 @@ class Test(ut.TestCase):
         (a, b, c), _ = scipy.optimize.curve_fit(
             lambda x, a, b, c: a * np.exp(-b * x) + c, xdata, ydata)
         # check histogram profile is roughly exponential
+
         self.assertAlmostEqual(a, 1., delta=0.2)
         self.assertAlmostEqual(b, 1. / method.kT, delta=0.3)
         self.assertAlmostEqual(c, 0., delta=0.01)
@@ -96,23 +88,6 @@ class Test(ut.TestCase):
             ydata, _ = np.histogram(series, bins=10, range=[0., 1.])
             ydata = ydata / np.mean(ydata)
             np.testing.assert_allclose(ydata, 1., atol=0.25)
-
-        # the velocity vector should follow a normal distribution
-        # -> mean = 0, median = 0, variance = kT
-        for axis in (0, 1, 2):
-            series = acc_vel.time_series()[:, p.id, axis]
-            ydata, xbins = np.histogram(series, bins=25, range=[-1.5, 1.5])
-            xdata = (xbins[1:] + xbins[:-1]) / 2.
-            ydata = ydata / len(series)
-            (_, b, c), _ = scipy.optimize.curve_fit(
-                lambda x, a, b, c: a * np.exp(-b * x**2) + c, xdata, ydata)
-            # check histogram profile is roughly gaussian
-            self.assertAlmostEqual(b, 0.5 / method.kT, delta=0.45)
-            self.assertAlmostEqual(c, 0., delta=0.002)
-            # check distribution parameters with high accuracy
-            self.assertAlmostEqual(np.mean(series), 0., delta=0.05)
-            self.assertAlmostEqual(np.median(series), 0., delta=0.025)
-            self.assertAlmostEqual(np.var(series), method.kT, delta=0.025)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/reaction_methods_interface.py
+++ b/testsuite/python/reaction_methods_interface.py
@@ -101,10 +101,6 @@ class ReactionMethods(ut.TestCase):
             self.assertAlmostEqual(method.constant_pH, 10., delta=1e-10)
             method.constant_pH = 8.
             self.assertAlmostEqual(method.constant_pH, 8., delta=1e-10)
-        self.assertFalse(method.displacement_mc_move_for_particles_of_type(
-            type_mc=0, particle_number_to_be_changed=0))
-        self.assertFalse(method.displacement_mc_move_for_particles_of_type(
-            type_mc=0, particle_number_to_be_changed=100000))
 
         # check constraints
         method.set_wall_constraints_in_z_direction(
@@ -293,12 +289,6 @@ class ReactionMethods(ut.TestCase):
         with self.assertRaisesRegex(ValueError, "Invalid value for 'kT'"):
             espressomd.reaction_methods.ReactionEnsemble(
                 kT=-1., exclusion_range=1., seed=12)
-        with self.assertRaisesRegex(ValueError, "Parameter 'particle_number_to_be_changed' must be >= 0"):
-            method.displacement_mc_move_for_particles_of_type(
-                type_mc=0, particle_number_to_be_changed=-1)
-        with self.assertRaisesRegex(ValueError, "Parameter 'type_mc' must be >= 0"):
-            method.displacement_mc_move_for_particles_of_type(
-                type_mc=-1, particle_number_to_be_changed=1)
 
         # check invalid exclusion ranges and radii
         with self.assertRaisesRegex(ValueError, "Invalid value for 'exclusion_range'"):


### PR DESCRIPTION
Description of changes:
- Substituted `bool ReactionAlgorithm::displacement_move_for_particles_of_type(int type, int n_part)` for a new method to perform MC displacement moves of particles `void ReactionAlgorithm::do_particle_displacement_MC_move( int mc_steps, std::vector<int> particle_types_to_move)`
- The new method takes the number of trial MC steps `mc_steps` as input instead of the number of particles to move, avoiding confusion on the actual number of MC steps performed. If no value is given performs one MC steps by default.
- Only one particle is moved in each MC step.
- The new method also takes an optional argument `particle_types_to_move`, which is the list of particle types  from which particles will be selected.  If no value is given all particle can be moved by default.
- The method `ReactionAlgorithm::generate_new_particle_positions(int type, int n_particles)` has been removed since it was only used by `ReactionAlgorithm::do_particle_displacement_MC_move`
- I renamed the variables `m_tried_configurational_MC_moves` and `m_accepted_configurational_MC_moves` to `N_trial_particle_displacement_MC_moves` and `N_accepted_particle_displacement_MC_moves` for clarity.
- I adapted all tests according these changes.

I provide below a minimal working script to test the new implementation.

```python
import espressomd
from espressomd import reaction_methods
import numpy as np
import espressomd.visualization
import threading


BOX_LENGTH=10

system = espressomd.System(box_l=[BOX_LENGTH,]*3)

types = {"A": 0, "B": 1, "C": 2}
N_types= {"A": 1, "B": 1, "C": 2}
particle_types_to_move=[2]
N_MC_STEPS=1

system.part.add(type=[types["A"]]*N_types["A"], pos=np.random.rand(N_types["A"], 3) * BOX_LENGTH)
system.part.add(type=[types["B"]]*N_types["B"], pos=np.random.rand(N_types["B"], 3) * BOX_LENGTH)
system.part.add(type=[types["C"]]*N_types["C"], pos=np.random.rand(N_types["C"], 3) * BOX_LENGTH)

RE = espressomd.reaction_methods.ReactionEnsemble(kT=1, exclusion_range=0, seed=12)


visualizer = espressomd.visualization.openGLLive(system)

def main_thread():
    while True:
        RE.do_particle_displacement_MC_move(mc_steps=N_MC_STEPS, particle_types_to_move=particle_types_to_move)
        visualizer.update()

t = threading.Thread(target=main_thread)
t.daemon = True
t.start()
visualizer.start()
```

