### PR TITLE
Add UTF-8 and pathlib.Path support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,13 +797,13 @@ if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
 
-list(APPEND BOOST_COMPONENTS mpi serialization filesystem system)
+list(APPEND ESPRESSO_BOOST_COMPONENTS mpi serialization)
 
 if(ESPRESSO_BUILD_TESTS)
-  list(APPEND BOOST_COMPONENTS unit_test_framework)
+  list(APPEND ESPRESSO_BOOST_COMPONENTS unit_test_framework)
 endif()
 
-find_package(Boost 1.83.0 REQUIRED ${BOOST_COMPONENTS})
+find_package(Boost 1.83.0 REQUIRED ${ESPRESSO_BOOST_COMPONENTS})
 
 # enable boost::variant with more than 20 types
 target_compile_options(

--- a/src/core/io/writer/CMakeLists.txt
+++ b/src/core/io/writer/CMakeLists.txt
@@ -26,8 +26,7 @@ if(ESPRESSO_BUILD_WITH_HDF5)
   target_link_libraries(
     espresso_hdf5
     PRIVATE HighFive hdf5 espresso::cpp_flags MPI::MPI_CXX Boost::mpi
-            Boost::filesystem espresso::utils espresso::config
-            espresso::instrumentation)
+            espresso::utils espresso::config espresso::instrumentation)
   target_link_libraries(espresso_core PUBLIC espresso_hdf5)
   install(TARGETS espresso_hdf5
           LIBRARY DESTINATION ${ESPRESSO_INSTALL_PYTHON}/espressomd)

--- a/src/core/io/writer/h5md_core.cpp
+++ b/src/core/io/writer/h5md_core.cpp
@@ -34,7 +34,6 @@
 #include <utils/Vector.hpp>
 
 #include <boost/array.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/mpi/collectives.hpp>
 #include <boost/multi_array.hpp>
 
@@ -45,6 +44,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iterator>
@@ -92,16 +92,17 @@ static auto fields_list_to_bitfield(std::vector<std::string> const &fields) {
   return bitfield;
 }
 
