### PR TITLE
Splitting kinetic energy into contributions

### DIFF
--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -47,16 +47,19 @@ Observable_stat::Observable_stat(std::size_t chunk_size, std::size_t n_bonded,
   constexpr std::size_t n_vs = 0;
 #endif
   auto const n_non_bonded = get_non_bonded_offset(max_type, max_type) + 1ul;
-  constexpr std::size_t n_ext_fields = 1; // reduction over all fields
-  constexpr std::size_t n_kinetic = 1; // linear+angular kinetic contributions
+  constexpr std::size_t n_ext_fields = 1;  // reduction over all fields
+  constexpr std::size_t n_kinetic_lin = 1; // linear kinetic contribution
+  constexpr std::size_t n_kinetic_rot = 1; // angular kinetic contribution
 
-  auto const n_elements = n_kinetic + n_bonded + 2ul * n_non_bonded +
-                          n_coulomb + n_dipolar + n_vs + n_ext_fields;
+  auto const n_elements = n_kinetic_lin + n_kinetic_rot + n_bonded +
+                          2ul * n_non_bonded + n_coulomb + n_dipolar + n_vs +
+                          n_ext_fields;
   m_data = std::vector<double>(m_chunk_size * n_elements);
 
   // spans for the different contributions
-  kinetic = std::span<double>(m_data.data(), m_chunk_size);
-  bonded = std::span<double>(kinetic.end(), n_bonded * m_chunk_size);
+  kinetic_lin = std::span<double>(m_data.data(), m_chunk_size);
+  kinetic_rot = std::span<double>(kinetic_lin.end(), m_chunk_size);
+  bonded = std::span<double>(kinetic_rot.end(), n_bonded * m_chunk_size);
   coulomb = std::span<double>(bonded.end(), n_coulomb * m_chunk_size);
   dipolar = std::span<double>(coulomb.end(), n_dipolar * m_chunk_size);
   virtual_sites = std::span<double>(dipolar.end(), n_vs * m_chunk_size);

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -70,8 +70,10 @@ public:
                            std::bind_front(std::multiplies{}, 1. / volume));
   }
 
-  /** Contribution from linear and angular kinetic energy (accumulated). */
-  std::span<double> kinetic;
+  /** Contribution from linear kinetic energy. */
+  std::span<double> kinetic_lin;
+  /** Contribution from angular kinetic energy. */
+  std::span<double> kinetic_rot;
   /** Contribution(s) from bonded interactions. */
   std::span<double> bonded;
   /** Contribution(s) from Coulomb interactions. */

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -56,7 +56,8 @@ std::shared_ptr<Observable_stat> System::calculate_energy() {
   auto const local_parts = cell_structure->local_particles();
 
   for (auto const &p : local_parts) {
-    obs_energy.kinetic[0] += calc_kinetic_energy(p);
+    obs_energy.kinetic_lin[0] += translational_kinetic_energy(p);
+    obs_energy.kinetic_rot[0] += rotational_kinetic_energy(p);
   }
 
   auto const coulomb_kernel = coulomb.pair_energy_kernel();

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -319,10 +319,3 @@ inline double rotational_kinetic_energy(Particle const &p) {
   return 0.0;
 #endif
 }
-
-/** Calculate kinetic energies for one particle.
- *  @param p   particle for which to calculate energies
- */
-inline double calc_kinetic_energy(Particle const &p) {
-  return translational_kinetic_energy(p) + rotational_kinetic_energy(p);
-}

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -178,5 +178,5 @@ inline void add_kinetic_virials(Particle const &p1,
   /* kinetic pressure */
   for (std::size_t k = 0u; k < 3u; k++)
     for (std::size_t l = 0u; l < 3u; l++)
-      obs_pressure.kinetic[k * 3u + l] += p1.v()[k] * p1.v()[l] * p1.mass();
+      obs_pressure.kinetic_lin[k * 3u + l] += p1.v()[k] * p1.v()[l] * p1.mass();
 }

--- a/src/core/reaction_methods/ReactionAlgorithm.cpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.cpp
@@ -631,7 +631,8 @@ void ReactionAlgorithm::setup_bookkeeping_of_empty_pids() {
 double ReactionAlgorithm::calculate_potential_energy() const {
   auto &system = System::get_system();
   auto const obs = system.calculate_energy();
-  auto pot = obs->accumulate(-obs->kinetic[0]);
+  auto const kinetic_energy = obs->kinetic_lin[0] + obs->kinetic_rot[0];
+  auto pot = obs->accumulate(-kinetic_energy);
   boost::mpi::broadcast(m_comm, pot, 0);
   return pot;
 }

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -222,7 +222,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
       if (rank == 0) {
         auto const &p = *p_opt;
         auto const kinetic_energy = 0.5 * p.mass() * p.v().norm2();
-        BOOST_CHECK_CLOSE(obs_energy->kinetic[0], kinetic_energy, tol);
+        BOOST_CHECK_CLOSE(obs_energy->kinetic_lin[0], kinetic_energy, tol);
       }
     }
   }

