### PR TITLE
Fix particle radius calculation in the visualizer

### DIFF
--- a/src/python/espressomd/visualization.py
+++ b/src/python/espressomd/visualization.py
@@ -998,7 +998,7 @@ class openGLLive():
     def _determine_radius(self, part_type):
         def radius_by_lj(part_type):
             ia = self.system.non_bonded_inter[part_type, part_type]
-            radius = 0.5
+            radius = 0.0
             if hasattr(ia, "lennard_jones"):
                 radius = ia.lennard_jones.sigma * 0.5
             if radius == 0.0 and hasattr(ia, "wca"):


### PR DESCRIPTION
Fixes #4719

Description of changes:
- extract the correct particle radius from the interaction list
