### PR TITLE
Throw runtime error on incorrect usage of `ObjectList`

### DIFF
--- a/src/core/accumulators.cpp
+++ b/src/core/accumulators.cpp
@@ -60,24 +60,33 @@ int auto_update_next_update() {
                            });
 }
 
+namespace detail {
+struct MatchPredicate {
+  AccumulatorBase const *m_acc;
+  template <typename T> bool operator()(T const &a) const {
+    return a.acc == m_acc;
+  }
+};
+} // namespace detail
+
 void auto_update_add(AccumulatorBase *acc) {
-  assert(acc);
-  assert(std::find_if(auto_update_accumulators.begin(),
-                      auto_update_accumulators.end(), [acc](auto const &a) {
-                        return a.acc == acc;
-                      }) == auto_update_accumulators.end());
+  assert(not auto_update_contains(acc));
   auto_update_accumulators.emplace_back(acc);
 }
+
 void auto_update_remove(AccumulatorBase *acc) {
-  assert(std::find_if(auto_update_accumulators.begin(),
-                      auto_update_accumulators.end(), [acc](auto const &a) {
-                        return a.acc == acc;
-                      }) != auto_update_accumulators.end());
+  assert(auto_update_contains(acc));
+  auto const beg = auto_update_accumulators.begin();
+  auto const end = auto_update_accumulators.end();
   auto_update_accumulators.erase(
-      boost::remove_if(
-          auto_update_accumulators,
-          [acc](AutoUpdateAccumulator const &au) { return au.acc == acc; }),
-      auto_update_accumulators.end());
+      std::remove_if(beg, end, detail::MatchPredicate{acc}), end);
+}
+
+bool auto_update_contains(AccumulatorBase const *acc) noexcept {
+  assert(acc);
+  auto const beg = auto_update_accumulators.begin();
+  auto const end = auto_update_accumulators.end();
+  return std::find_if(beg, end, detail::MatchPredicate{acc}) != end;
 }
 
 } // namespace Accumulators

