### PR TITLE
Build system maintenance

### DIFF
--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -18,7 +18,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: macos
-          save: ${{ ! startsWith(github.ref, 'refs/pull') }}
+          save: ${{ github.ref == 'refs/heads/python' }}
       - name: Setup Python environment
         uses: actions/setup-python@v4.3.1
         with:
@@ -35,7 +35,7 @@ jobs:
   debian:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/espressomd/docker/debian:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
+      image: ghcr.io/espressomd/docker/debian:fbdf2f2f9d76b761c0aa1308f17fb17e38501850-base-layer
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}
@@ -47,7 +47,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: debian
-          save: ${{ ! startsWith(github.ref, 'refs/pull') }}
+          save: ${{ github.ref == 'refs/heads/python' || ( github.repository != 'espressomd/espresso' && ! startsWith(github.ref, 'refs/pull') ) }}
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Get runner specifications
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'espressomd/espresso' }}
     container:
-      image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:f6cf74049a2521b2b5580d23d42c8290c5f7611e-base-layer
+      image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:fbdf2f2f9d76b761c0aa1308f17fb17e38501850-base-layer
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}
@@ -86,7 +86,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ubuntu
-          save: ${{ ! startsWith(github.ref, 'refs/pull') }}
+          save: ${{ github.ref == 'refs/heads/python' }}
       - name: Setup Git environment
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Get runner specifications

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/espressomd/docker/ubuntu-22.04:cb0a2886ebd6a4fbd372503d7b46fc05fb1da5d5
+image: ghcr.io/espressomd/docker/ubuntu-22.04:fbdf2f2f9d76b761c0aa1308f17fb17e38501850
 
 stages:
   - prepare
@@ -139,7 +139,7 @@ no_rotation:
 fedora:36:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/fedora:3fd42369f84239b8c4f5d77067d404789c55ff44
+  image: ghcr.io/espressomd/docker/fedora:fbdf2f2f9d76b761c0aa1308f17fb17e38501850
   variables:
      with_cuda: 'false'
      with_gsl: 'false'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 if(POLICY CMP0076)
   # make target_sources() convert relative paths to absolute
@@ -234,8 +234,7 @@ endif()
 # Python interpreter and Cython interface library
 if(ESPRESSO_BUILD_WITH_PYTHON)
   find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development NumPy)
-  # use version range 0.29.21...<3.0.0 in CMake 3.19
-  find_package(Cython 0.29.21 REQUIRED)
+  find_package(Cython 0.29.21...<3.0 REQUIRED)
   find_program(IPYTHON_EXECUTABLE NAMES jupyter ipython3 ipython)
 endif()
 

--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -44,5 +44,5 @@ if(CLANG_TIDY_EXE)
 endif()
 
 include( FindPackageHandleStandardArgs )
-FIND_PACKAGE_HANDLE_STANDARD_ARGS( ClangTidy REQUIRED_VARS CLANG_TIDY_EXE
+find_package_handle_standard_args( ClangTidy REQUIRED_VARS CLANG_TIDY_EXE
                                    VERSION_VAR CLANG_TIDY_VERSION)

--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -79,7 +79,8 @@ if(CYTHON_EXECUTABLE)
 endif()
 
 include(FindPackageHandleStandardArgs)
-# add HANDLE_VERSION_RANGE in CMake 3.19
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Cython REQUIRED_VARS CYTHON_EXECUTABLE VERSION_VAR CYTHON_VERSION)
+find_package_handle_standard_args(
+  Cython REQUIRED_VARS CYTHON_EXECUTABLE VERSION_VAR CYTHON_VERSION
+                                                     HANDLE_VERSION_RANGE)
 
 mark_as_advanced(CYTHON_EXECUTABLE)

--- a/maintainer/CI/dox_warnings.py
+++ b/maintainer/CI/dox_warnings.py
@@ -70,6 +70,9 @@ for (filepath, lineno, warning), warning_list in raw_warnings.items():
     if re.search('^no uniquely matching class member found for $', warning):
         # known bug, not fixed yet
         continue
