### PR TITLE
Improve stability of CI/CD pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install pandoc
         uses: r-lib/actions/setup-pandoc@v2
       - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.7.0
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_SSH_PRIVATE_KEY }}
       - name: Checkout

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -35,7 +35,7 @@ jobs:
   debian:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/espressomd/docker/debian:7843821c7cfe66dc8b718bb4041eba52adaa2df0-base-layer
+      image: ghcr.io/espressomd/docker/debian:f7f8ef2c0ca93c67aa16b9f91785492fb04ecc1b-base-layer
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'espressomd/espresso' }}
     container:
-      image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:7843821c7cfe66dc8b718bb4041eba52adaa2df0-base-layer
+      image: ghcr.io/espressomd/docker/ubuntu-wo-dependencies:f7f8ef2c0ca93c67aa16b9f91785492fb04ecc1b-base-layer
       credentials:
          username: ${{ github.actor }}
          password: ${{ secrets.github_token }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/espressomd/docker/ubuntu:7843821c7cfe66dc8b718bb4041eba52adaa2df0
+image: ghcr.io/espressomd/docker/ubuntu:f7f8ef2c0ca93c67aa16b9f91785492fb04ecc1b
 
 stages:
   - prepare
@@ -18,7 +18,7 @@ stages:
 
 .notification_job_template: &notification_job_definition
   <<: *global_job_definition
-  image: ghcr.io/espressomd/docker/fedora:7843821c7cfe66dc8b718bb4041eba52adaa2df0
+  image: ghcr.io/espressomd/docker/fedora:f7f8ef2c0ca93c67aa16b9f91785492fb04ecc1b
   variables:
     GIT_SUBMODULE_STRATEGY: none
   before_script:
@@ -145,7 +145,7 @@ no_rotation:
 fedora:40:
   <<: *global_job_definition
   stage: build
-  image: ghcr.io/espressomd/docker/fedora:7843821c7cfe66dc8b718bb4041eba52adaa2df0
+  image: ghcr.io/espressomd/docker/fedora:f7f8ef2c0ca93c67aa16b9f91785492fb04ecc1b
   variables:
      with_cuda: 'false'
      with_gsl: 'false'

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-[MASTER]
+[MAIN]
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and
 # 3 compatible code, which means that the block might have code that exists
@@ -8,14 +8,14 @@ analyse-fallback-blocks=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-allow-list=
 
-# Add files or directories to the blacklist. They should be base names, not
-# paths.
+# Files or directories to be skipped. They should be base names, not paths.
 ignore=CVS build
 
-# Add files or directories matching the regex patterns to the blacklist. The
-# regex matches against base names, not paths.
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
 ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
@@ -23,7 +23,8 @@ ignore-patterns=
 #init-hook=
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
-# number of processors available to use.
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
 jobs=2
 
 # Control the amount of potential inferred values when inferring a single
@@ -31,15 +32,16 @@ jobs=2
 # complex, nested conditions.
 limit-inference-results=100
 
-# List of plugins (as comma separated values of python modules names) to load,
+# List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
 load-plugins=
 
 # Pickle collected data for later comparisons.
 persistent=yes
 
-# Specify a configuration file.
-#rcfile=
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.12
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
@@ -56,13 +58,15 @@ unsafe-load-any-extension=no
 argument-naming-style=snake_case
 
 # Regular expression matching correct argument names. Overrides argument-
-# naming-style.
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
 #argument-rgx=
 
 # Naming style matching correct attribute names.
 attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
 # style.
 #attr-rgx=
 
@@ -78,20 +82,22 @@ bad-names=foo,
 class-attribute-naming-style=any
 
 # Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style.
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
 #class-attribute-rgx=
 
 # Naming style matching correct class names.
 class-naming-style=PascalCase
 
 # Regular expression matching correct class names. Overrides class-naming-
-# style.
+# style. If left empty, class names will be checked with the set naming style.
 #class-rgx=
 
 # Naming style matching correct constant names.
 const-naming-style=UPPER_CASE
 
 # Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
 # style.
 #const-rgx=
 
@@ -103,7 +109,8 @@ docstring-min-length=-1
 function-naming-style=snake_case
 
 # Regular expression matching correct function names. Overrides function-
-# naming-style.
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
 #function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
@@ -121,21 +128,22 @@ include-naming-hint=no
 inlinevar-naming-style=any
 
 # Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style.
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
 #inlinevar-rgx=
 
 # Naming style matching correct method names.
 method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
-# style.
+# style. If left empty, method names will be checked with the set naming style.
 #method-rgx=
 
 # Naming style matching correct module names.
 module-naming-style=snake_case
 
 # Regular expression matching correct module names. Overrides module-naming-
-# style.
+# style. If left empty, module names will be checked with the set naming style.
 #module-rgx=
 
 # Colon-delimited sets of names that determine each other's naming style when
@@ -155,11 +163,15 @@ property-classes=abc.abstractproperty
 variable-naming-style=snake_case
 
 # Regular expression matching correct variable names. Overrides variable-
-# naming-style.
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
 #variable-rgx=
 
 
 [CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,
@@ -189,7 +201,7 @@ max-args=5
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 
-# Maximum number of boolean expressions in an if statement.
+# Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
@@ -216,8 +228,7 @@ min-public-methods=2
 
 [EXCEPTIONS]
 
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
+# Exceptions that will emit a warning when caught.
 overgeneral-exceptions=BaseException,
                        Exception
 
@@ -267,16 +278,17 @@ allow-wildcard-with-all=no
 # Deprecated modules which should not be used, separated by a comma.
 deprecated-modules=optparse,tkinter.tix
 
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled).
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
 ext-import-graph=
 
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled).
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
 import-graph=
 
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled).
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
 int-import-graph=
 
 # Force import order to recognize a module as part of the standard
@@ -289,8 +301,8 @@ known-third-party=enchant
 
 [LOGGING]
 
-# Format style used to check logging format string. `old` means using %
-# formatting, while `new` is for `{}` formatting.
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
 logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging
@@ -301,14 +313,15 @@ logging-modules=logging
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
 confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
@@ -334,6 +347,13 @@ enable=dangerous-default-value, # W0102
        undefined-variable, # E0602
 
 
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
@@ -356,19 +376,20 @@ never-returning-functions=sys.exit
 
 [REPORTS]
 
-# Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables errors warning, statement which
-# respectively contain the number of errors / warnings messages and the total
-# number of statements analyzed. This is used by the global evaluation report
-# (RP0004).
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details.
-#msg-template=
+msg-template=
 
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
+# Set the output format. Available formats are: text, parseable, colorized,
+# json2 (improved json format), json (old json format) and msvs (visual
+# studio). You can also give a reporter class, e.g.
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
@@ -381,14 +402,17 @@ score=no
 
 [SIMILARITIES]
 
-# Ignore comments when computing similarities.
+# Comments are removed from the similarity computation
 ignore-comments=yes
 
-# Ignore docstrings when computing similarities.
+# Docstrings are removed from the similarity computation
 ignore-docstrings=yes
 
-# Ignore imports when computing similarities.
+# Imports are removed from the similarity computation
 ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4
@@ -399,27 +423,33 @@ min-similarity-lines=4
 # Limits count of emitted suggestions for spelling mistakes.
 max-spelling-suggestions=4
 
-# Spelling dictionary name. Available dictionaries: de (aspell), de_AT
-# (aspell), de_CH (aspell), de_DE (aspell), en (aspell), en_AU (aspell), en_CA
-# (aspell), en_GB (aspell), en_US (aspell)..
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
 spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
 
 # List of comma separated words that should not be checked.
 spelling-ignore-words=
 
-# A path to a file that contains private dictionary; one word per line.
+# A path to a file that contains the private dictionary; one word per line.
 spelling-private-dict-file=
 
-# Tells whether to store unknown words to indicated private dictionary in
-# --spelling-private-dict-file option instead of raising a message.
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
 spelling-store-unknown-words=no
 
 
 [STRING]
 
-# This flag controls whether the implicit-str-concat-in-sequence should
-# generate a warning on implicit string concatenation in sequences defined over
-# several lines.
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
 check-str-concat-over-line-jumps=no
 
 
@@ -493,8 +523,7 @@ callbacks=cb_,
 # not be used).
 dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
+# Argument names that match this expression will be ignored.
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,10 @@
 [MASTER]
 
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
@@ -43,205 +48,6 @@ suggestion-mode=yes
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
-
-
-[MESSAGES CONTROL]
-
-# Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
-confidence=
-
-# Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifiers separated by comma (,) or put this
-# option multiple times (only on the command line, not in the configuration
-# file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
-# you want to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use "--disable=all --enable=classes
-# --disable=W".
-disable=all
-
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time (only on the command line, not in the configuration file where
-# it should appear only once). See also the "--disable" option for examples.
-enable=dangerous-default-value, # W0102
-       duplicate-key, # W0109
-       wildcard-import, # W0401
-       assert-on-tuple, # W0199
-       unused-import, # W0611
-       unused-variable, # W0612
-       unused-argument, # W0613
-       unused-wildcard-import, # W0614
-       deprecated-method, # W1505
-       cyclic-import, # R0401
-       trailing-comma-tuple, # R1707
-       bad-classmethod-argument, # C0202
-       undefined-variable, # E0602
-
-
-[REPORTS]
-
-# Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables errors warning, statement which
-# respectively contain the number of errors / warnings messages and the total
-# number of statements analyzed. This is used by the global evaluation report
-# (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details.
-#msg-template=
-
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
-output-format=text
-
-# Tells whether to display a full report or only the messages.
-reports=no
-
-# Activate the evaluation score.
-score=no
-
-
-[REFACTORING]
-
-# Maximum number of nested blocks for function / method body
-max-nested-blocks=5
-
-# Complete name of functions that never returns. When checking for
-# inconsistent-return-statements if a never returning function is called then
-# it will be considered as an explicit return statement and no message will be
-# printed.
-never-returning-functions=sys.exit
-
-
-[VARIABLES]
-
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid defining new builtins when possible.
-additional-builtins=
-
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=yes
-
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks=cb_,
-          _cb
-
-# A regular expression matching the name of dummy variables (i.e. expected to
-# not be used).
-dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
-ignored-argument-names=_.*|^ignored_|^unused_
-
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
-
-# List of qualified module names which can have objects that can redefine
-# builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
-
-
-[TYPECHECK]
-
-# List of decorators that produce context managers, such as
-# contextlib.contextmanager. Add to this list to register other decorators that
-# produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=
-
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
-# Tells whether to warn about missing members when the owner of the attribute
-# is inferred to be None.
-ignore-none=yes
-
-# This flag controls whether pylint should warn about no-member and similar
-# checks whenever an opaque object is returned when inferring. The inference
-# can return multiple potential results while evaluating a Python object, but
-# some branches might not be evaluated, which results in partial inference. In
-# that case, it might be useful to still emit no-member and other checks for
-# the rest of the inferred objects.
-ignore-on-opaque-inference=yes
-
-# List of class names for which member attributes should not be checked (useful
-# for classes with dynamically set attributes). This supports the use of
-# qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis. It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
-
-# Show a hint with possible names when a member name was not found. The aspect
-# of finding the hint is based on edit distance.
-missing-member-hint=yes
-
-# The minimum edit distance a name should have in order to be considered a
-# similar match for a missing member name.
-missing-member-hint-distance=1
-
-# The total number of similar names that should be taken in consideration when
-# showing a hint for a missing member.
-missing-member-max-choices=1
-
-
-[SPELLING]
-
-# Limits count of emitted suggestions for spelling mistakes.
-max-spelling-suggestions=4
-
-# Spelling dictionary name. Available dictionaries: de (aspell), de_AT
-# (aspell), de_CH (aspell), de_DE (aspell), en (aspell), en_AU (aspell), en_CA
-# (aspell), en_GB (aspell), en_US (aspell)..
-spelling-dict=
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
-
-# A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file=
-
-# Tells whether to store unknown words to indicated private dictionary in
-# --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words=no
-
-
-[MISCELLANEOUS]
-
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,
-      XXX,
-      TODO
-
-
-[SIMILARITIES]
-
-# Ignore comments when computing similarities.
-ignore-comments=yes
-
-# Ignore docstrings when computing similarities.
-ignore-docstrings=yes
-
-# Ignore imports when computing similarities.
-ignore-imports=no
-
-# Minimum lines number of a similarity.
-min-similarity-lines=4
 
 
 [BASIC]
@@ -353,95 +159,6 @@ variable-naming-style=snake_case
 #variable-rgx=
 
 
-[FORMAT]
-
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Number of spaces of indent required inside a hanging or continued line.
-indent-after-paren=4
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
-
-# Maximum number of characters on a single line.
-max-line-length=100
-
-# Maximum number of lines in a module.
-max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
-# Allow the body of a class to be on the same line as the declaration if body
-# contains single statement.
-single-line-class-stmt=no
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt=no
-
-
-[LOGGING]
-
-# Format style used to check logging format string. `old` means using %
-# formatting, while `new` is for `{}` formatting.
-logging-format-style=old
-
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging-modules=logging
-
-
-[STRING]
-
-# This flag controls whether the implicit-str-concat-in-sequence should
-# generate a warning on implicit string concatenation in sequences defined over
-# several lines.
-check-str-concat-over-line-jumps=no
-
-
-[IMPORTS]
-
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all=no
-
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
-
-# Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=optparse,tkinter.tix
-
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled).
-ext-import-graph=
-
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled).
-import-graph=
-
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled).
-int-import-graph=
-
-# Force import order to recognize a module as part of the standard
-# compatibility libraries.
-known-standard-library=
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
-
-
 [CLASSES]
 
 # List of method names used to declare (i.e. assign) instance attributes.
