### PR TITLE
Fix CI reports

### DIFF
--- a/maintainer/gh_create_issue.sh
+++ b/maintainer/gh_create_issue.sh
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}"
+URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/-/pipelines/${CI_PIPELINE_ID}"
 
 curl -s "https://api.github.com/repos/espressomd/espresso/issues" \
      -H "Accept: application/vnd.github.full+json" \

--- a/maintainer/gh_post_status.sh
+++ b/maintainer/gh_post_status.sh
@@ -21,7 +21,7 @@
 [ "${#}" -eq 1 ] || exit 1
 
 GIT_COMMIT=$(git rev-parse HEAD)
-URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/pipelines/${CI_PIPELINE_ID}"
+URL="https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/-/pipelines/${CI_PIPELINE_ID}"
 STATUS="${1}"
 curl "https://api.github.com/repos/espressomd/espresso/statuses/${GIT_COMMIT}" \
      -H "Authorization: token ${GITHUB_TOKEN}" \

--- a/testsuite/python/sigint.py
+++ b/testsuite/python/sigint.py
@@ -25,6 +25,12 @@ import pathlib
 import os
 
 
+EXPECTED_TRACEBACK_ENDING = """ in handle_sigint
+    signal.raise_signal(signal.Signals.SIGINT)
+KeyboardInterrupt
+"""
+
+
 class SigintTest(ut.TestCase):
 
     script = str(pathlib.Path(__file__).parent / 'sigint_child.py')
@@ -43,8 +49,8 @@ class SigintTest(ut.TestCase):
             self.assertEqual(traceback, "")
         elif sig == signal.Signals.SIGINT:
             self.assertIn(" self.integrator.run(", traceback)
-            self.assertTrue(traceback.endswith(
-                " in handle_sigint\n    signal.raise_signal(signal.Signals.SIGINT)\nKeyboardInterrupt\n"))
+            self.assertTrue(traceback.endswith(EXPECTED_TRACEBACK_ENDING),
+                            msg=f"Traceback failed string match:\n{traceback}")
 
     def test_signal_handling(self):
         signals = [signal.Signals.SIGINT, signal.Signals.SIGTERM]


### PR DESCRIPTION
Fixes #4735

Description of changes:
- fix the URL in the GitHub CI report (new GitLab routing system)
- provide a useful error message when the sigint test times out
