### PR TITLE
Improve support for C++20 builds

### DIFF
--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -61,6 +61,7 @@ target_compile_options(
     $<$<CXX_COMPILER_ID:GNU>:-Wno-cpp>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-strict-aliasing>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-volatile>
     $<$<CXX_COMPILER_ID:Clang,AppleClang,IntelLLVM>:-Wno-sometimes-uninitialized>
     $<$<CXX_COMPILER_ID:Clang,AppleClang,IntelLLVM>:-Wno-\#warnings>
     -Wno-unused-variable)


### PR DESCRIPTION
Description of changes:
- silence non-critical deprecation warning in Cython-generated code when building in C++20 mode