@@ -503,3 +220,286 @@ min-public-methods=2
 # "BaseException, Exception".
 overgeneral-exceptions=BaseException,
                        Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=all
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=dangerous-default-value, # W0102
+       duplicate-key, # W0109
+       wildcard-import, # W0401
+       assert-on-tuple, # W0199
+       unused-import, # W0611
+       unused-variable, # W0612
+       unused-argument, # W0613
+       unused-wildcard-import, # W0614
+       deprecated-method, # W1505
+       cyclic-import, # R0401
+       trailing-comma-tuple, # R1707
+       bad-classmethod-argument, # C0202
+       undefined-variable, # E0602
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: de (aspell), de_AT
+# (aspell), de_CH (aspell), de_DE (aspell), en (aspell), en_AU (aspell), en_CA
+# (aspell), en_GB (aspell), en_US (aspell)..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@ analyse-fallback-blocks=no
 extension-pkg-allow-list=
 
 # Files or directories to be skipped. They should be base names, not paths.
-ignore=CVS build
+ignore=build
 
 # Files or directories matching the regular expression patterns are skipped.
 # The regex matches against base names, not paths. The default value ignores
@@ -25,7 +25,7 @@ ignore-patterns=
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use, and will cap the count on Windows to
 # avoid hangs.
-jobs=2
+jobs=4
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or
@@ -41,7 +41,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.12
+py-version=3.10
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
@@ -229,8 +229,7 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
 
 
 [FORMAT]
@@ -253,13 +252,6 @@ max-line-length=100
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -303,7 +295,7 @@ known-third-party=enchant
 
 # The type of string formatting that logging methods do. `old` means using %
 # formatting, `new` is for `{}` formatting.
-logging-format-style=old
+logging-format-style=new
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,14 +669,14 @@ if(ESPRESSO_BUILD_WITH_CALIPER)
   endif()
   set(CALIPER_BUILD_SHARED_LIBS on CACHE BOOL "")
   add_subdirectory("${caliper_SOURCE_DIR}")
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL
-                                              "GNU")
-    target_compile_options(caliper-services
-                           PRIVATE -Wno-deprecated-declarations)
-    target_compile_options(
-      caliper-runtime
-      PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>)
-  endif()
+  target_compile_options(
+    caliper-services
+    PRIVATE
+      $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-deprecated-declarations>)
+  target_compile_options(
+    caliper-runtime
+    PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>
+            $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-volatile>)
 endif()
 
 #

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -130,7 +130,7 @@ set_default_value with_scafacos false
 set_default_value with_walberla false
 set_default_value with_walberla_avx false
 set_default_value with_stokesian_dynamics false
-set_default_value test_timeout 400
+set_default_value test_timeout 500
 set_default_value hide_gpu false
 set_default_value mpiexec_preflags ""
 

--- a/maintainer/CI/jupyter_warnings.py
+++ b/maintainer/CI/jupyter_warnings.py
@@ -66,7 +66,7 @@ def detect_invalid_urls(nb, build_root='.', html_exporter=None):
             if filepath.is_file():
                 with open(filepath) as f:
                     config = json.load(f)
-                kwargs = config.get("Exporter", {})
+                kwargs = config.get("HTMLExporter", {})
                 break
         html_exporter = nbconvert.HTMLExporter(**kwargs)
     html_exporter.template_name = 'classic'

--- a/maintainer/check_features.py
+++ b/maintainer/check_features.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(sys.path[0], '..', 'config'))
 import featuredefs
 
 if len(sys.argv) != 2:
