### PR TITLE
Hide `Particle` substructure layout from public API

### DIFF
--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -401,25 +401,16 @@ struct ParticleRattle {
 
 /** Struct holding all information for one particle. */
 struct Particle { // NOLINT(bugprone-exception-escape)
-  ///
-  ParticleProperties p;
-  ///
-  ParticlePosition r;
-  ///
-  ParticleMomentum m;
-  ///
-  ParticleForce f;
-  ///
-  ParticleLocal l;
-
 private:
+  ParticleProperties p;
+  ParticlePosition r;
+  ParticleMomentum m;
+  ParticleForce f;
+  ParticleLocal l;
 #ifdef BOND_CONSTRAINT
-  ///
   ParticleRattle rattle;
 #endif
-
   BondList bl;
-
 #ifdef EXCLUSIONS
   /** list of particles, with which this particle has no non-bonded
    *  interactions
@@ -448,6 +439,8 @@ public:
   auto &v() { return m.v; }
   auto const &force() const { return f.f; }
   auto &force() { return f.f; }
+  auto const &force_and_torque() const { return f; }
+  auto &force_and_torque() { return f; }
 
   bool is_ghost() const { return l.ghost; }
   void set_ghost(bool const ghost_flag) { l.ghost = ghost_flag; }

--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -86,7 +86,7 @@ public:
         force += constraint->force(p, pos, t);
       }
 
-      p.f += force;
+      p.force_and_torque() += force;
     }
   }
 

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -127,20 +127,20 @@ static void init_forces(const ParticleRange &particles,
      set torque to zero for all and rescale quaternions
   */
   for (auto &p : particles) {
-    p.f = init_real_particle_force(p, time_step, kT);
+    p.force_and_torque() = init_real_particle_force(p, time_step, kT);
   }
 
   /* initialize ghost forces with zero
      set torque to zero for all and rescale quaternions
   */
   for (auto &p : ghost_particles) {
-    p.f = init_ghost_force(p);
+    p.force_and_torque() = init_ghost_force(p);
   }
 }
 
 void init_forces_ghosts(const ParticleRange &particles) {
   for (auto &p : particles) {
-    p.f = init_ghost_force(p);
+    p.force_and_torque() = init_ghost_force(p);
   }
 }
 

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -247,8 +247,8 @@ inline void add_non_bonded_pair_force(
   /* add total non-bonded forces to particles    */
   /***********************************************/
 
-  p1.f += pf;
-  p2.f += calc_opposing_force(pf, d);
+  p1.force_and_torque() += pf;
+  p2.force_and_torque() += calc_opposing_force(pf, d);
 }
 
 /** Compute the bonded interaction force between particle pairs.

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -354,7 +354,7 @@ static void add_forces_from_recv_buffer(CommBuf &recv_buffer,
     for (Particle &part : *part_list) {
       ParticleForce pf;
       archiver >> pf;
-      part.f += pf;
+      part.force_and_torque() += pf;
     }
   }
 }

--- a/src/core/magnetostatics/dipolar_direct_sum.cpp
+++ b/src/core/magnetostatics/dipolar_direct_sum.cpp
@@ -314,8 +314,8 @@ void DipolarDirectSum::add_long_range_forces(
       });
 
       fi += fij;
-      (*q)->f.f += prefactor * fji.f;
-      (*q)->f.torque += prefactor * fji.torque;
+      (*q)->force() += prefactor * fji.f;
+      (*q)->torque() += prefactor * fji.torque;
     }
 
     (*p)->force() += prefactor * fi.f;

--- a/src/core/stokesian_dynamics/sd_interface.cpp
+++ b/src/core/stokesian_dynamics/sd_interface.cpp
@@ -49,7 +49,7 @@
 struct SD_particle_data {
   SD_particle_data() = default;
   explicit SD_particle_data(Particle const &p)
-      : type(p.type()), pos(p.pos()), ext_force(p.f) {}
+      : type(p.type()), pos(p.pos()), ext_force(p.force_and_torque()) {}
 
   int type = 0;
 


### PR DESCRIPTION
Fixes #4694

