### PR TITLE
Errors when running lj_liquid_structurefactor.py with v4.2.2

### DIFF
--- a/samples/lj_liquid_structurefactor.py
+++ b/samples/lj_liquid_structurefactor.py
@@ -78,7 +78,7 @@ int_n_times = 20
 structurefactor_type_list = [0, 1]
 structurefactor_order = 20
 structurefactor_bins = len(system.analysis.structure_factor(
-    [0], structurefactor_order)[0])
+    sf_types=[0], sf_order=structurefactor_order)[0])
 structurefactor_k = np.zeros(structurefactor_bins)
 structurefactor_Sk = np.zeros(structurefactor_bins)
 
@@ -153,7 +153,7 @@ for i in range(int_n_times):
     system.integrator.run(int_steps)
 
     structurefactor_k, structurefactor_Sk = system.analysis.structure_factor(
-        structurefactor_type_list, structurefactor_order)
+        sf_types=structurefactor_type_list, sf_order=structurefactor_order)
 
     energies = system.analysis.energy()
     print(energies['total'])


### PR DESCRIPTION
The arguments of `system.analysis.structure_factor()` needed to be named to run the script without error message otherwise the error was:

```shell
pypresso samples/lj_liquid_structurefactor.py

=======================================================
=              lj_liquid_structurefactor.py           =
=======================================================

Traceback (most recent call last):
  File "/home/szitz/espresso-v422/samples/lj_liquid_structurefactor.py", line 80, in <module>
    structurefactor_bins = len(system.analysis.structure_factor())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "script_interface.pyx", line 476, in espressomd.script_interface.ScriptInterfaceHelper.generate_caller.template_method
  File "script_interface.pyx", line 172, in espressomd.script_interface.PScriptInterface.call_method
RuntimeError: Parameter 'sf_order' is missing.
```

Fixes #

Description of changes:
- 
