### PR TITLE
Redesign GitHub Actions workflows

### DIFF
--- a/.github/actions/build_and_check/action.yml
+++ b/.github/actions/build_and_check/action.yml
@@ -17,6 +17,7 @@ runs:
        brew install hdf5-mpi
        pip3 install -c requirements.txt numpy cython h5py scipy
       shell: bash
+      if: runner.os == 'macOS'
     - run: |
         export myconfig=maxset with_cuda=false with_gsl=false test_timeout=800 with_asan=${{ inputs.asan }} with_ubsan=${{ inputs.ubsan }} check_skip_long=true build_procs=2 check_procs=2
         bash maintainer/CI/build_cmake.sh

--- a/.github/actions/build_and_check/action.yml
+++ b/.github/actions/build_and_check/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       if: runner.os == 'macOS'
     - run: |
-        export myconfig=maxset with_cuda=false with_gsl=false test_timeout=800 with_asan=${{ inputs.asan }} with_ubsan=${{ inputs.ubsan }} check_skip_long=true build_procs=2 check_procs=2
+        export myconfig=maxset with_cuda=false with_gsl=false test_timeout=800 with_asan=${{ inputs.asan }} with_ubsan=${{ inputs.ubsan }} check_skip_long=true
         bash maintainer/CI/build_cmake.sh
       shell: bash
       # This is a workaround for the unfortunate interaction of MacOS and OpenMPI 4

--- a/.github/actions/build_and_check/action.yml
+++ b/.github/actions/build_and_check/action.yml
@@ -1,14 +1,5 @@
 name: 'Build and check'
 description: 'Build espresso and run checks'
-inputs:
-  asan:  # id of input
-    description: 'Whether to build with address sanitizer'
-    required: true
-    default: 'false'
-  ubsan:
-    description: 'Whether to build with undefined behavior sanitizer'
-    required: true
-    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -19,7 +10,7 @@ runs:
       shell: bash
       if: runner.os == 'macOS'
     - run: |
-        export myconfig=maxset with_cuda=false with_gsl=false test_timeout=800 with_asan=${{ inputs.asan }} with_ubsan=${{ inputs.ubsan }} check_skip_long=true
+        export myconfig=maxset with_cuda=false with_gsl=false test_timeout=800 check_skip_long=true
         bash maintainer/CI/build_cmake.sh
       shell: bash
       # This is a workaround for the unfortunate interaction of MacOS and OpenMPI 4

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-python@v4.3.1
         with:
           python-version: '3.9'
+      - name: Get runner specifications
+        run: system_profiler SPHardwareDataType
       - name: Check without sanitizer
         uses: ./.github/actions/build_and_check
         with:
@@ -40,6 +42,8 @@ jobs:
         uses: actions/setup-python@v4.3.1
         with:
           python-version: '3.9'
+      - name: Get runner specifications
+        run: system_profiler SPHardwareDataType
       - name: Check with sanitizer
         uses: ./.github/actions/build_and_check
         with:
@@ -68,6 +72,8 @@ jobs:
         uses: actions/checkout@main
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Get runner specifications
+        run: lscpu | egrep 'Model name|Socket|Thread|NUMA|CPU\(s\)'
       - name: Build and check
         uses: ./.github/actions/build_and_check
         with:
@@ -98,6 +104,8 @@ jobs:
         uses: actions/checkout@main
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Get runner specifications
+        run: lscpu | egrep 'Model name|Socket|Thread|NUMA|CPU\(s\)'
       - name: Build and check
         uses: ./.github/actions/build_and_check
         with:

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           asan: false
           ubsan: false
+        env:
+          build_procs: 3
+          check_procs: 3
 
   macos_sanitizers:
     permissions:
@@ -49,6 +52,9 @@ jobs:
         with:
           asan: true
           ubsan: true
+        env:
+          build_procs: 3
+          check_procs: 3
       - name: Setting job link variable
         if: ${{ failure() }}
         run: |
@@ -67,6 +73,7 @@ jobs:
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}
+      options: --cpus 2
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -80,6 +87,8 @@ jobs:
           asan: false
           ubsan: false
         env:
+          build_procs: 2
+          check_procs: 2
           myconfig: 'maxset'
           with_cuda: 'false'
           with_hdf5: 'true'