-    print("Usage: %s FILE" % sys.argv[0])
+    print(f"Usage: {sys.argv[0]} FILE")
     exit(2)
 
 fdefs = featuredefs.defs(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,12 @@ numpy>=1.26.4
 h5py>=3.10.0
 # optional scientific packages
 scipy>=1.11.4
+pandas>=1.3.5
 pint>=0.19.2
+ase>=3.22.1
 # optional packages for graphics and external devices
 matplotlib>=3.6.3
-vtk==9.1.0
+vtk>=9.1.0
 PyOpenGL>=3.1.5
 pygame>=2.1.2
 # waLBerla dependencies

--- a/samples/slice_input.py
+++ b/samples/slice_input.py
@@ -60,30 +60,30 @@ type_list = np.ones(n_part, dtype=int)
 partcls = system.part.add(id=id_list, pos=pos_list, type=type_list)
 p0p1 = system.part.by_ids([0, 1])
 
-print("TYPE\n%s" % partcls.type)
+print(f"TYPE\n{partcls.type}")
 p0p1.type = [3, 3]
-print("TYPE_NEW\n%s" % partcls.type)
+print(f"TYPE_NEW\n{partcls.type}")
 
-print("POS\n%s" % partcls.pos)
+print(f"POS\n%s" % partcls.pos)
 system.part.by_ids(range(5)).pos = [[1, 1, 1], [2, 2, 2], [
     3, 3, 3], [4, 4, 4], [5, 5, 5]]
-print("POS_NEW\n%s" % partcls.pos)
+print(f"POS_NEW\n{partcls.pos}")
 
-print("V\n%s" % partcls.v)
+print(f"V\n%s" % partcls.v)
 p0p1.v = [[1, 2, 3], [2, 3, 4]]
-print("V_NEW\n%s" % partcls.v)
+print(f"V_NEW\n{partcls.v}")
 
-print("F\n%s" % partcls.f)
+print(f"F\n{partcls.f}")
 p0p1.f = [[3, 4, 5], [4, 5, 6]]
-print("F_NEW\n%s" % partcls.f)
+print(f"F_NEW\n{partcls.f}")
 
 if espressomd.has_features(["MASS"]):
-    print("MASS\n%s" % partcls.mass)
+    print(f"MASS\n{partcls.mass}")
     p0p1.mass = [2, 3]
-    print("MASS_NEW\n%s" % partcls.mass)
+    print(f"MASS_NEW\n{partcls.mass}")
 
 if espressomd.has_features(["ELECTROSTATICS"]):
-    print("Q\n%s" % partcls.q)
+    print(f"Q\n{partcls.q}")
     system.part.by_ids(range(0, n_part, 2)).q = np.ones(n_part // 2)
     system.part.by_ids(range(1, n_part, 2)).q = -np.ones(n_part // 2)
-    print("Q_NEW\n%s" % partcls.q)
+    print(f"Q_NEW\n{partcls.q}")

--- a/samples/visualization_ljliquid.py
+++ b/samples/visualization_ljliquid.py
@@ -93,7 +93,7 @@ print(
     f"Simulate {n_part} particles in a cubic box {box_l} at density {density}.")
 print("Interactions:\n")
 act_min_dist = system.analysis.min_dist()
-print(f"Start with minimal distance {act_min_dist}")
+print(f"Start with minimal distance {act_min_dist:.3f}")
 
 visualizer = espressomd.visualization.openGLLive(system)
 
@@ -127,7 +127,7 @@ system.thermostat.set_langevin(kT=1.0, gamma=1.0, seed=42)
 #############################################################
 #      Integration                                          #
 #############################################################
-print("\nStart integration: run %d times %d steps" % (int_n_times, int_steps))
+print(f"\nStart integration: run {int_n_times} times {int_steps} steps")
 
 # print initial energies
 energies = system.analysis.energy()

--- a/src/core/bond_breakage/bond_breakage.hpp
+++ b/src/core/bond_breakage/bond_breakage.hpp
@@ -54,7 +54,7 @@ struct QueueEntry {
   // Serialization for synchronization across mpi ranks
   friend class boost::serialization::access;
   template <typename Archive>
-  void serialize(Archive &ar, const unsigned int version) {
+  void serialize(Archive &ar, unsigned int const /* version */) {
     ar & particle_id;
     ar & bond_partners;
     ar & bond_type;

--- a/src/core/cell_system/AtomDecomposition.cpp
+++ b/src/core/cell_system/AtomDecomposition.cpp
@@ -51,6 +51,7 @@ void AtomDecomposition::configure_neighbors() {
 
   local().m_neighbors = Neighbors<Cell *>(red_neighbors, black_neighbors);
 }
+
 GhostCommunicator AtomDecomposition::prepare_comm() {
   /* no need for comm for only 1 node */
   if (m_comm.size() == 1) {
@@ -68,6 +69,7 @@ GhostCommunicator AtomDecomposition::prepare_comm() {
 
   return ghost_comm;
 }
+
 void AtomDecomposition::configure_comms() {
   m_exchange_ghosts_comm = prepare_comm();
   m_collect_ghost_force_comm = prepare_comm();
@@ -90,6 +92,7 @@ void AtomDecomposition::configure_comms() {
     }
   }
 }
+
 void AtomDecomposition::mark_cells() {
   m_local_cells.resize(1, std::addressof(local()));
   m_ghost_cells.clear();
@@ -99,6 +102,7 @@ void AtomDecomposition::mark_cells() {
     }
   }
 }
+
 void AtomDecomposition::resort(bool global_flag,
                                std::vector<ParticleChange> &diff) {
   for (auto &p : local().particles()) {

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <iterator>
 #include <memory>
 #include <set>
@@ -69,7 +70,7 @@ void CellStructure::check_particle_index() const {
   }
 
   /* checks: local particle id */
-  int local_part_cnt = 0;
+  std::size_t local_part_cnt = 0u;
   for (int n = 0; n < get_max_local_particle_id() + 1; n++) {
     if (get_local_particle(n) != nullptr) {
       local_part_cnt++;

--- a/src/core/cell_system/HybridDecomposition.hpp
+++ b/src/core/cell_system/HybridDecomposition.hpp
@@ -125,6 +125,7 @@ public:
   Utils::Vector3d max_cutoff() const override {
     return m_n_square.max_cutoff();
   }
+
   Utils::Vector3d max_range() const override { return m_n_square.max_range(); }
 
   boost::optional<BoxGeometry> minimum_image_distance() const override {

--- a/src/core/cell_system/RegularDecomposition.cpp
+++ b/src/core/cell_system/RegularDecomposition.cpp
@@ -52,7 +52,7 @@ int RegularDecomposition::position_to_cell_index(
     Utils::Vector3d const &pos) const {
   Utils::Vector3i cpos;
 
-  for (unsigned int i = 0u; i < 3u; i++) {
+  for (auto i = 0u; i < 3u; i++) {
     cpos[i] = static_cast<int>(std::floor(pos[i] * inv_cell_size[i])) + 1 -
               cell_offset[i];
 
@@ -306,7 +306,7 @@ void RegularDecomposition::create_cell_grid(double range) {
     auto const volume = Utils::product(local_box_l);
     auto const scale = std::cbrt(RegularDecomposition::max_num_cells / volume);
 
-    for (unsigned int i = 0; i < 3; i++) {
+    for (auto i = 0u; i < 3u; i++) {
       /* this is at least 1 */
       cell_grid[i] = static_cast<int>(std::ceil(local_box_l[i] * scale));
       cell_range[i] = local_box_l[i] / static_cast<double>(cell_grid[i]);
@@ -336,11 +336,11 @@ void RegularDecomposition::create_cell_grid(double range) {
         break;
 
       /* find coordinate with the smallest cell range */
-      int min_ind = 0;
-      double min_size = cell_range[0];
+      auto min_ind = 0u;
+      auto min_size = cell_range[0];
 
-      for (int i = 1; i < 3; i++) {
-        if (cell_grid[i] > 1 && cell_range[i] < min_size) {
+      for (auto i = 1u; i < 3u; ++i) {
+        if (cell_grid[i] > 1 and cell_range[i] < min_size) {
           min_ind = i;
           min_size = cell_range[i];
         }
@@ -369,7 +369,7 @@ void RegularDecomposition::create_cell_grid(double range) {
 
   /* now set all dependent variables */
   int new_cells = 1;
-  for (unsigned int i = 0; i < 3; i++) {
+  for (auto i = 0u; i < 3u; i++) {
     ghost_cell_grid[i] = cell_grid[i] + 2;
     new_cells *= ghost_cell_grid[i];
     cell_size[i] = m_local_box.length()[i] / static_cast<double>(cell_grid[i]);

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -101,7 +101,7 @@ static void search_distance_sanity_check_max_range(System::System const &system,
 }
 static void
 search_distance_sanity_check_cell_structure(System::System const &system,
-                                            double const distance) {
+                                            double const) {
   auto const &cell_structure = *system.cell_structure;
   if (cell_structure.decomposition_type() == CellStructureType::HYBRID) {
     throw std::runtime_error("Cannot search for neighbors in the hybrid "

--- a/src/core/constraints/ShapeBasedConstraint.cpp
+++ b/src/core/constraints/ShapeBasedConstraint.cpp
@@ -95,7 +95,7 @@ ParticleForce ShapeBasedConstraint::force(Particle const &p,
 
     if (dist > 0) {
       outer_normal_vec = -dist_vec / dist;
-      pf = calc_central_radial_force(p, part_rep, ia_params, dist_vec, dist) +
+      pf = calc_central_radial_force(ia_params, dist_vec, dist) +
            calc_central_radial_charge_force(p, part_rep, ia_params, dist_vec,
                                             dist, get_ptr(coulomb_kernel)) +
            calc_non_central_force(p, part_rep, ia_params, dist_vec, dist);
@@ -111,11 +111,10 @@ ParticleForce ShapeBasedConstraint::force(Particle const &p,
 #endif
     } else if (m_penetrable && (dist <= 0)) {
       if ((!m_only_positive) && (dist < 0)) {
-        pf =
-            calc_central_radial_force(p, part_rep, ia_params, dist_vec, -dist) +
-            calc_central_radial_charge_force(p, part_rep, ia_params, dist_vec,
-                                             -dist, get_ptr(coulomb_kernel)) +
-            calc_non_central_force(p, part_rep, ia_params, dist_vec, -dist);
+        pf = calc_central_radial_force(ia_params, dist_vec, -dist) +
+             calc_central_radial_charge_force(p, part_rep, ia_params, dist_vec,
+                                              -dist, get_ptr(coulomb_kernel)) +
+             calc_non_central_force(p, part_rep, ia_params, dist_vec, -dist);
 
 #ifdef DPD
         if (m_system.thermostat->thermo_switch & THERMO_DPD) {

--- a/src/core/electrostatics/coulomb.cpp
+++ b/src/core/electrostatics/coulomb.cpp
@@ -116,11 +116,11 @@ struct LongRangePressure {
   }
 #endif // P3M
 
-  auto operator()(std::shared_ptr<DebyeHueckel> const &actor) const {
+  auto operator()(std::shared_ptr<DebyeHueckel> const &) const {
     return Utils::Vector9d{};
   }
 
-  auto operator()(std::shared_ptr<ReactionField> const &actor) const {
+  auto operator()(std::shared_ptr<ReactionField> const &) const {
     return Utils::Vector9d{};
   }
 
@@ -156,11 +156,11 @@ struct ShortRangeCutoff {
   }
 #endif // P3M
 #ifdef MMM1D_GPU
-  auto operator()(std::shared_ptr<CoulombMMM1DGpu> const &actor) const {
+  auto operator()(std::shared_ptr<CoulombMMM1DGpu> const &) const {
     return std::numeric_limits<double>::infinity();
   }
 #endif // MMM1D_GPU
-  auto operator()(std::shared_ptr<CoulombMMM1D> const &actor) const {
+  auto operator()(std::shared_ptr<CoulombMMM1D> const &) const {
     return std::numeric_limits<double>::infinity();
   }
 #ifdef SCAFACOS

--- a/src/core/electrostatics/elc.hpp
+++ b/src/core/electrostatics/elc.hpp
@@ -117,7 +117,7 @@ struct elc_data {
 
   /// pairwise contributions from the lowest and top layers
   template <typename Kernel>
-  void dielectric_layers_contribution(CoulombP3M const &p3m,
+  void dielectric_layers_contribution(CoulombP3M const &,
                                       BoxGeometry const &box_geo,
                                       Utils::Vector3d const &pos1,
                                       Utils::Vector3d const &pos2, double q1q2,

--- a/src/core/electrostatics/icc.cpp
+++ b/src/core/electrostatics/icc.cpp
@@ -51,6 +51,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <stdexcept>
 #include <variant>
@@ -223,13 +224,13 @@ void icc_data::sanity_checks() const {
     throw std::domain_error("Parameter 'first_id' must be >= 0");
   if (eps_out <= 0.)
     throw std::domain_error("Parameter 'eps_out' must be > 0");
-  if (areas.size() != n_icc)
+  if (areas.size() != static_cast<std::size_t>(n_icc))
     throw std::invalid_argument("Parameter 'areas' has incorrect shape");
-  if (epsilons.size() != n_icc)
+  if (epsilons.size() != static_cast<std::size_t>(n_icc))
     throw std::invalid_argument("Parameter 'epsilons' has incorrect shape");
-  if (sigmas.size() != n_icc)
+  if (sigmas.size() != static_cast<std::size_t>(n_icc))
     throw std::invalid_argument("Parameter 'sigmas' has incorrect shape");
-  if (normals.size() != n_icc)
+  if (normals.size() != static_cast<std::size_t>(n_icc))
     throw std::invalid_argument("Parameter 'normals' has incorrect shape");
 }
 
@@ -245,12 +246,10 @@ void ICCStar::on_activation() const {
 }
 
 struct SanityChecksICC {
-  template <typename T>
-  void operator()(std::shared_ptr<T> const &actor) const {}
+  template <typename T> void operator()(std::shared_ptr<T> const &) const {}
 #ifdef P3M
 #ifdef CUDA
-  [[noreturn]] void
-  operator()(std::shared_ptr<CoulombP3MGPU> const &actor) const {
+  [[noreturn]] void operator()(std::shared_ptr<CoulombP3MGPU> const &) const {
     throw std::runtime_error("ICC does not work with P3MGPU");
   }
 #endif // CUDA

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -216,7 +216,7 @@ void System::System::calculate_forces() {
 
   if (thermostat->lb and (propagation->used_propagations &
                           PropagationMode::TRANS_LB_MOMENTUM_EXCHANGE)) {
-    lb_couple_particles(time_step);
+    lb_couple_particles();
   }
 
 #ifdef CUDA

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -77,14 +77,12 @@
 #include <optional>
 #include <tuple>
 
-inline ParticleForce calc_central_radial_force(Particle const &p1,
-                                               Particle const &p2,
-                                               IA_parameters const &ia_params,
+inline ParticleForce calc_central_radial_force(IA_parameters const &ia_params,
                                                Utils::Vector3d const &d,
                                                double const dist) {
 
   ParticleForce pf{};
-  double force_factor = 0;
+  auto force_factor = 0.;
 /* Lennard-Jones */
 #ifdef LENNARD_JONES
   force_factor += lj_pair_force_factor(ia_params, dist);
@@ -219,7 +217,7 @@ inline void add_non_bonded_pair_force(
 #ifdef EXCLUSIONS
     if (do_nonbonded(p1, p2)) {
 #endif
-      pf += calc_central_radial_force(p1, p2, ia_params, d, dist);
+      pf += calc_central_radial_force(ia_params, d, dist);
       pf += calc_central_radial_charge_force(p1, p2, ia_params, d, dist,
                                              coulomb_kernel);
       pf += calc_non_central_force(p1, p2, ia_params, d, dist);

--- a/src/core/ghosts.cpp
+++ b/src/core/ghosts.cpp
@@ -94,7 +94,7 @@ class SerializationSizeCalculator {
 public:
   auto size() const { return m_size; }
 
-  template <class T> auto &operator<<(T &t) {
+  template <class T> auto &operator<<(T &) {
     m_size += sizeof(T);
     return *this;
   }

--- a/src/core/immersed_boundary/ImmersedBoundaries.hpp
+++ b/src/core/immersed_boundary/ImmersedBoundaries.hpp
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef IMMERSED_BOUNDARY_IMMERSED_BOUNDARIES_HPP
-#define IMMERSED_BOUNDARY_IMMERSED_BOUNDARIES_HPP
+
+#pragma once
 
 #include "config/config.hpp"
 
@@ -43,7 +43,7 @@ public:
   }
   double get_current_volume(int softID) const {
     assert(softID >= 0);
-    assert(softID < VolumesCurrent.size());
+    assert(static_cast<std::size_t>(softID) < VolumesCurrent.size());
     return VolumesCurrent[static_cast<unsigned int>(softID)];
   }
 
@@ -55,5 +55,3 @@ private:
   bool VolumeInitDone;
   bool BoundariesFound;
 };
-
-#endif

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -294,7 +294,8 @@ void walberla_agrid_sanity_checks(std::string method,
                       << "left waLBerla: [" << lattice_left << "]"
                       << "\nMPI rank " << ::this_node << ": "
                       << "right ESPResSo: [" << geo_right << "], "
-                      << "right waLBerla: [" << lattice_right << "]";
+                      << "right waLBerla: [" << lattice_right << "]"
+                      << "\nfor method: " << method;
     throw std::runtime_error(
         "waLBerla and ESPResSo disagree about domain decomposition.");
   }
@@ -588,7 +589,7 @@ int System::System::integrate(int n_steps, int reuse_forces) {
     if (thermostat->lb and
         (propagation.used_propagations & PropagationMode::TRANS_LB_TRACER)) {
       lb_tracers_add_particle_force_to_fluid(*cell_structure, *box_geo,
-                                             *local_geo, lb, time_step);
+                                             *local_geo, lb);
     }
 #endif
     integrator_step_2(particles, propagation, *thermostat, time_step);

--- a/src/core/lb/particle_coupling.cpp
+++ b/src/core/lb/particle_coupling.cpp
@@ -112,8 +112,6 @@ bool in_local_halo(LocalBox const &local_box, Utils::Vector3d const &pos,
 }
 
 static void positions_in_halo_impl(Utils::Vector3d const &pos_folded,
-                                   Utils::Vector3d const &fully_inside_lower,
-                                   Utils::Vector3d const &fully_inside_upper,
                                    Utils::Vector3d const &halo_lower_corner,
                                    Utils::Vector3d const &halo_upper_corner,
                                    BoxGeometry const &box_geo,
@@ -161,8 +159,8 @@ std::vector<Utils::Vector3d> positions_in_halo(Utils::Vector3d const &pos,
   auto const halo_lower_corner = local_box.my_left() - halo_vec;
   auto const halo_upper_corner = local_box.my_right() + halo_vec;
   std::vector<Utils::Vector3d> res;
-  positions_in_halo_impl(pos_folded, fully_inside_lower, fully_inside_upper,
-                         halo_lower_corner, halo_upper_corner, box_geo, res);
+  positions_in_halo_impl(pos_folded, halo_lower_corner, halo_upper_corner,
+                         box_geo, res);
   return res;
 }
 
@@ -204,9 +202,8 @@ void ParticleCoupling::kernel(std::vector<Particle *> const &particles) {
       positions_force_coupling.emplace_back(folded_pos);
     } else {
       auto const old_size = positions_force_coupling.size();
-      positions_in_halo_impl(folded_pos, fully_inside_lower, fully_inside_upper,
-                             halo_lower_corner, halo_upper_corner, m_box_geo,
-                             positions_force_coupling);
+      positions_in_halo_impl(folded_pos, halo_lower_corner, halo_upper_corner,
+                             m_box_geo, positions_force_coupling);
       auto const new_size = positions_force_coupling.size();
       span_size = static_cast<uint8_t>(new_size - old_size);
     }
@@ -304,7 +301,7 @@ static void lb_coupling_sanity_checks(Particle const &p) {
 
 } // namespace LB
 
-void System::System::lb_couple_particles(double time_step) {
+void System::System::lb_couple_particles() {
 #ifdef CALIPER
   CALI_CXX_MARK_FUNCTION;
 #endif

--- a/src/core/lees_edwards/LeesEdwardsBC.hpp
+++ b/src/core/lees_edwards/LeesEdwardsBC.hpp
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef CORE_LEES_EDWARDS_LEES_EDWARDS_BC_HPP
-#define CORE_LEES_EDWARDS_LEES_EDWARDS_BC_HPP
+
+#pragma once
 
 #include <utils/Vector.hpp>
 
@@ -32,7 +32,7 @@ struct LeesEdwardsBC {
   unsigned int shear_direction = invalid_dir;
   unsigned int shear_plane_normal = invalid_dir;
   Utils::Vector3d distance(Utils::Vector3d const &d, Utils::Vector3d const &l,
-                           Utils::Vector3d const &hal_l,
+                           Utils::Vector3d const &,
                            Utils::Vector3d const &l_inv,
                            std::bitset<3> const periodic) const {
 
@@ -58,5 +58,3 @@ struct LeesEdwardsBC {
     return res;
   }
 };
-
-#endif

--- a/src/core/lees_edwards/protocols.hpp
+++ b/src/core/lees_edwards/protocols.hpp
@@ -30,8 +30,8 @@ namespace LeesEdwards {
 
 /** Lees-Edwards protocol for un-altered periodic boundary conditions */
 struct Off {
-  double shear_velocity(double time) const { return 0.; }
-  double pos_offset(double time) const { return 0.; }
+  double shear_velocity(double) const { return 0.; }
+  double pos_offset(double) const { return 0.; }
 };
 
 /** Lees-Edwards protocol for linear shearing */
@@ -41,7 +41,7 @@ struct LinearShear {
   LinearShear(double initial_offset, double shear_velocity, double time_0)
       : m_initial_pos_offset{initial_offset}, m_shear_velocity{shear_velocity},
         m_time_0{time_0} {}
-  double shear_velocity(double time) const { return m_shear_velocity; }
+  double shear_velocity(double) const { return m_shear_velocity; }
   double pos_offset(double time) const {
     return m_initial_pos_offset + (time - m_time_0) * m_shear_velocity;
   }

--- a/src/core/magnetostatics/dipolar_direct_sum.cpp
+++ b/src/core/magnetostatics/dipolar_direct_sum.cpp
@@ -220,8 +220,7 @@ T image_sum(InputIterator begin, InputIterator end, InputIterator it,
 }
 
 static auto gather_particle_data(BoxGeometry const &box_geo,
-                                 ParticleRange const &particles,
-                                 int n_replicas) {
+                                 ParticleRange const &particles) {
   auto const &comm = ::comm_cart;
   std::vector<Particle *> local_particles;
   std::vector<PosMom> local_posmom;
@@ -293,7 +292,7 @@ void DipolarDirectSum::add_long_range_forces(
   auto const &box_geo = *get_system().box_geo;
   auto const &box_l = box_geo.length();
   auto [local_particles, all_posmom, reqs, offset] =
-      gather_particle_data(box_geo, particles, n_replicas);
+      gather_particle_data(box_geo, particles);
 
   /* Number of image boxes considered */
   auto const ncut = get_n_cut(box_geo, n_replicas);
@@ -381,7 +380,7 @@ double
 DipolarDirectSum::long_range_energy(ParticleRange const &particles) const {
   auto const &box_geo = *get_system().box_geo;
   auto [local_particles, all_posmom, reqs, offset] =
-      gather_particle_data(box_geo, particles, n_replicas);
+      gather_particle_data(box_geo, particles);
 
   /* Number of image boxes considered */
   auto const ncut = get_n_cut(box_geo, n_replicas);
@@ -421,7 +420,7 @@ void DipolarDirectSum::dipole_field_at_part(
   auto const &box_geo = *get_system().box_geo;
   /* collect particle data */
   auto [local_particles, all_posmom, reqs, offset] =
-      gather_particle_data(box_geo, particles, n_replicas);
+      gather_particle_data(box_geo, particles);
 
   auto const ncut = get_n_cut(box_geo, n_replicas);
   auto const with_replicas = (ncut.norm2() > 0);

--- a/src/core/magnetostatics/dp3m.cpp
+++ b/src/core/magnetostatics/dp3m.cpp
@@ -65,6 +65,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdio>
 #include <functional>
 #include <optional>
@@ -532,7 +533,7 @@ double DipolarP3M::calc_surface_term(bool force_flag, bool energy_flag,
   std::vector<double> my(n_local_part);
   std::vector<double> mz(n_local_part);
 
-  int ip = 0;
+  std::size_t ip = 0u;
   for (auto const &p : particles) {
     auto const dip = p.calc_dip();
     mx[ip] = dip[0];
@@ -543,7 +544,7 @@ double DipolarP3M::calc_surface_term(bool force_flag, bool energy_flag,
 
   // we will need the sum of all dipolar momenta vectors
   auto local_dip = Utils::Vector3d{};
-  for (int i = 0; i < n_local_part; i++) {
+  for (std::size_t i = 0u; i < n_local_part; i++) {
     local_dip[0] += mx[i];
     local_dip[1] += my[i];
     local_dip[2] += mz[i];
@@ -554,7 +555,7 @@ double DipolarP3M::calc_surface_term(bool force_flag, bool energy_flag,
   double energy = 0.;
   if (energy_flag) {
     double sum_e = 0.;
-    for (int i = 0; i < n_local_part; i++) {
+    for (std::size_t i = 0u; i < n_local_part; i++) {
       sum_e += mx[i] * box_dip[0] + my[i] * box_dip[1] + mz[i] * box_dip[2];
     }
     energy =
@@ -567,13 +568,13 @@ double DipolarP3M::calc_surface_term(bool force_flag, bool energy_flag,
     std::vector<double> sumiy(n_local_part);
     std::vector<double> sumiz(n_local_part);
 
-    for (int i = 0; i < n_local_part; i++) {
+    for (std::size_t i = 0u; i < n_local_part; i++) {
       sumix[i] = my[i] * box_dip[2] - mz[i] * box_dip[1];
       sumiy[i] = mz[i] * box_dip[0] - mx[i] * box_dip[2];
       sumiz[i] = mx[i] * box_dip[1] - my[i] * box_dip[0];
     }
 
-    ip = 0;
+    ip = 0u;
     for (auto &p : particles) {
       auto &torque = p.torque();
       torque[0] -= pref * sumix[ip];

--- a/src/core/observables/EnergyObservable.hpp
+++ b/src/core/observables/EnergyObservable.hpp
@@ -30,9 +30,9 @@ namespace Observables {
 
 class Energy : public Observable {
 public:
-  std::vector<std::size_t> shape() const override { return {1}; }
+  std::vector<std::size_t> shape() const override { return {1u}; }
   std::vector<double>
-  operator()(boost::mpi::communicator const &comm) const override {
+  operator()(boost::mpi::communicator const &) const override {
     return {System::get_system().calculate_energy()->accumulate(0u)};
   }
 };

--- a/src/core/observables/PidObservable.hpp
+++ b/src/core/observables/PidObservable.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OBSERVABLES_PIDOBSERVABLE_HPP
-#define OBSERVABLES_PIDOBSERVABLE_HPP
+#pragma once
 
 #include <particle_observables/observable.hpp>
 
@@ -214,7 +213,7 @@ public:
   std::vector<double>
   evaluate(boost::mpi::communicator const &comm,
            ParticleReferenceRange const &local_particles,
-           ParticleObservables::traits<Particle> const &traits) const override {
+           ParticleObservables::traits<Particle> const &) const override {
     if constexpr (is_map<ObsType>::value) {
       std::vector<double> local_traits{};
       local_traits.reserve(local_particles.size());
@@ -271,4 +270,3 @@ public:
 };
 
 } // namespace Observables
-#endif

--- a/src/core/observables/PressureObservable.hpp
+++ b/src/core/observables/PressureObservable.hpp
@@ -30,9 +30,9 @@ namespace Observables {
 
 class Pressure : public Observable {
 public:
-  std::vector<std::size_t> shape() const override { return {1}; }
+  std::vector<std::size_t> shape() const override { return {1u}; }
   std::vector<double>
-  operator()(boost::mpi::communicator const &comm) const override {
+  operator()(boost::mpi::communicator const &) const override {
     auto const obs = System::get_system().calculate_pressure();
 
     return {(obs->accumulate(0., 0u) + obs->accumulate(0., 4u) +

--- a/src/core/observables/PressureTensor.hpp
+++ b/src/core/observables/PressureTensor.hpp
@@ -30,9 +30,9 @@ namespace Observables {
 
 class PressureTensor : public Observable {
 public:
-  std::vector<std::size_t> shape() const override { return {3, 3}; }
+  std::vector<std::size_t> shape() const override { return {3u, 3u}; }
   std::vector<double>
-  operator()(boost::mpi::communicator const &comm) const override {
+  operator()(boost::mpi::communicator const &) const override {
     auto const obs = System::get_system().calculate_pressure();
 
     std::vector<double> result;

--- a/src/core/observables/RDF.cpp
+++ b/src/core/observables/RDF.cpp
@@ -27,10 +27,12 @@
 #include <utils/for_each_pair.hpp>
 #include <utils/math/int_pow.hpp>
 
+#include <boost/mpi/communicator.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/combine.hpp>
 
 #include <cmath>
+#include <cstddef>
 #include <vector>
 
 namespace Observables {
@@ -64,7 +66,7 @@ RDF::evaluate(boost::mpi::communicator const &comm,
   auto const &box_geo = *System::get_system().box_geo;
   auto const bin_width = (max_r - min_r) / static_cast<double>(n_r_bins);
   auto const inv_bin_width = 1.0 / bin_width;
-  std::vector<double> res(n_values(), 0.0);
+  std::vector<double> res(n_r_bins, 0.0);
   long int cnt = 0;
   auto op = [this, inv_bin_width, &cnt, &res, &box_geo](auto const &pos1,
                                                         auto const &pos2) {
@@ -102,8 +104,8 @@ RDF::evaluate(boost::mpi::communicator const &comm,
     return res;
   // normalization
   auto const volume = box_geo.volume();
-  for (int i = 0; i < n_r_bins; ++i) {
-    auto const r_in = i * bin_width + min_r;
+  for (std::size_t i = 0u; i < res.size(); ++i) {
+    auto const r_in = static_cast<double>(i) * bin_width + min_r;
     auto const r_out = r_in + bin_width;
     auto const bin_volume =
         (4.0 / 3.0) * Utils::pi() *

--- a/src/core/observables/RDF.hpp
+++ b/src/core/observables/RDF.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OBSERVABLES_RDF_HPP
-#define OBSERVABLES_RDF_HPP
+#pragma once
 
 #include "Observable.hpp"
 
@@ -53,8 +52,8 @@ public:
 
   std::vector<std::size_t> shape() const override { return {n_r_bins}; }
 
-  explicit RDF(std::vector<int> ids1, std::vector<int> ids2, int n_r_bins,
-               double min_r, double max_r)
+  RDF(std::vector<int> ids1, std::vector<int> ids2, int n_r_bins, double min_r,
+      double max_r)
       : m_ids1(std::move(ids1)), m_ids2(std::move(ids2)), min_r(min_r),
         max_r(max_r), n_r_bins(n_r_bins) {
     if (max_r <= min_r)
@@ -72,4 +71,3 @@ public:
 };
 
 } // Namespace Observables
-#endif

--- a/src/core/polymer.cpp
+++ b/src/core/polymer.cpp
@@ -193,7 +193,7 @@ draw_polymer_positions(System::System const &system, int const n_polymers,
   /* Try up to max_tries times to draw a valid position */
   auto draw_valid_monomer_position =
       [&](int p, int m) -> boost::optional<Utils::Vector3d> {
-    for (unsigned i = 0; i < max_tries; i++) {
+    for (auto i = 0; i < max_tries; i++) {
       auto const trial_pos = draw_monomer_position(p, m);
       if (is_valid_pos(trial_pos)) {
         return trial_pos;

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -64,7 +64,7 @@ inline void add_non_bonded_pair_virials(
   if (do_nonbonded(p1, p2))
 #endif
   {
-    auto const force = calc_central_radial_force(p1, p2, ia_params, d, dist).f +
+    auto const force = calc_central_radial_force(ia_params, d, dist).f +
                        calc_central_radial_charge_force(p1, p2, ia_params, d,
                                                         dist, kernel_forces)
                            .f +

--- a/src/core/rattle.cpp
+++ b/src/core/rattle.cpp
@@ -209,10 +209,8 @@ static bool calculate_velocity_correction(RigidBond const &ia_params,
  * @brief Apply velocity corrections
  *
  * @param particles particle range
- * @param box_geo Box geometry
  */
-static void apply_velocity_correction(ParticleRange const &particles,
-                                      BoxGeometry const &box_geo) {
+static void apply_velocity_correction(ParticleRange const &particles) {
   boost::for_each(particles,
                   [](Particle &p) { p.v() += p.rattle_params().correction; });
 }
@@ -237,7 +235,7 @@ void correct_velocity_shake(CellStructure &cs, BoxGeometry const &box_geo) {
 
     cs.ghosts_reduce_rattle_correction();
 
-    apply_velocity_correction(particles, box_geo);
+    apply_velocity_correction(particles);
     cs.ghosts_update(Cells::DATA_PART_MOMENTUM);
   }
 

--- a/src/core/system/Leaf.hpp
+++ b/src/core/system/Leaf.hpp
@@ -58,6 +58,7 @@ public:
     assert(system);
     assert(not m_system.expired());
     assert(system == m_system.lock());
+    static_cast<void>(system);
     m_system.reset();
   }
 };

--- a/src/core/system/System.hpp
+++ b/src/core/system/System.hpp
@@ -196,7 +196,7 @@ public:
   /** @brief Calculate initial particle forces from active thermostats. */
   void thermostat_force_init();
   /** @brief Calculate particle-lattice interactions. */
-  void lb_couple_particles(double time_step);
+  void lb_couple_particles();
 
   /** \name Hook procedures
    *  These procedures are called if several significant changes to

--- a/src/core/unit_tests/Particle_serialization_test.cpp
+++ b/src/core/unit_tests/Particle_serialization_test.cpp
@@ -152,7 +152,7 @@ class BitwiseSerializable {
 
 class NotBitwiseSerializable {
   friend boost::serialization::access;
-  template <class Archive> void serialize(Archive &ar, long int) {}
+  template <class Archive> void serialize(Archive &, long int) {}
 };
 
 class MixedSerializable {

--- a/src/core/unit_tests/grid_test.cpp
+++ b/src/core/unit_tests/grid_test.cpp
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(lees_edwards_mi_vector) {
 
     auto const result = box.get_mi_vector(a, b);
 
-    for (int i = 0; i < 3; i++) {
+    for (auto i = 0u; i < 3u; i++) {
       auto expected = get_mi_coord(a[i], b[i], box_l[i], box.periodic(i));
       if (i == le.shear_direction) {
         expected -= le.pos_offset = 1.;

--- a/src/core/unit_tests/lb_particle_coupling_test.cpp
+++ b/src/core/unit_tests/lb_particle_coupling_test.cpp
@@ -443,7 +443,7 @@ BOOST_DATA_TEST_CASE_F(CleanupActorLB, coupling_particle_lattice_ia,
     // check without LB coupling
     {
       system.thermostat->lb_coupling_deactivate();
-      system.lb_couple_particles(params.time_step);
+      system.lb_couple_particles();
       auto const p_opt = copy_particle_to_head_node(comm, system, pid);
       if (rank == 0) {
         auto const &p = *p_opt;
@@ -464,7 +464,7 @@ BOOST_DATA_TEST_CASE_F(CleanupActorLB, coupling_particle_lattice_ia,
         }
       }
       // couple particle to LB
-      system.lb_couple_particles(params.time_step);
+      system.lb_couple_particles();
       {
         auto const p_opt = copy_particle_to_head_node(comm, system, pid);
         if (rank == 0) {

--- a/src/core/unit_tests/link_cell_test.cpp
+++ b/src/core/unit_tests/link_cell_test.cpp
@@ -30,9 +30,9 @@
 #include <vector>
 
 BOOST_AUTO_TEST_CASE(link_cell) {
-  const unsigned n_cells = 10;
-  const auto n_part_per_cell = 10;
-  const auto n_part = n_cells * n_part_per_cell;
+  auto const n_cells = 10u;
+  auto const n_part_per_cell = 10u;
+  auto const n_part = n_cells * n_part_per_cell;
 
   std::vector<Cell> cells(n_cells);
 
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(link_cell) {
   }
 
   std::vector<std::pair<int, int>> lc_pairs;
-  lc_pairs.reserve((n_part * (n_part - 1)) / 2);
+  lc_pairs.reserve((n_part * (n_part - 1u)) / 2u);
 
   Algorithm::link_cell(cells.begin(), cells.end(),
                        [&lc_pairs](Particle const &p1, Particle const &p2) {
@@ -63,11 +63,11 @@ BOOST_AUTO_TEST_CASE(link_cell) {
                            lc_pairs.emplace_back(p1.id(), p2.id());
                        });
 
-  BOOST_CHECK(lc_pairs.size() == (n_part * (n_part - 1) / 2));
+  BOOST_CHECK(lc_pairs.size() == (n_part * (n_part - 1u) / 2u));
 
   auto it = lc_pairs.begin();
-  for (int i = 0; i < n_part; i++)
-    for (int j = i + 1; j < n_part; j++) {
+  for (auto i = 0; i < static_cast<int>(n_part); i++)
+    for (auto j = i + 1; j < static_cast<int>(n_part); j++) {
       BOOST_CHECK((it->first == i) && (it->second == j));
       ++it;
     }

--- a/src/core/virtual_sites/lb_tracers.cpp
+++ b/src/core/virtual_sites/lb_tracers.cpp
@@ -39,7 +39,7 @@ static bool lb_sanity_checks(LB::Solver const &lb) {
 void lb_tracers_add_particle_force_to_fluid(CellStructure &cell_structure,
                                             BoxGeometry const &box_geo,
                                             LocalBox const &local_box,
-                                            LB::Solver &lb, double time_step) {
+                                            LB::Solver &lb) {
   if (lb_sanity_checks(lb)) {
     return;
   }
@@ -84,7 +84,7 @@ void lb_tracers_propagate(CellStructure &cell_structure, LB::Solver const &lb,
     if (!LB::is_tracer(p))
       continue;
     p.v() = lb.get_coupling_interpolated_velocity(p.pos());
-    for (unsigned int i = 0u; i < 3u; i++) {
+    for (auto i = 0u; i < 3u; i++) {
       if (!p.is_fixed_along(i)) {
         p.pos()[i] += p.v()[i] * time_step;
       }

--- a/src/core/virtual_sites/lb_tracers.hpp
+++ b/src/core/virtual_sites/lb_tracers.hpp
@@ -31,7 +31,7 @@
 void lb_tracers_add_particle_force_to_fluid(CellStructure &cell_structure,
                                             BoxGeometry const &box_geo,
                                             LocalBox const &local_box,
-                                            LB::Solver &lb, double time_step);
+                                            LB::Solver &lb);
 void lb_tracers_propagate(CellStructure &cell_structure, LB::Solver const &lb,
                           double time_step);
 

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -285,13 +285,16 @@ class Analysis(ScriptInterfaceHelper):
             and [1] contains the structure factors S(q)
 
     distribution()
-        Calculates the distance distribution of particles (probability of
-        finding a particle of type A at a certain distance around a particle of
+        Calculate the minimal distance distribution of particles (probability of
+        finding a particle of type A at a certain distance to the nearest particle of
         type B, disregarding the fact that a spherical shell of a larger radius
         covers a larger volume). The distance is defined as the minimal distance
         between a particle of group ``type_list_a`` to any of the group
         ``type_list_b``. Returns two arrays, the bins and the (normalized)
         distribution.
+
+        For the radial distribution function,
+        use :class:`espressomd.observables.RDF` instead.
 
         Parameters
         ----------
@@ -319,7 +322,7 @@ class Analysis(ScriptInterfaceHelper):
         -------
         :obj:`ndarray`
             Where [0] contains the midpoints of the bins,
-            and [1] contains the values of the rdf.
+            and [1] contains the values of the minimal distance distribution function.
 
     """
     _so_name = "Analysis::Analysis"

--- a/src/scafacos/CMakeLists.txt
+++ b/src/scafacos/CMakeLists.txt
@@ -22,12 +22,6 @@ add_library(espresso_scafacos SHARED src/Scafacos.cpp src/Coulomb.cpp
 add_library(espresso::scafacos ALIAS espresso_scafacos)
 set_target_properties(espresso_scafacos PROPERTIES CXX_CLANG_TIDY
                                                    "${ESPRESSO_CXX_CLANG_TIDY}")
-if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10
-   AND ESPRESSO_INSIDE_DOCKER AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL
-                                  11 AND ESPRESSO_BUILD_WITH_COVERAGE)
-  target_link_libraries(espresso_scafacos
-                        PRIVATE "-L/usr/lib/gcc/x86_64-linux-gnu/10")
-endif()
 target_link_libraries(espresso_scafacos PUBLIC MPI::MPI_CXX
                       PRIVATE ${SCAFACOS_LDFLAGS} espresso::cpp_flags)
 

--- a/src/script_interface/ObjectHandle.hpp
+++ b/src/script_interface/ObjectHandle.hpp
@@ -119,7 +119,10 @@ public:
    * @param name Name of the parameter
    * @return Value of parameter @p name
    */
-  virtual Variant get_parameter(const std::string &name) const { return {}; }
+  virtual Variant get_parameter(std::string const &name) const {
+    static_cast<void>(name);
+    return {};
+  }
 
   /**
    * @brief Set single parameter.
@@ -169,6 +172,6 @@ public:
 
 private:
   virtual std::string get_internal_state() const { return {}; }
-  virtual void set_internal_state(std::string const &state) {}
+  virtual void set_internal_state(std::string const &) {}
 };
 } /* namespace ScriptInterface */

--- a/src/script_interface/accumulators/AccumulatorBase.hpp
+++ b/src/script_interface/accumulators/AccumulatorBase.hpp
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef SCRIPTINTERFACE_ACCUMULATORS_ACCUMULATORBASE_HPP
-#define SCRIPTINTERFACE_ACCUMULATORS_ACCUMULATORBASE_HPP
+
+#pragma once
 
 #include "core/accumulators/AccumulatorBase.hpp"
 #include "script_interface/ScriptInterface.hpp"
@@ -53,5 +53,3 @@ public:
 
 } // namespace Accumulators
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/accumulators/AutoUpdateAccumulators.hpp
+++ b/src/script_interface/accumulators/AutoUpdateAccumulators.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_ACCUMULATOR_AUTOUPDATEACCUMULATORS_HPP
-#define SCRIPT_INTERFACE_ACCUMULATOR_AUTOUPDATEACCUMULATORS_HPP
+#pragma once
 
 #include "AccumulatorBase.hpp"
 
@@ -46,9 +45,7 @@ class AutoUpdateAccumulators : public ObjectList<AccumulatorBase> {
 private:
   // disable serialization: pickling done by the python interface
   std::string get_internal_state() const override { return {}; }
-  void set_internal_state(std::string const &state) override {}
+  void set_internal_state(std::string const &) override {}
 };
 } /* namespace Accumulators */
 } /* namespace ScriptInterface */
-
-#endif // SCRIPT_INTERFACE_ACCUMULATOR_AUTOUPDATEACCUMULATORS_HPP

--- a/src/script_interface/constraints/Constraint.hpp
+++ b/src/script_interface/constraints/Constraint.hpp
@@ -19,8 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_CONSTRAINT_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_CONSTRAINT_HPP
+#pragma once
 
 #include "core/constraints/Constraint.hpp"
 #include "script_interface/ScriptInterface.hpp"
@@ -37,5 +36,3 @@ public:
 
 } /* namespace Constraints */
 } /* namespace ScriptInterface */
-
-#endif

--- a/src/script_interface/constraints/Constraints.hpp
+++ b/src/script_interface/constraints/Constraints.hpp
@@ -19,8 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_CONSTRAINTS_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_CONSTRAINTS_HPP
+#pragma once
 
 #include "Constraint.hpp"
 
@@ -45,9 +44,7 @@ class Constraints : public ObjectList<Constraint> {
 private:
   // disable serialization: pickling done by the python interface
   std::string get_internal_state() const override { return {}; }
-  void set_internal_state(std::string const &state) override {}
+  void set_internal_state(std::string const &) override {}
 };
 } /* namespace Constraints */
 } /* namespace ScriptInterface */
-
-#endif

--- a/src/script_interface/constraints/ExternalField.hpp
+++ b/src/script_interface/constraints/ExternalField.hpp
@@ -19,8 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_EXTERNAL_FIELD_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_EXTERNAL_FIELD_HPP
+#pragma once
 
 #include "couplings.hpp"
 #include "fields.hpp"
@@ -79,5 +78,3 @@ private:
 };
 } /* namespace Constraints */
 } /* namespace ScriptInterface */
-
-#endif

--- a/src/script_interface/constraints/ExternalPotential.hpp
+++ b/src/script_interface/constraints/ExternalPotential.hpp
@@ -19,8 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_EXTERNAL_POTENTIAL_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_EXTERNAL_POTENTIAL_HPP
+#pragma once
 
 #include "core/constraints/Constraint.hpp"
 #include "core/constraints/ExternalPotential.hpp"
@@ -83,5 +82,3 @@ private:
 };
 } // namespace Constraints
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/constraints/HomogeneousMagneticField.hpp
+++ b/src/script_interface/constraints/HomogeneousMagneticField.hpp
@@ -19,8 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_HOMOGENEOUSMAGNETICFIELD_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_HOMOGENEOUSMAGNETICFIELD_HPP
+#pragma once
 
 #include "core/constraints/Constraint.hpp"
 #include "core/constraints/HomogeneousMagneticField.hpp"
@@ -65,5 +64,3 @@ private:
 
 } /* namespace Constraints */
 } /* namespace ScriptInterface */
-
-#endif

--- a/src/script_interface/constraints/couplings.hpp
+++ b/src/script_interface/constraints/couplings.hpp
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_DETAIL_COUPLINGS_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_DETAIL_COUPLINGS_HPP
+
+#pragma once
 
 /**
  * @file
@@ -98,5 +98,3 @@ template <> inline Scaled make_coupling<Scaled>(const VariantMap &params) {
 } // namespace detail
 } // namespace Constraints
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/constraints/fields.hpp
+++ b/src/script_interface/constraints/fields.hpp
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_DETAIL_FIELDS_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_DETAIL_FIELDS_HPP
+
+#pragma once
 
 #include "core/field_coupling/fields/AffineMap.hpp"
 #include "core/field_coupling/fields/Constant.hpp"
@@ -165,5 +165,3 @@ template <typename Field> Field make_field(const VariantMap &params) {
 } // namespace detail
 } // namespace Constraints
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/constraints/initialize.hpp
+++ b/src/script_interface/constraints/initialize.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_CONSTRAINTS_INITIALIZE_HPP
-#define SCRIPT_INTERFACE_CONSTRAINTS_INITIALIZE_HPP
+#pragma once
 
 #include <script_interface/ObjectHandle.hpp>
 
@@ -31,5 +30,3 @@ void initialize(Utils::Factory<ObjectHandle> *om);
 
 } /* namespace Constraints */
 } /* namespace ScriptInterface */
-
-#endif

--- a/src/script_interface/electrostatics/Actor.hpp
+++ b/src/script_interface/electrostatics/Actor.hpp
@@ -30,9 +30,7 @@
 #include "script_interface/system/Leaf.hpp"
 
 #include <memory>
-#include <stdexcept>
 #include <string>
-#include <vector>
 
 namespace ScriptInterface {
 namespace Coulomb {

--- a/src/script_interface/electrostatics/Actor_impl.hpp
+++ b/src/script_interface/electrostatics/Actor_impl.hpp
@@ -30,6 +30,10 @@
 
 #include "script_interface/auto_parameters/AutoParameter.hpp"
 
+#include <cassert>
+#include <stdexcept>
+#include <string>
+
 namespace ScriptInterface {
 namespace Coulomb {
 
@@ -83,6 +87,7 @@ template <class SIClass, class CoreClass> Actor<SIClass, CoreClass>::Actor() {
 template <class SIClass, class CoreClass>
 Variant Actor<SIClass, CoreClass>::do_call_method(std::string const &name,
                                                   VariantMap const &params) {
+  assert(params.empty());
   if (name == "activate") {
     context()->parallel_try_catch([this]() {
       auto &system = get_system();

--- a/src/script_interface/electrostatics/Container.hpp
+++ b/src/script_interface/electrostatics/Container.hpp
@@ -59,6 +59,7 @@ class Container : public AutoParameters<Container, System::Leaf> {
   }
 
   void on_bind_system(::System::System &system) override {
+    static_cast<void>(system);
     auto const &params = *m_params;
     for (auto const &key : get_parameter_insertion_order()) {
       if (params.count(key)) {

--- a/src/script_interface/interactions/NonBondedInteraction.hpp
+++ b/src/script_interface/interactions/NonBondedInteraction.hpp
@@ -878,6 +878,7 @@ private:
 public:
   Variant do_call_method(std::string const &name,
                          VariantMap const &params) override {
+    assert(params.empty());
     if (name == "get_types") {
       return std::vector<int>{{m_types[0], m_types[1]}};
     }

--- a/src/script_interface/magnetostatics/Actor.hpp
+++ b/src/script_interface/magnetostatics/Actor.hpp
@@ -30,7 +30,6 @@
 #include "script_interface/system/Leaf.hpp"
 
 #include <memory>
-#include <stdexcept>
 #include <string>
 
 namespace ScriptInterface {

--- a/src/script_interface/magnetostatics/Actor_impl.hpp
+++ b/src/script_interface/magnetostatics/Actor_impl.hpp
@@ -30,12 +30,16 @@
 
 #include "script_interface/auto_parameters/AutoParameter.hpp"
 
+#include <cassert>
+#include <string>
+
 namespace ScriptInterface {
 namespace Dipoles {
 
 template <class SIClass, class CoreClass>
 Variant Actor<SIClass, CoreClass>::do_call_method(std::string const &name,
                                                   VariantMap const &params) {
+  assert(params.empty());
   if (name == "activate") {
     context()->parallel_try_catch([this]() {
       auto &system = get_system();

--- a/src/script_interface/magnetostatics/Container.hpp
+++ b/src/script_interface/magnetostatics/Container.hpp
@@ -47,6 +47,7 @@ class Container : public AutoParameters<Container, System::Leaf> {
   }
 
   void on_bind_system(::System::System &system) override {
+    static_cast<void>(system);
     auto const &params = *m_params;
     for (auto const &key : get_parameter_insertion_order()) {
       if (params.count(key)) {

--- a/src/script_interface/particle_data/ParticleHandle.hpp
+++ b/src/script_interface/particle_data/ParticleHandle.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_PARTICLE_HANDLE_HPP
-#define ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_PARTICLE_HANDLE_HPP
+#pragma once
 
 #include "script_interface/ScriptInterface.hpp"
 #include "script_interface/auto_parameters/AutoParameters.hpp"
@@ -57,5 +56,3 @@ public:
 
 } // namespace Particles
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/particle_data/ParticleList.cpp
+++ b/src/script_interface/particle_data/ParticleList.cpp
@@ -36,6 +36,7 @@
 #include <boost/mpi/communicator.hpp>
 #include <boost/range/algorithm.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -174,13 +175,13 @@ static void auto_exclusions(boost::mpi::communicator const &comm,
       for (auto const pid1 : pids) {
         // loop over partners (counter-based loops due to iterator invalidation)
         // NOLINTNEXTLINE(modernize-loop-convert)
-        for (int i = 0; i < partners[pid1].size(); ++i) {
+        for (std::size_t i = 0u; i < partners[pid1].size(); ++i) {
           auto const [pid2, dist21] = partners[pid1][i];
           if (dist21 > n_bonds_max)
             continue;
           // loop over all partners of the partner
           // NOLINTNEXTLINE(modernize-loop-convert)
-          for (int j = 0; j < partners[pid2].size(); ++j) {
+          for (std::size_t j = 0u; j < partners[pid2].size(); ++j) {
             auto const [pid3, dist32] = partners[pid2][j];
             auto const dist31 = dist32 + dist21;
             if (dist31 > n_bonds_max)

--- a/src/script_interface/particle_data/ParticleList.hpp
+++ b/src/script_interface/particle_data/ParticleList.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_PARTICLE_LIST_HPP
-#define ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_PARTICLE_LIST_HPP
+#pragma once
 
 #include "script_interface/ScriptInterface.hpp"
 
@@ -33,7 +32,7 @@ public:
   Variant do_call_method(std::string const &name,
                          VariantMap const &params) override;
 
-  void do_construct(VariantMap const &params) override {}
+  void do_construct(VariantMap const &) override {}
 
 private:
   std::string get_internal_state() const override;
@@ -42,5 +41,3 @@ private:
 
 } // namespace Particles
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/particle_data/ParticleSlice.hpp
+++ b/src/script_interface/particle_data/ParticleSlice.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_PARTICLE_SLICE_HPP
-#define ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_PARTICLE_SLICE_HPP
+#pragma once
 
 #include "ParticleHandle.hpp"
 
@@ -53,5 +52,3 @@ public:
 
 } // namespace Particles
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/particle_data/Polymer.hpp
+++ b/src/script_interface/particle_data/Polymer.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_POLYMER_HPP
-#define ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_POLYMER_HPP
+#pragma once
 
 #include "script_interface/ScriptInterface.hpp"
 
@@ -35,5 +34,3 @@ public:
 
 } // namespace Particles
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/particle_data/initialize.hpp
+++ b/src/script_interface/particle_data/initialize.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_INITIALIZE_HPP
-#define ESPRESSO_SRC_SCRIPT_INTERFACE_PARTICLE_DATA_INITIALIZE_HPP
+#pragma once
 
 #include <script_interface/ObjectHandle.hpp>
 
@@ -31,5 +30,3 @@ void initialize(Utils::Factory<ObjectHandle> *om);
 
 } // namespace Particles
 } // namespace ScriptInterface
-
-#endif

--- a/src/script_interface/scafacos/scafacos.cpp
+++ b/src/script_interface/scafacos/scafacos.cpp
@@ -57,7 +57,7 @@ struct ConvertToStringVector
   }
 
   template <typename T, typename = std::enable_if_t<!std::is_arithmetic_v<T>>>
-  std::vector<std::string> operator()(T const &value) const {
+  std::vector<std::string> operator()(T const &) const {
     throw std::runtime_error("Cannot convert " + Utils::demangle<T>());
   }
 

--- a/src/script_interface/tests/Accumulators_test.cpp
+++ b/src/script_interface/tests/Accumulators_test.cpp
@@ -53,7 +53,7 @@ namespace Observables {
 class MockObservable : public Observable {
 public:
   std::vector<double>
-  operator()(boost::mpi::communicator const &comm) const override {
+  operator()(boost::mpi::communicator const &) const override {
     return {1., 2., 3., 4.};
   }
   std::vector<std::size_t> shape() const override { return {2u, 2u}; }

--- a/src/script_interface/tests/AutoParameter_test.cpp
+++ b/src/script_interface/tests/AutoParameter_test.cpp
@@ -44,9 +44,8 @@ BOOST_AUTO_TEST_CASE(read_only) {
   BOOST_CHECK(boost::get<int>(p.get()) == i);
 
   /* Setting should throw */
-  BOOST_CHECK_EXCEPTION(
-      p.set(2), AutoParameter::WriteError,
-      [](AutoParameter::WriteError const &e) { return true; });
+  BOOST_CHECK_EXCEPTION(p.set(2), AutoParameter::WriteError,
+                        [](AutoParameter::WriteError const &) { return true; });
 }
 
 BOOST_AUTO_TEST_CASE(user_provided) {

--- a/src/script_interface/tests/ObjectHandle_test.cpp
+++ b/src/script_interface/tests/ObjectHandle_test.cpp
@@ -78,13 +78,13 @@ struct LogHandle : public ObjectHandle {
     call_log.emplace_back(MockCall::Construct{&params});
   }
 
-  void do_set_parameter(const std::string &name,
-                        const Variant &value) override {
+  void do_set_parameter(std::string const &name,
+                        Variant const &value) override {
     call_log.emplace_back(MockCall::SetParameter{&name, &value});
   }
 
-  Variant do_call_method(const std::string &name,
-                         const VariantMap &params) override {
+  Variant do_call_method(std::string const &name,
+                         VariantMap const &params) override {
     call_log.emplace_back(MockCall::CallMethod{&name, &params});
 
     return none;
@@ -177,19 +177,19 @@ namespace Testing {
  * Logging mock for Context.
  */
 struct LogContext : public Context {
-  std::vector<std::pair<const ObjectHandle *, MockCall::Info>> call_log;
+  std::vector<std::pair<ObjectHandle const *, MockCall::Info>> call_log;
 
-  void notify_call_method(const ObjectHandle *o, std::string const &n,
+  void notify_call_method(ObjectHandle const *o, std::string const &n,
                           VariantMap const &p) override {
     call_log.emplace_back(o, MockCall::CallMethod{&n, &p});
   }
-  void notify_set_parameter(const ObjectHandle *o, std::string const &n,
+  void notify_set_parameter(ObjectHandle const *o, std::string const &n,
                             Variant const &v) override {
     call_log.emplace_back(o, MockCall::SetParameter{&n, &v});
   }
 
   std::shared_ptr<ObjectHandle> make_shared(std::string const &,
-                                            const VariantMap &) override {
+                                            VariantMap const &) override {
     auto it = std::make_shared<Testing::LogHandle>();
     set_context(it.get());
 
@@ -200,7 +200,7 @@ struct LogContext : public Context {
     return make_shared(s, v);
   }
 
-  boost::string_ref name(const ObjectHandle *o) const override {
+  boost::string_ref name(ObjectHandle const *) const override {
     return "Dummy";
   }
 

--- a/src/utils/include/utils/Cache.hpp
+++ b/src/utils/include/utils/Cache.hpp
@@ -17,9 +17,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CORE_UTILS_CACHE_HPP
-#define CORE_UTILS_CACHE_HPP
+#pragma once
 
+#include <cstddef>
 #include <memory>
 #include <random>
 #include <type_traits>
@@ -149,11 +149,12 @@ public:
   KeyInputIterator put(KeyInputIterator kbegin, KeyInputIterator kend,
                        ValueInputIterator vbegin) {
     auto const range_len = std::distance(kbegin, kend);
-    auto const len = (range_len > max_size()) ? max_size() : range_len;
+    auto const size_max = static_cast<decltype(range_len)>(max_size());
+    auto const len = (range_len > size_max) ? size_max : range_len;
     kend = std::next(kbegin, len);
 
     /* Make some space. */
-    while ((max_size() - size()) < len) {
+    while (static_cast<decltype(len)>(max_size() - size()) < len) {
       drop_random_element();
     }
 
@@ -180,5 +181,3 @@ public:
   }
 };
 } // namespace Utils
-
-#endif

--- a/src/utils/include/utils/Histogram.hpp
+++ b/src/utils/include/utils/Histogram.hpp
@@ -108,7 +108,7 @@ public:
       for (std::size_t i = 0; i < M; ++i) {
         index[i] = calc_bin_index(pos[i], m_limits[i].first, m_bin_sizes[i]);
       }
-      for (array_index i = 0; i < N; ++i) {
+      for (array_index i = 0; i < static_cast<array_index>(N); ++i) {
         index.back() = i;
         m_array(index) += value[i];
         m_count(index)++;

--- a/src/utils/include/utils/interpolation/bspline_3d_gradient.hpp
+++ b/src/utils/include/utils/interpolation/bspline_3d_gradient.hpp
@@ -42,7 +42,7 @@ namespace Interpolation {
  * @param grid_spacing The distance between the grid points.
  * @param offset Shift of the grid relative to the origin.
  */
-template <std::size_t order, typename Kernel>
+template <int order, typename Kernel>
 void bspline_3d_gradient(Vector3d const &pos, Kernel const &kernel,
                          Vector3d const &grid_spacing, Vector3d const &offset) {
   using Utils::bspline;
@@ -81,7 +81,7 @@ void bspline_3d_gradient(Vector3d const &pos, Kernel const &kernel,
 /**
  * @brief cardinal B-spline weighted sum.
  */
-template <std::size_t order, typename T, typename Kernel>
+template <int order, typename T, typename Kernel>
 T bspline_3d_gradient_accumulate(Vector3d const &pos, Kernel const &kernel,
                                  Vector3d const &grid_spacing,
                                  Vector3d const &offset, T const &init) {

--- a/src/utils/include/utils/linear_interpolation.hpp
+++ b/src/utils/include/utils/linear_interpolation.hpp
@@ -16,10 +16,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef UTILS_LINEAR_INTERPOLATION_HPP
-#define UTILS_LINEAR_INTERPOLATION_HPP
+
+#pragma once
 
 #include <cassert>
+#include <cstddef>
 
 namespace Utils {
 /** Linear interpolation between two data points.
@@ -34,7 +35,7 @@ T linear_interpolation(Container const &table, T hi, T offset, T x) {
   auto const dind = (x - offset) * hi;
   auto const ind = static_cast<int>(dind);
   assert(ind <= dind);
-  assert((ind >= 0) and (ind < table.size()));
+  assert((ind >= 0) and (static_cast<std::size_t>(ind) < table.size()));
   auto const dx = dind - static_cast<T>(ind);
   auto const uind = static_cast<unsigned int>(ind);
 
@@ -42,5 +43,3 @@ T linear_interpolation(Container const &table, T hi, T offset, T x) {
   return table[uind] * (T{1} - dx) + table[uind + 1] * dx;
 }
 } // namespace Utils
-
-#endif

--- a/src/utils/include/utils/mpi/iall_gatherv.hpp
+++ b/src/utils/include/utils/mpi/iall_gatherv.hpp
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef UTILS_MPI_ALL_GATHERV_HPP
-#define UTILS_MPI_ALL_GATHERV_HPP
+#pragma once
 
 #include "utils/Span.hpp"
 
@@ -26,6 +25,7 @@
 #include <boost/mpi/request.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <vector>
 
 namespace Utils {
@@ -36,7 +36,7 @@ inline std::vector<int> displacements(Span<int const> sizes) {
   std::vector<int> displ(sizes.size());
 
   int offset = 0;
-  for (int i = 0; i < displ.size(); i++) {
+  for (std::size_t i = 0u; i < displ.size(); i++) {
     displ[i] = offset;
     offset += sizes[i];
   }
@@ -81,4 +81,3 @@ auto iall_gatherv(boost::mpi::communicator const &comm, T const *in_values,
 }
 } // namespace Mpi
 } // namespace Utils
-#endif

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ESPRESSO_MEMCPY_ARCHIVE_HPP
-#define ESPRESSO_MEMCPY_ARCHIVE_HPP
+
+#pragma once
 
 #include "utils/Span.hpp"
 
@@ -115,7 +115,7 @@ private:
     boost::serialization::serialize_adl(*static_cast<Derived *>(this), value,
                                         4);
     auto const new_pos = insert;
-    assert((new_pos - old_pos) <= sizeof(T));
+    assert(static_cast<std::size_t>(new_pos - old_pos) <= sizeof(T));
 
     auto const padding_size = sizeof(T) - (new_pos - old_pos);
     skip(padding_size);
@@ -226,5 +226,3 @@ public:
   }
 };
 } // namespace Utils
-
-#endif // ESPRESSO_MEMCPY_ARCHIVE_HPP

--- a/src/utils/tests/gather_buffer_test.cpp
+++ b/src/utils/tests/gather_buffer_test.cpp
@@ -42,9 +42,9 @@ void check_vector(const boost::mpi::communicator &comm, int root) {
 
   if (comm.rank() == root) {
     auto const n = comm.size();
-    const int total_size = n * (n + 1) / 2;
+    auto const total_size = n * (n + 1) / 2;
 
-    BOOST_CHECK(buf.size() == total_size);
+    BOOST_CHECK_EQUAL(static_cast<int>(buf.size()), total_size);
 
     /* Check order in result */
     BOOST_CHECK(std::is_sorted(buf.begin(), buf.end()));
@@ -57,9 +57,9 @@ void check_vector(const boost::mpi::communicator &comm, int root) {
     }
   } else {
     /* Check that buffer is unchanged */
-    BOOST_CHECK(buf.size() == comm.rank() + 1);
+    BOOST_CHECK_EQUAL(static_cast<int>(buf.size()), comm.rank() + 1);
     for (auto const &i : buf) {
-      BOOST_CHECK(i == comm.rank() + 1);
+      BOOST_CHECK_EQUAL(i, comm.rank() + 1);
     }
   }
 }
@@ -71,14 +71,14 @@ void check_vector_out_of_bounds(const boost::mpi::communicator &comm) {
   if (comm.rank() == 1) {
     std::vector<int> buf = {2, 2};
     gather_buffer(buf, comm, root);
-    BOOST_CHECK(buf.size() == 3);
+    BOOST_CHECK(buf.size() == 3u);
     BOOST_CHECK(buf[0] == 1);
     BOOST_CHECK(buf[1] == 2);
     BOOST_CHECK(buf[2] == 2);
   } else if (comm.rank() == 0) {
     std::vector<int> buf = {1};
     gather_buffer(buf, comm, root);
-    BOOST_CHECK(buf.size() == 1);
+    BOOST_CHECK(buf.size() == 1u);
     BOOST_CHECK(buf[0] == 1);
   } else {
     std::vector<int> buf = {};
@@ -92,7 +92,7 @@ void check_vector_empty(const boost::mpi::communicator &comm, int empty) {
   gather_buffer(buf, comm);
 
   if (comm.rank() == 0) {
-    BOOST_CHECK(buf.size() == (comm.size() - 1) * 11);
+    BOOST_CHECK_EQUAL(static_cast<int>(buf.size()), (comm.size() - 1) * 11);
 
     for (int i = 0; i < comm.size(); i++) {
       auto const [lower, upper] = std::equal_range(buf.begin(), buf.end(), i);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(non_trivial_type) {
 
   if (world.rank() == 0) {
     auto const n = world.size();
-    BOOST_CHECK(buf.size() == (n * (n + 1) / 2));
+    BOOST_CHECK_EQUAL(static_cast<int>(buf.size()), (n * (n + 1) / 2));
 
     for (auto const &e : buf) {
       BOOST_CHECK(e == s);

--- a/src/utils/tests/iall_gatherv_test.cpp
+++ b/src/utils/tests/iall_gatherv_test.cpp
@@ -27,6 +27,7 @@
 #include <boost/mpi.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -96,7 +97,7 @@ BOOST_AUTO_TEST_CASE(multiple_elements) {
     auto reqs = Utils::Mpi::iall_gatherv(world, in.data(), rank + 1, out.data(),
                                          sizes.data());
     boost::mpi::wait_all(reqs.begin(), reqs.end());
-    for (int i = 0; i < expected_values.size(); i++) {
+    for (std::size_t i = 0u; i < expected_values.size(); i++) {
       BOOST_CHECK_EQUAL(out.at(i), expected_values.at(i));
     }
   }
@@ -112,7 +113,7 @@ BOOST_AUTO_TEST_CASE(multiple_elements) {
     auto reqs = Utils::Mpi::iall_gatherv(world, out.data(), rank + 1,
                                          out.data(), sizes.data());
     boost::mpi::wait_all(reqs.begin(), reqs.end());
-    for (int i = 0; i < expected_values.size(); i++) {
+    for (std::size_t i = 0u; i < expected_values.size(); i++) {
       BOOST_CHECK_EQUAL(out.at(i), expected_values.at(i));
     }
   }

--- a/src/utils/tests/interpolation_test.cpp
+++ b/src/utils/tests/interpolation_test.cpp
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(nearest_point) {
 BOOST_AUTO_TEST_CASE(interpolation_points_3) {
   std::vector<std::array<int, 3>> int_points;
 
-  auto save_ind = [&int_points](const std::array<int, 3> &ind, double w) {
+  auto save_ind = [&int_points](const std::array<int, 3> &ind, double) {
     int_points.push_back(ind);
   };
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(interpolation_points_3) {
 BOOST_AUTO_TEST_CASE(interpolation_points_2) {
   std::vector<std::array<int, 3>> int_points;
 
-  auto save_ind = [&int_points](const std::array<int, 3> &ind, double w) {
+  auto save_ind = [&int_points](const std::array<int, 3> &ind, double) {
     int_points.push_back(ind);
   };
 

--- a/src/utils/tests/make_lin_space_test.cpp
+++ b/src/utils/tests/make_lin_space_test.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <vector>
 
@@ -35,7 +36,7 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
   {
     auto const start = 1.;
     auto const stop = 2.;
-    auto const num = 13;
+    auto const num = 13u;
 
     auto const lin_space =
         make_lin_space(start, stop, num, /* endpoint */ true);
@@ -45,10 +46,11 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
     BOOST_CHECK_EQUAL(values.front(), start);
     BOOST_CHECK_EQUAL(values.back(), stop);
 
-    auto const dx = (stop - start) / (num - 1);
-    for (int i = 0; i < values.size(); i++) {
-      BOOST_CHECK(std::fabs(start + i * dx - values.at(i)) <=
-                  std::numeric_limits<double>::epsilon());
+    auto const dx = (stop - start) / static_cast<double>(num - 1u);
+    for (std::size_t i = 0u; i < values.size(); i++) {
+      BOOST_CHECK(
+          std::fabs(start + static_cast<double>(i) * dx - values.at(i)) <=
+          std::numeric_limits<double>::epsilon());
     }
   }
 
@@ -56,7 +58,7 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
   {
     auto const start = 1.;
     auto const stop = 2.;
-    auto const num = 13;
+    auto const num = 13u;
 
     auto const lin_space =
         make_lin_space(start, stop, num, /* endpoint */ false);
@@ -66,10 +68,11 @@ BOOST_AUTO_TEST_CASE(make_lin_space_test) {
     BOOST_CHECK_EQUAL(values.front(), start);
     BOOST_CHECK_LT(values.back(), stop);
 
-    auto const dx = (stop - start) / num;
-    for (int i = 0; i < values.size(); i++) {
-      BOOST_CHECK(std::fabs(start + i * dx - values.at(i)) <=
-                  std::numeric_limits<double>::epsilon());
+    auto const dx = (stop - start) / static_cast<double>(num);
+    for (std::size_t i = 0u; i < values.size(); i++) {
+      BOOST_CHECK(
+          std::fabs(start + static_cast<double>(i) * dx - values.at(i)) <=
+          std::numeric_limits<double>::epsilon());
     }
   }
 }

--- a/src/utils/tests/scatter_buffer_test.cpp
+++ b/src/utils/tests/scatter_buffer_test.cpp
@@ -43,7 +43,7 @@ void check_pointer(boost::mpi::communicator comm, int root) {
       }
     }
 
-    BOOST_CHECK(buf.size() == total_size);
+    BOOST_CHECK_EQUAL(static_cast<int>(buf.size()), total_size);
 
     Utils::Mpi::scatter_buffer(buf.data(), comm.rank(), comm, root);
   } else {

--- a/src/walberla_bridge/CMakeLists.txt
+++ b/src/walberla_bridge/CMakeLists.txt
@@ -47,9 +47,8 @@ if(ESPRESSO_BUILD_WITH_CUDA AND WALBERLA_BUILD_WITH_CUDA)
   espresso_add_gpu_library(espresso_walberla_cuda SHARED)
   add_library(espresso::walberla_cuda ALIAS espresso_walberla_cuda)
   espresso_configure_walberla_target(espresso_walberla_cuda)
-  target_link_libraries(
-    espresso_walberla_cuda PUBLIC espresso::utils espresso::walberla
-    PRIVATE CUDA::cuda_driver CUDA::cudart)
+  target_link_libraries(espresso_walberla_cuda PUBLIC espresso::utils
+                        PRIVATE CUDA::cuda_driver CUDA::cudart)
 endif()
 
 add_subdirectory(src)

--- a/src/walberla_bridge/src/utils/boundary.hpp
+++ b/src/walberla_bridge/src/utils/boundary.hpp
@@ -87,7 +87,8 @@ void set_boundary_from_grid(BoundaryModel &boundary,
   auto const grid_size = lattice.get_grid_dimensions();
   auto const offset = lattice.get_local_grid_range().first;
   auto const gl = static_cast<int>(lattice.get_ghost_layers());
-  assert(raster_flat.size() == Utils::product(grid_size));
+  assert(raster_flat.size() ==
+         static_cast<std::size_t>(Utils::product(grid_size)));
   auto const n_y = grid_size[1];
   auto const n_z = grid_size[2];
 

--- a/testsuite/python/constant_pH.py
+++ b/testsuite/python/constant_pH.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# pylint: disable=cyclic-import
 import unittest as ut
 import numpy as np
 import espressomd


### PR DESCRIPTION
Description of changes:
- update the pylint config file (fixes #4918)
- C++: fix several instances of `-Wunused-parameter` and `-Wsign-compare`
- CMake: fix linker warnings in ScaFaCoS and Kokkos, simplify configuration of the `espresso::scafacos` target
- CMake: simplify dependency tree of `espresso::core`, `espresso::walberla`, `espresso::walberla_cuda` targets
- address Jupyter warnings with a newer Docker image where the Jupyter environment is properly set up
- bump Node.js to v20 to address GitHub Actions deprecation warnings
- add jq dependency to address GitHub bot script failures