### PR TITLE
Restore exclusions setter in ParticleHandle update method

### DIFF
--- a/src/script_interface/particle_data/ParticleHandle.cpp
+++ b/src/script_interface/particle_data/ParticleHandle.cpp
@@ -617,6 +617,7 @@ Variant ParticleHandle::do_call_method(std::string const &name,
         get_system()->on_particle_change();
       }
     }
+#ifdef ESPRESSO_EXCLUSIONS
     // set exclusions
     if (params.contains("exclusions")) {
       std::vector<int> exclusion_list;
@@ -644,6 +645,7 @@ Variant ParticleHandle::do_call_method(std::string const &name,
         }
       });
     }
+#endif // ESPRESSO_EXCLUSIONS
   }
   if (name == "get_bond_by_id") {
     if (not context()->is_head_node()) {

--- a/src/script_interface/particle_data/ParticleHandle.cpp
+++ b/src/script_interface/particle_data/ParticleHandle.cpp
@@ -621,10 +621,9 @@ Variant ParticleHandle::do_call_method(std::string const &name,
     // set exclusions
     if (params.contains("exclusions")) {
       std::vector<int> exclusion_list;
-      try {
-        auto const pid = get_value<int>(params, "exclusions");
-        exclusion_list.push_back(pid);
-      } catch (...) {
+      if (is_type<int>(params.at("exclusions"))) {
+        exclusion_list.emplace_back(get_value<int>(params, "exclusions"));
+      } else {
         exclusion_list = get_value<std::vector<int>>(params, "exclusions");
       }
       context()->parallel_try_catch([&]() {

--- a/src/script_interface/particle_data/ParticleHandle.cpp
+++ b/src/script_interface/particle_data/ParticleHandle.cpp
@@ -617,6 +617,33 @@ Variant ParticleHandle::do_call_method(std::string const &name,
         get_system()->on_particle_change();
       }
     }
+    // set exclusions
+    if (params.contains("exclusions")) {
+      std::vector<int> exclusion_list;
+      try {
+        auto const pid = get_value<int>(params, "exclusions");
+        exclusion_list.push_back(pid);
+      } catch (...) {
+        exclusion_list = get_value<std::vector<int>>(params, "exclusions");
+      }
+      context()->parallel_try_catch([&]() {
+        for (auto const pid : exclusion_list) {
+          particle_exclusion_sanity_checks(m_pid, pid);
+        }
+      });
+      set_particle_property([this, &exclusion_list](Particle &p) {
+        auto cell_structure_si = get_cell_structure();
+        auto &cell_structure = cell_structure_si->get_cell_structure();
+        for (auto const pid : p.exclusions()) {
+          local_remove_exclusion(m_pid, pid, cell_structure);
+        }
+        for (auto const pid : exclusion_list) {
+          if (!p.has_exclusion(pid)) {
+            local_add_exclusion(m_pid, pid, cell_structure);
+          }
+        }
+      });
+    }
   }
   if (name == "get_bond_by_id") {
     if (not context()->is_head_node()) {

--- a/testsuite/python/particle.py
+++ b/testsuite/python/particle.py
@@ -256,6 +256,29 @@ class ParticleProperties(ut.TestCase):
             p1.add_exclusion(pid2)
             p1.add_exclusion(pid2)
 
+    @utx.skipIfMissingFeatures(["EXCLUSIONS"])
+    def test_update_exclusions(self):
+        pid1 = self.pid
+        pid2 = self.pid + 1
+
+        p1 = self.partcl
+        with self.assertRaisesRegex(RuntimeError, rf"Particles cannot exclude themselves \(id {self.pid}\)"):
+            p1.update({"exclusions": pid1})
+        with self.assertRaisesRegex(RuntimeError, f"Particle with id {pid2} not found"):
+            p1.update({"exclusions": pid2})
+        for i in [-1, -3]:
+            with self.assertRaisesRegex(ValueError, f"Invalid particle id: {i}"):
+                p1.update({"exclusions": i})
+
+        self.system.part.add(id=pid2, pos=(0, 0, 0))
+        with self.assertRaisesRegex(RuntimeError, rf"Particles cannot exclude themselves \(id {self.pid}\)"):
+            p1.update({"exclusions": [pid1, pid2]})
+
+        p1.update({"exclusions": [pid2]})
+        self.assertEqual(p1.exclusions, [pid2])
+        p1.update({"exclusions": []})
+        self.assertTrue(p1.exclusions.size == 0)
+
     @utx.skipIfMissingFeatures(["ROTATION"])
     def test_contradicting_properties_quat(self):
         invalid_combinations = [


### PR DESCRIPTION
Trying to update the exclusions property via the `update` method of a particle failed silently as exclusions are not part of the list of `AutoParameters` added to `ParticleHandle` objects, and thus not affected by calls to `do_set_parameter`.

- Added logic for setting exclusions in code for _update_params_ in `do_call_method` of [`ParticleHandle`](https://github.com/espressomd/espresso/blob/python/src/script_interface/particle_data/ParticleHandle.cpp) script interface class.

- Added test case `test_update_exlusions` in [particle.py](https://github.com/espressomd/espresso/blob/python/testsuite/python/particle.py) to test updating exclusions. 