### PR TITLE
Efficient GPU utilization in CI

### DIFF
--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -17,8 +17,40 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-function(PYTHON_TEST)
-  cmake_parse_arguments(TEST "" "FILE;MAX_NUM_PROC;SUFFIX"
+#[=======================================================================[.rst:
+
+.. command:: python_test
+
+  Configure a python test case.
+
+  Flag arguments: none.
+
+  Single-value arguments:
+
+  * ``FILE``: testcase filename
+  * ``MAX_NUM_PROC``: maximal number of MPI ranks to use. In the CI pipeline,
+    there is one CI job that reduces the number of MPI ranks to 3.
+  * ``GPU_SLOTS``: number of GPU slots consumed by the test. The total number
+    of slots can be found in :file:`resources.json`. One slot corresponds to
+    roughly 250 MiB of VRAM. All GPU test cases must specify this value to
+    avoid oversubscribing the GPU with the lowest amount of VRAM among all CI
+    runners (note that one GPU is often used to run 2 CI jobs in parallel).
+  * ``SUFFIX``: suffix to append to the test name. Meant to disambiguate two
+    test cases sharing the same file but using different parameters or number
+    of MPI ranks.
+
+  Multi-value arguments:
+
+  * ``DEPENDS``: test cases that must pass before this test can run.
+  * ``DEPENDENCIES``: file dependencies.
+  * ``LABELS``: extra test labels. Labels are automatically generated based
+    on the number of GPU slots and MPI ranks. Extra labels include ``long``
+    for statistical tests that can safely be skipped in code coverage builds.
+  * ``ARGUMENTS``: arguments to pass to the test case command line.
+
+#]=======================================================================]
+function(python_test)
+  cmake_parse_arguments(TEST "" "FILE;MAX_NUM_PROC;GPU_SLOTS;SUFFIX"
                         "DEPENDS;DEPENDENCIES;LABELS;ARGUMENTS" ${ARGN})
   get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
   set(TEST_FILE_CONFIGURED "${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}.py")
@@ -34,6 +66,9 @@ function(PYTHON_TEST)
 
   if(NOT DEFINED TEST_MAX_NUM_PROC)
     set(TEST_MAX_NUM_PROC 4)
+  endif()
+  if(NOT DEFINED TEST_GPU_SLOTS)
+    set(TEST_GPU_SLOTS 0)
   endif()
 
   if(${TEST_MAX_NUM_PROC} GREATER ${ESPRESSO_TEST_NP})
@@ -58,10 +93,14 @@ function(PYTHON_TEST)
   set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${TEST_NUM_PROC}
                                                DEPENDS "${TEST_DEPENDS}")
 
-  if("gpu" IN_LIST TEST_LABELS AND ESPRESSO_BUILD_WITH_CUDA)
-    set_tests_properties(${TEST_NAME} PROPERTIES RESOURCE_LOCK GPU)
+  if(${TEST_GPU_SLOTS} GREATER 0 AND ESPRESSO_BUILD_WITH_CUDA)
+    set_property(TEST ${TEST_NAME} PROPERTY RESOURCE_GROUPS
+                                            "gpus:${TEST_GPU_SLOTS}")
   endif()
 
+  if(${TEST_GPU_SLOTS} GREATER 0)
+    list(APPEND TEST_LABELS "gpu")
+  endif()
   if(${TEST_NUM_PROC} EQUAL 2)
     list(APPEND TEST_LABELS "parallel")
   endif()
@@ -71,12 +110,28 @@ function(PYTHON_TEST)
   set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}")
 
   set(python_tests ${python_tests} ${TEST_FILE_CONFIGURED} PARENT_SCOPE)
-endfunction(PYTHON_TEST)
+endfunction(python_test)
 
