### PR TITLE
Rewrite particle serialization mechanism

### DIFF
--- a/src/script_interface/particle_data/ParticleList.cpp
+++ b/src/script_interface/particle_data/ParticleList.cpp
@@ -74,6 +74,8 @@ std::string ParticleList::get_internal_state() const {
     state.params.emplace_back(
         std::pair<std::string, PackedVariant>{"exclusions", pack(exclusions)});
 #endif // EXCLUSIONS
+    state.params.emplace_back(
+        std::pair<std::string, PackedVariant>{"__cpt_sentinel", pack(None{})});
     return Utils::pack(state);
   });
 

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -228,16 +228,23 @@ class ParticleProperties(ut.TestCase):
             p1.add_exclusion(pid2)
             p1.add_exclusion(pid2)
 
-    @utx.skipIfMissingFeatures("DIPOLES")
-    def test_contradicting_properties_dip_dipm(self):
-        with self.assertRaises(ValueError):
-            self.system.part.add(pos=[0, 0, 0], dip=[1, 1, 1], dipm=1.0)
-
-    @utx.skipIfMissingFeatures(["DIPOLES", "ROTATION"])
-    def test_contradicting_properties_dip_quat(self):
-        with self.assertRaises(ValueError):
-            self.system.part.add(pos=[0, 0, 0], dip=[1, 1, 1],
-                                 quat=[1.0, 1.0, 1.0, 1.0])
+    @utx.skipIfMissingFeatures(["ROTATION"])
+    def test_contradicting_properties_quat(self):
+        invalid_combinations = [
+            {'quat': [1., 1., 1., 1.], 'director': [1., 1., 1.]},
+        ]
+        if espressomd.has_features(["DIPOLES"]):
+            invalid_combinations += [
+                {'dip': [1., 1., 1.], 'dipm': 1.},
+                {'dip': [1., 1., 1.], 'quat': [1., 1., 1., 1.]},
+                {'dip': [1., 1., 1.], 'director': [1., 1., 1.]},
+            ]
+        # check all methods that can instantiate particles
+        for kwargs in invalid_combinations:
+            for make_new_particle in (
+                    self.system.part.add, espressomd.particle_data.ParticleHandle):
+                with self.assertRaises(ValueError):
+                    make_new_particle(pos=[0., 0., 0.], **kwargs)
 
     @utx.skipIfMissingFeatures(["ROTATION"])
     def test_invalid_quat(self):

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -357,6 +357,38 @@ if lbf_actor:
     lbf_cpt_path = path_cpt_root / "lb.cpt"
     lbf.save_checkpoint(str(lbf_cpt_path), lbf_cpt_mode)
 
+# set various properties
+p8 = system.part.add(id=8, pos=[2.0] * 3 + system.box_l)
+p8.lees_edwards_offset = 0.2
+p4.v = [-1., 2., -4.]
+if espressomd.has_features('MASS'):
+    p3.mass = 1.5
+if espressomd.has_features('ROTATION'):
+    p3.quat = [1., 2., 3., 4.]
+    p4.director = [3., 2., 1.]
+    p4.omega_body = [0.3, 0.5, 0.7]
+    p3.rotation = [True, False, True]
+if espressomd.has_features('EXTERNAL_FORCES'):
+    p3.fix = [False, True, False]
+    p3.ext_force = [-0.6, 0.1, 0.2]
+if espressomd.has_features(['EXTERNAL_FORCES', 'ROTATION']):
+    p3.ext_torque = [0.3, 0.5, 0.7]
+if espressomd.has_features('ROTATIONAL_INERTIA'):
+    p3.rinertia = [2., 3., 4.]
+if espressomd.has_features('THERMOSTAT_PER_PARTICLE'):
+    gamma = 2.
+    if espressomd.has_features('PARTICLE_ANISOTROPY'):
+        gamma = np.array([2., 3., 4.])
+    p4.gamma = gamma
+    if espressomd.has_features('ROTATION'):
+        p3.gamma_rot = 2. * gamma
+if espressomd.has_features('ENGINE'):
+    p3.swimming = {"f_swim": 0.03}
+if espressomd.has_features('ENGINE') and lbf_actor:
+    p4.swimming = {"v_swim": 0.02, "mode": "puller", "dipole_length": 1.}
+if espressomd.has_features('LB_ELECTROHYDRODYNAMICS') and lbf_actor:
+    p8.mu_E = [-0.1, 0.2, -0.3]
+
 # h5md output
 if espressomd.has_features("H5MD"):
     h5_units = espressomd.io.writer.h5md.UnitSystem(

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -249,25 +249,24 @@ if espressomd.has_features(['DPD']):
 harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0.0, k=1.0)
 system.bonded_inter.add(harmonic_bond)
 p2.add_bond((harmonic_bond, p1))
