### PR TITLE
Change coulomb_energy_kernel interface from AOS to SOA

### DIFF
--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -32,6 +32,12 @@
 #include <stdexcept>
 #include <utility>
 
+#if defined(__GNUG__) or defined(__clang__)
+#define ESPRESSO_ATTR_ALWAYS_INLINE [[gnu::always_inline]]
+#else
+#define ESPRESSO_ATTR_ALWAYS_INLINE
+#endif
+
 namespace detail {
 /**
  * @brief Get the minimum-image distance between two coordinates.
@@ -207,6 +213,7 @@ public:
    *         periodic images, i.e. <tt>a - b</tt>.
    */
   template <typename T>
+  ESPRESSO_ATTR_ALWAYS_INLINE inline
   Utils::Vector<T, 3> get_mi_vector(const Utils::Vector<T, 3> &a,
                                     const Utils::Vector<T, 3> &b) const {
     if (type() == BoxType::LEES_EDWARDS) {
@@ -240,6 +247,7 @@ public:
    *         periodic images, i.e. <tt>a - b</tt>.
    */
   template <typename T>
+  ESPRESSO_ATTR_ALWAYS_INLINE inline
   Utils::Vector<T, 3> get_mi_vector(T const &a0, T const &a1, T const &a2,
                                     T const &b0, T const &b1,
                                     T const &b2) const {

--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -213,9 +213,9 @@ public:
    *         periodic images, i.e. <tt>a - b</tt>.
    */
   template <typename T>
-  ESPRESSO_ATTR_ALWAYS_INLINE inline
-  Utils::Vector<T, 3> get_mi_vector(const Utils::Vector<T, 3> &a,
-                                    const Utils::Vector<T, 3> &b) const {
+  ESPRESSO_ATTR_ALWAYS_INLINE inline Utils::Vector<T, 3>
+  get_mi_vector(const Utils::Vector<T, 3> &a,
+                const Utils::Vector<T, 3> &b) const {
     if (type() == BoxType::LEES_EDWARDS) {
       auto const shear_plane_normal = lees_edwards_bc().shear_plane_normal;
       auto a_tmp = a;
@@ -247,10 +247,9 @@ public:
    *         periodic images, i.e. <tt>a - b</tt>.
    */
   template <typename T>
-  ESPRESSO_ATTR_ALWAYS_INLINE inline
-  Utils::Vector<T, 3> get_mi_vector(T const &a0, T const &a1, T const &a2,
-                                    T const &b0, T const &b1,
-                                    T const &b2) const {
+  ESPRESSO_ATTR_ALWAYS_INLINE inline Utils::Vector<T, 3>
+  get_mi_vector(T const &a0, T const &a1, T const &a2, T const &b0, T const &b1,
+                T const &b2) const {
     if (type() == BoxType::LEES_EDWARDS) {
       auto const shear_plane_normal = lees_edwards_bc().shear_plane_normal;
       auto a_tmp = Utils::Vector<T, 3>{a0, a1, a2};

--- a/src/core/bonded_interactions/bonded_coulomb_sr.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb_sr.hpp
@@ -54,9 +54,9 @@ struct BondedCoulombSR {
                                       double)> const &kernel) const;
   std::optional<double>
   energy(Particle const &p1, Particle const &p2, Utils::Vector3d const &dx,
-         std::function<double(Utils::Vector3d const &, Utils::Vector3d const &, double,
-                              Utils::Vector3d const &, double)> const &kernel)
-      const;
+         std::function<double(Utils::Vector3d const &, Utils::Vector3d const &,
+                              double, Utils::Vector3d const &, double)> const
+             &kernel) const;
 };
 
 /** Compute the short-range bonded Coulomb pair force.
@@ -82,9 +82,9 @@ inline std::optional<Utils::Vector3d> BondedCoulombSR::force(
  */
 inline std::optional<double> BondedCoulombSR::energy(
     Particle const &p1, Particle const &p2, Utils::Vector3d const &dx,
-    std::function<double(Utils::Vector3d const &, Utils::Vector3d const &, double,
-                         Utils::Vector3d const &, double)> const &kernel)
-    const {
+    std::function<double(Utils::Vector3d const &, Utils::Vector3d const &,
+                         double, Utils::Vector3d const &, double)> const
+        &kernel) const {
 #ifdef ELECTROSTATICS
   return kernel(p1.pos(), p2.pos(), q1q2, dx, dx.norm());
 #else

--- a/src/core/bonded_interactions/bonded_coulomb_sr.hpp
+++ b/src/core/bonded_interactions/bonded_coulomb_sr.hpp
@@ -54,7 +54,7 @@ struct BondedCoulombSR {
                                       double)> const &kernel) const;
   std::optional<double>
   energy(Particle const &p1, Particle const &p2, Utils::Vector3d const &dx,
-         std::function<double(Particle const &, Particle const &, double,
+         std::function<double(Utils::Vector3d const &, Utils::Vector3d const &, double,
                               Utils::Vector3d const &, double)> const &kernel)
       const;
 };
@@ -82,11 +82,11 @@ inline std::optional<Utils::Vector3d> BondedCoulombSR::force(
  */
 inline std::optional<double> BondedCoulombSR::energy(
     Particle const &p1, Particle const &p2, Utils::Vector3d const &dx,
-    std::function<double(Particle const &, Particle const &, double,
+    std::function<double(Utils::Vector3d const &, Utils::Vector3d const &, double,
                          Utils::Vector3d const &, double)> const &kernel)
     const {
 #ifdef ELECTROSTATICS
-  return kernel(p1, p2, q1q2, dx, dx.norm());
+  return kernel(p1.pos(), p2.pos(), q1q2, dx, dx.norm());
 #else
   return 0.;
 #endif

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -122,24 +122,26 @@ void CellStructure::rebuild_local_properties(double const pair_cutoff) {
   auto const num_threads = execution_space().concurrency();
   auto const num_part = get_unique_particles().size();
   auto max_counts = estimate_max_counts(m_max_prefactor, pair_cutoff, num_part);
-  if (m_local_force != nullptr) { //variables for local properties are reallocated.
+  if (m_local_force !=
+      nullptr) { // variables for local properties are reallocated.
     Kokkos::realloc(get_local_force(), num_part, num_threads);
 #ifdef ROTATION
     Kokkos::realloc(get_local_torque(), num_part, num_threads);
 #endif
     m_particle_storage->resize(num_part);
     m_verlet_list_cabana->reallocData(num_part, max_counts);
-  } else { //variables for local properties are generated.
+  } else { // variables for local properties are generated.
     m_local_force =
-	std::make_unique<ForceType>("local_force", num_part, num_threads);
+        std::make_unique<ForceType>("local_force", num_part, num_threads);
 #ifdef ROTATION
     m_local_torque =
-	std::make_unique<ForceType>("local_torque", num_part, num_threads);
+        std::make_unique<ForceType>("local_torque", num_part, num_threads);
 #endif
     m_particle_storage = std::make_unique<AoSoAType>("particles", num_part);
     m_particle_storage->resize(num_part);
 
-    m_verlet_list_cabana = std::make_unique<ListType>(0ul, num_part, max_counts);
+    m_verlet_list_cabana =
+        std::make_unique<ListType>(0ul, num_part, max_counts);
   }
 #ifdef NPT
   m_local_virial = std::make_unique<VirialType>("local_virial", num_threads);

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -121,22 +121,31 @@ void CellStructure::rebuild_local_properties(double const pair_cutoff) {
   using execution_space = Kokkos::DefaultExecutionSpace;
   auto const num_threads = execution_space().concurrency();
   auto const num_part = get_unique_particles().size();
-  m_local_force =
-      std::make_unique<ForceType>("local_force", num_part, num_threads);
+  auto max_counts = estimate_max_counts(m_max_prefactor, pair_cutoff, num_part);
+  if (m_local_force != nullptr) { //variables for local properties are reallocated.
+    Kokkos::realloc(get_local_force(), num_part, num_threads);
 #ifdef ROTATION
-  m_local_torque =
-      std::make_unique<ForceType>("local_torque", num_part, num_threads);
+    Kokkos::realloc(get_local_torque(), num_part, num_threads);
 #endif
+    m_particle_storage->resize(num_part);
+    m_verlet_list_cabana->reallocData(num_part, max_counts);
+  } else { //variables for local properties are generated.
+    m_local_force =
+	std::make_unique<ForceType>("local_force", num_part, num_threads);
+#ifdef ROTATION
+    m_local_torque =
+	std::make_unique<ForceType>("local_torque", num_part, num_threads);
+#endif
+    m_particle_storage = std::make_unique<AoSoAType>("particles", num_part);
+    m_particle_storage->resize(num_part);
+
+    m_verlet_list_cabana = std::make_unique<ListType>(0ul, num_part, max_counts);
+  }
 #ifdef NPT
   m_local_virial = std::make_unique<VirialType>("local_virial", num_threads);
 #endif
-  m_particle_storage = std::make_unique<AoSoAType>("particles", num_part);
-  m_particle_storage->resize(num_part);
   // particle properties are defined in aosoa_pack.hpp
   m_aosoa = std::make_unique<AoSoA_pack>(*m_particle_storage);
-
-  auto max_counts = estimate_max_counts(m_max_prefactor, pair_cutoff, num_part);
-  m_verlet_list_cabana = std::make_unique<ListType>(0ul, num_part, max_counts);
 }
 
 void CellStructure::reset_local_force() {

--- a/src/core/custom_verlet_list.hpp
+++ b/src/core/custom_verlet_list.hpp
@@ -55,6 +55,16 @@ public:
         max_neigh);
   }
 
+  // Method to realloc _data
+  KOKKOS_INLINE_FUNCTION
+  void reallocData(std::size_t const num_particles,
+                   std::size_t const max_neigh) {
+    Kokkos::realloc(counts, num_particles);
+    Kokkos::realloc(
+        Kokkos::WithoutInitializing, neighbors, num_particles,
+        max_neigh);
+  }
+
   // Method to add a neighbor
   KOKKOS_INLINE_FUNCTION
   void addNeighborAtomicLB(int pid, int nid) {

--- a/src/core/custom_verlet_list.hpp
+++ b/src/core/custom_verlet_list.hpp
@@ -60,9 +60,8 @@ public:
   void reallocData(std::size_t const num_particles,
                    std::size_t const max_neigh) {
     Kokkos::realloc(counts, num_particles);
-    Kokkos::realloc(
-        Kokkos::WithoutInitializing, neighbors, num_particles,
-        max_neigh);
+    Kokkos::realloc(Kokkos::WithoutInitializing, neighbors, num_particles,
+                    max_neigh);
   }
 
   // Method to add a neighbor

--- a/src/core/electrostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics/coulomb_inline.hpp
@@ -115,32 +115,33 @@ struct ShortRangeEnergyKernel {
   template <typename T>
   result_type operator()(std::shared_ptr<T> const &ptr) const {
     auto const &actor = *ptr;
-    return kernel_type{[&actor](Utils::Vector3d const &, Utils::Vector3d const &, double q1q2,
-                                Utils::Vector3d const &, double dist) {
-      return actor.pair_energy(q1q2, dist);
-    }};
+    return kernel_type{
+        [&actor](Utils::Vector3d const &, Utils::Vector3d const &, double q1q2,
+                 Utils::Vector3d const &,
+                 double dist) { return actor.pair_energy(q1q2, dist); }};
   }
 #ifdef P3M
   result_type
   operator()(std::shared_ptr<ElectrostaticLayerCorrection> const &ptr) const {
     auto const &actor = *ptr;
     auto const energy_kernel = std::visit(*this, actor.base_solver);
-    return kernel_type{[&actor, energy_kernel](
-                           Utils::Vector3d const &pos1, Utils::Vector3d const &pos2, double q1q2,
-                           Utils::Vector3d const &d, double dist) {
-      auto energy = 0.;
-      if (energy_kernel) {
-        energy = (*energy_kernel)(pos1, pos2, q1q2, d, dist);
-      }
-      return energy + actor.pair_energy_correction(pos1, pos2, q1q2);
-    }};
+    return kernel_type{
+        [&actor, energy_kernel](Utils::Vector3d const &pos1,
+                                Utils::Vector3d const &pos2, double q1q2,
+                                Utils::Vector3d const &d, double dist) {
+          auto energy = 0.;
+          if (energy_kernel) {
+            energy = (*energy_kernel)(pos1, pos2, q1q2, d, dist);
+          }
+          return energy + actor.pair_energy_correction(pos1, pos2, q1q2);
+        }};
   }
 #endif // P3M
   result_type operator()(std::shared_ptr<CoulombMMM1D> const &actor) const {
-    return kernel_type{[&actor](Utils::Vector3d const &, Utils::Vector3d const &, double q1q2,
-                                Utils::Vector3d const &d, double dist) {
-      return actor->pair_energy(q1q2, d, dist);
-    }};
+    return kernel_type{
+        [&actor](Utils::Vector3d const &, Utils::Vector3d const &, double q1q2,
+                 Utils::Vector3d const &d,
+                 double dist) { return actor->pair_energy(q1q2, d, dist); }};
   }
 #endif // ELECTROSTATICS
 };

--- a/src/core/electrostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics/coulomb_inline.hpp
@@ -132,7 +132,8 @@ struct ShortRangeEnergyKernel {
       if (energy_kernel) {
         energy = (*energy_kernel)(p1, p2, q1q2, d, dist);
       }
-      return energy + actor.pair_energy_correction(p1, p2, q1q2);
+      std::cout << "CHECK " << energy << std::endl;
+      return energy + actor.pair_energy_correction(p1.pos(), p2.pos(), q1q2);
     }};
   }
 #endif // P3M

--- a/src/core/electrostatics/coulomb_inline.hpp
+++ b/src/core/electrostatics/coulomb_inline.hpp
@@ -115,7 +115,7 @@ struct ShortRangeEnergyKernel {
   template <typename T>
   result_type operator()(std::shared_ptr<T> const &ptr) const {
     auto const &actor = *ptr;
-    return kernel_type{[&actor](Particle const &, Particle const &, double q1q2,
+    return kernel_type{[&actor](Utils::Vector3d const &, Utils::Vector3d const &, double q1q2,
                                 Utils::Vector3d const &, double dist) {
       return actor.pair_energy(q1q2, dist);
     }};
@@ -126,19 +126,18 @@ struct ShortRangeEnergyKernel {
     auto const &actor = *ptr;
     auto const energy_kernel = std::visit(*this, actor.base_solver);
     return kernel_type{[&actor, energy_kernel](
-                           Particle const &p1, Particle const &p2, double q1q2,
+                           Utils::Vector3d const &pos1, Utils::Vector3d const &pos2, double q1q2,
                            Utils::Vector3d const &d, double dist) {
       auto energy = 0.;
       if (energy_kernel) {
-        energy = (*energy_kernel)(p1, p2, q1q2, d, dist);
+        energy = (*energy_kernel)(pos1, pos2, q1q2, d, dist);
       }
-      std::cout << "CHECK " << energy << std::endl;
-      return energy + actor.pair_energy_correction(p1.pos(), p2.pos(), q1q2);
+      return energy + actor.pair_energy_correction(pos1, pos2, q1q2);
     }};
   }
 #endif // P3M
   result_type operator()(std::shared_ptr<CoulombMMM1D> const &actor) const {
-    return kernel_type{[&actor](Particle const &, Particle const &, double q1q2,
+    return kernel_type{[&actor](Utils::Vector3d const &, Utils::Vector3d const &, double q1q2,
                                 Utils::Vector3d const &d, double dist) {
       return actor->pair_energy(q1q2, d, dist);
     }};

--- a/src/core/electrostatics/elc.hpp
+++ b/src/core/electrostatics/elc.hpp
@@ -307,7 +307,7 @@ struct ElectrostaticLayerCorrection
 
   /** @brief Calculate short-range pair energy correction. */
   double pair_energy_correction(Utils::Vector3d const &pos1,
-		  		Utils::Vector3d const &pos2,
+                                Utils::Vector3d const &pos2,
                                 double q1q2) const {
     double energy = 0.;
     if (elc.dielectric_contrast_on) {

--- a/src/core/electrostatics/elc.hpp
+++ b/src/core/electrostatics/elc.hpp
@@ -333,8 +333,8 @@ struct ElectrostaticLayerCorrection
   }
 
   /** @brief Add short-range pair force corrections. */
-  void add_pair_force_corrections(Utils::Vector3d const pos1,
-                                  Utils::Vector3d const pos2,
+  void add_pair_force_corrections(Utils::Vector3d const &pos1,
+                                  Utils::Vector3d const &pos2,
                                   ParticleForce &p1f_asym,
                                   ParticleForce &p2f_asym, double q1q2) const {
     if (elc.dielectric_contrast_on) {

--- a/src/core/electrostatics/elc.hpp
+++ b/src/core/electrostatics/elc.hpp
@@ -306,14 +306,13 @@ struct ElectrostaticLayerCorrection
 #endif // SHARED_MEMORY_PARALLELISM
 
   /** @brief Calculate short-range pair energy correction. */
-  double pair_energy_correction(Particle const &p1, Particle const &p2,
+  double pair_energy_correction(Utils::Vector3d const &pos1,
+		  		Utils::Vector3d const &pos2,
                                 double q1q2) const {
     double energy = 0.;
     if (elc.dielectric_contrast_on) {
       energy = std::visit(
-          [this, &p1, &p2, q1q2](auto &p3m_ptr) {
-            auto const &pos1 = p1.pos();
-            auto const &pos2 = p2.pos();
+          [this, &pos1, &pos2, q1q2](auto &p3m_ptr) {
             auto const &p3m = *p3m_ptr;
             auto energy = 0.;
             elc.dielectric_layers_contribution(

--- a/src/core/electrostatics/solver.hpp
+++ b/src/core/electrostatics/solver.hpp
@@ -74,8 +74,8 @@ struct Solver {
   using ShortRangePressureKernel = std::function<Utils::Matrix<double, 3, 3>(
       double, Utils::Vector3d const &, double)>;
   using ShortRangeEnergyKernel =
-      std::function<double(Utils::Vector3d const &, Utils::Vector3d const &, double,
-                           Utils::Vector3d const &, double)>;
+      std::function<double(Utils::Vector3d const &, Utils::Vector3d const &,
+                           double, Utils::Vector3d const &, double)>;
 
   inline std::optional<ShortRangeForceKernel> pair_force_kernel() const;
   inline std::optional<ShortRangePressureKernel> pair_pressure_kernel() const;

--- a/src/core/electrostatics/solver.hpp
+++ b/src/core/electrostatics/solver.hpp
@@ -74,7 +74,7 @@ struct Solver {
   using ShortRangePressureKernel = std::function<Utils::Matrix<double, 3, 3>(
       double, Utils::Vector3d const &, double)>;
   using ShortRangeEnergyKernel =
-      std::function<double(Particle const &, Particle const &, double,
+      std::function<double(Utils::Vector3d const &, Utils::Vector3d const &, double,
                            Utils::Vector3d const &, double)>;
 
   inline std::optional<ShortRangeForceKernel> pair_force_kernel() const;

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -196,7 +196,8 @@ inline void add_non_bonded_pair_energy(
 #ifdef ELECTROSTATICS
   if (!obs_energy.coulomb.empty() and coulomb_kernel != nullptr) {
     auto const q1q2 = p1.q() * p2.q();
-    obs_energy.coulomb[0] += (*coulomb_kernel)(p1.pos(), p2.pos(), q1q2, d, dist);
+    obs_energy.coulomb[0] +=
+        (*coulomb_kernel)(p1.pos(), p2.pos(), q1q2, d, dist);
   }
 #endif
 

--- a/src/core/energy_inline.hpp
+++ b/src/core/energy_inline.hpp
@@ -196,7 +196,7 @@ inline void add_non_bonded_pair_energy(
 #ifdef ELECTROSTATICS
   if (!obs_energy.coulomb.empty() and coulomb_kernel != nullptr) {
     auto const q1q2 = p1.q() * p2.q();
-    obs_energy.coulomb[0] += (*coulomb_kernel)(p1, p2, q1q2, d, dist);
+    obs_energy.coulomb[0] += (*coulomb_kernel)(p1.pos(), p2.pos(), q1q2, d, dist);
   }
 #endif
 

--- a/src/core/forces_cabana.hpp
+++ b/src/core/forces_cabana.hpp
@@ -101,20 +101,20 @@ struct ForcesKernel {
         nonbonded_ias.get_ia_param(aosoa.type(i), aosoa.type(j));
 
     ParticleForce pf{};
-    Utils::Vector3d const &pos1 = {aosoa.position(i, 0), aosoa.position(i, 1), aosoa.position(i, 2)};
-    Utils::Vector3d const &pos2 = {aosoa.position(j, 0), aosoa.position(j, 1), aosoa.position(j, 2)};
+    Utils::Vector3d const pos1 = {aosoa.position(i, 0), aosoa.position(i, 1), aosoa.position(i, 2)};
+    Utils::Vector3d const pos2 = {aosoa.position(j, 0), aosoa.position(j, 1), aosoa.position(j, 2)};
 
 #ifdef NPT
     Utils::Vector3d virial{};
     auto *const virial_handle = global_virial ? &virial : nullptr;
 #endif
     auto const d = box_geo.get_mi_vector(pos1, pos2);
-        //aosoa.position(i, 0), aosoa.position(i, 1), aosoa.position(i, 2),
-        //aosoa.position(j, 0), aosoa.position(j, 1), aosoa.position(j, 2));
     auto const dist = d.norm();
 
+#if defined(EXCLUSIONS) or defined(DPD) or defined(DIPOLES)
     auto const &p1 = *unique_particles.at(i);
     auto const &p2 = *unique_particles.at(j);
+#endif
 
     /***********************************************/
     /* non-bonded pair potentials                  */
@@ -126,10 +126,14 @@ struct ForcesKernel {
 #endif
         pf += calc_central_radial_force(ia_params, d, dist);
 #ifdef THOLE
-	pf.f += thole_pair_force(p1, p2, ia_params, d, dist, bonded_ias,
+	pf.f += thole_pair_force(p1, p2,
+				 ia_params, d, dist, bonded_ias,
 				 coulomb_kernel);
 #endif
-	pf += calc_non_central_force(p1, p2, ia_params, d, dist);
+#ifdef GAY_BERNE
+	pf += calc_non_central_force(p1, p2,
+				     ia_params, d, dist);
+#endif
 #ifdef EXCLUSIONS
       }
 #endif
@@ -155,7 +159,8 @@ struct ForcesKernel {
     if (thermostat.thermo_switch & THERMO_DPD) {
       auto const dist2 = dist * dist;
       auto const force =
-	  dpd_pair_force(p1.pos(), p1.v(), p1.id(), p2.pos(), p2.v(), p2.id(),
+	  dpd_pair_force(pos1, p1.v(), aosoa.id(i),
+			 pos2, p2.v(), aosoa.id(j),
 			 *thermostat.dpd, box_geo, ia_params, d, dist, dist2);
       pf += force;
     }

--- a/src/core/forces_cabana.hpp
+++ b/src/core/forces_cabana.hpp
@@ -101,8 +101,10 @@ struct ForcesKernel {
         nonbonded_ias.get_ia_param(aosoa.type(i), aosoa.type(j));
 
     ParticleForce pf{};
-    Utils::Vector3d const pos1 = {aosoa.position(i, 0), aosoa.position(i, 1), aosoa.position(i, 2)};
-    Utils::Vector3d const pos2 = {aosoa.position(j, 0), aosoa.position(j, 1), aosoa.position(j, 2)};
+    Utils::Vector3d const pos1 = {aosoa.position(i, 0), aosoa.position(i, 1),
+                                  aosoa.position(i, 2)};
+    Utils::Vector3d const pos2 = {aosoa.position(j, 0), aosoa.position(j, 1),
+                                  aosoa.position(j, 2)};
 
 #ifdef NPT
     Utils::Vector3d virial{};
@@ -126,13 +128,11 @@ struct ForcesKernel {
 #endif
         pf += calc_central_radial_force(ia_params, d, dist);
 #ifdef THOLE
-	pf.f += thole_pair_force(p1, p2,
-				 ia_params, d, dist, bonded_ias,
-				 coulomb_kernel);
+        pf.f += thole_pair_force(p1, p2, ia_params, d, dist, bonded_ias,
+                                 coulomb_kernel);
 #endif
 #ifdef GAY_BERNE
-	pf += calc_non_central_force(p1, p2,
-				     ia_params, d, dist);
+        pf += calc_non_central_force(p1, p2, ia_params, d, dist);
 #endif
 #ifdef EXCLUSIONS
       }
@@ -159,9 +159,8 @@ struct ForcesKernel {
     if (thermostat.thermo_switch & THERMO_DPD) {
       auto const dist2 = dist * dist;
       auto const force =
-	  dpd_pair_force(pos1, p1.v(), aosoa.id(i),
-			 pos2, p2.v(), aosoa.id(j),
-			 *thermostat.dpd, box_geo, ia_params, d, dist, dist2);
+          dpd_pair_force(pos1, p1.v(), aosoa.id(i), pos2, p2.v(), aosoa.id(j),
+                         *thermostat.dpd, box_geo, ia_params, d, dist, dist2);
       pf += force;
     }
 #endif
@@ -174,11 +173,11 @@ struct ForcesKernel {
     if (q1q2 != 0. and coulomb_kernel != nullptr) {
       pf.f += (*coulomb_kernel)(q1q2, d, dist);
       if (elc_kernel) {
-	(*elc_kernel)(pos1, pos2, p1f_asym, p2f_asym, q1q2);
+        (*elc_kernel)(pos1, pos2, p1f_asym, p2f_asym, q1q2);
       }
 #ifdef NPT
       if (virial_handle) {
-	(*virial_handle)[0] += (*coulomb_u_kernel)(pos1, pos2, q1q2, d, dist);
+        (*virial_handle)[0] += (*coulomb_u_kernel)(pos1, pos2, q1q2, d, dist);
       }
 #endif // NPT
     }

--- a/src/core/forces_cabana.hpp
+++ b/src/core/forces_cabana.hpp
@@ -101,53 +101,81 @@ struct ForcesKernel {
         nonbonded_ias.get_ia_param(aosoa.type(i), aosoa.type(j));
 
     ParticleForce pf{};
-    ParticleForce p1f_asym{};
-    ParticleForce p2f_asym{};
+    Utils::Vector3d const &pos1 = {aosoa.position(i, 0), aosoa.position(i, 1), aosoa.position(i, 2)};
+    Utils::Vector3d const &pos2 = {aosoa.position(j, 0), aosoa.position(j, 1), aosoa.position(j, 2)};
 
 #ifdef NPT
     Utils::Vector3d virial{};
     auto *const virial_handle = global_virial ? &virial : nullptr;
-#else
-    Utils::Vector3d *const virial_handle = nullptr;
 #endif
-    auto const d = box_geo.get_mi_vector(
-        aosoa.position(i, 0), aosoa.position(i, 1), aosoa.position(i, 2),
-        aosoa.position(j, 0), aosoa.position(j, 1), aosoa.position(j, 2));
+    auto const d = box_geo.get_mi_vector(pos1, pos2);
+        //aosoa.position(i, 0), aosoa.position(i, 1), aosoa.position(i, 2),
+        //aosoa.position(j, 0), aosoa.position(j, 1), aosoa.position(j, 2));
     auto const dist = d.norm();
 
-    auto &p1 = *unique_particles.at(i);
-    auto &p2 = *unique_particles.at(j);
+    auto const &p1 = *unique_particles.at(i);
+    auto const &p2 = *unique_particles.at(j);
 
-#ifdef EXCLUSIONS
-    auto const do_nonbonded_flag = do_nonbonded(p1, p2);
-#else
-    auto constexpr do_nonbonded_flag = true;
-#endif
+    /***********************************************/
+    /* non-bonded pair potentials                  */
+    /***********************************************/
 
     if (dist < ia_params.max_cut) {
 #ifdef EXCLUSIONS
-      if (do_nonbonded_flag) {
+      if (do_nonbonded(p1, p2)) {
 #endif
         pf += calc_central_radial_force(ia_params, d, dist);
+#ifdef THOLE
+	pf.f += thole_pair_force(p1, p2, ia_params, d, dist, bonded_ias,
+				 coulomb_kernel);
+#endif
+	pf += calc_non_central_force(p1, p2, ia_params, d, dist);
 #ifdef EXCLUSIONS
       }
 #endif
     }
 
-#ifdef ELECTROSTATICS
-    auto const q1q2 = aosoa.charge(i) * aosoa.charge(j);
-#else
-    auto constexpr q1q2 = 0.;
+    /*********************************************************************/
+    /* everything before this contributes to the virial pressure in NpT, */
+    /* but nothing afterwards, since the contribution to pressure from   */
+    /* electrostatic is calculated by energy                             */
+    /*********************************************************************/
+#ifdef NPT
+    if (virial_handle) {
+      *virial_handle += hadamard_product(pf.f, d);
+    }
+#endif // NPT
+
+    /***********************************************/
+    /* thermostat                                  */
+    /***********************************************/
+
+    /* The inter dpd force should not be part of the virial */
+#ifdef DPD
+    if (thermostat.thermo_switch & THERMO_DPD) {
+      auto const dist2 = dist * dist;
+      auto const force =
+	  dpd_pair_force(p1.pos(), p1.v(), p1.id(), p2.pos(), p2.v(), p2.id(),
+			 *thermostat.dpd, box_geo, ia_params, d, dist, dist2);
+      pf += force;
+    }
 #endif
-    add_non_bonded_pair_force_with_p(
-        p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist * dist, q1q2, ia_params,
-        do_nonbonded_flag, thermostat, box_geo, bonded_ias, virial_handle,
-        coulomb_kernel, dipoles_kernel, elc_kernel, coulomb_u_kernel);
 
 #ifdef ELECTROSTATICS
+    auto const q1q2 = aosoa.charge(i) * aosoa.charge(j);
+    ParticleForce p1f_asym{};
+    ParticleForce p2f_asym{};
     // real-space electrostatic charge-charge interaction
     if (q1q2 != 0. and coulomb_kernel != nullptr) {
       pf.f += (*coulomb_kernel)(q1q2, d, dist);
+      if (elc_kernel) {
+	(*elc_kernel)(pos1, pos2, p1f_asym, p2f_asym, q1q2);
+      }
+#ifdef NPT
+      if (virial_handle) {
+	(*virial_handle)[0] += (*coulomb_u_kernel)(pos1, pos2, q1q2, d, dist);
+      }
+#endif // NPT
     }
 #endif // ELECTROSTATICS
 #ifdef DIPOLES

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -222,13 +222,10 @@ inline void add_non_bonded_pair_force_with_p(
 #ifdef ELECTROSTATICS
   // real-space electrostatic charge-charge interaction
   if (q1q2 != 0. and coulomb_kernel != nullptr) {
-#if not defined(SHARED_MEMORY_PARALLELISM)
     pf.f += (*coulomb_kernel)(q1q2, d, dist);
-#endif // not SHARED_MEMORY_PARALLELISM
 #ifdef NPT
     if (virial) {
       (*virial)[0] += (*coulomb_u_kernel)(p1.pos(), p2.pos(), q1q2, d, dist);
-      //(*virial)[0] += (*coulomb_u_kernel)(p1, p2, q1q2, d, dist);
     }
 #endif // NPT
     if (elc_kernel) {
@@ -256,7 +253,6 @@ inline void add_non_bonded_pair_force_with_p(
   /***********************************************/
 
 #ifdef DIPOLES
-#if not defined(SHARED_MEMORY_PARALLELISM)
   // real-space magnetic dipole-dipole
   if (dipoles_kernel) {
     auto const d1d2 = p1.dipm() * p2.dipm();
@@ -265,7 +261,6 @@ inline void add_non_bonded_pair_force_with_p(
           (*dipoles_kernel)(d1d2, p1.calc_dip(), p2.calc_dip(), d, dist, dist2);
     }
   }
-#endif // not SHARED_MEMORY_PARALLELISM
 #endif
 }
 
@@ -308,7 +303,6 @@ inline void add_non_bonded_pair_force(
   auto constexpr do_nonbonded_flag = true;
 #endif
 
-#ifndef SHARED_MEMORY_PARALLELISM
   if (dist < ia_params.max_cut) {
 #ifdef EXCLUSIONS
     if (do_nonbonded_flag) {
@@ -318,7 +312,6 @@ inline void add_non_bonded_pair_force(
     }
 #endif
   }
-#endif // not SHARED_MEMORY_PARALLELISM
 
   add_non_bonded_pair_force_with_p(
       p1, p2, pf, p1f_asym, p2f_asym, d, dist, dist2, q1q2, ia_params,
@@ -329,10 +322,8 @@ inline void add_non_bonded_pair_force(
   /* add total non-bonded forces to particles    */
   /***********************************************/
 
-#ifndef SHARED_MEMORY_PARALLELISM
   p1.force_and_torque() += pf + p1f_asym;
   p2.force_and_torque() += calc_opposing_force(pf, d) + p2f_asym;
-#endif
 }
 
 /** Compute the bonded interaction force between particle pairs.

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -75,9 +75,14 @@
 #include <tuple>
 #include <variant>
 
-inline ParticleForce calc_central_radial_force(IA_parameters const &ia_params,
-                                               Utils::Vector3d const &d,
-                                               double const dist) {
+#ifdef SHARED_MEMORY_PARALLELISM
+ESPRESSO_ATTR_ALWAYS_INLINE inline
+#else
+inline
+#endif
+ParticleForce calc_central_radial_force(IA_parameters const &ia_params,
+                                        Utils::Vector3d const &d,
+                                        double const dist) {
 
   ParticleForce pf{};
   auto force_factor = 0.;
@@ -170,40 +175,6 @@ inline ParticleForce calc_opposing_force(ParticleForce const &pf,
 }
 
 /**
- * For the interaction which need NO particle information
- */
-inline void add_non_bonded_pair_without_p(
-    ParticleForce &pf, Utils::Vector3d const &d, double dist, double q1q2,
-    IA_parameters const &ia_params, [[maybe_unused]] bool do_nonbonded,
-    Coulomb::ShortRangeForceKernel::kernel_type const *coulomb_kernel) {
-
-  /***********************************************/
-  /* non-bonded pair potentials                  */
-  /***********************************************/
-
-  if (dist < ia_params.max_cut) {
-#ifdef EXCLUSIONS
-    if (do_nonbonded) {
-#endif
-      pf += calc_central_radial_force(ia_params, d, dist);
-#ifdef EXCLUSIONS
-    }
-#endif
-  }
-
-  /***********************************************/
-  /* short-range electrostatics                  */
-  /***********************************************/
-
-#ifdef ELECTROSTATICS
-  // real-space electrostatic charge-charge interaction
-  if (q1q2 != 0. and coulomb_kernel != nullptr) {
-    pf.f += (*coulomb_kernel)(q1q2, d, dist);
-  }
-#endif // ELECTROSTATICS
-}
-
-/**
  * @brief For interactions which need particle information.
  */
 inline void add_non_bonded_pair_force_with_p(
@@ -260,8 +231,8 @@ inline void add_non_bonded_pair_force_with_p(
 #endif // not SHARED_MEMORY_PARALLELISM
 #ifdef NPT
     if (virial) {
-      //(*virial)[0] += (*coulomb_u_kernel)(p1.pos(), p2.pos(), q1q2, d, dist);
-      (*virial)[0] += (*coulomb_u_kernel)(p1, p2, q1q2, d, dist);
+      (*virial)[0] += (*coulomb_u_kernel)(p1.pos(), p2.pos(), q1q2, d, dist);
+      //(*virial)[0] += (*coulomb_u_kernel)(p1, p2, q1q2, d, dist);
     }
 #endif // NPT
     if (elc_kernel) {

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -260,6 +260,7 @@ inline void add_non_bonded_pair_force_with_p(
 #endif // not SHARED_MEMORY_PARALLELISM
 #ifdef NPT
     if (virial) {
+      //(*virial)[0] += (*coulomb_u_kernel)(p1.pos(), p2.pos(), q1q2, d, dist);
       (*virial)[0] += (*coulomb_u_kernel)(p1, p2, q1q2, d, dist);
     }
 #endif // NPT

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -75,14 +75,10 @@
 #include <tuple>
 #include <variant>
 
-#ifdef SHARED_MEMORY_PARALLELISM
-ESPRESSO_ATTR_ALWAYS_INLINE inline
-#else
-inline
-#endif
-ParticleForce calc_central_radial_force(IA_parameters const &ia_params,
-                                        Utils::Vector3d const &d,
-                                        double const dist) {
+ESPRESSO_ATTR_ALWAYS_INLINE
+inline ParticleForce calc_central_radial_force(IA_parameters const &ia_params,
+                                               Utils::Vector3d const &d,
+                                               double const dist) {
 
   ParticleForce pf{};
   auto force_factor = 0.;

--- a/src/core/nonbonded_interactions/thole.hpp
+++ b/src/core/nonbonded_interactions/thole.hpp
@@ -78,7 +78,7 @@ thole_pair_energy(Particle const &p1, Particle const &p2,
     auto const sd = thole_s * dist;
     auto const S_r = 1.0 - (1.0 + sd / 2.0) * exp(-sd);
     // Subtract p3m short-range energy and add thole energy
-    return (*kernel)(p1, p2, thole_q1q2 * (-1.0 + S_r), d, dist);
+    return (*kernel)(p1.pos(), p2.pos(), thole_q1q2 * (-1.0 + S_r), d, dist);
   }
   return 0.0;
 }


### PR DESCRIPTION
The computational rate with electrostatic interaction is improved by 10% without shared memory parallelization. With shared memory parallelization, there is no improvement.

Description of changes:
- Change API of Coulomb energy kernels
- Modify `rebuild_local_properties` to reallocate local properties during a rebuild instead of recreating them
- Remove code duplication in non-bonded kernels