### PR TITLE
Bump GitHub Actions dependencies

### DIFF
--- a/.github/actions/build_and_check/action.yml
+++ b/.github/actions/build_and_check/action.yml
@@ -15,7 +15,7 @@ runs:
     - run: |
        brew install boost boost-mpi fftw
        brew install hdf5-mpi
-       pip3 install numpy cython h5py scipy
+       pip3 install -c requirements.txt numpy cython h5py scipy
       shell: bash
     - run: |
         export myconfig=maxset with_cuda=false with_gsl=false test_timeout=800 with_asan=${{ inputs.asan }} with_ubsan=${{ inputs.ubsan }} check_skip_long=true build_procs=2 check_procs=2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,14 @@ permissions:
 
 jobs:
   deploy_docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'espressomd/espresso'
     environment: deploy_documentation
     steps:
       - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
       - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.5.2
+        uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_SSH_PRIVATE_KEY }}
       - name: Checkout

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -11,13 +11,13 @@ permissions:
 
 jobs:
   regular_check:
-    runs-on: macos-latest
+    runs-on: macos-12
     if: github.event_name != 'schedule'
     steps:
       - name: Checkout
         uses: actions/checkout@main
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.1
         with:
           python-version: '3.9'
       - name: Check without sanitizer
@@ -31,13 +31,13 @@ jobs:
       contents: read # to fetch code (actions/checkout)
       issues: write # to create an issue
 
-    runs-on: macos-latest
+    runs-on: macos-12
     if: (github.event_name == 'schedule' && github.repository == 'espressomd/espresso')
     steps:
       - name: Checkout
         uses: actions/checkout@main
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.1
         with:
           python-version: '3.9'
       - name: Check with sanitizer

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -168,10 +168,8 @@ To generate the Sphinx documentation, install the following packages:
 
 .. code-block:: bash
 
-    pip3 install --user \
-        'sphinx>=2.3.0,!=3.0.0' \
-        'sphinxcontrib-bibtex>=2.4.1' \
-        'sphinx-toggleprompt==0.0.5'
+    pip3 install --user -c requirements.txt \
+        sphinx sphinxcontrib-bibtex sphinx-toggleprompt
 
 To generate the Doxygen documentation, install the following packages:
 
@@ -311,7 +309,7 @@ Run the following commands:
       doxygen gsl numpy scipy ipython jupyter
     brew install hdf5-mpi
     brew link --force cython
-    pip install PyOpenGL matplotlib
+    pip install -c requirements.txt PyOpenGL matplotlib
 
 .. _Quick installation:
 


### PR DESCRIPTION
Description of changes:
- Bump all GitHub Actions dependencies to remove deprecation warnings about Node.js 12
- Update installation instructions to rely on `requirements.txt` when installing Python dependencies