-function(CHECKPOINT_TEST)
-  cmake_parse_arguments(TEST "" "MODES;MAX_NUM_PROC;SUFFIX" "LABELS" ${ARGN})
+#[=======================================================================[.rst:
+
+.. command:: checkpoint_test
+
+  Configure a python checkpoint test case.
+
+  This is a specialization of python_test() for the checkpointing test cases.
+  It uses sane default values that can be overriden if necessary. It has one
+  extra single-value argument ``MODES`` that lists the features to activate.
+  See the comment lines at the point of use for more details.
+
+#]=======================================================================]
+function(checkpoint_test)
+  cmake_parse_arguments(TEST "" "MODES;MAX_NUM_PROC;GPU_SLOTS;SUFFIX" "LABELS"
+                        ${ARGN})
   if(NOT DEFINED TEST_MAX_NUM_PROC)
     set(TEST_MAX_NUM_PROC 4)
+  endif()
+  if(NOT DEFINED TEST_GPU_SLOTS)
+    set(TEST_GPU_SLOTS 0)
   endif()
   if(TEST_SUFFIX)
     set(TEST_ARGUMENTS "Test_suffix_${TEST_SUFFIX}__${TEST_MODES}")
@@ -86,14 +141,27 @@ function(CHECKPOINT_TEST)
     set(TEST_SUFFIX "_${TEST_MODES}")
   endif()
   python_test(
-    FILE save_checkpoint.py MAX_NUM_PROC ${TEST_MAX_NUM_PROC} LABELS
-    ${TEST_LABELS} SUFFIX ${TEST_SUFFIX} ARGUMENTS ${TEST_ARGUMENTS}
-    DEPENDENCIES unittest_generator.py)
+    FILE
+    save_checkpoint.py
+    MAX_NUM_PROC
+    ${TEST_MAX_NUM_PROC}
+    LABELS
+    ${TEST_LABELS}
+    SUFFIX
+    ${TEST_SUFFIX}
+    ARGUMENTS
+    ${TEST_ARGUMENTS}
+    GPU_SLOTS
+    ${TEST_GPU_SLOTS}
+    DEPENDENCIES
+    unittest_generator.py)
   python_test(
     FILE
     test_checkpoint.py
     MAX_NUM_PROC
     ${TEST_MAX_NUM_PROC}
+    GPU_SLOTS
+    ${TEST_GPU_SLOTS}
     LABELS
     ${TEST_LABELS}
     SUFFIX
@@ -104,7 +172,7 @@ function(CHECKPOINT_TEST)
     unittest_generator.py
     DEPENDS
     save_checkpoint_${TEST_SUFFIX})
-endfunction(CHECKPOINT_TEST)
+endfunction(checkpoint_test)
 
 # Checkpoint tests run on 4 cores (can be overriden with MAX_NUM_PROC). The
 # combination of modes to activate is stored in MODES. A mode consists of a
@@ -115,8 +183,8 @@ checkpoint_test(MODES therm_lb__p3m_cpu__lj__lb_cpu_ascii SUFFIX 1_core
                 MAX_NUM_PROC 1)
 checkpoint_test(MODES therm_lb__p3m_cpu__lj__lb_cpu_ascii)
 checkpoint_test(MODES therm_lb__elc_cpu__lj__lb_cpu_binary)
-checkpoint_test(MODES therm_lb__elc_gpu__lj__lb_gpu_ascii LABELS gpu)
-checkpoint_test(MODES therm_lb__p3m_gpu__lj__lb_gpu_binary LABELS gpu)
+checkpoint_test(MODES therm_lb__elc_gpu__lj__lb_gpu_ascii GPU_SLOTS 3)
+checkpoint_test(MODES therm_lb__p3m_gpu__lj__lb_gpu_binary GPU_SLOTS 3)
 checkpoint_test(MODES therm_npt__int_npt)
 checkpoint_test(MODES int_sd__lj)
 checkpoint_test(MODES dp3m_cpu__therm_langevin__int_nvt)
@@ -134,20 +202,20 @@ python_test(FILE constraint_homogeneous_magnetic_field.py MAX_NUM_PROC 4)
 python_test(FILE cutoffs.py MAX_NUM_PROC 4)
 python_test(FILE cutoffs.py MAX_NUM_PROC 1 SUFFIX 1_core)
 python_test(FILE constraint_shape_based.py MAX_NUM_PROC 2)
