### PR TITLE
Make short-range electrostatic force correction thread safe

### DIFF
--- a/src/core/electrostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics/coulomb_inline.hpp
@@ -77,8 +77,9 @@ struct ShortRangeForceCorrectionsKernel {
   result_type
   operator()(std::shared_ptr<ElectrostaticLayerCorrection> const &ptr) const {
     auto const &actor = *ptr;
-    return kernel_type{[&actor](Particle &p1, Particle &p2, double q1q2) {
-      actor.add_pair_force_corrections(p1, p2, q1q2);
+    return kernel_type{[&actor](Utils::Vector3d const &pos1, Utils::Vector3d const &pos2,
+		    ParticleForce &p1f_asym, ParticleForce &p2f_asym, double q1q2) {
+      actor.add_pair_force_corrections(pos1, pos2, p1f_asym, p2f_asym, q1q2);
     }};
   }
 #endif // P3M

--- a/src/core/electrostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics/coulomb_inline.hpp
@@ -77,8 +77,10 @@ struct ShortRangeForceCorrectionsKernel {
   result_type
   operator()(std::shared_ptr<ElectrostaticLayerCorrection> const &ptr) const {
     auto const &actor = *ptr;
-    return kernel_type{[&actor](Utils::Vector3d const &pos1, Utils::Vector3d const &pos2,
-		    ParticleForce &p1f_asym, ParticleForce &p2f_asym, double q1q2) {
+    return kernel_type{[&actor](Utils::Vector3d const &pos1,
+                                Utils::Vector3d const &pos2,
+                                ParticleForce &p1f_asym,
+                                ParticleForce &p2f_asym, double q1q2) {
       actor.add_pair_force_corrections(pos1, pos2, p1f_asym, p2f_asym, q1q2);
     }};
   }

--- a/src/core/electrostatics/elc.hpp
+++ b/src/core/electrostatics/elc.hpp
@@ -335,9 +335,9 @@ struct ElectrostaticLayerCorrection
 
   /** @brief Add short-range pair force corrections. */
   void add_pair_force_corrections(Utils::Vector3d const pos1,
-				  Utils::Vector3d const pos2,
-				  ParticleForce &p1f_asym, ParticleForce &p2f_asym,
-                                  double q1q2) const {
+                                  Utils::Vector3d const pos2,
+                                  ParticleForce &p1f_asym,
+                                  ParticleForce &p2f_asym, double q1q2) const {
     if (elc.dielectric_contrast_on) {
       std::visit(
           [this, &pos1, &pos2, &p1f_asym, &p2f_asym, q1q2](auto &p3m_ptr) {

--- a/src/core/electrostatics/elc.hpp
+++ b/src/core/electrostatics/elc.hpp
@@ -334,23 +334,23 @@ struct ElectrostaticLayerCorrection
   }
 
   /** @brief Add short-range pair force corrections. */
-  void add_pair_force_corrections(Particle &p1, Particle &p2,
+  void add_pair_force_corrections(Utils::Vector3d const pos1,
+				  Utils::Vector3d const pos2,
+				  ParticleForce &p1f_asym, ParticleForce &p2f_asym,
                                   double q1q2) const {
     if (elc.dielectric_contrast_on) {
       std::visit(
-          [this, &p1, &p2, q1q2](auto &p3m_ptr) {
-            auto const &pos1 = p1.pos();
-            auto const &pos2 = p2.pos();
+          [this, &pos1, &pos2, &p1f_asym, &p2f_asym, q1q2](auto &p3m_ptr) {
             auto const &p3m = *p3m_ptr;
             elc.dielectric_layers_contribution(
                 *m_box_geo, pos1, pos2, q1q2,
                 [&](double q_eff, Utils::Vector3d const &d) {
-                  p1.force() += p3m.pair_force(q_eff, d, d.norm());
+                  p1f_asym.f += p3m.pair_force(q_eff, d, d.norm());
                 });
             elc.dielectric_layers_contribution(
                 *m_box_geo, pos2, pos1, q1q2,
                 [&](double q_eff, Utils::Vector3d const &d) {
-                  p2.force() += p3m.pair_force(q_eff, d, d.norm());
+                  p2f_asym.f += p3m.pair_force(q_eff, d, d.norm());
                 });
           },
           base_solver);

--- a/src/core/electrostatics/icc.cpp
+++ b/src/core/electrostatics/icc.cpp
@@ -95,7 +95,11 @@ static void force_calc_icc(
           p2.force() -= force;
 #ifdef P3M
           if (elc_kernel_ptr) {
-            (*elc_kernel_ptr)(p1, p2, q1q2);
+	    ParticleForce p1f_asym{};
+    	    ParticleForce p2f_asym{};
+            (*elc_kernel_ptr)(p1.pos(), p2.pos(), p1f_asym, p2f_asym, q1q2);
+            p1.force() += p1f_asym.f;
+            p2.force() += p2f_asym.f;
           }
 #endif // P3M
         }

--- a/src/core/electrostatics/icc.cpp
+++ b/src/core/electrostatics/icc.cpp
@@ -95,8 +95,8 @@ static void force_calc_icc(
           p2.force() -= force;
 #ifdef P3M
           if (elc_kernel_ptr) {
-	    ParticleForce p1f_asym{};
-    	    ParticleForce p2f_asym{};
+            ParticleForce p1f_asym{};
+            ParticleForce p2f_asym{};
             (*elc_kernel_ptr)(p1.pos(), p2.pos(), p1f_asym, p2f_asym, q1q2);
             p1.force() += p1f_asym.f;
             p2.force() += p2f_asym.f;

--- a/src/core/electrostatics/solver.hpp
+++ b/src/core/electrostatics/solver.hpp
@@ -69,7 +69,8 @@ struct Solver {
   using ShortRangeForceKernel =
       std::function<Utils::Vector3d(double, Utils::Vector3d const &, double)>;
   using ShortRangeForceCorrectionsKernel =
-      std::function<void(Utils::Vector3d const &, Utils::Vector3d const &, ParticleForce &, ParticleForce &, double)>;
+      std::function<void(Utils::Vector3d const &, Utils::Vector3d const &,
+                         ParticleForce &, ParticleForce &, double)>;
   using ShortRangePressureKernel = std::function<Utils::Matrix<double, 3, 3>(
       double, Utils::Vector3d const &, double)>;
   using ShortRangeEnergyKernel =

--- a/src/core/electrostatics/solver.hpp
+++ b/src/core/electrostatics/solver.hpp
@@ -69,7 +69,7 @@ struct Solver {
   using ShortRangeForceKernel =
       std::function<Utils::Vector3d(double, Utils::Vector3d const &, double)>;
   using ShortRangeForceCorrectionsKernel =
-      std::function<void(Particle &, Particle &, double)>;
+      std::function<void(Utils::Vector3d const &, Utils::Vector3d const &, ParticleForce &, ParticleForce &, double)>;
   using ShortRangePressureKernel = std::function<Utils::Matrix<double, 3, 3>(
       double, Utils::Vector3d const &, double)>;
   using ShortRangeEnergyKernel =

--- a/src/core/forces_cabana.hpp
+++ b/src/core/forces_cabana.hpp
@@ -140,9 +140,9 @@ struct ForcesKernel {
     auto constexpr q1q2 = 0.;
 #endif
     add_non_bonded_pair_force_with_p(
-        p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist * dist, q1q2, ia_params, do_nonbonded_flag,
-        thermostat, box_geo, bonded_ias, virial_handle, coulomb_kernel,
-        dipoles_kernel, elc_kernel, coulomb_u_kernel);
+        p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist * dist, q1q2, ia_params,
+        do_nonbonded_flag, thermostat, box_geo, bonded_ias, virial_handle,
+        coulomb_kernel, dipoles_kernel, elc_kernel, coulomb_u_kernel);
 
 #ifdef ELECTROSTATICS
     // real-space electrostatic charge-charge interaction

--- a/src/core/forces_cabana.hpp
+++ b/src/core/forces_cabana.hpp
@@ -101,6 +101,8 @@ struct ForcesKernel {
         nonbonded_ias.get_ia_param(aosoa.type(i), aosoa.type(j));
 
     ParticleForce pf{};
+    ParticleForce p1f_asym{};
+    ParticleForce p2f_asym{};
 
 #ifdef NPT
     Utils::Vector3d virial{};
@@ -138,7 +140,7 @@ struct ForcesKernel {
     auto constexpr q1q2 = 0.;
 #endif
     add_non_bonded_pair_force_with_p(
-        p1, p2, pf, d, dist, dist * dist, q1q2, ia_params, do_nonbonded_flag,
+        p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist * dist, q1q2, ia_params, do_nonbonded_flag,
         thermostat, box_geo, bonded_ias, virial_handle, coulomb_kernel,
         dipoles_kernel, elc_kernel, coulomb_u_kernel);
 
@@ -159,6 +161,12 @@ struct ForcesKernel {
     }
 #endif // DIPOLES
 
+    auto opf = calc_opposing_force(pf, d);
+#ifdef ELECTROSTATICS
+    pf += p1f_asym;
+    opf += p2f_asym;
+#endif // ELECTROSTATICS
+
     local_force(i, thread_id, 0) += pf.f[0];
     local_force(i, thread_id, 1) += pf.f[1];
     local_force(i, thread_id, 2) += pf.f[2];
@@ -168,7 +176,6 @@ struct ForcesKernel {
     local_torque(i, thread_id, 2) += pf.torque[2];
 #endif
 
-    auto const opf = calc_opposing_force(pf, d);
     local_force(j, thread_id, 0) += opf.f[0];
     local_force(j, thread_id, 1) += opf.f[1];
     local_force(j, thread_id, 2) += opf.f[2];

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -208,8 +208,8 @@ inline void add_non_bonded_pair_without_p(
  */
 inline void add_non_bonded_pair_force_with_p(
     Particle &p1, Particle &p2, ParticleForce &pf, ParticleForce &p1f_asym,
-    ParticleForce &p2f_asym, Utils::Vector3d const &d,
-    double dist, double dist2, double q1q2, IA_parameters const &ia_params,
+    ParticleForce &p2f_asym, Utils::Vector3d const &d, double dist,
+    double dist2, double q1q2, IA_parameters const &ia_params,
     [[maybe_unused]] bool do_nonbonded_flag,
     Thermostat::Thermostat const &thermostat, BoxGeometry const &box_geo,
     [[maybe_unused]] BondedInteractionsMap const &bonded_ias,
@@ -353,9 +353,9 @@ inline void add_non_bonded_pair_force(
 #endif // not SHARED_MEMORY_PARALLELISM
 
   add_non_bonded_pair_force_with_p(
-      p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist2, q1q2, ia_params, do_nonbonded_flag,
-      thermostat, box_geo, bonded_ias, virial, coulomb_kernel, dipoles_kernel,
-      elc_kernel, coulomb_u_kernel);
+      p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist2, q1q2, ia_params,
+      do_nonbonded_flag, thermostat, box_geo, bonded_ias, virial,
+      coulomb_kernel, dipoles_kernel, elc_kernel, coulomb_u_kernel);
 
   /***********************************************/
   /* add total non-bonded forces to particles    */

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -207,7 +207,8 @@ inline void add_non_bonded_pair_without_p(
  * @brief For interactions which need particle information.
  */
 inline void add_non_bonded_pair_force_with_p(
-    Particle &p1, Particle &p2, ParticleForce &pf, Utils::Vector3d const &d,
+    Particle &p1, Particle &p2, ParticleForce &pf, ParticleForce &p1f_asym,
+    ParticleForce &p2f_asym, Utils::Vector3d const &d,
     double dist, double dist2, double q1q2, IA_parameters const &ia_params,
     [[maybe_unused]] bool do_nonbonded_flag,
     Thermostat::Thermostat const &thermostat, BoxGeometry const &box_geo,
@@ -263,7 +264,7 @@ inline void add_non_bonded_pair_force_with_p(
     }
 #endif // NPT
     if (elc_kernel) {
-      (*elc_kernel)(p1, p2, q1q2);
+      (*elc_kernel)(p1.pos(), p2.pos(), p1f_asym, p2f_asym, q1q2);
     }
   }
 #endif // ELECTROSTATICS
@@ -330,6 +331,8 @@ inline void add_non_bonded_pair_force(
     Coulomb::ShortRangeEnergyKernel::kernel_type const *coulomb_u_kernel) {
 
   ParticleForce pf{};
+  ParticleForce p1f_asym{};
+  ParticleForce p2f_asym{};
 
 #ifdef EXCLUSIONS
   auto const do_nonbonded_flag = do_nonbonded(p1, p2);
@@ -350,7 +353,7 @@ inline void add_non_bonded_pair_force(
 #endif // not SHARED_MEMORY_PARALLELISM
 
   add_non_bonded_pair_force_with_p(
-      p1, p2, pf, d, dist, dist2, q1q2, ia_params, do_nonbonded_flag,
+      p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist2, q1q2, ia_params, do_nonbonded_flag,
       thermostat, box_geo, bonded_ias, virial, coulomb_kernel, dipoles_kernel,
       elc_kernel, coulomb_u_kernel);
 
@@ -359,8 +362,8 @@ inline void add_non_bonded_pair_force(
   /***********************************************/
 
 #ifndef SHARED_MEMORY_PARALLELISM
-  p1.force_and_torque() += pf;
-  p2.force_and_torque() += calc_opposing_force(pf, d);
+  p1.force_and_torque() += pf + p1f_asym;
+  p2.force_and_torque() += calc_opposing_force(pf, d) + p2f_asym;
 #endif
 }
 


### PR DESCRIPTION

Description of changes:
- Implement a thread-safe version of the short-range electrostatic force correction
  - In add_pair_force_corrections, the force is added to not `p.force()`, where `p` is a Particle pointer, but the thread-local variable `p1f_asym` and `p2f_asym`.
