### PR TITLE
Update P3MGPU documentation

### DIFF
--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -126,10 +126,8 @@ with only single precision which limits the maximum precision.
 The algorithm does not work in combination with the electrostatic extension
 :ref:`Dielectric interfaces with the ICC* algorithm <Dielectric interfaces with the ICC algorithm>`.
 
-The algorithm doesn't have kernels to compute energies, and will therefore
-contribute 0 to the long-range potential energy of the system. This can be
-an issue for other algorithms, such as :ref:`reaction methods <Reaction methods>`
-and :ref:`energy-based steepest descent <Using a custom convergence criterion>`.
+The algorithm doesn't have kernels to compute energies and pressures and therefore
+uses the respective CPU kernels with the parameters tuned for the GPU force kernel.
 
 .. _Debye-Hückel potential:
 


### PR DESCRIPTION
Description of changes:
- Update documentation to reflect that P3MGPU is in fact able to execute the CPU energy and pressure kernels using parameters tuned for the GPU force kernel since #4506.