### PR TITLE
remove dangerous ABI-breaking warning suppression

### DIFF
--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -59,7 +59,6 @@ target_compile_options(
     $<$<NOT:$<CXX_COMPILER_ID:IntelLLVM>>:-Wno-deprecated-declarations>
     $<$<CXX_COMPILER_ID:IntelLLVM>:-diag-disable=1224>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-cpp>
-    $<$<CXX_COMPILER_ID:GNU>:-Wno-strict-aliasing>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-volatile>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-shadow=compatible-local>


### PR DESCRIPTION
The Strict Aliasing rule is actually important, and not a mere style recommendation. Breaking it leads to Undefined Behavior and subsequently to mysterious crashes.

Building with -Wno-strict-aliasing does not get rid of the crashes but does tell the compiler to refrain from telling you about them. This flag does not, in the end, do anything when there are no warnings to ignore! But it does prevent catching future mistakes. The flag appears to have been added via cargo cult.

If not possible to fix a genuine aliasing issue correctly, a better option in 100% of cases is anyways to use -fno-strict-aliasing. This isn't a warning suppression flag -- it is a "disable the compiler optimizations" flag that reduces the risk of aliasing bugs resulting in runtime errors (because the compiler tries to avoid generating certain types of efficient code that knowingly rely on aliasing being correct).

Fixes #

Description of changes:
- 
