### PR TITLE
Prevent propagation of angular velocities with NpT

### DIFF
--- a/doc/sphinx/integration.rst
+++ b/doc/sphinx/integration.rst
@@ -199,6 +199,7 @@ Notes:
 * The particle forces :math:`F` include interactions as well as a friction (:math:`\gamma^0`) and noise term (:math:`\sqrt{k_B T \gamma^0 dt} \overline{\eta}`) analogous to the terms in the :ref:`Langevin thermostat`.
 * The particle forces are only calculated in step 5 and then reused in step 1 of the next iteration. See :ref:`Velocity Verlet Algorithm` for the implications of that.
 * The NpT algorithm doesn't support :ref:`Lees-Edwards boundary conditions`.
+* The NpT algorithm doesn't support propagation of angular velocities.
 
 .. _Steepest descent:
 

--- a/src/core/integrators/velocity_verlet_npt.cpp
+++ b/src/core/integrators/velocity_verlet_npt.cpp
@@ -30,7 +30,6 @@
 #include "errorhandling.hpp"
 #include "integrate.hpp"
 #include "npt.hpp"
-#include "rotation.hpp"
 #include "system/System.hpp"
 #include "thermostat.hpp"
 #include "thermostats/npt_inline.hpp"
@@ -170,7 +169,10 @@ void velocity_verlet_npt_propagate_vel(const ParticleRange &particles,
 
   for (auto &p : particles) {
 #ifdef ROTATION
-    propagate_omega_quat_particle(p, time_step);
+    if (p.can_rotate()) {
+      runtimeErrorMsg() << "The isotropic NpT integrator doesn't propagate "
+                           "angular velocities";
+    }
 #endif
 
     // Don't propagate translational degrees of freedom of vs
@@ -201,9 +203,6 @@ void velocity_verlet_npt_step_1(const ParticleRange &particles,
 void velocity_verlet_npt_step_2(const ParticleRange &particles,
                                 double time_step) {
   velocity_verlet_npt_propagate_vel_final(particles, time_step);
-#ifdef ROTATION
-  convert_torques_propagate_omega(particles, time_step);
-#endif
   velocity_verlet_npt_finalize_p_inst(time_step);
 }
 #endif // NPT


### PR DESCRIPTION
Fixes #4842

Description of changes:
- The current implementation of the velocity Verlet NpT propagator doesn't apply friction and noise on angular velocities. ESPResSo now throws an error when NpT encounters a rotating particle.
