### PR TITLE
Separate short-range forces by signature

### DIFF
--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -91,8 +91,11 @@ ParticleForce ShapeBasedConstraint::force(Particle const &p,
 
     if (dist > 0) {
       outer_normal_vec = -dist_vec / dist;
-      pf = calc_non_bonded_pair_force(p, part_rep, ia_params, dist_vec, dist,
-                                      get_ptr(coulomb_kernel));
+      pf = calc_central_radial_force(p, part_rep, ia_params, dist_vec, dist) +
+           calc_central_radial_charge_force(p, part_rep, ia_params, dist_vec,
+                                            dist, get_ptr(coulomb_kernel)) +
+           calc_non_central_force(p, part_rep, ia_params, dist_vec, dist);
+
 #ifdef DPD
       if (thermo_switch & THERMO_DPD) {
         dpd_force =
@@ -103,8 +106,12 @@ ParticleForce ShapeBasedConstraint::force(Particle const &p,
 #endif
     } else if (m_penetrable && (dist <= 0)) {
       if ((!m_only_positive) && (dist < 0)) {
-        pf = calc_non_bonded_pair_force(p, part_rep, ia_params, dist_vec, -dist,
-                                        get_ptr(coulomb_kernel));
+        pf =
+            calc_central_radial_force(p, part_rep, ia_params, dist_vec, -dist) +
+            calc_central_radial_charge_force(p, part_rep, ia_params, dist_vec,
+                                             -dist, get_ptr(coulomb_kernel)) +
+            calc_non_central_force(p, part_rep, ia_params, dist_vec, -dist);
+
 #ifdef DPD
         if (thermo_switch & THERMO_DPD) {
           dpd_force = dpd_pair_force(p, part_rep, ia_params, dist_vec, dist,

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -64,8 +64,11 @@ inline void add_non_bonded_pair_virials(
 #endif
   {
     auto const &ia_params = get_ia_param(p1.type(), p2.type());
-    auto const force =
-        calc_non_bonded_pair_force(p1, p2, ia_params, d, dist, kernel_forces).f;
+    auto const force = calc_central_radial_force(p1, p2, ia_params, d, dist).f +
+                       calc_central_radial_charge_force(p1, p2, ia_params, d,
+                                                        dist, kernel_forces)
+                           .f +
+                       calc_non_central_force(p1, p2, ia_params, d, dist).f;
     auto const stress = Utils::tensor_product(d, force);
 
     auto const type1 = p1.mol_id();


### PR DESCRIPTION
Fixes #4755

Description of changes:
- split short-range force kernel into a central radial kernel, a central radial with charge kernel, and a non-central kernel
