### PR TITLE
Implement override_cutoff_check property for vs.

### DIFF
--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -354,6 +354,10 @@ Please note:
    you need to set the system's :attr:`~espressomd.system.System.min_global_cut`
    attribute to this largest distance.
    An error is generated when this requirement is not met.
+   Under very specific circumstances it may be desirable to disable this check,
+   e.g. when using certain setups with the hybrid decomposition scheme.
+   You can do so by setting the virtual sites property ``override_cutoff_check = True``.
+   However, only consider this if you are absolutely sure of what you are doing.
 
 -  If the virtual sites represent actual particles carrying a mass, the
    inertia tensor of the non-virtual particle in the center of mass

--- a/src/core/virtual_sites.cpp
+++ b/src/core/virtual_sites.cpp
@@ -66,7 +66,8 @@ calculate_vs_relate_to_params(Particle const &p_current,
   // than minimum global cutoff. If so, warn user.
   auto const dist = d.norm();
   auto const min_global_cut = get_min_global_cut();
-  if (dist > min_global_cut && n_nodes > 1) {
+  if (dist > min_global_cut && n_nodes > 1 &&
+      not virtual_sites()->get_override_cutoff_check()) {
     runtimeErrorMsg()
         << "Warning: The distance between virtual and non-virtual particle ("
         << dist << ") is larger than the minimum global cutoff ("

--- a/src/core/virtual_sites/VirtualSites.hpp
+++ b/src/core/virtual_sites/VirtualSites.hpp
@@ -60,9 +60,15 @@ public:
     m_have_quaternion = have_quaternion;
   }
   bool have_quaternions() const { return m_have_quaternion; }
+  /**  @brief Enable/disable override for the vs cutoff check */
+  void set_override_cutoff_check(const bool &override_cutoff_check) {
+    m_override_cutoff_check = override_cutoff_check;
+  }
+  bool get_override_cutoff_check() const { return m_override_cutoff_check; }
 
 private:
   bool m_have_quaternion = false;
+  bool m_override_cutoff_check = false;
 };
 
 #endif

--- a/src/script_interface/virtual_sites/VirtualSites.hpp
+++ b/src/script_interface/virtual_sites/VirtualSites.hpp
@@ -43,7 +43,12 @@ public:
           [this](const Variant &v) {
             virtual_sites()->set_have_quaternion(get_value<bool>(v));
           },
-          [this]() { return virtual_sites()->have_quaternions(); }}});
+          [this]() { return virtual_sites()->have_quaternions(); }},
+         {"override_cutoff_check",
+          [this](const Variant &v) {
+            virtual_sites()->set_override_cutoff_check(get_value<bool>(v));
+          },
+          [this]() { return virtual_sites()->get_override_cutoff_check(); }}});
   }
   /** Vs implementation we are wrapping */
   virtual std::shared_ptr<::VirtualSites> virtual_sites() = 0;

--- a/testsuite/python/virtual_sites_relative.py
+++ b/testsuite/python/virtual_sites_relative.py
@@ -158,6 +158,9 @@ class VirtualSites(ut.TestCase):
         if system.cell_system.get_state()["n_nodes"] > 1:
             with self.assertRaisesRegex(Exception, r"The distance between virtual and non-virtual particle \([0-9\.]+\) is larger than the minimum global cutoff"):
                 p2.vs_auto_relate_to(p1)
+            # If overridden this check should not raise an exception
+            system.virtual_sites.override_cutoff_check = True
+            p2.vs_auto_relate_to(p1)
 
     def test_pos_vel_forces(self):
         system = self.system


### PR DESCRIPTION
Under specific circumstances one might have to override the cutoff check for virtual sites.

E.g. on `n>1` cores, when using the hybrid decomposition scheme to simulate a large virtual sites rigid object such as a large raspberry particle, the `min_global_cut` necessary to set up said object becomes quite large. Say the raspberry is surrounded by lots of small particles, e.g. a polymer suspension, which are put in the regular child decomposition of the `HybridDecomposition` cell system, the resulting minimum cell size of the regular cell decomposition is limited by this large `min_global_cut` -- even if the raspberry central particle resides in the N-square child decomposition, where it already interacts with all particles making the `min_global_cut` requirement superfluous. However, one forfeits the possible computational advantage of the hybrid decomposition.