--- a/src/core/unit_tests/energy_test.cpp
+++ b/src/core/unit_tests/energy_test.cpp
@@ -89,20 +89,3 @@ BOOST_AUTO_TEST_CASE(rotational_kinetic_energy_) {
   }
 #endif
 }
-
-BOOST_AUTO_TEST_CASE(kinetic_energy_) {
-  Particle p;
-#ifdef MASS
-  p.mass() = 2.;
-#endif
-  p.v() = {3., 4., 5.};
-
-#ifdef ROTATION
-  p.omega() = {1., 2., 3.};
-  p.set_can_rotate_all_axes();
-#endif
-
-  auto const expected =
-      translational_kinetic_energy(p) + rotational_kinetic_energy(p);
-  BOOST_CHECK_EQUAL(calc_kinetic_energy(p), expected);
-}

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -458,6 +458,8 @@ class Analysis(ScriptInterfaceHelper):
 
             * ``"total"``: total energy
             * ``"kinetic"``: linear and rotational kinetic energy
+            * ``"kinetic_lin"``: linear kinetic energy
+            * ``"kinetic_rot"``: rotational kinetic energy
             * ``"bonded"``: total bonded energy
             * ``"bonded", <bond_id>``: bonded energy from the bond
               identified by ``bond_id``

--- a/src/script_interface/analysis/ObservableStat.cpp
+++ b/src/script_interface/analysis/ObservableStat.cpp
@@ -71,8 +71,21 @@ static auto get_summary(::System::System const &system,
   };
 
   std::unordered_map<std::string, Variant> dict;
-  dict["kinetic"] = get_obs_contrib(obs.kinetic);
+  dict["kinetic_lin"] = get_obs_contrib(obs.kinetic_lin);
+  dict["kinetic_rot"] = get_obs_contrib(obs.kinetic_rot);
   dict["external_fields"] = get_obs_contrib(obs.external_fields);
