### PR TITLE
Add a Boltzmann Inversion Tutorial

### DIFF
--- a/doc/tutorials/boltzmann_inversion/tutorial_boltzmann_inversion.ipynb
+++ b/doc/tutorials/boltzmann_inversion/tutorial_boltzmann_inversion.ipynb
@@ -1,0 +1,896 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0969c2de-b4f4-4b98-b417-bf3697f553e1",
+   "metadata": {
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Systematic Coarse-Graining: Boltzmann Inversion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b28a690-e528-4315-90a2-1a1cd866ee2d",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "An important concept in statistical mechanics and molecular modeling is *coarse-graining*. \n",
+    "Coarse-graining is a procedure in which complexity of a system is reduced, leading to an effective description in terms of a smaller number of variables.\n",
+    "Due to the reduced number of degrees of freedom, such coarse-grained models can significantly reduce the time and computational resources required to simulate complex systems.\n",
+    "Therefore, coarse-grained simulations can also be used to simulate systems currently not accessible to atomistic simulation models.\n",
+    "Coarse-graining is a broadly applicable approach that encompasses many different methods, and consequently there exists a plethora of different ways to derive coarse-grained models.\n",
+    "In this tutorial, you will learn how to apply a systematic coarse-graining procedure, the Boltzmann inversion method.\n",
+    "\n",
+    "In the following, we consider a suspension of charged colloidal particles.\n",
+    "Colloidal particles (or colloids for short) are particles of sizes between 1 nanometer and 1 micrometer, which can be suspended in aqueous solution.\n",
+    "When colloidal particles carry an electrical charge, their interaction in solution is significantly modified by the large number of small salt ions, which dynamically rearrange in a charge cloud around the colloids that screens the bare Coulomb interactions.\n",
+    "However, including those small salt ions explicitly in a computer simulation of a colloidal suspension comes at a huge computational overhead. \n",
+    "In the spirit of coarse-grained modeling, in this tutorial we thus want to derive an effective pair potential between the colloids, which models the effect of the salt ions implicitly. \n",
+    "\n",
+    "To derive an effective pair potential between the colloidal particles, we first need to carry out simulations of a colloidal suspension including explicit salt ions. \n",
+    "In those simulations, we measure the radial distribution function (RDF) $g(r)$ between the colloids.\n",
+    "For sufficiently dilute systems, where many-body interactions are negligible, the RDF can be directly related to an effective pair potential $V^\\mathrm{eff}(r)$ between the colloids: $$g(r)\\propto \\exp\\left(-\\beta V^\\mathrm{eff}(r)\\right).$$\n",
+    "Here, we use a proportionality sign, because the effective pair potential is only determined up to an irrelevant additive constant, which does not contribute to the force.\n",
+    "The idea of Boltzmann inversion is to invert this relation, i.e. extract the effective pair potential as \n",
+    "$$V^\\mathrm{eff}(r) = -\\frac{1}{\\beta} \\ln\\left(g(r)\\right).$$\n",
+    "This effective interaction can then be used as a tabulated interaction in a simulation containing only colloids, providing an implicit description of the effects of salt."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fa4e954-d582-4380-8ada-09f331055ef9",
+   "metadata": {},
+   "source": [
+    "## Simulation with Explicit Salt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f0f62f2-2013-47c6-8fbb-67438bdc7ab2",
+   "metadata": {},
+   "source": [
+    "### Simulation Setup\n",
+    "\n",
+    "To measure the RDF and extract the effective pair potential, we now set up the simulation model of a colloidal suspension including explicit salt ions in ESPResSo. \n",
+    "Let us begin by importing the required Python modules:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c718f8-2f70-47af-bdf9-729a5e5a657f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tqdm\n",
+    "import os\n",
+    "\n",
+    "import espressomd\n",
+    "from espressomd import electrostatics\n",
+    "import espressomd.observables\n",
+    "\n",
+    "required_features = [\"LENNARD_JONES\", \"ELECTROSTATICS\"]\n",
+    "espressomd.assert_features(required_features)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ad4c405-66f9-4a4a-9059-66f3adb714a7",
+   "metadata": {},
+   "source": [
+    "In the simulations, there are three kinds of particles: small anions, small cations and large (positively charged) colloidal particles.\n",
+    "All three particle types are represented as spherical particles that carry an electrical charge and additionally interact through a WCA potential.\n",
+    "For the colloidal particles, the WCA potential is shifted, corresponding to a larger radius of the particles.\n",
+    "To implement this model conveniently, we define dictionaries `types` and `charges`. \n",
+    "We set the charge of the colloidal particles to `+3`, the charge of the small cations to `+1` and the charge of the anions to `-1`.\n",
+    "All charges are measured in units of the elementary charge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2df3e14-a676-4c40-af98-61b278c9d42f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Particle types and charges\n",
+    "types = {\n",
+    "        \"colloid\": 0,\n",
+    "        \"cation\": 1,\n",
+    "        \"anion\": 2,\n",
+    "        }\n",
+    "\n",
+    "charges = {\n",
+    "        \"colloid\": +3, \n",
+    "        \"cation\": +1,\n",
+    "        \"anion\": -1,\n",
+    "        }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f608be62-5b5f-4c7d-b7d0-9fbecce43191",
+   "metadata": {},
+   "source": [
+    "In the next step, we define our unit system. \n",
+    "Since ESPResSo works with reduced units, we need to establish a mapping between the simulation units and the usual SI units. \n",
+    "In the following, we take the unit of energy to be the thermal energy $k_{\\mathrm{B}}T$ at room temperature and the length scale $\\sigma = 3.55\\cdot 10^{-10}\\,\\mathrm{m}$, which roughly corresponds to the size of a solvated ion in aqueous solution.\n",
+    "Using these units, we can convert concentration between simulation units (number of particles / sigma**3) and SI units (mol/L) using the factor `PREF`.\n",
+    "We set the Bjerrum length to a value of `L_BJERRUM = 2.0`, which describes electrostatic interactions in water."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80350c63-9f8c-4876-9ecb-87c014b7b39b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Units\n",
+    "KT = 1.0\n",
+    "SIGMA = 3.55e-10 # Sigma in SI units\n",
+    "AVO = 6.022e+23 # Avogadro's number\n",
+    "PREF = 1/(10**3 * AVO * SIGMA**3) # Prefactor to mol/L\n",
+    "L_BJERRUM = 2.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ba5da5b-bab9-43cb-a69b-2796ff5a2f7c",
+   "metadata": {},
+   "source": [
+    "Now, we define the colloid radius and number, as well the concentrations of colloids and salt. \n",
+    "The chosen parameters are a good compromise between a colloid density that is still low enough such that colloidal three-body interactions are negligible and a density that is too low to lead to a sufficient sampling of the RDF in a short simulation time.\n",
+    "Furthermore, the colloid charge and salt concentration are in regimes where the analytical Debye-Hückel theory is generally accurate, which means that the Debye-Hückel prediction serves as a useful benchmark, as we will see below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4f73a73-279f-4631-ada5-293a29e1c12d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RADIUS_COLLOID = 3.0\n",
+    "N_COLLOID = 50\n",
+    "\n",
+    "c_colloid = 0.001\n",
+    "C_COLLOID = c_colloid / PREF # colloid concentration in number of particles / sigma**3\n",
+    "\n",
+    "c_salt = 0.01\n",
+    "C_SALT = c_salt / PREF # salt concentration in number of particles / sigma**3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "644628a8-f77c-4244-80f7-4e296804b0af",
+   "metadata": {},
+   "source": [
+    "Using the chosen colloid number and concentrations, we can then calculate the box size as well as the number of salt ions and counterions.\n",
+    "Note that the number of counterions corresponds to the number of salt ion pairs plus the number of ions required to neutralize the charge on the colloidal particles:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53bb44fc-61e5-48f7-b135-84406d1ee8cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BOX_LENGTH = np.power(N_COLLOID / C_COLLOID, 1.0/3.0)\n",
+    "N_SALT = int(round(C_SALT * BOX_LENGTH ** 3))\n",
+    "N_COUNTERION = N_SALT + charges[\"colloid\"]*N_COLLOID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da2e0879-2a87-4f5c-99d7-16a904048e04",
+   "metadata": {},
+   "source": [
+    "Finally, we set some parameters for the Langevin thermostat and the numerical integrator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4afb082-dbb2-4cbf-a858-7fc2552fe65b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Langevin-Thermostat and integrator\n",
+    "GAMMA = 1.0\n",
+    "DT = 0.01\n",
+    "SKIN = 1.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20656ae1-77ad-425a-a860-f50b1c157521",
+   "metadata": {},
+   "source": [
+    "We are now ready to create an instance of the ESPResSo system class and add the colloidal particles as well as the salt ions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bae1a0e-ad37-441c-9624-073975bba1d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Create an instance of the ESPResSo system class\n",
+    "system = espressomd.System(box_l=[BOX_LENGTH]*3)\n",
+    "system.time_step = DT\n",
+    "system.cell_system.skin = SKIN\n",
+    "system.setup_type_map(type_list=list(types.values()))\n",
+    "\n",
+    "##### Add the colloidal particles\n",
+    "system.part.add(type=[types[\"colloid\"]]*N_COLLOID, pos=np.random.rand(N_COLLOID, 3) * BOX_LENGTH, q = [charges[\"colloid\"]]*N_COLLOID)\n",
+    "\n",
+    "##### Add the salt particles\n",
+    "if N_SALT>0:\n",
+    "    system.part.add(type=[types[\"anion\"]]*N_COUNTERION, pos=np.random.rand(N_COUNTERION, 3) * BOX_LENGTH, q = [charges[\"anion\"]]*N_COUNTERION)\n",
+    "    system.part.add(type=[types[\"cation\"]]*N_SALT, pos=np.random.rand(N_SALT, 3) * BOX_LENGTH, q = [charges[\"cation\"]]*N_SALT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e20854e2-ed5c-4601-adb6-574104c4404e",
+   "metadata": {},
+   "source": [
+    "In the next step, we add the electrostatics solver. \n",
+    "While the chosen accuracy of the P3M solver is rather low, it suffices for the purpose of this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0709d540-675d-4116-a7c7-896b395ea5d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p3m = electrostatics.P3M(prefactor = L_BJERRUM * KT, accuracy=1e-2)\n",
+    "system.electrostatics.solver = p3m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37b4d53b-e653-4c63-a992-1d7322838e5c",
+   "metadata": {},
+   "source": [
+    "At last, we can set up the WCA interactions between all particles. \n",
+    "Due to the offset in the WCA interactions involving colloids, the simulation setup requires a bit of care to avoid divergences in the forces, because the particle positions are initalized randomly.\n",
+    "Therefore, we initially assign all particles the same short-range WCA interactions, corresponding to a particle diameter of 1.0 sigma:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12ba048f-96b5-430c-ac79-c7bb4e9641dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.non_bonded_inter[types[\"anion\"], types[\"anion\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\")\n",
+    "system.non_bonded_inter[types[\"cation\"], types[\"cation\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\")\n",
+    "system.non_bonded_inter[types[\"anion\"], types[\"cation\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\")\n",
+    "system.non_bonded_inter[types[\"anion\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\")\n",
+    "system.non_bonded_inter[types[\"cation\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\")\n",
+    "system.non_bonded_inter[types[\"colloid\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a188dc5-3bd8-4c87-a0f5-501e44979044",
+   "metadata": {},
+   "source": [
+    "### Warmup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "258819a3-d6d9-4b3b-9e98-806496623a75",
+   "metadata": {},
+   "source": [
+    "Before we can start the actual simulation, we have to set the colloid radius to the desired size.\n",
+    "To achieve this, we increase the particle diameter of the colloids in small steps and run a steepest descent integration after each increase to relax the system and avoid divergences.\n",
+    "Once the colloidal particles have the desired size, we run a final steepest descent integration."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "941e5239-465c-4540-88f6-d3fcb459bc31",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "\n",
+    "* Set up the steepest descent integrator with parameters `f_max=0`, `gamma=1` and `max_displacement=0.01`.\n",
+    "* Write loop that slowly increases the colloid radius in steps of `delta_r = 0.1` until the final colloid size is reached. After each increase, run 100 integration steps to relax the system.\n",
+    "\n",
+    "**Hint**\n",
+    "\n",
+    "* You can change the parameters of the LJ interaction by invoking `lennard_jones.set_params` again.\n",
+    "* You need to change the offset for all LJ interactions involving the colloids. The final offset for colloid-colloid interactions should be `2*RADIUS_COLLOID` and that for colloid-ion interactions `RADIUS_COLLOID`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3610a4c5-f3c1-477a-b45f-6a6d57a138a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SOLUTION CELL\n",
+    "##### Determine the number of steps needed\n",
+    "delta_r = 0.1\n",
+    "steps_needed = int(RADIUS_COLLOID/delta_r)\n",
+    "\n",
+    "##### CSet steepest descent integrator\n",
+    "system.integrator.set_steepest_descent(f_max=0, gamma=1, max_displacement=0.01)\n",
+    "system.integrator.run(100)\n",
+    "\n",
+    "##### Gradually increase colloid radius\n",
+    "current_radius = 0\n",
+    "for i in tqdm.tqdm(range(steps_needed)):\n",
+    "    current_radius += delta_r\n",
+    "    system.non_bonded_inter[types[\"anion\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\", offset=current_radius)\n",
+    "    system.non_bonded_inter[types[\"cation\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\", offset=current_radius)\n",
+    "    system.non_bonded_inter[types[\"colloid\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\", offset=2*current_radius)\n",
+    "    system.integrator.run(100)\n",
+    "\n",
+    "system.non_bonded_inter[types[\"anion\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\", offset=RADIUS_COLLOID)\n",
+    "system.non_bonded_inter[types[\"cation\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\", offset=RADIUS_COLLOID)\n",
+    "system.non_bonded_inter[types[\"colloid\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\", offset=2*RADIUS_COLLOID)\n",
+    "system.integrator.run(100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e0950ae-f51f-41d7-931a-22df2ff0d463",
+   "metadata": {},
+   "source": [
+    "Now, we turn on the Langevin thermostat and run a short warmup integration to equilibrate the system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85a30ada-bec8-4a41-90cf-cf603402a24f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.integrator.set_vv()\n",
+    "system.thermostat.set_langevin(seed=42, gamma=GAMMA, kT=KT)\n",
+    "\n",
+    "print(\"Warming up the system...\")\n",
+    "for i in tqdm.tqdm(range(10)):\n",
+    "    system.integrator.run(1000)\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1033120c-885c-4149-a3f0-6c5ed5ae1e25",
+   "metadata": {},
+   "source": [
+    "### Production Run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44575b31-fa2b-44eb-b25a-3f77207b4390",
+   "metadata": {},
+   "source": [
+    "Almost everything is ready now to start the production run.\n",
+    "As the last prepration step, we need to set up an observable to measure the RDF. \n",
+    "The chosen bin size for the RDF is rather large at 0.5 sigma, but allows for a good estimate of the effective interaction with a comparatively small number of samples.\n",
+    "This choice is valid, because except for the short-ranged, strongly repulsive WCA part, the effective potential varies on a much longer length scale than the bin size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c91bc6b-5b57-4df5-8b30-181a674d7b5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters for the radial distribution function\n",
+    "BIN_WIDTH = 0.5\n",
+    "R_MIN = 0.0\n",
+    "R_MAX = system.box_l[0] / 2.0\n",
+    "N_BINS = int((R_MAX-R_MIN)/BIN_WIDTH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9551fb6f-eb67-4225-81ca-98025d601520",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "* Instantiate a [RDF](https://espressomd.github.io/doc/espressomd.html#espressomd.observables.RDF) observable\n",
+    "* Instantiate a [MeanVarianceCalculator](https://espressomd.github.io/doc/analysis.html#mean-variance-calculator) accumulator to track the RDF over time. Samples should be taken every ``steps_per_subsample`` steps.\n",
+    "* Add the accumulator to the [auto_update_accumulators](https://espressomd.github.io/doc/espressomd.html#espressomd.accumulators.AutoUpdateAccumulators) of the system for automatic updates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "549819d4-b55b-4f87-bf5d-f1487950a50c",
+   "metadata": {
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# SOLUTION CELL\n",
+    "rdf_obs = espressomd.observables.RDF(ids1=system.part.select(type=types[\"colloid\"]).id, min_r=R_MIN, max_r=R_MAX, n_r_bins=N_BINS)\n",
+    "rdf_acc = espressomd.accumulators.MeanVarianceCalculator(obs=rdf_obs, delta_N=100)\n",
+    "system.auto_update_accumulators.add(rdf_acc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3151a483-bce2-4636-ab39-efbd3c0e9974",
+   "metadata": {},
+   "source": [
+    "Now, we are ready to perform our production run in order to measure the RDF:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc0d438f-e196-47e3-bb0c-53645097a495",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Performing the production run...\")\n",
+    "for i in tqdm.tqdm(range(2000)):\n",
+    "    system.integrator.run(100)\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d006f57f-9c5f-4ae6-bc47-d7b6e27e970e",
+   "metadata": {},
+   "source": [
+    "## Data Analysis and Boltzmann Inversion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "683a9beb-e632-459f-bb9c-4d0f284f49a8",
+   "metadata": {},
+   "source": [
+    "We can now analyze our simulation results. \n",
+    "In the first step, we analyze the RDF obtained from the simulation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7b727c0-ca1f-457e-8c3b-fdad445ceed6",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "* Get the mean RDF (define ``rdf``) from the accumulator and the histogram bin centers (define ``rs``) from the observable.\n",
+    "* Plot the RDF. Interpret your result physically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd68724d-b339-41d3-a724-47512755569e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SOLUTION CELL\n",
+    "rdf = rdf_acc.mean()\n",
+    "rs = rdf_obs.bin_centers()\n",
+    "\n",
+    "plt.plot(rs, rdf)\n",
+    "plt.xlabel(r'distance $r$/$\\sigma$')\n",
+    "plt.ylabel('colloid-colloid RDF $g(r)$')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ab797a6-ef3d-4f6a-84d2-14bf7edf34e5",
+   "metadata": {},
+   "source": [
+    "Using the RDF, we can now calculate a numerical approximation of the effective pair potential between colloids."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f729275-d538-4998-b94d-c1125e48c678",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "* Use the Boltzmann inversion method, i.e. the equation $V^\\mathrm{eff}(r) = -\\frac{1}{\\beta} \\ln\\left(g(r)\\right)$ to calculate the effective pair potential using the RDF.\n",
+    "* Create a plot of the effective pair potential and interpret it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9421e0b7-9b11-4784-bbf3-5607384b14c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SOLUTION CELL\n",
+    "veff = -np.log(rdf)\n",
+    "\n",
+    "plt.plot(rs, veff)\n",
+    "plt.xlabel(r\"distance $r$/$\\sigma$\")\n",
+    "plt.ylabel(\"effective pair potential $V_{eff}(r)$/$kT$\")\n",
+    "plt.ylim((-0.3,2.0))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8c3ad6a-76b3-4b28-bc09-3a29d28e5ae5",
+   "metadata": {},
+   "source": [
+    "For charged colloids with small electrostatic surface potentials, the effective pair potential can be calculated analytically using the Debye-Hückel theory, which was first applied to colloids by Derjaguin, Landau, Verwey and Overbeek, resulting in the famous [DLVO theory](https://en.wikipedia.org/wiki/DLVO_theory).\n",
+    "The theory predicts that the effective potential between two colloids of charge $Z$ and radius $R$ is given by\n",
+    "$$\\beta V^{\\mathrm{eff}}(r) = Z^2 \\lambda_\\text{B} \\, \\left(\\frac{e^{\\kappa R}}{1 + \\kappa R}\\right)^2 \\, \\frac{e^{-\\kappa r}}{r}.$$\n",
+    "Here, $\\kappa$ is the salt concentration-dependent Debye screening constant and $\\lambda_\\text{B}$ is the Bjerrum length.\n",
+    "The inverse $\\kappa^{-1}$ of the Debye screening constant is called the Debye length and characterizes the range of the effective interaction.\n",
+    "For our system, the analytical result for the effective potential is a useful benchmark to test the simulation results against."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc1f76ae-2523-4b08-b639-23f2277b6a98",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "* Use the function `veff_debye_hueckel` defined below to plot a comparison of the Debye-Hückel potential and the effective pair potential obtained from the simulations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bc2b1ae-7b82-45a3-b348-6fbab9811039",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def veff_debye_hueckel(r, q, c_salt, c_colloid, radius_colloid):\n",
+    "    \"\"\"\n",
+    "    Calculate the effective potential between the colloids according to the Debye-Hückel theory.\n",
+    "    The calculation takes into account both the salt and the additional counterions.\n",
+    "\n",
+    "    Args:\n",
+    "        r (float): The distance between the colloids in sigma.\n",
+    "        q (float): The charge of the colloids in elementary charge units.\n",
+    "        c_salt (float): The concentration of salt in the solution in M (mol/L).\n",
+    "        c_colloid (float): The concentration of colloids in the solution in M (mol/L).\n",
+    "        radius_colloid (float): The radius of the colloids in sigma.\n",
+    "\n",
+    "    Returns:\n",
+    "        float: The effective potential between the colloids in kT.\n",
+    "    \"\"\"\n",
+    "    bjerrum_length = 2.0\n",
+    "    lambda_D = (0.304 / (np.sqrt(c_salt) * np.sqrt(1 + q * c_colloid/ (2 * c_salt)))) / (0.355) # Calculate the Debye screening length\n",
+    "    kappa = 1/lambda_D # Calculate the Debye screening parameter\n",
+    "\n",
+    "    if r > 2*(radius_colloid+0.5):\n",
+    "        return q**2 * bjerrum_length * (np.exp(kappa * radius_colloid) /(1 + kappa*radius_colloid))**2 * np.exp(-kappa * r) / r\n",
+    "    else:\n",
+    "        return np.nan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8c8e795-6f2c-42d6-b3e8-c7935b9d368c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SOLUTION CELL\n",
+    "plt.plot(rs, veff, label=\"Boltzmann Inversion\")\n",
+    "plt.plot(rs, [veff_debye_hueckel(r, charges[\"colloid\"], c_salt, c_colloid, RADIUS_COLLOID) for r in rs], label=\"Debye-Hückel\")\n",
+    "plt.legend()\n",
+    "plt.xlabel(r\"distance $r$/$\\sigma$\")\n",
+    "plt.ylabel(\"effective pair potential $V_{eff}(r)$/$kT$\")\n",
+    "plt.ylim((-0.3,2.0))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3825c4a2-cc21-4311-913f-ff827f60720e",
+   "metadata": {},
+   "source": [
+    "## Simulation using the Developed Coarse-Grained Potential"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6666389-1011-4ff3-abc4-4de9c4c669c5",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d253fd9-7dd9-4bae-abea-af0228a6eaa0",
+   "metadata": {},
+   "source": [
+    "Having obtained the effective potential between the colloidal particles, we can now perform a coarse-grained simulation using this potential. \n",
+    "In a first step, we remove all particles from the system and turn off the electrostatics solver and the thermostat:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7836da6-2c3e-49fe-82d4-ed7bd785acef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system.part.clear()\n",
+    "system.electrostatics.clear()\n",
+    "system.thermostat.turn_off()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e46bdb24-531b-4cc9-b314-c248a4c48b02",
+   "metadata": {},
+   "source": [
+    "Now, we add back the relevant particles to the system. \n",
+    "In contrast to the simulations we carried out before, we only need to add the colloidal particles, because there are no explicit salt ions present in the simulations.\n",
+    "The effect of salt is taken into account implicitly through the use of the effective potential that we have derived using Boltzmann inversion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01dcb94e-285a-4a7a-8c9c-f3afd82b9591",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Add the colloidal particles\n",
+    "system.part.add(type=[types[\"colloid\"]]*N_COLLOID, pos=np.random.rand(N_COLLOID, 3) * BOX_LENGTH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70c5b89c-3d53-4b35-a61f-9af363433f31",
+   "metadata": {},
+   "source": [
+    "In principle, we would now have to add only the effective potential. \n",
+    "However, because we ran only very short, unconstrained MD simulations, the strongly repulsive part of the effective potential is not properly sampled.\n",
+    "This can lead to instabilites that make the simulation crash.\n",
+    "As a solution, we will cut off the tabulated interaction for small distances and still retain the WCA interaction to stabilize the system.\n",
+    "Note that we set the initial particle diameter to `1.0` again in order to avoid diverging forces:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfa7a4d6-961a-48a5-abd1-93e8f295c132",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Add excluded volume interactions\n",
+    "system.non_bonded_inter[types[\"colloid\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=(2)**(1.0/6.0), shift=\"auto\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dbce44f-91d7-4da2-ae5b-849ec1e0a05d",
+   "metadata": {},
+   "source": [
+    "The only part that is missing now is the effective potential we calculated in the previous section. \n",
+    "To avoid double-counting the repulsive WCA potential we just added, we account for the effective potential only at distances larger than `2*RADIUS_COLLOID+2**(1/6)`, i.e. the cutoff of the WCA interaction.\n",
+    "Furthermore, as plot we generated above shows, the interaction rapidly decays for large distances. \n",
+    "Accordingly, we can also introduce an upper cutoff."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6569c310-bd10-4a14-b8d4-526962067345",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "* Calculate the effective force from the effective potential using a numerical derivative.\n",
+    "* Examine your plot of the effective potential and decide on an upper cutoff for the tabulated interaction. Why did you choose this value?\n",
+    "* Use the effective potential and the effective force to set up a tabulated interaction in ESPResSo. The tabulated interaction should be defined only between a minimum distance of `2*RADIUS_COLLOID+2**(1/6)` (the cutoff of the WCA interaction) and the upper cutoff you determined in the previous step.\n",
+    "\n",
+    "**Hint**\n",
+    "\n",
+    "* Use the NumPy function `np.gradient` to numerically calculate the effective force from the effective potential.\n",
+    "* Use NumPy array filtering to select the relevant values of the effective potential and effective force for distances that lie between the minimum distance and the upper cutoff.\n",
+    "* Refer to the the [documentation](https://espressomd.github.io/doc/inter_non-bonded.html#tabulated-interaction) to learn how tabulated interactions can be set up in ESPResSo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ceafda5-1c73-4507-9105-0b58e96908cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SOLUTION CELL\n",
+    "##### Calculate the effective force\n",
+    "effective_force = -np.gradient(veff, rs)\n",
+    "\n",
+    "##### Set the range of interaction\n",
+    "cutoff_tabulated = 25\n",
+    "veff = veff[(2*RADIUS_COLLOID+2**(1/6)<rs) & (rs<cutoff_tabulated)]\n",
+    "effective_force = effective_force[(2*RADIUS_COLLOID+2**(1/6)<rs) & (rs<cutoff_tabulated)]\n",
+    "rs = rs[(2*RADIUS_COLLOID+2**(1/6)<rs) & (rs<cutoff_tabulated)]\n",
+    "\n",
+    "##### Add the tabulated interaction in ESPResSo\n",
+    "system.non_bonded_inter[types[\"colloid\"], types[\"colloid\"]].tabulated.set_params(min=rs[0], max=rs[-1], energy=veff, force=effective_force)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e6d14df-585b-4b0c-8626-f4a79c426025",
+   "metadata": {},
+   "source": [
+    "Like in the simulations with explicit salt, we now slowly increase the colloid radius to avoid divergences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16c15f21-0f2b-4278-ad64-49ffdd7e5f97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Slowly increase the colloid radius to avoid numerical problems\n",
+    "print(\"Removing overlaps and slowly increasing colloid radius...\")\n",
+    "delta_r = 0.1\n",
+    "steps_needed = int(RADIUS_COLLOID/delta_r)\n",
+    "\n",
+    "system.integrator.set_steepest_descent(f_max=0, gamma=1, max_displacement=0.01)\n",
+    "system.integrator.run(100)\n",
+    "\n",
+    "current_radius = 0\n",
+    "for i in tqdm.tqdm(range(steps_needed)):\n",
+    "    current_radius += delta_r\n",
+    "    system.non_bonded_inter[types[\"colloid\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=2**(1.0/6.0), shift=\"auto\", offset=2*current_radius)\n",
+    "    system.integrator.run(100)\n",
+    "\n",
+    "system.non_bonded_inter[types[\"colloid\"], types[\"colloid\"]].lennard_jones.set_params(epsilon=1.0, sigma=1.0, cutoff=2**(1.0/6.0), shift=\"auto\", offset=2*RADIUS_COLLOID)\n",
+    "system.integrator.run(100)\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da06883d-12ff-42d5-9f78-745242a4b44c",
+   "metadata": {},
+   "source": [
+    "Lastly, we add the Langevin thermostat and run a short equilibration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51410a6a-1e45-46e2-9de3-8778b1421d3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Add thermostat\n",
+    "system.integrator.set_vv()\n",
+    "system.thermostat.set_langevin(seed=42, gamma=GAMMA, kT=KT)\n",
+    "print(\"Added thermostat.\")\n",
+    "\n",
+    "print(\"Warming up the system...\")\n",
+    "for i in tqdm.tqdm(range(10)):\n",
+    "    system.integrator.run(1000)\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09df507a-009f-4ab1-86fb-bd0d9ff472c1",
+   "metadata": {},
+   "source": [
+    "### Production Run and Analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8816a482-489d-4ee4-a9be-47f292a8d48b",
+   "metadata": {},
+   "source": [
+    "We are now ready to perform our production run. \n",
+    "Like in the simulation with explicit salt, we measure the RDF between colloids.\n",
+    "Furthermore, the number of MD steps we perform is exactly the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99059d32-f256-4eb6-951f-5b20df6e1ab0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rdf_obs = espressomd.observables.RDF(ids1=system.part.select(type=types[\"colloid\"]).id, min_r=R_MIN, max_r=R_MAX, n_r_bins=N_BINS)\n",
+    "rdf_acc = espressomd.accumulators.MeanVarianceCalculator(obs=rdf_obs, delta_N=100)\n",
+    "system.auto_update_accumulators.add(rdf_acc)\n",
+    "\n",
+    "# Perform the production run\n",
+    "print(\"Performing the production run...\")\n",
+    "for i in tqdm.tqdm(range(2000)):\n",
+    "    system.integrator.run(100)\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ee610f5-707a-44c5-902a-589c73b15661",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "* Compare the required CPU time for the simulation with the coarse-grained potential to the simulation with explicit salt. How much faster is the simulation using the effective potential?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4b3ce0d-0c51-47c0-8c98-2da7368a96d0",
+   "metadata": {},
+   "source": [
+    "**Exercise**\n",
+    "* Plot a comparison of the RDFs obtained from simulations with explicit and implicit salt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d515274-33ce-496f-8928-b991cc06f858",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SOLUTION CELL\n",
+    "rdf_dh = rdf_acc.mean()\n",
+    "rs_dh = rdf_obs.bin_centers()\n",
+    "\n",
+    "plt.plot(rs_dh, rdf, label='Explicit salt')\n",
+    "plt.plot(rs_dh, rdf_dh, label='Implicit salt')\n",
+    "plt.legend()\n",
+    "plt.xlabel(r'$r$/$\\sigma$')\n",
+    "plt.ylabel('colloid-colloid RDF g(r)')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Fixes #5160 

Together with @hidekb, I created a tutorial on the Boltzmann inversion method. In the tutorial, students simulate a suspension of charged colloids with explicit ions and subsequently generate an effective pair potential from the RDF using the Boltzmann inversion method. This potential is then used as a tabulated interaction to perform a coarse-grained (implicit salt) simulation of the same system.
