### PR TITLE
Hide FFT implementation details

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -95,6 +95,10 @@ if(ESPRESSO_BUILD_WITH_WALBERLA)
             $<$<BOOL:${ESPRESSO_BUILD_WITH_CUDA}>:espresso::walberla_cuda>)
 endif()
 
+if(ESPRESSO_BUILD_WITH_FFTW)
+  add_subdirectory(fft)
+endif()
+
 add_subdirectory(accumulators)
 add_subdirectory(analysis)
 add_subdirectory(bond_breakage)

--- a/src/core/electrostatics/elc.cpp
+++ b/src/core/electrostatics/elc.cpp
@@ -1128,7 +1128,7 @@ void charge_assign(elc_data const &elc, CoulombP3M &solver,
   }
   /* prepare local FFT mesh */
   for (int i = 0; i < solver.p3m.local_mesh.size; i++)
-    solver.p3m.rs_mesh[i] = 0.;
+    solver.p3m.mesh.rs_scalar[i] = 0.;
 
   for (auto zipped : p_q_pos_range) {
     auto const p_q = boost::get<0>(zipped);

--- a/src/core/electrostatics/p3m.hpp
+++ b/src/core/electrostatics/p3m.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 The ESPResSo project
+ * Copyright (C) 2010-2024 The ESPResSo project
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
  *   Max-Planck-Institute for Polymer Research, Theory Group
  *
@@ -42,7 +42,6 @@
 
 #include "p3m/common.hpp"
 #include "p3m/data_struct.hpp"
-#include "p3m/fft.hpp"
 #include "p3m/interpolation.hpp"
 #include "p3m/send_mesh.hpp"
 
@@ -54,37 +53,26 @@
 #include <array>
 #include <cmath>
 #include <numbers>
-
-struct p3m_data_struct : public p3m_data_struct_base {
-  explicit p3m_data_struct(P3MParameters &&parameters)
-      : p3m_data_struct_base{std::move(parameters)} {}
-
-  /** local mesh. */
-  P3MLocalMesh local_mesh;
-  /** real space mesh (local) for CA/FFT. */
-  fft_vector<double> rs_mesh;
-  /** mesh (local) for the electric field. */
-  std::array<fft_vector<double>, 3> E_mesh;
-
-  /** number of charged particles (only on head node). */
-  int sum_qpart = 0;
-  /** Sum of square of charges (only on head node). */
-  double sum_q2 = 0.;
-  /** square of sum of charges (only on head node). */
-  double square_sum_q = 0.;
-
-  p3m_interpolation_cache inter_weights;
-
-  /** send/recv mesh sizes */
-  p3m_send_mesh sm;
-
-  fft_data_struct fft;
-};
+#include <utility>
 
 /** @brief P3M solver. */
 struct CoulombP3M : public Coulomb::Actor<CoulombP3M> {
+  struct p3m_data_struct_impl : public p3m_data_struct {
+    explicit p3m_data_struct_impl(P3MParameters &&parameters)
+        : p3m_data_struct{std::move(parameters)} {}
+
+    /** number of charged particles (only on head node). */
+    int sum_qpart = 0;
+    /** Sum of square of charges (only on head node). */
+    double sum_q2 = 0.;
+    /** square of sum of charges (only on head node). */
+    double square_sum_q = 0.;
+
+    p3m_interpolation_cache inter_weights;
+  };
+
   /** P3M parameters. */
-  p3m_data_struct p3m;
+  p3m_data_struct_impl p3m;
 
   int tune_timings;
   bool tune_verbose;

--- a/src/core/fft/CMakeLists.txt
+++ b/src/core/fft/CMakeLists.txt
@@ -17,5 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-target_sources(espresso_core PRIVATE common.cpp send_mesh.cpp
-                                     TuningAlgorithm.cpp FFTBackendLegacy.cpp)
+if(FFTW3_FOUND)
+  target_link_libraries(espresso_core PUBLIC FFTW3::FFTW3)
+endif()
+
+target_sources(espresso_core PRIVATE fft.cpp)

--- a/src/core/fft/fft.hpp
+++ b/src/core/fft/fft.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 The ESPResSo project
+ * Copyright (C) 2010-2024 The ESPResSo project
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
  *   Max-Planck-Institute for Polymer Research, Theory Group
  *
@@ -26,71 +26,49 @@
  *  Routines, row decomposition, data structures and communication for the
  *  3D-FFT.
  *
- *  The 3D-FFT is split into 3 ond dimensional FFTs. The data is
+ *  The 3D-FFT is split into three 1D-FFTs. The data is
  *  distributed in such a way, that for the actual direction of the
  *  FFT each node has a certain number of rows for which it performs a
  *  1D-FFT. After performing the FFT on that direction the data is
  *  redistributed.
  *
- *  For simplicity at the moment I have implemented a full complex to
- *  complex FFT (even though a real to complex FFT would be sufficient).
- *
- *  For more information about FFT usage, see \ref fft.cpp "fft.cpp".
+ *  For simplicity, a full complex-to-complex FFT is implemented,
+ *  even though a real-to-complex FFT would be sufficient.
  */
 
-#include "config/config.hpp"
-
-#if defined(P3M) || defined(DP3M)
+#include "vector.hpp"
 
 #include <utils/Vector.hpp>
 
-#include <boost/mpi/communicator.hpp>
-
-#include <fftw3.h>
-
+#include <array>
 #include <cstddef>
-#include <limits>
-#include <new>
+#include <memory>
+#include <optional>
+#include <span>
+#include <utility>
 #include <vector>
 
-/** Aligned allocator for fft data. */
-template <class T> struct fft_allocator {
-  typedef T value_type;
-  fft_allocator() noexcept = default; // default ctor not required
-  template <class U> explicit fft_allocator(const fft_allocator<U> &) {}
-  template <class U> bool operator==(const fft_allocator<U> &) const {
-    return true;
-  }
-  template <class U> bool operator!=(const fft_allocator<U> &) const {
-    return false;
-  }
+struct fftw_plan_s;
+namespace boost::mpi {
+class environment;
+class communicator;
+} // namespace boost::mpi
 
-  T *allocate(const std::size_t n) const {
-    if (n == 0) {
-      return nullptr;
-    }
-    if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) {
-      throw std::bad_array_new_length();
-    }
-    void *const pv = fftw_malloc(n * sizeof(T));
-    if (!pv) {
-      throw std::bad_alloc();
-    }
-    return static_cast<T *>(pv);
-  }
-  void deallocate(T *const p, std::size_t) const noexcept { fftw_free(p); }
-};
-
-template <class T> using fft_vector = std::vector<T, fft_allocator<T>>;
+namespace fft {
 
 struct fft_plan {
+  using fftw_plan = fftw_plan_s *;
+
+  ~fft_plan() { destroy_plan(); }
+
   /** plan direction: forward or backward FFT (enum value from FFTW). */
   int dir;
   /** plan for the FFT. */
-  fftw_plan our_fftw_plan;
+  fftw_plan plan_handle = nullptr;
   /** packing function for send blocks. */
   void (*pack_function)(double const *const, double *const, int const *,
                         int const *, int const *, int);
+  void destroy_plan();
 };
 
 /** @brief Plan for a forward 1D FFT of a flattened 3D array. */
@@ -129,18 +107,27 @@ struct fft_forw_plan : public fft_plan {
 /** @brief Plan for a backward 1D FFT of a flattened 3D array. */
 struct fft_back_plan : public fft_plan {};
 
-/** Information about the three one dimensional FFTs and how the nodes
- *  have to communicate inbetween.
+/**
+ * @brief Information about the three one dimensional FFTs and how the nodes
+ * have to communicate inbetween.
  *
- *  @note FFT numbering starts with 1 for technical reasons (because we have 4
- *        node grids, the index 0 is used for the real space charge assignment
- *        grid).
+ * @note FFT numbering starts with 1 for technical reasons (because we have 4
+ * node grids, the index 0 is used for the real space charge assignment grid).
  */
-struct fft_data_struct { // NOLINT(bugprone-reserved-identifier)
+struct fft_data_struct {
+private:
+  /**
+   * @brief Handle to the MPI environment.
+   * Has to be the first member in the class definition, so that FFT plans
+   * are destroyed before the MPI environment expires (non-static class
+   * members are destroyed in the reverse order of their initialization).
+   */
+  std::shared_ptr<boost::mpi::environment> m_mpi_env;
+
   /** Information for forward FFTs. */
-  fft_forw_plan plan[4];
+  std::array<fft_forw_plan, 4u> forw;
   /** Information for backward FFTs. */
-  fft_back_plan back[4];
+  std::array<fft_back_plan, 4u> back;
 
   /** Whether FFT is initialized or not. */
   bool init_tag = false;
@@ -156,46 +143,63 @@ struct fft_data_struct { // NOLINT(bugprone-reserved-identifier)
   /** receive buffer. */
   std::vector<double> recv_buf;
   /** Buffer for receive data. */
-  fft_vector<double> data_buf;
+  fft::vector<double> data_buf;
+
+public:
+  explicit fft_data_struct(decltype(m_mpi_env) mpi_env)
+      : m_mpi_env{std::move(mpi_env)} {}
+
+  // disable copy construction: unsafe because we store raw pointers
+  // to FFT plans (avoids double-free and use-after-free)
+  fft_data_struct &operator=(fft_data_struct const &) = delete;
+  fft_data_struct(fft_data_struct const &) = delete;
+
+  /** Initialize everything connected to the 3D-FFT.
+   *
+   *  \param[in]  comm            MPI communicator.
+   *  \param[in]  ca_mesh_dim     Local CA mesh dimensions.
+   *  \param[in]  ca_mesh_margin  Local CA mesh margins.
+   *  \param[in]  global_mesh_dim Global CA mesh dimensions.
+   *  \param[in]  global_mesh_off Global CA mesh offset.
+   *  \param[out] ks_pnum         Number of permutations in k-space.
+   *  \param[in]  grid            Number of nodes in each spatial dimension.
+   *  \return Maximal size of local fft mesh (needed for allocation of ca_mesh).
+   */
+  int initialize_fft(boost::mpi::communicator const &comm,
+                     Utils::Vector3i const &ca_mesh_dim,
+                     int const *ca_mesh_margin,
+                     Utils::Vector3i const &global_mesh_dim,
+                     Utils::Vector3d const &global_mesh_off, int &ks_pnum,
+                     Utils::Vector3i const &grid);
+
+  /** Perform an in-place forward 3D FFT.
+   *  \warning The content of \a data is overwritten.
+   *  \param[in,out] data  Mesh.
+   *  \param[in]     comm  MPI communicator
+   */
+  void forward_fft(boost::mpi::communicator const &comm, double *data);
+
+  /** Perform an in-place backward 3D FFT.
+   *  \warning The content of \a data is overwritten.
+   *  \param[in,out] data           Mesh.
+   *  \param[in]     check_complex  Throw an error if the complex component is
+   *                                non-zero.
+   *  \param[in]     comm           MPI communicator.
+   */
+  void backward_fft(boost::mpi::communicator const &comm, double *data,
+                    bool check_complex);
+
+  auto get_mesh_size() const { return forw[3u].new_mesh; }
+
+  auto get_mesh_start() const { return forw[3u].start; }
+
+private:
+  void forw_grid_comm(boost::mpi::communicator const &comm,
+                      fft_forw_plan const &plan, double const *in, double *out);
+  void back_grid_comm(boost::mpi::communicator const &comm,
+                      fft_forw_plan const &plan_f, fft_back_plan const &plan_b,
+                      double const *in, double *out);
 };
-
-/** Initialize everything connected to the 3D-FFT.
- *
- *  \param[in]  ca_mesh_dim     Local CA mesh dimensions.
- *  \param[in]  ca_mesh_margin  Local CA mesh margins.
- *  \param[in]  global_mesh_dim Global CA mesh dimensions.
- *  \param[in]  global_mesh_off Global CA mesh offset.
- *  \param[out] ks_pnum         Number of permutations in k-space.
- *  \param[out] fft             FFT plan.
- *  \param[in]  grid            Number of nodes in each spatial dimension.
- *  \param[in]  comm            MPI communicator.
- *  \return Maximal size of local fft mesh (needed for allocation of ca_mesh).
- */
-int fft_init(Utils::Vector3i const &ca_mesh_dim, int const *ca_mesh_margin,
-             Utils::Vector3i const &global_mesh_dim,
-             Utils::Vector3d const &global_mesh_off, int &ks_pnum,
-             fft_data_struct &fft, Utils::Vector3i const &grid,
-             boost::mpi::communicator const &comm);
-
-/** Perform an in-place forward 3D FFT.
- *  \warning The content of \a data is overwritten.
- *  \param[in,out] data  Mesh.
- *  \param[in,out] fft   FFT plan.
- *  \param[in]     comm  MPI communicator
- */
-void fft_perform_forw(double *data, fft_data_struct &fft,
-                      const boost::mpi::communicator &comm);
-
-/** Perform an in-place backward 3D FFT.
- *  \warning The content of \a data is overwritten.
- *  \param[in,out] data           Mesh.
- *  \param[in]     check_complex  Throw an error if the complex component is
- *                                non-zero.
- *  \param[in,out] fft            FFT plan.
- *  \param[in]     comm           MPI communicator.
- */
-void fft_perform_back(double *data, bool check_complex, fft_data_struct &fft,
-                      const boost::mpi::communicator &comm);
 
 /** Pack a block (<tt>size[3]</tt> starting at <tt>start[3]</tt>) of an input
  *  3d-grid with dimension <tt>dim[3]</tt> into an output 3d-block with
@@ -234,4 +238,10 @@ void fft_unpack_block(double const *in, double *out, int const start[3],
 
 int map_3don2d_grid(int const g3d[3], int g2d[3]);
 
-#endif // defined(P3M) || defined(DP3M)
+std::optional<std::vector<int>> find_comm_groups(Utils::Vector3i const &,
+                                                 Utils::Vector3i const &,
+                                                 std::span<int const>,
+                                                 std::span<int>, std::span<int>,
+                                                 std::span<int>, int);
+
+} // namespace fft

--- a/src/core/fft/vector.hpp
+++ b/src/core/fft/vector.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2010-2024 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace fft {
+namespace detail {
+void fft_free(void *p);
+void *fft_malloc(std::size_t length);
+} // namespace detail
+
+/** @brief Aligned allocator for FFT data. */
+template <class T> struct allocator {
+  typedef T value_type;
+  allocator() noexcept = default; // default ctor not required
+  template <class U> explicit allocator(const allocator<U> &) {}
+  template <class U> bool operator==(const allocator<U> &) const {
+    return true;
+  }
+  template <class U> bool operator!=(const allocator<U> &) const {
+    return false;
+  }
+
+  T *allocate(const std::size_t n) const {
+    if (n == 0) {
+      return nullptr;
+    }
+    if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) {
+      throw std::bad_array_new_length();
+    }
+    void *const pv = detail::fft_malloc(n * sizeof(T));
+    if (!pv) {
+      throw std::bad_alloc();
+    }
+    return static_cast<T *>(pv);
+  }
+
+  void deallocate(T *const p, std::size_t) const noexcept {
+    detail::fft_free(static_cast<void *>(p));
+  }
+};
+
+template <class T> using vector = std::vector<T, allocator<T>>;
+
+} // namespace fft

--- a/src/core/magnetostatics/dp3m.hpp
+++ b/src/core/magnetostatics/dp3m.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 The ESPResSo project
+ * Copyright (C) 2010-2024 The ESPResSo project
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
  *   Max-Planck-Institute for Polymer Research, Theory Group
  *
@@ -39,7 +39,6 @@
 
 #include "p3m/common.hpp"
 #include "p3m/data_struct.hpp"
-#include "p3m/fft.hpp"
 #include "p3m/interpolation.hpp"
 #include "p3m/send_mesh.hpp"
 
@@ -52,6 +51,7 @@
 #include <array>
 #include <cmath>
 #include <numbers>
+#include <utility>
 #include <vector>
 
 #ifdef NPT
@@ -59,42 +59,28 @@
 void npt_add_virial_magnetic_contribution(double energy);
 #endif
 
-struct dp3m_data_struct : public p3m_data_struct_base {
-  explicit dp3m_data_struct(P3MParameters &&parameters)
-      : p3m_data_struct_base{std::move(parameters)} {}
-
-  /** local mesh. */
-  P3MLocalMesh local_mesh;
-  /** real space mesh (local) for CA/FFT. */
-  fft_vector<double> rs_mesh;
-  /** real space mesh (local) for CA/FFT of the dipolar field. */
-  std::array<fft_vector<double>, 3> rs_mesh_dip;
-  /** k-space mesh (local) for k-space calculation and FFT. */
-  std::vector<double> ks_mesh;
-
-  /** number of dipolar particles (only on head node). */
-  int sum_dip_part = 0;
-  /** Sum of square of magnetic dipoles (only on head node). */
-  double sum_mu2 = 0.;
-
-  /** position shift for calculation of first assignment mesh point. */
-  double pos_shift = 0.;
-
-  p3m_interpolation_cache inter_weights;
-
-  /** send/recv mesh sizes */
-  p3m_send_mesh sm;
-
-  /** cached k-space self-energy correction */
-  double energy_correction = 0.;
-
-  fft_data_struct fft;
-};
-
 /** @brief Dipolar P3M solver. */
 struct DipolarP3M : public Dipoles::Actor<DipolarP3M> {
+  struct p3m_data_struct_impl : public p3m_data_struct {
+    explicit p3m_data_struct_impl(P3MParameters &&parameters)
+        : p3m_data_struct{std::move(parameters)} {}
+
+    /** number of dipolar particles (only on head node). */
+    int sum_dip_part = 0;
+    /** Sum of square of magnetic dipoles (only on head node). */
+    double sum_mu2 = 0.;
+
+    /** position shift for calculation of first assignment mesh point. */
+    double pos_shift = 0.;
+
+    p3m_interpolation_cache inter_weights;
+
+    /** cached k-space self-energy correction */
+    double energy_correction = 0.;
+  };
+
   /** Dipolar P3M parameters. */
-  dp3m_data_struct dp3m;
+  p3m_data_struct_impl dp3m;
 
   /** Magnetostatics prefactor. */
   int tune_timings;

--- a/src/core/p3m/FFTBackendLegacy.cpp
+++ b/src/core/p3m/FFTBackendLegacy.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2010-2024 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config/config.hpp"
+
+#if defined(P3M) or defined(DP3M)
+
+#include "FFTBackendLegacy.hpp"
+
+#include "communication.hpp"
+
+#include "fft/fft.hpp"
+
+#include <utils/Vector.hpp>
+
+#include <array>
+#include <memory>
+#include <span>
+#include <utility>
+
+FFTBackendLegacy::FFTBackendLegacy(p3m_data_struct &obj)
+    : FFTBackend(obj),
+      fft{std::make_unique<fft::fft_data_struct>(
+          ::Communication::mpiCallbacksHandle()->share_mpi_env())} {}
+
+FFTBackendLegacy::~FFTBackendLegacy() = default;
+
+void FFTBackendLegacy::update_mesh_data() {
+  auto const mesh_size_ptr = fft->get_mesh_size();
+  auto const mesh_start_ptr = fft->get_mesh_start();
+  for (auto i = 0u; i < 3u; ++i) {
+    mesh.size[i] = mesh_size_ptr[i];
+    mesh.start[i] = mesh_start_ptr[i];
+  }
+  mesh.stop = mesh.start + mesh.size;
+  mesh.ks_scalar = std::span(ks_mesh);
+  mesh.rs_scalar = std::span(rs_mesh);
+  for (auto i = 0u; i < 3u; ++i) {
+    mesh.rs_fields[i] = std::span(rs_mesh_fields[i]);
+  }
+}
+
+void FFTBackendLegacy::init_fft() {
+  mesh_comm.resize(::comm_cart, local_mesh);
+  auto ca_mesh_size = fft->initialize_fft(
+      ::comm_cart, local_mesh.dim, local_mesh.margin, params.mesh,
+      params.mesh_off, mesh.ks_pnum, ::communicator.node_grid);
+  rs_mesh.resize(ca_mesh_size);
+  if (dipolar) {
+    ks_mesh.resize(ca_mesh_size);
+  }
+  for (auto &rs_mesh_field : rs_mesh_fields) {
+    rs_mesh_field.resize(ca_mesh_size);
+  }
+  update_mesh_data();
+}
+
+void FFTBackendLegacy::perform_field_back_fft() {
+  /* Back FFT force component mesh */
+  for (auto &rs_mesh_field : rs_mesh_fields) {
+    fft->backward_fft(::comm_cart, rs_mesh_field.data(),
+                      check_complex_residuals);
+  }
+  /* redistribute force component mesh */
+  std::array<double *, 3u> meshes = {{rs_mesh_fields[0u].data(),
+                                      rs_mesh_fields[1u].data(),
+                                      rs_mesh_fields[2u].data()}};
+  mesh_comm.spread_grid(::comm_cart, meshes, local_mesh.dim);
+}
+
+void FFTBackendLegacy::perform_fwd_fft() {
+  if (dipolar) {
+    std::array<double *, 3u> meshes = {{rs_mesh_fields[0u].data(),
+                                        rs_mesh_fields[1u].data(),
+                                        rs_mesh_fields[2u].data()}};
+    mesh_comm.gather_grid(::comm_cart, meshes, local_mesh.dim);
+    for (auto &rs_mesh_field : rs_mesh_fields) {
+      fft->forward_fft(::comm_cart, rs_mesh_field.data());
+    }
+  } else {
+    mesh_comm.gather_grid(::comm_cart, rs_mesh.data(), local_mesh.dim);
+    fft->forward_fft(::comm_cart, rs_mesh.data());
+  }
+  update_mesh_data();
+}
+
+void FFTBackendLegacy::perform_space_back_fft() {
+  /* Back FFT force component mesh */
+  fft->backward_fft(::comm_cart, rs_mesh.data(), check_complex_residuals);
+  /* redistribute force component mesh */
+  mesh_comm.spread_grid(::comm_cart, rs_mesh.data(), local_mesh.dim);
+}
+
+#endif // defined(P3M) or defined(DP3M)

--- a/src/core/p3m/FFTBackendLegacy.cpp
+++ b/src/core/p3m/FFTBackendLegacy.cpp
@@ -36,8 +36,8 @@
 #include <span>
 #include <utility>
 
-FFTBackendLegacy::FFTBackendLegacy(p3m_data_struct &obj)
-    : FFTBackend(obj),
+FFTBackendLegacy::FFTBackendLegacy(p3m_data_struct &obj, bool dipolar)
+    : FFTBackend(obj), dipolar{dipolar},
       fft{std::make_unique<fft::fft_data_struct>(
           ::Communication::mpiCallbacksHandle()->share_mpi_env())} {}
 

--- a/src/core/p3m/FFTBackendLegacy.hpp
+++ b/src/core/p3m/FFTBackendLegacy.hpp
@@ -44,6 +44,7 @@ struct fft_data_struct;
  * The 3D FFT is split into three 1D FFTs.
  */
 class FFTBackendLegacy : public FFTBackend {
+  bool dipolar;
   std::unique_ptr<fft::fft_data_struct> fft;
   /** @brief k-space mesh (local) for k-space calculations. */
   std::vector<double> ks_mesh;
@@ -54,7 +55,7 @@ class FFTBackendLegacy : public FFTBackend {
   p3m_send_mesh mesh_comm;
 
 public:
-  explicit FFTBackendLegacy(p3m_data_struct &obj);
+  explicit FFTBackendLegacy(p3m_data_struct &obj, bool dipolar);
   ~FFTBackendLegacy() override;
   void init_fft() override;
   void perform_fwd_fft() override;

--- a/src/core/p3m/FFTBackendLegacy.hpp
+++ b/src/core/p3m/FFTBackendLegacy.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2010-2024 The ESPResSo project
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
+ *   Max-Planck-Institute for Polymer Research, Theory Group
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config/config.hpp"
+
+#if defined(P3M) or defined(DP3M)
+
+#include "common.hpp"
+#include "data_struct.hpp"
+#include "send_mesh.hpp"
+
+#include "fft/vector.hpp"
+
+#include <array>
+#include <memory>
+#include <tuple>
+
+namespace fft {
+struct fft_data_struct;
+} // namespace fft
+
+/**
+ * @brief Historic FFT backend based on FFTW3.
+ * The 3D FFT is split into three 1D FFTs.
+ */
+class FFTBackendLegacy : public FFTBackend {
+  std::unique_ptr<fft::fft_data_struct> fft;
+  /** @brief k-space mesh (local) for k-space calculations. */
+  std::vector<double> ks_mesh;
+  /** @brief real-space mesh (local) for CA/FFT. */
+  fft::vector<double> rs_mesh;
+  /** @brief real-space mesh (local) for the electric or dipolar field. */
+  std::array<fft::vector<double>, 3> rs_mesh_fields;
+  p3m_send_mesh mesh_comm;
+
+public:
+  explicit FFTBackendLegacy(p3m_data_struct &obj);
+  ~FFTBackendLegacy() override;
+  void init_fft() override;
+  void perform_fwd_fft() override;
+  void perform_field_back_fft() override;
+  void perform_space_back_fft() override;
+  void update_mesh_data();
+
+  /**
+   * @brief Index helpers for reciprocal space.
+   * After the FFT the data is in order YZX, which
+   * means that Y is the slowest changing index.
+   */
+  std::tuple<int, int, int> get_permutations() const override {
+    constexpr static int KX = 2;
+    constexpr static int KY = 0;
+    constexpr static int KZ = 1;
+    return {KX, KY, KZ};
+  }
+};
+
+#endif // defined(P3M) or defined(DP3M)

--- a/src/core/p3m/common.cpp
+++ b/src/core/p3m/common.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 The ESPResSo project
+ * Copyright (C) 2010-2024 The ESPResSo project
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
  *   Max-Planck-Institute for Polymer Research, Theory Group
  *
@@ -21,7 +21,7 @@
 
 #include "config/config.hpp"
 
-#if defined(P3M) || defined(DP3M)
+#if defined(P3M) or defined(DP3M)
 
 #include "common.hpp"
 
@@ -105,4 +105,4 @@ void P3MLocalMesh::calc_local_ca_mesh(P3MParameters const &params,
   q_21_off = dim[2] * (dim[1] - params.cao);
 }
 
-#endif /* defined(P3M) || defined(DP3M) */
+#endif // defined(P3M) or defined(DP3M)

--- a/src/core/p3m/common.hpp
+++ b/src/core/p3m/common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 The ESPResSo project
+ * Copyright (C) 2010-2024 The ESPResSo project
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
  *   Max-Planck-Institute for Polymer Research, Theory Group
  *
@@ -45,27 +45,15 @@
 /** This value indicates metallic boundary conditions. */
 auto constexpr P3M_EPSILON_METALLIC = 0.0;
 
-#if defined(P3M) || defined(DP3M)
+#if defined(P3M) or defined(DP3M)
 
 #include "LocalBox.hpp"
 
-#include <array>
 #include <cstddef>
+#include <span>
 #include <stdexcept>
-#include <vector>
 
-namespace detail {
-/** @brief Index helpers for direct and reciprocal space.
- *  After the FFT the data is in order YZX, which
- *  means that Y is the slowest changing index.
- */
-namespace FFT_indexing {
-enum FFT_REAL_VECTOR : int { RX = 0, RY = 1, RZ = 2 };
-enum FFT_WAVE_VECTOR : int { KY = 0, KZ = 1, KX = 2 };
-} // namespace FFT_indexing
-} // namespace detail
-
-/** Structure to hold P3M parameters and some dependent variables. */
+/** @brief Structure to hold P3M parameters and some dependent variables. */
 struct P3MParameters {
   /** tuning or production? */
   bool tuning;
@@ -181,9 +169,8 @@ struct P3MParameters {
   }
 };
 
-/** Structure for local mesh parameters. */
+/** @brief Properties of the local mesh. */
 struct P3MLocalMesh {
-  /* local mesh characterization. */
   /** dimension (size) of local mesh. */
   Utils::Vector3i dim;
   /** number of local mesh points. */
@@ -228,7 +215,27 @@ struct P3MLocalMesh {
                           double space_layer);
 };
 
-#endif /* P3M || DP3M */
+/** @brief Local mesh FFT buffers. */
+struct P3MFFTMesh {
+  /** @brief k-space scalar mesh for k-space calculations. */
+  std::span<double> ks_scalar;
+  /** @brief real-space scalar mesh for charge assignment and FFT. */
+  std::span<double> rs_scalar;
+  /** @brief real-space 3D meshes for the electric or dipolar field. */
+  std::array<std::span<double>, 3> rs_fields;
+
+  /** @brief Indices of the lower left corner of the local mesh grid. */
+  Utils::Vector3i start;
+  /** @brief Indices of the upper right corner of the local mesh grid. */
+  Utils::Vector3i stop;
+  /** @brief Extents of the local mesh grid. */
+  Utils::Vector3i size;
+
+  /** @brief number of permutations in k_space */
+  int ks_pnum = 0;
+};
+
+#endif // defined(P3M) or defined(DP3M)
 
 namespace detail {
 /** Calculate indices that shift @ref P3MParameters::mesh "mesh" by `mesh/2`.

--- a/src/core/p3m/data_struct.hpp
+++ b/src/core/p3m/data_struct.hpp
@@ -77,8 +77,6 @@ struct p3m_data_struct {
     assert(fft == nullptr);
     fft = std::make_unique<T>(*this, args...);
   }
-
-  inline void set_dipolar_mode();
 };
 
 /**
@@ -94,7 +92,6 @@ protected:
   P3MFFTMesh &mesh;
 
 public:
-  bool dipolar = false;
   bool check_complex_residuals = false;
   explicit FFTBackend(p3m_data_struct &obj)
       : params{obj.params}, local_mesh{obj.local_mesh}, mesh{obj.mesh} {}
@@ -110,12 +107,5 @@ public:
   /** @brief Get indices of the k-space data layout. */
   virtual std::tuple<int, int, int> get_permutations() const = 0;
 };
-
-void p3m_data_struct::set_dipolar_mode() {
-  assert(g_energy.empty() and g_force.empty());
-  assert(d_op[0u].empty() and d_op[1u].empty() and d_op[2u].empty());
-  assert(not fft->dipolar);
-  fft->dipolar = true;
-}
 
 #endif // defined(P3M) or defined(DP3M)

--- a/src/core/p3m/for_each_3d.hpp
+++ b/src/core/p3m/for_each_3d.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <concepts>
+#include <cstddef>
 
 namespace detail {
 

--- a/src/core/p3m/interpolation.hpp
+++ b/src/core/p3m/interpolation.hpp
@@ -18,8 +18,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ESPRESSO_CORE_P3M_INTERPOLATION_HPP
-#define ESPRESSO_CORE_P3M_INTERPOLATION_HPP
+
+#pragma once
 
 #include <utils/index.hpp>
 #include <utils/math/bspline.hpp>
@@ -206,5 +206,3 @@ void p3m_interpolate(P3MLocalMesh const &local_mesh,
     q_ind += local_mesh.q_21_off;
   }
 }
-
-#endif

--- a/src/core/p3m/send_mesh.cpp
+++ b/src/core/p3m/send_mesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 The ESPResSo project
+ * Copyright (C) 2010-2024 The ESPResSo project
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
  *   Max-Planck-Institute for Polymer Research, Theory Group
  *
@@ -18,12 +18,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "config/config.hpp"
 
-#if defined(P3M) || defined(DP3M)
+#if defined(P3M) or defined(DP3M)
 
+#include "fft/fft.hpp"
 #include "p3m/common.hpp"
-#include "p3m/fft.hpp"
 #include "p3m/send_mesh.hpp"
 
 #include <utils/Vector.hpp>
@@ -70,8 +71,8 @@ static void p3m_add_block(double const *in, double *out, int const start[3],
   }
 }
 
-void p3m_send_mesh::resize(const boost::mpi::communicator &comm,
-                           const P3MLocalMesh &local_mesh) {
+void p3m_send_mesh::resize(boost::mpi::communicator const &comm,
+                           P3MLocalMesh const &local_mesh) {
   int done[3] = {0, 0, 0};
   /* send grids */
   for (int i = 0; i < 3; i++) {
@@ -145,9 +146,9 @@ void p3m_send_mesh::resize(const boost::mpi::communicator &comm,
   }
 }
 
-void p3m_send_mesh::gather_grid(std::span<double *> meshes,
-                                const boost::mpi::communicator &comm,
-                                const Utils::Vector3i &dim) {
+void p3m_send_mesh::gather_grid(boost::mpi::communicator const &comm,
+                                std::span<double *> meshes,
+                                Utils::Vector3i const &dim) {
   auto const node_neighbors = Utils::Mpi::cart_neighbors<3>(comm);
   send_grid.resize(max * meshes.size());
   recv_grid.resize(max * meshes.size());
@@ -159,8 +160,8 @@ void p3m_send_mesh::gather_grid(std::span<double *> meshes,
     /* pack send block */
     if (s_size[s_dir] > 0)
       for (std::size_t i = 0; i < meshes.size(); i++) {
-        fft_pack_block(meshes[i], send_grid.data() + i * s_size[s_dir],
-                       s_ld[s_dir], s_dim[s_dir], dim.data(), 1);
+        fft::fft_pack_block(meshes[i], send_grid.data() + i * s_size[s_dir],
+                            s_ld[s_dir], s_dim[s_dir], dim.data(), 1);
       }
 
     /* communication */
@@ -183,9 +184,9 @@ void p3m_send_mesh::gather_grid(std::span<double *> meshes,
   }
 }
 
-void p3m_send_mesh::spread_grid(std::span<double *> meshes,
-                                const boost::mpi::communicator &comm,
-                                const Utils::Vector3i &dim) {
+void p3m_send_mesh::spread_grid(boost::mpi::communicator const &comm,
+                                std::span<double *> meshes,
+                                Utils::Vector3i const &dim) {
   auto const node_neighbors = Utils::Mpi::cart_neighbors<3>(comm);
   send_grid.resize(max * meshes.size());
   recv_grid.resize(max * meshes.size());
@@ -197,8 +198,8 @@ void p3m_send_mesh::spread_grid(std::span<double *> meshes,
     /* pack send block */
     if (r_size[r_dir] > 0)
       for (std::size_t i = 0; i < meshes.size(); i++) {
-        fft_pack_block(meshes[i], send_grid.data() + i * r_size[r_dir],
-                       r_ld[r_dir], r_dim[r_dir], dim.data(), 1);
+        fft::fft_pack_block(meshes[i], send_grid.data() + i * r_size[r_dir],
+                            r_ld[r_dir], r_dim[r_dir], dim.data(), 1);
       }
     /* communication */
     if (node_neighbors[r_dir] != comm.rank()) {
@@ -213,11 +214,11 @@ void p3m_send_mesh::spread_grid(std::span<double *> meshes,
     /* un pack recv block */
     if (s_size[s_dir] > 0) {
       for (std::size_t i = 0; i < meshes.size(); i++) {
-        fft_unpack_block(recv_grid.data() + i * s_size[s_dir], meshes[i],
-                         s_ld[s_dir], s_dim[s_dir], dim.data(), 1);
+        fft::fft_unpack_block(recv_grid.data() + i * s_size[s_dir], meshes[i],
+                              s_ld[s_dir], s_dim[s_dir], dim.data(), 1);
       }
     }
   }
 }
 
-#endif
+#endif // defined(P3M) or defined(DP3M)

--- a/src/core/p3m/send_mesh.hpp
+++ b/src/core/p3m/send_mesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 The ESPResSo project
+ * Copyright (C) 2010-2024 The ESPResSo project
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010
  *   Max-Planck-Institute for Polymer Research, Theory Group
  *
@@ -18,12 +18,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ESPRESSO_CORE_P3M_SEND_MESH_HPP
-#define ESPRESSO_CORE_P3M_SEND_MESH_HPP
+
+#pragma once
 
 #include "config/config.hpp"
 
-#if defined(P3M) || defined(DP3M)
+#if defined(P3M) or defined(DP3M)
 
 #include "p3m/common.hpp"
 
@@ -66,22 +66,20 @@ class p3m_send_mesh {
   std::vector<double> recv_grid;
 
 public:
-  void resize(const boost::mpi::communicator &comm,
-              const P3MLocalMesh &local_mesh);
-  void gather_grid(std::span<double *> meshes,
-                   const boost::mpi::communicator &comm,
-                   const Utils::Vector3i &dim);
-  void gather_grid(double *mesh, const boost::mpi::communicator &comm,
-                   const Utils::Vector3i &dim) {
-    gather_grid(std::span(&mesh, 1u), comm, dim);
+  void resize(boost::mpi::communicator const &comm,
+              P3MLocalMesh const &local_mesh);
+  void gather_grid(boost::mpi::communicator const &comm,
+                   std::span<double *> meshes, Utils::Vector3i const &dim);
+  void gather_grid(boost::mpi::communicator const &comm, double *mesh,
+                   Utils::Vector3i const &dim) {
+    gather_grid(comm, std::span(&mesh, 1u), dim);
   }
-  void spread_grid(std::span<double *> meshes,
-                   const boost::mpi::communicator &comm,
-                   const Utils::Vector3i &dim);
-  void spread_grid(double *mesh, const boost::mpi::communicator &comm,
-                   const Utils::Vector3i &dim) {
-    spread_grid(std::span(&mesh, 1u), comm, dim);
+  void spread_grid(boost::mpi::communicator const &comm,
+                   std::span<double *> meshes, Utils::Vector3i const &dim);
+  void spread_grid(boost::mpi::communicator const &comm, double *mesh,
+                   Utils::Vector3i const &dim) {
+    spread_grid(comm, std::span(&mesh, 1u), dim);
   }
 };
-#endif
-#endif
+
+#endif // defined(P3M) or defined(DP3M)

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -49,6 +49,7 @@ namespace utf = boost::unit_test;
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "observables/ParticleVelocities.hpp"
 #include "observables/PidObservable.hpp"
+#include "p3m/FFTBackendLegacy.hpp"
 #include "particle_node.hpp"
 #include "system/System.hpp"
 
@@ -313,6 +314,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
                              1e-3};
     auto solver =
         std::make_shared<CoulombP3M>(std::move(p3m), prefactor, 1, false, true);
+    solver->p3m.make_fft_instance<FFTBackendLegacy>();
     add_actor(comm, espresso::system, system.coulomb.impl->solver, solver,
               [&system]() { system.on_coulomb_change(); });
 

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -314,7 +314,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
                              1e-3};
     auto solver =
         std::make_shared<CoulombP3M>(std::move(p3m), prefactor, 1, false, true);
-    solver->p3m.make_fft_instance<FFTBackendLegacy>();
+    solver->p3m.make_fft_instance<FFTBackendLegacy>(false);
     add_actor(comm, espresso::system, system.coulomb.impl->solver, solver,
               [&system]() { system.on_coulomb_change(); });
 

--- a/src/core/unit_tests/fft_test.cpp
+++ b/src/core/unit_tests/fft_test.cpp
@@ -22,11 +22,12 @@
 
 #include "config/config.hpp"
 
-#if defined(P3M) || defined(DP3M)
+#if defined(P3M) or defined(DP3M)
 
 #include <boost/test/unit_test.hpp>
 
-#include "p3m/fft.hpp"
+#include "fft/fft.hpp"
+#include "fft/vector.hpp"
 #include "p3m/for_each_3d.hpp"
 
 #include <utils/Vector.hpp>
@@ -39,13 +40,8 @@
 #include <stdexcept>
 #include <vector>
 
-std::optional<std::vector<int>> find_comm_groups(Utils::Vector3i const &,
-                                                 Utils::Vector3i const &,
-                                                 std::span<int const>,
-                                                 std::span<int>, std::span<int>,
-                                                 std::span<int>, int);
-
 BOOST_AUTO_TEST_CASE(fft_find_comm_groups_mismatch) {
+  using fft::find_comm_groups;
   int my_pos[3] = {0};
   int nodelist[4] = {0};
   int nodepos[12] = {0};
@@ -68,6 +64,7 @@ BOOST_AUTO_TEST_CASE(fft_find_comm_groups_mismatch) {
 }
 
 BOOST_AUTO_TEST_CASE(fft_map_grid) {
+  using fft::map_3don2d_grid;
   {
     auto g3d = Utils::Vector3i{{3, 2, 1}};
     auto g2d = Utils::Vector3i{{3, 2, 1}};
@@ -161,7 +158,7 @@ BOOST_AUTO_TEST_CASE(fft_map_grid) {
 BOOST_AUTO_TEST_CASE(fft_exceptions) {
   auto constexpr size_max = std::numeric_limits<std::size_t>::max();
   auto constexpr bad_size = size_max / sizeof(int) + 1ul;
-  fft_allocator<int> allocator{};
+  fft::allocator<int> allocator{};
   BOOST_CHECK_EQUAL(allocator.allocate(0ul), nullptr);
   BOOST_CHECK_THROW(allocator.allocate(bad_size), std::bad_array_new_length);
 }
@@ -203,6 +200,6 @@ BOOST_AUTO_TEST_CASE(for_each_3d_test) {
   }
 }
 
-#else  // defined(P3M) || defined(DP3M)
+#else  // defined(P3M) or defined(DP3M)
 int main(int argc, char **argv) {}
-#endif // defined(P3M) || defined(DP3M)
+#endif // defined(P3M) or defined(DP3M)

--- a/src/script_interface/electrostatics/CoulombP3M.hpp
+++ b/src/script_interface/electrostatics/CoulombP3M.hpp
@@ -26,6 +26,7 @@
 #include "Actor.hpp"
 
 #include "core/electrostatics/p3m.hpp"
+#include "core/p3m/FFTBackendLegacy.hpp"
 
 #include "script_interface/get_value.hpp"
 
@@ -88,6 +89,7 @@ public:
           std::move(p3m), get_value<double>(params, "prefactor"),
           get_value<int>(params, "timings"), get_value<bool>(params, "verbose"),
           get_value<bool>(params, "check_complex_residuals"));
+      m_actor->p3m.make_fft_instance<FFTBackendLegacy>();
     });
     set_charge_neutrality_tolerance(params);
   }

--- a/src/script_interface/electrostatics/CoulombP3M.hpp
+++ b/src/script_interface/electrostatics/CoulombP3M.hpp
@@ -89,7 +89,7 @@ public:
           std::move(p3m), get_value<double>(params, "prefactor"),
           get_value<int>(params, "timings"), get_value<bool>(params, "verbose"),
           get_value<bool>(params, "check_complex_residuals"));
-      m_actor->p3m.make_fft_instance<FFTBackendLegacy>();
+      m_actor->p3m.make_fft_instance<FFTBackendLegacy>(false);
     });
     set_charge_neutrality_tolerance(params);
   }

--- a/src/script_interface/electrostatics/CoulombP3MGPU.hpp
+++ b/src/script_interface/electrostatics/CoulombP3MGPU.hpp
@@ -27,6 +27,7 @@
 #include "Actor.hpp"
 
 #include "core/electrostatics/p3m_gpu.hpp"
+#include "core/p3m/FFTBackendLegacy.hpp"
 
 #include "script_interface/get_value.hpp"
 
@@ -89,6 +90,7 @@ public:
           std::move(p3m), get_value<double>(params, "prefactor"),
           get_value<int>(params, "timings"), get_value<bool>(params, "verbose"),
           get_value<bool>(params, "check_complex_residuals"));
+      m_actor->p3m.make_fft_instance<FFTBackendLegacy>(); // for CPU part
     });
     set_charge_neutrality_tolerance(params);
   }

--- a/src/script_interface/electrostatics/CoulombP3MGPU.hpp
+++ b/src/script_interface/electrostatics/CoulombP3MGPU.hpp
@@ -90,7 +90,7 @@ public:
           std::move(p3m), get_value<double>(params, "prefactor"),
           get_value<int>(params, "timings"), get_value<bool>(params, "verbose"),
           get_value<bool>(params, "check_complex_residuals"));
-      m_actor->p3m.make_fft_instance<FFTBackendLegacy>(); // for CPU part
+      m_actor->p3m.make_fft_instance<FFTBackendLegacy>(false); // for CPU part
     });
     set_charge_neutrality_tolerance(params);
   }

