### PR TITLE
Enable P3M for hybrid decomposition with one MPI node

### DIFF
--- a/src/core/electrostatics/p3m.cpp
+++ b/src/core/electrostatics/p3m.cpp
@@ -769,9 +769,17 @@ void CoulombP3M::sanity_checks_periodicity() const {
 
 void CoulombP3M::sanity_checks_cell_structure() const {
   if (local_geo.cell_structure_type() !=
-      CellStructureType::CELL_STRUCTURE_REGULAR) {
+          CellStructureType::CELL_STRUCTURE_REGULAR &&
+      local_geo.cell_structure_type() !=
+          CellStructureType::CELL_STRUCTURE_HYBRID) {
     throw std::runtime_error(
-        "CoulombP3M: requires the regular decomposition cell system");
+        "CoulombP3M: requires the regular or hybrid decomposition cell system");
+  }
+  if (n_nodes > 1 && local_geo.cell_structure_type() ==
+                         CellStructureType::CELL_STRUCTURE_HYBRID) {
+    throw std::runtime_error(
+        "CoulombP3M: does not work with the hybrid decomposition cell system, "
+        "if using more than one MPI node");
   }
 }
 

--- a/src/core/magnetostatics/dp3m.cpp
+++ b/src/core/magnetostatics/dp3m.cpp
@@ -889,9 +889,17 @@ void DipolarP3M::sanity_checks_periodicity() const {
 
 void DipolarP3M::sanity_checks_cell_structure() const {
   if (local_geo.cell_structure_type() !=
-      CellStructureType::CELL_STRUCTURE_REGULAR) {
+          CellStructureType::CELL_STRUCTURE_REGULAR &&
+      local_geo.cell_structure_type() !=
+          CellStructureType::CELL_STRUCTURE_HYBRID) {
     throw std::runtime_error(
-        "DipolarP3M: requires the regular decomposition cell system");
+        "DipolarP3M: requires the regular or hybrid decomposition cell system");
+  }
+  if (n_nodes > 1 && local_geo.cell_structure_type() ==
+                         CellStructureType::CELL_STRUCTURE_HYBRID) {
+    throw std::runtime_error(
+        "DipolarP3M: does not work with the hybrid decomposition cell system, "
+        "if using more than one MPI node");
   }
 }
 

--- a/testsuite/python/p3m_tuning_exceptions.py
+++ b/testsuite/python/p3m_tuning_exceptions.py
@@ -231,7 +231,7 @@ class Test(ut.TestCase):
         self.system.periodicity = (True, True, True)
 
         # check cell system exceptions
-        with self.assertRaisesRegex(Exception, "P3M: requires the regular decomposition cell system"):
+        with self.assertRaisesRegex(Exception, "P3M: requires the regular or hybrid decomposition cell system"):
             self.system.cell_system.set_n_square()
             self.system.analysis.energy()
         self.system.cell_system.set_regular_decomposition()


### PR DESCRIPTION
Description of changes:
- removed sanity checks preventing hybrid decomposition from being used with P3M/Dipolar P3M on a single MPI node
- added tests to ensure forces/energies of the hybrid decomposition with P3M are equal to those calculated using the regular decomposition