@@ -99,6 +108,7 @@ jobs:
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}
+      options: --cpus 2
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -112,6 +122,8 @@ jobs:
           asan: false
           ubsan: false
         env:
+          build_procs: 2
+          check_procs: 2
           myconfig: 'maxset'
           with_cuda: 'false'
           with_hdf5: 'false'

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -3,8 +3,6 @@ name: run tests
 on:
   push:
   pull_request:
-  schedule:
-    - cron: '0 3 * * *'
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -12,7 +10,7 @@ permissions:
 jobs:
   macos:
     runs-on: macos-12
-    if: github.event_name != 'schedule'
+    if: ${{ github.repository == 'espressomd/espresso' }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -20,6 +18,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: macos
+          save: ${{ ! startsWith(github.ref, 'refs/pull') }}
       - name: Setup Python environment
         uses: actions/setup-python@v4.3.1
         with:
@@ -36,7 +35,7 @@ jobs:
   debian:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jngrad/espresso-docker/debian:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
+      image: ghcr.io/espressomd/docker/debian:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}
@@ -48,6 +47,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: debian
+          save: ${{ ! startsWith(github.ref, 'refs/pull') }}
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Get runner specifications
@@ -70,10 +70,11 @@ jobs:
           OMPI_ALLOW_RUN_AS_ROOT: 1
           OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
 
-  ubuntu-without-dependencies:
+  ubuntu:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'espressomd/espresso' }}
     container:
-      image: ghcr.io/jngrad/espresso-docker/ubuntu-wo-dependencies:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
+      image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}
@@ -84,7 +85,8 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ubuntu-without-dependencies
+          key: ubuntu
+          save: ${{ ! startsWith(github.ref, 'refs/pull') }}
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Get runner specifications

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -26,55 +26,12 @@ jobs:
           python-version: '3.9'
       - name: Get runner specifications
         run: system_profiler SPHardwareDataType
-      - name: Check without sanitizer
+      - name: Build and check
         uses: ./.github/actions/build_and_check
-        with:
-          asan: false
-          ubsan: false
         env:
           build_procs: 3
           check_procs: 3
           with_ccache: 'true'
