### PR TITLE
Add Kokkos and Cabana to the build process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,6 +219,7 @@ cuda12-coverage:
      with_scafacos: 'true'
      with_walberla: 'true'
      with_stokesian_dynamics: 'true'
+     with_cabana: 'true'
   script:
     - bash maintainer/CI/build_cmake.sh
   timeout: 90m
@@ -245,6 +246,7 @@ cuda12-maxset:
      with_walberla_avx: 'true'
      with_stokesian_dynamics: 'true'
      with_caliper: 'true'
+     with_cabana: 'true'
   script:
     - bash maintainer/CI/build_cmake.sh
   artifacts:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,20 +480,20 @@ if(ESPRESSO_BUILD_WITH_CABANA)
   # Find kokkos
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../kokkos")
     set(Kokkos_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../kokkos/build")
-    find_package(Kokkos REQUIRED) 
   endif()
 
-  # Fetch Cabana
+  # Fetch Cabana 0.7.0
+  # Cabana already uses find_package(Kokkos) internally
   include(FetchContent)
   if(EXISTS "${CMAKE_BINARY_DIR}/_deps/cabana-build")
     FetchContent_Declare(cabana
       GIT_REPOSITORY https://github.com/ECP-copa/Cabana.git
-      GIT_TAG 07573782590e223edc6e5f83ec0807be5941df14
+      GIT_TAG 7914d28708b1c67b40d5743c1fbc09e221144dd3
     )
   else() # Fix Cabana/Doxygen with Espresso/Doxygen conflict
     FetchContent_Declare(cabana
       GIT_REPOSITORY https://github.com/ECP-copa/Cabana.git
-      GIT_TAG 07573782590e223edc6e5f83ec0807be5941df14
+      GIT_TAG 7914d28708b1c67b40d5743c1fbc09e221144dd3
       PATCH_COMMAND patch -N --reject-file=- -i "${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_cabana_doxygen.diff" 
     )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ option(ESPRESSO_BUILD_WITH_WALBERLA
 option(ESPRESSO_BUILD_WITH_WALBERLA_AVX
        "Build waLBerla lattice-Boltzmann with AVX vectorization" OFF)
 option(ESPRESSO_BUILD_WITH_WALBERLA_FFT "Build waLBerla with FFT support" OFF)
+option(ESPRESSO_BUILD_WITH_CABANA "Build with Cabana and Kokkos packages" ON)
 option(ESPRESSO_BUILD_BENCHMARKS "Enable benchmarks" OFF)
 option(ESPRESSO_BUILD_WITH_VALGRIND "Build with Valgrind instrumentation" OFF)
 option(ESPRESSO_BUILD_WITH_CALIPER "Build with Caliper instrumentation" OFF)
@@ -474,6 +475,30 @@ endif()
 #
 # Libraries
 #
+
+if(ESPRESSO_BUILD_WITH_CABANA)
+  # Find kokkos
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../kokkos")
+    set(Kokkos_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../kokkos/build")
+    find_package(Kokkos REQUIRED) 
+  endif()
+
+  # Fetch Cabana
+  include(FetchContent)
+  if(EXISTS "${CMAKE_BINARY_DIR}/_deps/cabana-build")
+    FetchContent_Declare(cabana
+      GIT_REPOSITORY https://github.com/ECP-copa/Cabana.git
+      GIT_TAG 07573782590e223edc6e5f83ec0807be5941df14
+    )
+  else() # Fix Cabana/Doxygen with Espresso/Doxygen conflict
+    FetchContent_Declare(cabana
+      GIT_REPOSITORY https://github.com/ECP-copa/Cabana.git
+      GIT_TAG 07573782590e223edc6e5f83ec0807be5941df14
+      PATCH_COMMAND patch -N --reject-file=- -i "${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_cabana_doxygen.diff" 
+    )
+  endif()
+  FetchContent_MakeAvailable(cabana)
+endif()
 
 if(ESPRESSO_BUILD_WITH_FFTW)
   find_package(FFTW3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ option(ESPRESSO_BUILD_WITH_WALBERLA
 option(ESPRESSO_BUILD_WITH_WALBERLA_AVX
        "Build waLBerla lattice-Boltzmann with AVX vectorization" OFF)
 option(ESPRESSO_BUILD_WITH_WALBERLA_FFT "Build waLBerla with FFT support" OFF)
-option(ESPRESSO_BUILD_WITH_CABANA "Build with Cabana and Kokkos packages" ON)
+option(ESPRESSO_BUILD_WITH_CABANA "Build with Cabana and Kokkos packages" OFF)
 option(ESPRESSO_BUILD_BENCHMARKS "Enable benchmarks" OFF)
 option(ESPRESSO_BUILD_WITH_VALGRIND "Build with Valgrind instrumentation" OFF)
 option(ESPRESSO_BUILD_WITH_CALIPER "Build with Caliper instrumentation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,12 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/icl-utk-edu/heffte.git
   GIT_TAG        v2.4.1
 )
+FetchContent_Declare(
+  cabana
+  GIT_REPOSITORY https://github.com/ECP-copa/Cabana.git
+  GIT_TAG        7914d28708b1c67b40d5743c1fbc09e221144dd3
+  PATCH_COMMAND  patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_cabana_doxygen.diff
+)
 # cmake-format: on
 
 # ##############################################################################
@@ -478,26 +484,17 @@ endif()
 
 if(ESPRESSO_BUILD_WITH_CABANA)
   # Find kokkos
-  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../kokkos")
-    set(Kokkos_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../kokkos/build")
+  if(NOT EXISTS Kokkos_DIR)
+    message(
+      FATAL_ERROR
+        "Kokkos_DIR not set. Please set it to the directory containing KokkosConfig.cmake (typically the Kokkos build folder)"
+    )
   endif()
 
-  # Fetch Cabana 0.7.0
-  # Cabana already uses find_package(Kokkos) internally
-  include(FetchContent)
-  if(EXISTS "${CMAKE_BINARY_DIR}/_deps/cabana-build")
-    FetchContent_Declare(cabana
-      GIT_REPOSITORY https://github.com/ECP-copa/Cabana.git
-      GIT_TAG 7914d28708b1c67b40d5743c1fbc09e221144dd3
-    )
-  else() # Fix Cabana/Doxygen with Espresso/Doxygen conflict
-    FetchContent_Declare(cabana
-      GIT_REPOSITORY https://github.com/ECP-copa/Cabana.git
-      GIT_TAG 7914d28708b1c67b40d5743c1fbc09e221144dd3
-      PATCH_COMMAND patch -N --reject-file=- -i "${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_cabana_doxygen.diff" 
-    )
+  # Fetch Cabana 0.7.0 Cabana already uses find_package(Kokkos) internally
+  if(NOT cabana_POPULATED)
+    FetchContent_MakeAvailable(cabana)
   endif()
-  FetchContent_MakeAvailable(cabana)
 endif()
 
 if(ESPRESSO_BUILD_WITH_FFTW)

--- a/cmake/espresso_cmake_config.cmakein
+++ b/cmake/espresso_cmake_config.cmakein
@@ -23,6 +23,8 @@
 
 #cmakedefine ESPRESSO_BUILD_WITH_FPE
 
+#cmakedefine ESPRESSO_BUILD_WITH_CABANA
+
 #define PACKAGE_NAME "${PROJECT_NAME}"
 
 /**

--- a/cmake/patch_cabana_doxygen.diff
+++ b/cmake/patch_cabana_doxygen.diff
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c228d50a..00693256 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -216,12 +216,6 @@ if(Cabana_ENABLE_TESTING)
+   enable_testing()
+ endif()
+ 
+-# enable doxygen
+-find_package(Doxygen)
+-if(Doxygen_FOUND)
+-  doxygen_add_docs(doxygen core/src grid/src)
+-endif()
+-
+ ##---------------------------------------------------------------------------##
+ ## Libraries and Examples
+ ##---------------------------------------------------------------------------##

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -101,6 +101,7 @@ set_default_value with_asan false
 set_default_value with_static_analysis false
 set_default_value with_caliper false
 set_default_value with_fpe false
+set_default_value with_cabana false
 set_default_value myconfig "default"
 set_default_value build_procs ${ci_procs}
 set_default_value check_procs ${build_procs}

--- a/src/config/features.def
+++ b/src/config/features.def
@@ -116,3 +116,4 @@ WALBERLA_FFT external
 VALGRIND external
 CALIPER external
 FPE external
+CABANA external

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -101,6 +101,10 @@ if(ESPRESSO_BUILD_WITH_FFTW)
   add_subdirectory(p3m)
 endif()
 
+if(ESPRESSO_BUILD_WITH_CABANA)
+  target_link_libraries(espresso_core PRIVATE Cabana::Core)
+endif()
+
 add_subdirectory(accumulators)
 add_subdirectory(analysis)
 add_subdirectory(bond_breakage)

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -30,6 +30,10 @@
 #include <walberla_bridge/walberla_init.hpp>
 #endif
 
+#ifdef CABANA
+#include <Cabana_Core.hpp>
+#endif
+
 #include <utils/Vector.hpp>
 #include <utils/mpi/cart_comm.hpp>
 
@@ -84,10 +88,20 @@ void init(std::shared_ptr<boost::mpi::environment> mpi_env) {
 #ifdef CUDA
   cuda_on_program_start();
 #endif
+
+#ifdef CABANA
+  Kokkos::initialize();
+#endif
 }
 
-void deinit() { Communication::m_callbacks.reset(); }
-} // namespace Communication
+void deinit() {
+  Communication::m_callbacks.reset(); 
+
+#ifdef CABANA 
+  Kokkos::finalize();
+#endif
+  }
+}
 
 Communicator::Communicator()
     : comm{::comm_cart}, node_grid{}, this_node{::this_node}, size{-1} {}

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -32,6 +32,7 @@
 
 #ifdef CABANA
 #include <Cabana_Core.hpp>
+#include <Kokkos_Core.hpp>
 #endif
 
 #include <utils/Vector.hpp>

--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -96,13 +96,13 @@ void init(std::shared_ptr<boost::mpi::environment> mpi_env) {
 }
 
 void deinit() {
-  Communication::m_callbacks.reset(); 
+  Communication::m_callbacks.reset();
 
-#ifdef CABANA 
+#ifdef CABANA
   Kokkos::finalize();
 #endif
-  }
 }
+} // namespace Communication
 
 Communicator::Communicator()
     : comm{::comm_cart}, node_grid{}, this_node{::this_node}, size{-1} {}


### PR DESCRIPTION
Adds the Kokkos and Cabana Libraries to the build process of ESPResSo.

Cabana requires Kokkos to be built from source with a minimum Kokkos version of 4.1.

To install Kokkos you can run the following:

```
# In the same folder where top espresso folder is
git clone https://github.com/kokkos/kokkos.git -b 4.2.00

cd kokkos
mkdir build
cd build
cmake \
      -D CMAKE_BUILD_TYPE="Release" \
      -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
      -D Kokkos_ENABLE_OPENMP=ON \
      -D Kokkos_ENABLE_SERIAL=ON \
      .. ;
make
cd ../..
```
Before building ESPResSo you have to define the environment variable
```
export Kokkos_DIR=/parent_dir/kokkos/build
```
which specifies where the Kokkos build folder can be found.

If Kokkos is successfully installed, Kokkos and Cabana can both be easily enabled in the ESPResSo build process by using the cmake build option `-D ESPRESSO_BUILD_WITH_CABANA=on`.

If for some reason your build fails mid build process, you might need to build from scratch as during the build process there are conflict patches between Cabana and ESPResSo that can cause problems if interrupted.