### PR TITLE
Remove MPI static globals

### DIFF
--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   macos:
     runs-on: macos-12
-    if: false
+    if: ${{ github.repository == 'espressomd/espresso' }}
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,9 +435,6 @@ if(ESPRESSO_BUILD_TESTS)
 endif()
 
 find_package(Boost 1.74.0 REQUIRED ${BOOST_COMPONENTS})
-if(${Boost_VERSION} VERSION_GREATER_EQUAL 1.84.0)
-  message(FATAL_ERROR "Boost version ${Boost_VERSION} is unsupported.")
-endif()
 
 #
 # Paths

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -83,6 +83,7 @@ namespace Communication {
  * @brief Returns a reference to the global callback class instance.
  */
 MpiCallbacks &mpiCallbacks();
+std::shared_ptr<MpiCallbacks> mpiCallbacksHandle();
 } // namespace Communication
 
 /**************************************************
@@ -124,12 +125,18 @@ namespace Communication {
 /**
  * @brief Init globals for communication.
  *
- * and calls @ref cuda_on_program_start. Keeps a copy of
- * the pointer to the mpi environment to keep it alive
- * while the program is loaded.
- *
  * @param mpi_env MPI environment that should be used
  */
 void init(std::shared_ptr<boost::mpi::environment> mpi_env);
+void deinit();
 } // namespace Communication
+
+struct MpiContainerUnitTest {
+  std::shared_ptr<boost::mpi::environment> m_mpi_env;
+  MpiContainerUnitTest(int argc, char **argv) {
+    m_mpi_env = mpi_init(argc, argv);
+    Communication::init(m_mpi_env);
+  }
+  ~MpiContainerUnitTest() { Communication::deinit(); }
+};
 #endif

--- a/src/core/errorhandling.hpp
+++ b/src/core/errorhandling.hpp
@@ -31,6 +31,7 @@
 #include "error_handling/RuntimeError.hpp"
 #include "error_handling/RuntimeErrorStream.hpp"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -85,7 +86,7 @@ namespace ErrorHandling {
  *
  * @param callbacks Callbacks system the error handler should be on.
  */
-void init_error_handling(Communication::MpiCallbacks &callbacks);
+void init_error_handling(std::weak_ptr<Communication::MpiCallbacks> callbacks);
 
 RuntimeErrorStream _runtimeMessageStream(RuntimeError::ErrorLevel level,
                                          const std::string &file, int line,

--- a/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
+++ b/src/core/reaction_methods/tests/ReactionAlgorithm_test.cpp
@@ -330,7 +330,7 @@ BOOST_FIXTURE_TEST_CASE(ReactionAlgorithm_test, ParticleFactory) {
 }
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
   espresso::system = System::System::create();
   espresso::system->set_cell_structure_topology(CellStructureType::REGULAR);
   ::System::set_system(espresso::system);

--- a/src/core/system/System.cpp
+++ b/src/core/system/System.cpp
@@ -463,10 +463,3 @@ unsigned System::get_global_ghost_flags() const {
 }
 
 } // namespace System
-
-void mpi_init_stand_alone(int argc, char **argv) {
-  auto mpi_env = mpi_init(argc, argv);
-
-  // initialize the MpiCallbacks framework
-  Communication::init(mpi_env);
-}

--- a/src/core/system/System.hpp
+++ b/src/core/system/System.hpp
@@ -308,10 +308,3 @@ void reset_system();
 bool is_system_set();
 
 } // namespace System
-
-/**
- * @brief Initialize MPI global state to run ESPResSo in stand-alone mode.
- * Use this function in simulations written in C++, such as unit tests.
- * The script interface has its own MPI initialization mechanism.
- */
-void mpi_init_stand_alone(int argc, char **argv);

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -483,7 +483,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
 }
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
   espresso::system = System::System::create();
   espresso::system->set_cell_structure_topology(CellStructureType::REGULAR);
   ::System::set_system(espresso::system);

--- a/src/core/unit_tests/EspressoSystem_test.cpp
+++ b/src/core/unit_tests/EspressoSystem_test.cpp
@@ -151,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE(check_with_gpu, ParticleFactory,
 }
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
 
   return boost::unit_test::unit_test_main(init_unit_test, argc, argv);
 }

