### PR TITLE
Rewrite ParticleForce operator+ to improve performance.

### DIFF
--- a/src/core/Particle.hpp
+++ b/src/core/Particle.hpp
@@ -299,15 +299,17 @@ struct ParticleForce {
 
   friend ParticleForce operator+(ParticleForce const &lhs,
                                  ParticleForce const &rhs) {
-#ifdef ROTATION
-    return {lhs.f + rhs.f, lhs.torque + rhs.torque};
-#else
-    return lhs.f + rhs.f;
-#endif
+    ParticleForce result = lhs;
+    result += rhs;
+    return result;
   }
 
   ParticleForce &operator+=(ParticleForce const &rhs) {
-    return *this = *this + rhs;
+    f += rhs.f;
+#ifdef ROTATION
+    torque += rhs.torque;
+#endif
+    return *this;
   }
 
   /** force. */


### PR DESCRIPTION
Description of changes:

- Reduce potential copies made in operator+ of the ParticleForce struct by using operator+= to implement operator+ instead of the other way around.
- More information about the performance impact of this are here: https://github.com/espressomd/espresso/issues/4866.