### PR TITLE
WIP: Make espresso pip-installable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,8 +266,8 @@ set(ESPRESSO_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 # python site-packages, can be overriden with CMake options
 if(ESPRESSO_BUILD_WITH_PYTHON)
   # override: package C++, CUDA and Cython shared objects together
-	set(ESPRESSO_INSTALL_PYTHON "${Python_SITEARCH}")
-	set(ESPRESSO_INSTALL_LIBDIR "${ESPRESSO_INSTALL_PYTHON}/espressomd")
+  set(ESPRESSO_INSTALL_PYTHON "${Python_SITEARCH}")
+  set(ESPRESSO_INSTALL_LIBDIR "${ESPRESSO_INSTALL_PYTHON}/espressomd")
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,17 +265,9 @@ set(ESPRESSO_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 # python site-packages, can be overriden with CMake options
 if(ESPRESSO_BUILD_WITH_PYTHON)
-  if(NOT ESPRESSO_INSTALL_PYTHON)
-    if(CMAKE_INSTALL_PREFIX STREQUAL "/")
-      set(ESPRESSO_INSTALL_PYTHON "${Python_SITEARCH}")
-    else()
-      set(ESPRESSO_INSTALL_PYTHON
-          "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages"
-      )
-    endif()
-  endif()
   # override: package C++, CUDA and Cython shared objects together
-  set(ESPRESSO_INSTALL_LIBDIR "${ESPRESSO_INSTALL_PYTHON}/espressomd")
+	set(ESPRESSO_INSTALL_PYTHON "${Python_SITEARCH}")
+	set(ESPRESSO_INSTALL_LIBDIR "${ESPRESSO_INSTALL_PYTHON}/espressomd")
 endif()
 
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,26 @@
 [build-system]
 requires = [
-  "setuptools>=42",
-  "scikit-build>=0.13",
+  "scikit-build-core",
   "cmake>=3.18",
   "numpy>=1.23",
   "cython>=0.29.21,<=3.0.7",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "espressomd"
+version = "4.3"
+requires-python = ">=3.9"
+dependencies = [
+  "numpy>=1.23"
+]
+description = "Extensible Simulation Package for Research on Soft Matter Systems"
+readme = "Readme.md"
+authors = [{name = "The ESPResSo project"}]
+license = {file = "COPYING"}
+
+[project.urls]
+Homepage = "https://espressomd.org"
+Repository = "https://github.com/espressomd/espresso"
+Issues = "https://github.com/espressomd/espresso/issues"
+Documentation = "https://espressomd.github.io/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+  "setuptools>=42",
+  "scikit-build>=0.13",
+  "cmake>=3.18",
+  "numpy>=1.23",
+  "cython>=0.29.21,<=3.0.7",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+from skbuild import setup
+
+setup(
+    name="espressomd",
+    version="4.3",
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-from skbuild import setup
-
-setup(
-    name="espressomd",
-    version="4.3",
-)


### PR DESCRIPTION
Closes #4222 

`scikit-build` is used to build espresso with CMake and install `espressond` in the `site-packages` directory.
This should also resolve the issue with paths in virtual environments without needing to add a `.pth` file (#4872) and should make espresso pretty easy to install in any environment.

Things I haven't touched:
 - Adding metadata to the `setup.py`, such as the license or description.
 - Building should happen in parralel with `ninja` but I am not sure if this was the case on my PC, so parallel building should be checked.
 - Documentation
 - of course updating the CI etc.