--- a/src/core/unit_tests/Verlet_list_test.cpp
+++ b/src/core/unit_tests/Verlet_list_test.cpp
@@ -273,7 +273,7 @@ BOOST_DATA_TEST_CASE_F(ParticleFactory, verlet_list_update,
 }
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
   espresso::system = System::System::create();
   espresso::system->set_cell_structure_topology(CellStructureType::REGULAR);
   ::System::set_system(espresso::system);

--- a/src/core/unit_tests/ek_interface_test.cpp
+++ b/src/core/unit_tests/ek_interface_test.cpp
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(ek_interface_none) {
 BOOST_AUTO_TEST_SUITE_END()
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
   espresso::system = System::System::create();
   espresso::system->set_box_l(params.box_dimensions);
   espresso::system->set_time_step(params.time_step);

--- a/src/core/unit_tests/lb_particle_coupling_test.cpp
+++ b/src/core/unit_tests/lb_particle_coupling_test.cpp
@@ -635,7 +635,7 @@ BOOST_AUTO_TEST_CASE(lb_exceptions) {
 }
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
   espresso::system = System::System::create();
   espresso::system->set_box_l(params.box_dimensions);
   espresso::system->set_time_step(params.time_step);

--- a/src/python/espressomd/_init.pyx
+++ b/src/python/espressomd/_init.pyx
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import sys
+import atexit
 from . cimport script_interface
 from . cimport communication
 from libcpp.memory cimport shared_ptr
@@ -28,7 +29,16 @@ communication.init(mpi_env)
 
 # Initialize script interface
 # Has to be _after_ mpi_init
-script_interface.init(communication.mpiCallbacks())
+script_interface.init(communication.mpiCallbacksHandle())
+
+
+def session_shutdown():
+    mpi_env.reset()
+    communication.deinit()
+    script_interface.deinit()
+
+
+atexit.register(session_shutdown)
 
 # Block the worker nodes in the callback loop.
 # The head node is just returning to the user script.

--- a/src/python/espressomd/communication.pxd
+++ b/src/python/espressomd/communication.pxd
@@ -30,4 +30,6 @@ cdef extern from "communication.hpp":
 
 cdef extern from "communication.hpp" namespace "Communication":
     MpiCallbacks & mpiCallbacks()
+    shared_ptr[MpiCallbacks] mpiCallbacksHandle()
     void init(shared_ptr[environment])
+    void deinit()

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -62,7 +62,7 @@ cdef extern from "script_interface/ContextManager.hpp" namespace "ScriptInterfac
 
 cdef extern from "script_interface/ContextManager.hpp" namespace "ScriptInterface":
     cdef cppclass ContextManager:
-        ContextManager(MpiCallbacks & , const Factory[ObjectHandle] & )
+        ContextManager(const shared_ptr[MpiCallbacks] & , const Factory[ObjectHandle] & )
         shared_ptr[ObjectHandle] make_shared(CreationPolicy, const string &, const VariantMap) except +
         shared_ptr[ObjectHandle] deserialize(const string &) except +
         string serialize(const ObjectHandle *) except +
@@ -76,4 +76,5 @@ cdef extern from "script_interface/get_value.hpp" namespace "ScriptInterface":
 cdef extern from "script_interface/code_info/CodeInfo.hpp" namespace "ScriptInterface::CodeInfo":
     void check_features(const vector[string] & features) except +
 
-cdef void init(MpiCallbacks &)
+cdef void init(const shared_ptr[MpiCallbacks] &)
+cdef void deinit()

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -571,10 +571,15 @@ def script_interface_register(c):
     return c
 
 
-cdef void init(MpiCallbacks & cb):
+cdef void init(const shared_ptr[MpiCallbacks] & cb):
     cdef Factory[ObjectHandle] f
 
     initialize(& f)
 
     global _om
     _om = make_shared[ContextManager](cb, f)
+
+
+cdef void deinit():
+    global _om
+    _om.reset()

--- a/src/script_interface/ContextManager.cpp
+++ b/src/script_interface/ContextManager.cpp
@@ -53,15 +53,16 @@ std::string ContextManager::serialize(const ObjectHandle *o) const {
   return Utils::pack(std::make_pair(policy(ctx), o->serialize()));
 }
 
-ContextManager::ContextManager(Communication::MpiCallbacks &callbacks,
-                               const Utils::Factory<ObjectHandle> &factory) {
+ContextManager::ContextManager(
+    std::shared_ptr<Communication::MpiCallbacks> const &callbacks,
+    const Utils::Factory<ObjectHandle> &factory) {
   auto local_context =
-      std::make_shared<LocalContext>(factory, callbacks.comm());
+      std::make_shared<LocalContext>(factory, callbacks->comm());
 
   /* If there is only one node, we can treat all objects as local, and thus
    * never invoke any callback. */
   m_global_context =
-      (callbacks.comm().size() > 1)
+      (callbacks->comm().size() > 1)
           ? std::make_shared<GlobalContext>(callbacks, local_context)
           : std::static_pointer_cast<Context>(local_context);
 

--- a/src/script_interface/ContextManager.hpp
+++ b/src/script_interface/ContextManager.hpp
@@ -67,7 +67,7 @@ public:
     GLOBAL
   };
 
-  ContextManager(Communication::MpiCallbacks &callbacks,
+  ContextManager(std::shared_ptr<Communication::MpiCallbacks> const &callbacks,
                  const Utils::Factory<ObjectHandle> &factory);
 
   /**

--- a/src/script_interface/h5md/h5md.hpp
+++ b/src/script_interface/h5md/h5md.hpp
@@ -26,6 +26,8 @@
 
 #ifdef H5MD
 
+#include "core/MpiCallbacks.hpp"
+#include "core/communication.hpp"
 #include "io/writer/h5md_core.hpp"
 
 #include "script_interface/ScriptInterface.hpp"
@@ -66,8 +68,16 @@ private:
         params, "file_path", "script_path", "fields", "mass_unit",
         "length_unit", "time_unit", "force_unit", "velocity_unit",
         "charge_unit");
+    // MPI communicator is needed to close parallel file handles
+    m_mpi_env_lock = ::Communication::mpiCallbacksHandle()->share_mpi_env();
   }
 
+  ~H5md() override {
+    m_h5md.reset();
+    m_mpi_env_lock.reset();
+  }
+
+  std::shared_ptr<boost::mpi::environment> m_mpi_env_lock;
   std::shared_ptr<::Writer::H5md::File> m_h5md;
   std::vector<std::string> m_output_fields;
 };

--- a/src/script_interface/tests/ConstantpHEnsemble_test.cpp
+++ b/src/script_interface/tests/ConstantpHEnsemble_test.cpp
@@ -32,6 +32,7 @@
 
 #include "core/Particle.hpp"
 #include "core/cell_system/CellStructureType.hpp"
+#include "core/communication.hpp"
 #include "core/particle_node.hpp"
 #include "core/unit_tests/ParticleFactory.hpp"
 
@@ -131,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(ConstantpHEnsemble_test, ParticleFactory) {
 }
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
   espresso::system = System::System::create();
   espresso::system->set_cell_structure_topology(CellStructureType::REGULAR);
   ::System::set_system(espresso::system);

--- a/src/script_interface/tests/GlobalContext_test.cpp
+++ b/src/script_interface/tests/GlobalContext_test.cpp
@@ -26,11 +26,14 @@
 
 #include <boost/mpi.hpp>
 #include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
 
 #include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <string>
+
+static std::weak_ptr<boost::mpi::environment> mpi_env;
 
 namespace si = ScriptInterface;
 
@@ -54,19 +57,19 @@ struct Dummy : si::ObjectHandle {
   }
 };
 
-auto make_global_context(boost::mpi::communicator const &comm,
-                         Communication::MpiCallbacks &cb) {
+auto make_global_context(std::shared_ptr<Communication::MpiCallbacks> &cb) {
   Utils::Factory<si::ObjectHandle> factory;
   factory.register_new<Dummy>("Dummy");
 
   return std::make_shared<si::GlobalContext>(
-      cb, std::make_shared<si::LocalContext>(factory, comm));
+      cb, std::make_shared<si::LocalContext>(factory, cb->comm()));
 }
 
 BOOST_AUTO_TEST_CASE(GlobalContext_make_shared) {
   boost::mpi::communicator world;
-  Communication::MpiCallbacks cb{world};
-  auto ctx = make_global_context(world, cb);
+  auto cb =
+      std::make_shared<Communication::MpiCallbacks>(world, ::mpi_env.lock());
+  auto ctx = make_global_context(cb);
 
   if (world.rank() == 0) {
     auto res = ctx->make_shared("Dummy", {});
@@ -74,14 +77,15 @@ BOOST_AUTO_TEST_CASE(GlobalContext_make_shared) {
     BOOST_CHECK_EQUAL(res->context(), ctx.get());
     BOOST_CHECK_EQUAL(ctx->name(res.get()), "Dummy");
   } else {
-    cb.loop();
+    cb->loop();
   }
 }
 
 BOOST_AUTO_TEST_CASE(GlobalContext_serialization) {
   boost::mpi::communicator world;
-  Communication::MpiCallbacks cb{world};
-  auto ctx = make_global_context(world, cb);
+  auto cb =
+      std::make_shared<Communication::MpiCallbacks>(world, ::mpi_env.lock());
+  auto ctx = make_global_context(cb);
 
   if (world.rank() == 0) {
     auto const serialized = [&]() {
@@ -108,12 +112,13 @@ BOOST_AUTO_TEST_CASE(GlobalContext_serialization) {
     BOOST_REQUIRE(d3);
     BOOST_CHECK_EQUAL(boost::get<int>(d3->get_parameter("id")), 3);
   } else {
-    cb.loop();
+    cb->loop();
   }
 }
 
 int main(int argc, char **argv) {
-  boost::mpi::environment mpi_env(argc, argv);
+  auto const mpi_env = std::make_shared<boost::mpi::environment>(argc, argv);
+  ::mpi_env = mpi_env;
 
   return boost::unit_test::unit_test_main(init_unit_test, argc, argv);
 }

--- a/src/script_interface/tests/ReactionEnsemble_test.cpp
+++ b/src/script_interface/tests/ReactionEnsemble_test.cpp
@@ -33,6 +33,7 @@
 
 #include "core/Particle.hpp"
 #include "core/cell_system/CellStructureType.hpp"
+#include "core/communication.hpp"
 #include "core/particle_node.hpp"
 #include "core/unit_tests/ParticleFactory.hpp"
 
@@ -262,7 +263,7 @@ BOOST_FIXTURE_TEST_CASE(ReactionEnsemble_test, ParticleFactory) {
 }
 
 int main(int argc, char **argv) {
-  mpi_init_stand_alone(argc, argv);
+  auto const mpi_handle = MpiContainerUnitTest(argc, argv);
   espresso::system = System::System::create();
   espresso::system->set_cell_structure_topology(CellStructureType::REGULAR);
   ::System::set_system(espresso::system);

--- a/src/walberla_bridge/include/walberla_bridge/utils/ResourceManager.hpp
+++ b/src/walberla_bridge/include/walberla_bridge/utils/ResourceManager.hpp
@@ -22,6 +22,7 @@
 #include <list>
 #include <memory>
 #include <stack>
+#include <utility>
 
 /**
  * @brief Manager to control the lifetime of shared resources.
@@ -58,8 +59,8 @@ class ResourceManager {
     std::shared_ptr<T> m_resource;
 
   public:
-    explicit ResourceLockImpl(std::shared_ptr<T> const &resource)
-        : m_resource(resource) {}
+    explicit ResourceLockImpl(std::shared_ptr<T> resource)
+        : m_resource(std::move(resource)) {}
     ~ResourceLockImpl() override { m_resource.reset(); }
   };
 


### PR DESCRIPTION
Fixes #4856

Description of changes:
- fix multiple bugs caused by undefined behavior due to the static initialization order of MPI global objects
- ESPResSo is now compatible with Boost 1.84+
