### PR TITLE
Disable box length reset when particles are present

### DIFF
--- a/samples/h5md_trajectory.py
+++ b/samples/h5md_trajectory.py
@@ -66,7 +66,8 @@ h5.write()
 xyz_folded.append(system.part.all().pos_folded[:])
 xyz_unfolded.append(system.part.all().pos[:])
 # resize box (simulates NpT)
-system.box_l = system.box_l + 1.
+for i in range(3):
+    system.change_volume_and_rescale_particles(system.box_l[i] + 1., "xyz"[i])
 system.integrator.run(10)
 h5.write()
 xyz_folded.append(system.part.all().pos_folded[:])

--- a/src/core/constraints/Constraints.hpp
+++ b/src/core/constraints/Constraints.hpp
@@ -105,12 +105,14 @@ public:
     }
   }
 
-  void on_boxl_change() const {
+  void veto_boxl_change() const {
     if (not m_constraints.empty()) {
       throw std::runtime_error("The box size can not be changed because there "
                                "are active constraints.");
     }
   }
+
+  void on_boxl_change() const { veto_boxl_change(); }
 };
 } // namespace Constraints
 

--- a/src/core/ek/EKNone.hpp
+++ b/src/core/ek/EKNone.hpp
@@ -34,6 +34,7 @@ struct EKNone {
   void veto_time_step(double) const { throw NoEKActive{}; }
   void veto_kT(double) const { throw NoEKActive{}; }
   void sanity_checks(System::System const &) const { throw NoEKActive{}; }
+  void veto_boxl_change() const { throw NoEKActive{}; }
   void on_cell_structure_change() const { throw NoEKActive{}; }
   void on_boxl_change() const { throw NoEKActive{}; }
   void on_node_grid_change() const { throw NoEKActive{}; }

--- a/src/core/ek/EKWalberla.hpp
+++ b/src/core/ek/EKWalberla.hpp
@@ -62,9 +62,10 @@ struct EKWalberla {
   void perform_reactions();
 
   void on_cell_structure_change() const {}
-  void on_boxl_change() const {
+  void veto_boxl_change() const {
     throw std::runtime_error("MD cell geometry change not supported by EK");
   }
+  void on_boxl_change() const { veto_boxl_change(); }
   void on_node_grid_change() const {
     throw std::runtime_error("MPI topology change not supported by EK");
   }

--- a/src/core/ek/Solver.cpp
+++ b/src/core/ek/Solver.cpp
@@ -90,6 +90,12 @@ void Solver::veto_kT(double kT) const {
   }
 }
 
+void Solver::veto_boxl_change() const {
+  if (impl->solver) {
+    std::visit([](auto const &ptr) { ptr->veto_boxl_change(); }, *impl->solver);
+  }
+}
+
 void Solver::on_cell_structure_change() {
   if (impl->solver) {
     auto &solver = *impl->solver;

--- a/src/core/ek/Solver.hpp
+++ b/src/core/ek/Solver.hpp
@@ -95,6 +95,7 @@ struct Solver : public System::Leaf<Solver> {
   void on_cell_structure_change();
   void on_timestep_change();
   void on_temperature_change();
+  void veto_boxl_change() const;
 
 private:
   /** @brief Pointer-to-implementation. */

--- a/src/core/lb/LBNone.hpp
+++ b/src/core/lb/LBNone.hpp
@@ -52,6 +52,7 @@ struct LBNone {
   void lebc_sanity_checks(unsigned int, unsigned int) const {
     throw NoLBActive{};
   }
+  void veto_boxl_change() const { throw NoLBActive{}; }
   void on_cell_structure_change() const { throw NoLBActive{}; }
   void on_boxl_change() const { throw NoLBActive{}; }
   void on_node_grid_change() const { throw NoLBActive{}; }

--- a/src/core/lb/LBWalberla.hpp
+++ b/src/core/lb/LBWalberla.hpp
@@ -74,9 +74,10 @@ struct LBWalberla {
                           unsigned int shear_plane_normal) const;
 
   void on_cell_structure_change() const {}
-  void on_boxl_change() const {
+  void veto_boxl_change() const {
     throw std::runtime_error("MD cell geometry change not supported by LB");
   }
+  void on_boxl_change() const { veto_boxl_change(); }
   void on_node_grid_change() const {
     throw std::runtime_error("MPI topology change not supported by LB");
   }

--- a/src/core/lb/Solver.cpp
+++ b/src/core/lb/Solver.cpp
@@ -107,6 +107,12 @@ void Solver::on_cell_structure_change() {
   }
 }
 
+void Solver::veto_boxl_change() const {
+  if (impl->solver) {
+    std::visit([](auto const &ptr) { ptr->veto_boxl_change(); }, *impl->solver);
+  }
+}
+
 void Solver::on_boxl_change() {
   if (impl->solver) {
     std::visit([](auto &ptr) { ptr->on_boxl_change(); }, *impl->solver);

--- a/src/core/lb/Solver.hpp
+++ b/src/core/lb/Solver.hpp
@@ -154,6 +154,7 @@ struct Solver : public System::Leaf<Solver> {
   void on_cell_structure_change();
   void on_timestep_change();
   void on_temperature_change();
+  void veto_boxl_change() const;
 
 private:
   /** @brief Pointer-to-implementation. */

--- a/src/core/system/System.cpp
+++ b/src/core/system/System.cpp
@@ -167,6 +167,20 @@ void System::on_boxl_change(bool skip_method_adaption) {
   Constraints::constraints.on_boxl_change();
 }
 
+void System::veto_boxl_change(bool skip_particle_checks) const {
+  if (not skip_particle_checks) {
+    auto const n_part = boost::mpi::all_reduce(
+        ::comm_cart, cell_structure->local_particles().size(), std::plus<>());
+    if (n_part > 0ul) {
+      throw std::runtime_error(
+          "Cannot reset the box length when particles are present");
+    }
+  }
+  Constraints::constraints.veto_boxl_change();
+  lb.veto_boxl_change();
+  ek.veto_boxl_change();
+}
+
 void System::on_node_grid_change() {
   update_local_geo();
   lb.on_node_grid_change();

--- a/src/core/system/System.hpp
+++ b/src/core/system/System.hpp
@@ -241,6 +241,7 @@ public:
    *  initialized immediately (P3M etc.).
    */
   void on_observable_calc();
+  void veto_boxl_change(bool skip_particle_checks = false) const;
   /**@}*/
 
   /**

--- a/src/core/unit_tests/ek_interface_test.cpp
+++ b/src/core/unit_tests/ek_interface_test.cpp
@@ -188,6 +188,7 @@ BOOST_AUTO_TEST_CASE(ek_interface_walberla) {
       espresso::ek_container->add(ek_species);
       BOOST_CHECK_THROW(ek.veto_kT(params.kT + 1.), std::runtime_error);
       BOOST_CHECK_THROW(ek.on_boxl_change(), std::runtime_error);
+      BOOST_CHECK_THROW(ek.veto_boxl_change(), std::runtime_error);
       BOOST_CHECK_THROW(ek.veto_time_step(ek.get_tau() * 2.),
                         std::invalid_argument);
       BOOST_CHECK_THROW(ek.veto_time_step(ek.get_tau() / 2.5),
@@ -215,6 +216,7 @@ BOOST_AUTO_TEST_CASE(ek_interface_none) {
     BOOST_CHECK_THROW(ek.propagate(), NoEKActive);
     BOOST_CHECK_THROW(ek.get_tau(), NoEKActive);
     BOOST_CHECK_THROW(ek.sanity_checks(), NoEKActive);
+    BOOST_CHECK_THROW(ek.veto_boxl_change(), NoEKActive);
     BOOST_CHECK_THROW(ek.veto_time_step(0.), NoEKActive);
     BOOST_CHECK_THROW(ek.veto_kT(0.), NoEKActive);
     BOOST_CHECK_THROW(ek.on_cell_structure_change(), NoEKActive);

--- a/src/core/unit_tests/lb_particle_coupling_test.cpp
+++ b/src/core/unit_tests/lb_particle_coupling_test.cpp
@@ -520,6 +520,7 @@ BOOST_AUTO_TEST_CASE(runtime_exceptions) {
   // LB prevents changing most of the system state
   {
     BOOST_CHECK_THROW(lb.on_boxl_change(), std::runtime_error);
+    BOOST_CHECK_THROW(lb.veto_boxl_change(), std::runtime_error);
     BOOST_CHECK_THROW(lb.veto_time_step(lb.get_tau() * 2.),
                       std::invalid_argument);
     BOOST_CHECK_THROW(lb.veto_time_step(lb.get_tau() / 2.5),
@@ -618,6 +619,7 @@ BOOST_AUTO_TEST_CASE(lb_exceptions) {
     BOOST_CHECK_THROW(lb.get_pressure_tensor(), NoLBActive);
     BOOST_CHECK_THROW(lb.get_momentum(), NoLBActive);
     BOOST_CHECK_THROW(lb.sanity_checks(), NoLBActive);
+    BOOST_CHECK_THROW(lb.veto_boxl_change(), NoLBActive);
     BOOST_CHECK_THROW(lb.veto_time_step(0.), NoLBActive);
     BOOST_CHECK_THROW(lb.veto_kT(0.), NoLBActive);
     BOOST_CHECK_THROW(lb.lebc_sanity_checks(0u, 1u), NoLBActive);

--- a/testsuite/python/analyze_chains.py
+++ b/testsuite/python/analyze_chains.py
@@ -126,7 +126,8 @@ class AnalyzeChain(ut.TestCase):
         # increase PBC to remove interactions with periodic images
         all_partcls = self.system.part.all()
         old_pos = all_partcls.pos.copy()
-        self.system.box_l = self.system.box_l * 2.
+        self.system.change_volume_and_rescale_particles(
+            2. * self.system.box_l[0], "xyz")
         all_partcls.pos = old_pos
         # compare calc_re()
         core_re = self.system.analysis.calc_re(chain_start=0,

--- a/testsuite/python/array_properties.py
+++ b/testsuite/python/array_properties.py
@@ -102,14 +102,15 @@ class ArrayPropertyTest(ArrayCommon):
     system.box_l = [12.0, 12.0, 12.0]
     system.time_step = 0.01
     system.cell_system.skin = 0.01
-    partcl = system.part.add(pos=[0, 0, 0])
 
     def setUp(self):
         self.system.box_l = [12.0, 12.0, 12.0]
+        self.partcl = self.system.part.add(pos=[0, 0, 0])
 
     def tearDown(self):
         if espressomd.has_features("WALBERLA"):
             self.system.lb = None
+        self.system.part.clear()
 
     def assert_copy_is_writable(self, array):
         cpy = np.copy(array)

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -1072,14 +1072,26 @@ class ShapeBasedConstraintTest(ut.TestCase):
 
     def test_exceptions(self):
         system = self.system
+        box_l = self.box_l
         wall = espressomd.shapes.Wall(normal=[0., 1., 0.], dist=0.)
         constraint = espressomd.constraints.ShapeBasedConstraint(
             shape=wall, particle_type=1)
         system.constraints.add(constraint)
         with self.assertRaisesRegex(RuntimeError, "there are active constraints"):
             system.box_l = 0.5 * system.box_l
+        np.testing.assert_allclose(np.copy(system.box_l), box_l, atol=1e-7)
+        with self.assertRaisesRegex(RuntimeError, "there are active constraints"):
+            system.change_volume_and_rescale_particles(
+                0.5 * system.box_l[0], "xyz")
+        np.testing.assert_allclose(np.copy(system.box_l), box_l, atol=1e-7)
         system.constraints.remove(constraint)
         system.box_l = 0.75 * system.box_l
+        np.testing.assert_allclose(
+            np.copy(system.box_l), 0.75 * box_l, atol=1e-7)
+        system.change_volume_and_rescale_particles(
+            0.5 * system.box_l[0], "xyz")
+        np.testing.assert_allclose(
+            np.copy(system.box_l), 0.75 * 0.5 * box_l, atol=1e-7)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/coulomb_interface.py
+++ b/testsuite/python/coulomb_interface.py
@@ -253,12 +253,12 @@ class Test(ut.TestCase):
             self.assertEqual(
                 list(self.system.cell_system.node_grid),
                 list(self.original_node_grid))
-        with self.assertRaisesRegex(Exception, "while setting parameter 'box_l': ERROR: ELC gap size .+ larger than box length in z-direction"):
-            self.system.box_l = [10., 10., 2.5]
-        self.system.box_l = [10., 10., 10.]
+        with self.assertRaisesRegex(Exception, "ERROR: ELC gap size .+ larger than box length in z-direction"):
+            self.system.change_volume_and_rescale_particles(2.5, "z")
+        self.system.change_volume_and_rescale_particles(10., "z")
         self.system.electrostatics.solver = None
         with self.assertRaisesRegex(RuntimeError, "P3M real-space cutoff too large for ELC w/ dielectric contrast"):
-            self.system.box_l = [10., 10., 5.]
+            self.system.change_volume_and_rescale_particles(5., "z")
             elc = espressomd.electrostatics.ELC(
                 actor=p3m,
                 gap_size=1.,
@@ -271,7 +271,7 @@ class Test(ut.TestCase):
             )
             self.system.electrostatics.solver = elc
         self.assertIsNone(self.system.electrostatics.solver)
-        self.system.box_l = [10., 10., 10.]
+        self.system.change_volume_and_rescale_particles(10., "z")
         self.system.periodicity = [True, True, False]
         with self.assertRaisesRegex(RuntimeError, periodicity_err_msg):
             elc = espressomd.electrostatics.ELC(

--- a/testsuite/python/dds-and-bh-gpu.py
+++ b/testsuite/python/dds-and-bh-gpu.py
@@ -80,7 +80,7 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
                 prefactor=pf_dds_gpu)
             system.magnetostatics.solver = dds_gpu
             # check MD cell reset has no impact
-            system.box_l = system.box_l
+            system.change_volume_and_rescale_particles(system.box_l[0], "x")
             system.periodicity = system.periodicity
             system.cell_system.node_grid = system.cell_system.node_grid
             system.integrator.run(steps=0, recalc_forces=True)
@@ -97,7 +97,7 @@ class BH_DDS_gpu_multCPU_test(ut.TestCase):
                 prefactor=pf_bh_gpu, epssq=200.0, itolsq=8.0)
             system.magnetostatics.solver = bh_gpu
             # check MD cell reset has no impact
-            system.box_l = system.box_l
+            system.change_volume_and_rescale_particles(system.box_l[0], "x")
             system.periodicity = system.periodicity
             system.cell_system.node_grid = system.cell_system.node_grid
             system.integrator.run(steps=0, recalc_forces=True)

--- a/testsuite/python/dipolar_direct_summation.py
+++ b/testsuite/python/dipolar_direct_summation.py
@@ -49,7 +49,8 @@ class Test(ut.TestCase):
         dds_cpu = espressomd.magnetostatics.DipolarDirectSumGpu(prefactor=1.2)
         system.magnetostatics.solver = dds_cpu
         # check MD cell reset has no impact
-        self.system.box_l = self.system.box_l
+        self.system.change_volume_and_rescale_particles(
+            self.system.box_l[0], "x")
         self.system.periodicity = self.system.periodicity
         self.system.cell_system.node_grid = self.system.cell_system.node_grid
 
@@ -68,7 +69,8 @@ class Test(ut.TestCase):
         dds_cpu = espressomd.magnetostatics.DipolarDirectSumCpu(prefactor=1.2)
         system.magnetostatics.solver = dds_cpu
         # check MD cell reset has no impact
-        self.system.box_l = self.system.box_l
+        self.system.change_volume_and_rescale_particles(
+            self.system.box_l[0], "x")
         self.system.periodicity = self.system.periodicity
         self.system.cell_system.node_grid = self.system.cell_system.node_grid
 

--- a/testsuite/python/dipolar_interface.py
+++ b/testsuite/python/dipolar_interface.py
@@ -112,7 +112,7 @@ class Test(ut.TestCase):
             self.system.magnetostatics.solver = mdlc
         self.assertIsNone(self.system.magnetostatics.solver)
         self.system.periodicity = [True, True, True]
-        self.system.box_l = [10., 10. + 2e-3, 10.]
+        self.system.change_volume_and_rescale_particles(10. + 2e-3, "y")
         with self.assertRaisesRegex(Exception, "box size in x direction is different from y direction"):
             mdlc = MDLC(gap_size=1., maxPWerror=1e-5, actor=ddsr)
             self.system.magnetostatics.solver = mdlc
@@ -128,14 +128,14 @@ class Test(ut.TestCase):
             self.system.magnetostatics.clear()
         # check it's safe to resize the box, i.e. there are no currently
         # active sanity check in the core
-        self.system.box_l = [10., 10., 10.]
+        self.system.change_volume_and_rescale_particles(10., "y")
         with self.assertRaisesRegex(Exception, "box size in x direction is different from y direction"):
             ddsr = DDSR(prefactor=1., n_replicas=1)
             mdlc = MDLC(gap_size=1., maxPWerror=1e-5, actor=ddsr)
             self.system.magnetostatics.solver = mdlc
-            self.system.box_l = [9., 10., 10.]
+            self.system.change_volume_and_rescale_particles(9., "x")
         self.system.magnetostatics.clear()
-        self.system.box_l = [10., 10., 10.]
+        self.system.change_volume_and_rescale_particles(10., "x")
 
     @utx.skipIfMissingFeatures(["DP3M"])
     def test_exceptions_p3m(self):

--- a/testsuite/python/dipolar_p3m.py
+++ b/testsuite/python/dipolar_p3m.py
@@ -92,7 +92,8 @@ class MagnetostaticsP3M(ut.TestCase):
         ref_mdlc_torque_metallic = np.copy(partcls.torque_lab)
 
         # solvers should remain in a valid state after a cell system reset
-        self.system.box_l = self.system.box_l
+        self.system.change_volume_and_rescale_particles(
+            self.system.box_l[0], "x")
         self.system.periodicity = self.system.periodicity
         self.system.cell_system.node_grid = self.system.cell_system.node_grid
         self.system.integrator.run(0, recalc_forces=True)

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -229,8 +229,7 @@ class EKTest:
             self.system.electrostatics.clear()
         with self.assertRaisesRegex(RuntimeError, "MD cell geometry change not supported by EK"):
             self.system.box_l = [1., 2., 3.]
-        np.testing.assert_allclose(
-            np.copy(self.system.box_l), [1., 2., 3.], atol=1e-7)
+        np.testing.assert_allclose(np.copy(self.system.box_l), 6., atol=1e-7)
         with self.assertRaisesRegex(RuntimeError, "MPI topology change not supported by EK"):
             self.system.cell_system.node_grid = self.system.cell_system.node_grid
 

--- a/testsuite/python/elc_vs_analytic.py
+++ b/testsuite/python/elc_vs_analytic.py
@@ -53,14 +53,13 @@ class Test:
         simulation box with dielectric contrast on the bottom of the box,
         which can be calculated analytically with image charges.
         """
-        self.system.part.add(pos=self.system.box_l / 2., q=self.q[0])
-        self.system.part.add(pos=self.system.box_l / 2. + [0, 0, self.distance],
-                             q=-self.q[0])
-
         self.system.box_l = [self.box_l, self.box_l, self.box_l + self.elc_gap]
         self.system.cell_system.set_regular_decomposition(
             use_verlet_lists=True)
         self.system.periodicity = [True, True, True]
+        self.system.part.add(pos=self.system.box_l / 2., q=self.q[0])
+        self.system.part.add(pos=self.system.box_l / 2. + [0, 0, self.distance],
+                             q=-self.q[0])
         prefactor = 2.0
         p3m = self.p3m_class(prefactor=prefactor, accuracy=self.accuracy,
                              mesh=[58, 58, 70], cao=4)

--- a/testsuite/python/electrostatic_interactions.py
+++ b/testsuite/python/electrostatic_interactions.py
@@ -133,7 +133,8 @@ class ElectrostaticInteractionsTests(ut.TestCase):
 
         self.system.electrostatics.solver = dh
         # actor should remain in a valid state after a cell system reset
-        self.system.box_l = self.system.box_l
+        self.system.change_volume_and_rescale_particles(
+            self.system.box_l[0], "x")
         self.system.periodicity = self.system.periodicity
         self.system.cell_system.node_grid = self.system.cell_system.node_grid
 
@@ -209,7 +210,8 @@ class ElectrostaticInteractionsTests(ut.TestCase):
 
         self.system.electrostatics.solver = rf
         # actor should remain in a valid state after a cell system reset
-        self.system.box_l = self.system.box_l
+        self.system.change_volume_and_rescale_particles(
+            self.system.box_l[0], "x")
         self.system.periodicity = self.system.periodicity
         self.system.cell_system.node_grid = self.system.cell_system.node_grid
 

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -414,8 +414,7 @@ class LBTest:
             self.system.electrostatics.clear()
         with self.assertRaisesRegex(RuntimeError, "MD cell geometry change not supported by LB"):
             self.system.box_l = [1., 2., 3.]
-        np.testing.assert_allclose(
-            np.copy(self.system.box_l), [1., 2., 3.], atol=1e-7)
+        np.testing.assert_allclose(np.copy(self.system.box_l), 6., atol=1e-7)
         with self.assertRaisesRegex(RuntimeError, "MPI topology change not supported by LB"):
             self.system.cell_system.node_grid = self.system.cell_system.node_grid
 

--- a/testsuite/python/mmm1d.py
+++ b/testsuite/python/mmm1d.py
@@ -101,7 +101,8 @@ class ElectrostaticInteractionsTests:
 
         # actor should remain in a valid state after a cell system reset
         forces1 = np.copy(self.system.part.all().f)
-        self.system.box_l = self.system.box_l
+        self.system.change_volume_and_rescale_particles(
+            self.system.box_l[0], "x")
         self.system.periodicity = self.system.periodicity
         self.system.cell_system.node_grid = self.system.cell_system.node_grid
         self.system.integrator.run(steps=0, recalc_forces=True)

--- a/testsuite/python/npt_thermostat.py
+++ b/testsuite/python/npt_thermostat.py
@@ -45,8 +45,8 @@ class NPTThermostat(ut.TestCase):
     def test_01__rng(self):
         """Test for RNG consistency."""
         def reset_particle_and_box():
-            self.system.box_l = [1, 1, 1]
             self.system.part.clear()
+            self.system.box_l = [1, 1, 1]
             p = self.system.part.add(pos=[0, 0, 0])
             return p
 
@@ -123,13 +123,13 @@ class NPTThermostat(ut.TestCase):
 
         system = self.system
         system.box_l = 3 * [ref_box_l]
-        system.part.add(pos=data[:, 0:3], type=len(data) * [2])
         system.non_bonded_inter[2, 2].wca.set_params(epsilon=1., sigma=1.)
         system.time_step = 0.01
 
         for n in range(3):
             direction = np.roll([True, False, False], n)
             system.box_l = 3 * [ref_box_l]
+            system.part.add(pos=data[:, 0:3], type=len(data) * [2])
             system.part.all().pos = data[:, 0:3]
             system.part.all().v = data[:, 3:6]
             system.thermostat.set_npt(kT=1.0, gamma0=2, gammav=0.004, seed=42)
@@ -140,6 +140,7 @@ class NPTThermostat(ut.TestCase):
             box_l_rel_ref = np.roll([np.max(box_l_rel), 1., 1.], n)
             np.testing.assert_allclose(box_l_rel, box_l_rel_ref, atol=1e-10)
             self.assertGreater(np.max(box_l_rel), 2)
+            system.part.clear()
 
     def test_07__virtual(self):
         system = self.system

--- a/testsuite/python/rescale.py
+++ b/testsuite/python/rescale.py
@@ -81,12 +81,20 @@ class RescaleTest(ut.TestCase):
         self.dir_test(2)
 
     def test_exceptions(self):
+        box_l = np.copy(self.system.box_l)
         with self.assertRaisesRegex(ValueError, "Parameter 'd_new' must be > 0"):
             self.system.change_volume_and_rescale_particles(d_new=0.)
         with self.assertRaisesRegex(ValueError, "Parameter 'd_new' must be > 0"):
             self.system.change_volume_and_rescale_particles(d_new=-1.)
         with self.assertRaisesRegex(ValueError, "Usage: change_volume_and_rescale_particles"):
             self.system.change_volume_and_rescale_particles(d_new=1., dir=5)
+        with self.assertRaisesRegex(RuntimeError, "Cannot reset the box length when particles are present"):
+            self.system.box_l = 0.5 * box_l
+        np.testing.assert_allclose(
+            np.copy(self.system.box_l), box_l, atol=1e-7)
+        self.system.change_volume_and_rescale_particles(0.5 * box_l[0], "xyz")
+        np.testing.assert_allclose(
+            np.copy(self.system.box_l), 0.5 * box_l, atol=1e-7)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/scafacos_dipoles_1d_2d.py
+++ b/testsuite/python/scafacos_dipoles_1d_2d.py
@@ -54,9 +54,9 @@ class Scafacos1d2d(ut.TestCase):
         particle_radius = 0.5
 
         box_l = np.cbrt(4 * n_particle * np.pi / (3 * rho)) * particle_radius
-        system.box_l = 3 * [box_l]
 
         for dim in (2, 1):
+            system.box_l = 3 * [box_l]
             with self.subTest(f"{dim} dimensions"):
                 # Read reference data
                 if dim == 2:
@@ -92,7 +92,9 @@ class Scafacos1d2d(ut.TestCase):
                             "p2nfft_epsB": "0.05"})
                     # change box geometry in x,y direction to ensure that
                     # scafacos survives it
-                    system.box_l = np.array([1., 1., 1.3]) * box_l
+                    system.change_volume_and_rescale_particles(
+                        1.3 * box_l, "z")
+                    system.part.all().pos = data[:, 1:4]
                 else:
                     # 1d periodic in x
                     scafacos = espressomd.magnetostatics.Scafacos(
@@ -112,7 +114,7 @@ class Scafacos1d2d(ut.TestCase):
                             "pnfft_m": "8",
                             "pnfft_diff_ik": "1",
                             "p2nfft_epsB": "0.125"})
-                    system.box_l = np.array([1., 1., 1.]) * box_l
+                    system.change_volume_and_rescale_particles(box_l, "z")
 
                 system.magnetostatics.solver = scafacos
                 system.integrator.run(0)

--- a/testsuite/python/scafacos_interface.py
+++ b/testsuite/python/scafacos_interface.py
@@ -119,7 +119,7 @@ class ScafacosInterface(ut.TestCase):
                           'p3m_grid': 32, 'p3m_alpha': 2.799269})
 
         # check MD cell reset event
-        system.box_l = system.box_l
+        system.change_volume_and_rescale_particles(system.box_l[0], "x")
         system.periodicity = system.periodicity
 
         # force data array update, no-op since there are no particles
@@ -256,7 +256,7 @@ class ScafacosInterface(ut.TestCase):
                          {k: type(v) for k, v in method_params_ref.items()})
 
         # check MD cell reset event
-        system.box_l = system.box_l
+        system.change_volume_and_rescale_particles(system.box_l[0], "x")
         system.periodicity = system.periodicity
 
         # force data array update, no-op since there are no particles
@@ -340,7 +340,7 @@ class ScafacosInterface(ut.TestCase):
         ref_torques = np.copy(system.part.all().torque_lab)
 
         # check MD cell reset has no impact
-        system.box_l = system.box_l
+        system.change_volume_and_rescale_particles(system.box_l[0], "x")
         system.periodicity = system.periodicity
         system.cell_system.node_grid = system.cell_system.node_grid
         system.integrator.run(0, recalc_forces=True)

--- a/testsuite/python/virtual_sites_tracers_common.py
+++ b/testsuite/python/virtual_sites_tracers_common.py
@@ -150,6 +150,7 @@ class VirtualSitesTracersCommon:
                 self.assertAlmostEqual(tracer_dist / ref_dist, 1., delta=0.01)
 
             system.lb = None
+            system.part.clear()
 
     def test_zz_exceptions_without_lb(self):
         """


### PR DESCRIPTION
Fixes #4834

Description of changes:
- Resizing the box via `system.box_l = new_box_l` now throws a runtime error if there are particles present, because particle position folding cannot be guaranteed to be correct; use `system.change_volume_and_rescale_particles()` instead, which properly rescales particle positions.
