### PR TITLE
Update Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cython>=0.29.21,<3.0.10
 setuptools>=68.1.2
 packaging>=24.0
 # required scientific packages
-numpy>=1.26.4
+numpy>=1.26.4,<2.0
 h5py>=3.10.0
 # optional scientific packages
 scipy>=1.11.4
@@ -18,16 +18,16 @@ pygame>=2.1.2
 # waLBerla dependencies
 pystencils==1.2
 lbmpy==1.2
-sympy==1.12
+sympy==1.9
 islpy==2022.2.1
 jinja2>=3.1.2
 # CI-related
-requests>=2.31.0
+requests>=2.32.0
 lxml>=5.1.0
 coverage>=7.4.4
 # sphinx and its dependencies
 sphinx>=7.2.6
-sphinx-toggleprompt==0.4.0
+sphinx-toggleprompt==0.5.2
 sphinxcontrib-bibtex>=2.6.2
 numpydoc>=1.6.0
 pybtex>=0.24.0

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-cimport numpy as np
 import numpy as np
 
 

--- a/testsuite/python/cutoffs.py
+++ b/testsuite/python/cutoffs.py
@@ -42,7 +42,7 @@ class CutOff(ut.TestCase):
         fene = FeneBond(r_0=1, d_r_max=2, k=1)
         system.bonded_inter.add(fene)
         self.assertEqual(system.cell_system.max_cut_bonded, 3)
-        n_nodes = np.product(system.cell_system.node_grid)
+        n_nodes = np.prod(system.cell_system.node_grid)
         if n_nodes == 1:
             # Bonds don't influence interaction range
             self.assertEqual(system.cell_system.interaction_range, -1)

--- a/testsuite/python/ek_bulk_reactions.py
+++ b/testsuite/python/ek_bulk_reactions.py
@@ -112,7 +112,7 @@ class EKReaction(ut.TestCase):
 
         self.system.integrator.run(self.TIME)
 
-        domain_volume = np.product(ek_species_product.shape)
+        domain_volume = np.prod(ek_species_product.shape)
         analytic_time = (self.TIME + 0.5) * self.system.time_step
 
         measured_educt_densities = np.zeros(len(stoech_coeffs))

--- a/testsuite/python/lb_stats.py
+++ b/testsuite/python/lb_stats.py
@@ -106,9 +106,9 @@ class TestLB:
             fluid_temp += np.sum(np.multiply(nodes_dens, nodes_vel))
 
             # Normalize
-            fluid_mass /= np.product(self.lbf.shape)
+            fluid_mass /= np.prod(self.lbf.shape)
             fluid_temp *= self.system.volume() / (
-                3. * np.product(self.lbf.shape)**2)
+                3. * np.prod(self.lbf.shape)**2)
 
             # check mass conversation
             self.assertAlmostEqual(fluid_mass, self.params["dens"], delta=1E-9)

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -209,7 +209,7 @@ class ParticleProperties(ut.TestCase):
         self.assertEqual(res[0], 0, f"vs_relative: {res}")
         self.assertEqual(res[1], 5.0, f"vs_relative: {res}")
         np.testing.assert_allclose(
-            res[2], np.array((0.5, -0.5, -0.5, -0.5)),
+            np.copy(res[2]), np.array([0.5, -0.5, -0.5, -0.5]),
             err_msg=f"vs_relative: {res}", atol=self.tol)
         # check exceptions
         error_msg = r"attribute 'vs_relative' of 'ParticleHandle' must take the form \[id, distance, quaternion\]"


### PR DESCRIPTION
Description of changes:
- replace `np.product()` (deprecated in NumPy 1.15 and removed in NumPy 2.0) by `np.prod()`
- bump Python version requirement of `requests` due to CVE-2024-35195
- adjust Python version requirements to resolve all dependency issues
   - `python3 -m pip install -r requirements.txt` now works again