### PR TITLE
Restore constraints event handling

### DIFF
--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -102,7 +102,7 @@ public:
   }
 
   void on_boxl_change() const {
-    if (not this->empty()) {
+    if (not m_constraints.empty()) {
       throw std::runtime_error("The box size can not be changed because there "
                                "are active constraints.");
     }

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -31,6 +31,7 @@
 #include "collision.hpp"
 #include "communication.hpp"
 #include "config/config.hpp"
+#include "constraints.hpp"
 #include "cuda/init.hpp"
 #include "cuda/utils.hpp"
 #include "electrostatics/coulomb.hpp"
@@ -241,6 +242,8 @@ void on_boxl_change(bool skip_method_adaption) {
     system.dipoles.on_boxl_change();
 #endif
   }
+
+  Constraints::constraints.on_boxl_change();
 }
 
 void on_cell_structure_change() {

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -36,6 +36,9 @@ class ShapeBasedConstraintTest(ut.TestCase):
     box_l = 30.
     system = espressomd.System(box_l=3 * [box_l])
 
+    def setUp(self):
+        self.system.box_l = 3 * [self.box_l]
+
     def tearDown(self):
         self.system.part.clear()
         self.system.constraints.clear()
@@ -1066,6 +1069,17 @@ class ShapeBasedConstraintTest(ut.TestCase):
         # Reset
         system.non_bonded_inter[0, 1].lennard_jones.set_params(
             epsilon=0.0, sigma=0.0, cutoff=0.0, shift=0)
+
+    def test_exceptions(self):
+        system = self.system
+        wall = espressomd.shapes.Wall(normal=[0., 1., 0.], dist=0.)
+        constraint = espressomd.constraints.ShapeBasedConstraint(
+            shape=wall, particle_type=1)
+        system.constraints.add(constraint)
+        with self.assertRaisesRegex(RuntimeError, "there are active constraints"):
+            system.box_l = 0.5 * system.box_l
+        system.constraints.remove(constraint)
+        system.box_l = 0.75 * system.box_l
 
 
 if __name__ == "__main__":

--- a/testsuite/python/integrator_steepest_descent.py
+++ b/testsuite/python/integrator_steepest_descent.py
@@ -55,6 +55,7 @@ class IntegratorSteepestDescent(ut.TestCase):
 
     def tearDown(self):
         self.system.part.clear()
+        self.system.constraints.clear()
         self.system.integrator.set_vv()
 
     def test_relaxation_integrator(self):


### PR DESCRIPTION
Description of changes:
- Resizing the box now throws a runtime error if there are constraints present, since constraint preconditions might no longer be fulfilled (e.g. a wall constraint might end up outside the box boundaries when the box shrinks)
- This feature was originally introduced in ESPResSo 4.0.0 (#2031), but never actually worked because the PR accidentally removed the event function call during merge conflict resolution