+    if re.search('^no matching (class|file) member found for $', warning):
+        # known bug, not fixed yet
+        continue
     if re.search(
             '^The following parameters? of .+ (is|are) not documented:$', warning):
         # non-critical warning, enforcing it would encourage bad behavior, i.e.

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -338,16 +338,18 @@ static void write_le_off(LeesEdwardsBC const &lebc, h5xx::dataset &dataset) {
 }
 
 static void write_le_dir(LeesEdwardsBC const &lebc, h5xx::dataset &dataset) {
+  auto const shear_direction = static_cast<int>(lebc.shear_direction);
   auto const extents = static_cast<h5xx::dataspace>(dataset).extents();
   extend_dataset(dataset, Vector2hs{1, 0});
-  h5xx::write_dataset(dataset, Utils::Vector<int, 1>{lebc.shear_direction},
+  h5xx::write_dataset(dataset, Utils::Vector<int, 1>{shear_direction},
                       h5xx::slice(Vector2hs{extents[0], 0}, Vector2hs{1, 1}));
 }
 
 static void write_le_normal(LeesEdwardsBC const &lebc, h5xx::dataset &dataset) {
+  auto const shear_plane_normal = static_cast<int>(lebc.shear_plane_normal);
   auto const extents = static_cast<h5xx::dataspace>(dataset).extents();
   extend_dataset(dataset, Vector2hs{1, 0});
-  h5xx::write_dataset(dataset, Utils::Vector<int, 1>{lebc.shear_plane_normal},
+  h5xx::write_dataset(dataset, Utils::Vector<int, 1>{shear_plane_normal},
                       h5xx::slice(Vector2hs{extents[0], 0}, Vector2hs{1, 1}));
 }
 

--- a/src/core/lees_edwards/LeesEdwardsBC.hpp
+++ b/src/core/lees_edwards/LeesEdwardsBC.hpp
@@ -26,10 +26,11 @@
 #include <initializer_list>
 
 struct LeesEdwardsBC {
+  static auto constexpr invalid_dir = 3u;
   double pos_offset = 0.;
   double shear_velocity = 0.;
-  int shear_direction = -1;
-  int shear_plane_normal = -1;
+  unsigned int shear_direction = invalid_dir;
+  unsigned int shear_plane_normal = invalid_dir;
   Utils::Vector3d distance(Utils::Vector3d const &d, Utils::Vector3d const &l,
                            Utils::Vector3d const &hal_l,
                            Utils::Vector3d const &l_inv,

--- a/src/script_interface/lees_edwards/LeesEdwards.hpp
+++ b/src/script_interface/lees_edwards/LeesEdwards.hpp
@@ -22,6 +22,7 @@
 #include "Protocol.hpp"
 
 #include "core/grid.hpp"
+#include "core/lees_edwards/LeesEdwardsBC.hpp"
 #include "core/lees_edwards/lees_edwards.hpp"
 
 #include "script_interface/ScriptInterface.hpp"
@@ -35,7 +36,7 @@ namespace LeesEdwards {
 
 class LeesEdwards : public AutoParameters<LeesEdwards> {
   std::shared_ptr<Protocol> m_protocol;
-  LeesEdwardsBC const &m_lebc = box_geo.lees_edwards_bc();
+  LeesEdwardsBC const &m_lebc = ::box_geo.lees_edwards_bc();
 
 public:
   LeesEdwards() : m_protocol{nullptr} {
@@ -44,13 +45,14 @@ public:
           [this](Variant const &value) {
             if (is_none(value)) {
               m_protocol = nullptr;
-              box_geo.set_lees_edwards_bc(LeesEdwardsBC{0., 0., -1, -1});
+              ::box_geo.set_lees_edwards_bc(LeesEdwardsBC{});
               ::LeesEdwards::unset_protocol();
               return;
             }
             context()->parallel_try_catch([this]() {
-              if (m_lebc.shear_direction == -1 or
-                  m_lebc.shear_plane_normal == -1) {
+              auto constexpr invalid_dir = LeesEdwardsBC::invalid_dir;
+              if (m_lebc.shear_direction == invalid_dir or
+                  m_lebc.shear_plane_normal == invalid_dir) {
                 throw std::runtime_error(
                     "Parameters 'shear_plane_normal' and 'shear_direction' "
                     "must be initialized together with 'protocol' on first "
@@ -94,7 +96,7 @@ public:
                                       "'shear_plane_normal' must differ");
         }
         // update box geometry and cell structure
-        box_geo.set_lees_edwards_bc(
+        ::box_geo.set_lees_edwards_bc(
             LeesEdwardsBC{0., 0., shear_direction, shear_plane_normal});
         ::LeesEdwards::set_protocol(m_protocol->protocol());
       });
@@ -109,28 +111,28 @@ public:
   }
 
 private:
-  int get_shear_axis(VariantMap const &params, std::string name) {
+  unsigned int get_shear_axis(VariantMap const &params, std::string name) {
     auto const value = get_value<std::string>(params, name);
     if (value == "x") {
-      return 0;
+      return 0u;
     }
     if (value == "y") {
-      return 1;
+      return 1u;
     }
     if (value == "z") {
-      return 2;
+      return 2u;
     }
     throw std::invalid_argument("Parameter '" + name + "' is invalid");
   }
 
-  Variant get_shear_name(int axis) {
-    if (axis == 0) {
+  Variant get_shear_name(unsigned int axis) {
+    if (axis == 0u) {
       return {std::string("x")};
     }
-    if (axis == 1) {
+    if (axis == 1u) {
       return {std::string("y")};
     }
-    if (axis == 2) {
+    if (axis == 2u) {
       return {std::string("z")};
     }
     return {none};

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -448,7 +448,7 @@ auto hadamard_division(T const &a, U const &b) {
   return a / b;
 }
 
-template <typename T> Vector<T, 3> unit_vector(int i) {
+template <typename T> Vector<T, 3> unit_vector(unsigned int i) {
   if (i == 0)
     return {T{1}, T{0}, T{0}};
   if (i == 1)


### PR DESCRIPTION
Description of changes:
- bump requirements: CMake >= 3.20
- block CMake at configuration stage when Cython >= 3.0 is found
   - Cython 3.0 is not supported in ESPResSo, more details in https://github.com/espressomd/espresso/issues/4542#issuecomment-1534719580
- add an extra guard for a known Doxygen bug
- use a ScaFaCoS library built for x86_64 architectures
- fix implicit type conversions in Lees-Edwards and use a named constant for invalid or uninitialized axes