### PR TITLE
Add support for ARM architectures

### DIFF
--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -141,7 +141,7 @@ if [ "${with_coverage}" = true ]; then
 fi
 
 if [ "${with_fast_math}" = true ]; then
-    cmake_param_protected="-DCMAKE_CXX_FLAGS=-ffast-math -fno-finite-math-only"
+    cmake_param_protected="-DCMAKE_CXX_FLAGS=-ffast-math"
 fi
 
 cmake_params="-D CMAKE_BUILD_TYPE=${build_type} -D CMAKE_CXX_STANDARD=${with_cxx_standard} -D ESPRESSO_WARNINGS_ARE_ERRORS=ON ${cmake_params}"

--- a/src/core/analysis/statistics_chain.cpp
+++ b/src/core/analysis/statistics_chain.cpp
@@ -35,12 +35,11 @@
 #include <cmath>
 #include <stdexcept>
 
-std::array<double, 4> calc_re(int chain_start, int chain_n_chains,
-                              int chain_length) {
+std::array<double, 4> calc_re(int chain_start, int n_chains, int chain_length) {
   double dist = 0.0, dist2 = 0.0, dist4 = 0.0;
   std::array<double, 4> re;
 
-  for (int i = 0; i < chain_n_chains; i++) {
+  for (int i = 0; i < n_chains; i++) {
     auto const &p1 =
         get_particle_data(chain_start + i * chain_length + chain_length - 1);
     auto const &p2 = get_particle_data(chain_start + i * chain_length);
@@ -53,7 +52,7 @@ std::array<double, 4> calc_re(int chain_start, int chain_n_chains,
     dist2 += norm2;
     dist4 += norm2 * norm2;
   }
-  auto const tmp = static_cast<double>(chain_n_chains);
+  auto const tmp = static_cast<double>(n_chains);
   re[0] = dist / tmp;
   re[2] = dist2 / tmp;
   re[1] = sqrt(re[2] - re[0] * re[0]);
@@ -61,12 +60,11 @@ std::array<double, 4> calc_re(int chain_start, int chain_n_chains,
   return re;
 }
 
-std::array<double, 4> calc_rg(int chain_start, int chain_n_chains,
-                              int chain_length) {
+std::array<double, 4> calc_rg(int chain_start, int n_chains, int chain_length) {
   double r_G = 0.0, r_G2 = 0.0, r_G4 = 0.0;
   std::array<double, 4> rg;
 
-  for (int i = 0; i < chain_n_chains; i++) {
+  for (int i = 0; i < n_chains; i++) {
     double M = 0.0;
     Utils::Vector3d r_CM{};
     for (int j = 0; j < chain_length; j++) {
@@ -94,7 +92,7 @@ std::array<double, 4> calc_rg(int chain_start, int chain_n_chains,
     r_G2 += tmp;
     r_G4 += tmp * tmp;
   }
-  auto const tmp = static_cast<double>(chain_n_chains);
+  auto const tmp = static_cast<double>(n_chains);
   rg[0] = r_G / tmp;
   rg[2] = r_G2 / tmp;
   rg[1] = sqrt(rg[2] - Utils::sqr(rg[0]));
@@ -102,14 +100,13 @@ std::array<double, 4> calc_rg(int chain_start, int chain_n_chains,
   return rg;
 }
 
-std::array<double, 2> calc_rh(int chain_start, int chain_n_chains,
-                              int chain_length) {
+std::array<double, 2> calc_rh(int chain_start, int n_chains, int chain_length) {
   double r_H = 0.0, r_H2 = 0.0;
   std::array<double, 2> rh;
 
   auto const chain_l = static_cast<double>(chain_length);
   auto const prefac = 0.5 * chain_l * (chain_l - 1.);
-  for (int p = 0; p < chain_n_chains; p++) {
+  for (int p = 0; p < n_chains; p++) {
     double ri = 0.0;
     for (int i = chain_start + chain_length * p;
          i < chain_start + chain_length * (p + 1); i++) {
@@ -126,7 +123,7 @@ std::array<double, 2> calc_rh(int chain_start, int chain_n_chains,
     r_H += tmp;
     r_H2 += tmp * tmp;
   }
-  auto const tmp = static_cast<double>(chain_n_chains);
+  auto const tmp = static_cast<double>(n_chains);
   rh[0] = r_H / tmp;
   rh[1] = sqrt(r_H2 / tmp - Utils::sqr(rh[0]));
   return rh;

--- a/src/core/analysis/statistics_chain.cpp
+++ b/src/core/analysis/statistics_chain.cpp
@@ -55,8 +55,8 @@ std::array<double, 4> calc_re(int chain_start, int n_chains, int chain_length) {
   auto const tmp = static_cast<double>(n_chains);
   re[0] = dist / tmp;
   re[2] = dist2 / tmp;
-  re[1] = sqrt(re[2] - re[0] * re[0]);
-  re[3] = sqrt(dist4 / tmp - re[2] * re[2]);
+  re[1] = (n_chains == 1) ? 0. : std::sqrt(re[2] - Utils::sqr(re[0]));
+  re[3] = (n_chains == 1) ? 0. : std::sqrt(dist4 / tmp - Utils::sqr(re[2]));
   return re;
 }
 
@@ -95,8 +95,8 @@ std::array<double, 4> calc_rg(int chain_start, int n_chains, int chain_length) {
   auto const tmp = static_cast<double>(n_chains);
   rg[0] = r_G / tmp;
   rg[2] = r_G2 / tmp;
-  rg[1] = sqrt(rg[2] - Utils::sqr(rg[0]));
-  rg[3] = sqrt(r_G4 / tmp - Utils::sqr(rg[2]));
+  rg[1] = (n_chains == 1) ? 0. : std::sqrt(rg[2] - Utils::sqr(rg[0]));
+  rg[3] = (n_chains == 1) ? 0. : std::sqrt(r_G4 / tmp - Utils::sqr(rg[2]));
   return rg;
 }
 
@@ -125,6 +125,6 @@ std::array<double, 2> calc_rh(int chain_start, int n_chains, int chain_length) {
   }
   auto const tmp = static_cast<double>(n_chains);
   rh[0] = r_H / tmp;
-  rh[1] = sqrt(r_H2 / tmp - Utils::sqr(rh[0]));
+  rh[1] = (n_chains == 1) ? 0. : std::sqrt(r_H2 / tmp - Utils::sqr(rh[0]));
   return rh;
 }

--- a/src/core/analysis/statistics_chain.hpp
+++ b/src/core/analysis/statistics_chain.hpp
@@ -34,11 +34,10 @@
  * of monodisperse polymers with continuous ids.
  *
  * @param chain_start The id of the first monomer of the first chain.
- * @param chain_n_chains Number of chains contained in the range.
+ * @param n_chains Number of chains contained in the range.
  * @param chain_length The length of every chain.
  */
-std::array<double, 4> calc_re(int chain_start, int chain_n_chains,
-                              int chain_length);
+std::array<double, 4> calc_re(int chain_start, int n_chains, int chain_length);
 
 /**
  * @brief Calculate the radius of gyration.
@@ -47,11 +46,10 @@ std::array<double, 4> calc_re(int chain_start, int chain_n_chains,
  * of monodisperse polymers with continuous ids.
  *
  * @param chain_start The id of the first monomer of the first chain.
- * @param chain_n_chains Number of chains contained in the range.
+ * @param n_chains Number of chains contained in the range.
  * @param chain_length The length of every chain.
  */
-std::array<double, 4> calc_rg(int chain_start, int chain_n_chains,
-                              int chain_length);
+std::array<double, 4> calc_rg(int chain_start, int n_chains, int chain_length);
 
 /**
  * @brief Calculate the hydrodynamic radius (ref. Kirkwood-Zimm theory).
@@ -60,10 +58,9 @@ std::array<double, 4> calc_rg(int chain_start, int chain_n_chains,
  * of monodisperse polymers with continuous ids.
  *
  * @param chain_start The id of the first monomer of the first chain.
- * @param chain_n_chains Number of chains contained in the range.
+ * @param n_chains Number of chains contained in the range.
  * @param chain_length The length of every chain.
  */
-std::array<double, 2> calc_rh(int chain_start, int chain_n_chains,
-                              int chain_length);
+std::array<double, 2> calc_rh(int chain_start, int n_chains, int chain_length);
 
 #endif

--- a/src/core/electrostatics/icc.cpp
+++ b/src/core/electrostatics/icc.cpp
@@ -129,6 +129,12 @@ void ICCStar::iteration(CellStructure &cell_structure,
     for (auto &p : particles) {
       auto const pid = p.id();
       if (pid >= icc_cfg.first_id and pid < icc_cfg.n_icc + icc_cfg.first_id) {
+        if (p.q() == 0.) {
+          runtimeErrorMsg()
+              << "ICC found zero electric charge on a particle. This must "
+                 "never happen";
+          break;
+        }
         auto const id = p.id() - icc_cfg.first_id;
         /* the dielectric-related prefactor: */
         auto const eps_in = icc_cfg.epsilons[id];
@@ -176,7 +182,7 @@ void ICCStar::iteration(CellStructure &cell_structure,
               << "Particle with id " << p.id() << " has a charge (q=" << p.q()
               << ") that is too large for the ICC algorithm";
 
-          max_rel_diff = std::numeric_limits<double>::infinity();
+          max_rel_diff = std::numeric_limits<double>::max();
           break;
         }
       }

--- a/src/core/particle_node.cpp
+++ b/src/core/particle_node.cpp
@@ -457,18 +457,6 @@ static bool maybe_move_particle(int p_id, Utils::Vector3d const &pos) {
   return true;
 }
 
-void particle_checks(int p_id, Utils::Vector3d const &pos) {
-  if (p_id < 0) {
-    throw std::domain_error("Invalid particle id: " + std::to_string(p_id));
-  }
-#ifndef __FAST_MATH__
-  if (std::isnan(pos[0]) or std::isnan(pos[1]) or std::isnan(pos[2]) or
-      std::isinf(pos[0]) or std::isinf(pos[1]) or std::isinf(pos[2])) {
-    throw std::domain_error("Particle position must be finite");
-  }
-#endif // __FAST_MATH__
-}
-
 void remove_all_particles() {
   ::cell_structure.remove_all_particles();
   on_particle_change();

--- a/src/core/particle_node.hpp
+++ b/src/core/particle_node.hpp
@@ -82,7 +82,6 @@ void clear_particle_node();
  * @param pos   The particle position.
  */
 void make_new_particle(int p_id, Utils::Vector3d const &pos);
-void particle_checks(int p_id, Utils::Vector3d const &pos);
 
 /**
  * @brief Move particle to a new position.

--- a/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
+++ b/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
@@ -68,7 +68,7 @@ public:
 // Check the base class for all Monte Carlo algorithms.
 BOOST_FIXTURE_TEST_CASE(ReactionAlgorithm_test, ParticleFactory) {
   using ReactionMethods::SingleReaction;
-  auto constexpr tol = 100. * std::numeric_limits<double>::epsilon();
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
   auto const comm = boost::mpi::communicator();
 
   // check acceptance rate

--- a/src/core/reaction_methods/tests/SingleReaction_test.cpp
+++ b/src/core/reaction_methods/tests/SingleReaction_test.cpp
@@ -32,7 +32,7 @@
 // and the configurational move probability for a given system state.
 BOOST_AUTO_TEST_CASE(SingleReaction_test) {
   using namespace ReactionMethods;
-  constexpr double tol = 100 * std::numeric_limits<double>::epsilon();
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
 
   // create a reaction A -> 3 B + 4 C
   int const type_A = 0;
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(SingleReaction_test) {
             std::unordered_map<int, int>{{type_A, i}, {type_B, j}, {type_C, k}};
         auto const val = calculate_factorial_expression(reaction, p_numbers);
         auto const ref = g(i, -1) * g(j, 3) * g(k, 4);
-        BOOST_CHECK_CLOSE(val, ref, 5 * tol);
+        BOOST_CHECK_CLOSE(val, ref, 5. * tol);
       }
     }
   }

--- a/src/core/reaction_methods/tests/reaction_methods_utils_test.cpp
+++ b/src/core/reaction_methods/tests/reaction_methods_utils_test.cpp
@@ -28,7 +28,7 @@
 
 BOOST_AUTO_TEST_CASE(factorial_Ni0_divided_by_factorial_Ni0_plus_nu_i_test) {
   using namespace ReactionMethods;
-  constexpr double tol = 100. * std::numeric_limits<double>::epsilon();
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
 
   auto const reaction_ensemble_combinations = [](int N, int nu) {
     return (N + nu < 0) ? 0. : std::tgamma(N + 1) / std::tgamma(N + nu + 1);

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -92,7 +92,7 @@ static auto copy_particle_to_head_node(boost::mpi::communicator const &comm,
 }
 
 BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
-  constexpr auto tol = 100. * std::numeric_limits<double>::epsilon();
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
   auto const comm = boost::mpi::communicator();
   auto const rank = comm.rank();
   auto const n_nodes = comm.size();

--- a/src/core/unit_tests/Verlet_list_test.cpp
+++ b/src/core/unit_tests/Verlet_list_test.cpp
@@ -167,7 +167,7 @@ auto const propagators =
 BOOST_DATA_TEST_CASE_F(ParticleFactory, verlet_list_update,
                        bdata::make(node_grids) * bdata::make(propagators),
                        node_grid, integration_helper) {
-  constexpr auto tol = 100. * std::numeric_limits<double>::epsilon();
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
   auto const comm = boost::mpi::communicator();
   auto const rank = comm.rank();
 

--- a/src/core/unit_tests/field_coupling_couplings_test.cpp
+++ b/src/core/unit_tests/field_coupling_couplings_test.cpp
@@ -16,7 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define BOOST_TEST_MODULE AutoParameter test
+
+#define BOOST_TEST_MODULE Field coupling test for fields
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 

--- a/src/core/unit_tests/field_coupling_fields_test.cpp
+++ b/src/core/unit_tests/field_coupling_fields_test.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_MODULE AutoParameter test
+#define BOOST_TEST_MODULE Field coupling test for fields
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
@@ -37,7 +37,7 @@
 #include <limits>
 #include <type_traits>
 
-constexpr auto eps = 10 * std::numeric_limits<double>::epsilon();
+auto constexpr eps = 10. * std::numeric_limits<double>::epsilon();
 
 using namespace FieldCoupling::Fields;
 
@@ -269,6 +269,7 @@ BOOST_AUTO_TEST_CASE(interpolated_scalar_field) {
     BOOST_CHECK_SMALL(std::abs(interpolated_value - field_value), eps);
   }
 
+#ifndef __FAST_MATH__
   /* jacobian value */
   {
     using Utils::Interpolation::bspline_3d_gradient_accumulate;
@@ -296,6 +297,7 @@ BOOST_AUTO_TEST_CASE(interpolated_scalar_field) {
 
     BOOST_CHECK_SMALL((interpolated_value - field_value).norm(), eps);
   }
+#endif // __FAST_MATH__
 }
 
 BOOST_AUTO_TEST_CASE(interpolated_vector_field) {
@@ -342,6 +344,7 @@ BOOST_AUTO_TEST_CASE(interpolated_vector_field) {
     BOOST_CHECK_SMALL((interpolated_value - field_value).norm(), eps);
   }
 
+#ifndef __FAST_MATH__
   /* jacobian value */
   {
     using Utils::Interpolation::bspline_3d_gradient_accumulate;
@@ -380,4 +383,5 @@ BOOST_AUTO_TEST_CASE(interpolated_vector_field) {
     BOOST_CHECK_SMALL(
         (interpolated_value.row<1>() - field_value.row<1>()).norm(), eps);
   }
+#endif // __FAST_MATH__
 }

--- a/src/core/unit_tests/field_coupling_force_field_test.cpp
+++ b/src/core/unit_tests/field_coupling_force_field_test.cpp
@@ -16,7 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define BOOST_TEST_MODULE test
+
+#define BOOST_TEST_MODULE Field coupling test for force fields
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 

--- a/src/core/unit_tests/p3m_test.cpp
+++ b/src/core/unit_tests/p3m_test.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(calc_meshift_true) {
 #if defined(P3M) || defined(DP3M)
 BOOST_AUTO_TEST_CASE(analytic_cotangent_sum) {
   auto constexpr kernel = p3m_analytic_cotangent_sum;
-  auto constexpr tol = 100. * std::numeric_limits<double>::epsilon();
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
 
   // check only trivial cases
   for (auto const cao : {1, 2, 3, 4, 5, 6, 7}) {

--- a/src/core/unit_tests/periodic_fold_test.cpp
+++ b/src/core/unit_tests/periodic_fold_test.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(with_image_count) {
     BOOST_CHECK(res.first >= 0.);
     BOOST_CHECK(res.first <= box);
     BOOST_CHECK(std::abs(res.first - x + res.second * box) <=
-                std::numeric_limits<double>::epsilon());
+                4. * std::numeric_limits<double>::epsilon());
   }
 
   /* Corner right */
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(with_image_count) {
     BOOST_CHECK(res.first >= 0.);
     BOOST_CHECK(res.first < box);
     BOOST_CHECK(std::abs(res.first - x + res.second * box) <=
-                std::numeric_limits<double>::epsilon());
+                4. * std::numeric_limits<double>::epsilon());
   }
 }
 

--- a/src/core/unit_tests/specfunc_test.cpp
+++ b/src/core/unit_tests/specfunc_test.cpp
@@ -26,7 +26,7 @@
 #include <cmath>
 #include <limits>
 
-constexpr auto eps = 100. * std::numeric_limits<double>::epsilon();
+auto constexpr eps = 8. * 100. * std::numeric_limits<double>::epsilon();
 
 BOOST_AUTO_TEST_CASE(hurwitz_zeta_function) {
   constexpr auto max_bits = 54.0;

--- a/src/core/unit_tests/thermostats_test.cpp
+++ b/src/core/unit_tests/thermostats_test.cpp
@@ -42,7 +42,7 @@
 
 // multiply by 100 because BOOST_CHECK_CLOSE takes a percentage tolerance,
 // and by 6 to account for error accumulation in thermostat functions
-constexpr auto tol = 6 * 100 * std::numeric_limits<double>::epsilon();
+auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
 
 Particle particle_factory() {
   Particle p{};

--- a/src/core/unit_tests/thermostats_test.cpp
+++ b/src/core/unit_tests/thermostats_test.cpp
@@ -41,7 +41,7 @@
 #include <tuple>
 
 // multiply by 100 because BOOST_CHECK_CLOSE takes a percentage tolerance,
-// and by 6 to account for error accumulation in thermostat functions
+// and by 8 to account for error accumulation in thermostat functions
 auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
 
 Particle particle_factory() {

--- a/src/particle_observables/tests/algorithms.cpp
+++ b/src/particle_observables/tests/algorithms.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(algorithms_integer) {
 }
 
 BOOST_AUTO_TEST_CASE(algorithms_double) {
-  auto constexpr tol = 100 * std::numeric_limits<double>::epsilon();
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
   std::vector<double> const values{1., 2., 3., 4.};
   {
     auto const res = WeightedAverage<Testing::Identity, Testing::One>()(values);

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -60,6 +60,10 @@ target_link_libraries(
   PUBLIC espresso::utils MPI::MPI_CXX Boost::mpi espresso::shapes
   PRIVATE espresso::cpp_flags)
 
+set_source_files_properties(
+  ${CMAKE_CURRENT_SOURCE_DIR}/particle_data/ParticleHandle.cpp
+  PROPERTIES COMPILE_FLAGS -fno-finite-math-only)
+
 target_include_directories(espresso_script_interface
                            PUBLIC ${CMAKE_SOURCE_DIR}/src)
 

--- a/src/script_interface/analysis/Analysis.cpp
+++ b/src/script_interface/analysis/Analysis.cpp
@@ -48,6 +48,12 @@ namespace Analysis {
 
 /** @brief Check if a contiguous range of particle ids exists. */
 static void check_topology(int chain_start, int chain_length, int n_chains) {
+  if (n_chains <= 0) {
+    throw std::domain_error("Chain analysis needs at least 1 chain");
+  }
+  if (chain_length <= 0) {
+    throw std::domain_error("Chain analysis needs at least 1 bead per chain");
+  }
   for (int i = 0; i < chain_length * n_chains; ++i) {
     auto const pid = chain_start + i;
     if (not particle_exists(pid)) {

--- a/src/script_interface/particle_data/ParticleHandle.cpp
+++ b/src/script_interface/particle_data/ParticleHandle.cpp
@@ -58,6 +58,18 @@
 namespace ScriptInterface {
 namespace Particles {
 
+static void particle_checks(int p_id, Utils::Vector3d const &pos) {
+  if (p_id < 0) {
+    throw std::domain_error("Invalid particle id: " + std::to_string(p_id));
+  }
+#ifndef __FAST_MATH__
+  if (std::isnan(pos[0]) or std::isnan(pos[1]) or std::isnan(pos[2]) or
+      std::isinf(pos[0]) or std::isinf(pos[1]) or std::isinf(pos[2])) {
+    throw std::domain_error("Particle position must be finite");
+  }
+#endif // __FAST_MATH__
+}
+
 static uint8_t bitfield_from_flag(Utils::Vector3i const &flag) {
   auto bitfield = static_cast<uint8_t>(0u);
   if (flag[0])
@@ -173,7 +185,9 @@ ParticleHandle::ParticleHandle() {
        [this]() { return get_particle_data(m_pid).type(); }},
       {"pos",
        [this](Variant const &value) {
-         set_particle_pos(m_pid, get_value<Utils::Vector3d>(value));
+         auto const pos = get_value<Utils::Vector3d>(value);
+         particle_checks(m_pid, pos);
+         set_particle_pos(m_pid, pos);
        },
        [this]() {
          auto const p = get_particle_data(m_pid);

--- a/src/shapes/unit_tests/Ellipsoid_test.cpp
+++ b/src/shapes/unit_tests/Ellipsoid_test.cpp
@@ -34,7 +34,7 @@
 
 BOOST_AUTO_TEST_CASE(dist_function) {
   // multiply by 100 because BOOST_REQUIRE_CLOSE takes a percentage tolerance
-  auto constexpr tol = std::numeric_limits<double>::epsilon() * 100;
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
   double const semiaxes[3] = {3.1, 2.2, 1.3};
 
   Shapes::Ellipsoid e;

--- a/src/shapes/unit_tests/Sphere_test.cpp
+++ b/src/shapes/unit_tests/Sphere_test.cpp
@@ -34,7 +34,7 @@ void check_distance_function(Shapes::Sphere &s) {
   Utils::Vector3d vec;
   double dist;
   // multiply by 100 because BOOST_REQUIRE_CLOSE takes a percentage tolerance
-  auto const tol = std::numeric_limits<double>::epsilon() * 100;
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
 
   s.rad() = 1.0;
   pos = {0., 0., 0.};

--- a/src/utils/tests/Vector_test.cpp
+++ b/src/utils/tests/Vector_test.cpp
@@ -119,10 +119,11 @@ BOOST_AUTO_TEST_CASE(test_norm2) {
 }
 
 BOOST_AUTO_TEST_CASE(normalize) {
-  Utils::Vector3d v{1, 2, 3};
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
+  Utils::Vector3d v{1., 2., 3.};
   v.normalize();
 
-  BOOST_CHECK((v.norm2() - 1.0) <= std::numeric_limits<double>::epsilon());
+  BOOST_CHECK_CLOSE(v.norm2(), 1.0, tol);
 }
 
 BOOST_AUTO_TEST_CASE(comparison_operators) {

--- a/src/utils/tests/interpolation_test.cpp
+++ b/src/utils/tests/interpolation_test.cpp
@@ -135,6 +135,7 @@ BOOST_AUTO_TEST_CASE(sum_of_weights_odd) {
 }
 
 BOOST_AUTO_TEST_CASE(nearest_point) {
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
   std::array<int, 3> nmp;
   double weight;
   auto save_ind = [&nmp, &weight](const std::array<int, 3> &ind, double w) {
@@ -145,7 +146,7 @@ BOOST_AUTO_TEST_CASE(nearest_point) {
   bspline_3d<1>({.1, .2, .3}, save_ind, {0.5, 0.5, 0.5}, {});
 
   BOOST_CHECK((std::array<int, 3>{{0, 0, 1}} == nmp));
-  BOOST_CHECK_CLOSE(weight, 1., 100. * std::numeric_limits<double>::epsilon());
+  BOOST_CHECK_CLOSE(weight, 1., tol);
 }
 
 BOOST_AUTO_TEST_CASE(interpolation_points_3) {

--- a/src/utils/tests/matrix_vector_product.cpp
+++ b/src/utils/tests/matrix_vector_product.cpp
@@ -32,10 +32,11 @@ static constexpr std::array<std::array<int, 3>, 3> matrix{
     {{{1, 2, 9}}, {{8, 41, 6}}, {{31, 15, 99}}}};
 
 BOOST_AUTO_TEST_CASE(inner_product) {
+  auto constexpr tol = 8. * 100. * std::numeric_limits<double>::epsilon();
   const std::array<double, 3> vector{{0.5, 1.25, 3.1}};
   auto const result = Utils::matrix_vector_product<double, 3, matrix>(vector);
   for (int i = 0; i < 3; ++i) {
-    BOOST_CHECK_CLOSE(result[i], boost::inner_product(matrix[i], vector, 0.0),
-                      100. * std::numeric_limits<double>::epsilon());
+    auto const ref = boost::inner_product(matrix[i], vector, 0.0);
+    BOOST_CHECK_CLOSE(result[i], ref, tol);
   }
 }

--- a/src/utils/tests/vec_rotate_test.cpp
+++ b/src/utils/tests/vec_rotate_test.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(rotation) {
   auto const is = Utils::vec_rotate(k, t, v);
   auto const rel_diff = (expected - is).norm() / expected.norm();
 
-  BOOST_CHECK(rel_diff < std::numeric_limits<double>::epsilon());
+  BOOST_CHECK(rel_diff < 8. * std::numeric_limits<double>::epsilon());
 }
 
 BOOST_AUTO_TEST_CASE(angle_between) {

--- a/testsuite/python/analyze_chains.py
+++ b/testsuite/python/analyze_chains.py
@@ -72,8 +72,12 @@ class AnalyzeChain(ut.TestCase):
         dist = self.system.part.by_ids(
             head_ids).pos - self.system.part.by_ids(tail_ids).pos
         dist = np.sum(dist**2, axis=-1)
-        return np.mean(np.sqrt(dist)), np.std(
-            np.sqrt(dist)), np.mean(dist), np.std(dist)
+        return (
+            np.mean(np.sqrt(dist)),
+            0. if num_mono == 1 else np.std(np.sqrt(dist), ddof=0),
+            np.mean(dist),
+            0. if num_mono == 1 else np.std(dist, ddof=0),
+        )
 
     # python version of the espresso core function,
     # does not check mirror distances
@@ -87,8 +91,12 @@ class AnalyzeChain(ut.TestCase):
             rg2.append(np.var(r, axis=0))
         rg2 = np.array(rg2)
         rg2 = np.sum(rg2, axis=1)
-        return np.mean(np.sqrt(rg2)), np.std(
-            np.sqrt(rg2)), np.mean(rg2), np.std(rg2)
+        return (
+            np.mean(np.sqrt(rg2)),
+            0. if num_mono == 1 else np.std(np.sqrt(rg2), ddof=0),
+            np.mean(rg2),
+            0. if num_mono == 1 else np.std(rg2, ddof=0),
+        )
 
     # python version of the espresso core function,
     # does not check mirror distances
@@ -105,7 +113,7 @@ class AnalyzeChain(ut.TestCase):
             dist = np.linalg.norm(r_ij, axis=1)
             rh.append(1. / np.mean(1. / dist))
         rh = np.array(rh)
-        return np.mean(rh), np.std(rh)
+        return (np.mean(rh), 0. if num_mono == 1 else np.std(rh, ddof=0))
 
     # python version of the espresso core function,
     # does not check mirror distances

--- a/testsuite/python/analyze_chains.py
+++ b/testsuite/python/analyze_chains.py
@@ -131,17 +131,20 @@ class AnalyzeChain(ut.TestCase):
         core_re = self.system.analysis.calc_re(chain_start=0,
                                                number_of_chains=num_poly,
                                                chain_length=num_mono)
-        np.testing.assert_allclose(core_re, self.calc_re(num_poly, num_mono))
+        np.testing.assert_allclose(core_re, self.calc_re(num_poly, num_mono),
+                                   atol=1e-8)
         # compare calc_rg()
         core_rg = self.system.analysis.calc_rg(chain_start=0,
                                                number_of_chains=num_poly,
                                                chain_length=num_mono)
-        np.testing.assert_allclose(core_rg, self.calc_rg(num_poly, num_mono))
+        np.testing.assert_allclose(core_rg, self.calc_rg(num_poly, num_mono),
+                                   atol=1e-8)
         # compare calc_rh()
         core_rh = self.system.analysis.calc_rh(chain_start=0,
                                                number_of_chains=num_poly,
                                                chain_length=num_mono)
-        np.testing.assert_allclose(core_rh, self.calc_rh(num_poly, num_mono))
+        np.testing.assert_allclose(core_rh, self.calc_rh(num_poly, num_mono),
+                                   atol=1e-8)
 
     def test_observables_lebc(self):
         lin_protocol = espressomd.lees_edwards.LinearShear(
@@ -171,7 +174,8 @@ class AnalyzeChain(ut.TestCase):
         core_re = self.system.analysis.calc_re(chain_start=0,
                                                number_of_chains=num_poly,
                                                chain_length=num_mono)
-        np.testing.assert_allclose(core_re, self.calc_re(num_poly, num_mono))
+        np.testing.assert_allclose(core_re, self.calc_re(num_poly, num_mono),
+                                   atol=1e-8)
         # compare calc_rg()
         core_rg = self.system.analysis.calc_rg(chain_start=0,
                                                number_of_chains=num_poly,
@@ -182,7 +186,8 @@ class AnalyzeChain(ut.TestCase):
         core_rh = self.system.analysis.calc_rh(chain_start=0,
                                                number_of_chains=num_poly,
                                                chain_length=num_mono)
-        np.testing.assert_allclose(core_rh, self.calc_rh(num_poly, num_mono))
+        np.testing.assert_allclose(core_rh, self.calc_rh(num_poly, num_mono),
+                                   atol=1e-8)
 
     def test_exceptions(self):
         num_poly = 2

--- a/testsuite/python/analyze_chains.py
+++ b/testsuite/python/analyze_chains.py
@@ -189,6 +189,14 @@ class AnalyzeChain(ut.TestCase):
             with self.assertRaisesRegex(RuntimeError, err_msg):
                 method(chain_start=0, number_of_chains=num_poly,
                        chain_length=2 * num_mono)
+            with self.assertRaisesRegex(ValueError, "needs at least 1 bead per chain"):
+                method(chain_start=0, number_of_chains=1, chain_length=0)
+            with self.assertRaisesRegex(ValueError, "needs at least 1 bead per chain"):
+                method(chain_start=0, number_of_chains=1, chain_length=-1)
+            with self.assertRaisesRegex(ValueError, "needs at least 1 chain"):
+                method(chain_start=0, number_of_chains=0, chain_length=1)
+            with self.assertRaisesRegex(ValueError, "needs at least 1 chain"):
+                method(chain_start=0, number_of_chains=-1, chain_length=1)
         self.assertIsNone(analysis.call_method("unknown"))
 
 

--- a/testsuite/python/icc_interface.py
+++ b/testsuite/python/icc_interface.py
@@ -137,6 +137,9 @@ class Test(ut.TestCase):
         icc, (_, p) = self.setup_icc_particles_and_solver(max_iterations=1)
         self.system.actors.add(icc)
         with self.assertRaisesRegex(Exception, "ICC failed to converge in the given number of maximal steps"):
+            p.q = 1.
+            self.system.integrator.run(0)
+        with self.assertRaisesRegex(Exception, "ICC found zero electric charge on a particle"):
             p.q = 0.
             self.system.integrator.run(0)
 

--- a/testsuite/python/integrator_npt_stats.py
+++ b/testsuite/python/integrator_npt_stats.py
@@ -70,7 +70,7 @@ class IntegratorNPT(ut.TestCase):
         compressibility = np.var(Vs) / np.average(Vs)
 
         self.assertAlmostEqual(avp, p_ext, delta=0.02)
-        self.assertAlmostEqual(compressibility, 0.32, delta=0.025)
+        self.assertAlmostEqual(compressibility, 0.32, delta=0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Description of changes:
- adjust test tolerances for architectures that don't have double extended precision, e.g. ARM
- add sanity checks in chain analysis functions and handle the corner case `number_of_chains=1`
- re-enable support for fast-math mode