-if 'THERM.LB' not in modes:
-    # create 3 thermalized bonds that will overwrite each other's seed
-    thermalized_bond_params = dict(temp_com=0.1, temp_distance=0.2,
-                                   gamma_com=0.3, gamma_distance=0.5, r_cut=2.)
-    thermalized_bond1 = espressomd.interactions.ThermalizedBond(
-        seed=1, **thermalized_bond_params)
-    thermalized_bond2 = espressomd.interactions.ThermalizedBond(
-        seed=2, **thermalized_bond_params)
-    thermalized_bond3 = espressomd.interactions.ThermalizedBond(
-        seed=3, **thermalized_bond_params)
-    system.bonded_inter.add(thermalized_bond1)
-    p2.add_bond((thermalized_bond1, p1))
-    checkpoint.register("thermalized_bond2")
-    checkpoint.register("thermalized_bond_params")
-    if espressomd.has_features(['ELECTROSTATICS', 'MASS', 'ROTATION']):
-        dh = espressomd.drude_helpers.DrudeHelpers()
-        dh.add_drude_particle_to_core(system, harmonic_bond, thermalized_bond1,
-                                      p2, 10, 1., 4.6, 0.8, 2.)
-        checkpoint.register("dh")
+# create 3 thermalized bonds that will overwrite each other's seed
+therm_params = dict(temp_com=0.1, temp_distance=0.2, gamma_com=0.3,
+                    gamma_distance=0.5, r_cut=2.)
+therm_bond1 = espressomd.interactions.ThermalizedBond(seed=1, **therm_params)
+therm_bond2 = espressomd.interactions.ThermalizedBond(seed=2, **therm_params)
+therm_bond3 = espressomd.interactions.ThermalizedBond(seed=3, **therm_params)
+system.bonded_inter.add(therm_bond1)
+p2.add_bond((therm_bond1, p1))
+checkpoint.register("therm_bond2")
+checkpoint.register("therm_params")
+# create Drude particles
+if espressomd.has_features(['ELECTROSTATICS', 'MASS', 'ROTATION']):
+    dh = espressomd.drude_helpers.DrudeHelpers()
+    dh.add_drude_particle_to_core(
+        system=system, harmonic_bond=harmonic_bond,
+        thermalized_bond=therm_bond1, p_core=p2, type_drude=10,
+        alpha=1., mass_drude=0.6, coulomb_prefactor=0.8, thole_damping=2.)
+    checkpoint.register("dh")
 strong_harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0.0, k=5e5)
 system.bonded_inter.add(strong_harmonic_bond)
 p4.add_bond((strong_harmonic_bond, p3))
@@ -281,17 +280,6 @@ break_spec = espressomd.bond_breakage.BreakageSpec(
     breakage_length=5., action_type="delete_bond")
 system.bond_breakage[strong_harmonic_bond._bond_id] = break_spec
 
-# h5md output
-if espressomd.has_features("H5MD"):
-    h5_units = espressomd.io.writer.h5md.UnitSystem(
-        time="ps", mass="u", length="m", charge="e")
-    h5 = espressomd.io.writer.h5md.H5md(
-        file_path=str(path_cpt_root / "test.h5"),
-        unit_system=h5_units)
-    h5.write()
-    h5.flush()
-    h5.close()
-
 checkpoint.register("system")
 checkpoint.register("acc_mean_variance")
 checkpoint.register("acc_time_series")