-python_test(FILE coulomb_cloud_wall.py MAX_NUM_PROC 4 LABELS gpu)
-python_test(FILE coulomb_tuning.py MAX_NUM_PROC 4 LABELS gpu long)
+python_test(FILE coulomb_cloud_wall.py MAX_NUM_PROC 4 GPU_SLOTS 3)
+python_test(FILE coulomb_tuning.py MAX_NUM_PROC 4 GPU_SLOTS 3 LABELS long)
 python_test(FILE accumulator_correlator.py MAX_NUM_PROC 4)
 python_test(FILE accumulator_mean_variance.py MAX_NUM_PROC 4)
 python_test(FILE accumulator_time_series.py MAX_NUM_PROC 1)
-python_test(FILE dawaanr-and-dds-gpu.py MAX_NUM_PROC 1 LABELS gpu)
-python_test(FILE dawaanr-and-bh-gpu.py MAX_NUM_PROC 1 LABELS gpu)
-python_test(FILE dds-and-bh-gpu.py MAX_NUM_PROC 4 LABELS gpu)
+python_test(FILE dawaanr-and-dds-gpu.py MAX_NUM_PROC 1 GPU_SLOTS 1)
+python_test(FILE dawaanr-and-bh-gpu.py MAX_NUM_PROC 1 GPU_SLOTS 1)
+python_test(FILE dds-and-bh-gpu.py MAX_NUM_PROC 4 GPU_SLOTS 3)
 python_test(FILE electrostatic_interactions.py MAX_NUM_PROC 2)
 python_test(FILE engine_langevin.py MAX_NUM_PROC 4)
-python_test(FILE engine_lb.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE engine_lb.py MAX_NUM_PROC 1 LABELS gpu SUFFIX 1_core)
+python_test(FILE engine_lb.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE engine_lb.py MAX_NUM_PROC 1 GPU_SLOTS 1 SUFFIX 1_core)
 python_test(FILE icc.py MAX_NUM_PROC 4)
-python_test(FILE icc_interface.py MAX_NUM_PROC 1 LABELS gpu)
+python_test(FILE icc_interface.py MAX_NUM_PROC 1 GPU_SLOTS 1)
 python_test(FILE mass-and-rinertia_per_particle.py MAX_NUM_PROC 2 LABELS long)
 python_test(FILE integrate.py MAX_NUM_PROC 4)
 python_test(FILE interactions_bond_angle.py MAX_NUM_PROC 4)
@@ -162,8 +230,8 @@ python_test(FILE particle.py MAX_NUM_PROC 4)
 python_test(FILE pressure.py MAX_NUM_PROC 4)
 python_test(FILE scafacos_dipoles_1d_2d.py MAX_NUM_PROC 4)
 python_test(FILE scafacos_interface.py MAX_NUM_PROC 2)
-python_test(FILE long_range_actors.py MAX_NUM_PROC 4 LABELS gpu)
-python_test(FILE long_range_actors.py MAX_NUM_PROC 1 LABELS gpu SUFFIX 1_core)
+python_test(FILE long_range_actors.py MAX_NUM_PROC 4 GPU_SLOTS 2)
+python_test(FILE long_range_actors.py MAX_NUM_PROC 1 GPU_SLOTS 1 SUFFIX 1_core)
 python_test(FILE tabulated.py MAX_NUM_PROC 2)
 python_test(FILE particle_slice.py MAX_NUM_PROC 4)
 python_test(FILE rigid_bond.py MAX_NUM_PROC 4)
@@ -181,15 +249,15 @@ python_test(FILE constant_pH.py MAX_NUM_PROC 1)
 python_test(FILE constant_pH_stats.py MAX_NUM_PROC 4 LABELS long)
 python_test(FILE canonical_ensemble.py MAX_NUM_PROC 2)
 python_test(FILE writevtf.py MAX_NUM_PROC 4)
