### PR TITLE
Restructure installation documentation 

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,50 +5,28 @@
 ******************************************************************************
 
 The ESPResSo compilation and installation process is decribed in
-detail in the ESPResSo user's guide. When you have obtained the
-sources in a .tar.gz file, the user's guide can be found in the file
-"index.html" in the subdirectory "doc/sphinx/html/" relative to the directory where
-this file resided.
+detail in the ESPResSo user's guide, which is available online at
 
-When you have obtained the sources from the git repository or by other
-means, the user's guide can always be found on the ESPResSo-Homepage at
-
-	http://espressomd.org/html/doc/
+	https://espressomd.github.io/doc/index.html
 
 
 QUICK START
 -----------
-The recommended way is to build by the cmake tool.
-CMake recommends to build in a build directory not inside the
-source. On Linux you can create and enter directory in a location
-of your choice by
+Create a build directory and run CMake in it:
 
-> mkdir <path-to-build-dir> && cd <path-to-build-dir>
-
-Then you can run cmake and build ESPResSo by
-
-> cmake <path-to-espresso-source>
+> mkdir build
+> cd build
+> cmake ..
 > cmake --build .
 
-If you have installed the curses frontend to cmake you can see
-and modify the build options graphically by running
-
-> ccmake <path-to-espresso-source>
-
-When these steps have completed successfully, you can run Espresso with
-help of the command
+When these steps have completed successfully, you can run ESPResSo with:
 
 > ./pypresso
-
-Copying and distribution of this file, with or without modification,
-are permitted in any medium without royalty provided the copyright
-notice and this notice are preserved.  This file is offered as-is,
-without any warranty.
 
 
 LICENSE
 -------
-Copyright (C) 2010,2011,2012,2013,2014 The ESPResSo project
+Copyright (C) 2010-2025 The ESPResSo project
 
 Copying and distribution of this file, with or without modification,
 are permitted in any medium without royalty provided the copyright

--- a/Readme.md
+++ b/Readme.md
@@ -92,7 +92,7 @@ publications, as indicated in the documentation. For detailed instructions, see
 
 ## License
 
-Copyright (C) 2010-2022 The ESPResSo project
+Copyright (C) 2010-2025 The ESPResSo project
 
 Copyright (C) 2002-2010 Max-Planck-Institute for Polymer Research, Theory Group
 

