### PR TITLE
Fix issues with cluster analysis and chain analysis

### DIFF
--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -295,57 +295,16 @@ assuming the ``image_box`` values were properly set up. This is important to
 consider when setting up systems where the polymers are much longer than the
 box length, which is common when simulating polymer melts.
 
-.. _End to end distance:
+.. _Available chain analysis functions:
 
-End-to-end distance
-^^^^^^^^^^^^^^^^^^^
-:meth:`espressomd.analyze.Analysis.calc_re`
+Available chain analysis functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Returns the mean end-to-end-distance and its standard deviation,
-as well as its mean squared value over all chains.
+* :meth:`espressomd.analyze.Analysis.calc_re`: average end-to-end-distance
 
-.. _Radius of gyration:
+* :meth:`espressomd.analyze.Analysis.calc_rg`: average radius of gyration
 
-Radius of gyration
-^^^^^^^^^^^^^^^^^^
-:meth:`espressomd.analyze.Analysis.calc_rg`
-
-Returns the radius of gyration averaged over all chains.
-It is a radius of a sphere, which would have the same moment of inertia as the
-molecule, defined as
-
-.. math::
-
-   \label{eq:Rg}
-   R_{\mathrm G}^2 = \frac{1}{N} \sum\limits_{i=1}^{N} \left(\vec r_i - \vec r_{\mathrm{cm}}\right)^2\,,
-
-where :math:`\vec r_i` are position vectors of individual particles
-constituting a molecule and :math:`\vec r_{\mathrm{cm}}` is the position
-vector of its center of mass. The sum runs over all :math:`N` particles
-comprising the molecule. For more information see any polymer science
-book, e.g. :cite:`rubinstein03a`.
-
-
-.. _Hydrodynamic radius:
-
-Hydrodynamic radius
-^^^^^^^^^^^^^^^^^^^
-:meth:`espressomd.analyze.Analysis.calc_rh`
-
-Returns the hydrodynamic radius averaged over all chains.
-The following formula is used for the computation:
-
-.. math::
-
-   \label{eq:Rh}
-   \frac{1}{R_{\mathrm H}} = \frac{2}{N(N-1)} \sum\limits_{i=1}^{N} \sum\limits_{j<i}^{N} \frac{1}{|\vec r_i - \vec r_j|}\,,
-
-The above-mentioned formula is only valid under certain assumptions.
-For more information, see chapter 4 and equation 4.102 in :cite:`doi86a`.
-Note that the hydrodynamic radius is sometimes defined in a similar fashion
-but with a denominator of :math:`N^2` instead of :math:`N(N-1)` in the prefactor.
-Both versions are equivalent in the :math:`N\rightarrow \infty` limit but give
-numerically different values for finite polymers.
+* :meth:`espressomd.analyze.Analysis.calc_rh`: average hydrodynamic radius
 
 
 .. _Observables framework:

