### PR TITLE
Remove deprecated numpy options

### DIFF
--- a/testsuite/python/observable_profile.py
+++ b/testsuite/python/observable_profile.py
@@ -51,7 +51,7 @@ class ProfileObservablesTest(ut.TestCase):
         obs_bin_centers = density_profile.bin_centers()
         np_hist, np_edges = tests_common.get_histogram(
             np.copy(self.system.part.all().pos), self.kwargs, 'cartesian',
-            normed=True)
+            density=True)
         np_hist *= len(self.system.part)
         np.testing.assert_array_almost_equal(obs_data, np_hist)
         for i in range(3):

--- a/testsuite/python/observable_profileLB.py
+++ b/testsuite/python/observable_profileLB.py
@@ -91,7 +91,7 @@ class ObservableProfileLBCommon:
         obs_edges = obs.call_method("edges")
         _, np_edges = tests_common.get_histogram(
             np.zeros([1, 3]), LB_VELOCITY_PROFILE_PARAMS, 'cartesian',
-            normed=True)
+            density=True)
         for i in range(3):
             np.testing.assert_array_almost_equal(obs_edges[i], np_edges[i])
         for x in range(obs_data.shape[0]):


### PR DESCRIPTION
Fixes #4632, fixes #4634, fixes #4636

Description of changes:
- remove deprecated numpy options in the observable tests
