### PR TITLE
User guide improvements

### DIFF
--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -11,40 +11,43 @@
   url                      = {https://store.doverpublications.com/0486612724.html},
 }
 
-@article{ahlrichs99a,
-author = {Ahlrichs, Patrick and D\"{u}nweg, Burkhard},
-title = {Simulation of a single polymer chain in solution by combining lattice {B}oltzmann and molecular dynamics},
-journal = {The Journal of Chemical Physics},
-volume = {111},
-number = {17},
-pages = {8225--8239},
-year = {1999},
-doi = {10.1063/1.480156}
+@Article{ahlrichs99a,
+  author    = {Ahlrichs, Patrick and D{\"u}nweg, Burkhard},
+  title     = {Simulation of a single polymer chain in solution by combining lattice {B}oltzmann and molecular dynamics},
+  journal   = {The Journal of Chemical Physics},
+  year      = {1999},
+  volume    = {111},
+  number    = {17},
+  pages     = {8225--8239},
+  doi       = {10.1063/1.480156},
 }
 
-@book{allen17a,
-  title={Computer simulation of liquids},
-  author={Allen, Michael P. and Tildesley, Dominic J.},
-  year={2017},
-  publisher={Oxford University Press},
-  doi={10.1093/oso/9780198803195.001.0001},
-  isbn={9780198803195},
-  edition={2nd},
+@Book{allen17a,
+  title     = {Computer Simulation of Liquids},
+  author    = {Allen, Michael P. and Tildesley, Dominic J.},
+  year      = {2017},
+  edition   = {2nd},
+  series    = {Oxford Science Publications},
+  publisher = {Oxford University Press},
+  isbn      = {978-0-19-880319-5},
+  doi       = {10.1093/oso/9780198803195.001.0001},
+  address   = {Oxford},
 }
 
-@ARTICLE{andersen83a,
-  author = {Andersen, Hans C.},
-  title = {Rattle: A "Velocity" Version of the Shake Algorithm for Molecular Dynamics Calculations},
-  journal = {Journal of Computational Physics},
-  year = {1983},
-  volume = {52},
-  doi = {10.1016/0021-9991(83)90014-1},
-  pages = {24--34}
+@Article{andersen83a,
+  author    = {Andersen, Hans C.},
+  title     = {Rattle: {A} ``Velocity'' Version of the Shake Algorithm for Molecular Dynamics Calculations},
+  journal   = {Journal of Computational Physics},
+  year      = {1983},
+  volume    = {52},
+  number    = {1},
+  pages     = {24--34},
+  doi       = {10.1016/0021-9991(83)90014-1},
 }
 
-@ARTICLE{arnold02a,
+@Article{arnold02a,
   author = {Arnold, Axel and Holm, Christian},
-  title = {{MMM2D}: A fast and accurate summation method for electrostatic interactions in {2D} slab geometries},
+  title = {{MMM2D}: {A} fast and accurate summation method for electrostatic interactions in {2D} slab geometries},
   journal = {Computer Physics Communications},
   year = {2002},
   volume = {148},
@@ -53,19 +56,20 @@ doi = {10.1063/1.480156}
   doi = {10.1016/S0010-4655(02)00586-6},
 }
 
-@ARTICLE{arnold02b,
-  author = {Axel Arnold and Christian Holm},
-  title = {A novel method for calculating electrostatic interactions in 2{D} periodic slab geometries},
+@Article{arnold02b,
+  author = {Arnold, Axel and Holm, Christian},
+  title = {A novel method for calculating electrostatic interactions in {2D} periodic slab geometries},
   journal = {Chemical Physics Letters},
   year = {2002},
   volume = {354},
+  number = {3--4},
   pages = {324--330},
   doi = {10.1016/S0009-2614(02)00131-8},
 }
 
-@ARTICLE{arnold02c,
-  author = {A. Arnold and J. de Joannis and C. Holm},
-  title = {Electrostatics in Periodic Slab Geometries {I}},
+@Article{arnold02c,
+  author = {Arnold, Axel and de Joannis, Jason and Holm, Christian},
+  title = {Electrostatics in Periodic Slab Geometries. {I}},
   journal = {The Journal of Chemical Physics},
   year = {2002},
   volume = {117},
@@ -73,28 +77,27 @@ doi = {10.1063/1.480156}
   doi = {10.1063/1.1491955},
 }
 
-@ARTICLE{arnold02d,
-  title = {Electrostatics in Periodic Slab Geometries {II}},
-  author = {A. Arnold and J. de Joannis and C. Holm},
+@Article{dejoannis02a,
+  author = {de Joannis, Jason and Arnold, Axel and Holm, Christian},
+  title = {Electrostatics in Periodic Slab Geometries. {II}},
   journal = {The Journal of Chemical Physics},
   year = {2002},
   volume = {117},
   pages = {2503--2512},
   doi = {10.1063/1.1491954},
 }
-
-@ARTICLE{arnold05a,
-  author = {A. Arnold and C. Holm},
-  title = {{MMM1D}: {A} method for calculating electrostatic interactions in one-dimensional periodic geometries},
-  journal = {The Journal of Chemical Physics},
-  year = {2005},
-  volume = {123},
-  pages = {144103},
-  doi = {10.1063/1.2052647},
-  number = {12}
+@Article{arnold05b,
+  author    = {Arnold, Axel and Holm, Christian},
+  title     = {{MMM1D}: {A} method for calculating electrostatic interactions in one-dimensional periodic geometries},
+  journal   = {The Journal of Chemical Physics},
+  year      = {2005},
+  volume    = {123},
+  number    = {12},
+  pages     = {144103},
+  doi       = {10.1063/1.2052647},
 }
 
-@INCOLLECTION{arnold13a,
+@InCollection{arnold13a,
   author = {A. Arnold and O. Lenz and S. Kesselheim and R. Weeber and F. Fahrenberger and D. R\"{o}hm and P. Ko\v{s}ovan and C. Holm},
   title = {{ESPResSo}~3.1 --- Molecular Dynamics Software for Coarse-Grained Models},
   booktitle = {Meshfree Methods for Partial Differential Equations {VI}},
@@ -107,7 +110,7 @@ doi = {10.1063/1.480156}
   doi = {10.1007/978-3-642-32979-1_1},
 }
 
-@ARTICLE{ballenegger09a,
+@Article{ballenegger09a,
   author = {V. Ballenegger and A. Arnold and J. J. Cerda},
   title = {Simulations of non-neutral slab systems with long-range electrostatic interactions in two-dimensional periodic boundary conditions},
   journal = {The Journal of Chemical Physics},
@@ -115,20 +118,19 @@ doi = {10.1063/1.480156}
   volume = {131},
   pages = {094107},
   number = {9},
-  eid = {094107},
   doi = {10.1063/1.3216473},
   numpages = {10},
   publisher = {AIP},
 }
 
 @Article{banchio03a,
-  author  = {Adolfo J. Banchio and John F. Brady},
-  title   = {Accelerated Stokesian dynamics: Brownian motion},
+  author  = {Banchio, Adolfo J. and Brady, John F.},
+  title   = {Accelerated {S}tokesian dynamics: {B}rownian motion},
   journal = {Journal of Chemical Physics},
   year    = {2003},
   volume  = {118},
   number  = {22},
-  pages   = {10323},
+  pages   = {10323--10332},
   doi     = {10.1063/1.1571819},
 }
 
@@ -146,7 +148,7 @@ doi = {10.1063/1.480156}
 
 @Article{bindgen21a,
   author = {Bindgen, Sebastian and Weik, Florian and Weeber, Rudolf and Koos, Erin and de Buyl, Pierre},
-  title = {Lees-Edwards boundary conditions for translation invariant shear flow: implementation and transport properties},
+  title = {{L}ees--{E}dwards boundary conditions for translation invariant shear flow: {I}mplementation and transport properties},
   journal = {Physics of Fluids},
   year = {2021},
   volume = {33},
@@ -156,8 +158,8 @@ doi = {10.1063/1.480156}
 }
 
 @Article{brady88a,
-  author  = {J. F. Brady and G. Bossis},
-  title   = {Stokesian Dynamics},
+  author  = {Brady, John F and Bossis, Georges},
+  title   = {{S}tokesian Dynamics},
   journal = {Annual Review of Fluid Mechanics},
   year    = {1988},
   volume  = {20},
@@ -165,18 +167,18 @@ doi = {10.1063/1.480156}
   doi     = {10.1146/annurev.fl.20.010188.000551},
 }
 
-@ARTICLE{brodka04a,
-  author = {Br\'{o}dka, A.},
+@Article{brodka04a,
+  author = {Br{\'o}dka, A.},
   title = {{E}wald summation method with electrostatic layer correction for interactions of point dipoles in slab geometry},
   journal = {Chemical Physics Letters},
   year = {2004},
   number = {1--3},
   volume = {400},
+  pages = {62--67},
   doi = {10.1016/j.cplett.2004.10.086},
-  pages = {62--67}
 }
 
-@article{brown95a,
+@Article{brown95a,
   title={A general pressure tensor calculation for molecular dynamics simulations},
   author={Brown, David and Neyertz, Sylvie},
   journal={Molecular Physics},
@@ -185,7 +187,7 @@ doi = {10.1063/1.480156}
   pages={577--595},
   year={1995},
   doi={10.1080/00268979500100371},
-  publisher={Taylor \&{} Francis}
+  publisher={Taylor \& Francis},
 }
 
 @InCollection{burtscher11a,
@@ -224,29 +226,29 @@ doi = {10.1016/B978-0-12-384988-5.00006-1},
   doi       = {10.1016/j.rinp.2019.102325},
 }
 
-@ARTICLE{cimrak12a,
+@Article{cimrak12a,
 author = {Cimr\'{a}k, I. and Gusenbauer, M. and Schrefl, T.},
 title = {Modelling and simulation of processes in microfluidic devices for biomedical applications},
-journal = {Computers \&{} Mathematics with Applications},
+journal = {Computers \& Mathematics with Applications},
 year = {2012},
-number = {3},
 volume = {64},
+number = {3},
+pages = {278--288},
 doi = {10.1016/j.camwa.2012.01.062},
-pages = {278--288}
 }
 
-@ARTICLE{cimrak14a,
+@Article{cimrak14a,
   author = {I. Cimr\'{a}k and M. Gusenbauer and I. Jan\v{c}igov\'{a}},
   title = {An {ESPResSo} implementation of elastic objects immersed in a fluid},
   journal = {Computer Physics Communications},
   year = {2014},
   volume = {185},
+  number = {3},
   pages = {900--907},
   doi = {10.1016/j.cpc.2013.12.013},
-  number = {3}
 }
 
-@article{crowl10a,
+@Article{crowl10a,
 author = {Crowl, Lindsay M. and Fogelson, Aaron L.},
 title = {Computational model of whole blood exhibiting lateral platelet motion induced by red blood cells},
 journal = {International Journal for Numerical Methods in Biomedical Engineering},
@@ -257,7 +259,7 @@ pages = {471--487},
 doi = {10.1002/cnm.1274},
 }
 
-@article{debuyl18a,
+@Article{debuyl18a,
   author = {de Buyl, Pierre},
   title = {{tidynamics}: {A} tiny package to compute the dynamics of stochastic and molecular simulations},
   journal = {Journal of Open Source Software},
@@ -268,7 +270,7 @@ doi = {10.1002/cnm.1274},
   doi = {10.21105/joss.00877},
 }
 
-@ARTICLE{degraaf16a,
+@Article{degraaf16a,
   author = {de Graaf, Joost and Menke, Henri and Mathijssen, Arnold J.T.M. and Fabritius, Marc and Holm, Christian and Shendruk, Tyler N.},
   title = {Lattice-{B}oltzmann Hydrodynamics of Anisotropic Active Matter},
   journal = {The Journal of Chemical Physics},
@@ -278,7 +280,7 @@ doi = {10.1002/cnm.1274},
   doi = {10.1063/1.4944962},
 }
 
-@PHDTHESIS{deserno00b,
+@PhdThesis{deserno00b,
   author = {Deserno, Markus},
   title = {Counterion condensation for rigid linear polyelectrolytes},
   school = {Universit\"{a}t Mainz},
@@ -288,7 +290,7 @@ doi = {10.1002/cnm.1274},
 }
 
 @InProceedings{deserno00e,
-  title = {How to mesh up {E}wald sums.},
+  title = {How to mesh up {E}wald sums},
   booktitle = {Molecular Dynamics on Parallel Computers},
   publisher = {World Scientific, Singapore},
   year = {2000},
@@ -298,7 +300,7 @@ doi = {10.1002/cnm.1274},
   doi = {10.1142/9789812793768_0023},
 }
 
-@ARTICLE{deserno98a,
+@Article{deserno98a,
   author = {Deserno, Markus and Holm, Christian},
   title = {How to mesh up {E}wald sums. {I.} {A} theoretical and numerical comparison of various particle mesh routines},
   journal = {The Journal of Chemical Physics},
@@ -308,7 +310,7 @@ doi = {10.1002/cnm.1274},
   doi = {10.1063/1.477414},
 }
 
-@ARTICLE{deserno98b,
+@Article{deserno98b,
   author = {Deserno, Markus and Holm, Christian},
   title = {How to mesh up {E}wald sums. {II.} {A}n accurate error estimate for the {P}article-{P}article-{P}article-{M}esh algorithm},
   journal = {The Journal of Chemical Physics},
@@ -319,26 +321,27 @@ doi = {10.1002/cnm.1274},
 }
 
 @Article{dhumieres09a,
-  title                    = {Viscosity independent numerical errors for lattice Boltzmann models: from recurrence equations to ``magic'' collision numbers},
-  author                   = {d'Humi\`{e}res, Dominique and Ginzburg, Irina},
-  journal                  = {Computers \&{} Mathematics with Applications},
+  title                    = {Viscosity independent numerical errors for {L}attice {B}oltzmann models: from recurrence equations to ``magic'' collision numbers},
+  author                   = {d'Humi{\`e}res, Dominique and Ginzburg, Irina},
+  journal                  = {Computers \& Mathematics with Applications},
   year                     = {2009},
   number                   = {5},
   pages                    = {823--840},
   volume                   = {58},
-  doi                      = {10.1016/j.camwa.2009.02.008}
+  doi                      = {10.1016/j.camwa.2009.02.008},
+  publisher                = {Elsevier},
 }
 
-@BOOK{doi86a,
-  title = {The Theory of Polymer Dynamics},
-  author = {Doi, Masao and Edwards, Samuel Frederick},
-  publisher = {Clarendon Press: Oxford},
-  year = {1986},
-  isbn = {9780198519768},
+@Book{doi86a,
+  title                    = {The Theory of Polymer Dynamics},
+  author                   = {Doi, Masao and Edwards, Samuel Frederick},
+  publisher                = {Clarendon Press: Oxford},
+  year                     = {1986},
+  isbn                     = {9780198519768},
 }
 
 @Article{dunweg07a,
-  author    = {D\"{u}nweg, Burkhard and Schiller, Ulf D. and Ladd, Anthony J. C.},
+  author    = {D{\"u}nweg, Burkhard and Schiller, Ulf D. and Ladd, Anthony J. C.},
   title     = {Statistical mechanics of the fluctuating lattice {B}oltzmann equation},
   journal   = {Physical Review E},
   year      = {2007},
@@ -362,7 +365,7 @@ doi = {10.1002/cnm.1274},
   isbn      = {978-3-540-87706-6},
 }
 
-@ARTICLE{dupin07a,
+@Article{dupin07a,
   author = {Dupin, Michael M. and Halliday, Ian and Care, Chris M. and Alboul, Lyuba and Munn, Lance L.},
   title = {Modeling the flow of dense suspensions of deformable particles in three dimensions},
   journal = {Physical Review E},
@@ -395,9 +398,9 @@ doi = {10.1080/10618560802238242},
   doi     = {10.1017/S002211208700171X},
 }
 
-@article{ermak78a,
-  title={Brownian dynamics with hydrodynamic interactions},
-  author={Ermak, Donald L and McCammon, J Andrew},
+@Article{ermak78a,
+  title={{B}rownian dynamics with hydrodynamic interactions},
+  author={Ermak, Donald L. and McCammon, J. A.},
   journal={The Journal of Chemical Physics},
   volume={69},
   number={4},
@@ -407,7 +410,7 @@ doi = {10.1080/10618560802238242},
   doi={10.1063/1.436761},
 }
 
-@article{essmann95a,
+@Article{essmann95a,
   title={A smooth particle mesh {E}wald method},
   author={Essmann, Ulrich and Perera, Lalith and Berkowitz, Max L. and Darden, Tom and Lee, Hsing and Pedersen, Lee G.},
   journal={The Journal of Chemical Physics},
@@ -431,7 +434,7 @@ doi = {10.1080/10618560802238242},
   publisher = {American Physical Society},
 }
 
-@ARTICLE{ewald21a,
+@Article{ewald21a,
   author = {Ewald, P. P.},
   title = {Die {B}erechnung optischer und elektrostatischer {G}itterpotentiale},
   journal = {Annalen der Physik},
@@ -444,13 +447,15 @@ doi = {10.1080/10618560802238242},
 
 @Book{frenkel02b,
   author     = {Frenkel, Daan and Smit, Berend},
-  title      = {Understanding molecular simulation: {F}rom algorithms to applications},
+  title      = {Understanding Molecular Simulation: {F}rom Algorithms to Applications},
   year       = {2002},
   edition    = {2nd},
   publisher  = {Academic Press},
   isbn       = {978-0-12-267351-1},
   doi        = {10.1016/B978-0-12-267351-1.X5000-7},
   address    = {San Diego},
+  volume     = {1},
+  series     = {Computational Science},
 }
 
 @Article{gay81a,
@@ -465,17 +470,17 @@ doi = {10.1080/10618560802238242},
 }
 
 @Article{gompper96a,
-author={Gompper, G. and Kroll, D. M.},
-journal={Journal de Physique I France},
-number={10},
-pages={1305--1320},
-title={Random surface discretizations and the renormalization of the bending rigidity},
-volume={6},
-year={1996},
-doi={10.1051/jp1:1996246},
+  author    = {Gompper, G. and Kroll, D. M.},
+  title     = {Random Surface Discretizations and the Renormalization of the Bending Rigidity},
+  journal   = {Journal de Physique I France},
+  year      = {1996},
+  volume    = {6},
+  number    = {10},
+  pages     = {1305--1320},
+  doi       = {10.1051/jp1:1996246},
 }
 
-@article{guckenberger17a,
+@Article{guckenberger17a,
 author = {Achim Guckenberger and Stephan Gekle},
 title = {Theory and Algorithms to Compute {H}elfrich Bending Forces: {A} Review},
 journal = {Journal of Physics: Condensed Matter},
@@ -497,14 +502,14 @@ pages = {203001},
   doi                      = {10.1103/PhysRevE.65.046308},
 }
 
-@ARTICLE{hickey10a,
+@Article{hickey10a,
   author = {Hickey, Owen A. and Holm, Christian and Harden, James L. and Slater, Gary W.},
   title = {Implicit Method for Simulating Electrohydrodynamics of Polyelectrolytes},
   journal = {Physical Review Letters},
   year = {2010},
   volume = {105},
   number = {14},
-  doi = {10.1103/PhysRevLett.105.148301}
+  doi = {10.1103/PhysRevLett.105.148301},
 }
 
 @Book{hockney88a,
@@ -513,24 +518,27 @@ pages = {203001},
   publisher = {CRC Press},
   year      = {1988},
   isbn      = {9780852743928},
+  url       = {https://www.routledge.com/Computer-Simulation-Using-Particles/Hockney-Eastwood/p/book/9780852743928},
 }
 
 @Article{hofling11a,
   title = {Anomalous transport resolved in space and time by fluorescence correlation spectroscopy},
-  author = {Felix H\"{o}fling and Karl-Ulrich Bamberg and Thomas Franosch},
+  author = {H{\"{o}}fling, Felix and Bamberg, Karl-Ulrich and Franosch, Thomas},
   journal = {Soft Matter},
   year = {2011},
-  pages = {1358},
   volume = {7},
+  number  = {4},
+  pages   = {1358--1363},
   doi = {10.1039/C0SM00718H},
 }
 
-@ARTICLE{humphrey96a,
-  author = {W. Humphrey and A. Dalke and K. Schulten},
+@Article{humphrey96a,
+  author = {Humphrey, William and Dalke, Andrew and Schulten, Klaus},
   title = {{VMD}: Visual Molecular Dynamics},
   journal = {Journal of Molecular Graphics},
   year = {1996},
   volume = {14},
+  number = {1},
   pages = {33--38},
   doi = {10.1016/0263-7855(96)00018-5},
 }
@@ -546,8 +554,8 @@ year = {2016},
 doi = {10.1002/cnm.2757},
 }
 
-@ARTICLE{kesselheim11a,
-  author = {Stefan Kesselheim and Marcello Sega and Christian Holm},
+@Article{kesselheim11a,
+  author = {Kesselheim, Stefan and Sega, Marcello and Holm, Christian},
   title = {Applying {ICC}* to {DNA} translocation. {E}ffect of dielectric boundaries},
   journal = {Computer Physics Communications},
   year = {2011},
@@ -558,7 +566,7 @@ doi = {10.1002/cnm.2757},
   issn = {0010-4655},
 }
 
-@ARTICLE{kolafa92a,
+@Article{kolafa92a,
   author = {Kolafa, Jiri and Perram, John W.},
   title = {Cutoff Errors in the {E}wald Summation Formulae for Point Charge Systems},
   journal = {Molecular Simulation},
@@ -569,7 +577,7 @@ doi = {10.1002/cnm.2757},
   doi = {10.1080/08927029208049126},
 }
 
-@ARTICLE{kolb99a,
+@Article{kolb99a,
   author = {A. Kolb and B. D\"{u}nweg},
   title = {Optimized constant pressure stochastic dynamics},
   journal = {The Journal of Chemical Physics},
@@ -580,7 +588,7 @@ doi = {10.1002/cnm.2757},
   doi = {10.1063/1.479208},
 }
 
-@PHDTHESIS{kruger11a,
+@PhdThesis{kruger11a,
 author = {Kr\"{u}ger, Timm},
 title = {Computer simulation study of collective phenomena in dense suspensions of red blood cells under shear},
 school = {Universit\"{a}t Bochum},
@@ -598,13 +606,13 @@ doi={10.1007/978-3-8348-2376-2},
 }
 
 @Book{kruger17a,
-author={Kr{\"u}ger, Timm and Kusumaatmaja, Halim and Kuzmin, Alexandr and Shardt, Orest and Silva, Goncalo and Viggen, Erlend Magnus},
-title={The Lattice Boltzmann Method},
-subtitle={Principles and Practice},
-year={2017},
-publisher={Springer International Publishing},
-isbn={978-3-319-44649-3},
-doi={10.1007/978-3-319-44649-3},
+  author    = {Kr{\"u}ger, Timm and Kusumaatmaja, Halim and Kuzmin, Alexandr and Shardt, Orest and Silva, Goncalo and Viggen, Erlend Magnus},
+  title     = {The Lattice {B}oltzmann Method: Principles and Practice},
+  year      = {2017},
+  publisher = {Springer International Publishing},
+  isbn      = {978-3-319-44649-3},
+  doi       = {10.1007/978-3-319-44649-3},
+  address   = {Cham},
 }
 
 @Book{kundu01a,
@@ -614,6 +622,7 @@ year      = {2001},
 edition   = {2nd},
 publisher = {Elsevier Science},
 isbn      = {9780080545585},
+doi       = {10.1016/C2009-0-20716-1},
 }
 
 @Article{ladd01a,
@@ -638,14 +647,14 @@ isbn      = {9780080545585},
 }
 
 @Article{landsgesell17b,
-title                      = {Simulation of weak polyelectrolytes: {A} comparison between the constant p{H} and the reaction ensemble method},
+title                      = {Simulation of weak polyelectrolytes: {A} comparison between the constant {pH} and the reaction ensemble method},
 author                     = {Landsgesell, Jonas and Holm, Christian and Smiatek, Jens},
 journal                    = {European Physical Journal Special Topics},
 year                       = {2017},
 volume                     = {226},
 number                     = {4},
 pages                      = {725--736},
-doi                        = {10.1140/epjst/e2016-60324-3}
+doi                        = {10.1140/epjst/e2016-60324-3},
 }
 
 @Article{lees72a,
@@ -658,7 +667,7 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   doi       = {10.1088/0022-3719/5/15/006},
 }
 
-@ARTICLE{limbach06a,
+@Article{limbach06a,
   author = {H. J. Limbach and A. Arnold and B. A. Mann and C. Holm},
   title = {{ESPResSo} -- An Extensible Simulation Package for Research on Soft Matter Systems},
   journal = {Computer Physics Communications},
@@ -669,19 +678,18 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   doi = {10.1016/j.cpc.2005.10.005},
 }
 
-@ARTICLE{magatti01a,
-  author = {Magatti, D and Ferri, F},
-  title = {Fast multi-tau real-time software correlator for dynamic light scattering},
-  journal = {Applied Optics},
-  year = {2001},
-  volume = {40},
-  pages = {4011--4021},
-  number = {24},
-  doi = {10.1364/AO.40.004011},
-  issn = {0003-6935},
+@Article{magatti01a,
+  author    = {Magatti, Davide and Ferri, Fabio},
+  title     = {Fast multi-tau real-time software correlator for dynamic light scattering},
+  journal   = {Applied Optics},
+  year      = {2001},
+  volume    = {40},
+  number    = {24},
+  pages     = {4011--4021},
+  doi       = {10.1364/ao.40.004011},
 }
 
-@article{martys99a,
+@Article{martys99a,
   title = {Velocity {V}erlet algorithm for dissipative-particle-dynamics-based models of suspensions},
   author = {Martys, Nicos S. and Mountain, Raymond D.},
   journal = {Physical Review E},
@@ -692,7 +700,7 @@ doi                        = {10.1140/epjst/e2016-60324-3}
   doi = {10.1103/PhysRevE.59.3733},
 }
 
-@book{moshier89a,
+@Book{moshier89a,
   title={Methods and Programs for Mathematical Functions},
   author={Moshier, Stephen Lloyd Baluk},
   isbn={9780470216095},
@@ -702,14 +710,14 @@ doi                        = {10.1140/epjst/e2016-60324-3}
 }
 
 @Article{moss96a,
-author={Moss, G. P.},
-journal={Pure and Applied Chemistry},
-number={12},
-pages={2193--2222},
-title={Basic terminology of stereochemistry},
-volume={68},
-year={1996},
-doi={10.1351/pac199668122193},
+  author    = {Moss, G. P.},
+  title     = {Basic terminology of stereochemistry},
+  journal   = {Pure and Applied Chemistry},
+  year      = {1996},
+  volume    = {68},
+  number    = {12},
+  pages     = {2193-2222},
+  doi       = {10.1351/pac199668122193},
 }
 
 @Article{neumann85b,
@@ -723,7 +731,7 @@ year = {1985},
 doi = {10.1063/1.448553},
 }
 
-@article{omelyan98a,
+@Article{omelyan98a,
 author = {Omelyan, Igor P.},
 title = {On the numerical integration of motion for rigid polyatomics: The modified quaternion approach},
 journal = {Computers in Physics},
@@ -734,18 +742,17 @@ year = {1998},
 doi = {10.1063/1.168642},
 }
 
-@article{panneton06a,
+@Article{panneton06a,
 author = {Panneton, Fran\c{c}ois and L'Ecuyer, Pierre and Matsumoto, Makoto},
 title = {Improved long-period generators based on linear recurrences modulo 2},
+journal = {{ACM} Transactions on Mathematical Software},
 year = {2006},
 publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
 volume = {32},
 number = {1},
-issn = {0098-3500},
-doi = {10.1145/1132973.1132974},
-journal = {ACM Transactions on Mathematical Software (TOMS)},
 pages = {1--16},
+doi = {10.1145/1132973.1132974},
 }
 
 @Article{peskin02a,
@@ -754,8 +761,8 @@ title = {The immersed boundary method},
 journal = {Acta Numerica},
 year = {2002},
 volume = {11},
+pages = {479--517},
 doi = {10.1017/S0962492902000077},
-pages = {479--517}
 }
 
 @Article{plimpton95a,
@@ -770,14 +777,15 @@ pages = {479--517}
   publisher={Elsevier}
 }
 
-@ARTICLE{polyakov13a,
+@Article{polyakov13a,
 author = {Polyakov, A. Yu. and Lyutyy, T. V. and Denisov, S. and Reva, V. V. and H\"{a}nggi, P.},
 title = {Large-scale ferrofluid simulations on graphics processing units},
 journal = {Computer Physics Communications},
 year = {2013},
 volume = {184},
+number = {6},
+pages = {1483--1489},
 doi = {10.1016/j.cpc.2013.01.016},
-pages = {1483--1489}
 }
 
 @Book{pottier10a,
@@ -791,19 +799,18 @@ pages = {1483--1489}
   url={https://global.oup.com/academic/product/nonequilibrium-statistical-physics-9780199556885},
 }
 
-@ARTICLE{ramirez10a,
-  author = {Ramirez, Jorge and Sukumaran, Sathish K. and Vorselaars, Bart and Likhtman, Alexei E.},
+@Article{ramirez10a,
+  author = {Ram{\'i}rez, Jorge and Sukumaran, Sathish K. and Vorselaars, Bart and Likhtman, Alexei E.},
   title = {Efficient on the fly calculation of time correlation functions in computer simulations},
   journal = {The Journal of Chemical Physics},
   year = {2010},
   volume = {133},
-  pages = {154103},
   number = {15},
+  pages = {154103},
   doi = {10.1063/1.3491098},
-  issn = {0021-9606},
 }
 
-@book{rapaport04a,
+@Book{rapaport04a,
  author = {Rapaport, D. C.},
  title = {The Art of Molecular Dynamics Simulation},
  year = {2004},
@@ -814,7 +821,7 @@ pages = {1483--1489}
  address = {New York, NY, USA},
 }
 
-@article{reed92a,
+@Article{reed92a,
   title={{M}onte {C}arlo study of titration of linear polyelectrolytes},
   author={Reed, Christopher E and Reed, Wayne F},
   journal={The Journal of Chemical Physics},
@@ -832,11 +839,12 @@ pages = {1483--1489}
   journal = {European Physical Journal Special Topics},
   year = {2012},
   volume = {210},
-  doi = {10.1140/epjst/e2012-01639-6},
+  number = {1},
   pages = {89--100},
+  doi = {10.1140/epjst/e2012-01639-6},
 }
 
-@BOOK{rubinstein03a,
+@Book{rubinstein03a,
   title = {Polymer Physics},
   publisher = {Oxford University Press},
   year = {2003},
@@ -844,19 +852,18 @@ pages = {1483--1489}
   address = {Oxford, UK},
 }
 
-@ARTICLE{schatzel88a,
-  author = {Sch\"{a}tzel, K. and Drewel, M. and Stimac, S},
-  title = {Photon Correlation Measurements at Large Lag Times: Improving Statistical Accuracy},
+@Article{schatzel88a,
+  author = {Sch\"{a}tzel, Klaus and Drewel, Martin and Stimac, Sven},
+  title = {Photon correlation Measurements at Large Lag Times: Improving Statistical Accuracy},
   journal = {Journal of Modern Optics},
   year = {1988},
   volume = {35},
-  pages = {711--718},
   number = {4},
+  pages = {711--718},
   doi = {10.1080/09500348814550731},
-  issn = {0950-0340},
 }
 
-@book{schlick10a,
+@Book{schlick10a,
 address = {New York, NY},
 author = {Schlick, Tamar},
 doi = {10.1007/978-1-4419-6351-2},
@@ -868,8 +875,8 @@ volume = {21},
 year = {2010},
 }
 
-@ARTICLE{smith81a,
-  author = {E. R. Smith},
+@Article{smith81a,
+  author = {Smith, E. R.},
   title = {Electrostatic energy in ionic crystals},
   journal = {Proceedings of the Royal Society of London A: Mathematical and Physical Sciences},
   year = {1981},
@@ -878,7 +885,7 @@ year = {2010},
   doi = {10.1098/rspa.1981.0064},
 }
 
-@article{smith94c,
+@Article{smith94c,
   title={The reaction ensemble method for the computer simulation of chemical and phase equilibria. {I.} {T}heory and basic examples},
   author={Smith, W. R. and Triska, B.},
   journal={The Journal of Chemical Physics},
@@ -890,8 +897,8 @@ year = {2010},
   publisher={AIP Publishing}
 }
 
-@ARTICLE{soddemann01a,
-  author = {T. Soddemann and B. D\"{u}nweg and K. Kremer},
+@Article{soddemann01a,
+  author = {Soddemann, T. and D{\"u}nweg, B. and Kremer, K.},
   title = {A generic computer model for amphiphilic systems},
   journal = {European Physical Journal E},
   year = {2001},
@@ -900,15 +907,15 @@ year = {2010},
   pages = {409--419}
 }
 
-@ARTICLE{soddemann03a,
+@Article{soddemann03a,
   author = {Soddemann, T. and D\"{u}nweg, B. and Kremer, K.},
   title = {Dissipative particle dynamics: A useful thermostat for equilibrium and nonequilibrium molecular dynamics simulations},
   journal = {Physical Review E},
   year = {2003},
   volume = {68},
   number = {4},
+  pages = {046702},
   doi = {10.1103/PhysRevE.68.046702},
-  pages = {046702}
 }
 
 @Article{sonnenschein85a,
@@ -922,8 +929,8 @@ year = {1985},
 doi = {10.1016/0021-9991(85)90151-2},
 }
 
-@PHDTHESIS{strebel99a,
-  author = {R. Strebel},
+@PhdThesis{strebel99a,
+  author = {Strebel, R.},
   title = {Pieces of software for the {C}oulombic m body problem},
   school = {ETH Z\"{u}rich},
   year = {1999},
@@ -933,22 +940,25 @@ doi = {10.1016/0021-9991(85)90151-2},
   doi = {10.3929/ethz-a-003856704}
 }
 
-@BOOK{succi01a,
+@Book{succi01a,
+  author = {Succi, Sauro},
   title = {The lattice {B}oltzmann equation for fluid dynamics and beyond},
-  publisher = {Oxford University Press, USA},
+  publisher = {Oxford University Press},
   year = {2001},
-  author = {Succi, S.},
+  isbn = {9780198503989},
+  url = {https://global.oup.com/academic/product/the-lattice-boltzmann-equation-9780198503989},
+  address = {New York, USA},
 }
 
 @Article{swope92a,
-author = {Swope, William C. and Ferguson, David M.},
-title = {Alternative expressions for energies and forces due to angle bending and torsional energy},
-journal = {Journal of Computational Chemistry},
-volume = {13},
-number = {5},
-pages = {585--594},
-year = {1992},
-doi = {10.1002/jcc.540130508},
+  author    = {Swope, William C. and Ferguson, David M.},
+  title     = {Alternative expressions for energies and forces due to angle bending and torsional energy},
+  journal   = {Journal of Computational Chemistry},
+  year      = {1992},
+  volume    = {13},
+  number    = {5},
+  pages     = {585--594},
+  doi       = {10.1002/jcc.540130508},
 }
 
 @Article{thole81a,
@@ -962,15 +972,15 @@ doi = {10.1002/jcc.540130508},
   doi       = {10.1016/0301-0104(81)85176-2},
 }
 
-@ARTICLE{thompson09a,
-  author = {Thompson, A. P. and Plimpton, S. J. and Mattson, W.},
+@Article{thompson09a,
+  author = {Thompson, Aidan P. and Plimpton, Steven J. and Mattson, William},
   title = {General formulation of pressure and stress tensor for arbitrary many-body interaction potentials under periodic boundary conditions},
   journal = {The Journal of Chemical Physics},
   year = {2009},
   volume = {131},
   number = {15},
-  doi = {10.1063/1.3245303},
   pages = {154107},
+  doi = {10.1063/1.3245303},
 }
 
 @Article{tironi95a,
@@ -984,45 +994,47 @@ doi = {10.1002/jcc.540130508},
   doi       = {10.1063/1.469273},
 }
 
-@article{turner08a,
+@Article{turner08a,
   title={Simulation of chemical reaction equilibria by the reaction ensemble {M}onte {C}arlo method: {A} review},
-  author={Heath Turner, C. and Brennan, John K. and L\'{i}sal, Martin and Smith, William R. and Karl Johnson, J. and Gubbins, Keith E.},
+  author={Turner, C. Heath and Brennan, John K. and L{\'i}sal, Martin and Smith, William R. and Johnson, J. Karl and Gubbins, Keith E.},
   journal={Molecular Simulation},
   volume={34},
   number={2},
   pages={119--146},
   year={2008},
   doi={10.1080/08927020801986564},
-  publisher={Taylor \&{} Francis Group}
+  publisher={Taylor \& Francis Group}
 }
 
-@ARTICLE{tyagi07a,
-  author = {S. Tyagi and A. Arnold and C. Holm},
+@Article{tyagi07a,
+  author = {Tyagi, Sandeep and Arnold, Axel and Holm, Christian},
   title = {{ICMMM2D}: An accurate method to include planar dielectric interfaces via image charge summation},
   journal = {The Journal of Chemical Physics},
   year = {2007},
   volume = {127},
+  number = {15},
+  pages = {154723},
   doi = {10.1063/1.2790428},
-  pages = {154723}
 }
 
-@ARTICLE{tyagi08a,
+@Article{tyagi08a,
   author = {Sandeep Tyagi and Axel Arnold and Christian Holm},
-  title = {Electrostatic layer correction with image charges: A linear scaling method to treat slab 2{D} + h systems with dielectric interfaces},
+  title = {Electrostatic layer correction with image charges: {A} linear scaling method to treat slab 2{D} + h systems with dielectric interfaces},
   journal = {The Journal of Chemical Physics},
   year = {2008},
   volume = {129},
+  number = {20},
   pages = {204102},
   doi = {10.1063/1.3021064},
-  number = {20}
 }
 
-@ARTICLE{tyagi10a,
-  author = {Tyagi, Sandeep and S\"{u}zen, Mehmet and Sega, Marcello and Barbosa, Marcia C. and Kantorovich, Sofia S. and Holm, Christian},
+@Article{tyagi10a,
+  author = {Tyagi, Sandeep and S{\"u}zen, Mehmet and Sega, Marcello and Barbosa, Marcia C. and Kantorovich, Sofia S. and Holm, Christian},
   title = {An iterative, fast, linear-scaling method for computing induced charges on arbitrary dielectric boundaries},
   journal = {The Journal of Chemical Physics},
   year = {2010},
   volume = {132},
+  number = {15},
   pages = {154112},
   doi = {10.1063/1.3376011},
 }
@@ -1037,12 +1049,13 @@ doi = {10.1002/jcc.540130508},
   doi                      = {10.1063/1.1854151},
 }
 
-@article{wagner02a,
+@Article{wagner02a,
   author = {Wagner, Alexander J. and Pagonabarraga, Ignacio},
   title = {{L}ees--{E}dwards boundary conditions for lattice {B}oltzmann},
   journal = {Journal of Statistical Physics},
   year = {2002},
   volume = {107},
+  number = {112},
   pages = {521--537},
   doi = {10.1023/A:1014595628808}
 }
@@ -1068,7 +1081,7 @@ doi = {10.1002/jcc.540130508},
   doi       = {10.1140/epjst/e2019-800186-9},
 }
 
-@article{yaghoubi15a,
+@Article{yaghoubi15a,
   title={New modified weight function for the dissipative force in the {DPD} method to increase the {S}chmidt number},
   author={Yaghoubi, S. and Shirani, E. and Pishevar, A. R. and Afshar, Y.},
   journal={EPL (Europhysics Letters)},
@@ -1085,16 +1098,16 @@ doi = {10.1002/jcc.540130508},
   author                   = {Yeh, In-Chul and Berkowitz, Max L.},
   journal                  = {Journal of Chemical Physics},
   year                     = {1999},
+  volume                   = {111},
   number                   = {7},
   pages                    = {3155--3162},
-  volume                   = {111},
   doi                      = {10.1063/1.479595},
 }
 
 @InProceedings{zhang01b,
 author={Zhang, Cha and Chen, Tsuhan},
 booktitle={Proceedings 2001 International Conference on Image Processing (Cat. No.01CH37205)},
-title={Efficient feature extraction for {2D/3D} objects in mesh representation},
+title={Efficient feature extraction for {2D}/{3D} objects in mesh representation},
 year={2001},
 volume={3},
 pages={935--938},

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -158,7 +158,7 @@
 }
 
 @Article{brady88a,
-  author  = {Brady, John F and Bossis, Georges},
+  author  = {Brady, John F. and Bossis, Georges},
   title   = {{S}tokesian Dynamics},
   journal = {Annual Review of Fluid Mechanics},
   year    = {1988},
@@ -716,7 +716,7 @@ doi                        = {10.1140/epjst/e2016-60324-3},
   year      = {1996},
   volume    = {68},
   number    = {12},
-  pages     = {2193-2222},
+  pages     = {2193--2222},
   doi       = {10.1351/pac199668122193},
 }
 
@@ -854,7 +854,7 @@ doi = {10.1016/j.cpc.2013.01.016},
 
 @Article{schatzel88a,
   author = {Sch\"{a}tzel, Klaus and Drewel, Martin and Stimac, Sven},
-  title = {Photon correlation Measurements at Large Lag Times: Improving Statistical Accuracy},
+  title = {Photon Correlation Measurements at Large Lag Times: Improving Statistical Accuracy},
   journal = {Journal of Modern Optics},
   year = {1988},
   volume = {35},

--- a/doc/sphinx/appendix.rst
+++ b/doc/sphinx/appendix.rst
@@ -292,7 +292,7 @@ In pseudo code, the far formula algorithm looks like:
          :math:`\xi^{(+,s/c,s/c)}_j\Xi^{(l,s/c,s/c)}_s` and
          :math:`\xi^{(-,s/c,s/c)}_j\Xi^{(h,s/c,s/c)}_s`
 
-For further details, see :cite:`arnold02a,arnold02b,arnold02c,arnold02d`.
+For further details, see :cite:`arnold02a,arnold02b,arnold02c,dejoannis02a`.
 
 .. _Dielectric contrast:
 
@@ -366,7 +366,7 @@ neither the near nor far formula allow a product decomposition or
 similar tricks. MMM1D has to be implemented as a simple NxN loop.
 However, the formulas can be evaluated efficiently, so that MMM1D can
 still be used reasonably for up to 400 particles on a single processor
-:cite:`arnold05a`.
+:cite:`arnold05b`.
 
 .. _ELC theory:
 
@@ -467,7 +467,7 @@ Ewald methods, for which decreasing the error bound can lead to
 excessive computation time. For example, P3M cannot reach a precision
 beyond :math:`10^{-5}` in general. The precise form of the error
 estimates is of little importance here, for details see
-:cite:`arnold02c,arnold02d`.
+:cite:`arnold02c,dejoannis02a`.
 
 One important aspect is that the error estimates are also exponential in
 the non-periodic coordinate. Since the number of close by and far away

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -270,16 +270,16 @@ systems. It can account for different dielectric jumps on both sides of the
 non-periodic direction. In more detail, it is a special procedure that
 converts a 3D electrostatic method to a 2D method in computational order N.
 The periodicity has to be set to ``(True, True, True)``. *ELC* cancels the electrostatic
-contribution of the periodic replica in **z-direction**. Make sure that you
+contribution of the periodic replica in :math:`z`-direction. Make sure that you
 read the papers on *ELC* (:cite:`arnold02c,dejoannis02a,tyagi08a`) before using it.
 See :ref:`ELC theory` for more details.
 
 Usage notes:
 
-* The non-periodic direction is always the **z-direction**.
+* The non-periodic direction is always the :math:`z`-direction.
 
 * The method relies on a slab of the simulation box perpendicular to the
-  z-direction not to contain particles. The size in z-direction of this slab
+  :math:`z`-direction not to contain particles. The size in :math:`z`-direction of this slab
   is controlled by the ``gap_size`` parameter. The user has to ensure that
   no particles enter this region by means of constraints or by fixing the
   particles' z-coordinate. When particles enter the slab of the specified

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -271,7 +271,7 @@ non-periodic direction. In more detail, it is a special procedure that
 converts a 3D electrostatic method to a 2D method in computational order N.
 The periodicity has to be set to ``(True, True, True)``. *ELC* cancels the electrostatic
 contribution of the periodic replica in **z-direction**. Make sure that you
-read the papers on ELC (:cite:`arnold02c,arnold02d,tyagi08a`) before using it.
+read the papers on *ELC* (:cite:`arnold02c,dejoannis02a,tyagi08a`) before using it.
 See :ref:`ELC theory` for more details.
 
 Usage notes:
@@ -340,7 +340,7 @@ MMM1D
     Required features: ``ELECTROSTATICS`` for MMM1D, the GPU version
     additionally needs the features ``CUDA`` and ``MMM1D_GPU``.
 
-Please cite :cite:`arnold05a` when using MMM1D. See :ref:`MMM1D theory` for
+Please cite :cite:`arnold05b` when using MMM1D. See :ref:`MMM1D theory` for
 the details.
 
 MMM1D is used with::

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -67,7 +67,7 @@ Coulomb P3M
 For this feature to work, you need to have the ``fftw3`` library
 installed on your system. In |es|, you can check if it is compiled in by
 checking for the feature ``FFTW`` with ``espressomd.features``.
-P3M requires full periodicity (1 1 1). When using a non-metallic dielectric
+P3M requires full periodicity ``(True, True, True)``. When using a non-metallic dielectric
 constant (``epsilon != 0.0``), the box must be cubic.
 Make sure that you know the relevance of the P3M parameters before using P3M!
 If you are not sure, read the following references:
@@ -269,7 +269,7 @@ Electrostatic Layer Correction (ELC)
 systems. It can account for different dielectric jumps on both sides of the
 non-periodic direction. In more detail, it is a special procedure that
 converts a 3D electrostatic method to a 2D method in computational order N.
-The periodicity has to be set to (1 1 1). *ELC* cancels the electrostatic
+The periodicity has to be set to ``(True, True, True)``. *ELC* cancels the electrostatic
 contribution of the periodic replica in **z-direction**. Make sure that you
 read the papers on ELC (:cite:`arnold02c,arnold02d,tyagi08a`) before using it.
 See :ref:`ELC theory` for more details.

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -334,7 +334,7 @@ lines below (optional steps which modify the build process are commented out):
     cd build
     cmake ..
     #ccmake . // in order to add/remove features like ScaFaCoS or CUDA
-    make -j
+    make -j$(nproc)
 
 This will build |es| with a default feature set, namely
 :file:`src/config/myconfig-default.hpp`. This file is a C++ header file,
@@ -389,13 +389,19 @@ This chapter describes the features that can be activated in |es|. Even if
 possible, it is not recommended to activate all features, because this
 will negatively affect |es|'s performance.
 
-Features can be activated in the configuration header :file:`myconfig.hpp`
+Most features can be activated in the configuration header :file:`myconfig.hpp`
 (see section :ref:`myconfig.hpp\: Activating and deactivating features`).
 To activate ``FEATURE``, add the following line to the header file:
 
 .. code-block:: c++
 
     #define FEATURE
+
+Some features cannot be manually enabled; they are instead automatically
+enabled when a specific list of dependent features are enabled. For example,
+``DIPOLAR_DIRECT_SUM`` is automatically enabled when ``DIPOLES``, ``ROTATION``
+and ``CUDA`` are enabled. Please note that ``CUDA`` is an external feature
+and can only be enabled via a CMake option (see :ref:`External features`).
 
 
 .. _General features:
@@ -449,15 +455,17 @@ General features
 
    .. seealso:: :attr:`espressomd.particle_data.ParticleHandle.mass`
 
--  ``EXCLUSIONS`` Allows to exclude any two particles
+-  ``EXCLUSIONS`` Allows particle pairs to be excluded from non-bonded interaction calculations.
 
    .. seealso:: :meth:`espressomd.particle_data.ParticleHandle.add_exclusion`
 
 -  ``BOND_CONSTRAINT`` Turns on the RATTLE integrator which allows for fixed lengths bonds
    between particles.
 
--  ``VIRTUAL_SITES`` Allows to set particles wthout meaningful mass, whose position is generally fixed in the simula
-   box or fixed to other particles.
+-  ``VIRTUAL_SITES`` Allows the creation of pseudo-particles whose forces,
+   torques and orientations can be transferred to real particle.
+   They don't have a meaningful mass, and their position is generally
+   fixed in the simulation box or fixed to other particles.
 
 -  ``VIRTUAL_SITES_INERTIALESS_TRACERS`` Allows to use virtual sites as tracers by advecting them with a LB fluid 
 
@@ -473,13 +481,13 @@ General features
 In addition, there are switches that enable additional features in the
 integrator or thermostat:
 
--  ``NPT`` Enables an on-the-fly NpT integration scheme.
+-  ``NPT`` Enables the NpT integration scheme.
 
    .. seealso:: :ref:`Isotropic NpT thermostat`
 
--  ``ENGINE`` Allows to set swimming parameters for active particles
+-  ``ENGINE`` Activates swimming parameters for active particles (self-propelled particles)
 
--  ``PARTICLE_ANISOTROPY`` Allows to incorporate the non-sphericity in particles 
+-  ``PARTICLE_ANISOTROPY`` Allows the use of non-isotropic friction coefficients in thermostats.
 
 .. _Fluid dynamics and fluid structure interaction:
 
@@ -490,18 +498,18 @@ Fluid dynamics and fluid structure interaction
 
    .. seealso:: :ref:`DPD interaction`
 
--  ``LB_BOUNDARIES``
+-  ``LB_BOUNDARIES`` Enables the construction of LB boundaries from shape-based constraints on the CPU.
 
--  ``LB_BOUNDARIES_GPU``
+-  ``LB_BOUNDARIES_GPU`` Enables the construction of LB boundaries from shape-based constraints on the GPU.
 
 -  ``LB_ELECTROHYDRODYNAMICS`` Enables the implicit calculation of electro-hydrodynamics for charged
    particles and salt ions in an electric field.
 
--  ``ELECTROKINETICS``
+-  ``ELECTROKINETICS`` Enables the description of chemical species advected by a LB fluid on the GPU.
 
--  ``EK_BOUNDARIES``
+-  ``EK_BOUNDARIES`` Enables the construction of electrokinetic boundaries from shape-based constraints on the GPU.
 
--  ``EK_DEBUG``
+-  ``EK_DEBUG`` Enables additional checks in electrokinetic simulations.
 
 
 .. _Interaction features:
@@ -708,7 +716,7 @@ are ever modified by the build process.
 
     cd build
     cmake ..
-    make -j
+    make -j$(nproc)
 
 Afterwards |es| can be run by calling ``./pypresso`` from the command line.
 
@@ -960,7 +968,7 @@ assertions. This is achieved by updating the CMake project and rebuilding
 .. code-block:: bash
 
     cmake . -D CMAKE_BUILD_TYPE=RelWithAssert
-    make -j
+    make -j$(nproc)
 
 The resulting build will run slightly slower, but will produce an error
 message for common issues, such as divisions by zero, array access out
@@ -972,7 +980,7 @@ instrumentation:
 .. code-block:: bash
 
     cmake . -D CMAKE_BUILD_TYPE=Debug
-    make -j
+    make -j$(nproc)
 
 The resulting build will be quite slow but will allow many debugging tools
 to be used. For details, please refer to chapter :ref:`Debugging es`.
@@ -984,7 +992,7 @@ you can as a last resort activate sanitizers:
 .. code-block:: bash
 
     cmake . -D ESPRESSO_BUILD_WITH_ASAN=ON -D ESPRESSO_BUILD_WITH_UBSAN=ON -D CMAKE_BUILD_TYPE=Release
-    make -j
+    make -j$(nproc)
 
 The resulting build will be around 5 times slower that a debug build,
 but it will generate valuable reports when detecting fatal exceptions.

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -463,8 +463,8 @@ General features
    between particles.
 
 -  ``VIRTUAL_SITES`` Allows the creation of pseudo-particles whose forces,
-   torques and orientations can be transferred to real particle.
-   They don't have a meaningful mass, and their position is generally
+   torques, and orientations can be transferred to real particles.
+   They don't have mass, and their position is generally
    fixed in the simulation box or fixed to other particles.
 
 -  ``VIRTUAL_SITES_INERTIALESS_TRACERS`` Allows to use virtual sites as tracers by advecting them with a LB fluid 

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -48,6 +48,18 @@ For many non-bonded interactions, it is possible to artificially cap the
 forces, which often allows to equilibrate the system much faster. See
 the subsection :ref:`Capping the force during warmup` for more details.
 
+It is possible to exclude particle pairs from the non-bonded interaction
+calculation. For example::
+
+    system.part.by_id(0).exclusions = [1, 2]
+
+exclude short-range interactions of the particle pairs ``0 <-> 1`` and ``0 <-> 2``.
+It is possible to automatically exclude particle pairs that are involved in
+bonded interactions, for example to prevent virtual sites from interacting
+with the real particles they are tracking, or to facilitate the use of custom
+potentials in polymers. This is achieved via the
+:meth:`espressomd.particle_data.ParticleList.auto_exclusions()` method.
+
 .. _Isotropic non-bonded interactions:
 
 Isotropic non-bonded interactions

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -53,7 +53,7 @@ calculation. For example::
 
     system.part.by_id(0).exclusions = [1, 2]
 
-exclude short-range interactions of the particle pairs ``0 <-> 1`` and ``0 <-> 2``.
+excludes short-range interactions of the particle pairs ``0 <-> 1`` and ``0 <-> 2``.
 It is possible to automatically exclude particle pairs that are involved in
 bonded interactions, for example to prevent virtual sites from interacting
 with the real particles they are tracking, or to facilitate the use of custom

--- a/doc/sphinx/particles.rst
+++ b/doc/sphinx/particles.rst
@@ -393,8 +393,8 @@ Interacting with groups of particles
 ------------------------------------
 
 Groups of particles are addressed using :class:`~espressomd.particle_data.ParticleSlice` objects.
-Usually, these objects do not have to be instantiated by the user. There are several ways
-to retrieve a particle slice:
+The objects behave similarly to :class:`~espressomd.particle_data.ParticleList` objects.
+There are several ways to retrieve a particle slice:
 
 - By calling :meth:`ParticleList.add() <espressomd.particle_data.ParticleList.add>`
 

--- a/doc/sphinx/reaction_methods.rst
+++ b/doc/sphinx/reaction_methods.rst
@@ -11,6 +11,9 @@ property. Chemical reactions take place by changing the value in the
 moves using the potential energy of the system before and after the reaction
 :cite:`turner08a`.
 
+For a description of the common functionality of all reaction methods,
+see :class:`espressomd.reaction_methods.ReactionAlgorithm`.
+
 Please keep in mind the following remarks:
 
 * All reaction methods uses Monte Carlo moves which require potential energies.

--- a/doc/sphinx/system_setup.rst
+++ b/doc/sphinx/system_setup.rst
@@ -320,13 +320,18 @@ in total, or more than 4 MPI ranks per direction. In this situation,
 consider increasing the box size or decreasing the interaction cutoff
 or Verlet list skin.
 
+This scheme is also known as the spatial decomposition cell scheme
+:cite:`plimpton95a`, and requires communicating particle information
+from neighboring cells at every time step.
+
 .. _N-squared:
 
 N-squared
 ^^^^^^^^^
 
 Invoking :py:meth:`~espressomd.cell_system.CellSystem.set_n_square`
-selects the very primitive N-squared cellsystem, which calculates
+selects the very primitive N-squared cellsystem, also known as the atom
+decomposition cell scheme :cite:`plimpton95a`, which calculates
 the interactions for all particle pairs. Therefore it loops over all
 particles, giving an unfavorable computation time scaling of
 :math:`N^2`. However, algorithms like MMM1D or the plain Coulomb
@@ -341,10 +346,10 @@ In a multiple processor environment, the N-squared cellsystem uses a
 simple particle balancing scheme to have a nearly equal number of
 particles per CPU, :math:`n` nodes have :math:`m` particles, and
 :math:`p-n` nodes have :math:`m+1` particles, such that
-:math:`n \cdot m + (p - n) \cdot (m + 1) = N`, the total number of particles. Therefore the
-computational load should be balanced fairly equal among the nodes, with
-one exception: This code always uses one CPU for the interaction between
-two different nodes. For an odd number of nodes, this is fine, because
+:math:`n \cdot m + (p - n) \cdot (m + 1) = N`, the total number of particles.
+Therefore the computational load should be balanced fairly equal among the
+nodes, with one exception: this code always uses one CPU for the interaction
+between two different nodes. For an odd number of nodes, this is fine, because
 the total number of interactions to calculate is a multiple of the
 number of nodes, but for an even number of nodes, for each of the
 :math:`p-1` communication rounds, one processor is idle.
@@ -355,6 +360,9 @@ But the 0-1 interaction is treated by node 1 alone, so the workload for
 this node is twice as high. For 3 processors, the interactions are 0-0,
 1-1, 2-2, 0-1, 1-2, 0-2. Of these interactions, node 0 treats 0-0 and
 0-2, node 1 treats 1-1 and 0-1, and node 2 treats 2-2 and 1-2.
+
+In addition, this scheme requires an all-to-all communication of all particles
+at every time step, which is time-consuming when the number of nodes is large.
 
 Therefore it is highly recommended that you use N-squared only with an
 odd number of nodes, if with multiple processors at all.

--- a/doc/tutorials/visualization/visualization.ipynb
+++ b/doc/tutorials/visualization/visualization.ipynb
@@ -263,6 +263,7 @@
     "    plt.xlabel(\"Time\")\n",
     "    plt.ylabel(\"Energy\")\n",
     "    plot, = plt.plot([0], [0])\n",
+    "    plt.xlim(left=0)\n",
     "\n",
     "# execute main() in a secondary thread\n",
     "t = threading.Thread(target=main)\n",


### PR DESCRIPTION
Fixes #4653

Description of changes:
- fix errors in installation instructions: `make -j` without a number will start more processes than threads
- document particle exclusions and compile-time features 
- improve bibliography