-python_test(FILE lb_stokes_sphere.py MAX_NUM_PROC 4 LABELS gpu long)
-python_test(FILE lb_pressure_tensor.py MAX_NUM_PROC 1 LABELS gpu long)
-python_test(FILE ek_fluctuations.py MAX_NUM_PROC 1 LABELS gpu)
-python_test(FILE ek_charged_plate.py MAX_NUM_PROC 1 LABELS gpu)
-python_test(FILE ek_eof_one_species.py MAX_NUM_PROC 1 LABELS gpu SUFFIX x
+python_test(FILE lb_stokes_sphere.py MAX_NUM_PROC 4 GPU_SLOTS 1 LABELS long)
+python_test(FILE lb_pressure_tensor.py MAX_NUM_PROC 1 GPU_SLOTS 3 LABELS long)
+python_test(FILE ek_fluctuations.py MAX_NUM_PROC 1 GPU_SLOTS 1)
+python_test(FILE ek_charged_plate.py MAX_NUM_PROC 1 GPU_SLOTS 1)
+python_test(FILE ek_eof_one_species.py MAX_NUM_PROC 1 GPU_SLOTS 2 SUFFIX x
             ARGUMENTS Test__axis_x DEPENDENCIES unittest_generator.py)
-python_test(FILE ek_eof_one_species.py MAX_NUM_PROC 1 LABELS gpu SUFFIX y
+python_test(FILE ek_eof_one_species.py MAX_NUM_PROC 1 GPU_SLOTS 2 SUFFIX y
             ARGUMENTS Test__axis_y DEPENDENCIES unittest_generator.py)
-python_test(FILE ek_eof_one_species.py MAX_NUM_PROC 1 LABELS gpu SUFFIX z
+python_test(FILE ek_eof_one_species.py MAX_NUM_PROC 1 GPU_SLOTS 2 SUFFIX z
             ARGUMENTS Test__axis_z DEPENDENCIES unittest_generator.py)
 python_test(FILE exclusions.py MAX_NUM_PROC 2)
 python_test(FILE langevin_thermostat.py MAX_NUM_PROC 1)
@@ -201,7 +269,7 @@ python_test(FILE nsquare.py MAX_NUM_PROC 4)
 python_test(FILE virtual_sites_relative.py MAX_NUM_PROC 2)
 python_test(FILE virtual_sites_tracers.py MAX_NUM_PROC 2 DEPENDENCIES
             virtual_sites_tracers_common.py)
-python_test(FILE virtual_sites_tracers_gpu.py MAX_NUM_PROC 2 LABELS gpu
+python_test(FILE virtual_sites_tracers_gpu.py MAX_NUM_PROC 2 GPU_SLOTS 1
             DEPENDENCIES virtual_sites_tracers_common.py)
 python_test(FILE regular_decomposition.py MAX_NUM_PROC 4)
 python_test(FILE hybrid_decomposition.py MAX_NUM_PROC 1 SUFFIX 1_core)
@@ -211,34 +279,35 @@ python_test(FILE integrator_npt_stats.py MAX_NUM_PROC 4 LABELS long)
 python_test(FILE integrator_steepest_descent.py MAX_NUM_PROC 4)
 python_test(FILE ibm.py MAX_NUM_PROC 2)
 python_test(FILE dipolar_mdlc_p3m_scafacos_p2nfft.py MAX_NUM_PROC 1)
-python_test(FILE dipolar_direct_summation.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE dipolar_direct_summation.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE dipolar_p3m.py MAX_NUM_PROC 2)
-python_test(FILE dipolar_interface.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE coulomb_interface.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb_stats.py MAX_NUM_PROC 2 LABELS gpu long)
-python_test(FILE lb_stats.py MAX_NUM_PROC 1 LABELS gpu long SUFFIX 1_core)
-python_test(FILE lb_vtk.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE dipolar_interface.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE coulomb_interface.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb_stats.py MAX_NUM_PROC 2 GPU_SLOTS 2 LABELS long)
+python_test(FILE lb_stats.py MAX_NUM_PROC 1 GPU_SLOTS 2 LABELS long SUFFIX
+            1_core)
+python_test(FILE lb_vtk.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE force_cap.py MAX_NUM_PROC 2)
 python_test(FILE dpd.py MAX_NUM_PROC 4)
 python_test(FILE dpd_stats.py MAX_NUM_PROC 4 LABELS long)
 python_test(FILE hat.py MAX_NUM_PROC 4)
-python_test(FILE analyze_energy.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE analyze_energy.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE analyze_mass_related.py MAX_NUM_PROC 4)
 python_test(FILE rdf.py MAX_NUM_PROC 1)
 python_test(FILE sf_simple_lattice.py MAX_NUM_PROC 1)
 python_test(FILE coulomb_mixed_periodicity.py MAX_NUM_PROC 4)
-python_test(FILE coulomb_cloud_wall_duplicated.py MAX_NUM_PROC 4 LABELS gpu)
+python_test(FILE coulomb_cloud_wall_duplicated.py MAX_NUM_PROC 4 GPU_SLOTS 3)
 python_test(FILE collision_detection.py MAX_NUM_PROC 4)
 python_test(FILE collision_detection_interface.py MAX_NUM_PROC 2)
-python_test(FILE lb_get_u_at_pos.py MAX_NUM_PROC 4 LABELS gpu)
+python_test(FILE lb_get_u_at_pos.py MAX_NUM_PROC 4 GPU_SLOTS 1)
 python_test(FILE lj.py MAX_NUM_PROC 4)
 python_test(FILE pairs.py MAX_NUM_PROC 4)
 python_test(FILE polymer_linear.py MAX_NUM_PROC 4)
 python_test(FILE polymer_diamond.py MAX_NUM_PROC 4)
 python_test(FILE auto_exclusions.py MAX_NUM_PROC 4)
 python_test(FILE observable_cylindrical.py MAX_NUM_PROC 4)
-python_test(FILE observable_cylindricalLB.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE observable_cylindricalLB.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE analyze_chains.py MAX_NUM_PROC 1)
 python_test(FILE analyze_distance.py MAX_NUM_PROC 2)
 python_test(FILE analyze_acf.py MAX_NUM_PROC 1)
@@ -247,11 +316,11 @@ python_test(FILE rescale.py MAX_NUM_PROC 2)
 python_test(FILE array_properties.py MAX_NUM_PROC 4)
 python_test(FILE analyze_distribution.py MAX_NUM_PROC 1)
 python_test(FILE observable_profile.py MAX_NUM_PROC 4)
-python_test(FILE observable_profileLB.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE observable_profileLB.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE rotate_system.py MAX_NUM_PROC 4)
 python_test(FILE es_math.py MAX_NUM_PROC 1)
 python_test(FILE random_pairs.py MAX_NUM_PROC 4)
-python_test(FILE lb_electrohydrodynamics.py MAX_NUM_PROC 4 LABELS gpu)
+python_test(FILE lb_electrohydrodynamics.py MAX_NUM_PROC 4 GPU_SLOTS 1)
 python_test(FILE cluster_analysis.py MAX_NUM_PROC 4)
 python_test(FILE pair_criteria.py MAX_NUM_PROC 4)
 python_test(FILE actor.py MAX_NUM_PROC 1)
@@ -259,44 +328,44 @@ python_test(FILE drude.py MAX_NUM_PROC 2)
 python_test(FILE thermalized_bond.py MAX_NUM_PROC 4)
 python_test(FILE thole.py MAX_NUM_PROC 4)
 python_test(FILE lb_slice.py MAX_NUM_PROC 1)
-python_test(FILE lb_switch.py MAX_NUM_PROC 1 LABELS gpu)
+python_test(FILE lb_switch.py MAX_NUM_PROC 1 GPU_SLOTS 1)
 python_test(FILE lb_boundary_velocity.py MAX_NUM_PROC 1)
 python_test(FILE lb_boundary_volume_force.py MAX_NUM_PROC 4)
-python_test(FILE lb_circular_couette.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb_thermo_virtual.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb_poiseuille.py MAX_NUM_PROC 4 LABELS gpu)
-python_test(FILE lb_poiseuille_cylinder.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb_interpolation.py MAX_NUM_PROC 4 LABELS gpu)
+python_test(FILE lb_circular_couette.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb_thermo_virtual.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb_poiseuille.py MAX_NUM_PROC 4 GPU_SLOTS 1)
+python_test(FILE lb_poiseuille_cylinder.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb_interpolation.py MAX_NUM_PROC 4 GPU_SLOTS 1)
 python_test(FILE analyze_gyration_tensor.py MAX_NUM_PROC 1)
 python_test(FILE oif_volume_conservation.py MAX_NUM_PROC 2)
 python_test(FILE simple_pore.py MAX_NUM_PROC 1)
 python_test(FILE field_test.py MAX_NUM_PROC 1)
-python_test(FILE lb_boundary.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb_streaming.py MAX_NUM_PROC 4 LABELS gpu)
-python_test(FILE lb_shear.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb_thermostat.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE lb_buoyancy_force.py MAX_NUM_PROC 4 LABELS gpu)
-python_test(FILE lb_momentum_conservation.py MAX_NUM_PROC 4 LABELS gpu)
-python_test(FILE lb_momentum_conservation.py MAX_NUM_PROC 1 LABELS gpu SUFFIX
+python_test(FILE lb_boundary.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb_streaming.py MAX_NUM_PROC 4 GPU_SLOTS 1)
+python_test(FILE lb_shear.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb_thermostat.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE lb_buoyancy_force.py MAX_NUM_PROC 4 GPU_SLOTS 1)
+python_test(FILE lb_momentum_conservation.py MAX_NUM_PROC 4 GPU_SLOTS 1)
+python_test(FILE lb_momentum_conservation.py MAX_NUM_PROC 1 GPU_SLOTS 1 SUFFIX
             1_core)
-python_test(FILE p3m_electrostatic_pressure.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE p3m_madelung.py MAX_NUM_PROC 2 LABELS gpu long)
+python_test(FILE p3m_electrostatic_pressure.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE p3m_madelung.py MAX_NUM_PROC 2 GPU_SLOTS 2 LABELS long)
 python_test(FILE sigint.py DEPENDENCIES sigint_child.py MAX_NUM_PROC 1)
 python_test(FILE lb_density.py MAX_NUM_PROC 1)
 python_test(FILE observable_chain.py MAX_NUM_PROC 4)
 python_test(FILE mpiio.py MAX_NUM_PROC 4)
 python_test(FILE mpiio_exceptions.py MAX_NUM_PROC 1)
-python_test(FILE gpu_availability.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE gpu_availability.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE features.py MAX_NUM_PROC 1)
 python_test(FILE decorators.py MAX_NUM_PROC 1)
 python_test(FILE galilei.py MAX_NUM_PROC 4)
 python_test(FILE linear_momentum.py MAX_NUM_PROC 4)
-python_test(FILE linear_momentum_lb.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE mmm1d.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE linear_momentum_lb.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE mmm1d.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE stokesian_dynamics.py MAX_NUM_PROC 2 LABELS long)
 python_test(FILE stokesian_thermostat.py MAX_NUM_PROC 2)
-python_test(FILE elc.py MAX_NUM_PROC 2 LABELS gpu)
-python_test(FILE elc_vs_analytic.py MAX_NUM_PROC 2 LABELS gpu)
+python_test(FILE elc.py MAX_NUM_PROC 2 GPU_SLOTS 1)
+python_test(FILE elc_vs_analytic.py MAX_NUM_PROC 2 GPU_SLOTS 1)
 python_test(FILE rotation.py MAX_NUM_PROC 1)
 python_test(FILE shapes.py MAX_NUM_PROC 1)
 python_test(FILE h5md.py MAX_NUM_PROC 2)
@@ -305,12 +374,16 @@ python_test(FILE p3m_fft.py MAX_NUM_PROC 6)
 if(${ESPRESSO_TEST_NP} GREATER_EQUAL 8)
   python_test(FILE p3m_fft.py MAX_NUM_PROC 8 SUFFIX 8_cores)
 endif()
-python_test(FILE p3m_tuning_exceptions.py MAX_NUM_PROC 1 LABELS gpu)
+python_test(FILE p3m_tuning_exceptions.py MAX_NUM_PROC 1 GPU_SLOTS 1)
 python_test(FILE integrator_exceptions.py MAX_NUM_PROC 1)
 python_test(FILE utils.py MAX_NUM_PROC 1)
 python_test(FILE npt_thermostat.py MAX_NUM_PROC 4)
 python_test(FILE box_geometry.py MAX_NUM_PROC 1)
 
+set(ESPRESSO_CTEST_RESOURCE_SPEC_FILE resources.json)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/${ESPRESSO_CTEST_RESOURCE_SPEC_FILE}
+  ${CMAKE_CURRENT_BINARY_DIR}/${ESPRESSO_CTEST_RESOURCE_SPEC_FILE} COPYONLY)
 add_custom_target(
   python_test_data
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data
@@ -326,24 +399,32 @@ add_custom_target(
 
 add_custom_target(
   check_python_parallel_odd
-  COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT} -L
-          parallel_odd ${ESPRESSO_CTEST_ARGS} --output-on-failure)
+  COMMAND
+    ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT} -L parallel_odd
+    --resource-spec-file ${ESPRESSO_CTEST_RESOURCE_SPEC_FILE}
+    ${ESPRESSO_CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_parallel_odd pypresso python_test_data)
 add_custom_target(
   check_python_gpu
-  COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT} -L gpu
-          ${ESPRESSO_CTEST_ARGS} --output-on-failure)
+  COMMAND
+    ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT} -L gpu
+    --resource-spec-file ${ESPRESSO_CTEST_RESOURCE_SPEC_FILE}
+    ${ESPRESSO_CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_gpu pypresso python_test_data)
 
 add_custom_target(
   check_python_skip_long
-  COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT} -LE long
-          ${ESPRESSO_CTEST_ARGS} --output-on-failure)
+  COMMAND
+    ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT} -LE long
+    --resource-spec-file ${ESPRESSO_CTEST_RESOURCE_SPEC_FILE}
+    ${ESPRESSO_CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python_skip_long pypresso python_test_data)
 
 add_custom_target(
   check_python
-  COMMAND ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT}
-          ${ESPRESSO_CTEST_ARGS} --output-on-failure)
+  COMMAND
+    ${CMAKE_CTEST_COMMAND} --timeout ${ESPRESSO_TEST_TIMEOUT}
+    --resource-spec-file ${ESPRESSO_CTEST_RESOURCE_SPEC_FILE}
+    ${ESPRESSO_CTEST_ARGS} --output-on-failure)
 add_dependencies(check_python pypresso python_test_data)
 add_dependencies(check check_python)

