### PR TITLE
Address API change in Python 3.12 unittest module

### DIFF
--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -100,8 +100,6 @@ function(python_test)
     add_test(${TEST_NAME} ${CMAKE_BINARY_DIR}/pypresso ${PYPRESSO_OPTIONS}
              ${TEST_FILE_CONFIGURED} ${TEST_ARGUMENTS})
   endif()
-  set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${TEST_NUM_PROC}
-                                               DEPENDS "${TEST_DEPENDS}")
 
   if(${TEST_GPU_SLOTS} GREATER 0 AND ESPRESSO_BUILD_WITH_CUDA)
     set_property(TEST ${TEST_NAME} PROPERTY RESOURCE_GROUPS
@@ -117,7 +115,10 @@ function(python_test)
   if(${TEST_NUM_PROC} EQUAL 3)
     list(APPEND TEST_LABELS "parallel_odd")
   endif()
-  set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}")
+
+  set_tests_properties(
+    ${TEST_NAME} PROPERTIES PROCESSORS ${TEST_NUM_PROC} SKIP_RETURN_CODE 5
+                            DEPENDS "${TEST_DEPENDS}" LABELS "${TEST_LABELS}")
 
   set(python_tests ${python_tests} ${TEST_FILE_CONFIGURED} PARENT_SCOPE)
 endfunction(python_test)

--- a/testsuite/scripts/CMakeLists.txt
+++ b/testsuite/scripts/CMakeLists.txt
@@ -39,9 +39,9 @@ macro(PYTHON_SCRIPTS_TEST)
   string(REGEX REPLACE "^test_" "${TEST_TYPE}_" TEST_NAME ${TEST_NAME})
   add_test(${TEST_NAME} ${CMAKE_BINARY_DIR}/pypresso ${PYPRESSO_OPTIONS}
            ${TEST_FILE_CONFIGURED})
-  set_tests_properties(${TEST_NAME} PROPERTIES FIXTURES_REQUIRED
-                                               IMPORTLIB_WRAPPER)
-  set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}")
+  set_tests_properties(
+    ${TEST_NAME} PROPERTIES FIXTURES_REQUIRED IMPORTLIB_WRAPPER
+                            SKIP_RETURN_CODE 5 LABELS "${TEST_LABELS}")
   if("gpu" IN_LIST TEST_LABELS AND ESPRESSO_BUILD_WITH_CUDA)
     set_tests_properties(${TEST_NAME} PROPERTIES RESOURCE_LOCK GPU)
   endif()

--- a/testsuite/scripts/benchmarks/CMakeLists.txt
+++ b/testsuite/scripts/benchmarks/CMakeLists.txt
@@ -25,8 +25,9 @@ endfunction(BENCHMARK_TEST)
 # configure Python module importlib_wrapper.py
 add_test(importlib_wrapper ${CMAKE_BINARY_DIR}/pypresso ${PYPRESSO_OPTIONS}
          ${TEST_FILE_CONFIGURED_IMPORTLIB_WRAPPER})
-set_tests_properties(importlib_wrapper PROPERTIES FIXTURES_SETUP
-                                                  IMPORTLIB_WRAPPER)
+set_tests_properties(
+  importlib_wrapper PROPERTIES FIXTURES_SETUP IMPORTLIB_WRAPPER
+                               SKIP_RETURN_CODE 5)
 set(benchmarks_tests ${benchmarks_tests}
                      ${TEST_FILE_CONFIGURED_IMPORTLIB_WRAPPER} PARENT_SCOPE)
 configure_file(../importlib_wrapper.py

--- a/testsuite/scripts/samples/CMakeLists.txt
+++ b/testsuite/scripts/samples/CMakeLists.txt
@@ -25,8 +25,9 @@ endfunction(SAMPLE_TEST)
 # configure Python module importlib_wrapper.py
 add_test(importlib_wrapper ${CMAKE_BINARY_DIR}/pypresso ${PYPRESSO_OPTIONS}
          ${TEST_FILE_CONFIGURED_IMPORTLIB_WRAPPER})
-set_tests_properties(importlib_wrapper PROPERTIES FIXTURES_SETUP
-                                                  IMPORTLIB_WRAPPER)
+set_tests_properties(
+  importlib_wrapper PROPERTIES FIXTURES_SETUP IMPORTLIB_WRAPPER
+                               SKIP_RETURN_CODE 5)
 set(samples_tests ${samples_tests} ${TEST_FILE_CONFIGURED_IMPORTLIB_WRAPPER}
     PARENT_SCOPE)
 configure_file(../importlib_wrapper.py

--- a/testsuite/scripts/tutorials/CMakeLists.txt
+++ b/testsuite/scripts/tutorials/CMakeLists.txt
@@ -28,9 +28,9 @@ add_test(importlib_wrapper ${CMAKE_BINARY_DIR}/pypresso ${PYPRESSO_OPTIONS}
          ${TEST_FILE_CONFIGURED_IMPORTLIB_WRAPPER})
 add_test(convert ${CMAKE_BINARY_DIR}/pypresso ${PYPRESSO_OPTIONS}
          ${CMAKE_CURRENT_BINARY_DIR}/test_convert.py)
-set_tests_properties(importlib_wrapper PROPERTIES FIXTURES_SETUP
-                                                  IMPORTLIB_WRAPPER)
-set_tests_properties(convert PROPERTIES FIXTURES_SETUP IMPORTLIB_WRAPPER)
+set_tests_properties(
+  importlib_wrapper convert PROPERTIES FIXTURES_SETUP IMPORTLIB_WRAPPER
+                                       SKIP_RETURN_CODE 5)
 set(tutorials_tests ${tutorials_tests} ${TEST_FILE_CONFIGURED_IMPORTLIB_WRAPPER}
     PARENT_SCOPE)
 configure_file(../importlib_wrapper.py


### PR DESCRIPTION
Starting with Python 3.12, package `unittest` returns exit code 5 when all tests are skipped. By default, CTest treats any non-zero exit code as a failure. This can be remediated by setting test property [`SKIP_RETURN_CODE`](https://cmake.org/cmake/help/latest/prop_test/SKIP_RETURN_CODE.html) to 5.

Description of changes:
- skipped tests are no longer treated as failures by CTest