### PR TITLE
Introduce an event on_lees_edwards_change

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -435,7 +435,8 @@ check_sphinx:
   <<: *global_job_definition
   stage: additional_checks
   needs:
-    - cuda12-maxset
+    - job: cuda12-maxset
+      artifacts: true
   when: on_success
   script:
     - cd ${CI_PROJECT_DIR}/build
@@ -458,7 +459,8 @@ run_tutorials:
   <<: *global_job_definition
   stage: additional_checks
   needs:
-    - cuda12-maxset
+    - job: cuda12-maxset
+      artifacts: true
   when: on_success
   script:
     - cd ${CI_PROJECT_DIR}/build
@@ -486,7 +488,8 @@ run_doxygen:
   <<: *global_job_definition
   stage: additional_checks
   needs:
-    - cuda12-maxset
+    - job: cuda12-maxset
+      artifacts: true
   when: on_success
   only:
     - python
@@ -508,7 +511,8 @@ maxset_no_gpu:
   stage: additional_checks
   when: on_success
   needs:
-    - cuda12-maxset
+    - job: cuda12-maxset
+      artifacts: true
   script:
     - export CUDA_VISIBLE_DEVICES=""
     - cd ${CI_PROJECT_DIR}/build
@@ -524,15 +528,32 @@ maxset_3_cores:
   stage: additional_checks
   when: on_success
   needs:
-    - cuda12-maxset
+    - job: cuda12-maxset
+      artifacts: false
+  variables:
+     CC: 'gcc-12'
+     CXX: 'g++-12'
+     GCOV: 'gcov-12'
+     myconfig: 'maxset'
+     with_cuda: 'true'
+     with_coverage: 'false'
+     with_coverage_python: 'false'
+     srcdir: '${CI_PROJECT_DIR}'
+     with_scafacos: 'true'
+     with_walberla: 'true'
+     with_walberla_avx: 'true'
+     with_stokesian_dynamics: 'true'
+     with_caliper: 'true'
+     check_odd_only: 'true'
+     cmake_params: '-D ESPRESSO_TEST_NP=3'
   script:
-    - cd ${CI_PROJECT_DIR}/build
-    - cmake -D ESPRESSO_TEST_NP=3 .
-    - make -t && make check_unit_tests && make check_python_parallel_odd
+    - bash maintainer/CI/build_cmake.sh
+  timeout: 90m
   tags:
     - espresso
     - cuda
     - numa
+    - avx2
     - reuse-artifacts-same-arch
 
 status_success:

--- a/src/core/lb/LBNone.hpp
+++ b/src/core/lb/LBNone.hpp
@@ -67,6 +67,8 @@ struct LBNone {
   void on_node_grid_change() const { throw NoLBActive{}; }
   void on_timestep_change() const { throw NoLBActive{}; }
   void on_temperature_change() const { throw NoLBActive{}; }
+  void on_lees_edwards_change() const { throw NoLBActive{}; }
+  void update_collision_model() const { throw NoLBActive{}; }
 };
 
 } // namespace LB

--- a/src/core/lb/LBWalberla.cpp
+++ b/src/core/lb/LBWalberla.cpp
@@ -38,6 +38,7 @@
 #include <utils/math/int_pow.hpp>
 
 #include <optional>
