### PR TITLE
Reduce overhead of particle creation

### DIFF
--- a/src/python/espressomd/particle_data.py
+++ b/src/python/espressomd/particle_data.py
@@ -1129,8 +1129,7 @@ class ParticleList(ScriptInterfaceHelper):
             bonds = p_dict.pop("bonds")
             if nesting_level(bonds) == 1:
                 bonds = [bonds]
-        p_id = self.call_method("add_particle", **p_dict)
-        p = self.by_id(p_id)
+        p = self.call_method("add_particle", **p_dict)
         for bond in bonds:
             if len(bond):
                 bond = p.normalize_and_check_bond_or_throw_exception(bond)

--- a/src/script_interface/particle_data/ParticleList.cpp
+++ b/src/script_interface/particle_data/ParticleList.cpp
@@ -194,7 +194,7 @@ Variant ParticleList::do_call_method(std::string const &name,
       so->call_method("set_exclusions", {{"p_ids", params.at("exclusions")}});
     }
 #endif // EXCLUSIONS
-    return so->get_parameter("id");
+    return so;
   }
   return {};
 }


### PR DESCRIPTION
Description of changes:
- Return the ParticleHandle object directly from add_particle in the C++ Script Interface instead of just its ID.
- This eliminates an unnecessary call to retrieve the particle by ID after creation, improving efficiency, as investigated in #5011.

This does not fix #5011 but is still an improvement, especially for lower core counts.