-static void backup_file(const std::string &from, const std::string &to) {
+static void backup_file(std::filesystem::path const &from,
+                        std::filesystem::path const &to) {
   /*
    * If the file itself *and* a backup file exists, something must
    * have gone wrong.
    */
-  boost::filesystem::path pfrom(from), pto(to);
-  auto constexpr option_fail_if_exists = boost::filesystem::copy_options::none;
+  std::filesystem::path pfrom(from), pto(to);
+  auto constexpr option_fail_if_exists = std::filesystem::copy_options::none;
   try {
-    boost::filesystem::copy_file(pfrom, pto, option_fail_if_exists);
-  } catch (const boost::filesystem::filesystem_error &) {
+    std::filesystem::copy_file(from, to, option_fail_if_exists);
+  } catch (std::filesystem::filesystem_error const &) {
     throw left_backupfile();
   }
 }
@@ -137,9 +138,9 @@ static void write_dataset(value_type const &data, HighFive::DataSet &dataset,
 }
 
 static void write_script(HighFive::File &h5md_file,
-                         boost::filesystem::path const &script_path) {
+                         std::filesystem::path const &script_path) {
   if (!script_path.empty()) {
-    std::ifstream scriptfile(script_path.string());
+    std::ifstream scriptfile(script_path);
     std::string buffer(std::istreambuf_iterator<char>(scriptfile),
                        std::istreambuf_iterator<char>{});
     h5md_file.createGroup("/parameters");
@@ -149,21 +150,14 @@ static void write_script(HighFive::File &h5md_file,
 }
 
 /* Initialize the file-related variables after parameters have been set. */
-void File::init_file(std::string const &file_path) {
-  m_backup_filename = file_path + ".bak";
-  if (m_script_path.empty()) {
-    m_absolute_script_path = boost::filesystem::path();
-  } else {
-    boost::filesystem::path script_path(m_script_path);
-    m_absolute_script_path = boost::filesystem::canonical(script_path);
-  }
-  auto const file_exists = boost::filesystem::exists(file_path);
-  auto const backup_file_exists = boost::filesystem::exists(m_backup_filename);
+void File::init_file() {
+  auto const file_exists = std::filesystem::exists(m_file_path);
+  auto const backup_file_exists = std::filesystem::exists(m_backup_path);
   /* Perform a barrier synchronization. Otherwise one process might already
    * create the file while another still checks for its existence. */
   m_comm.barrier();
   if (file_exists) {
-    if (m_h5md_specification.is_compliant(file_path)) {
+    if (m_h5md_specification.is_compliant(m_file_path)) {
       /*
        * If the file exists and has a valid H5MD structure, let's create a
        * backup of it. This has the advantage, that the new file can
@@ -171,15 +165,15 @@ void File::init_file(std::string const &file_path) {
        * still have a valid trajectory backed up, from which we can restart.
        */
       if (m_comm.rank() == 0)
-        backup_file(file_path, m_backup_filename);
-      load_file(file_path);
+        backup_file(m_file_path, m_backup_path);
+      load_file();
     } else {
       throw incompatible_h5mdfile();
     }
   } else {
     if (backup_file_exists)
       throw left_backupfile();
-    create_file(file_path);
+    create_file();
   }
 }
 
@@ -268,12 +262,12 @@ void File::create_datasets() {
   }
 }
 
-void File::load_file(const std::string &file_path) {
+void File::load_file() {
   HighFive::FileAccessProps fapl;
   fapl.add(HighFive::MPIOFileAccess{m_comm, MPI_INFO_NULL});
   fapl.add(HighFive::MPIOCollectiveMetadata{});
   m_h5md_file = std::make_unique<HighFive::File>(
-      file_path, HighFive::File::ReadWrite, fapl);
+      m_file_path.string(), HighFive::File::ReadWrite, fapl);
   load_datasets();
 }
 
@@ -350,12 +344,12 @@ void File::create_hard_links() {
   }
 }
 
-void File::create_file(const std::string &file_path) {
+void File::create_file() {
   HighFive::FileAccessProps fapl;
   fapl.add(HighFive::MPIOFileAccess{m_comm, MPI_INFO_NULL});
   fapl.add(HighFive::MPIOCollectiveMetadata{});
-  m_h5md_file =
-      std::make_unique<HighFive::File>(file_path, HighFive::File::Create, fapl);
+  m_h5md_file = std::make_unique<HighFive::File>(m_file_path.string(),
+                                                 HighFive::File::Create, fapl);
   write_script(*m_h5md_file, m_absolute_script_path);
   create_groups();
   create_datasets();
@@ -365,8 +359,9 @@ void File::create_file(const std::string &file_path) {
 }
 
 void File::close() {
-  if (m_comm.rank() == 0)
-    boost::filesystem::remove(m_backup_filename);
+  if (m_comm.rank() == 0) {
+    std::filesystem::remove(m_backup_path);
+  }
 }
 
 namespace detail {
@@ -680,21 +675,24 @@ void File::write_connectivity(const ParticleRange &particles) {
 
 void File::flush() { m_h5md_file->flush(); }
 
-std::string File::file_path() const { return m_h5md_file->getName(); }
-
 std::vector<std::string> File::valid_fields() const {
   auto const view = std::views::elements<0>(fields_map);
   return {view.begin(), view.end()};
 }
 
-File::File(std::string file_path, std::string script_path,
+File::File(std::filesystem::path file_path, std::filesystem::path script_path,
            std::vector<std::string> const &output_fields, std::string mass_unit,
            std::string length_unit, std::string time_unit,
            std::string force_unit, std::string velocity_unit,
            std::string charge_unit, int chunk_size)
-    : m_script_path(std::move(script_path)), m_mass_unit(std::move(mass_unit)),
-      m_length_unit(std::move(length_unit)), m_time_unit(std::move(time_unit)),
-      m_force_unit(std::move(force_unit)),
+    : m_file_path(std::move(file_path)), m_backup_path(m_file_path),
+      m_script_path(std::move(script_path)),
+      m_absolute_script_path(
+          m_script_path.empty()
+              ? std::filesystem::path()
+              : std::filesystem::weakly_canonical(m_script_path)),
+      m_mass_unit(std::move(mass_unit)), m_length_unit(std::move(length_unit)),
+      m_time_unit(std::move(time_unit)), m_force_unit(std::move(force_unit)),
       m_velocity_unit(std::move(velocity_unit)),
       m_charge_unit(std::move(charge_unit)),
       m_chunk_size(static_cast<std::size_t>(std::max(0, chunk_size))),
@@ -705,7 +703,8 @@ File::File(std::string file_path, std::string script_path,
   if (chunk_size <= 0) {
     throw std::domain_error("Parameter 'chunk_size' must be > 0");
   }
-  init_file(file_path);
+  m_backup_path += ".bak";
+  init_file();
 }
 
 File::~File() = default;

--- a/src/core/io/writer/h5md_core.hpp
+++ b/src/core/io/writer/h5md_core.hpp
@@ -27,10 +27,10 @@
 
 #include <utils/Vector.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/mpi/communicator.hpp>
 
 #include <cstddef>
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -87,7 +87,7 @@ public:
    * @param charge_unit The unit for charge.
    * @param chunk_size The chunk size for DataSet in hdf5 file
    */
-  File(std::string file_path, std::string script_path,
+  File(std::filesystem::path file_path, std::filesystem::path script_path,
        std::vector<std::string> const &output_fields, std::string mass_unit,
        std::string length_unit, std::string time_unit, std::string force_unit,
        std::string velocity_unit, std::string charge_unit, int chunk_size);
@@ -111,13 +111,13 @@ public:
 
   /**
    * @brief Retrieve the path to the hdf5 file.
-   * @return The path as a string.
+   * @return The path as a file system object.
    */
-  std::string file_path() const;
+  auto const &file_path() const { return m_file_path; }
 
   /**
    * @brief Retrieve the path to the simulation script.
-   * @return The path as a string.
+   * @return The path as a file system object.
    */
   auto const &script_path() const { return m_script_path; }
 
@@ -177,19 +177,17 @@ private:
   /**
    * @brief Initialize the File object.
    */
-  void init_file(std::string const &file_path);
+  void init_file();
 
   /**
    * @brief Creates a new H5MD file.
-   * @param file_path The filename.
    */
-  void create_file(const std::string &file_path);
+  void create_file();
 
   /**
    * @brief Loads an existing H5MD file.
-   * @param file_path The filename.
    */
-  void load_file(const std::string &file_path);
+  void load_file();
 
   /**
    * @brief Create the HDF5 groups according to the H5MD specification.
@@ -217,12 +215,15 @@ private:
    */
   void write_units();
   /**
-   * @brief Create hard links for the time and step entries of time-dependent
-   * datasets.
+   * @brief Create hard links for the simulation time and simulation step
+   * entries of time-dependent datasets.
    */
   void create_hard_links();
 
-  std::string m_script_path;
+  std::filesystem::path m_file_path;
+  std::filesystem::path m_backup_path;
+  std::filesystem::path m_script_path;
+  std::filesystem::path m_absolute_script_path;
   std::string m_mass_unit;
   std::string m_length_unit;
   std::string m_time_unit;
@@ -232,8 +233,6 @@ private:
   int m_chunk_size;
   boost::mpi::communicator m_comm;
   unsigned int m_fields;
-  std::string m_backup_filename;
-  boost::filesystem::path m_absolute_script_path;
   std::unique_ptr<HighFive::File> m_h5md_file;
   std::unique_ptr<std::unordered_map<std::string, HighFive::DataSet>>
       m_datasets;

--- a/src/core/io/writer/h5md_specification.cpp
+++ b/src/core/io/writer/h5md_specification.cpp
@@ -30,6 +30,7 @@
 #include <hdf5.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <string>
 #include <utility>
 
@@ -96,8 +97,8 @@ Specification::Specification(unsigned int fields) {
   }
 }
 
-bool Specification::is_compliant(std::string const &filename) const {
-  HighFive::File h5md_file(filename, HighFive::File::ReadOnly);
+bool Specification::is_compliant(std::filesystem::path const &file) const {
+  HighFive::File h5md_file(file.string(), HighFive::File::ReadOnly);
 
   auto const all_groups_exist =
       std::ranges::all_of(m_datasets, [&h5md_file](auto const &d) {

--- a/src/core/io/writer/h5md_specification.hpp
+++ b/src/core/io/writer/h5md_specification.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <string>
+#include <filesystem>
 #include <vector>
 
 namespace Writer {
@@ -40,7 +40,7 @@ struct Specification {
 
   auto const &get_datasets() const { return m_datasets; }
 
-  bool is_compliant(std::string const &filename) const;
+  bool is_compliant(std::filesystem::path const &file) const;
 
 private:
   std::vector<Dataset> m_datasets;

--- a/src/python/espressomd/checkpointing.py
+++ b/src/python/espressomd/checkpointing.py
@@ -19,9 +19,9 @@
 import collections
 import inspect
 import pickle
-import os
 import re
 import signal
+import pathlib
 from . import utils
 from . import script_interface
 
@@ -34,7 +34,7 @@ class Checkpoint:
     ----------
     checkpoint_id : :obj:`str`
         A string identifying a specific checkpoint.
-    checkpoint_path : :obj:`str`, optional
+    checkpoint_path : :obj:`str` or :obj:`pathlib.Path`, optional
         Path for reading and writing the checkpoint.
         If not given, the current working directory is used.
 
@@ -42,11 +42,11 @@ class Checkpoint:
 
     def __init__(self, checkpoint_id=None, checkpoint_path="."):
         # check if checkpoint_id is valid (only allow a-z A-Z 0-9 _ -)
-        if not isinstance(checkpoint_id, str) or bool(
-                re.compile(r"[^a-zA-Z0-9_\-]").search(checkpoint_id)):
+        if not isinstance(checkpoint_id, str) or re.search(
+                r"[^a-zA-Z0-9_\-]", checkpoint_id) is not None:
             raise ValueError("Invalid checkpoint id.")
 
-        if not isinstance(checkpoint_path, str):
+        if not isinstance(checkpoint_path, (str, pathlib.Path)):
             raise ValueError("Invalid checkpoint path.")
 
         self.checkpoint_objects = []
@@ -54,26 +54,24 @@ class Checkpoint:
         frm = inspect.stack()[1]
         self.calling_module = inspect.getmodule(frm[0])
 
-        checkpoint_path = os.path.join(checkpoint_path, checkpoint_id)
-        self.checkpoint_dir = os.path.realpath(checkpoint_path)
-
-        if not os.path.isdir(self.checkpoint_dir):
-            os.makedirs(self.checkpoint_dir)
+        checkpoint_path = pathlib.Path(checkpoint_path) / checkpoint_id
+        self.root = checkpoint_path.resolve()
+        self.root.mkdir(exist_ok=True)
+        self.path_signals = self.root / "signals"
 
         # update checkpoint counter
         self.counter = 0
-        while os.path.isfile(os.path.join(
-                self.checkpoint_dir, f"{self.counter}.checkpoint")):
+        while (self.root / f"{self.counter}.checkpoint").is_file():
             self.counter += 1
 
         # init signals
         for signum in self.read_signals():
             self.register_signal(signum)
 
-    def __getattr_submodule(self, obj, name, default):
+    def _getattr_submodule(self, obj, name, default):
         """
         Generalization of ``getattr()``.
-        ``__getattr_submodule(object, "name1.sub1.sub2", None)`` will return
+        ``_getattr_submodule(object, "name1.sub1.sub2", None)`` will return
         attribute ``sub2`` if available otherwise ``None``.
 
         """
@@ -84,10 +82,10 @@ class Checkpoint:
 
         return getattr(obj, names[-1], default)
 
-    def __setattr_submodule(self, obj, name, value):
+    def _setattr_submodule(self, obj, name, value):
         """
         Generalization of ``setattr()``.
-        ``__setattr_submodule(object, "name1.sub1.sub2", value)`` will set
+        ``_setattr_submodule(object, "name1.sub1.sub2", value)`` will set
         attribute ``sub2`` to ``value``. Will raise exception if parent
         modules do not exist.
 
@@ -138,7 +136,7 @@ class Checkpoint:
                 raise KeyError(
                     f"The given object '{varname}' is already registered for checkpointing.")
 
-            obj = self.__getattr_submodule(self.calling_module, varname, None)
+            obj = self._getattr_submodule(self.calling_module, varname, None)
             if isinstance(
                     obj, script_interface.ScriptInterfaceHelper) and not obj._so_checkpointable:
                 raise TypeError(
@@ -205,18 +203,17 @@ class Checkpoint:
         # get attributes of registered objects
         checkpoint_data = collections.OrderedDict()
         for obj_name in self.checkpoint_objects:
-            checkpoint_data[obj_name] = self.__getattr_submodule(
+            checkpoint_data[obj_name] = self._getattr_submodule(
                 self.calling_module, obj_name, None)
 
         if checkpoint_index is None:
             checkpoint_index = self.counter
-        filename = os.path.join(
-            self.checkpoint_dir, f"{checkpoint_index}.checkpoint")
 
-        tmpname = filename + ".__tmp__"
-        with open(tmpname, "wb") as checkpoint_file:
-            pickle.dump(checkpoint_data, checkpoint_file, -1)
-        os.rename(tmpname, filename)
+        checkpoint_file = self.root / f"{checkpoint_index}.checkpoint"
+        checkpoint_file_tmp = checkpoint_file.with_suffix(".checkpoint.tmp")
+        with checkpoint_file_tmp.open("wb") as f:
+            pickle.dump(checkpoint_data, f, -1)
+        checkpoint_file_tmp.rename(checkpoint_file)
 
     def load(self, checkpoint_index=None):
         """
@@ -232,17 +229,16 @@ class Checkpoint:
         if checkpoint_index is None:
             checkpoint_index = self.get_last_checkpoint_index()
 
-        filename = os.path.join(
-            self.checkpoint_dir, f"{checkpoint_index}.checkpoint")
-        with open(filename, "rb") as f:
+        checkpoint_file = self.root / f"{checkpoint_index}.checkpoint"
+        with checkpoint_file.open("rb") as f:
             checkpoint_data = pickle.load(f)
 
         for key in checkpoint_data:
-            self.__setattr_submodule(
+            self._setattr_submodule(
                 self.calling_module, key, checkpoint_data[key])
             self.checkpoint_objects.append(key)
 
-    def __signal_handler(self, signum, frame):  # pylint: disable=unused-argument
+    def _signal_handler(self, signum, frame):  # pylint: disable=unused-argument
         """
         Will be called when a registered signal was sent.
 
@@ -256,20 +252,14 @@ class Checkpoint:
         integers.
 
         """
-        if not os.path.isfile(os.path.join(self.checkpoint_dir, "signals")):
-            return []
+        if self.path_signals.is_file():
+            return [int(i) for i in self.path_signals.read_text().split()]
+        return []
 
-        with open(os.path.join(self.checkpoint_dir, "signals"), "r") as signal_file:
-            signals = signal_file.readline().strip().split()
-            signals = [int(i)
-                       for i in signals]  # will raise exception if signal file contains invalid entries
-        return signals
-
-    def __write_signal(self, signum=None):
+    def _write_signal(self, signum=None):
         """Writes the given signal integer signum to the signal file.
 
         """
-        signum = int(signum)
         if not utils.is_valid_type(signum, int):
             raise ValueError("Signal must be an integer number.")
 
@@ -277,9 +267,7 @@ class Checkpoint:
 
         if signum not in signals:
             signals.append(signum)
-            signals = " ".join(str(i) for i in signals)
-            with open(os.path.join(self.checkpoint_dir, "signals"), "w") as signal_file:
-                signal_file.write(signals)
+            self.path_signals.write_text(" ".join(str(i) for i in signals))
 
     def register_signal(self, signum=None):
         """Register a signal that will trigger the signal handler.
@@ -297,6 +285,6 @@ class Checkpoint:
             raise KeyError(
                 f"The signal {signum} is already registered for checkpointing.")
 
-        signal.signal(signum, self.__signal_handler)
+        signal.signal(int(signum), self._signal_handler)
         self.checkpoint_signals.append(signum)
-        self.__write_signal(signum)
+        self._write_signal(signum)

--- a/src/python/espressomd/detail/walberla.py
+++ b/src/python/espressomd/detail/walberla.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
+import pathlib
 import itertools
 import numpy as np
 
@@ -91,9 +91,10 @@ class LatticeWalberla(ScriptInterfaceHelper):
 class LatticeModel:
 
     def save_checkpoint(self, path, binary):
-        tmp_path = path + ".__tmp__"
+        path = pathlib.Path(path)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
         self.call_method("save_checkpoint", path=tmp_path, mode=int(binary))
-        os.rename(tmp_path, path)
+        tmp_path.rename(path)
 
     def load_checkpoint(self, path, binary):
         return self.call_method("load_checkpoint", path=path, mode=int(binary))

--- a/src/python/espressomd/electrokinetics.py
+++ b/src/python/espressomd/electrokinetics.py
@@ -129,7 +129,7 @@ class EKSpecies(ScriptInterfaceHelper,
 
         Parameters
         ----------
-        path : :obj:`str`
+        path : :obj:`str` or :obj:`pathlib.Path`
             Destination file path.
         binary : :obj:`bool`
             Whether to write in binary or ASCII mode.
@@ -139,7 +139,7 @@ class EKSpecies(ScriptInterfaceHelper,
 
         Parameters
         ----------
-        path : :obj:`str`
+        path : :obj:`str` or :obj:`pathlib.Path`
             File path to read from.
         binary : :obj:`bool`
             Whether to read in binary or ASCII mode.
@@ -564,8 +564,8 @@ class VTKOutput(VTKOutputBase):
     """
     Create a VTK writer.
 
-    Files are written to ``<base_folder>/<identifier>/<prefix>_*.vtu``.
-    Summary is written to ``<base_folder>/<identifier>.pvd``.
+    Files are written to :file:`<base_folder>/<identifier>/<prefix>_*.vtu`.
+    Summary is written to :file:`<base_folder>/<identifier>.pvd`.
 
     Manual VTK callbacks can be called at any time to take a snapshot
     of the current state of the EK species.
@@ -586,7 +586,7 @@ class VTKOutput(VTKOutputBase):
         manual VTK callback that must be triggered manually. Otherwise,
         it is an automatic callback that is added to the time loop and
         writes every ``delta_N`` EK steps.
-    base_folder : :obj:`str` (optional), default is 'vtk_out'
+    base_folder : :obj:`str` or :obj:`pathlib.Path` (optional), default is :file:`vtk_out`
         Path to the output VTK folder.
     prefix : :obj:`str` (optional), default is 'simulation_step'
         Prefix for VTK files.

--- a/src/python/espressomd/io/mpiio.py
+++ b/src/python/espressomd/io/mpiio.py
@@ -52,7 +52,7 @@ class Mpiio(ScriptInterfaceHelper):
 
         Parameters
         ----------
-        prefix : :obj:`str`
+        prefix : :obj:`str` or :obj:`pathlib.Path`
             Common prefix for the filenames.
         positions : :obj:`bool`, optional
             Indicates if positions should be dumped.
@@ -82,7 +82,7 @@ class Mpiio(ScriptInterfaceHelper):
              types=False, bonds=False):
         """MPI-IO read.
 
-        This function reads data dumped by :meth`write`. See the :meth`write`
+        This function reads data dumped by :meth:`write`. See the :meth:`write`
         documentation for details.
 
         .. note::

--- a/src/python/espressomd/io/writer/h5md.py
+++ b/src/python/espressomd/io/writer/h5md.py
@@ -64,7 +64,7 @@ class H5md(ScriptInterfaceHelper):
 
     Parameters
     ----------
-    file_path : :obj:`str`
+    file_path : :obj:`str` or :obj:`pathlib.Path`
         Path to the trajectory file, or an existing file to append data to
         (it must have the same specifications).
     unit_system : :obj:`UnitSystem`, optional
@@ -130,8 +130,9 @@ class H5md(ScriptInterfaceHelper):
         script_path = ""
         if sys.argv and sys.argv[0]:
             script_path = str(pathlib.Path(sys.argv[0]).resolve())
-        if not isinstance(params["file_path"], str):
-            raise TypeError("Parameter 'file_path' should be a string")
+        if not isinstance(params["file_path"], (str, pathlib.Path)):
+            raise TypeError(
+                "Parameter 'file_path' should be a string or a path")
         params["file_path"] = str(pathlib.Path(params["file_path"]).resolve())
         super().__init__(
             script_path=script_path,

--- a/src/python/espressomd/lb.py
+++ b/src/python/espressomd/lb.py
@@ -178,7 +178,7 @@ class LBFluidWalberla(HydrodynamicInteraction,
 
         Parameters
         ----------
-        path : :obj:`str`
+        path : :obj:`str` or :obj:`pathlib.Path`
             Destination file path.
         binary : :obj:`bool`
             Whether to write in binary or ASCII mode.
@@ -188,7 +188,7 @@ class LBFluidWalberla(HydrodynamicInteraction,
 
         Parameters
         ----------
-        path : :obj:`str`
+        path : :obj:`str` or :obj:`pathlib.Path`
             File path to read from.
         binary : :obj:`bool`
             Whether to read in binary or ASCII mode.
@@ -639,8 +639,8 @@ class VTKOutput(VTKOutputBase):
     """
     Create a VTK writer.
 
-    Files are written to ``<base_folder>/<identifier>/<prefix>_*.vtu``.
-    Summary is written to ``<base_folder>/<identifier>.pvd``.
+    Files are written to :file:`<base_folder>/<identifier>/<prefix>_*.vtu`.
+    Summary is written to :file:`<base_folder>/<identifier>.pvd`.
 
     Manual VTK callbacks can be called at any time to take a snapshot
     of the current state of the LB fluid.
@@ -661,7 +661,7 @@ class VTKOutput(VTKOutputBase):
         manual VTK callback that must be triggered manually. Otherwise,
         it is an automatic callback that is added to the time loop and
         writes every ``delta_N`` LB steps.
-    base_folder : :obj:`str` (optional), default is 'vtk_out'
+    base_folder : :obj:`str` or :obj:`pathlib.Path` (optional), default is :file:`vtk_out`
         Path to the output VTK folder.
     prefix : :obj:`str` (optional), default is 'simulation_step'
         Prefix for VTK files.

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -15,8 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
+import pathlib
 from . import utils
 from .utils cimport Vector3b, Vector3i, Vector2d, Vector3d, Vector4d
+from .utils cimport path
 cimport cpython.object
 
 from libcpp.memory cimport shared_ptr, make_shared
@@ -235,6 +237,7 @@ cdef Variant python_object_to_variant(value) except *:
     cdef int * data_int
     cdef double[::1] view_double
     cdef double * data_double
+    cdef path fs_path
 
     if value is None:
         return Variant()
@@ -267,6 +270,9 @@ cdef Variant python_object_to_variant(value) except *:
                     f" to 'Variant[std::unordered_map<std::string, Variant>]'")
     elif isinstance(value, (str, bytes)):
         return make_variant[string](utils.to_bytes(value))
+    elif isinstance(value, pathlib.Path):
+        fs_path.assign(utils.to_bytes(str(value)))
+        return make_variant[path](fs_path)
     elif isinstance(value, array_variant) and np.issubdtype(value.dtype, np.signedinteger):
         view_int = np.ascontiguousarray(value, dtype=np.int32)
         data_int = &view_int[0]
@@ -335,6 +341,9 @@ cdef variant_to_python_object(const Variant & value):
         return get_value[double](value)
     if is_type[string](value):
         return utils.to_str(get_value[string](value))
+    if is_type[path](value):
+        filepath = utils.to_str(get_value[path](value).generic_string())
+        return pathlib.Path(filepath)
     if is_type[vector[int]](value):
         return get_value[vector[int]](value)
     if is_type[vector[double]](value):

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -93,12 +93,12 @@ cdef class PScriptInterface:
         else:
             global _om
             for pname in kwargs:
-                out_params[utils.to_char_pointer(pname)] = python_object_to_variant(
+                out_params[utils.to_bytes(pname)] = python_object_to_variant(
                     kwargs[pname])
             self.set_sip(
                 _om.get().make_shared(
                     policy_,
-                    utils.to_char_pointer(name),
+                    utils.to_bytes(name),
                     out_params))
             utils.handle_errors(f"Exception during instantiation of '{name}'")
 
@@ -158,12 +158,12 @@ cdef class PScriptInterface:
         cdef Variant value
 
         for name in kwargs:
-            parameters[utils.to_char_pointer(name)] = python_object_to_variant(
+            parameters[utils.to_bytes(name)] = python_object_to_variant(
                 kwargs[name])
 
         # the internal buffer of a cython bytestring object can be accessed as
         # a raw char pointer, but then the bytestring object must be kept alive
-        method_name_bytes_counted_reference = utils.to_char_pointer(method)
+        method_name_bytes_counted_reference = utils.to_bytes(method)
         cdef char * method_name_char = method_name_bytes_counted_reference
 
         if with_nogil:
@@ -192,12 +192,12 @@ cdef class PScriptInterface:
 
     def set_params(self, **kwargs):
         for name, value in kwargs.items():
-            self.sip.get().set_parameter(utils.to_char_pointer(name),
+            self.sip.get().set_parameter(utils.to_bytes(name),
                                          python_object_to_variant(value))
             utils.handle_errors(f"while setting parameter '{name}'")
 
     def get_parameter(self, name):
-        cdef Variant value = self.sip.get().get_parameter(utils.to_char_pointer(name))
+        cdef Variant value = self.sip.get().get_parameter(utils.to_bytes(name))
         return variant_to_python_object(value)
 
     def get_params(self):
@@ -255,8 +255,8 @@ cdef Variant python_object_to_variant(value) except *:
             return make_variant[unordered_map[int, Variant]](map_int2var)
         elif all(map(lambda x: isinstance(x, (str, np.str_)), value.keys())):
             for key, value in value.items():
-                map_str2var[utils.to_char_pointer(
-                    str(key))] = python_object_to_variant(value)
+                map_str2var[utils.to_bytes(
+                    key)] = python_object_to_variant(value)
             return make_variant[unordered_map[string, Variant]](map_str2var)
         for k, v in value.items():
             if not isinstance(k, (str, int, np.integer, np.str_)):
@@ -265,8 +265,8 @@ cdef Variant python_object_to_variant(value) except *:
                     f"'dict_item([({type(k).__name__}, {type(v).__name__})])'"
                     f" to 'Variant[std::unordered_map<int, Variant>]' or"
                     f" to 'Variant[std::unordered_map<std::string, Variant>]'")
-    elif type(value) in (str, np.str_):
-        return make_variant[string](utils.to_char_pointer(str(value)))
+    elif isinstance(value, (str, bytes)):
+        return make_variant[string](utils.to_bytes(value))
     elif isinstance(value, array_variant) and np.issubdtype(value.dtype, np.signedinteger):
         view_int = np.ascontiguousarray(value, dtype=np.int32)
         data_int = &view_int[0]
@@ -439,7 +439,7 @@ class ScriptInterfaceHelper(PScriptInterface):
         cdef vector[string] features_vec
         if self._so_features:
             for feature in self._so_features:
-                features_vec.push_back(utils.to_char_pointer(feature))
+                features_vec.push_back(utils.to_bytes(feature))
             check_features(features_vec)
         super().__init__(self._so_name, policy=self._so_creation_policy,
                          **kwargs)

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -21,6 +21,15 @@ from libcpp.string cimport string  # import std::string as string
 from libcpp.vector cimport vector  # import std::vector as vector
 from libcpp cimport bool as cbool
 
+cdef extern from "<filesystem>" namespace "std::filesystem" nogil:
+    cdef cppclass path:
+        ctypedef char value_type
+        path() except +
+        path(const string & source) except +
+        path & assign(const string & source) except +
+        string native_string "string"() except +
+        string generic_string() except +
+
 cdef extern from "error_handling/RuntimeError.hpp" namespace "ErrorHandling::RuntimeError":
     cdef cppclass ErrorLevel:
         pass

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -82,19 +82,21 @@ def check_type_or_throw_except(x, n, t, msg):
                 f"{msg} -- Item {i} was of type {type(x[i]).__name__}")
 
 
-def to_char_pointer(s):
+def to_bytes(s):
     """
     Returns a Cython bytes object which contains the information of the provided
     Python string. Cython bytes objects implicitly cast to raw char pointers.
 
     Parameters
     ----------
-    s : :obj:`str`
+    s : :obj:`str` or :obj:`bytes`
 
     """
-    if isinstance(s, unicode):
-        s = ( < unicode > s).encode('utf8')
-    return s
+    if isinstance(s, str):
+        return bytes(s.encode("utf8"))
+    if isinstance(s, bytes):
+        return bytes(s)
+    raise ValueError(f'Unknown string type {type(s)}')
 
 
 def to_str(s):
@@ -106,12 +108,11 @@ def to_str(s):
     s : char*
 
     """
-    if isinstance(s, unicode):
-        return < unicode > s
-    elif isinstance(s, bytes):
-        return ( < bytes > s).decode('ascii')
-    else:
-        raise ValueError(f'Unknown string type {type(s)}')
+    if isinstance(s, str):
+        return str(s)
+    if isinstance(s, bytes):
+        return str(s.decode("utf8"))
+    raise ValueError(f'Unknown string type {type(s)}')
 
 
 class array_locked(np.ndarray):

--- a/src/script_interface/Variant.hpp
+++ b/src/script_interface/Variant.hpp
@@ -22,6 +22,7 @@
 #include "None.hpp"
 
 #include <utils/Vector.hpp>
+#include <utils/serialization/filesystem.hpp>
 #include <utils/serialization/unordered_map.hpp>
 
 #include <boost/serialization/serialization.hpp>
@@ -31,6 +32,7 @@
 #include <boost/variant.hpp>
 
 #include <cstddef>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -62,7 +64,7 @@ using Variant = boost::make_recursive_variant<
     None, bool, int, std::size_t, double, std::string, ObjectRef,
     Utils::Vector3b, Utils::Vector3i, Utils::Vector2d, Utils::Vector3d,
     Utils::Vector4d, std::vector<int>, std::vector<double>,
-    std::vector<boost::recursive_variant_>,
+    std::vector<boost::recursive_variant_>, std::filesystem::path,
     std::unordered_map<int, boost::recursive_variant_>,
     std::unordered_map<std::string, boost::recursive_variant_>>::type;
 

--- a/src/script_interface/get_value.hpp
+++ b/src/script_interface/get_value.hpp
@@ -301,6 +301,16 @@ struct get_value_helper<std::unordered_map<std::string, T>> {
   }
 };
 
+/* std::filesystem::path case */
+template <> struct get_value_helper<std::filesystem::path> {
+  auto operator()(Variant const &v) const {
+    if (auto const *source = boost::get<std::string>(&v)) {
+      return std::filesystem::path(*source);
+    }
+    return boost::get<std::filesystem::path>(v);
+  }
+};
+
 /** Custom error for a conversion that fails when the value is a nullptr. */
 class bad_get_nullptr : public boost::bad_get {};
 

--- a/src/script_interface/h5md/h5md.cpp
+++ b/src/script_interface/h5md/h5md.cpp
@@ -33,6 +33,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -56,12 +57,14 @@ H5md::H5md() {
 
 void H5md::do_construct(VariantMap const &params) {
   m_output_fields = get_value<std::vector<std::string>>(params, "fields");
-  m_h5md = make_shared_from_args<::Writer::H5md::File, std::string, std::string,
-                                 std::vector<std::string>, std::string,
-                                 std::string, std::string, std::string,
-                                 std::string, std::string, int>(
-      params, "file_path", "script_path", "fields", "mass_unit", "length_unit",
-      "time_unit", "force_unit", "velocity_unit", "charge_unit", "chunk_size");
+  m_h5md =
+      make_shared_from_args<::Writer::H5md::File, std::filesystem::path,
+                            std::filesystem::path, std::vector<std::string>,
+                            std::string, std::string, std::string, std::string,
+                            std::string, std::string, int>(
+          params, "file_path", "script_path", "fields", "mass_unit",
+          "length_unit", "time_unit", "force_unit", "velocity_unit",
+          "charge_unit", "chunk_size");
   // MPI communicator is needed to close parallel file handles
   m_mpi_env_lock = ::Communication::mpiCallbacksHandle()->share_mpi_env();
 }

--- a/src/script_interface/mpiio/mpiio.hpp
+++ b/src/script_interface/mpiio/mpiio.hpp
@@ -31,6 +31,7 @@
 #include "core/io/mpiio/mpiio.hpp"
 #include "core/system/System.hpp"
 
+#include <filesystem>
 #include <memory>
 #include <string>
 
@@ -50,7 +51,7 @@ public:
   Variant do_call_method(std::string const &name,
                          VariantMap const &parameters) override {
 
-    auto prefix = get_value<std::string>(parameters.at("prefix"));
+    auto prefix = get_value<std::filesystem::path>(parameters.at("prefix"));
     auto pos = get_value<bool>(parameters.at("pos"));
     auto vel = get_value<bool>(parameters.at("vel"));
     auto typ = get_value<bool>(parameters.at("typ"));
@@ -66,14 +67,14 @@ public:
       auto &system = system_si->get_system();
       auto &cell_structure = *system.cell_structure;
       auto &bonded_ias = *system.bonded_ias;
-      Mpiio::mpi_mpiio_common_write(prefix, fields, bonded_ias,
+      Mpiio::mpi_mpiio_common_write(prefix.string(), fields, bonded_ias,
                                     cell_structure.local_particles(),
                                     *m_buffers);
     } else if (name == "read") {
       auto const system_si = m_system.lock();
       auto &system = system_si->get_system();
       auto &cell_structure = *system.cell_structure;
-      Mpiio::mpi_mpiio_common_read(prefix, fields, cell_structure);
+      Mpiio::mpi_mpiio_common_read(prefix.string(), fields, cell_structure);
     }
 
     return {};

--- a/src/script_interface/packed_variant.hpp
+++ b/src/script_interface/packed_variant.hpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <filesystem>
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -56,7 +57,7 @@ using PackedVariant = boost::make_recursive_variant<
     None, bool, int, std::size_t, double, std::string, ObjectId,
     Utils::Vector3b, Utils::Vector3i, Utils::Vector2d, Utils::Vector3d,
     Utils::Vector4d, std::vector<int>, std::vector<double>,
-    std::vector<boost::recursive_variant_>,
+    std::vector<boost::recursive_variant_>, std::filesystem::path,
     std::unordered_map<int, boost::recursive_variant_>,
     std::unordered_map<std::string, boost::recursive_variant_>>::type;
 

--- a/src/script_interface/tests/get_value_test.cpp
+++ b/src/script_interface/tests/get_value_test.cpp
@@ -25,6 +25,7 @@
 #include "script_interface/get_value.hpp"
 
 #include <cassert>
+#include <filesystem>
 #include <memory>
 #include <regex>
 #include <stdexcept>
@@ -41,6 +42,12 @@ BOOST_AUTO_TEST_CASE(default_case) {
     auto const v = Variant(s);
 
     BOOST_CHECK_EQUAL(get_value<std::string>(v), s);
+  }
+  {
+    auto const p = std::filesystem::path("ab/cd/ef/gemäß.txt");
+    auto const v = Variant(p);
+
+    BOOST_CHECK_EQUAL(get_value<std::filesystem::path>(v), p);
   }
   {
     auto const vec = Utils::Vector<double, 3>{1., 2., 3.};

--- a/src/script_interface/tests/get_value_test.cpp
+++ b/src/script_interface/tests/get_value_test.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(default_case) {
   using ScriptInterface::Variant;
 
   {
-    auto const s = std::string{"Abc"};
+    auto const s = std::string{"gemäß"};
     auto const v = Variant(s);
 
     BOOST_CHECK_EQUAL(get_value<std::string>(v), s);

--- a/src/script_interface/walberla/EKSpecies.cpp
+++ b/src/script_interface/walberla/EKSpecies.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -72,13 +73,13 @@ Variant EKSpecies::do_call_method(std::string const &method,
     return {};
   }
   if (method == "save_checkpoint") {
-    auto const path = get_value<std::string>(parameters, "path");
+    auto const path = get_value<std::filesystem::path>(parameters, "path");
     auto const mode = get_value<int>(parameters, "mode");
     save_checkpoint(path, mode);
     return {};
   }
   if (method == "load_checkpoint") {
-    auto const path = get_value<std::string>(parameters, "path");
+    auto const path = get_value<std::filesystem::path>(parameters, "path");
     auto const mode = get_value<int>(parameters, "mode");
     load_checkpoint(path, mode);
     return {};
@@ -146,7 +147,7 @@ void EKSpecies::do_construct(VariantMap const &params) {
   });
 }
 
-void EKSpecies::load_checkpoint(std::string const &filename, int mode) {
+void EKSpecies::load_checkpoint(std::filesystem::path const &path, int mode) {
   auto &ek_obj = *m_instance;
 
   auto const read_metadata = [&ek_obj](CheckpointFile &cpfile) {
@@ -194,11 +195,11 @@ void EKSpecies::load_checkpoint(std::string const &filename, int mode) {
 
   auto const on_success = [&ek_obj]() { ek_obj.ghost_communication(); };
 
-  load_checkpoint_common(*context(), "EK", filename, mode, read_metadata,
-                         read_data, on_success);
+  load_checkpoint_common(*context(), "EK", path, mode, read_metadata, read_data,
+                         on_success);
 }
 
-void EKSpecies::save_checkpoint(std::string const &filename, int mode) {
+void EKSpecies::save_checkpoint(std::filesystem::path const &path, int mode) {
   auto &ek_obj = *m_instance;
 
   auto const write_metadata = [&ek_obj,
@@ -298,7 +299,7 @@ void EKSpecies::save_checkpoint(std::string const &filename, int mode) {
     }
   };
 
-  save_checkpoint_common(*context(), "EK", filename, mode, write_metadata,
+  save_checkpoint_common(*context(), "EK", path, mode, write_metadata,
                          write_data, on_failure);
 }
 

--- a/src/script_interface/walberla/EKSpecies.hpp
+++ b/src/script_interface/walberla/EKSpecies.hpp
@@ -35,6 +35,7 @@
 
 #include <utils/math/int_pow.hpp>
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -159,8 +160,8 @@ public:
   }
 
 private:
-  void load_checkpoint(std::string const &filename, int mode);
-  void save_checkpoint(std::string const &filename, int mode);
+  void load_checkpoint(std::filesystem::path const &path, int mode);
+  void save_checkpoint(std::filesystem::path const &path, int mode);
 };
 
 } // namespace ScriptInterface::walberla

--- a/src/script_interface/walberla/LBFluid.cpp
+++ b/src/script_interface/walberla/LBFluid.cpp
@@ -47,6 +47,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -95,13 +96,13 @@ Variant LBFluid::do_call_method(std::string const &name,
     return get_average_pressure_tensor();
   }
   if (name == "load_checkpoint") {
-    auto const path = get_value<std::string>(params, "path");
+    auto const path = get_value<std::filesystem::path>(params, "path");
     auto const mode = get_value<int>(params, "mode");
     load_checkpoint(path, mode);
     return {};
   }
   if (name == "save_checkpoint") {
-    auto const path = get_value<std::string>(params, "path");
+    auto const path = get_value<std::filesystem::path>(params, "path");
     auto const mode = get_value<int>(params, "mode");
     save_checkpoint(path, mode);
     return {};
@@ -222,7 +223,7 @@ Variant LBFluid::get_interpolated_velocity(Utils::Vector3d const &pos) const {
          m_conv_speed;
 }
 
-void LBFluid::load_checkpoint(std::string const &filename, int mode) {
+void LBFluid::load_checkpoint(std::filesystem::path const &path, int mode) {
   auto &lb_obj = *m_instance;
 
   auto const read_metadata = [&lb_obj](CheckpointFile &cpfile) {
@@ -277,11 +278,11 @@ void LBFluid::load_checkpoint(std::string const &filename, int mode) {
     lb_obj.reallocate_ubb_field();
   };
 
-  load_checkpoint_common(*context(), "LB", filename, mode, read_metadata,
-                         read_data, on_success);
+  load_checkpoint_common(*context(), "LB", path, mode, read_metadata, read_data,
+                         on_success);
 }
 
-void LBFluid::save_checkpoint(std::string const &filename, int mode) {
+void LBFluid::save_checkpoint(std::filesystem::path const &path, int mode) {
   auto &lb_obj = *m_instance;
 
   auto const write_metadata = [&lb_obj,
@@ -374,7 +375,7 @@ void LBFluid::save_checkpoint(std::string const &filename, int mode) {
     }
   };
 
-  save_checkpoint_common(*context(), "LB", filename, mode, write_metadata,
+  save_checkpoint_common(*context(), "LB", path, mode, write_metadata,
                          write_data, on_failure);
 }
 

--- a/src/script_interface/walberla/LBFluid.hpp
+++ b/src/script_interface/walberla/LBFluid.hpp
@@ -37,6 +37,7 @@
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -137,8 +138,8 @@ public:
   }
 
 private:
-  void load_checkpoint(std::string const &filename, int mode);
-  void save_checkpoint(std::string const &filename, int mode);
+  void load_checkpoint(std::filesystem::path const &path, int mode);
+  void save_checkpoint(std::filesystem::path const &path, int mode);
   std::vector<Variant> get_average_pressure_tensor() const;
   Variant get_interpolated_velocity(Utils::Vector3d const &pos) const;
 };

--- a/src/script_interface/walberla/VTKHandle.hpp
+++ b/src/script_interface/walberla/VTKHandle.hpp
@@ -48,7 +48,7 @@ private:
   int m_delta_N;
   int m_obs_flag;
   std::string m_identifier;
-  std::string m_base_folder;
+  std::filesystem::path m_base_folder;
   std::string m_prefix;
   std::shared_ptr<::VTKHandle> m_vtk_handle;
   std::weak_ptr<Field> m_field;
@@ -56,7 +56,7 @@ private:
   std::vector<Variant> m_pending_arguments;
 
   [[nodiscard]] auto get_vtk_uid() const {
-    return m_base_folder + '/' + m_identifier;
+    return m_base_folder.generic_string() + "/" + m_identifier;
   }
 
   [[nodiscard]] std::shared_ptr<Field> get_field_instance() const {
@@ -129,7 +129,7 @@ private:
   void do_construct(VariantMap const &params) override {
     m_delta_N = get_value<int>(params, "delta_N");
     m_identifier = get_value<std::string>(params, "identifier");
-    m_base_folder = get_value<std::string>(params, "base_folder");
+    m_base_folder = get_value<std::filesystem::path>(params, "base_folder");
     m_prefix = get_value<std::string>(params, "prefix");
     auto const is_enabled = get_value<bool>(params, "enabled");
     auto const execution_count = get_value<int>(params, "execution_count");
@@ -205,12 +205,13 @@ public:
     assert(m_pending_arguments.size() == 2u);
     auto const is_enabled = get_value<bool>(m_pending_arguments[0]);
     auto const execution_count = get_value<int>(m_pending_arguments[1]);
+    auto const base_folder = m_base_folder.generic_string();
     m_units = units;
     m_field = field;
     auto instance = get_field_instance();
     m_vtk_handle =
         instance->create_vtk(m_delta_N, execution_count, m_obs_flag, m_units,
-                             m_identifier, m_base_folder, m_prefix);
+                             m_identifier, base_folder, m_prefix);
     if (m_delta_N and not is_enabled) {
       instance->switch_vtk(get_vtk_uid(), false);
     }

--- a/src/script_interface/walberla/WalberlaCheckpoint.hpp
+++ b/src/script_interface/walberla/WalberlaCheckpoint.hpp
@@ -29,6 +29,7 @@
 
 #include <boost/mpi/collectives/broadcast.hpp>
 
+#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <memory>
@@ -69,13 +70,13 @@ private:
 public:
   std::fstream stream;
 
-  CheckpointFile(std::string const &filename, std::ios_base::openmode mode,
-                 bool binary) {
+  CheckpointFile(std::filesystem::path const &path,
+                 std::ios_base::openmode mode, bool binary) {
     m_binary = binary;
     auto flags = mode;
     if (m_binary)
       flags |= std::ios_base::binary;
-    stream.open(filename, flags);
+    stream.open(path, flags);
   }
 
   ~CheckpointFile() = default;
@@ -141,7 +142,7 @@ public:
 
 template <typename F1, typename F2, typename F3>
 void load_checkpoint_common(Context const &context, std::string const classname,
-                            std::string const &filename, int mode,
+                            std::filesystem::path const &path, int mode,
                             F1 const read_metadata, F2 const read_data,
                             F3 const on_success) {
   auto const err_msg =
@@ -151,10 +152,11 @@ void load_checkpoint_common(Context const &context, std::string const classname,
   auto const is_head_node = context.is_head_node();
 
   // open file and set exceptions
-  CheckpointFile cpfile(filename, std::ios_base::in, binary);
+  CheckpointFile cpfile(path, std::ios_base::in, binary);
   if (!cpfile.stream) {
     if (is_head_node) {
-      throw std::runtime_error(err_msg + "could not open file " + filename);
+      throw std::runtime_error(err_msg + "could not open file " +
+                               path.string());
     }
     return;
   }
@@ -198,7 +200,7 @@ void load_checkpoint_common(Context const &context, std::string const classname,
 
 template <typename F1, typename F2, typename F3>
 void save_checkpoint_common(Context const &context, std::string const classname,
-                            std::string const &filename, int mode,
+                            std::filesystem::path const &path, int mode,
                             F1 const write_metadata, F2 const write_data,
                             F3 const on_failure) {
   auto const err_msg =
@@ -211,12 +213,12 @@ void save_checkpoint_common(Context const &context, std::string const classname,
   auto failure = false;
   std::shared_ptr<CheckpointFile> cpfile;
   if (is_head_node) {
-    cpfile =
-        std::make_shared<CheckpointFile>(filename, std::ios_base::out, binary);
+    cpfile = std::make_shared<CheckpointFile>(path, std::ios_base::out, binary);
     failure = !cpfile->stream;
     boost::mpi::broadcast(comm, failure, 0);
     if (failure) {
-      throw std::runtime_error(err_msg + "could not open file " + filename);
+      throw std::runtime_error(err_msg + "could not open file " +
+                               path.string());
     }
     cpfile->stream.exceptions(std::ios_base::failbit | std::ios_base::badbit);
     if (!binary) {
@@ -238,7 +240,8 @@ void save_checkpoint_common(Context const &context, std::string const classname,
     if (is_head_node) {
       cpfile->stream.close();
       if (dynamic_cast<std::ios_base::failure const *>(&error)) {
-        throw std::runtime_error(err_msg + "could not write to " + filename);
+        throw std::runtime_error(err_msg + "could not write to " +
+                                 path.string());
       }
       throw;
     }

--- a/src/utils/include/utils/serialization/filesystem.hpp
+++ b/src/utils/include/utils/serialization/filesystem.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/utility.hpp>
+
+#include <filesystem>
+#include <string>
+
+namespace boost::serialization {
+
+template <typename Archive>
+void load(Archive &ar, std::filesystem::path &path, unsigned int const) {
+  std::string source;
+  ar >> source;
+  path = std::filesystem::path(source, std::filesystem::path::generic_format);
+}
+
+template <typename Archive>
+void save(Archive &ar, std::filesystem::path const &path, unsigned int const) {
+  ar << path.generic_string();
+}
+
+template <typename Archive>
+void serialize(Archive &ar, std::filesystem::path &path,
+               unsigned int const version) {
+  split_free(ar, path, version);
+}
+
+} // namespace boost::serialization

--- a/src/walberla_bridge/src/LatticeModel.cpp
+++ b/src/walberla_bridge/src/LatticeModel.cpp
@@ -25,7 +25,6 @@
 #include <vtk/VTKOutput.h>
 
 #include <memory>
-#include <sstream>
 #include <string>
 
 std::shared_ptr<VTKHandle> LatticeModel::create_vtk(
@@ -36,9 +35,7 @@ std::shared_ptr<VTKHandle> LatticeModel::create_vtk(
   using walberla::uint_c;
 
   // VTKOutput object must be unique
-  std::stringstream unique_identifier;
-  unique_identifier << base_folder << "/" << identifier;
-  std::string const vtk_uid = unique_identifier.str();
+  auto const vtk_uid = base_folder + "/" + identifier;
   if (m_vtk_auto.find(vtk_uid) != m_vtk_auto.end() or
       m_vtk_manual.find(vtk_uid) != m_vtk_manual.end()) {
     throw vtk_runtime_error(vtk_uid, "already exists");

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -86,7 +86,7 @@ class H5mdTests(ut.TestCase):
         h5_units = espressomd.io.writer.h5md.UnitSystem(
             time='ps', mass='u', length='m', charge='e')
         h5 = espressomd.io.writer.h5md.H5md(
-            file_path=str(cls.temp_file), unit_system=h5_units)
+            file_path=cls.temp_file, unit_system=h5_units)
         h5.write()
         h5.write()
         h5.flush()
@@ -115,6 +115,10 @@ class H5mdTests(ut.TestCase):
         cls.temp_dir.cleanup()
 
     def test_opening(self):
+        # as pathlib object
+        h5 = espressomd.io.writer.h5md.H5md(file_path=self.temp_file)
+        h5.close()
+        # as string object
         h5 = espressomd.io.writer.h5md.H5md(file_path=str(self.temp_file))
         h5.close()
 
@@ -124,12 +128,12 @@ class H5mdTests(ut.TestCase):
         import time
         # write one frame to the file
         temp_file = self.temp_path / 'appending.h5'
-        h5 = espressomd.io.writer.h5md.H5md(file_path=str(temp_file))
+        h5 = espressomd.io.writer.h5md.H5md(file_path=temp_file)
         h5.write()
         h5.flush()
         h5.close()
         # append one frame to the file
-        h5 = espressomd.io.writer.h5md.H5md(file_path=str(temp_file))
+        h5 = espressomd.io.writer.h5md.H5md(file_path=temp_file)
         h5.write()
         h5.flush()
         h5.close()
@@ -158,32 +162,31 @@ class H5mdTests(ut.TestCase):
         # write a non-compliant file
         temp_file.write_bytes(b'')
         with self.assertRaisesRegex(RuntimeError, "Not an HDF5 file"):
-            h5md.H5md(file_path=str(temp_file), unit_system=h5_units)
+            h5md.H5md(file_path=temp_file, unit_system=h5_units)
         # cannot append to a closed file with a leftover backup file
         main_file = self.temp_path / 'main.h5'
-        h5 = h5md.H5md(file_path=str(main_file))
+        h5 = h5md.H5md(file_path=main_file)
         h5.write()
         h5.flush()
         h5.close()
         main_file.with_suffix(temp_file.suffix + '.bak').write_bytes(b'')
         with self.assertRaisesRegex(RuntimeError, 'A backup of the .h5 file exists'):
-            h5md.H5md(file_path=str(main_file))
+            h5md.H5md(file_path=main_file)
         # cannot create a new file when a leftover backup file exists
         main_file.unlink()
         with self.assertRaisesRegex(RuntimeError, 'A backup of the .h5 file exists'):
-            h5md.H5md(file_path=str(main_file))
+            h5md.H5md(file_path=main_file)
         # open a file with different specifications
         temp_file = self.temp_path / 'wrong_spec.h5'
-        h5 = espressomd.io.writer.h5md.H5md(
-            file_path=str(temp_file), fields=[])
+        h5 = espressomd.io.writer.h5md.H5md(file_path=temp_file, fields=[])
         h5.write()
         h5.flush()
         h5.close()
         with self.assertRaisesRegex(RuntimeError, "The given .h5 file does not match the specifications in 'fields'"):
-            h5md.H5md(file_path=str(temp_file), fields='all')
+            h5md.H5md(file_path=temp_file, fields='all')
         # open a file with invalid specifications
         with self.assertRaisesRegex(ValueError, "Unknown field 'lb'"):
-            h5md.H5md(file_path=str(temp_file), fields='lb')
+            h5md.H5md(file_path=temp_file, fields='lb')
         # check read-only parameters
         for key in self.h5_obj.get_params():
             with self.assertRaisesRegex(RuntimeError, f"Parameter '{key}' is read-only"):
@@ -191,16 +194,15 @@ class H5mdTests(ut.TestCase):
         # check invalid parameters
         temp_file = self.temp_path / 'invalid_params.h5'
         with self.assertRaisesRegex(RuntimeError, "Provided argument of type 'double' for parameter 'chunk_size' is not convertible to 'int'"):
-            h5md.H5md(file_path=str(temp_file), chunk_size=1.0)
+            h5md.H5md(file_path=temp_file, chunk_size=1.0)
         with self.assertRaisesRegex(ValueError, "Parameter 'chunk_size' must be > 0"):
-            h5md.H5md(file_path=str(temp_file), chunk_size=-1)
-        with self.assertRaisesRegex(TypeError, "Parameter 'file_path' should be a string"):
+            h5md.H5md(file_path=temp_file, chunk_size=-1)
+        with self.assertRaisesRegex(TypeError, "Parameter 'file_path' should be a string or a path"):
             h5md.H5md(file_path=None)
 
     def test_empty(self):
         temp_file = self.temp_path / 'empty.h5'
-        h5 = espressomd.io.writer.h5md.H5md(
-            file_path=str(temp_file), fields=[])
+        h5 = espressomd.io.writer.h5md.H5md(file_path=temp_file, fields=[])
         h5.write()
         h5.flush()
         h5.close()
@@ -308,7 +310,7 @@ class H5mdTests(ut.TestCase):
         # case #2: running an interactive Python session
         temp_file = self.temp_path / 'no_script.h5'
         sys.argv[0] = ''
-        h5 = espressomd.io.writer.h5md.H5md(file_path=str(temp_file))
+        h5 = espressomd.io.writer.h5md.H5md(file_path=temp_file)
         sys.argv[0] = __file__
         h5.write()
         h5.flush()
@@ -332,7 +334,7 @@ class H5mdTests(ut.TestCase):
         self.assertEqual(get_unit('particles/atoms/velocity/value'), 'm ps-1')
 
     def test_getters(self):
-        self.assertEqual(self.h5_params['file_path'], str(self.temp_file))
+        self.assertEqual(self.h5_params['file_path'], self.temp_file)
         self.assertEqual(pathlib.Path(self.h5_params['script_path']).resolve(),
                          pathlib.Path(__file__).resolve())
         self.assertEqual(self.h5_params['fields'], ['all'])

--- a/testsuite/python/lattice_vtk.py
+++ b/testsuite/python/lattice_vtk.py
@@ -229,6 +229,21 @@ class TestLBVTK(TestVTK):
                 np.testing.assert_allclose(
                     vtk_pressure, lb_pressure, rtol=1e-6, atol=0.)
 
+    @utx.skipIfMissingModules("espressomd.io.vtk")
+    def test_utf8_support(self):
+        """Check UTF-8 support in filepaths and VTK identifiers."""
+        with tempfile.TemporaryDirectory() as tmp_directory:
+            root = pathlib.Path(tmp_directory) / "gemäß"
+            label = "çåš"
+            vtk_obs = list(self.valid_obs)
+            vtk_obj = self.vtk_class(
+                identifier=label, delta_N=0, observables=vtk_obs, base_folder=str(root))
+            self.lbf.add_vtk_writer(vtk=vtk_obj)
+            self.assertEqual(vtk_obj.identifier, label)
+            vtk_obj.write()
+            path = root / label / "simulation_step_0.vtu"
+            self.assertTrue(path.exists(), f"File \"{path}\" not found")
+
 
 class TestEKVTK(TestVTK):
 

--- a/testsuite/python/lattice_vtk.py
+++ b/testsuite/python/lattice_vtk.py
@@ -146,26 +146,26 @@ class TestLBVTK(TestVTK):
         self.lbf[-3, :, :].density = 1.3
 
         with tempfile.TemporaryDirectory() as tmp_directory:
-            path_vtk_root = pathlib.Path(tmp_directory)
-            label_vtk_end = f"test_vtk_{self.vtk_id}_end"
+            root = pathlib.Path(tmp_directory)
+            label_vtk_last_frame = f"test_vtk_{self.vtk_id}_last_frame"
             label_vtk_continuous = f"test_vtk_{self.vtk_id}_continuous"
-            path_vtk_end = path_vtk_root / label_vtk_end / "simulation_step_0.vtu"
+            path_vtk_last_frame = root / label_vtk_last_frame / "simulation_step_0.vtu"
             path_vtk_continuous = [
-                path_vtk_root / label_vtk_continuous / f"simulation_step_{i}.vtu" for i in range(n_steps)]
-            filepaths = [path_vtk_end] + path_vtk_continuous
+                root / label_vtk_continuous / f"simulation_step_{i}.vtu" for i in range(n_steps)]
+            filepaths = [path_vtk_last_frame] + path_vtk_continuous
 
             # write VTK files
             vtk_obs = list(self.valid_obs)
             vtk_obj = self.vtk_class(
                 identifier=label_vtk_continuous, delta_N=1, observables=vtk_obs,
-                base_folder=str(path_vtk_root))
+                base_folder=root)
             actor.add_vtk_writer(vtk=vtk_obj)
             vtk_obj.disable()
             vtk_obj.enable()
             self.system.integrator.run(n_steps)
             vtk_obj = self.vtk_class(
-                identifier=label_vtk_end, delta_N=0, observables=vtk_obs,
-                base_folder=str(path_vtk_root))
+                identifier=label_vtk_last_frame, delta_N=0, observables=vtk_obs,
+                base_folder=root)
             actor.add_vtk_writer(vtk=vtk_obj)
             vtk_obj.write()
             self.assertEqual(sorted(vtk_obj.observables), sorted(vtk_obs))
@@ -176,7 +176,7 @@ class TestLBVTK(TestVTK):
                 self.assertTrue(
                     filepath.exists(),
                     f"VTK file \"{filepath}\" not written to disk")
-            for filepath in [path_vtk_end.parent.with_suffix(".pvd"),
+            for filepath in [path_vtk_last_frame.parent.with_suffix(".pvd"),
                              path_vtk_continuous[0].parent.with_suffix(".pvd")]:
                 self.assertTrue(
                     filepath.exists(),
@@ -203,7 +203,7 @@ class TestLBVTK(TestVTK):
 
             # read VTK output of final time step
             last_frames = []
-            for filepath in (path_vtk_end, path_vtk_continuous[-1]):
+            for filepath in (path_vtk_last_frame, path_vtk_continuous[-1]):
                 grids = vtk_reader.parse(filepath)
                 last_frames.append((
                     grids[label_density],
@@ -237,9 +237,10 @@ class TestLBVTK(TestVTK):
             label = "çåš"
             vtk_obs = list(self.valid_obs)
             vtk_obj = self.vtk_class(
-                identifier=label, delta_N=0, observables=vtk_obs, base_folder=str(root))
+                identifier=label, delta_N=0, observables=vtk_obs, base_folder=root)
             self.lbf.add_vtk_writer(vtk=vtk_obj)
             self.assertEqual(vtk_obj.identifier, label)
+            self.assertEqual(vtk_obj.base_folder, root)
             vtk_obj.write()
             path = root / label / "simulation_step_0.vtu"
             self.assertTrue(path.exists(), f"File \"{path}\" not found")
@@ -287,26 +288,26 @@ class TestEKVTK(TestVTK):
         label_density = "density"
 
         with tempfile.TemporaryDirectory() as tmp_directory:
-            path_vtk_root = pathlib.Path(tmp_directory)
-            label_vtk_end = f"test_vtk_{self.vtk_id}_end"
+            root = pathlib.Path(tmp_directory)
+            label_vtk_last_frame = f"test_vtk_{self.vtk_id}_end"
             label_vtk_continuous = f"test_vtk_{self.vtk_id}_continuous"
-            path_vtk_end = path_vtk_root / label_vtk_end / "simulation_step_0.vtu"
+            path_vtk_last_frame = root / label_vtk_last_frame / "simulation_step_0.vtu"
             path_vtk_continuous = [
-                path_vtk_root / label_vtk_continuous / f"simulation_step_{i}.vtu" for i in range(n_steps)]
-            filepaths = [path_vtk_end] + path_vtk_continuous
+                root / label_vtk_continuous / f"simulation_step_{i}.vtu" for i in range(n_steps)]
+            filepaths = [path_vtk_last_frame] + path_vtk_continuous
 
             # write VTK files
             vtk_obs = list(self.valid_obs)
             vtk_obj = self.vtk_class(
                 identifier=label_vtk_continuous, delta_N=1, observables=vtk_obs,
-                base_folder=str(path_vtk_root))
+                base_folder=root)
             actor.add_vtk_writer(vtk=vtk_obj)
             vtk_obj.disable()
             vtk_obj.enable()
             self.system.integrator.run(n_steps)
             vtk_obj = self.vtk_class(
-                identifier=label_vtk_end, delta_N=0, observables=vtk_obs,
-                base_folder=str(path_vtk_root))
+                identifier=label_vtk_last_frame, delta_N=0, observables=vtk_obs,
+                base_folder=root)
             actor.add_vtk_writer(vtk=vtk_obj)
             vtk_obj.write()
             self.assertEqual(sorted(vtk_obj.observables), sorted(vtk_obs))
@@ -317,7 +318,7 @@ class TestEKVTK(TestVTK):
                 self.assertTrue(
                     filepath.exists(),
                     f"VTK file \"{filepath}\" not written to disk")
-            for filepath in [path_vtk_end.parent.with_suffix(".pvd"),
+            for filepath in [path_vtk_last_frame.parent.with_suffix(".pvd"),
                              path_vtk_continuous[0].parent.with_suffix(".pvd")]:
                 self.assertTrue(
                     filepath.exists(),
@@ -325,7 +326,7 @@ class TestEKVTK(TestVTK):
 
             # read VTK output of final time step
             last_frames = []
-            for filepath in (path_vtk_end, path_vtk_continuous[-1]):
+            for filepath in (path_vtk_last_frame, path_vtk_continuous[-1]):
                 grids = vtk_reader.parse(filepath)
                 last_frames.append(grids[label_density])
 

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -65,7 +65,6 @@ n_nodes = system.cell_system.get_state()["n_nodes"]
 config.cleanup_old_checkpoint()
 checkpoint = espressomd.checkpointing.Checkpoint(
     **config.get_checkpoint_params())
-path_cpt_root = pathlib.Path(checkpoint.checkpoint_dir)
 
 # Lees-Edwards boundary conditions
 if 'INT.NPT' not in modes and 'LB.GPU' not in modes and (
@@ -406,11 +405,11 @@ if lbf_class:
     lbf[:, :, :].last_applied_force = np.einsum(
         'abc,d->abcd', grid_3D, np.arange(1, 4))
     # save LB checkpoint file
-    lbf_cpt_path = path_cpt_root / "lb.cpt"
+    lbf_cpt_path = checkpoint.root / "lb.cpt"
     lbf.save_checkpoint(str(lbf_cpt_path), lbf_cpt_mode)
     # save EK checkpoint file
     ek_species[:, :, :].density = grid_3D
-    ek_cpt_path = path_cpt_root / "ek.cpt"
+    ek_cpt_path = checkpoint.root / "ek.cpt"
     ek_species.save_checkpoint(str(ek_cpt_path), lbf_cpt_mode)
     # setup VTK folder
     vtk_suffix = config.test_name
@@ -488,7 +487,7 @@ if espressomd.has_features("H5MD"):
     h5_units = espressomd.io.writer.h5md.UnitSystem(
         time="ps", mass="u", length="m", charge="e")
     h5 = espressomd.io.writer.h5md.H5md(
-        file_path=str(path_cpt_root / "test.h5"),
+        file_path=checkpoint.root / "test.h5",
         unit_system=h5_units)
     h5.write()
     h5.flush()
@@ -506,10 +505,10 @@ class TestCheckpoint(ut.TestCase):
         '''
         Check for the presence of the checkpoint files.
         '''
-        self.assertTrue(path_cpt_root.is_dir(),
+        self.assertTrue(checkpoint.root.is_dir(),
                         "checkpoint directory not created")
 
-        checkpoint_filepath = path_cpt_root / "0.checkpoint"
+        checkpoint_filepath = checkpoint.root / "0.checkpoint"
         self.assertTrue(checkpoint_filepath.is_file(),
                         "checkpoint file not created")
 
@@ -537,22 +536,22 @@ class TestCheckpoint(ut.TestCase):
         lbf_cpt_root = lbf_cpt_path.parent
         with self.assertRaisesRegex(RuntimeError, "could not open file"):
             invalid_path = lbf_cpt_root / "unknown_dir" / "lb.cpt"
-            lbf.save_checkpoint(str(invalid_path), lbf_cpt_mode)
+            lbf.save_checkpoint(invalid_path, lbf_cpt_mode)
         with self.assertRaisesRegex(RuntimeError, "unit test error"):
-            lbf.save_checkpoint(str(lbf_cpt_root / "lb_err.cpt"), -1)
+            lbf.save_checkpoint(lbf_cpt_root / "lb_err.cpt", -1)
         with self.assertRaisesRegex(RuntimeError, "could not write to"):
-            lbf.save_checkpoint(str(lbf_cpt_root / "lb_err.cpt"), -2)
+            lbf.save_checkpoint(lbf_cpt_root / "lb_err.cpt", -2)
         with self.assertRaisesRegex(ValueError, "Unknown mode -3"):
-            lbf.save_checkpoint(str(lbf_cpt_root / "lb_err.cpt"), -3)
+            lbf.save_checkpoint(lbf_cpt_root / "lb_err.cpt", -3)
         with self.assertRaisesRegex(ValueError, "Unknown mode 2"):
-            lbf.save_checkpoint(str(lbf_cpt_root / "lb_err.cpt"), 2)
+            lbf.save_checkpoint(lbf_cpt_root / "lb_err.cpt", 2)
 
         # deactivate LB actor
         system.lb = None
 
         # read the valid LB checkpoint file
         lbf_cpt_data = lbf_cpt_path.read_bytes()
-        cpt_path = str(path_cpt_root / "lb") + "{}.cpt"
+        cpt_path = str(checkpoint.root / "lb") + "{}.cpt"
         # write checkpoint file with missing data
         with open(cpt_path.format("-missing-data"), "wb") as f:
             f.write(lbf_cpt_data[:len(lbf_cpt_data) // 2])
@@ -582,19 +581,19 @@ class TestCheckpoint(ut.TestCase):
         ek_cpt_root = ek_cpt_path.parent
         with self.assertRaisesRegex(RuntimeError, "could not open file"):
             invalid_path = ek_cpt_root / "unknown_dir" / "ek.cpt"
-            ek_species.save_checkpoint(str(invalid_path), lbf_cpt_mode)
+            ek_species.save_checkpoint(invalid_path, lbf_cpt_mode)
         with self.assertRaisesRegex(RuntimeError, "unit test error"):
-            ek_species.save_checkpoint(str(ek_cpt_root / "ek_err.cpt"), -1)
+            ek_species.save_checkpoint(ek_cpt_root / "ek_err.cpt", -1)
         with self.assertRaisesRegex(RuntimeError, "could not write to"):
-            ek_species.save_checkpoint(str(ek_cpt_root / "ek_err.cpt"), -2)
+            ek_species.save_checkpoint(ek_cpt_root / "ek_err.cpt", -2)
         with self.assertRaisesRegex(ValueError, "Unknown mode -3"):
-            ek_species.save_checkpoint(str(ek_cpt_root / "ek_err.cpt"), -3)
+            ek_species.save_checkpoint(ek_cpt_root / "ek_err.cpt", -3)
         with self.assertRaisesRegex(ValueError, "Unknown mode 2"):
-            ek_species.save_checkpoint(str(ek_cpt_root / "ek_err.cpt"), 2)
+            ek_species.save_checkpoint(ek_cpt_root / "ek_err.cpt", 2)
 
         # read the valid EK checkpoint file
         ek_cpt_data = ek_cpt_path.read_bytes()
-        cpt_path = str(path_cpt_root / "ek") + "{}.cpt"
+        cpt_path = str(checkpoint.root / "ek") + "{}.cpt"
         # write checkpoint file with missing data
         with open(cpt_path.format("-missing-data"), "wb") as f:
             f.write(ek_cpt_data[:len(ek_cpt_data) // 2])

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -66,7 +66,6 @@ class CheckpointTest(ut.TestCase):
         **config.get_checkpoint_params())
     checkpoint.load(0)
     checkpoint.save(1)
-    path_cpt_root = pathlib.Path(checkpoint.checkpoint_dir)
     n_nodes = system.cell_system.get_state()["n_nodes"]
 
     @classmethod
@@ -84,8 +83,7 @@ class CheckpointTest(ut.TestCase):
     def test_lb_fluid(self):
         lbf = system.lb
         cpt_mode = 0 if 'LB.ASCII' in modes else 1
-        cpt_root = pathlib.Path(self.checkpoint.checkpoint_dir)
-        cpt_path = str(cpt_root / "lb") + "{}.cpt"
+        cpt_path = str(self.checkpoint.root / "lb") + "{}.cpt"
 
         # LB boundaries are loaded at the same time as LB populations
         np.testing.assert_equal(np.copy(lbf[:, :, :].velocity), 0.)
@@ -187,8 +185,7 @@ class CheckpointTest(ut.TestCase):
     @ut.skipIf(not has_lb_mode, "Skipping test due to missing EK mode.")
     def test_ek_species(self):
         cpt_mode = 0 if 'LB.ASCII' in modes else 1
-        cpt_root = pathlib.Path(self.checkpoint.checkpoint_dir)
-        cpt_path = str(cpt_root / "ek") + "{}.cpt"
+        cpt_path = str(self.checkpoint.root / "ek") + "{}.cpt"
 
         self.assertEqual(len(system.ekcontainer), 1)
         ek_species = system.ekcontainer[0]
@@ -816,12 +813,12 @@ class CheckpointTest(ut.TestCase):
     @utx.skipIfMissingModules("h5py")
     def test_h5md(self):
         # check attributes
-        file_path = self.path_cpt_root / "test.h5"
+        file_path = self.checkpoint.root / "test.h5"
         script_path = pathlib.Path(
             __file__).resolve().parent / "save_checkpoint.py"
         self.assertEqual(h5.fields, ['all'])
-        self.assertEqual(h5.script_path, str(script_path))
-        self.assertEqual(h5.file_path, str(file_path))
+        self.assertEqual(h5.script_path, script_path)
+        self.assertEqual(h5.file_path, file_path)
 
         # write new frame
         h5.write()

--- a/testsuite/python/utils.py
+++ b/testsuite/python/utils.py
@@ -80,6 +80,31 @@ class Test(ut.TestCase):
         self.assertEqual(utils.nesting_level([1, ]), 1)
         self.assertEqual(utils.nesting_level([[1]]), 2)
 
+    def test_string_conversion_to_str(self):
+        def check_to_str(obj, ref):
+            res = utils.to_str(obj)
+            self.assertEqual(res, ref)
+            self.assertIsInstance(res, str)
+            self.assertNotIsInstance(res, (bytes, np.bytes_, np.str_))
+        check_to_str(b"abc", "abc")
+        check_to_str("abc", "abc")
+        check_to_str("Åüb", "Åüb")
+        check_to_str(np.str_("abc"), "abc")
+        check_to_str(np.str_("Åüb"), "Åüb")
+        check_to_str(np.bytes_(b"abc"), "abc")
+
+    def test_string_conversion_to_bytes(self):
+        def check_to_bytes(obj, ref):
+            res = utils.to_bytes(obj)
+            self.assertEqual(res, ref)
+            self.assertIsInstance(res, bytes)
+            self.assertNotIsInstance(res, (str, np.str_, np.bytes_))
+        check_to_bytes(b"abc", b"abc")
+        check_to_bytes("abc", b"abc")
+        check_to_bytes("Åüb", b"\xc3\x85\xc3\xbcb")
+        check_to_bytes(b"\xc3\x85\xc3\xbcb", b"\xc3\x85\xc3\xbcb")
+        check_to_bytes(np.bytes_(b"abc"), b"abc")
+
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
Fixes #5126

Description of changes:
- allow UTF-8 strings in the ESPResSo core and script interface
- allow `pathlib.Path` objects in functions that expect file paths