-
-  macos_sanitizers:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-      issues: write # to create an issue
-
-    runs-on: macos-12
-    if: (github.event_name == 'schedule' && github.repository == 'espressomd/espresso')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: macos_sanitizers
-      - name: Setup Python environment
-        uses: actions/setup-python@v4.3.1
-        with:
-          python-version: '3.9'
-      - name: Get runner specifications
-        run: system_profiler SPHardwareDataType
-      - name: Check with sanitizer
-        uses: ./.github/actions/build_and_check
-        with:
-          asan: true
-          ubsan: true
-        env:
-          build_procs: 3
-          check_procs: 3
-          with_ccache: 'true'
-      - name: Setting job link variable
-        if: ${{ failure() }}
-        run: |
-          echo "job_link=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
-      - uses: alialaa/issue-action@v1
-        if: ${{ failure() }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: Scheduled CI job has failed
-          body: ${{ env.job_link }}
 
   debian:
     runs-on: ubuntu-latest
@@ -97,9 +54,6 @@ jobs:
         run: lscpu | egrep 'Model name|Socket|Thread|NUMA|CPU\(s\)'
       - name: Build and check
         uses: ./.github/actions/build_and_check
-        with:
-          asan: false
-          ubsan: false
         env:
           build_procs: 2
           check_procs: 2
@@ -137,9 +91,6 @@ jobs:
         run: lscpu | egrep 'Model name|Socket|Thread|NUMA|CPU\(s\)'
       - name: Build and check
         uses: ./.github/actions/build_and_check
-        with:
-          asan: false
-          ubsan: false
         env:
           build_procs: 2
           check_procs: 2

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: macos
       - name: Setup Python environment
         uses: actions/setup-python@v4.3.1
         with:
@@ -30,6 +34,7 @@ jobs:
         env:
           build_procs: 3
           check_procs: 3
+          with_ccache: 'true'
 
   macos_sanitizers:
     permissions:
@@ -41,6 +46,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: macos_sanitizers
       - name: Setup Python environment
         uses: actions/setup-python@v4.3.1
         with:
@@ -55,6 +64,7 @@ jobs:
         env:
           build_procs: 3
           check_procs: 3
+          with_ccache: 'true'
       - name: Setting job link variable
         if: ${{ failure() }}
         run: |
@@ -77,6 +87,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: debian
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Get runner specifications
@@ -90,6 +104,7 @@ jobs:
           build_procs: 2
           check_procs: 2
           myconfig: 'maxset'
+          with_ccache: 'true'
           with_cuda: 'false'
           with_hdf5: 'true'
           with_fftw: 'true'
@@ -112,6 +127,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ubuntu-without-dependencies
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Get runner specifications
@@ -125,6 +144,7 @@ jobs:
           build_procs: 2
           check_procs: 2
           myconfig: 'maxset'
+          with_ccache: 'true'
           with_cuda: 'false'
           with_hdf5: 'false'
           with_fftw: 'false'

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -1,4 +1,4 @@
-name: run tests on mac
+name: run tests
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  regular_check:
+  macos:
     runs-on: macos-12
     if: github.event_name != 'schedule'
     steps:
@@ -26,7 +26,7 @@ jobs:
           asan: false
           ubsan: false
 
-  sanitizer_check:
+  macos_sanitizers:
     permissions:
       contents: read # to fetch code (actions/checkout)
       issues: write # to create an issue
@@ -55,3 +55,63 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: Scheduled CI job has failed
           body: ${{ env.job_link }}
+
+  debian:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jngrad/espresso-docker/debian:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
+      credentials:
+         username: ${{ github.actor }}
+         password: ${{ secrets.github_token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Setup Git environment
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build and check
+        uses: ./.github/actions/build_and_check
+        with:
+          asan: false
+          ubsan: false
+        env:
+          myconfig: 'maxset'
+          with_cuda: 'false'
+          with_hdf5: 'true'
+          with_fftw: 'true'
+          with_gsl: 'false'
+          with_scafacos: 'false'
+          with_stokesian_dynamics: 'false'
+          make_check_unit_tests: 'true'
+          make_check_python: 'false'
+          OMPI_ALLOW_RUN_AS_ROOT: 1
+          OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+
+  ubuntu-without-dependencies:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jngrad/espresso-docker/ubuntu-wo-dependencies:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
+      credentials:
+         username: ${{ github.actor }}
+         password: ${{ secrets.github_token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Setup Git environment
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build and check
+        uses: ./.github/actions/build_and_check
+        with:
+          asan: false
+          ubsan: false
+        env:
+          myconfig: 'maxset'
+          with_cuda: 'false'
+          with_hdf5: 'false'
+          with_fftw: 'false'
+          with_gsl: 'false'
+          with_scafacos: 'false'
+          with_stokesian_dynamics: 'false'
+          make_check_unit_tests: 'false'
+          make_check_python: 'false'
+          OMPI_ALLOW_RUN_AS_ROOT: 1
+          OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,42 +136,6 @@ no_rotation:
     - no-cuda
     - numa
 
-ubuntu:wo-dependencies:
-  <<: *global_job_definition
-  stage: build
-  image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:3fd42369f84239b8c4f5d77067d404789c55ff44
-  variables:
-     myconfig: 'maxset'
-     with_cuda: 'false'
-     with_hdf5: 'false'
-     with_fftw: 'false'
-     with_gsl: 'false'
-     make_check_unit_tests: 'false'
-     make_check_python: 'false'
-  script:
-    - bash maintainer/CI/build_cmake.sh
-  tags:
-    - espresso
-    - no-cuda
-
-### Builds with different distributions
-
-debian:10:
-  <<: *global_job_definition
-  stage: build
-  image: ghcr.io/espressomd/docker/debian:3fd42369f84239b8c4f5d77067d404789c55ff44
-  variables:
-     with_cuda: 'false'
-     with_gsl: 'false'
-     myconfig: 'maxset'
-     make_check_python: 'false'
-     with_stokesian_dynamics: 'true'
-  script:
-    - bash maintainer/CI/build_cmake.sh
-  tags:
-    - espresso
-    - no-cuda
-
 fedora:36:
   <<: *global_job_definition
   stage: build


### PR DESCRIPTION
Follow-up to espressomd/docker#212

Description of changes:
- move `debian` and `ubuntu-wo-dependencies` jobs to GitHub Actions
- remove brittle macOS `sanitizer_check` job from the scheduled jobs
- introduce ccache on all GitHub Actions to reduce compilation times