--- a/Readme.md
+++ b/Readme.md
@@ -63,14 +63,32 @@ The official website is https://espressomd.org/wordpress/.
 
 Detailed installation instructions for Ubuntu and macOS can be found in the
 user guide, section [Installation](https://espressomd.github.io/doc/installation.html).
-Common installation issues are addressed in the
-[FAQ](https://github.com/espressomd/espresso/wiki/Installation-FAQ).
+For most users, we recommend downloading the latest release version of ESPResSo.
+The [release page](https://github.com/espressomd/espresso/releases) shows all
+releases since 4.0. When choosing a release, we recommend the latest bugfix
+release in that line. For example, in the 4.2 line, choose 4.2.2.
 
-For most users, we recommend downloading the latest release version of ESPResSo. You
-can find it in the [release page](https://github.com/espressomd/espresso/releases),
-together with past releases until 4.0. When choosing a release, we recommend that
-you get the latest bugfix release in that line. For example, for 4.2 you would like
-to use 4.2.2.
+Quickstart:
+
+1. download the source code: one of the
+   [stable releases](https://github.com/espressomd/espresso/releases)
+   (.tar.gz files before 2025) or the development version
+   (`git clone -b python https://github.com/espressomd/espresso.git`)
+2. install dependencies on
+   [Ubuntu](https://espressomd.github.io/doc/installation.html#installing-requirements-on-ubuntu),
+   [macOS](https://espressomd.github.io/doc/installation.html#installing-requirements-on-macos),
+   [Windows](https://espressomd.github.io/doc/installation.html#installing-requirements-on-windows-via-wsl),
+   or [other Linux distributions](https://espressomd.github.io/doc/installation.html#installing-requirements-on-other-linux-distributions)
+3. build the application: default build ([Quick installation](https://espressomd.github.io/doc/installation.html#quick-installation)),
+   or custom build ([Configuring](https://espressomd.github.io/doc/installation.html#configuring))
+
+Common installation issues are addressed in the
+[FAQ](https://github.com/espressomd/espresso/wiki/Installation-FAQ),
+together with contributed patches for compiler-related and library-related issues.
+
+You can also try ESPReSSo in the cloud using
+[Binder](https://mybinder.org/v2/gh/jngrad/espresso-binder/HEAD) or
+[Gitpod](https://gitpod.io/#https://github.com/espressomd/espresso).
 
 ### Join the community
 

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -936,6 +936,18 @@ pages = {1--16},
 doi = {10.1145/1132973.1132974},
 }
 
+@Article{perez07a,
+  author={P\'erez, Fernando and Granger, Brian E.},
+  journal={Computing in Science {\&} Engineering},
+  title={{IP}ython: A System for Interactive Scientific Computing},
+  year={2007},
+  volume={9},
+  number={3},
+  pages={21--29},
+  issn={1558-366X},
+  doi={10.1109/MCSE.2007.53},
+}
+
 @Article{peskin02a,
 author = {Peskin, Charles S.},
 title = {The immersed boundary method},

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -247,7 +247,8 @@ rst_prolog = """
 """
 # Style ESPResSo
 rst_epilog = """
-.. |es| replace:: *ESPResSo*
+.. |es| replace:: ESPResSo
+.. |p3m| replace:: P\\ :superscript:`3`\\ M
 """
 # Re-enable grouping of arguments in numpydoc
 # https://github.com/sphinx-doc/sphinx/issues/2227

--- a/doc/sphinx/electrostatics.rst
+++ b/doc/sphinx/electrostatics.rst
@@ -35,7 +35,7 @@ the particles via the particle property
 :py:attr:`~espressomd.particle_data.ParticleHandle.q`.
 
 All solvers need a prefactor and a set of other required parameters.
-This example shows the general usage of the electrostatic method ``P3M``.
+This example shows the general usage of the electrostatic method P3M (often stylized as |p3m|).
 An instance of the solver is created and attached to the system, at which
 point it will be automatically activated. This activation will internally
 call a tuning function to achieve the requested accuracy::

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -54,11 +54,11 @@ are required to be able to compile and use |es|:
         A number of advanced C++ features used by |es| are provided by Boost.
 
     FFTW
-        For some algorithms like P\ :math:`^3`\ M, |es| needs the FFTW library
+        For some algorithms like |p3m|, |es| needs the FFTW library
         version 3 or later [5]_ for Fourier transforms, including header files.
 
     CUDA
-        For some algorithms like P\ :math:`^3`\ M,
+        For some algorithms like |p3m|,
         |es| provides GPU-accelerated implementations for NVIDIA GPUs.
         We strongly recommend CUDA 12.0 or later [6]_.
 
@@ -90,6 +90,8 @@ are required to be able to compile and use |es|:
         ``sudo apt install python3-numpy python3-scipy``
         can be rewritten as ``python3 -m pip install numpy scipy``,
         and thus do not require root privileges.
+        Whenever this documentation refers to :file:`requirements.txt`,
+        it is the one located in the top-level directory of the project.
 
         Depending on your needs, you may choose to install all |es|
         dependencies inside the environment, or only the subset of
@@ -108,24 +110,27 @@ are required to be able to compile and use |es|:
         include paths to find the correct :file:`Python.h` header file.
 
 
-.. _Installing requirements on Ubuntu Linux:
+.. _Installing requirements on Ubuntu:
 
-Installing requirements on Ubuntu Linux
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing requirements on Ubuntu
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To compile |es| on Ubuntu 24.04 LTS, install the following dependencies:
+To compile |es| on Ubuntu 24.04 LTS, install the following build dependencies:
 
 .. code-block:: bash
 
-    sudo apt install build-essential cmake cython3 python3-dev openmpi-bin \
+    sudo apt install build-essential cmake cmake-curses-gui python3-dev openmpi-bin \
       libboost-all-dev libfftw3-dev libfftw3-mpi-dev libhdf5-dev libhdf5-openmpi-dev \
-      python3-pip python3-numpy python3-scipy python3-opengl libgsl-dev freeglut3-dev
+      python3-pip libgsl-dev freeglut3-dev
 
-Optionally the ccmake utility can be installed for easier configuration:
+To run |es|, install the following Python dependencies:
 
 .. code-block:: bash
 
-    sudo apt install cmake-curses-gui
+    python3 -m venv espresso_env # here other virtual environment tools are also ok
+    . espresso_env/bin/activate
+    python3 -m pip install -c requirements.txt \
+      cmake cython numpy scipy packaging setuptools h5py PyOpenGL
 
 To install the ZnDraw visualizer:
 
@@ -138,8 +143,8 @@ To install the ZnDraw visualizer:
 Nvidia GPU acceleration
 """""""""""""""""""""""
 
-If your computer has an Nvidia graphics card, you should also download and install the
-CUDA SDK to make use of GPU computation:
+If your computer has an Nvidia graphics card and you would like to leverage
+|es|'s GPU algorithms, you should also download and install the CUDA SDK:
 
 .. code-block:: bash
 
@@ -224,7 +229,8 @@ To run the samples and tutorials, start by installing the following packages:
 
 .. code-block:: bash
 
-    sudo apt install python3-matplotlib python3-pint python3-tqdm ffmpeg
+    sudo apt install ffmpeg
+    python3 -m pip install -c requirements.txt matplotlib pint tqdm
 
 The tutorials are written in the
 `Notebook Format <https://nbformat.readthedocs.io/en/latest/>`__
@@ -281,7 +287,7 @@ required to compile |es| on other Linux distributions:
 Installing requirements on Windows via WSL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To run |es| on Windows, use the Linux subsystem. For that you need to
+To run |es| on Windows, use the Linux subsystem (WSL). For that you need to
 
 * follow `these instructions <https://learn.microsoft.com/en-us/windows/wsl/install>`__ to install Ubuntu
 * start Ubuntu (or open an Ubuntu tab in `Windows Terminal <https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-us&gl=US>`__)
@@ -289,7 +295,7 @@ To run |es| on Windows, use the Linux subsystem. For that you need to
 * optional step: If you have a NVIDIA graphics card available and want to make
   use of |es|'s GPU acceleration, follow `these instructions <https://docs.nvidia.com/cuda/wsl-user-guide/index.html>`__
   to set up CUDA.
-* follow the instructions for :ref:`Installing requirements on Ubuntu Linux`
+* follow the instructions for :ref:`Installing requirements on Ubuntu`
 
 .. _Installing requirements on macOS:
 
@@ -358,7 +364,7 @@ the :file:`build` directory to :file:`myconfig.hpp` and only uncomment
 the features you want to use in your simulation.
 
 The ``cmake`` command looks for libraries and tools needed by |es|.
-So |es| can only be built if ``cmake`` reports no errors.
+The application can only be built if CMake reports no errors.
 
 The command ``make`` will compile the source code. Depending on the
 options passed to the program, ``make`` can also be used for a number of
@@ -785,7 +791,7 @@ The following options control how the project is built and tested:
 * ``ESPRESSO_BUILD_WITH_CCACHE``: Enable compiler cache for faster rebuilds.
 * ``ESPRESSO_BUILD_TESTS``: Enable C++ and Python tests.
 * ``ESPRESSO_BUILD_BENCHMARKS``: Enable benchmarks.
-* ``ESPRESSO_CTEST_ARGS`` (string): Arguments passed to the ``ctest`` command.
+* ``ESPRESSO_CTEST_ARGS`` (string): Arguments passed to the ``ctest`` command (semicolon-separated list).
 * ``ESPRESSO_TEST_TIMEOUT``: Test timeout.
 * ``ESPRESSO_ADD_OMPI_SINGLETON_WARNING``: Add a runtime warning in the
   pypresso and ipypresso scripts that is triggered in singleton mode
@@ -911,12 +917,11 @@ When no target is given, the target ``all`` is used. The following
 targets are available:
 
 ``all``
-    Compiles the complete source code. The variable can be used to
-    specify the name of the configuration header to be used.
+    Compiles the complete source code.
 
 ``check``
-    Runs the testsuite. By default, all available tests will be run on
-    1, 2, 3, 4, 6, or 8 processors.
+    Runs the full testsuite. More fine-grained testsuites are available,
+    such as ``check_unit_tests`` and ``check_python_skip_long``.
 
 ``test``
     Do not use this target, it is a broken feature

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -33,6 +33,26 @@ on the `Gitpod <https://gitpod.io>`__ platform can build the software
 automatically in the cloud and skip this chapter. For more details on
 running |es| in Gitpod, go to section :ref:`Running in the cloud`.
 
+Quickstart
+----------
+
+Installing |es| usually involves the following steps:
+
+#. downloading the source code: one of the
+   `stable releases <https://github.com/espressomd/espresso/releases>`__
+   (.zip files, or .tar.gz files before 2025) or the development version
+   (``git clone -b python https://github.com/espressomd/espresso.git``)
+#. installing dependencies on
+   :ref:`Ubuntu <Installing requirements on Ubuntu>`,
+   :ref:`macOS <Installing requirements on macOS>`,
+   :ref:`Windows <Installing requirements on Windows via WSL>`,
+   or :ref:`other Linux distributions <Installing requirements on other Linux distributions>`
+#. building the application: default build (:ref:`Quick installation`)
+   or custom build (requires :ref:`Configuring`)
+
+A troubleshooting guide is available on the project
+`GitHub wiki <https://github.com/espressomd/espresso/wiki/Installation-FAQ>`__,
+featuring contributed patches for compiler-related and library-related issues.
 
 .. _Requirements:
 
@@ -130,13 +150,11 @@ To run |es|, install the following Python dependencies:
     python3 -m venv espresso_env # here other virtual environment tools are also ok
     . espresso_env/bin/activate
     python3 -m pip install -c requirements.txt \
-      cmake cython numpy scipy packaging setuptools h5py PyOpenGL
+      cmake cython numpy scipy packaging setuptools h5py
 
-To install the ZnDraw visualizer:
-
-.. code-block:: bash
-
-    python3 -m pip install -c requirements.txt 'zndraw==0.4.6'
+These are the only hard requirements. In the following subsections,
+only optional dependencies will be discussed. Unless you need extra features,
+you can jump directly to the next section :ref:`Quick installation`.
 
 .. _Nvidia GPU acceleration:
 
@@ -202,24 +220,6 @@ GCC version, which is GCC 13 on Ubuntu 24.04. It is not possible to install
 the NVIDIA driver without GCC 13 due to a dependency resolution issue
 (``nvidia-dkms`` depends on ``dkms`` which depends on ``gcc-13``).
 
-.. _Requirements for building the documentation:
-
-Requirements for building the documentation
-"""""""""""""""""""""""""""""""""""""""""""
-
-To generate the Sphinx documentation, install the following packages:
-
-.. code-block:: bash
-
-    python3 -m pip install -c requirements.txt \
-        sphinx sphinxcontrib-bibtex sphinx-toggleprompt
-
-To generate the Doxygen documentation, install the following packages:
-
-.. code-block:: bash
-
-    sudo apt install doxygen graphviz
-
 .. _Setting up a Jupyter environment:
 
 Setting up a Jupyter environment
@@ -270,6 +270,41 @@ Alternatively, to use VS Code Jupyter, install the following extensions:
     code --install-extension ms-toolsai.jupyter
     code --install-extension ms-toolsai.jupyter-keymap
     code --install-extension ms-toolsai.jupyter-renderers
+
+.. _Requirements for visualizers:
+
+Requirements for visualizers
+""""""""""""""""""""""""""""
+
+To install the OpenGL visualizer:
+
+.. code-block:: bash
+
+    python3 -m pip install -c requirements.txt PyOpenGL
+
+To install the ZnDraw visualizer:
+
+.. code-block:: bash
+
+    python3 -m pip install -c requirements.txt 'zndraw==0.4.6'
+
+.. _Requirements for building the documentation:
+
+Requirements for building the documentation
+"""""""""""""""""""""""""""""""""""""""""""
+
+To generate the Sphinx documentation, install the following packages:
+
+.. code-block:: bash
+
+    python3 -m pip install -c requirements.txt \
+        sphinx sphinxcontrib-bibtex sphinx-toggleprompt
+
+To generate the Doxygen documentation, install the following packages:
+
+.. code-block:: bash
+
+    sudo apt install doxygen graphviz
 
 .. _Installing requirements on other Linux distributions:
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -85,7 +85,7 @@ are required to be able to compile and use |es|:
 
         We strongly recommend using Python environments to isolate
         packages required by |es| from packages installed system-wide.
-        This can be achieved using venv [7]_, conda [8]_, or any similar tool.
+        This can be achieved using venv [7]_, conda [8]_, uv [9]_, or any similar tool.
         Inside an environment, commands of the form
         ``sudo apt install python3-numpy python3-scipy``
         can be rewritten as ``python3 -m pip install numpy scipy``,
@@ -296,51 +296,40 @@ To run |es| on Windows, use the Linux subsystem. For that you need to
 Installing requirements on macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To build |es| on macOS 10.15 or higher, you need to install its dependencies.
-There are two possibilities for this, MacPorts and Homebrew. We strongly
-recommend Homebrew, but if you already have MacPorts installed, you can use
-that too, although we do not provide MacPorts installation instructions.
+The first step is to install a C++ compiler, such as Xcode [10]_.
 
-To check whether you already have one or the other installed, run the
-following commands:
+To install libraries, a package manager will be needed.
+While our instructions below are specific to Homebrew,
+they should be fairly easy to adapt for other package managers.
+If Homebrew isn't available, it can be installed with
+`these instructions <https://docs.brew.sh/Installation>`__,
+but bear in mind that it might conflict with other installed managers,
+such as MacPorts.
 
-.. code-block:: bash
-
-    test -e /opt/local/bin/port && echo "MacPorts is installed"
-    test -e /usr/local/bin/brew && echo "Homebrew is installed"
-
-If Homebrew is already installed, you should resolve any problems reported by
-the command
+If Homebrew is already installed, resolve any problems reported by the command:
 
 .. code-block:: bash
 
     brew doctor
 
-If you want to install Homebrew, follow the installation instructions at
-https://docs.brew.sh/Installation, but bear in mind that MacPorts and Homebrew
-may conflict with one another.
-
-If Anaconda Python or the Python from www.python.org are installed, you
-will likely not be able to run |es|. Therefore, please uninstall them
-using the following commands:
+Install the following libraries:
 
 .. code-block:: bash
 
-    sudo rm -r ~/anaconda[23]
-    sudo rm -r /Library/Python
+    brew install boost boost-mpi fftw gsl freeglut hdf5-mpi
 
-Installing packages using Homebrew
-""""""""""""""""""""""""""""""""""
-
-Run the following commands:
+For the last step, we will use the uv utility
+(`installation instructions <https://docs.astral.sh/uv/getting-started/installation/>`__)
+to install the Python interpreter and all required Python packages
+in a virtual environment:
 
 .. code-block:: bash
 
-    brew install cmake python cython boost boost-mpi fftw \
-      doxygen gsl numpy scipy ipython jupyter freeglut
-    brew install hdf5-mpi
-    brew link --force cython
-    python -m pip install -c requirements.txt PyOpenGL matplotlib
+    uv venv --python 3.13
+    . .venv/bin/activate
+    uv pip install -c requirements.txt \
+      cmake cython numpy scipy matplotlib tqdm packaging setuptools h5py \
+      PyOpenGL "jupyterlab>=4.3" nbformat nbconvert "lxml[html_clean]"
 
 .. _Quick installation:
 
@@ -1001,3 +990,9 @@ ____
 
 .. [8]
    https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
+
+.. [9]
+   https://docs.astral.sh/uv/
+
+.. [10]
+   https://developer.apple.com/xcode/

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -68,7 +68,8 @@ which is also located in the build directory:
 
     ./ipypresso console
 
-The name comes from the IPython interpreter, today known as Jupyter.
+The name comes from the IPython interpreter :cite:`perez07a`,
+whose notebook feature is today known as Jupyter :cite:`kluyver16a`.
 
 Interactive notebooks
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #4981

Description of changes:
- add a quickstart section in the readme and Sphinx docs
- make Ubuntu installation instructions more fine-grained
- update macOS installation instructions