--- a/src/script_interface/magnetostatics/DipolarP3M.hpp
+++ b/src/script_interface/magnetostatics/DipolarP3M.hpp
@@ -86,8 +86,7 @@ public:
           std::move(p3m), get_value<double>(params, "prefactor"),
           get_value<int>(params, "timings"),
           get_value<bool>(params, "verbose"));
-      m_actor->dp3m.make_fft_instance<FFTBackendLegacy>();
-      m_actor->dp3m.set_dipolar_mode();
+      m_actor->dp3m.make_fft_instance<FFTBackendLegacy>(true);
     });
   }
 };

--- a/src/script_interface/magnetostatics/DipolarP3M.hpp
+++ b/src/script_interface/magnetostatics/DipolarP3M.hpp
@@ -26,6 +26,7 @@
 #include "Actor.hpp"
 
 #include "core/magnetostatics/dp3m.hpp"
+#include "core/p3m/FFTBackendLegacy.hpp"
 
 #include "script_interface/get_value.hpp"
 
@@ -85,6 +86,8 @@ public:
           std::move(p3m), get_value<double>(params, "prefactor"),
           get_value<int>(params, "timings"),
           get_value<bool>(params, "verbose"));
+      m_actor->dp3m.make_fft_instance<FFTBackendLegacy>();
+      m_actor->dp3m.set_dipolar_mode();
     });
   }
 };


### PR DESCRIPTION
Fixes #4945

Description of changes:
- fully encapsulate the historic FFT implementation
   - electrostatics and magnetostatics now share the same FFT operations
   - FFT operations and mesh buffers are now better documented
   - all temporary mesh buffers are now private data members
- provide a type-erased API for the FFT backend
   - the P3M algorithm no longer has visibility of the FFT library
   - new FFT libraries can be used in place of the historic FFT implementation
- bugfixes:
   - the P3M algorithm no longer leaks memory when FFT plans are discarded
   - the FFT implementation now keeps the MPI environment alive until all FFT plans have been destroyed
      - avoids a race condition, since the FFT plan destructor need a MPI communicator