### PR TITLE
Kokkos version of for_each_particle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,8 @@ if(ESPRESSO_BUILD_WITH_FFTW)
 endif()
 
 if(ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM)
+  find_package(OpenMP REQUIRED)
+
   if(NOT EXISTS ${FETCHCONTENT_BASE_DIR}/kokkos-src)
     find_package(Kokkos 4.3 QUIET)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,6 +829,14 @@ if(ESPRESSO_BUILD_TESTS)
             "Extra arguments to give to ctest calls (separated by semicolons)")
   set(ESPRESSO_TEST_NP "4" CACHE STRING
                                  "Maximal number of MPI ranks to use per test")
+  add_library(espresso_tests_cpp_flags INTERFACE)
+  add_library(espresso::tests::cpp_flags ALIAS espresso_tests_cpp_flags)
+  if(ESPRESSO_BUILD_WITH_COVERAGE)
+    target_compile_options(
+      espresso_tests_cpp_flags
+      INTERFACE $<$<CXX_COMPILER_ID:GNU>:-fno-default-inline>
+                $<$<CXX_COMPILER_ID:GNU>:-fno-elide-constructors>)
+  endif()
   if(ESPRESSO_BUILD_WITH_PYTHON)
     add_subdirectory(testsuite)
   endif()
@@ -848,6 +856,7 @@ if(ESPRESSO_BUILD_WITH_WALBERLA)
   FetchContent_Declare(
     walberla
     GIT_REPOSITORY https://i10git.cs.fau.de/walberla/walberla.git
+                   https://github.com/lssfau/walberla.git
     GIT_TAG        0aab9c0af2335b1f6fec75deae06e514ccb233ab
     PATCH_COMMAND  patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/walberla.patch
   )
@@ -861,7 +870,6 @@ if(ESPRESSO_BUILD_WITH_WALBERLA)
   set(WALBERLA_BUILD_SHOWCASES off CACHE BOOL "")
   set(WALBERLA_BUILD_DOC off CACHE BOOL "")
   set(WALBERLA_LOGLEVEL "WARNING" CACHE STRING "")
-  set(CMAKE_POSITION_INDEPENDENT_CODE on CACHE BOOL "")
   if(ESPRESSO_BUILD_WITH_CUDA)
     set(WALBERLA_BUILD_WITH_CUDA "on" CACHE BOOL "")
     if(NOT ESPRESSO_CUDA_COMPILER STREQUAL "clang")

--- a/cmake/espresso_unit_test.cmake
+++ b/cmake/espresso_unit_test.cmake
@@ -18,7 +18,7 @@
 #
 
 function(ESPRESSO_UNIT_TEST)
-  cmake_parse_arguments(TEST "" "SRC;NAME;NUM_PROC" "DEPENDS" ${ARGN})
+  cmake_parse_arguments(TEST "" "SRC;NAME;NUM_PROC;NUM_THREADS" "DEPENDS" ${ARGN})
   if(NOT DEFINED TEST_NAME)
     cmake_path(GET TEST_SRC STEM TEST_NAME)
     set(TEST_NAME ${TEST_NAME} PARENT_SCOPE)
@@ -36,14 +36,10 @@ function(ESPRESSO_UNIT_TEST)
     target_link_libraries(${TEST_NAME} PRIVATE ${TEST_DEPENDS})
   endif()
   target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src/core)