--- a/src/core/accumulators.hpp
+++ b/src/core/accumulators.hpp
@@ -31,6 +31,7 @@ namespace Accumulators {
  */
 void auto_update(boost::mpi::communicator const &comm, int steps);
 int auto_update_next_update();
+bool auto_update_contains(AccumulatorBase const *) noexcept;
 void auto_update_add(AccumulatorBase *);
 void auto_update_remove(AccumulatorBase *);
 

--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -49,22 +49,20 @@ private:
   container_type m_constraints;
 
 public:
+  bool contains(std::shared_ptr<Constraint> const &constraint) const noexcept {
+    return std::find(begin(), end(), constraint) != end();
+  }
   void add(std::shared_ptr<Constraint> const &constraint) {
     if (not constraint->fits_in_box(box_geo.length())) {
       throw std::runtime_error("Constraint not compatible with box size.");
     }
-    assert(std::find(m_constraints.begin(), m_constraints.end(), constraint) ==
-           m_constraints.end());
-
+    assert(not contains(constraint));
     m_constraints.emplace_back(constraint);
     on_constraint_change();
   }
   void remove(std::shared_ptr<Constraint> const &constraint) {
-    assert(std::find(m_constraints.begin(), m_constraints.end(), constraint) !=
-           m_constraints.end());
-    m_constraints.erase(
-        std::remove(m_constraints.begin(), m_constraints.end(), constraint),
-        m_constraints.end());
+    assert(contains(constraint));
+    m_constraints.erase(std::remove(begin(), end(), constraint), end());
     on_constraint_change();
   }
 

--- a/src/script_interface/ObjectList.hpp
+++ b/src/script_interface/ObjectList.hpp
@@ -52,6 +52,8 @@ private:
 
   virtual void add_in_core(const std::shared_ptr<ManagedType> &obj_ptr) = 0;
   virtual void remove_in_core(const std::shared_ptr<ManagedType> &obj_ptr) = 0;
+  virtual bool
+  has_in_core(const std::shared_ptr<ManagedType> &obj_ptr) const = 0;
 
 public:
   ObjectList() {
@@ -74,6 +76,12 @@ public:
    * @param element The element to add.
    */
   void add(std::shared_ptr<ManagedType> const &element) {
+    if (has_in_core(element)) {
+      if (Base::context()->is_head_node()) {
+        throw std::runtime_error("This object is already present in the list");
+      }
+      throw Exception("");
+    }
     add_in_core(element);
     m_elements.push_back(element);
   }
@@ -84,6 +92,12 @@ public:
    * @param element The element to remove.
    */
   void remove(std::shared_ptr<ManagedType> const &element) {
+    if (not has_in_core(element)) {
+      if (Base::context()->is_head_node()) {
+        throw std::runtime_error("This object is absent from the list");
+      }
+      throw Exception("");
+    }
     remove_in_core(element);
     m_elements.erase(std::remove(m_elements.begin(), m_elements.end(), element),
                      m_elements.end());

--- a/src/script_interface/accumulators/AutoUpdateAccumulators.hpp
+++ b/src/script_interface/accumulators/AutoUpdateAccumulators.hpp
@@ -29,6 +29,11 @@
 namespace ScriptInterface {
 namespace Accumulators {
 class AutoUpdateAccumulators : public ObjectList<AccumulatorBase> {
+  bool
+  has_in_core(std::shared_ptr<AccumulatorBase> const &obj_ptr) const override {
+    return ::Accumulators::auto_update_contains(obj_ptr->accumulator().get());
+  }
+
   void add_in_core(std::shared_ptr<AccumulatorBase> const &obj_ptr) override {
     ::Accumulators::auto_update_add(obj_ptr->accumulator().get());
   }

--- a/src/script_interface/constraints/Constraints.hpp
+++ b/src/script_interface/constraints/Constraints.hpp
@@ -32,6 +32,9 @@
 namespace ScriptInterface {
 namespace Constraints {
 class Constraints : public ObjectList<Constraint> {
+  bool has_in_core(std::shared_ptr<Constraint> const &obj_ptr) const override {
+    return ::Constraints::constraints.contains(obj_ptr->constraint());
+  }
   void add_in_core(std::shared_ptr<Constraint> const &obj_ptr) override {
     ::Constraints::constraints.add(obj_ptr->constraint());
   }

--- a/src/script_interface/shapes/Union.hpp
+++ b/src/script_interface/shapes/Union.hpp
@@ -39,6 +39,9 @@ public:
   Union() : m_core_shape(std::make_shared<::Shapes::Union>()) {}
 
 private:
+  bool has_in_core(const std::shared_ptr<Shape> &obj_ptr) const override {
+    return m_core_shape->contains(obj_ptr->shape());
+  }
   void add_in_core(const std::shared_ptr<Shape> &obj_ptr) override {
     m_core_shape->add(obj_ptr->shape());
   }

--- a/src/script_interface/tests/ObjectList_test.cpp
+++ b/src/script_interface/tests/ObjectList_test.cpp
@@ -43,6 +43,10 @@ struct ObjectListImpl : ObjectList<ObjectHandle> {
   std::vector<ObjectRef> mock_core;
 
 private:
+  bool has_in_core(const ObjectRef &obj_ptr) const override {
+    return std::find(mock_core.begin(), mock_core.end(), obj_ptr) !=
+           mock_core.end();
+  }
   void add_in_core(const ObjectRef &obj_ptr) override {
     mock_core.push_back(obj_ptr);
   }
@@ -82,8 +86,8 @@ BOOST_AUTO_TEST_CASE(removing_elements) {
 BOOST_AUTO_TEST_CASE(clearing_elements) {
   // A cleared list is empty.
   ObjectListImpl list;
-  list.add(ObjectRef{});
-  list.add(ObjectRef{});
+  list.add(std::make_shared<ObjectListImpl>());
+  list.add(std::make_shared<ObjectListImpl>());
   list.clear();
   BOOST_CHECK(list.elements().empty());
   BOOST_CHECK(list.mock_core.empty());

--- a/src/script_interface/walberla/EKContainer.hpp
+++ b/src/script_interface/walberla/EKContainer.hpp
@@ -61,6 +61,9 @@ class EKContainer : public ObjectList<EKSpecies> {
   std::shared_ptr<::EK::EKWalberla::ek_container_type> m_ek_container;
   bool m_is_active;
 
+  bool has_in_core(std::shared_ptr<EKSpecies> const &obj_ptr) const override {
+    return m_ek_container->contains(obj_ptr->get_ekinstance());
+  }
   void add_in_core(std::shared_ptr<EKSpecies> const &obj_ptr) override {
     context()->parallel_try_catch(
         [this, &obj_ptr]() { m_ek_container->add(obj_ptr->get_ekinstance()); });

--- a/src/script_interface/walberla/EKReactions.hpp
+++ b/src/script_interface/walberla/EKReactions.hpp
@@ -40,6 +40,9 @@ namespace ScriptInterface::walberla {
 class EKReactions : public ObjectList<EKReaction> {
   std::shared_ptr<::EK::EKWalberla::ek_reactions_type> m_ek_reactions;
 
+  bool has_in_core(std::shared_ptr<EKReaction> const &obj_ptr) const override {
+    return m_ek_reactions->contains(obj_ptr->get_instance());
+  }
   void add_in_core(std::shared_ptr<EKReaction> const &obj_ptr) override {
     m_ek_reactions->add(obj_ptr->get_instance());
   }

--- a/src/shapes/include/shapes/Union.hpp
+++ b/src/shapes/include/shapes/Union.hpp
@@ -33,6 +33,10 @@ namespace Shapes {
 
 class Union : public Shape {
 public:
+  bool contains(std::shared_ptr<Shapes::Shape> const &shape) const noexcept {
+    return std::find(m_shapes.begin(), m_shapes.end(), shape) != m_shapes.end();
+  }
+
   void add(std::shared_ptr<Shapes::Shape> const &shape) {
     m_shapes.emplace_back(shape);
   }

--- a/src/shapes/unit_tests/Union_test.cpp
+++ b/src/shapes/unit_tests/Union_test.cpp
@@ -42,8 +42,12 @@ BOOST_AUTO_TEST_CASE(dist_function) {
     wall2->d() = -10.0;
 
     Shapes::Union uni;
+    BOOST_CHECK(not uni.contains(wall1));
+    BOOST_CHECK(not uni.contains(wall2));
     uni.add(wall1);
     uni.add(wall2);
+    BOOST_CHECK(uni.contains(wall1));
+    BOOST_CHECK(uni.contains(wall2));
 
     auto check_union = [&wall1, &wall2, &uni](Utils::Vector3d const &pos) {
       double wall1_dist;

--- a/testsuite/python/script_interface.py
+++ b/testsuite/python/script_interface.py
@@ -102,6 +102,22 @@ class ScriptInterface(ut.TestCase):
         with self.assertRaisesRegex(AttributeError, "Object 'HarmonicBond' has no attribute 'unknown'"):
             bond.unknown
 
+    def test_objectlist_exceptions(self):
+        """Check ObjectList framework"""
+        wall = espressomd.shapes.Wall(normal=[-1, 0, 0])
+        constraint = espressomd.constraints.ShapeBasedConstraint(shape=wall)
+        constraints = espressomd.constraints.Constraints()
+        self.assertEqual(len(constraints), 0)
+        constraints.add(constraint)
+        self.assertEqual(len(constraints), 1)
+        with self.assertRaisesRegex(RuntimeError, "This object is already present in the list"):
+            constraints.add(constraint)
+        self.assertEqual(len(constraints), 1)
+        constraints.remove(constraint)
+        self.assertEqual(len(constraints), 0)
+        with self.assertRaisesRegex(RuntimeError, "This object is absent from the list"):
+            constraints.remove(constraint)
+
     def test_feature_exceptions(self):
         """Check feature verification"""
         all_features = set(espressomd.code_info.all_features())


### PR DESCRIPTION
Adding the same object twice in an `ObjectList` can lead to unintentional side-effects. For example, an `EKSpecies` added twice would be integrated twice per time step, since the two shared pointers point to the same species, until the system is checkpointed, at which point the two species become deep copies of one another and no longer share the same memory address. In addition, when removing an object that was never added to an `ObjectList`, no error message is generated to notify users they may have used the wrong variable to remove an object. There are currently assertions in the core to prevent both duplicate objects and removal of nonexistent objects, but those are not triggered in release builds.

Description of changes:
- convert `ObjectList` assertions to recoverable runtime errors (i.e. the system reverts to the last valid state)
   - adding the same object twice in an `ObjectList` now raises a runtime error
   - removing an unknown object from an `ObjectList` now raises a runtime error