+#include <variant>
 
 namespace LB {
 
@@ -128,7 +129,9 @@ void LBWalberla::update_collision_model(LBWalberlaBase &lb,
                                         LBWalberlaParams &params, double kT,
                                         unsigned int seed) {
   auto const &system = ::System::get_system();
-  if (auto le_protocol = system.lees_edwards->get_protocol()) {
+  auto le_protocol = system.lees_edwards->get_protocol();
+  if (le_protocol and
+      not std::holds_alternative<LeesEdwards::Off>(*le_protocol)) {
     if (kT != 0.) {
       throw std::runtime_error(
           "Lees-Edwards LB doesn't support thermalization");

--- a/src/core/lb/LBWalberla.hpp
+++ b/src/core/lb/LBWalberla.hpp
@@ -88,6 +88,11 @@ struct LBWalberla {
   }
   void on_timestep_change() const {}
   void on_temperature_change() const {}
+  void on_lees_edwards_change();
+  void update_collision_model();
+  static void update_collision_model(LBWalberlaBase &instance,
+                                     LBWalberlaParams &params, double kT,
+                                     unsigned int seed);
 };
 
 } // namespace LB

--- a/src/core/lb/Solver.cpp
+++ b/src/core/lb/Solver.cpp
@@ -140,6 +140,18 @@ void Solver::on_temperature_change() {
   }
 }
 
+void Solver::on_lees_edwards_change() {
+  if (impl->solver) {
+    std::visit([](auto &ptr) { ptr->on_lees_edwards_change(); }, *impl->solver);
+  }
+}
+
+void Solver::update_collision_model() {
+  if (impl->solver) {
+    std::visit([](auto &ptr) { ptr->update_collision_model(); }, *impl->solver);
+  }
+}
+
 bool Solver::is_gpu() const {
   check_solver(impl);
   return std::visit([](auto &ptr) { return ptr->is_gpu(); }, *impl->solver);

--- a/src/core/lb/Solver.hpp
+++ b/src/core/lb/Solver.hpp
@@ -168,6 +168,8 @@ struct Solver : public System::Leaf<Solver> {
   void on_cell_structure_change();
   void on_timestep_change();
   void on_temperature_change();
+  void on_lees_edwards_change();
+  void update_collision_model();
   void veto_boxl_change() const;
 
 private:

--- a/src/core/system/System.cpp
+++ b/src/core/system/System.cpp
@@ -378,6 +378,8 @@ void System::on_observable_calc() {
   clear_particle_node();
 }
 
+void System::on_lees_edwards_change() { lb.on_lees_edwards_change(); }
+
 void System::update_local_geo() {
   *local_geo = LocalBox::make_regular_decomposition(
       box_geo->length(), ::communicator.calc_node_index(),

--- a/src/core/system/System.hpp
+++ b/src/core/system/System.hpp
@@ -253,6 +253,7 @@ public:
    *  initialized immediately (P3M etc.).
    */
   void on_observable_calc();
+  void on_lees_edwards_change();
   void veto_boxl_change(bool skip_particle_checks = false) const;
   /**@}*/
 

--- a/src/core/unit_tests/lb_particle_coupling_test.cpp
+++ b/src/core/unit_tests/lb_particle_coupling_test.cpp
@@ -608,11 +608,13 @@ BOOST_AUTO_TEST_CASE(lb_exceptions) {
     BOOST_CHECK_THROW(lb.veto_kT(0.), NoLBActive);
     BOOST_CHECK_THROW(lb.lebc_sanity_checks(0u, 1u), NoLBActive);
     BOOST_CHECK_THROW(lb.propagate(), NoLBActive);
+    BOOST_CHECK_THROW(lb.update_collision_model(), NoLBActive);
     BOOST_CHECK_THROW(lb.on_cell_structure_change(), NoLBActive);
     BOOST_CHECK_THROW(lb.on_boxl_change(), NoLBActive);
     BOOST_CHECK_THROW(lb.on_node_grid_change(), NoLBActive);
     BOOST_CHECK_THROW(lb.on_timestep_change(), NoLBActive);
     BOOST_CHECK_THROW(lb.on_temperature_change(), NoLBActive);
+    BOOST_CHECK_THROW(lb.on_lees_edwards_change(), NoLBActive);
     BOOST_CHECK_THROW(lb_impl->get_density_at_pos(vec, true), NoLBActive);
     BOOST_CHECK_THROW(lb_impl->get_velocity_at_pos(vec, true), NoLBActive);
     BOOST_CHECK_THROW(lb_impl->add_force_at_pos(vec, vec), NoLBActive);

--- a/src/script_interface/lees_edwards/LeesEdwards.hpp
+++ b/src/script_interface/lees_edwards/LeesEdwards.hpp
@@ -103,12 +103,13 @@ public:
           throw std::invalid_argument("Parameters 'shear_direction' and "
                                       "'shear_plane_normal' must differ");
         }
-        auto const &system = get_system();
+        auto &system = get_system();
         system.lb.lebc_sanity_checks(shear_direction, shear_plane_normal);
         // update box geometry and cell structure
         system.box_geo->set_lees_edwards_bc(
             LeesEdwardsBC{0., 0., shear_direction, shear_plane_normal});
         m_lees_edwards->set_protocol(m_protocol->protocol());
+        system.on_lees_edwards_change();
       });
     }
     return {};

--- a/src/script_interface/lees_edwards/LeesEdwards.hpp
+++ b/src/script_interface/lees_edwards/LeesEdwards.hpp
@@ -45,15 +45,16 @@ public:
     add_parameters(
         {{"protocol",
           [this](Variant const &value) {
+            auto &system = get_system();
             if (is_none(value)) {
-              auto const &system = get_system();
-              context()->parallel_try_catch([&system]() {
+              context()->parallel_try_catch([&]() {
                 auto constexpr invalid_dir = LeesEdwardsBC::invalid_dir;
                 system.lb.lebc_sanity_checks(invalid_dir, invalid_dir);
               });
               m_protocol = nullptr;
               system.box_geo->set_lees_edwards_bc(LeesEdwardsBC{});
               m_lees_edwards->unset_protocol();
+              system.on_lees_edwards_change();
               return;
             }
             context()->parallel_try_catch([this]() {
@@ -67,8 +68,15 @@ public:
                     "activation via set_boundary_conditions()");
               }
             });
-            m_protocol = get_value<std::shared_ptr<Protocol>>(value);
-            m_lees_edwards->set_protocol(m_protocol->protocol());
+            auto const protocol = get_value<std::shared_ptr<Protocol>>(value);
+            context()->parallel_try_catch([&]() {
+              try {
+                set_protocol(protocol);
+              } catch (...) {
+                set_protocol(m_protocol);
+                throw;
+              }
+            });
           },
           [this]() {
             if (m_protocol)
@@ -89,13 +97,13 @@ public:
                          VariantMap const &params) override {
     if (name == "set_boundary_conditions") {
       context()->parallel_try_catch([this, &params]() {
-        auto const protocol = params.at("protocol");
-        if (is_none(protocol)) {
-          do_set_parameter("protocol", protocol);
+        auto const variant = params.at("protocol");
+        if (is_none(variant)) {
+          do_set_parameter("protocol", variant);
           return;
         }
         // check input arguments
-        m_protocol = get_value<std::shared_ptr<Protocol>>(protocol);
+        auto const protocol = get_value<std::shared_ptr<Protocol>>(variant);
         auto const shear_direction = get_shear_axis(params, "shear_direction");
         auto const shear_plane_normal =
             get_shear_axis(params, "shear_plane_normal");
@@ -106,10 +114,18 @@ public:
         auto &system = get_system();
         system.lb.lebc_sanity_checks(shear_direction, shear_plane_normal);
         // update box geometry and cell structure
-        system.box_geo->set_lees_edwards_bc(
-            LeesEdwardsBC{0., 0., shear_direction, shear_plane_normal});
-        m_lees_edwards->set_protocol(m_protocol->protocol());
-        system.on_lees_edwards_change();
+        auto const old_shear_direction = get_lebc().shear_direction;
+        auto const old_shear_plane_normal = get_lebc().shear_plane_normal;
+        try {
+          system.box_geo->set_lees_edwards_bc(
+              LeesEdwardsBC{0., 0., shear_direction, shear_plane_normal});
+          set_protocol(protocol);
+        } catch (...) {
+          system.box_geo->set_lees_edwards_bc(LeesEdwardsBC{
+              0., 0., old_shear_direction, old_shear_plane_normal});
+          set_protocol(m_protocol);
+          throw;
+        }
       });
     }
     return {};
@@ -158,6 +174,18 @@ private:
       do_call_method("set_boundary_conditions", params);
     }
     m_params.reset();
+  }
+
+  void set_protocol(std::shared_ptr<Protocol> const &protocol) {
+    auto &system = get_system();
+    if (protocol) {
+      m_lees_edwards->set_protocol(protocol->protocol());
+    } else {
+      system.box_geo->set_lees_edwards_bc(LeesEdwardsBC{});
+      m_lees_edwards->unset_protocol();
+    }
+    system.on_lees_edwards_change();
+    m_protocol = protocol;
   }
 };
 

--- a/src/script_interface/walberla/LBFluid.hpp
+++ b/src/script_interface/walberla/LBFluid.hpp
@@ -51,7 +51,6 @@ protected:
   using Base = LatticeModel<::LBWalberlaBase, LBVTKHandle>;
   std::shared_ptr<::LB::LBWalberlaParams> m_lb_params;
   bool m_is_active;
-  int m_seed;
   double m_conv_dist;
   double m_conv_visc;
   double m_conv_dens;
@@ -77,7 +76,8 @@ public:
          [this]() { return m_instance->get_lattice().get_grid_dimensions(); }},
         {"kT", AutoParameter::read_only,
          [this]() { return m_instance->get_kT() / m_conv_energy; }},
-        {"seed", AutoParameter::read_only, [this]() { return m_seed; }},
+        {"seed", AutoParameter::read_only,
+         [this]() { return static_cast<int>(m_instance->get_seed()); }},
         {"rng_state",
          [this](Variant const &v) {
            auto const rng_state = get_value<int>(v);

--- a/src/walberla_bridge/include/walberla_bridge/lattice_boltzmann/LBWalberlaBase.hpp
+++ b/src/walberla_bridge/include/walberla_bridge/lattice_boltzmann/LBWalberlaBase.hpp
@@ -257,10 +257,13 @@ public:
   /** @brief Get the fluid temperature (if thermalized). */
   virtual double get_kT() const noexcept = 0;
 
+  /** @brief Get the RNG seed (if thermalized). */
+  virtual unsigned int get_seed() const noexcept = 0;
+
   /** @brief Set the RNG counter (if thermalized). */
   [[nodiscard]] virtual std::optional<uint64_t> get_rng_state() const = 0;
 
-  /** @brief Set the rng state of thermalized LBs */
+  /** @brief Set the RNG counter (if thermalized). */
   virtual void set_rng_state(uint64_t counter) = 0;
 
   /** @brief get the velocity field id */

--- a/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
@@ -257,6 +257,7 @@ protected:
   FloatType m_viscosity; /// kinematic viscosity
   FloatType m_density;
   FloatType m_kT;
+  unsigned int m_seed;
 
   // Block data access handles
   BlockDataID m_pdf_field_id;
@@ -401,7 +402,7 @@ public:
   LBWalberlaImpl(std::shared_ptr<LatticeWalberla> lattice, double viscosity,
                  double density)
       : m_viscosity(FloatType_c(viscosity)), m_density(FloatType_c(density)),
-        m_kT(FloatType{0}), m_lattice(std::move(lattice)) {
+        m_kT(FloatType{0}), m_seed(0u), m_lattice(std::move(lattice)) {
 
     auto const &blocks = m_lattice->get_blocks();
     auto const n_ghost_layers = m_lattice->get_ghost_layers();
@@ -592,6 +593,7 @@ public:
     auto const omega_odd = odd_mode_relaxation_rate(omega);
     auto const blocks = get_lattice().get_blocks();
     m_kT = FloatType_c(kT);
+    m_seed = seed;
     auto obj = CollisionModelThermalized(m_last_applied_force_field_id,
                                          m_pdf_field_id, m_kT, omega, omega,
                                          omega_odd, omega, seed, uint32_t{0u});
@@ -1364,6 +1366,10 @@ public:
 
   [[nodiscard]] double get_kT() const noexcept override {
     return numeric_cast<double>(m_kT);
+  }
+
+  [[nodiscard]] unsigned int get_seed() const noexcept override {
+    return m_seed;
   }
 
   [[nodiscard]] std::optional<uint64_t> get_rng_state() const override {

--- a/testsuite/python/integrator_exceptions.py
+++ b/testsuite/python/integrator_exceptions.py
@@ -170,7 +170,8 @@ class Test(ut.TestCase):
                 shear_direction="x", shear_plane_normal="y", protocol=protocol)
             self.system.integrator.run(0)
         with self.assertRaisesRegex(Exception, self.msg + 'The NpT integrator cannot use Lees-Edwards'):
-            self.system.lees_edwards.protocol = espressomd.lees_edwards.Off()
+            self.system.lees_edwards.protocol = espressomd.lees_edwards.LinearShear(
+                shear_velocity=0., initial_pos_offset=0., time_0=0.)
             self.system.integrator.run(0)
         self.system.lees_edwards.protocol = None
         self.system.integrator.run(0)

--- a/testsuite/python/lb_lees_edwards.py
+++ b/testsuite/python/lb_lees_edwards.py
@@ -191,8 +191,6 @@ class LBLeesEdwards(ut.TestCase):
             with LBContextManager() as lbf:
                 for profile in self.sample_lb_velocities(lbf):
                     self.check_profile(profile, stencil_D2Q8, '', 'SNWE', tol)
-
-        # order of instantiation doesn't matter
         with LBContextManager() as lbf:
             with LEContextManager('x', 'y', 0):
                 for profile in self.sample_lb_velocities(lbf):
@@ -206,6 +204,13 @@ class LBLeesEdwards(ut.TestCase):
                        'S~': (8 + le_offset, 16),
                        **stencil_D2Q8}
             with LBContextManager() as lbf:
+                for profile in self.sample_lb_velocities(lbf):
+                    self.check_profile(profile, stencil, 'SN', 'WE', tol)
+        with LBContextManager() as lbf:
+            with LEContextManager('x', 'y', le_offset):
+                stencil = {'N~': (8 - le_offset, 0),
+                           'S~': (8 + le_offset, 16),
+                           **stencil_D2Q8}
                 for profile in self.sample_lb_velocities(lbf):
                     self.check_profile(profile, stencil, 'SN', 'WE', tol)
 
@@ -253,8 +258,6 @@ class LBLeesEdwards(ut.TestCase):
                 create_impulse(lbf, stencil_D2Q8)
                 for profile in self.sample_lb_velocities(lbf):
                     self.check_profile(profile, stencil_D2Q8, '', 'SNWE', tol)
-
-        # order of instantiation doesn't matter
         with LBContextManager() as lbf:
             with LEContextManager('x', 'y', 0):
                 create_impulse(lbf, stencil_D2Q8)
@@ -269,6 +272,14 @@ class LBLeesEdwards(ut.TestCase):
                        'S~': (8 + le_offset, 15),
                        **stencil_D2Q8}
             with LBContextManager() as lbf:
+                create_impulse(lbf, stencil_D2Q8)
+                for profile in self.sample_lb_velocities(lbf):
+                    self.check_profile(profile, stencil, 'SN', 'WE', tol)
+        with LBContextManager() as lbf:
+            with LEContextManager('x', 'y', le_offset):
+                stencil = {'N~': (8 - le_offset, 1),
+                           'S~': (8 + le_offset, 15),
+                           **stencil_D2Q8}
                 create_impulse(lbf, stencil_D2Q8)
                 for profile in self.sample_lb_velocities(lbf):
                     self.check_profile(profile, stencil, 'SN', 'WE', tol)
@@ -334,6 +345,10 @@ class LBLeesEdwards(ut.TestCase):
                 system.lb = espressomd.lb.LBFluidWalberla(
                     agrid=1., density=1., kinematic_viscosity=1., kT=1., seed=42,
                     tau=system.time_step)
+        self.assertIsNone(system.lb)
+        with self.assertRaisesRegex(RuntimeError, "Lees-Edwards LB doesn't support thermalization"):
+            with LBContextManager(kT=1., seed=42) as lbf:
+                LEContextManager('x', 'y', 1.)
         self.assertIsNone(system.lb)
 
         with self.assertRaisesRegex(ValueError, "Lees-Edwards sweep is implemented for a ghost layer of thickness 1"):


### PR DESCRIPTION
Fixes #4874

Description of changes:
- introduced a new event function on_lees_edwards_change() to be triggered when the LE BC is changed
- the order of instantiation of LB and LEbc no longer matters: collision kernel is automatically updated
