### PR TITLE
Add ASE interface

### DIFF
--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -30,6 +30,7 @@ set(cython_AUX "${cython_AUX}" CACHE INTERNAL "cython_AUX")
 
 add_subdirectory(io)
 add_subdirectory(detail)
+add_subdirectory(plugins)
 
 list(REMOVE_DUPLICATES cython_SRC)
 

--- a/src/python/espressomd/plugins/CMakeLists.txt
+++ b/src/python/espressomd/plugins/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2024 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+configure_file(ase.py ase.py COPYONLY)
+set(cython_AUX ${cython_AUX}
+               "${CMAKE_SOURCE_DIR}/src/python/espressomd/io/__init__.py"
+    CACHE INTERNAL "cython_AUX" FORCE)

--- a/src/python/espressomd/plugins/ase.py
+++ b/src/python/espressomd/plugins/ase.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2024 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import dataclasses
+import typing
+import ase
+from ase.calculators.singlepoint import SinglePointCalculator
+import numpy as np
+if typing.TYPE_CHECKING:
+    from espressomd.system import System
+
+
+@dataclasses.dataclass
+class ASEInterface:
+    """
+    ASE interface for ESPResSo.
+    """
+
+    type_mapping: dict
+    """
+    Mapping of ESPResSo particle types to ASE symbols. E.g. ``{0: "H", 1: "O"}``.
+    """
+    _system: typing.Union["System", None] = None
+
+    def register_system(self, system):
+        """Register the system."""
+        self._system = system
+
+    def __getstate__(self):
+        return {"type_mapping": self.type_mapping}
+
+    def get(self) -> ase.Atoms:
+        """Export the ESPResSo system particle data to an ASE atoms object."""
+        particles = self._system.part.all()
+        positions = np.copy(particles.pos)
+        types = np.copy(particles.type)
+        forces = np.copy(particles.f)
+        unknown_types = set(types) - set(self.type_mapping)
+        if unknown_types:
+            raise RuntimeError(
+                f"Particle types '{unknown_types}' haven't been registered in the ASE type map"  # nopep8
+            )
+        if any(p.is_virtual() for p in particles):
+            raise RuntimeError("ASE doesn't support virtual sites")
+
+        atoms = ase.Atoms(
+            positions=positions,
+            symbols=[self.type_mapping[t] for t in types],
+            pbc=np.copy(self._system.periodicity),
+            cell=np.copy(self._system.box_l),
+        )
+        atoms.calc = SinglePointCalculator(atoms, forces=forces)
+        return atoms

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -202,6 +202,7 @@ checkpoint_test(MODES dp3m_cpu__therm_langevin__int_nvt)
 checkpoint_test(MODES therm_dpd__int_nvt)
 checkpoint_test(MODES scafacos__therm_bd__int_bd)
 checkpoint_test(MODES therm_sdm__int_sdm)
+checkpoint_test(MODES lj__ase SUFFIX 1_core MAX_NUM_PROC 1)
 
 python_test(FILE bond_breakage.py MAX_NUM_PROC 4)
 python_test(FILE cell_system.py MAX_NUM_PROC 4)

--- a/testsuite/python/ase_interface.py
+++ b/testsuite/python/ase_interface.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2024 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import unittest as ut
+import unittest_decorators as utx
+import espressomd
+import espressomd.plugins.ase
+import numpy as np
+import ase
+
+
+class ASEInterfaceTest(ut.TestCase):
+
+    system = espressomd.System(
+        box_l=[10., 10., 10.], periodicity=[True, True, False])
+
+    def setUp(self):
+        self.system.part.add(pos=[0., 0., 0.], f=[1., -1., 0.], type=0)
+        self.system.part.add(pos=[0., 0., 1.], f=[0., 12., 0.], type=1)
+        self.system.ase = espressomd.plugins.ase.ASEInterface(
+            type_mapping={0: "H", 1: "O"},
+        )
+
+    def tearDown(self):
+        self.system.part.clear()
+
+    def test_ase_get(self):
+        """Test the ``ASEInterface.get()`` method."""
+        # Create a simple ASE atoms object
+        atoms = self.system.ase.get()
+        self.assertIsInstance(atoms, ase.Atoms)
+        self.assertEqual(set(atoms.get_chemical_symbols()), {"H", "O"})
+        np.testing.assert_equal(atoms.pbc, np.copy(self.system.periodicity))
+        np.testing.assert_allclose(atoms.cell, np.diag(self.system.box_l))
+        np.testing.assert_allclose(atoms.get_positions(),
+                                   [[0., 0., 0.], [0., 0., 1.]])
+        np.testing.assert_allclose(atoms.get_forces(),
+                                   [[1., -1., 0.], [0., 12., 0.]])
+
+    @utx.skipIfMissingFeatures("VIRTUAL_SITES_RELATIVE")
+    def test_exceptions(self):
+        p = self.system.part.add(pos=[0., 0., 0.], type=10)
+        with self.assertRaisesRegex(RuntimeError, r"Particle types '\{10\}' haven't been registered"):
+            self.system.ase.get()
+        p.type = 1
+        vs = self.system.part.add(pos=[0., 0., 0.], type=1)
+        vs.vs_relative = (p.id, 0.01, (1., 0., 0., 0.))
+        with self.assertRaisesRegex(RuntimeError, "ASE doesn't support virtual sites"):
+            self.system.ase.get()
+
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
Fixes #4771

Add a property to the `System` class that enables exporting particle data to `ase.Atoms` objects. It provides a foundation for interfacing Machine-Learning Potentials and simplifies the export for visualization with ZnDraw.