### PR TITLE
Fix memory leaks on the GPU

### DIFF
--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -785,6 +785,17 @@ doi                        = {10.1140/epjst/e2016-60324-3},
   doi = {10.1103/PhysRevE.59.3733},
 }
 
+@TechReport{misc-compute-sanitizer,
+  author      = {{NVIDIA}},
+  title       = {{COMPUTE SANITIZER}},
+  type        = {User manual},
+  number      = {v2023.2.0},
+  year        = {2023},
+  month       = jun,
+  institution = {NVIDIA},
+  url         = {https://docs.nvidia.com/compute-sanitizer/pdf/ComputeSanitizer.pdf},
+}
+
 @TechReport{misc-cuda-gdb,
   author      = {{NVIDIA}},
   title       = {{CU-GDB}},

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -563,21 +563,23 @@ no arguments are passed, sensible default values will be used instead.
 
 .. table:: Tools for the Python wrapper to |es|.
 
-    +---------------------+-------------------------------------------------+
-    | Tool                | Effect                                          |
-    +=====================+=================================================+
-    | ``--gdb``           | ``gdb --args python script.py``                 |
-    +---------------------+-------------------------------------------------+
-    | ``--lldb``          | ``lldb -- python script.py``                    |
-    +---------------------+-------------------------------------------------+
-    | ``--valgrind``      | ``valgrind --leak-check=full python script.py`` |
-    +---------------------+-------------------------------------------------+
-    | ``--cuda-gdb``      | ``cuda-gdb --args python script.py``            |
-    +---------------------+-------------------------------------------------+
-    | ``--cuda-memcheck`` | ``cuda-memcheck python script.py``              |
-    +---------------------+-------------------------------------------------+
-    | ``--kernprof``      | ``kernprof --line-by-line --view script.py``    |
-    +---------------------+-------------------------------------------------+
+    +------------------------+-------------------------------------------------------------+
+    | Tool                   | Effect                                                      |
+    +========================+=============================================================+
+    | ``--gdb``              | ``gdb --args python script.py``                             |
+    +------------------------+-------------------------------------------------------------+
+    | ``--lldb``             | ``lldb -- python script.py``                                |
+    +------------------------+-------------------------------------------------------------+
+    | ``--valgrind``         | ``valgrind --leak-check=full python script.py``             |
+    +------------------------+-------------------------------------------------------------+
+    | ``--cuda-gdb``         | ``cuda-gdb --args python script.py``                        |
+    +------------------------+-------------------------------------------------------------+
+    | ``--cuda-memcheck``    | ``cuda-memcheck python script.py``                          |
+    +------------------------+-------------------------------------------------------------+
+    | ``--cuda-sanitizer``   | ``compute-sanitizer --leak-check full python script.py``    |
+    +------------------------+-------------------------------------------------------------+
+    | ``--kernprof``         | ``kernprof --line-by-line --view script.py``                |
+    +------------------------+-------------------------------------------------------------+
 
 .. _Profiling:
 
@@ -898,6 +900,39 @@ the call graph interactively and visualize the time spent in each function:
 
     kcachegrind ${callgrind_out}
 
+.. _Compute Sanitizer:
+
+Compute Sanitizer
+~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    Requires a CUDA build, enabled with the CMake options
+    ``-D ESPRESSO_BUILD_WITH_CUDA=ON``.
+
+The Compute Sanitizer [9]_ :cite:`misc-compute-sanitizer` framework is similar
+to :ref:`Valgrind`, but for NVIDIA GPUs. The exact command line options
+differ with the CUDA version. If the command line examples below don't work,
+please refer to the NVIDIA user guide version that corresponds to the locally
+installed CUDA toolkit.
+
+To detect memory leaks:
+
+.. code-block:: bash
+
+    ./pypresso --cuda-sanitizer="--tool memcheck --leak-check full" script.py
+
+Add option ``--error-exitcode 1`` to return an error code when issues are detected.
+
+To detect access to uninitialized data:
+
+.. code-block:: bash
+
+    ./pypresso --cuda-sanitizer="--tool initcheck" script.py
+
+Checking for uninitialized data is quite expensive
+for the GPU and can slow down other running GPU processes.
+
 .. _perf:
 
 perf
@@ -1067,3 +1102,6 @@ ____
 
 .. [8]
    https://github.com/pyutils/line_profiler
+
+.. [9]
+   https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html

--- a/src/core/electrostatics/mmm1d_gpu_cuda.cu
+++ b/src/core/electrostatics/mmm1d_gpu_cuda.cu
@@ -178,20 +178,29 @@ void CoulombMMM1DGpu::setup() {
       break;
     }
   }
-  if (dev_forcePairs)
-    cudaFree(dev_forcePairs);
+  if (dev_forcePairs) {
+    cuda_safe_mem(cudaFree(dev_forcePairs));
+  }
   if (pairs) {
     // we need memory to store force pairs
     cuda_safe_mem(cudaMalloc((void **)&dev_forcePairs, part_mem_size));
   }
-  if (dev_energyBlocks)
-    cudaFree(dev_energyBlocks);
+  if (dev_energyBlocks) {
+    cuda_safe_mem(cudaFree(dev_energyBlocks));
+  }
   cuda_safe_mem(cudaMalloc((void **)&dev_energyBlocks,
                            numBlocks(n_part) * sizeof(float)));
   host_npart = static_cast<unsigned int>(n_part);
 }
 
-CoulombMMM1DGpu::~CoulombMMM1DGpu() { cudaFree(dev_forcePairs); }
+CoulombMMM1DGpu::~CoulombMMM1DGpu() {
+  if (dev_forcePairs) {
+    cuda_safe_mem(cudaFree(dev_forcePairs));
+  }
+  if (dev_energyBlocks) {
+    cuda_safe_mem(cudaFree(dev_energyBlocks));
+  }
+}
 
 __forceinline__ __device__ float sqpow(float x) { return x * x; }
 __forceinline__ __device__ float cbpow(float x) { return x * x * x; }