--- a/testsuite/python/long_range_actors.py
+++ b/testsuite/python/long_range_actors.py
@@ -327,7 +327,9 @@ class Test(ut.TestCase):
 
     @utx.skipIfMissingGPU()
     @utx.skipIfMissingFeatures(["MMM1D_GPU"])
+    @ut.skipIf(n_nodes > 3, "only runs for 3 or less MPI ranks")
     def test_mmm1d_gpu_exceptions(self):
+        # VRAM peak memory usage: 700 MiB on 4 MPI cores, 500 on 3 MPI cores
         self.system.periodicity = (False, False, True)
         self.check_mmm1d_exceptions(espressomd.electrostatics.MMM1DGPU)
 

--- a/testsuite/python/resources.json
+++ b/testsuite/python/resources.json
@@ -1,0 +1,16 @@
+{
+  "version": {
+    "major": 1,
+    "minor": 0
+  },
+  "local": [
+    {
+      "gpus": [
+        {
+          "id": "0",
+          "slots": 4
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Until now, GPU tests were running in serial to avoid oversubscribing device memory, while CPU tests were running in parallel using the standard CTest processor resource scheduler via `MAX_NUM_PROC`. With the recent performance improvements in CPU-based algorithms, GPU tests have now become a bottleneck, leaving CPU resources idle in the last 2 minutes of each CI job that has CUDA enabled. This PR introduces a [resource specification file](https://cmake.org/cmake/help/v3.22/manual/ctest.1.html#ctest-resource-specification-file) to help CTest schedule GPU tests in parallel based on the amount of device memory they consume, via the newly introduced `GPU_SLOTS` argument.