--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -188,12 +188,6 @@ public:
                                     const Utils::Vector<T, 3> &b) const {
     if (type() == BoxType::LEES_EDWARDS) {
       auto const &shear_plane_normal = lees_edwards_bc().shear_plane_normal;
-      //      if (a[shear_plane_normal] <0 or a[shear_plane_normal]
-      //      >=length()[shear_plane_normal]
-      //          or b[shear_plane_normal] <0 or b[shear_plane_normal]
-      //          >=length()[shear_plane_normal]) throw
-      //          std::runtime_error("Unfolded position in shear plane normal
-      //          direction in LE get_mi_vector will lead to wrong result");
       auto a_tmp = a;
       auto b_tmp = b;
       a_tmp[shear_plane_normal] = Algorithm::periodic_fold(

--- a/src/core/bonded_interactions/bonded_interactions.dox
+++ b/src/core/bonded_interactions/bonded_interactions.dox
@@ -60,10 +60,12 @@
  *    double cutoff() const { return r0 + drmax; }
  *    @endcode
  *    The return value of \c cutoff() should be as large as the interaction
- *    range of the new interaction. This is only relevant to pairwise bonds
- *    and dihedral bonds. In all other cases, the return value should be -1,
- *    namely angle bonds as well as other bonds that don't have an interaction
- *    range.
+ *    range of the new interaction. This is only relevant to pairwise bonds.
+ *    In all other cases, the return value should be 0, namely angle bonds,
+ *    dihedral bonds as well as other bonds that don't have an interaction
+ *    range. The @ref VirtualBond is the exception to this rule; its range
+ *    is @ref BONDED_INACTIVE_CUTOFF to ensure that it is always skipped by
+ *    the short-range loop.
  *  * @code{.cpp}
  *    boost::optional<Utils::Vector3d> force(Utils::Vector3d const &dx) const;
  *    @endcode

--- a/src/core/cluster_analysis/Cluster.cpp
+++ b/src/core/cluster_analysis/Cluster.cpp
@@ -37,6 +37,7 @@
 #include <cmath>
 #include <cstddef>
 #include <numeric>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -50,6 +51,7 @@ Utils::Vector3d Cluster::center_of_mass() {
 // Center of mass of an aggregate
 Utils::Vector3d
 Cluster::center_of_mass_subcluster(std::vector<int> const &particle_ids) {
+  sanity_checks();
   Utils::Vector3d com{};
 
   // The distances between the particles are "folded", such that all distances
@@ -79,6 +81,7 @@ Cluster::center_of_mass_subcluster(std::vector<int> const &particle_ids) {
 }
 
 double Cluster::longest_distance() {
+  sanity_checks();
   double ld = 0.;
   for (auto a = particles.begin(); a != particles.end(); a++) {
     for (auto b = a; ++b != particles.end();) {
@@ -101,6 +104,7 @@ double Cluster::radius_of_gyration() {
 
 double
 Cluster::radius_of_gyration_subcluster(std::vector<int> const &particle_ids) {
+  sanity_checks();
   // Center of mass
   Utils::Vector3d com = center_of_mass_subcluster(particle_ids);
   double sum_sq_dist = 0.;
@@ -128,6 +132,7 @@ std::vector<std::size_t> sort_indices(const std::vector<T> &v) {
 
 std::pair<double, double> Cluster::fractal_dimension(double dr) {
 #ifdef GSL
+  sanity_checks();
   Utils::Vector3d com = center_of_mass();
   // calculate Df using linear regression on the logarithms of the radii of
   // gyration against the number of particles in sub-clusters. Particles are
@@ -174,6 +179,13 @@ std::pair<double, double> Cluster::fractal_dimension(double dr) {
                        "dimension calculation.";
   return {0, 0};
 #endif
+}
+
+void Cluster::sanity_checks() const {
+  if (::box_geo.type() != BoxType::CUBOID) {
+    throw std::runtime_error(
+        "Cluster analysis is not compatible with non-cuboid box types");
+  }
 }
 
 } // namespace ClusterAnalysis

--- a/src/core/cluster_analysis/Cluster.hpp
+++ b/src/core/cluster_analysis/Cluster.hpp
@@ -53,6 +53,9 @@ public:
    *
    *  @return fractal dimension, rms error of the fit */
   std::pair<double, double> fractal_dimension(double dr);
+
+private:
+  void sanity_checks() const;
 };
 
 } // namespace ClusterAnalysis

--- a/src/core/cluster_analysis/ClusterStructure.cpp
+++ b/src/core/cluster_analysis/ClusterStructure.cpp
@@ -18,9 +18,11 @@
  */
 #include "ClusterStructure.hpp"
 
+#include "BoxGeometry.hpp"
 #include "Cluster.hpp"
 #include "PartCfg.hpp"
 #include "errorhandling.hpp"
+#include "grid.hpp"
 #include "partCfg_global.hpp"
 #include "particle_node.hpp"
 
@@ -28,6 +30,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -49,6 +52,7 @@ inline bool ClusterStructure::part_of_cluster(const Particle &p) {
 void ClusterStructure::run_for_all_pairs() {
   // clear data structs
   clear();
+  sanity_checks();
 
   // Iterate over pairs
   Utils::for_each_pair(partCfg().begin(), partCfg().end(),
@@ -60,6 +64,7 @@ void ClusterStructure::run_for_all_pairs() {
 
 void ClusterStructure::run_for_bonded_particles() {
   clear();
+  sanity_checks();
   for (const auto &p : partCfg()) {
     for (auto const bond : p.bonds()) {
       if (bond.partner_ids().size() == 1) {
@@ -187,6 +192,13 @@ int ClusterStructure::get_next_free_cluster_id() {
     }
   }
   return max_seen_cluster + 1;
+}
+
+void ClusterStructure::sanity_checks() const {
+  if (::box_geo.type() != BoxType::CUBOID) {
+    throw std::runtime_error(
+        "Cluster analysis is not compatible with non-cuboid box types");
+  }
 }
 
 } // namespace ClusterAnalysis

--- a/src/core/cluster_analysis/ClusterStructure.hpp
+++ b/src/core/cluster_analysis/ClusterStructure.hpp
@@ -76,6 +76,7 @@ private:
   inline int find_id_for(int x);
   /** @brief Get next free cluster id */
   inline int get_next_free_cluster_id();
+  void sanity_checks() const;
 };
 
 } // namespace ClusterAnalysis

--- a/src/core/virtual_sites/VirtualSitesRelative.cpp
+++ b/src/core/virtual_sites/VirtualSitesRelative.cpp
@@ -116,17 +116,6 @@ void VirtualSitesRelative::update() const {
 
     auto const &p_ref = *p_ref_ptr;
     p.pos() = p_ref.pos() + connection_vector(p_ref, p);
-    //    auto new_pos = p_ref.pos() + connection_vector(p_ref, p);
-    //    /* The shift has to respect periodic boundaries: if the reference
-    //     * particles is not in the same image box, we potentially avoid
-    //     shifting
-    //     * to the other side of the box. */
-    //    auto shift = box_geo.get_mi_vector(new_pos, p.pos());
-    //    p.pos() += shift;
-    //    Utils::Vector3i image_shift{};
-    //    fold_position(shift, image_shift, box_geo);
-    //    p.image_box() = p_ref.image_box() - image_shift;
-    //
     p.v() = velocity(p_ref, p);
 
     if (box_geo.type() == BoxType::LEES_EDWARDS) {

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -237,6 +237,19 @@ class Analysis(ScriptInterfaceHelper):
         numbered, the last particle in that topology having id number
         ``chain_start + number_of_chains * chain_length - 1``.
 
+        The radius of gyration is the radius of a sphere which would have
+        the same moment of inertia as a polymer, and is defined as
+
+        .. math::
+
+           R_{\\mathrm G}^2 = \\frac{1}{N} \\sum\\limits_{i=1}^{N} \\left(\\vec r_i - \\vec r_{\\mathrm{cm}}\\right)^2\\,,
+
+        where :math:`\\vec r_i` are position vectors of individual particles
+        constituting the polymer and :math:`\\vec r_{\\mathrm{cm}}` is the
+        position of its center of mass. The sum runs over all :math:`N`
+        particles comprising the polymer. For more information see any
+        polymer science book, e.g. :cite:`rubinstein03a`.
+
         Parameters
         ----------
         chain_start : :obj:`int`
@@ -254,13 +267,27 @@ class Analysis(ScriptInterfaceHelper):
             its standard deviation.
 
     calc_rh()
-        Calculate the hydrodynamic mean radius of chains and its standard
+        Calculate the mean hydrodynamic radius of chains and its standard
         deviation.
 
         This requires that a set of chains of equal length which start
         with the particle number ``chain_start`` and are consecutively
         numbered, the last particle in that topology having id number
         ``chain_start + number_of_chains * chain_length - 1``.
+
+        The following formula is used for the calculation:
+
+        .. math::
+
+           \\frac{1}{R_{\\mathrm H}} = \\frac{2}{N(N-1)} \\sum\\limits_{i=1}^{N} \\sum\\limits_{j<i}^{N} \\frac{1}{|\\vec r_i - \\vec r_j|}\\,,
+
+        This formula is only valid under certain assumptions. For more
+        information, see chapter 4 and equation 4.102 in :cite:`doi86a`.
+        Note that the hydrodynamic radius is sometimes defined in a similar
+        fashion but with a denominator of :math:`N^2` instead of :math:`N(N-1)`
+        in the prefactor. Both versions are equivalent in the
+        :math:`N\\rightarrow \\infty` limit but give numerically different
+        values for finite polymers.
 
         Parameters
         ----------

--- a/testsuite/python/analyze_chains.py
+++ b/testsuite/python/analyze_chains.py
@@ -99,17 +99,15 @@ class AnalyzeChain(ut.TestCase):
             ij = np.triu_indices(len(r), k=1)
             r_ij = r[ij[0]] - r[ij[1]]
             dist = np.linalg.norm(r_ij, axis=1)
-            # rh.append(self.num_mono*self.num_mono*0.5/(np.sum(1./dist)))
-            # the other way do it, with the proper prefactor of N(N-1)
             rh.append(1. / np.mean(1. / dist))
         rh = np.array(rh)
         return np.mean(rh), np.std(rh)
 
     # python version of the espresso core function,
     # does not check mirror distances
-    # test core results versus python variants (no PBC)
+    # test core results versus python results (no PBC)
     def test_radii(self):
-        # increase PBC for remove mirror images
+        # increase PBC to remove interactions with periodic images
         all_partcls = self.system.part.all()
         old_pos = all_partcls.pos.copy()
         self.system.box_l = self.system.box_l * 2.

--- a/testsuite/python/cluster_analysis.py
+++ b/testsuite/python/cluster_analysis.py
@@ -21,6 +21,7 @@ import espressomd
 import espressomd.utils
 import numpy as np
 import espressomd.interactions
+import espressomd.lees_edwards
 import espressomd.pair_criteria
 import espressomd.cluster_analysis
 
@@ -30,6 +31,8 @@ class ClusterAnalysis(ut.TestCase):
     """Tests the cluster analysis"""
 
     system = espressomd.System(box_l=(1, 1, 1))
+    system.time_step = 0.01
+    system.cell_system.skin = 0.1
 
     fene = espressomd.interactions.FeneBond(k=1, d_r_max=0.05)
     system.bonded_inter.add(fene)
@@ -53,6 +56,7 @@ class ClusterAnalysis(ut.TestCase):
 
     def setUp(self):
         self.system.periodicity = [True, True, True]
+        self.system.time = 0.
 
     def tearDown(self):
         self.system.part.clear()
@@ -117,6 +121,32 @@ class ClusterAnalysis(ut.TestCase):
             visited_sizes.append(c[1].size())
         visited_sizes = sorted(visited_sizes)
         self.assertEqual(visited_sizes, [2, 4])
+
+    def test_single_cluster_analysis_lees_edwards(self):
+        self.set_two_clusters()
+        dc = espressomd.pair_criteria.DistanceCriterion(cut_off=0.12)
+        self.cs.set_params(pair_criterion=dc)
+        self.cs.run_for_all_pairs()
+
+        lin_protocol = espressomd.lees_edwards.LinearShear(
+            initial_pos_offset=-0.02, time_0=0., shear_velocity=0.)
+        self.system.lees_edwards.set_boundary_conditions(
+            shear_direction="y", shear_plane_normal="x", protocol=lin_protocol)
+
+        cluster = list(self.cs.clusters)[0][1]
+        if espressomd.has_features("GSL"):
+            with self.assertRaises(RuntimeError):
+                cluster.fractal_dimension(dr=0.)
+        with self.assertRaises(RuntimeError):
+            cluster.longest_distance()
+        with self.assertRaises(RuntimeError):
+            cluster.center_of_mass()
+        with self.assertRaises(RuntimeError):
+            cluster.radius_of_gyration()
+        with self.assertRaises(RuntimeError):
+            self.cs.run_for_all_pairs()
+        with self.assertRaises(RuntimeError):
+            self.cs.run_for_bonded_particles()
 
     def test_single_cluster_analysis(self):
         # Place particles on a line (crossing periodic boundaries)

--- a/testsuite/python/cluster_analysis.py
+++ b/testsuite/python/cluster_analysis.py
@@ -51,10 +51,12 @@ class ClusterAnalysis(ut.TestCase):
         system.part.add(id=4, pos=(0.5, 0.5, 0.5))
         system.part.add(id=5, pos=(0.55, 0.5, 0.5))
 
+    def setUp(self):
+        self.system.periodicity = [True, True, True]
+
     def tearDown(self):
         self.system.part.clear()
         self.cs.clear()
-        self.system.periodicity = [True, True, True]
 
     def test_00_fails_without_criterion_set(self):
         self.set_two_clusters()

--- a/testsuite/python/lees_edwards.py
+++ b/testsuite/python/lees_edwards.py
@@ -36,7 +36,6 @@ params_osc = {'initial_pos_offset': 0.1, 'time_0': -2.1, 'amplitude': 2.3,
 lin_protocol = espressomd.lees_edwards.LinearShear(**params_lin)
 
 
-# pass in **params_lin
 def get_lin_pos_offset(time, initial_pos_offset=None,
                        time_0=None, shear_velocity=None):
     return initial_pos_offset + (time - time_0) * shear_velocity
@@ -434,7 +433,6 @@ class LeesEdwards(ut.TestCase):
         p2.vs_auto_relate_to(p1)
         p3 = system.part.add(pos=(2.5, 4.0, 2.5))
         p3.vs_auto_relate_to(p1)
-        #system.integrator.run(0, recalc_forces=True)
 
         system.lees_edwards.set_boundary_conditions(
             shear_direction="x", shear_plane_normal="y", protocol=lin_protocol)


### PR DESCRIPTION
Fixes #4689

Description of changes:
- disable cluster analysis methods when Lees-Edwards boundary conditions are used
- document caveats from chain analysis methods
- cleanup doxygen and comment blocks