@@ -279,7 +288,7 @@ void CoulombMMM1DGpu::tune(double maxPWerror, double far_switch_radius,
     int best_cutoff = 0;
     cuda_safe_mem(cudaMemcpy(&best_cutoff, dev_cutoff, sizeof(int),
                              cudaMemcpyDeviceToHost));
-    cudaFree(dev_cutoff);
+    cuda_safe_mem(cudaFree(dev_cutoff));
     if (bessel_cutoff != -2 && best_cutoff >= maxCut) {
       // we already had our switching radius and only needed to
       // determine the cutoff, i.e. this was the final tuning round

--- a/src/core/electrostatics/p3m_gpu.cpp
+++ b/src/core/electrostatics/p3m_gpu.cpp
@@ -36,7 +36,7 @@
 
 void CoulombP3MGPU::add_long_range_forces(ParticleRange const &) {
   if (this_node == 0) {
-    p3m_gpu_add_farfield_force(prefactor);
+    p3m_gpu_add_farfield_force(*m_gpu_data, prefactor);
   }
 }
 
@@ -45,7 +45,8 @@ void CoulombP3MGPU::init() {
           System::get_system().coulomb.impl->solver)) {
     init_cpu_kernels();
   }
-  p3m_gpu_init(p3m.params.cao, p3m.params.mesh.data(), p3m.params.alpha);
+  p3m_gpu_init(m_gpu_data, p3m.params.cao, p3m.params.mesh.data(),
+               p3m.params.alpha);
 }
 
 void CoulombP3MGPU::init_cpu_kernels() { CoulombP3M::init(); }

--- a/src/core/electrostatics/p3m_gpu.hpp
+++ b/src/core/electrostatics/p3m_gpu.hpp
@@ -34,6 +34,10 @@
 
 #include "ParticleRange.hpp"
 
+#include <memory>
+
+struct P3MGpuParams;
+
 struct CoulombP3MGPU : public CoulombP3M {
   using CoulombP3M::CoulombP3M;
 
@@ -56,6 +60,7 @@ private:
    * that are only relevant for ELC force corrections.
    */
   void init_cpu_kernels();
+  std::shared_ptr<P3MGpuParams> m_gpu_data = nullptr;
 };
 
 #endif // CUDA

--- a/src/core/electrostatics/p3m_gpu_cuda.cuh
+++ b/src/core/electrostatics/p3m_gpu_cuda.cuh
@@ -20,7 +20,12 @@
 #ifndef ESPRESSO_SRC_CORE_ELECTROSTATICS_P3M_GPU_CUDA_CUH
 #define ESPRESSO_SRC_CORE_ELECTROSTATICS_P3M_GPU_CUDA_CUH
 
-void p3m_gpu_init(int cao, const int mesh[3], double alpha);
-void p3m_gpu_add_farfield_force(double prefactor);
+#include <memory>
+
+struct P3MGpuParams;
+
+void p3m_gpu_init(std::shared_ptr<P3MGpuParams> &p3m_gpu_data_ptr, int cao,
+                  const int mesh[3], double alpha);
+void p3m_gpu_add_farfield_force(P3MGpuParams &data, double prefactor);
 
 #endif

--- a/src/core/system/GpuParticleData_cuda.cu
+++ b/src/core/system/GpuParticleData_cuda.cu
@@ -423,7 +423,7 @@ void GpuParticleData::Storage::realloc_device_memory() {
 }
 
 void GpuParticleData::Storage::free_device_memory() {
-  auto const free_device_pointer = [](float *&ptr) {
+  auto const free_device_pointer = [](auto *&ptr) {
     if (ptr != nullptr) {
       cuda_safe_mem(cudaFree(reinterpret_cast<void *>(ptr)));
       ptr = nullptr;
@@ -441,4 +441,5 @@ void GpuParticleData::Storage::free_device_memory() {
 #ifdef ELECTROSTATICS
   free_device_pointer(particle_q_device);
 #endif
+  free_device_pointer(energy_device);
 }

--- a/src/python/pypresso.cmakein
+++ b/src/python/pypresso.cmakein
@@ -85,6 +85,10 @@ case "$1" in
         shift
         exec cuda-memcheck "@ESPRESSO_PYTHON_FRONTEND@" "$@"
         ;;
+    --cuda-sanitizer)
+        shift
+        exec compute-sanitizer --leak-check full "@ESPRESSO_PYTHON_FRONTEND@" "$@"
+        ;;
     --kernprof)
         shift
         exec "@ESPRESSO_PYTHON_FRONTEND@" $(which kernprof) --line-by-line --view "$@"
@@ -114,6 +118,11 @@ case "$1" in
         options="${1#*=}"
         shift
         exec cuda-memcheck ${options} "@ESPRESSO_PYTHON_FRONTEND@" "$@"
+        ;;
+    --cuda-sanitizer=*)
+        options="${1#*=}"
+        shift
+        exec compute-sanitizer ${options} "@ESPRESSO_PYTHON_FRONTEND@" "$@"
         ;;
     --kernprof=*)
         options="${1#*=}"


### PR DESCRIPTION
Description of changes:
- remove two P3M global variables (partial fix for #2628)
- add missing `cudaFree`  to fix all remaining memory leaks on the GPU
- add a new `pypresso` option `--cuda-sanitizer` to run the NVIDIA Compute Sanitizer suite
   - by default, runs `memcheck`, but one can select another tool via command line options
   - the stand-alone tool `cuda-memcheck` is deprecated in CUDA 12.0