### PR TITLE
Fix bugs in testcases.

### DIFF
--- a/src/core/unit_tests/Verlet_list_test.cpp
+++ b/src/core/unit_tests/Verlet_list_test.cpp
@@ -243,8 +243,8 @@ BOOST_DATA_TEST_CASE_F(ParticleFactory, verlet_list_update,
 #endif // EXTERNAL_FORCES
       if (rank == 0) {
         auto const &p1 = *p1_opt;
-        auto const &p2 = *p2_opt;
 #ifdef EXTERNAL_FORCES
+        auto const &p2 = *p2_opt;
         BOOST_CHECK_CLOSE(p1.force()[0] - p1.ext_force()[0], 480., 1e-9);
 #endif // EXTERNAL_FORCES
         BOOST_CHECK_CLOSE(p1.force()[1], 0., tol);

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -237,15 +237,15 @@ if espressomd.has_features(['LENNARD_JONES']) and 'LJ' in modes:
         epsilon=1.2, sigma=1.7, cutoff=2.0, shift=0.1)
     system.non_bonded_inter[1, 7].lennard_jones.set_params(
         epsilon=1.2e5, sigma=1.7, cutoff=2.0, shift=0.1)
+    handle_ia = espressomd.interactions.NonBondedInteractionHandle(
+        _types=(0, 0))
+    checkpoint.register("handle_ia")
 if espressomd.has_features(['DPD']):
     dpd_params = {"weight_function": 1, "gamma": 2., "trans_r_cut": 2., "k": 2.,
                   "trans_weight_function": 0, "trans_gamma": 1., "r_cut": 2.}
     dpd_ia = espressomd.interactions.DPDInteraction(**dpd_params)
-    handle_ia = espressomd.interactions.NonBondedInteractionHandle(
-        _types=(0, 0))
     checkpoint.register("dpd_ia")
     checkpoint.register("dpd_params")
-    checkpoint.register("handle_ia")
 
 # bonded interactions
 harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0.0, k=1.0)


### PR DESCRIPTION
Description of changes:
- fix feature guards in the testsuite

To reproduce the errors that this PR fixes, build without `EXTERNAL_FORCES` and `DPD`, respectively. E.g. use only the following features in your `myconfig.hpp`:
```c++
#define ROTATION
#define ROTATIONAL_INERTIA
#define MASS
#define THERMOSTAT_PER_PARTICLE
#define LENNARD_JONES
#define VIRTUAL_SITES_RELATIVE
#define PARTICLE_ANISOTROPY
```
