### PR TITLE
Fix DPD thermostat

### DIFF
--- a/src/core/system/System.cpp
+++ b/src/core/system/System.cpp
@@ -295,8 +295,7 @@ void System::on_short_range_ia_change() {
 void System::on_non_bonded_ia_change() {
   nonbonded_ias->recalc_maximal_cutoffs();
   rebuild_cell_structure();
-  thermostat->recalc_prefactors(time_step);
-  reinit_thermo = false;
+  on_thermostat_param_change();
   propagation->recalc_forces = true;
 }
 

--- a/src/core/system/System.cpp
+++ b/src/core/system/System.cpp
@@ -295,6 +295,8 @@ void System::on_short_range_ia_change() {
 void System::on_non_bonded_ia_change() {
   nonbonded_ias->recalc_maximal_cutoffs();
   rebuild_cell_structure();
+  thermostat->recalc_prefactors(time_step);
+  reinit_thermo = false;
   propagation->recalc_forces = true;
 }
 

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -170,6 +170,20 @@ class DPDThermostat(ut.TestCase):
             np.copy(p0.f), gamma * v, rtol=0, atol=1e-11)
         np.testing.assert_array_equal(np.copy(p0.f), -np.copy(p1.f))
 
+        # check prefactors are recalculated when non-bonded IAs are modified
+        # *before* a particle of the matching type exists in the system
+        system.non_bonded_inter[2, 0].dpd.set_params(
+            weight_function=0, gamma=1.5 * gamma, r_cut=1.2,
+            trans_weight_function=0, trans_gamma=1.5 * gamma, trans_r_cut=1.4)
+        p1.type = 2
+        p1.pos = [5. - 1.1, 5, 5]
+
+        system.integrator.run(0)
+
+        np.testing.assert_allclose(
+            np.copy(p0.f), 1.5 * gamma * v, rtol=0, atol=1e-11)
+        np.testing.assert_array_equal(np.copy(p0.f), -np.copy(p1.f))
+
     def test_linear_weight_function(self):
         system = self.system
         kT = 0.

--- a/testsuite/python/dpd.py
+++ b/testsuite/python/dpd.py
@@ -184,6 +184,17 @@ class DPDThermostat(ut.TestCase):
             np.copy(p0.f), 1.5 * gamma * v, rtol=0, atol=1e-11)
         np.testing.assert_array_equal(np.copy(p0.f), -np.copy(p1.f))
 
+        # check prefactors are recalculated when time step changes
+        force_without_noise = np.copy(p0.f)
+        system.thermostat.set_dpd(kT=1, seed=42)
+        system.integrator.run(0)
+        old_noise = np.copy(p0.f) - force_without_noise
+        system.time_step = 2. * system.time_step
+        system.integrator.run(0)
+        new_noise = np.copy(p0.f) - force_without_noise
+        np.testing.assert_array_almost_equal(
+            new_noise, old_noise / np.sqrt(2.))
+
     def test_linear_weight_function(self):
         system = self.system
         kT = 0.


### PR DESCRIPTION
Description of changes:
- DPD thermostat prefactors are now always up-to-date, regardless of the order in which the DPD thermostat and DPD non-bonded interaction are set up