@@ -301,9 +289,6 @@ checkpoint.register("ibm_tribend_bond")
 checkpoint.register("ibm_triel_bond")
 checkpoint.register("break_spec")
 checkpoint.register("p_slice")
-if espressomd.has_features("H5MD"):
-    checkpoint.register("h5")
-    checkpoint.register("h5_units")
 
 # calculate forces
 system.integrator.run(0)
@@ -371,6 +356,19 @@ if lbf_actor:
     # save LB checkpoint file
     lbf_cpt_path = path_cpt_root / "lb.cpt"
     lbf.save_checkpoint(str(lbf_cpt_path), lbf_cpt_mode)
+
+# h5md output
+if espressomd.has_features("H5MD"):
+    h5_units = espressomd.io.writer.h5md.UnitSystem(
+        time="ps", mass="u", length="m", charge="e")
+    h5 = espressomd.io.writer.h5md.H5md(
+        file_path=str(path_cpt_root / "test.h5"),
+        unit_system=h5_units)
+    h5.write()
+    h5.flush()
+    h5.close()
+    checkpoint.register("h5")
+    checkpoint.register("h5_units")
 
 # save checkpoint file
 checkpoint.save(0)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -361,12 +361,11 @@ class CheckpointTest(ut.TestCase):
         reference = {'r_0': 0.0, 'k': 1.0, 'r_cut': 0.0}
         self.assertEqual(partcl_1.bonds[0][0].params, reference)
         self.assertEqual(system.bonded_inter[0].params, reference)
-        if 'THERM.LB' not in modes:
-            # all thermalized bonds should be identical
-            reference = {**thermalized_bond_params, 'seed': 3}
-            self.assertEqual(partcl_1.bonds[1][0].params, reference)
-            self.assertEqual(system.bonded_inter[1].params, reference)
-            self.assertEqual(thermalized_bond2.params, reference)
+        # all thermalized bonds should be identical
+        reference = {**therm_params, 'seed': 3}
+        self.assertEqual(partcl_1.bonds[1][0].params, reference)
+        self.assertEqual(system.bonded_inter[1].params, reference)
+        self.assertEqual(therm_bond2.params, reference)
         # immersed boundary bonds
         self.assertEqual(
             ibm_volcons_bond.params, {'softID': 15, 'kappaV': 0.01})
@@ -394,7 +393,6 @@ class CheckpointTest(ut.TestCase):
             delta=1e-10)
         self.assertEqual(break_spec.action_type, cpt_spec.action_type)
 
-    @ut.skipIf('THERM.LB' in modes, 'LB thermostat in modes')
     @utx.skipIfMissingFeatures(['ELECTROSTATICS', 'MASS', 'ROTATION'])
     def test_drude_helpers(self):
         drude_type = 10
@@ -467,9 +465,8 @@ class CheckpointTest(ut.TestCase):
             def predicate(cur, key):
                 np.testing.assert_allclose(cur[key][0], cur[key][1],
                                            err_msg=f"mismatch for '{key}'")
-            # note: cannot compare forces since they are NaN in frame #1
-            for key in ('position', 'image', 'velocity',
-                        'id', 'species', 'mass', 'charge'):
+            for key in ('id', 'position', 'image', 'velocity',
+                        'species', 'mass', 'charge', 'force'):
                 predicate(cur, f'particles/atoms/{key}/value')
             for key in ('offset', 'direction', 'normal'):
                 predicate(cur, f'particles/atoms/lees_edwards/{key}/value')


### PR DESCRIPTION
Fixes #4633

Release 4.2.0 introduced a regression that causes checkpoint files to overwrite the particle quaternion/director by a unit vector pointing along the z direction, when the `DIPOLES` feature is part of the myconfig file. This leads to incorrect trajectories when reloading a simulation from a checkpoint file, if the particle director plays a role in the simulation (ex: relative virtual sites, Gay-Berne potential, anisotropic particles, active particles, etc.). Since the default myconfig file contains `DIPOLES`, most ESPResSo users are affected.

Description of changes:
- write new checkpointing logic to avoid overwriting the particle director with the particle dipole moment
- add checks to verify particle properties are correctly reloaded from a checkpoint file
- fix regressions in the checkpointing tests