### PR TITLE
Disable flaky tutorial test

### DIFF
--- a/testsuite/scripts/tutorials/CMakeLists.txt
+++ b/testsuite/scripts/tutorials/CMakeLists.txt
@@ -62,7 +62,7 @@ tutorial_test(FILE test_ferrofluid_2.py)
 tutorial_test(FILE test_ferrofluid_3.py)
 tutorial_test(FILE test_constant_pH__ideal.py)
 tutorial_test(FILE test_electrodes_1.py)
-tutorial_test(FILE test_electrodes_2.py)
+# tutorial_test(FILE test_electrodes_2.py) # TODO: unstable, see issue #4798
 tutorial_test(FILE test_constant_pH__interactions.py)
 tutorial_test(FILE test_widom_insertion.py)
 


### PR DESCRIPTION
Fixes #4797, fixes #4800, fixes #4801, fixes #4802, fixes #4803

Description of changes:
- disable tests for flaky electrodes tutorial (see #4798)
