### PR TITLE
for each particle

### DIFF
--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <concepts>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -52,6 +53,11 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
+
+template <typename Callable>
+concept ParticleCallback = requires(Callable c, Particle &p) {
+  { c(p) } -> std::same_as<void>;
+};
 
 namespace Cells {
 enum Resort : unsigned {
@@ -273,6 +279,30 @@ public:
 
   ParticleRange ghost_particles() const {
     return Cells::particles(decomposition().ghost_cells());
+  }
+
+  /**
+   * @brief Run a kernel on all local particles.
+   * The kernel is assumed to be thread-safe.
+   */
+  template <typename Kernel>
+    requires ParticleCallback<Kernel>
+  void for_each_local_particle(Kernel f) const {
+    for (auto &p : local_particles()) {
+      f(p);
+    }
+  }
+
+  /**
+   * @brief Run a kernel on all ghost particles.
+   * The kernel is assumed to be thread-safe.
+   */
+  template <typename Kernel>
+    requires ParticleCallback<Kernel>
+  void for_each_ghost_particle(Kernel f) const {
+    for (auto &p : ghost_particles()) {
+      f(p);
+    }
   }
 
 private:

--- a/src/core/error_handling/RuntimeErrorCollector.cpp
+++ b/src/core/error_handling/RuntimeErrorCollector.cpp
@@ -45,10 +45,12 @@ RuntimeErrorCollector::~RuntimeErrorCollector() {
 }
 
 void RuntimeErrorCollector::message(const RuntimeError &message) {
+  std::lock_guard<std::mutex> lock(mutex);
   m_errors.emplace_back(message);
 }
 
 void RuntimeErrorCollector::message(RuntimeError message) {
+  std::lock_guard<std::mutex> lock(mutex);
   m_errors.emplace_back(std::move(message));
 }
 
@@ -56,6 +58,7 @@ void RuntimeErrorCollector::message(RuntimeError::ErrorLevel level,
                                     const std::string &msg,
                                     const char *function, const char *file,
                                     const int line) {
+  std::lock_guard<std::mutex> lock(mutex);
   m_errors.emplace_back(level, m_comm.rank(), msg, std::string(function),
                         std::string(file), line);
 }
@@ -63,6 +66,7 @@ void RuntimeErrorCollector::message(RuntimeError::ErrorLevel level,
 void RuntimeErrorCollector::warning(const std::string &msg,
                                     const char *function, const char *file,
                                     const int line) {
+  std::lock_guard<std::mutex> lock(mutex);
   m_errors.emplace_back(RuntimeError::ErrorLevel::WARNING, m_comm.rank(), msg,
                         std::string(function), std::string(file), line);
 }
@@ -80,6 +84,7 @@ void RuntimeErrorCollector::warning(const std::ostringstream &mstr,
 
 void RuntimeErrorCollector::error(const std::string &msg, const char *function,
                                   const char *file, const int line) {
+  std::lock_guard<std::mutex> lock(mutex);
   m_errors.emplace_back(RuntimeError::ErrorLevel::ERROR, m_comm.rank(), msg,
                         std::string(function), std::string(file), line);
 }
@@ -96,6 +101,7 @@ void RuntimeErrorCollector::error(const std::ostringstream &mstr,
 }
 
 int RuntimeErrorCollector::count() const {
+  std::lock_guard<std::mutex> lock(mutex);
   return boost::mpi::all_reduce(m_comm, static_cast<int>(m_errors.size()),
                                 std::plus<>());
 }
@@ -105,16 +111,23 @@ int RuntimeErrorCollector::count(RuntimeError::ErrorLevel level) {
       m_errors, [level](auto const &e) { return e.level() >= level; }));
 }
 
-void RuntimeErrorCollector::clear() { m_errors.clear(); }
+void RuntimeErrorCollector::clear() {
+  std::lock_guard<std::mutex> lock(mutex);
+  m_errors.clear();
+}
 
 void RuntimeErrorCollector::flush() {
-  for (auto const &e : m_errors) {
-    std::cerr << e.format() << std::endl;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (auto const &e : m_errors) {
+      std::cerr << e.format() << std::endl;
+    }
   }
   this->clear();
 }
 
 std::vector<RuntimeError> RuntimeErrorCollector::gather() {
+  std::lock_guard<std::mutex> lock(mutex);
   std::vector<RuntimeError> all_errors{};
   std::swap(all_errors, m_errors);
 
@@ -124,8 +137,10 @@ std::vector<RuntimeError> RuntimeErrorCollector::gather() {
 }
 
 void RuntimeErrorCollector::gather_local() {
-  Utils::Mpi::gather_buffer(m_errors, m_comm);
-
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    Utils::Mpi::gather_buffer(m_errors, m_comm);
+  }
   this->clear();
 }
 

--- a/src/core/error_handling/RuntimeErrorCollector.hpp
+++ b/src/core/error_handling/RuntimeErrorCollector.hpp
@@ -24,6 +24,7 @@
 
 #include <boost/mpi/communicator.hpp>
 
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -85,6 +86,7 @@ public:
   const boost::mpi::communicator &comm() const { return m_comm; }
 
 private:
+  mutable std::mutex mutex;
   std::vector<RuntimeError> m_errors;
   boost::mpi::communicator m_comm;
 };

--- a/src/core/forces.cpp
+++ b/src/core/forces.cpp
@@ -87,34 +87,32 @@ static ParticleForce external_force(Particle const &p) {
   return f;
 }
 
-static void init_forces(ParticleRange const &particles,
-                        ParticleRange const &ghost_particles) {
+void init_forces(const CellStructure &cell_structure) {
 #ifdef CALIPER
   CALI_CXX_MARK_FUNCTION;
 #endif
 
-  for (auto &p : particles) {
-    p.force_and_torque() = external_force(p);
-  }
+  cell_structure.for_each_local_particle(
+      [](Particle &p) { p.force_and_torque() = external_force(p); });
 
-  init_forces_ghosts(ghost_particles);
+  init_forces_ghosts(cell_structure);
 }
 
-void init_forces_ghosts(ParticleRange const &particles) {
-  for (auto &p : particles) {
-    p.force_and_torque() = {};
-  }
+void init_forces_ghosts(const CellStructure &cell_structure) {
+  cell_structure.for_each_ghost_particle(
+      [](Particle &p) { p.force_and_torque() = {}; });
 }
 
-static void force_capping(ParticleRange const &particles, double force_cap) {
+static void force_capping(CellStructure &cell_structure, double force_cap) {
   if (force_cap > 0.) {
     auto const force_cap_sq = Utils::sqr(force_cap);
-    for (auto &p : particles) {
-      auto const force_sq = p.force().norm2();
-      if (force_sq > force_cap_sq) {
-        p.force() *= force_cap / std::sqrt(force_sq);
-      }
-    }
+    cell_structure.for_each_local_particle(
+        [&force_cap, &force_cap_sq](Particle &p) {
+          auto const force_sq = p.force().norm2();
+          if (force_sq > force_cap_sq) {
+            p.force() *= force_cap / std::sqrt(force_sq);
+          }
+        });
   }
 }
 
@@ -137,11 +135,11 @@ void System::System::calculate_forces() {
 #endif
   bond_breakage->clear_queue();
   auto particles = cell_structure->local_particles();
-  auto ghost_particles = cell_structure->ghost_particles();
 #ifdef ELECTROSTATICS
   if (coulomb.impl->extension) {
     if (auto icc = std::get_if<std::shared_ptr<ICCStar>>(
             get_ptr(coulomb.impl->extension))) {
+      auto ghost_particles = cell_structure->ghost_particles();
       (**icc).iteration(*cell_structure, particles, ghost_particles);
     }
   }
@@ -152,7 +150,7 @@ void System::System::calculate_forces() {
     npt_inst_pressure->p_vir = Utils::Vector3d{};
   }
 #endif
-  init_forces(particles, ghost_particles);
+  init_forces(*cell_structure);
   thermostat_force_init();
 
   calc_long_range_forces(particles);
@@ -245,7 +243,7 @@ void System::System::calculate_forces() {
   comfixed->apply(particles);
 
   // Needs to be the last one to be effective
-  force_capping(particles, force_cap);
+  force_capping(*cell_structure, force_cap);
 
   // mark that forces are now up-to-date
   propagation->recalc_forces = false;

--- a/src/core/forces.hpp
+++ b/src/core/forces.hpp
@@ -32,10 +32,10 @@
 #include <utils/Vector.hpp>
 
 /** Assign external forces/torques to real particles and zero to ghosts. */
-void init_forces(ParticleRange const &particles, double time_step);
+void init_forces(const CellStructure &cell_structure);
 
 /** Set forces of all ghosts to zero */
-void init_forces_ghosts(ParticleRange const &particles);
+void init_forces_ghosts(const CellStructure &cell_structure);
 
 /** Calculate long range forces (P3M, ...). */
 void calc_long_range_forces(ParticleRange const &particles);

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -325,7 +325,7 @@ void System::System::thermostat_force_init() {
   }
   auto const &langevin = *thermostat->langevin;
   auto const kT = thermostat->kT;
-  for (auto &p : cell_structure->local_particles()) {
+  cell_structure->for_each_local_particle([&](Particle &p) {
     if (propagation.should_propagate_with(p, PropagationMode::TRANS_LANGEVIN))
       p.force() += friction_thermo_langevin(langevin, p, time_step, kT);
 #ifdef ROTATION
@@ -333,26 +333,26 @@ void System::System::thermostat_force_init() {
       p.torque() += convert_vector_body_to_space(
           p, friction_thermo_langevin_rotation(langevin, p, time_step, kT));
 #endif
-  }
+  });
 }
 
 /** @brief Calls the hook for propagation kernels before the force calculation
  *  @return whether or not to stop the integration loop early.
  */
-static bool integrator_step_1(ParticleRange const &particles,
+static bool integrator_step_1(CellStructure &cell_structure,
                               Propagation const &propagation,
                               System::System &system, double time_step) {
   // steepest decent
   if (propagation.integ_switch == INTEG_METHOD_STEEPEST_DESCENT)
-    return steepest_descent_step(particles);
+    return steepest_descent_step(cell_structure.local_particles());
 
   auto const &thermostat = *system.thermostat;
   auto const kT = thermostat.kT;
-  for (auto &p : particles) {
+  cell_structure.for_each_local_particle([&](Particle &p) {
 #ifdef VIRTUAL_SITES
     // virtual sites are updated later in the integration loop
     if (p.is_virtual())
-      continue;
+      return;
 #endif
     if (propagation.should_propagate_with(
             p, PropagationMode::TRANS_LB_MOMENTUM_EXCHANGE))
@@ -375,14 +375,14 @@ static bool integrator_step_1(ParticleRange const &particles,
     if (propagation.should_propagate_with(p, PropagationMode::ROT_BROWNIAN))
       brownian_dynamics_rotator(*thermostat.brownian, p, time_step, kT);
 #endif
-  }
+  });
 
 #ifdef NPT
   if ((propagation.used_propagations & PropagationMode::TRANS_LANGEVIN_NPT) and
       (propagation.default_propagation & PropagationMode::TRANS_LANGEVIN_NPT)) {
     auto pred = PropagationPredicateNPT(propagation.default_propagation);
-    velocity_verlet_npt_step_1(particles.filter(pred), *thermostat.npt_iso,
-                               time_step, system);
+    velocity_verlet_npt_step_1(cell_structure.local_particles().filter(pred),
+                               *thermostat.npt_iso, time_step, system);
   }
 #endif
 
@@ -390,26 +390,26 @@ static bool integrator_step_1(ParticleRange const &particles,
   if ((propagation.used_propagations & PropagationMode::TRANS_STOKESIAN) and
       (propagation.default_propagation & PropagationMode::TRANS_STOKESIAN)) {
     auto pred = PropagationPredicateStokesian(propagation.default_propagation);
-    stokesian_dynamics_step_1(particles.filter(pred), *thermostat.stokesian,
-                              time_step, kT);
+    stokesian_dynamics_step_1(cell_structure.local_particles().filter(pred),
+                              *thermostat.stokesian, time_step, kT);
   }
 #endif // STOKESIAN_DYNAMICS
 
   return false;
 }
 
-static void integrator_step_2(ParticleRange const &particles,
+static void integrator_step_2(CellStructure &cell_structure,
                               Propagation const &propagation,
                               [[maybe_unused]] System::System &system,
                               double time_step) {
   if (propagation.integ_switch == INTEG_METHOD_STEEPEST_DESCENT)
     return;
 
-  for (auto &p : particles) {
+  cell_structure.for_each_local_particle([&](Particle &p) {
 #ifdef VIRTUAL_SITES
     // virtual sites are updated later in the integration loop
     if (p.is_virtual())
-      continue;
+      return;
 #endif
     if (propagation.should_propagate_with(
             p, PropagationMode::TRANS_LB_MOMENTUM_EXCHANGE))
@@ -426,13 +426,14 @@ static void integrator_step_2(ParticleRange const &particles,
     if (propagation.should_propagate_with(p, PropagationMode::ROT_LANGEVIN))
       velocity_verlet_rotator_2(p, time_step);
 #endif
-  }
+  });
 
 #ifdef NPT
   if ((propagation.used_propagations & PropagationMode::TRANS_LANGEVIN_NPT) and
       (propagation.default_propagation & PropagationMode::TRANS_LANGEVIN_NPT)) {
     auto pred = PropagationPredicateNPT(propagation.default_propagation);
-    velocity_verlet_npt_step_2(particles.filter(pred), time_step, system);
+    velocity_verlet_npt_step_2(cell_structure.local_particles().filter(pred),
+                               time_step, system);
   }
 #endif
 }
@@ -529,25 +530,23 @@ int System::System::integrate(int n_steps, int reuse_forces) {
     CALI_CXX_MARK_LOOP_ITERATION(integration_loop, step);
 #endif
 
-    auto particles = cell_structure->local_particles();
-
 #ifdef BOND_CONSTRAINT
     if (n_rigid_bonds)
-      save_old_position(particles, cell_structure->ghost_particles());
+      save_old_position(cell_structure->local_particles(),
+                        cell_structure->ghost_particles());
 #endif
 
     lees_edwards->update_box_params(*box_geo, sim_time);
     bool early_exit =
-        integrator_step_1(particles, propagation, *this, time_step);
+        integrator_step_1(*cell_structure, propagation, *this, time_step);
     if (early_exit)
       break;
 
     sim_time += time_step;
     if (box_geo->type() == BoxType::LEES_EDWARDS) {
       auto const kernel = LeesEdwards::Push{*box_geo};
-      for (auto &p : particles) {
-        kernel(p);
-      }
+      cell_structure->for_each_local_particle(
+          [&kernel](Particle &p) { kernel(p); });
     }
 
 #ifdef NPT
@@ -585,8 +584,6 @@ int System::System::integrate(int n_steps, int reuse_forces) {
     // Communication step: distribute ghost positions
     cell_structure->update_ghosts_and_resort_particle(get_global_ghost_flags());
 
-    particles = cell_structure->local_particles();
-
     calculate_forces();
 
 #ifdef VIRTUAL_SITES_INERTIALESS_TRACERS
@@ -596,15 +593,14 @@ int System::System::integrate(int n_steps, int reuse_forces) {
                                              *local_geo, lb);
     }
 #endif
-    integrator_step_2(particles, propagation, *this, time_step);
+    integrator_step_2(*cell_structure, propagation, *this, time_step);
     if (propagation.integ_switch == INTEG_METHOD_BD) {
       resort_particles_if_needed(*this);
     }
     if (box_geo->type() == BoxType::LEES_EDWARDS) {
       auto const kernel = LeesEdwards::UpdateOffset{*box_geo};
-      for (auto &p : particles) {
-        kernel(p);
-      }
+      cell_structure->for_each_local_particle(
+          [&kernel](Particle &p) { kernel(p); });
     }
 #ifdef BOND_CONSTRAINT
     if (n_rigid_bonds) {

--- a/src/core/virtual_sites/lb_tracers.cpp
+++ b/src/core/virtual_sites/lb_tracers.cpp
@@ -46,7 +46,7 @@ void lb_tracers_add_particle_force_to_fluid(CellStructure &cell_structure,
   auto const agrid = lb.get_agrid();
 
   // Distribute summed-up forces from physical particles to ghosts
-  init_forces_ghosts(cell_structure.ghost_particles());
+  init_forces_ghosts(cell_structure);
   cell_structure.update_ghosts_and_resort_particle(Cells::DATA_PART_FORCE);
 
   // Keep track of ghost particles (ids) that have already been coupled
@@ -68,7 +68,7 @@ void lb_tracers_add_particle_force_to_fluid(CellStructure &cell_structure,
   }
 
   // Clear ghost forces to avoid double counting later
-  init_forces_ghosts(cell_structure.ghost_particles());
+  init_forces_ghosts(cell_structure);
 }
 
 void lb_tracers_propagate(CellStructure &cell_structure, LB::Solver const &lb,

--- a/src/core/virtual_sites/relative.cpp
+++ b/src/core/virtual_sites/relative.cpp
@@ -124,15 +124,14 @@ void vs_relative_update_particles(CellStructure &cell_structure,
   cell_structure.ghosts_update(Cells::DATA_PART_POSITION |
                                Cells::DATA_PART_MOMENTUM);
 
-  auto const particles = cell_structure.local_particles();
-  for (auto &p : particles) {
+  cell_structure.for_each_local_particle([&](Particle &p) {
     if (!is_vs_relative(p)) {
-      continue;
+      return;
     }
 
     auto const *p_ref_ptr = get_reference_particle(cell_structure, p);
     if (!p_ref_ptr)
-      continue;
+      return;
 
     auto const &p_ref = *p_ref_ptr;
 
@@ -154,7 +153,7 @@ void vs_relative_update_particles(CellStructure &cell_structure,
     if (is_vs_relative_rot(p)) {
       p.quat() = p_ref.quat() * p.vs_relative().quat;
     }
-  }
+  });
 
   if (cell_structure.check_resort_required()) {
     cell_structure.set_resort_particles(Cells::RESORT_LOCAL);
@@ -167,12 +166,12 @@ void vs_relative_back_transfer_forces_and_torques(
     CellStructure &cell_structure) {
   cell_structure.ghosts_reduce_forces();
 
-  init_forces_ghosts(cell_structure.ghost_particles());
+  init_forces_ghosts(cell_structure);
 
   // Iterate over all the particles in the local cells
-  for (auto &p : cell_structure.local_particles()) {
+  cell_structure.for_each_local_particle([&](Particle &p) {
     if (!is_vs_relative(p))
-      continue;
+      return;
 
     auto *p_ref_ptr = get_reference_particle(cell_structure, p);
     assert(p_ref_ptr != nullptr);
@@ -186,7 +185,7 @@ void vs_relative_back_transfer_forces_and_torques(
     if (is_vs_relative_rot(p)) {
       p_ref.torque() += p.torque();
     }
-  }
+  });
 }
 
 // Rigid body contribution to scalar pressure and pressure tensor


### PR DESCRIPTION
Description of changes:
- introduce `for_each_{local,ghost}_particle()`
- make `RuntimeErrorCollector` thread-safe

This introduces `cell_structure.for_each_local_particle()` and `cell_structure.for_each_ghost_particle()` templates and uses them in integrators / virtual sites / force setup etc. For now, I rolled it out only where the per-particle operation has no side effects and is safe to execute in parallel. The one exception is the `RuntimeErrorCollector`, where a mutex was added.

Once we have Kokkos-support in, we can implement parallel versions of the templates without modifying the call sites. Probably some sort of heuristics will be needed to only use the parallel version for a high enough number of particles.

The most relevant places still missing (because they have side effects) is bonded force calculation and LB coupling. I'm not sure about side effects of constraints, in particular how DPD-based constraints handle the counter.