+  if (is_type<double>(dict["kinetic_lin"])) {
+    dict["kinetic"] = get_value<double>(dict["kinetic_lin"]) +
+                      get_value<double>(dict["kinetic_rot"]);
+  } else {
+    auto const v1 = get_value<std::vector<double>>(dict["kinetic_lin"]);
+    auto const v2 = get_value<std::vector<double>>(dict["kinetic_rot"]);
+    std::vector<double> value{};
+    for (auto i = 0u; i < 9u; ++i) {
+      value.emplace_back(v1[i] + v2[i]);
+    }
+    dict["kinetic"] = value;
+  }
 
   {
     auto values = std::vector<double>(obs_dim);

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -66,6 +66,8 @@ class AnalyzeEnergy(ut.TestCase):
         p1.v = [0, 0, 0]
         energy = self.system.analysis.energy()
         self.assertAlmostEqual(energy["total"], 25., delta=1e-7)
+        self.assertAlmostEqual(energy["kinetic_lin"], 25., delta=1e-7)
+        self.assertAlmostEqual(energy["kinetic_rot"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["kinetic"], 25., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 0., delta=1e-7)
@@ -73,9 +75,20 @@ class AnalyzeEnergy(ut.TestCase):
         p1.v = [3, 4, 5]
         energy = self.system.analysis.energy()
         self.assertAlmostEqual(energy["total"], 50., delta=1e-7)
+        self.assertAlmostEqual(energy["kinetic_lin"], 50., delta=1e-7)
+        self.assertAlmostEqual(energy["kinetic_rot"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["kinetic"], 50., delta=1e-7)
         self.assertAlmostEqual(energy["bonded"], 0., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 0., delta=1e-7)
+        if espressomd.has_features(["ROTATION"]):
+            p0.omega_lab = [1, 2, 3]
+            p1.omega_lab = [1, 2, 3]
+            p0.rotation = [True, True, True]
+            p1.rotation = [False, False, False]
+            energy = self.system.analysis.energy()
+            self.assertAlmostEqual(energy["kinetic_lin"], 50., delta=1e-7)
+            self.assertAlmostEqual(energy["kinetic_rot"], 7., delta=1e-7)
+            self.assertAlmostEqual(energy["kinetic"], 57., delta=1e-7)
 
     def test_non_bonded(self):
         p0, p1 = self.system.part.all()

--- a/testsuite/python/pressure.py
+++ b/testsuite/python/pressure.py
@@ -138,6 +138,10 @@ class PressureLJ(ut.TestCase):
 
         sim_pressure_tensor = system.analysis.pressure_tensor()
         sim_pressure_tensor_kinetic = np.copy(sim_pressure_tensor['kinetic'])
+        sim_pressure_tensor_kinetic_lin = np.copy(
+            sim_pressure_tensor['kinetic_lin'])
+        sim_pressure_tensor_kinetic_rot = np.copy(
+            sim_pressure_tensor['kinetic_rot'])
         sim_pressure_tensor_bonded = np.copy(sim_pressure_tensor['bonded'])
         sim_pressure_tensor_bonded_harmonic = np.copy(
             sim_pressure_tensor['bonded', len(system.bonded_inter) - 1])
@@ -155,6 +159,8 @@ class PressureLJ(ut.TestCase):
 
         sim_pressure = system.analysis.pressure()
         sim_pressure_kinetic = sim_pressure['kinetic']
+        sim_pressure_kinetic_lin = sim_pressure['kinetic_lin']
+        sim_pressure_kinetic_rot = sim_pressure['kinetic_rot']
         sim_pressure_bonded = sim_pressure['bonded']
         sim_pressure_bonded_harmonic = sim_pressure[
             'bonded', len(system.bonded_inter) - 1]
@@ -192,6 +198,12 @@ class PressureLJ(ut.TestCase):
             sim_pressure_tensor_kinetic, anal_pressure_tensor_kinetic, rtol=0, atol=tol,
             err_msg='kinetic pressure tensor does not match analytical result')
         np.testing.assert_allclose(
+            sim_pressure_tensor_kinetic_lin, anal_pressure_tensor_kinetic, rtol=0, atol=tol,
+            err_msg='kinetic pressure tensor does not match analytical result')
+        np.testing.assert_allclose(
+            sim_pressure_tensor_kinetic_rot, np.zeros((3, 3)), rtol=0, atol=tol,
+            err_msg='kinetic pressure tensor does not match analytical result')
+        np.testing.assert_allclose(
             sim_pressure_tensor_bonded, anal_pressure_tensor_bonded, rtol=0, atol=tol,
             err_msg='bonded pressure tensor does not match analytical result')
         np.testing.assert_allclose(
@@ -220,6 +232,12 @@ class PressureLJ(ut.TestCase):
             err_msg='total pressure tensor is not given as the sum of all major pressure components')
         self.assertAlmostEqual(
             sim_pressure_kinetic, anal_pressure_kinetic, delta=tol,
+            msg='kinetic pressure does not match analytical result')
+        self.assertAlmostEqual(
+            sim_pressure_kinetic_lin, anal_pressure_kinetic, delta=tol,
+            msg='kinetic pressure does not match analytical result')
+        self.assertAlmostEqual(
+            sim_pressure_kinetic_rot, 0., delta=tol,
             msg='kinetic pressure does not match analytical result')
         self.assertAlmostEqual(
             sim_pressure_bonded, anal_pressure_bonded, delta=tol,


### PR DESCRIPTION
Fixes #1400 

Description of changes:
- Splits the kinetic energy returned by `espressomd.analyze.Analysis.energy()` into contributions due to translation and rotation