-  if(ESPRESSO_BUILD_WITH_COVERAGE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(
-      ${TEST_NAME} PRIVATE -fno-default-inline -fno-elide-constructors)
-  endif()
   if(${TEST_SRC} MATCHES ".*\.cu$")
     target_link_libraries(${TEST_NAME} PRIVATE espresso::config CUDA::cuda_driver CUDA::cudart)
   else()
-    target_link_libraries(${TEST_NAME} PRIVATE espresso::config espresso::cpp_flags)
+    target_link_libraries(${TEST_NAME} PRIVATE espresso::config espresso::cpp_flags espresso::tests::cpp_flags)
   endif()
 
   # If NUM_PROC is given, set up MPI parallel test case
@@ -59,6 +55,9 @@ function(ESPRESSO_UNIT_TEST)
   else()
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
   endif()
+  if(NOT DEFINED TEST_NUM_THREADS)
+    set(TEST_NUM_THREADS 2)
+  endif()
 
   if(ESPRESSO_WARNINGS_ARE_ERRORS)
     set(SANITIZERS_HALT_ON_ERROR "halt_on_error=1")
@@ -71,7 +70,7 @@ function(ESPRESSO_UNIT_TEST)
   if(NOT TEST_NUM_PROC AND ESPRESSO_MPIEXEC_GUARD_SINGLETON_NUMA AND "${TEST_DEPENDS}" MATCHES "(^|;)([Bb]oost::mpi|MPI::MPI_CXX)($|;)")
     list(APPEND TEST_ENV_VARIABLES "OMPI_MCA_hwloc_base_binding_policy=none")
   endif()
-  list(APPEND TEST_ENV_VARIABLES "OMP_PROC_BIND=false" "OMP_NUM_THREADS=2")
+  list(APPEND TEST_ENV_VARIABLES "OMP_PROC_BIND=false" "OMP_NUM_THREADS=${TEST_NUM_THREADS}")
   set_tests_properties(
     ${TEST_NAME} PROPERTIES ENVIRONMENT "${TEST_ENV_VARIABLES}")
 

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -280,6 +280,32 @@ extra arguments are passed to the ``mpiexec`` program.
 On cluster computers, it might be necessary to load the MPI library with
 ``module load openmpi`` or similar.
 
+On modern NUMA architectures, |es| can leverage shared-memory parallelism
+(SMP) using the `OpenMP <https://www.openmp.org>`__ programming model.
+This is enabled via the CMake option ``-D SHARED_MEMORY_PARALLELISM=ON``.
+To run a simulation with 4 OpenMP threads, use the following syntax:
+
+.. code-block:: bash
+
+    OMP_NUM_THREADS=4 OMP_PROC_BIND=true ./pypresso simulation.py
+
+Not all features benefit from SMP. For example, the P3M tuning algorithm
+might choose to use only 1 thread for small enough mesh sizes.
+
+To run a simulation with :math:`n` MPI ranks and :math:`p` OpenMP threads
+per MPI rank, one has to specify a PE value of :math:`p` to avoid overlaps
+between threads. This can be achieved with the following syntax:
+
+.. code-block:: bash
+
+    OMP_NUM_THREADS=4 OMP_PROC_BIND=close OMP_PLACES=cores mpiexec \
+        -n 2 --map-by socket:PE=4 --bind-to core ./pypresso simulation.py
+
+This simulation will reserve 8 cores, but the simulation box will only be
+partitioned into 2 MPI domains. The affinity policy needs to be adjusted
+according to the hardware and simulation type.
+See next section for more details.
+
 .. _Performance gain:
 
 Performance gain
@@ -321,6 +347,19 @@ split the data structures over multiple machines. This becomes necessary
 when running simulations with millions of particles, as the memory
 available on a single compute node would otherwise saturate.
 
+With OpenMP algorithms, the affinity policy must be chosen according
+to the hardware and algorithms.
+Setting ``OMP_PROC_BIND=close`` packs cores as closely as possible,
+and ``OMP_PLACES=ll_caches`` resp. ``OMP_PLACES=numa_domain`` will
+bind threads to cores that share the same L3 cache resp. NUMA domain,
+ensuring that threads can access each other's data with minimal latency.
+Setting ``OMP_PROC_BIND=spread`` spreads out the cores, which can be
+beneficial in bandwidth-limited problems, for example when each GPU
+belongs to a different NUMA domain or core complex.
+When in doubt, use ``lstopo`` to show the CPU topology
+and ``numactl -H`` to show which GPUs belong to which NUMA domain;
+on Ubuntu these tools are provided by packages ``hwloc`` and ``numactl``.
+
 .. _Communication model:
 
 Communication model
@@ -329,9 +368,14 @@ Communication model
 |es| was originally designed for the "flat" model of communication:
 each MPI rank binds to a logical CPU core. This communication model
 doesn't fully leverage shared memory on recent CPUs, such as `NUMA
-architectures <https://en.wikipedia.org/wiki/Non-uniform_memory_access>`__,
-and |es| currently doesn't support the hybrid
-MPI+\ `OpenMP <https://www.openmp.org>`__ programming model.
+architectures <https://en.wikipedia.org/wiki/Non-uniform_memory_access>`__.
+
+The hybrid MPI+\ `OpenMP <https://www.openmp.org>`__ programming model
+is supported by a few |es| features. For small simulations, users will
+typically prefer running |es| with :math:`p` OpenMP threads and 1 MPI rank.
+For larger jobs that reserve more cores than a NUMA domain can provide,
+it is usually best to request one MPI rank per NUMA domain and as many
+OpenMP threads as cores in the NUMA domain.
 
 The MPI+CUDA programming model is supported, although only one GPU can be
 used for the entire simulation. As a result, a blocking *gather* operation
@@ -340,6 +384,7 @@ blocking *scatter* operation is carried out to transfer the result of the
 GPU calculation from the main rank back to all ranks. This latency limits
 GPU-acceleration to simulations running on fewer than 8 MPI ranks.
 For more details, see section :ref:`GPU acceleration`.
+Lattice-Boltzmann is the only algorithm that can use multiple GPUs.
 
 .. _The MPI callbacks framework:
 

--- a/maintainer/CI/build_cmake.sh
+++ b/maintainer/CI/build_cmake.sh
@@ -75,20 +75,30 @@ set_default_value() {
 }
 
 # the number of available processors depends on the CI runner
-ci_procs=2
+set_default_value with_cuda false
+default_build_procs=2
+default_check_procs=2
 if [ "${GITLAB_CI}" = "true" ]; then
     if [[ "${OSTYPE}" == "linux-gnu"* ]]; then
         # Linux runner
-        ci_procs=4
+        default_build_procs=4
+        default_check_procs=4
+        if [ "${with_cuda}" = "true" ]; then
+            default_build_procs=6
+            default_check_procs=4 # buffer for oversubscribed OpenMP threads
+        fi
     elif [[ "${OSTYPE}" == "darwin"* ]]; then
         # macOS runner
-        ci_procs=4
+        default_build_procs=4
+        default_check_procs=4
     fi
 elif [ "${GITHUB_ACTIONS}" = "true" ]; then
     # GitHub Actions provide 4 cores
-    ci_procs=4
+    default_build_procs=4
+    default_check_procs=4
 else
-    ci_procs=$(nproc)
+    default_build_procs=$(nproc)
+    default_check_procs=$(nproc)
 fi
 
 # handle environment variables
@@ -103,8 +113,8 @@ set_default_value with_caliper false
 set_default_value with_fpe false
 set_default_value with_shared_memory_parallelism false
 set_default_value myconfig "default"
-set_default_value build_procs ${ci_procs}
-set_default_value check_procs ${build_procs}
+set_default_value build_procs ${default_build_procs}
+set_default_value check_procs ${default_check_procs}
 set_default_value check_odd_only false
 set_default_value check_gpu_only false
 set_default_value check_skip_long false
@@ -114,7 +124,6 @@ set_default_value make_check_tutorials false
 set_default_value make_check_samples false
 set_default_value make_check_benchmarks false
 set_default_value with_fast_math false
-set_default_value with_cuda false
 set_default_value with_cuda_compiler "nvcc"
 set_default_value build_type "RelWithAssert"
 set_default_value with_ccache false

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -90,7 +90,11 @@ install(TARGETS espresso_core
 target_link_libraries(
   espresso_core
   PRIVATE
-    espresso::config espresso::utils::mpi espresso::shapes espresso::cpp_flags
+    espresso::config
+    espresso::utils::mpi
+    espresso::shapes
+    espresso::cpp_flags
+    $<$<BOOL:${ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM}>:OpenMP::OpenMP_CXX>
     $<$<BOOL:${ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM}>:Kokkos::kokkos>
     $<$<BOOL:${ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM}>:Cabana::Core>
   PUBLIC espresso::utils MPI::MPI_CXX Random123 espresso::particle_observables

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -51,6 +51,10 @@
 #include <utility>
 #include <vector>
 
+#ifdef SHARED_MEMORY_PARALLELISM
+#include <Kokkos_Core.hpp>
+#endif
+
 CellStructure::CellStructure(BoxGeometry const &box)
     : m_decomposition{std::make_unique<AtomDecomposition>(box)} {}
 
@@ -327,3 +331,21 @@ void CellStructure::update_ghosts_and_resort_particle(unsigned data_parts) {
     ghosts_update(data_parts & ~resort_only_parts);
   }
 }
+
+#ifdef SHARED_MEMORY_PARALLELISM
+void CellStructure::parallel_for_each_particle_impl(
+    std::span<Cell *const> cells, ParticleUnaryOp &f) const {
+  if (cells.size() > 1) {
+    Kokkos::parallel_for( // loop over cells
+        "for_each_local_particle", cells.size(), [&](auto cell_idx) {
+          for (auto &p : cells[cell_idx]->particles())
+            f(p);
+        });
+  } else if (cells.size() == 1) {
+    auto &particles = cells.front()->particles();
+    Kokkos::parallel_for( // loop over particles
+        "for_each_local_particle", particles.size(),
+        [&](auto part_idx) { f(*(particles.begin() + part_idx)); });
+  }
+}
+#endif // SHARED_MEMORY_PARALLELISM

--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <cassert>
 #include <concepts>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -54,10 +55,7 @@
 #include <utility>
 #include <vector>
 
-template <typename Callable>
-concept ParticleCallback = requires(Callable c, Particle &p) {
-  { c(p) } -> std::same_as<void>;
-};
+using ParticleUnaryOp = std::function<void(Particle &)>;
 
 namespace Cells {
 enum Resort : unsigned {
@@ -280,14 +278,26 @@ public:
   ParticleRange ghost_particles() const {
     return Cells::particles(decomposition().ghost_cells());
   }
+  /** @brief whether to use parallel version of @ref for_each_local_particle */
+  bool use_parallel_for_each_local_particle() const {
+#ifdef SHARED_MEMORY_PARALLELISM
+    return true;
+#else
+    return false;
+#endif
+  }
 
   /**
    * @brief Run a kernel on all local particles.
    * The kernel is assumed to be thread-safe.
    */
-  template <typename Kernel>
-    requires ParticleCallback<Kernel>
-  void for_each_local_particle(Kernel f) const {
+  void for_each_local_particle(ParticleUnaryOp &&f) const {
+#ifdef SHARED_MEMORY_PARALLELISM
+    if (use_parallel_for_each_local_particle()) {
+      parallel_for_each_particle_impl(decomposition().local_cells(), f);
+      return;
+    }
+#endif
     for (auto &p : local_particles()) {
       f(p);
     }
@@ -297,9 +307,7 @@ public:
    * @brief Run a kernel on all ghost particles.
    * The kernel is assumed to be thread-safe.
    */
-  template <typename Kernel>
-    requires ParticleCallback<Kernel>
-  void for_each_ghost_particle(Kernel f) const {
+  void for_each_ghost_particle(ParticleUnaryOp &&f) const {
     for (auto &p : ghost_particles()) {
       f(p);
     }
@@ -318,6 +326,11 @@ private:
   Cell const *particle_to_cell(const Particle &p) const {
     return decomposition().particle_to_cell(p);
   }
+
+#ifdef SHARED_MEMORY_PARALLELISM
+  void parallel_for_each_particle_impl(std::span<Cell *const> cells,
+                                       ParticleUnaryOp &f) const;
+#endif
 
 public:
   /**

--- a/src/core/magnetostatics/CMakeLists.txt
+++ b/src/core/magnetostatics/CMakeLists.txt
@@ -22,5 +22,11 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/dipolar_direct_sum.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/dipolar_direct_sum_gpu.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/dlc.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/dp3m.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/scafacos_impl.cpp)
+
+if(ESPRESSO_BUILD_WITH_FFTW)
+  target_sources(espresso_p3m PRIVATE dp3m.cpp)
+  set_source_files_properties(
+    dp3m.cpp TARGET_DIRECTORY espresso_p3m
+    PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/src/core)
+endif()

--- a/src/core/npt.cpp
+++ b/src/core/npt.cpp
@@ -20,7 +20,9 @@
 
 #ifdef NPT
 
+#include "BoxGeometry.hpp"
 #include "PropagationMode.hpp"
+#include "cell_system/CellStructure.hpp"
 #include "communication.hpp"
 #include "config/config.hpp"
 #include "electrostatics/coulomb.hpp"

--- a/src/core/p3m/CMakeLists.txt
+++ b/src/core/p3m/CMakeLists.txt
@@ -37,8 +37,15 @@ if(ESPRESSO_BUILD_WITH_FFTW)
   target_link_libraries(
     espresso_p3m
     PRIVATE
-      espresso::cpp_flags espresso::p3m::cpp_flags espresso::instrumentation
-      espresso::utils espresso::config Boost::mpi MPI::MPI_CXX Heffte::Heffte
+      espresso::cpp_flags
+      espresso::p3m::cpp_flags
+      espresso::instrumentation
+      espresso::utils
+      espresso::config
+      Boost::mpi
+      MPI::MPI_CXX
+      Heffte::Heffte
+      $<$<BOOL:${ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM}>:OpenMP::OpenMP_CXX>
       $<$<BOOL:${ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM}>:Kokkos::kokkos>
       $<$<BOOL:${ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM}>:Cabana::Core>)
   set_target_properties(espresso_p3m PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/walberla_bridge/CMakeLists.txt
+++ b/src/walberla_bridge/CMakeLists.txt
@@ -49,24 +49,28 @@ if(WALBERLA_BUILD_WITH_CUDA)
        "-clang-analyzer-core.NonNullParamChecker")
 endif()
 
-espresso_override_clang_tidy_checks(
-  WALBERLA_CXX_CLANG_TIDY "${SKIP_CLANG_TIDY_CHECKS}"
-  "${SKIP_CLANG_TIDY_CHECKS_CXX}")
-espresso_override_clang_tidy_checks(
-  WALBERLA_CUDA_CLANG_TIDY "${SKIP_CLANG_TIDY_CHECKS}"
-  "${SKIP_CLANG_TIDY_CHECKS_CUDA}")
+if(ESPRESSO_BUILD_WITH_CLANG_TIDY)
+  espresso_override_clang_tidy_checks(
+    WALBERLA_CXX_CLANG_TIDY "${SKIP_CLANG_TIDY_CHECKS}"
+    "${SKIP_CLANG_TIDY_CHECKS_CXX}")
+  espresso_override_clang_tidy_checks(
+    WALBERLA_CUDA_CLANG_TIDY "${SKIP_CLANG_TIDY_CHECKS}"
+    "${SKIP_CLANG_TIDY_CHECKS_CUDA}")
+endif()
 
 # codegen-specific Clang-Tidy overrides
 list(APPEND SKIP_CLANG_TIDY_CHECKS_CUDA
      "-bugprone-multi-level-implicit-pointer-conversion")
-espresso_override_clang_tidy_checks(
-  WALBERLA_CXX_CLANG_TIDY_CODEGEN "${SKIP_CLANG_TIDY_CHECKS}"
-  "${SKIP_CLANG_TIDY_CHECKS_CXX}")
-espresso_override_clang_tidy_checks(
-  WALBERLA_CUDA_CLANG_TIDY_CODEGEN "${SKIP_CLANG_TIDY_CHECKS}"
-  "${SKIP_CLANG_TIDY_CHECKS_CUDA}")
+if(ESPRESSO_BUILD_WITH_CLANG_TIDY)
+  espresso_override_clang_tidy_checks(
+    WALBERLA_CXX_CLANG_TIDY_CODEGEN "${SKIP_CLANG_TIDY_CHECKS}"
+    "${SKIP_CLANG_TIDY_CHECKS_CXX}")
+  espresso_override_clang_tidy_checks(
+    WALBERLA_CUDA_CLANG_TIDY_CODEGEN "${SKIP_CLANG_TIDY_CHECKS}"
+    "${SKIP_CLANG_TIDY_CHECKS_CUDA}")
+endif()
 
-function(espresso_configure_walberla_target)
+function(espresso_configure_walberla_target_clangtidy)
   set(TARGET_NAME ${ARGV0})
   if(ESPRESSO_BUILD_WITH_CLANG_TIDY)
     set(TARGET_LANG "CXX")
@@ -82,12 +86,23 @@ function(espresso_configure_walberla_target)
       PROPERTIES ${TARGET_LANG}_CLANG_TIDY
                  "${WALBERLA_${TARGET_LANG}_CLANG_TIDY${TARGET_SUFFIX}}")
   endif()
+endfunction()
+
+function(espresso_configure_walberla_target)
+  set(TARGET_NAME ${ARGV0})
+  espresso_configure_walberla_target_clangtidy(${TARGET_NAME})
   target_link_libraries(${TARGET_NAME} PRIVATE ${WALBERLA_LIBS})
   target_include_directories(
     ${TARGET_NAME} PUBLIC include PRIVATE ${WALBERLA_INCLUDE_DIRS}
                                           ${walberla_BINARY_DIR}/src)
-  install(TARGETS ${TARGET_NAME}
-          LIBRARY DESTINATION ${ESPRESSO_INSTALL_PYTHON}/espressomd)
+  get_target_property(TARGET_TYPE ${TARGET_NAME} TYPE)
+  if(TARGET_TYPE STREQUAL "OBJECT_LIBRARY")
+    set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE
+                                                    ON)
+  else()
+    install(TARGETS ${TARGET_NAME}
+            LIBRARY DESTINATION ${ESPRESSO_INSTALL_PYTHON}/espressomd)
+  endif()
 endfunction()
 
 add_library(espresso_walberla_cpp_flags INTERFACE)
@@ -104,7 +119,7 @@ target_link_libraries(
             $<$<BOOL:${ESPRESSO_BUILD_WITH_WALBERLA_AVX}>:espresso::avx_flags>)
 
 add_library(espresso_walberla SHARED)
-add_library(espresso_walberla_codegen SHARED)
+add_library(espresso_walberla_codegen OBJECT)
 add_library(espresso::walberla ALIAS espresso_walberla)
 add_library(espresso::walberla_codegen ALIAS espresso_walberla_codegen)
 
@@ -119,7 +134,7 @@ target_link_libraries(espresso_walberla_codegen
 
 if(WALBERLA_BUILD_WITH_CUDA)
   espresso_add_gpu_library(espresso_walberla_cuda SHARED)
-  espresso_add_gpu_library(espresso_walberla_codegen_cuda SHARED)
+  espresso_add_gpu_library(espresso_walberla_codegen_cuda OBJECT)
   add_library(espresso::walberla_cuda ALIAS espresso_walberla_cuda)
   add_library(espresso::walberla_codegen_cuda ALIAS
               espresso_walberla_codegen_cuda)

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/CMakeLists.txt
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/CMakeLists.txt
@@ -34,6 +34,6 @@ foreach(precision double_precision single_precision)
     AdvectiveFluxKernel_${precision}.cpp
     DiffusiveFluxKernelWithElectrostatic_${precision}.cpp
     DiffusiveFluxKernelWithElectrostaticThermalized_${precision}.cpp
-    TARGET_DIRECTORY espresso_walberla PROPERTIES COMPILE_FLAGS
-                                                  -fno-sanitize=undefined)
+    TARGET_DIRECTORY espresso_walberla_codegen
+    PROPERTIES COMPILE_FLAGS -fno-sanitize=undefined)
 endforeach()

--- a/src/walberla_bridge/tests/CMakeLists.txt
+++ b/src/walberla_bridge/tests/CMakeLists.txt
@@ -23,11 +23,9 @@ function(ESPRESSO_ADD_TEST)
   cmake_parse_arguments(TEST "" "SRC;NAME;NUM_PROC" "DEPENDS" ${ARGN})
   espresso_unit_test(
     SRC ${TEST_SRC} NAME ${TEST_NAME} NUM_PROC ${TEST_NUM_PROC} DEPENDS
-    ${TEST_DEPENDS} espresso::walberla espresso::walberla_codegen
-    espresso::utils)
+    ${TEST_DEPENDS} espresso::walberla espresso::utils)
   if(WALBERLA_BUILD_WITH_CUDA)
-    target_link_libraries(${TEST_NAME} PRIVATE espresso::walberla_cuda
-                                               espresso::walberla_codegen_cuda)
+    target_link_libraries(${TEST_NAME} PRIVATE espresso::walberla_cuda)
   endif()
   if(${TEST_SRC} MATCHES ".*\.cu$")
     target_link_libraries(${TEST_NAME} PRIVATE espresso::walberla::cuda_flags)

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -174,8 +174,10 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
             [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
-        self.assertAlmostEqual(energy["virtual_sites"], 0., delta=1e-7)
-        self.assertAlmostEqual(energy["dpd"], 0., delta=1e-7)
+        if espressomd.has_features(["VIRTUAL_SITES"]):
+            self.assertAlmostEqual(energy["virtual_sites"], 0., delta=1e-7)
+        if espressomd.has_features(["DPD"]):
+            self.assertAlmostEqual(energy["dpd"], 0., delta=1e-7)
         # two bonds
         p1.add_bond((self.harmonic, p0))
         energy = self.system.analysis.energy()

--- a/testsuite/python/exclusions.py
+++ b/testsuite/python/exclusions.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Integration test for exclusions
 import unittest as ut
 import unittest_decorators as utx
 import espressomd
@@ -33,7 +32,8 @@ class Exclusions(ut.TestCase):
         self.system.time_step = 0.01
 
     def tearDown(self):
-        self.system.electrostatics.clear()
+        if espressomd.has_features("P3M"):
+            self.system.electrostatics.clear()
         self.system.part.clear()
 
     def test_add_remove(self):

--- a/testsuite/python/long_range_actors.py
+++ b/testsuite/python/long_range_actors.py
@@ -270,27 +270,27 @@ class Test(ut.TestCase):
         self.assertFalse(p3m.is_tuned)
         self.assertIsNone(self.system.electrostatics.solver)
 
-    def check_p3m_tuning_errors(self, p3m):
+    def check_p3m_tuning_errors(self, module, p3m):
         # set an incompatible combination of thermostat and integrators
         self.system.integrator.set_isotropic_npt(ext_pressure=2., piston=0.01)
         self.system.thermostat.set_brownian(kT=1.0, gamma=1.0, seed=42)
         with self.assertRaisesRegex(RuntimeError, r"tuning failed: an exception was thrown while benchmarking the integration loop"):
-            self.system.electrostatics.solver = p3m
+            getattr(self.system, module).solver = p3m
         self.assertFalse(p3m.is_tuned)
-        self.assertIsNone(self.system.electrostatics.solver)
+        self.assertIsNone(getattr(self.system, module).solver)
 
     @utx.skipIfMissingFeatures(["P3M", "NPT"])
     def test_p3m_cpu_tuning_errors(self):
         self.add_charged_particles()
         p3m = espressomd.electrostatics.P3M(prefactor=1., accuracy=1e-3)
-        self.check_p3m_tuning_errors(p3m)
+        self.check_p3m_tuning_errors("electrostatics", p3m)
 
     @utx.skipIfMissingFeatures(["DP3M", "NPT"])
     def test_dp3m_cpu_tuning_errors(self):
         self.add_magnetic_particles()
         dp3m = espressomd.magnetostatics.DipolarP3M(
             prefactor=1., accuracy=1e-3)
-        self.check_p3m_tuning_errors(dp3m)
+        self.check_p3m_tuning_errors("magnetostatics", dp3m)
 
     @utx.skipIfMissingFeatures(["ELECTROSTATICS"])
     def test_mmm1d_cpu_exceptions(self):


### PR DESCRIPTION
There are 2 implementations. When there are many cells (regular decomposition) the parallel loop is over cells, when there is only one (N-square) the parallel loop is over particles.

Notes: 
* `Kokkos::Experimental::for_each()` only works on Kokkos views, therefore `parallel_for()` is used instead
* So far, the `for_each_particle()` template is only used in cases, where no shared data is accessed. With 4 OpenMP threads, this reduces the time for the LJ benchmark by a few percents.
* next step is to make access to the most important shared data thread safe, particularly, the particle forces and the P3M real space charge density field