### PR TITLE
Improve P3M scalability

### DIFF
--- a/src/core/algorithm/periodic_fold.hpp
+++ b/src/core/algorithm/periodic_fold.hpp
@@ -16,21 +16,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef CORE_ALGORITHM_PERIODIC_FOLD_HPP
-#define CORE_ALGORITHM_PERIODIC_FOLD_HPP
+
+#pragma once
 
 #include <cmath>
 #include <concepts>
 #include <limits>
-#include <type_traits>
 #include <utility>
-
-// Define a concept that checks if a type T is an integer or a reference to an
-// integer
-template <typename T>
-concept IntegralOrRef = std::integral<std::remove_reference_t<T>>;
-template <typename T>
-concept FloatingPointOrRef = std::floating_point<std::remove_reference_t<T>>;
 
 namespace Algorithm {
 /**
@@ -41,11 +33,13 @@ namespace Algorithm {
  * @param l Length of primary interval
  * @return x folded into [0, l) and number of folds.
  */
-template <FloatingPointOrRef T, IntegralOrRef I>
-std::pair<T, I> periodic_fold(T x, I i, T const l) {
-  using limits = std::numeric_limits<I>;
+inline auto periodic_fold(std::floating_point auto x, std::integral auto i,
+                          std::floating_point auto l) {
+  static_assert(std::is_same_v<decltype(x), decltype(l)>);
+  using limits = std::numeric_limits<decltype(i)>;
+  using value_type = decltype(x);
 
-  while ((x < T{0}) && (i > limits::min())) {
+  while ((x < value_type{0}) && (i > limits::min())) {
     x += l;
     --i;
   }
@@ -55,7 +49,7 @@ std::pair<T, I> periodic_fold(T x, I i, T const l) {
     ++i;
   }
 
-  return {x, i};
+  return std::make_pair(x, i);
 }
 
 /**
@@ -65,10 +59,12 @@ std::pair<T, I> periodic_fold(T x, I i, T const l) {
  * @param l Length of primary interval
  * @return x folded into [0, l).
  */
-template <FloatingPointOrRef T> T periodic_fold(T x, T const l) {
+inline auto periodic_fold(std::floating_point auto x,
+                          std::floating_point auto l) {
+  using value_type = decltype(x);
 #ifndef __FAST_MATH__
   /* Can't fold if either x or l is nan or inf. */
-  if (std::isnan(x) or std::isnan(l) or std::isinf(x) or (l == T{0})) {
+  if (std::isnan(x) or std::isnan(l) or std::isinf(x) or (l == value_type{0})) {
     return std::nan("");
   }
   if (std::isinf(l)) {
@@ -76,7 +72,7 @@ template <FloatingPointOrRef T> T periodic_fold(T x, T const l) {
   }
 #endif // __FAST_MATH__
 
-  while (x < 0) {
+  while (x < value_type{0}) {
     x += l;
   }
 
@@ -87,5 +83,3 @@ template <FloatingPointOrRef T> T periodic_fold(T x, T const l) {
   return x;
 }
 } // namespace Algorithm
-
-#endif

--- a/src/core/electrostatics/elc.hpp
+++ b/src/core/electrostatics/elc.hpp
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_P3M
 

--- a/src/core/electrostatics/p3m.cpp
+++ b/src/core/electrostatics/p3m.cpp
@@ -24,7 +24,7 @@
  *  The corresponding header file is @ref p3m.hpp.
  */
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_P3M
 
@@ -356,7 +356,7 @@ template <int cao> struct AssignCharge {
   void operator()(auto &p3m, double q, Utils::Vector3d const &real_pos,
                   p3m_interpolation_cache &inter_weights) {
     auto constexpr memory_order =
-        std::remove_reference<decltype(p3m)>::type::memory_order;
+        std::remove_reference_t<decltype(p3m)>::memory_order;
     auto const weights = p3m_calculate_interpolation_weights<cao, memory_order>(
         real_pos, p3m.params.ai, p3m.local_mesh);
     inter_weights.store(weights);
@@ -365,7 +365,7 @@ template <int cao> struct AssignCharge {
 
   void operator()(auto &p3m, double q, Utils::Vector3d const &real_pos) {
     auto constexpr memory_order =
-        std::remove_reference<decltype(p3m)>::type::memory_order;
+        std::remove_reference_t<decltype(p3m)>::memory_order;
     auto const weights = p3m_calculate_interpolation_weights<cao, memory_order>(
         real_pos, p3m.params.ai, p3m.local_mesh);
     this->operator()(p3m, q, weights);
@@ -373,24 +373,40 @@ template <int cao> struct AssignCharge {
 
 #ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
   void operator()(auto &p3m, auto &cell_structure) {
+    using CoulombP3MStateClass = std::remove_reference_t<decltype(p3m)>;
+    using value_type = CoulombP3MStateClass::value_type;
     auto const &aosoa = cell_structure.get_aosoa();
     auto const n_part = cell_structure.count_local_particles();
     p3m.inter_weights.zfill(n_part); // allocate buffer for parallel write
     kokkos_parallel_range_for(
-        "InterpolationWeights", std::size_t{0u}, n_part, [&](auto p_index) {
-          auto const p_pos = aosoa.get_vector_at(aosoa.position, p_index);
-          auto constexpr memory_order =
-              std::remove_reference<decltype(p3m)>::type::memory_order;
+        "InterpolateCharges", std::size_t{0u}, n_part, [&](auto p_index) {
+          auto const tid = omp_get_thread_num();
+          auto const pos = aosoa.get_vector_at(aosoa.position, p_index);
+          auto const q = aosoa.charge(p_index);
+          auto constexpr memory_order = CoulombP3MStateClass::memory_order;
           auto const weights =
               p3m_calculate_interpolation_weights<cao, memory_order>(
-                  p_pos, p3m.params.ai, p3m.local_mesh);
+                  pos, p3m.params.ai, p3m.local_mesh);
           p3m.inter_weights.store_at(p_index, weights);
+          p3m_interpolate(
+              p3m.local_mesh, weights, [&, tid, q](int ind, double w) {
+                p3m.rs_charge_density_kokkos(tid, ind) += value_type(w * q);
+              });
         });
-    // serial part of charge assignment
-    for (std::size_t p_index{0}; p_index < n_part; ++p_index) {
-      auto const weights = p3m.inter_weights.template load<cao>(p_index);
-      this->operator()(p3m, aosoa.charge(p_index), weights);
-    }
+    Kokkos::fence();
+    using execution_space = Kokkos::DefaultExecutionSpace;
+    int num_threads = execution_space().concurrency();
+    Kokkos::RangePolicy<execution_space> policy(std::size_t{0},
+                                                p3m.local_mesh.size);
+    Kokkos::parallel_for("ReduceInterpolatedCharges", policy,
+                         [&p3m, num_threads](std::size_t const i) {
+                           value_type acc{};
+                           for (int tid = 0; tid < num_threads; ++tid) {
+                             acc += p3m.rs_charge_density_kokkos(tid, i);
+                           }
+                           p3m.rs_charge_density.at(i) += acc;
+                         });
+    Kokkos::fence();
   }
 #else  // ESPRESSO_SHARED_MEMORY_PARALLELISM
   void operator()(auto &p3m, auto const &p_q_pos_range) {
@@ -469,7 +485,7 @@ template <int cao> struct AssignForces {
     };
 
 #ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
-    auto const n_part = p3m.inter_weights.size();
+    auto const n_part = cell_structure.count_local_particles();
     auto const &aosoa = cell_structure.get_aosoa();
     auto &local_force = cell_structure.get_local_force();
     kokkos_parallel_range_for(
@@ -770,7 +786,7 @@ double CoulombP3MImpl<FloatType, Architecture>::long_range_kernel(
     node_energy /= 2. * volume;
 
     // add up energy contributions from all mpi ranks
-    boost::mpi::reduce(comm_cart, node_energy, energy, std::plus<>(), 0);
+    boost::mpi::reduce(::comm_cart, node_energy, energy, std::plus<>(), 0);
     if (this_node == 0) {
       /* self energy correction */
       // Eq. (3.8) @cite deserno00b
@@ -801,7 +817,8 @@ double CoulombP3MImpl<FloatType, Architecture>::long_range_kernel(
 
 template <typename FloatType, Arch Architecture>
 class CoulombTuningAlgorithm : public TuningAlgorithm {
-  CoulombP3MState<FloatType> &p3m;
+  using CoulombP3MStateClass = CoulombP3MState<FloatType>;
+  CoulombP3MStateClass &p3m;
   double m_mesh_density_min = -1., m_mesh_density_max = -1.;
   // indicates if mesh should be tuned
   bool m_tune_mesh = false;
@@ -822,7 +839,7 @@ public:
   void setup_logger(bool verbose) override {
     auto const &box_geo = *m_system.box_geo;
 #ifdef ESPRESSO_CUDA
-    auto const on_gpu = Architecture == Arch::GPU;
+    auto const on_gpu = Architecture == Arch::CUDA;
 #else
     auto const on_gpu = false;
 #endif
@@ -846,7 +863,7 @@ public:
   std::optional<std::string> fft_decomposition_veto(
       Utils::Vector3i const &mesh_size_r_space) const override {
 #ifdef ESPRESSO_CUDA
-    if constexpr (Architecture == Arch::GPU) {
+    if constexpr (Architecture == Arch::CUDA) {
       return std::nullopt;
     }
 #endif
@@ -903,7 +920,7 @@ public:
     rs_err = p3m_real_space_error(m_prefactor, r_cut_iL, p3m.sum_qpart,
                                   p3m.sum_q2, alpha_L, box_geo.length());
 #ifdef ESPRESSO_CUDA
-    if constexpr (Architecture == Arch::GPU) {
+    if constexpr (Architecture == Arch::CUDA) {
       if (this_node == 0) {
         ks_err =
             p3m_k_space_error_gpu(m_prefactor, mesh.data(), cao, p3m.sum_qpart,
@@ -1034,8 +1051,8 @@ void CoulombP3MImpl<FloatType, Architecture>::tune() {
     }
     try {
       CoulombTuningAlgorithm<FloatType, Architecture> parameters(
-          system, p3m, prefactor, tune_timings, tune_limits);
-      parameters.setup_logger(tune_verbose);
+          system, p3m, prefactor, tuning.timings, tuning.limits);
+      parameters.setup_logger(tuning.verbose);
       // parameter ranges
       parameters.determine_mesh_limits();
       parameters.determine_r_cut_limits();
@@ -1123,7 +1140,7 @@ void CoulombP3MImpl<FloatType, Architecture>::scaleby_box_l() {
 template <typename FloatType, Arch Architecture>
 void CoulombP3MImpl<FloatType, Architecture>::add_long_range_forces_gpu(
     ParticleRange const &particles) {
-  if constexpr (Architecture == Arch::GPU) {
+  if constexpr (Architecture == Arch::CUDA) {
 #ifdef ESPRESSO_NPT
     if (get_system().has_npt_enabled()) {
       get_system().npt_add_virial_contribution(long_range_energy(particles));
@@ -1146,7 +1163,7 @@ void CoulombP3MImpl<FloatType, Architecture>::add_long_range_forces_gpu(
  */
 template <typename FloatType, Arch Architecture>
 void CoulombP3MImpl<FloatType, Architecture>::init_gpu_kernels() {
-  if constexpr (Architecture == Arch::GPU) {
+  if constexpr (Architecture == Arch::CUDA) {
     auto &system = get_system();
     if (has_actor_of_type<ElectrostaticLayerCorrection>(
             system.coulomb.impl->solver)) {
@@ -1159,7 +1176,7 @@ void CoulombP3MImpl<FloatType, Architecture>::init_gpu_kernels() {
 
 template <typename FloatType, Arch Architecture>
 void CoulombP3MImpl<FloatType, Architecture>::request_gpu() const {
-  if constexpr (Architecture == Arch::GPU) {
+  if constexpr (Architecture == Arch::CUDA) {
     auto &gpu_particle_data = get_system().gpu;
     gpu_particle_data.enable_property(GpuParticleData::prop::force);
     gpu_particle_data.enable_property(GpuParticleData::prop::q);
@@ -1168,9 +1185,36 @@ void CoulombP3MImpl<FloatType, Architecture>::request_gpu() const {
 }
 #endif // ESPRESSO_CUDA
 
-template struct CoulombP3MImpl<float, Arch::CPU>;
-template struct CoulombP3MImpl<float, Arch::GPU>;
-template struct CoulombP3MImpl<double, Arch::CPU>;
-template struct CoulombP3MImpl<double, Arch::GPU>;
+template <typename FloatType, Arch Architecture>
+std::shared_ptr<CoulombP3M>
+new_coulomb_p3m_impl(P3MParameters &&p3m, TuningParameters const &tuning_params,
+                     double prefactor) {
+  auto state_ptr = std::make_unique<CoulombP3MState<FloatType>>(std::move(p3m));
+  auto obj = std::make_shared<CoulombP3MImpl<FloatType, Architecture>>(
+      std::move(state_ptr), tuning_params, prefactor);
+  return obj;
+}
+
+std::shared_ptr<CoulombP3M>
+new_coulomb_p3m(P3MParameters &&p3m_params,
+                TuningParameters const &tuning_params, double prefactor,
+                bool single_precision, Arch arch) {
+  auto fptr = &new_coulomb_p3m_impl<float, Arch::CPU>;
+  if (single_precision) {
+    if (arch == Arch::CPU) {
+      fptr = new_coulomb_p3m_impl<float, Arch::CPU>;
+    } else {
+      fptr = new_coulomb_p3m_impl<float, Arch::CUDA>;
+    }
+  } else {
+    if (arch == Arch::CPU) {
+      fptr = new_coulomb_p3m_impl<double, Arch::CPU>;
+    } else {
+      throw std::invalid_argument(
+          "P3M GPU only implemented in single-precision mode");
+    }
+  }
+  return fptr(std::move(p3m_params), tuning_params, prefactor);
+}
 
 #endif // ESPRESSO_P3M

--- a/src/core/electrostatics/p3m.hpp
+++ b/src/core/electrostatics/p3m.hpp
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_P3M
 
@@ -200,5 +200,10 @@ protected:
 
   virtual void scaleby_box_l() = 0;
 };
+
+std::shared_ptr<CoulombP3M>
+new_coulomb_p3m(P3MParameters &&p3m_params,
+                TuningParameters const &tuning_params, double prefactor,
+                bool single_precision, Arch arch);
 
 #endif // ESPRESSO_P3M

--- a/src/core/electrostatics/p3m.impl.hpp
+++ b/src/core/electrostatics/p3m.impl.hpp
@@ -21,13 +21,14 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_P3M
 
 #include "electrostatics/p3m.hpp"
 
 #include "ParticleRange.hpp"
+#include "communication.hpp"
 #include "p3m/common.hpp"
 #include "p3m/data_struct.hpp"
 #include "p3m/interpolation.hpp"
@@ -70,6 +71,16 @@ struct CoulombP3MState : public P3MStateCommon<FloatType> {
   std::vector<std::complex<FloatType>> rs_E_fields_no_halo;
   p3m_send_mesh<FloatType> halo_comm;
   std::shared_ptr<P3MFFT<FloatType>> fft;
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+  Kokkos::View<FloatType **, Kokkos::LayoutRight, Kokkos::HostSpace>
+      rs_charge_density_kokkos;
+
+  void init_labels() {
+    assert(rs_charge_density.empty());
+    rs_charge_density_kokkos = decltype(rs_charge_density_kokkos)(
+        "CoulombP3MState::rs_charge_density_kokkos", 0, 0);
+  }
+#endif
 };
 
 #ifdef ESPRESSO_CUDA
@@ -80,19 +91,21 @@ template <typename FloatType, Arch Architecture>
 struct CoulombP3MImpl : public CoulombP3M {
   ~CoulombP3MImpl() override = default;
 
+  using CoulombP3MStateClass = CoulombP3MState<FloatType>;
   /** @brief Coulomb P3M parameters. */
   CoulombP3MState<FloatType> &p3m;
 
 private:
-  std::unique_ptr<CoulombP3MState<FloatType>> p3m_state_ptr;
-  int tune_timings;
-  std::pair<std::optional<int>, std::optional<int>> tune_limits;
-  bool tune_verbose;
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+  // kokkos handle must outlive kokkos data structures from other class members
+  std::shared_ptr<KokkosHandle> m_kokkos_handle;
+#endif
+  std::unique_ptr<CoulombP3MStateClass> p3m_state_ptr;
+  TuningParameters tuning;
   bool m_is_tuned;
 
   constexpr const Utils::Vector3i get_memory_layout() const {
-    auto constexpr memory_order =
-        std::remove_reference<decltype(p3m)>::type::memory_order;
+    auto constexpr memory_order = CoulombP3MStateClass::memory_order;
     if constexpr (memory_order == Utils::MemoryOrder::COLUMN_MAJOR) {
       return {2, 1, 0};
     }
@@ -100,19 +113,23 @@ private:
   }
 
 public:
-  CoulombP3MImpl(std::unique_ptr<CoulombP3MState<FloatType>> &&p3m_state,
-                 double prefactor, int tune_timings, bool tune_verbose,
-                 decltype(tune_limits) tune_limits)
+  CoulombP3MImpl(std::unique_ptr<CoulombP3MStateClass> &&p3m_state,
+                 TuningParameters tuning_params, double prefactor)
       : CoulombP3M(p3m_state->params), p3m{*p3m_state},
-        p3m_state_ptr{std::move(p3m_state)}, tune_timings{tune_timings},
-        tune_limits{std::move(tune_limits)}, tune_verbose{tune_verbose} {
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+        m_kokkos_handle{::kokkos_handle},
+#endif
+        p3m_state_ptr{std::move(p3m_state)}, tuning{std::move(tuning_params)} {
 
-    if (tune_timings <= 0) {
+    if (tuning.timings <= 0) {
       throw std::domain_error("Parameter 'timings' must be > 0");
     }
     m_is_tuned = not p3m.params.tuning;
     p3m.params.tuning = false;
     set_prefactor(prefactor);
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    p3m.init_labels();
+#endif
   }
 
   void init() override {
@@ -120,7 +137,7 @@ public:
       init_cpu_kernels();
     }
 #ifdef ESPRESSO_CUDA
-    if constexpr (Architecture == Arch::GPU) {
+    if constexpr (Architecture == Arch::CUDA) {
       init_gpu_kernels();
     }
 #endif
@@ -139,7 +156,7 @@ public:
 
   [[nodiscard]] bool is_tuned() const noexcept override { return m_is_tuned; }
   [[nodiscard]] bool is_gpu() const noexcept override {
-    return Architecture == Arch::GPU;
+    return Architecture != Arch::CPU;
   }
   [[nodiscard]] bool is_double_precision() const noexcept override {
     return std::is_same_v<FloatType, double>;
@@ -147,14 +164,14 @@ public:
 
   void on_activation() override {
 #ifdef ESPRESSO_CUDA
-    if constexpr (Architecture == Arch::GPU) {
+    if constexpr (Architecture == Arch::CUDA) {
       request_gpu();
     }
 #endif
     sanity_checks();
     tune();
 #ifdef ESPRESSO_CUDA
-    if constexpr (Architecture == Arch::GPU) {
+    if constexpr (Architecture == Arch::CUDA) {
       if (is_tuned()) {
         init_cpu_kernels();
       }
@@ -171,7 +188,7 @@ public:
       long_range_kernel(true, false, particles);
     }
 #ifdef ESPRESSO_CUDA
-    if constexpr (Architecture == Arch::GPU) {
+    if constexpr (Architecture == Arch::CUDA) {
       add_long_range_forces_gpu(particles);
     }
 #endif
@@ -186,7 +203,14 @@ public:
     if (reset_weights) {
       p3m.inter_weights.reset(p3m.params.cao);
     }
-    p3m.rs_charge_density.resize(Utils::product(p3m.local_mesh.dim));
+    p3m.rs_charge_density.resize(p3m.local_mesh.size);
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    using execution_space = Kokkos::DefaultExecutionSpace;
+    auto const num_threads = execution_space().concurrency();
+    Kokkos::realloc(Kokkos::WithoutInitializing, p3m.rs_charge_density_kokkos,
+                    num_threads, p3m.local_mesh.size);
+    Kokkos::deep_copy(p3m.rs_charge_density_kokkos, FloatType{0});
+#endif // ESPRESSO_SHARED_MEMORY_PARALLELISM
     std::ranges::fill(p3m.rs_charge_density, FloatType{});
   }
 
@@ -208,15 +232,5 @@ private:
   void kernel_ks_charge_density();
   void kernel_rs_electric_field();
 };
-
-template <typename FloatType, Arch Architecture, typename... Args>
-std::shared_ptr<CoulombP3M> new_coulomb_p3m(P3MParameters &&p3m_params,
-                                            Args &&...args) {
-  auto state_ptr =
-      std::make_unique<CoulombP3MState<FloatType>>(std::move(p3m_params));
-  auto obj = std::make_shared<CoulombP3MImpl<FloatType, Architecture>>(
-      std::move(state_ptr), std::forward<Args>(args)...);
-  return obj;
-}
 
 #endif // ESPRESSO_P3M

--- a/src/core/electrostatics/p3m.impl.hpp
+++ b/src/core/electrostatics/p3m.impl.hpp
@@ -88,7 +88,6 @@ private:
   int tune_timings;
   std::pair<std::optional<int>, std::optional<int>> tune_limits;
   bool tune_verbose;
-  bool check_complex_residuals;
   bool m_is_tuned;
 
   constexpr const Utils::Vector3i get_memory_layout() const {
@@ -103,12 +102,10 @@ private:
 public:
   CoulombP3MImpl(std::unique_ptr<CoulombP3MState<FloatType>> &&p3m_state,
                  double prefactor, int tune_timings, bool tune_verbose,
-                 decltype(tune_limits) tune_limits,
-                 bool check_complex_residuals)
+                 decltype(tune_limits) tune_limits)
       : CoulombP3M(p3m_state->params), p3m{*p3m_state},
         p3m_state_ptr{std::move(p3m_state)}, tune_timings{tune_timings},
-        tune_limits{std::move(tune_limits)}, tune_verbose{tune_verbose},
-        check_complex_residuals{check_complex_residuals} {
+        tune_limits{std::move(tune_limits)}, tune_verbose{tune_verbose} {
 
     if (tune_timings <= 0) {
       throw std::domain_error("Parameter 'timings' must be > 0");

--- a/src/core/fft/fft.cpp
+++ b/src/core/fft/fft.cpp
@@ -762,7 +762,7 @@ void fft_data_struct<FloatType>::forward_fft(
 
 template <typename FloatType>
 void fft_data_struct<FloatType>::backward_fft(
-    boost::mpi::communicator const &comm, FloatType *data, bool check_complex) {
+    boost::mpi::communicator const &comm, FloatType *data) {
 
   auto *c_data = (typename fftw<FloatType>::complex *)data;
   auto *c_data_buf = (typename fftw<FloatType>::complex *)data_buf.data();
@@ -786,13 +786,6 @@ void fft_data_struct<FloatType>::backward_fft(
   /* throw away the (hopefully) empty complex component (in is data) */
   for (int i = 0; i < forw[1].new_size; i++) {
     data_buf[i] = data[2 * i]; /* real value */
-    // Vincent:
-    if (check_complex and std::abs(data[2 * i + 1]) > FloatType{1e-5}) {
-      printf("Complex value is not zero (i=%d,data=%g)!!!\n", i,
-             data[2 * i + 1]);
-      if (i > 100)
-        throw std::runtime_error("Complex value is not zero");
-    }
   }
   /* communicate (in is data_buf) */
   back_grid_comm(comm, forw[1], back[1], data_buf.data(), data);

--- a/src/core/fft/fft.hpp
+++ b/src/core/fft/fft.hpp
@@ -190,12 +190,9 @@ public:
   /** Perform an in-place backward 3D FFT.
    *  \warning The content of \a data is overwritten.
    *  \param[in,out] data           Mesh.
-   *  \param[in]     check_complex  Throw an error if the complex component is
-   *                                non-zero.
    *  \param[in]     comm           MPI communicator.
    */
-  void backward_fft(boost::mpi::communicator const &comm, FloatType *data,
-                    bool check_complex);
+  void backward_fft(boost::mpi::communicator const &comm, FloatType *data);
 
   auto const &get_mesh_size() const { return forw[3u].new_mesh; }
 

--- a/src/core/forces_cabana.hpp
+++ b/src/core/forces_cabana.hpp
@@ -94,12 +94,14 @@ struct ForcesKernel {
   }
 
   // Helper functions to check if specific algorithms are active
-#ifdef ESPRESSO_GAY_BERNE
   ESPRESSO_ATTR_ALWAYS_INLINE KOKKOS_INLINE_FUNCTION bool
   gay_berne_active(double dist, IA_parameters const &ia_params) const {
+#ifdef ESPRESSO_GAY_BERNE
     return dist < ia_params.gay_berne.cut;
-  }
+#else
+    return false;
 #endif
+  }
 
 #ifdef ESPRESSO_NPT
   ESPRESSO_ATTR_ALWAYS_INLINE KOKKOS_INLINE_FUNCTION bool npt_active() const {

--- a/src/core/magnetostatics/dp3m.cpp
+++ b/src/core/magnetostatics/dp3m.cpp
@@ -25,7 +25,7 @@
  *  By default the magnetic epsilon is metallic = 0.
  */
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_DP3M
 
@@ -174,24 +174,37 @@ template <int cao> struct AssignDipole {
     auto const n_part = cell_structure.count_local_particles();
     dp3m.inter_weights.zfill(n_part); // allocate buffer for parallel write
     kokkos_parallel_range_for(
-        "InterpolationWeights", std::size_t{0u}, n_part, [&](auto p_index) {
+        "InterpolateDipoles", std::size_t{0u}, n_part, [&](auto p_index) {
+          auto const tid = omp_get_thread_num();
           auto const p_pos = aosoa.get_vector_at(aosoa.position, p_index);
+          auto const dip = unique_particles.at(p_index)->calc_dip();
           auto const weights =
               p3m_calculate_interpolation_weights<cao, memory_order>(
                   p_pos, dp3m.params.ai, dp3m.local_mesh);
           dp3m.inter_weights.store_at(p_index, weights);
+          p3m_interpolate(
+              dp3m.local_mesh, weights, [&dip, tid, &dp3m](int ind, double w) {
+                dp3m.rs_fields_kokkos(tid, 0u, ind) += value_type(w * dip[0u]);
+                dp3m.rs_fields_kokkos(tid, 1u, ind) += value_type(w * dip[1u]);
+                dp3m.rs_fields_kokkos(tid, 2u, ind) += value_type(w * dip[2u]);
+              });
         });
-    // serial part of dipole assignment
-    for (std::size_t p_index{0}; p_index < n_part; ++p_index) {
-      auto const weights = dp3m.inter_weights.template load<cao>(p_index);
-      auto const dip = unique_particles.at(p_index)->calc_dip();
-      p3m_interpolate<cao>(
-          dp3m.local_mesh, weights, [&dip, &dp3m](int ind, double w) {
-            dp3m.mesh.rs_fields[0u][ind] += value_type(w * dip[0u]);
-            dp3m.mesh.rs_fields[1u][ind] += value_type(w * dip[1u]);
-            dp3m.mesh.rs_fields[2u][ind] += value_type(w * dip[2u]);
-          });
-    }
+    Kokkos::fence();
+    using execution_space = Kokkos::DefaultExecutionSpace;
+    int num_threads = execution_space().concurrency();
+    Kokkos::RangePolicy<execution_space> policy(std::size_t{0},
+                                                dp3m.local_mesh.size);
+    Kokkos::parallel_for("ReduceInterpolatedDipoles", policy,
+                         [&dp3m, num_threads](std::size_t const i) {
+                           for (int dir = 0; dir < 3; ++dir) {
+                             value_type acc{};
+                             for (int tid = 0; tid < num_threads; ++tid) {
+                               acc += dp3m.rs_fields_kokkos(tid, dir, i);
+                             }
+                             dp3m.mesh.rs_fields[dir][i] += acc;
+                           }
+                         });
+    Kokkos::fence();
   }
 #else  // ESPRESSO_SHARED_MEMORY_PARALLELISM
   void operator()(auto &dp3m, Utils::Vector3d const &real_pos,
@@ -217,12 +230,7 @@ template <int cao> struct AssignDipole {
 template <typename FloatType, Arch Architecture>
 void DipolarP3MImpl<FloatType, Architecture>::dipole_assign(
     [[maybe_unused]] ParticleRange const &particles) {
-  dp3m.inter_weights.reset(dp3m.params.cao);
-
-  /* prepare local FFT mesh */
-  for (auto &rs_mesh_field : dp3m.mesh.rs_fields) {
-    std::ranges::fill_n(rs_mesh_field.data(), dp3m.local_mesh.size, 0.);
-  }
+  prepare_fft_mesh();
 
 #ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
   Utils::integral_parameter<int, AssignDipole, p3m_min_cao, p3m_max_cao>(
@@ -793,8 +801,8 @@ void DipolarP3MImpl<FloatType, Architecture>::tune() {
     }
     try {
       DipolarTuningAlgorithm<FloatType, Architecture> parameters(
-          system, dp3m, prefactor, tune_timings, tune_limits);
-      parameters.setup_logger(tune_verbose);
+          system, dp3m, prefactor, tuning.timings, tuning.limits);
+      parameters.setup_logger(tuning.verbose);
       // parameter ranges
       parameters.determine_mesh_limits();
       parameters.determine_r_cut_limits();
@@ -1042,7 +1050,29 @@ void DipolarP3MImpl<FloatType, Architecture>::npt_add_virial_contribution(
 }
 #endif // ESPRESSO_NPT
 
-template struct DipolarP3MImpl<float, Arch::CPU>;
-template struct DipolarP3MImpl<double, Arch::CPU>;
+template <typename FloatType, Arch Architecture>
+std::shared_ptr<DipolarP3M>
+new_dipolar_p3m_impl(P3MParameters &&p3m, TuningParameters const &tuning_params,
+                     double prefactor) {
+  auto obj = std::make_shared<DipolarP3MImpl<FloatType, Architecture>>(
+      std::make_unique<p3m_data_struct_dipoles<FloatType>>(std::move(p3m)),
+      tuning_params, prefactor);
+  obj->dp3m.template make_mesh_instance<FFTBuffersLegacy<FloatType>>();
+  obj->dp3m.template make_fft_instance<FFTBackendLegacy<FloatType>>();
+  return obj;
+}
+
+std::shared_ptr<DipolarP3M>
+new_dipolar_p3m(P3MParameters &&p3m_params,
+                TuningParameters const &tuning_params, double prefactor,
+                bool single_precision, Arch arch) {
+  auto fptr = &new_dipolar_p3m_impl<float, Arch::CPU>;
+  if (single_precision) {
+    fptr = new_dipolar_p3m_impl<float, Arch::CPU>;
+  } else {
+    fptr = new_dipolar_p3m_impl<double, Arch::CPU>;
+  }
+  return fptr(std::move(p3m_params), tuning_params, prefactor);
+}
 
 #endif // ESPRESSO_DP3M

--- a/src/core/magnetostatics/dp3m.hpp
+++ b/src/core/magnetostatics/dp3m.hpp
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_DP3M
 
@@ -259,5 +259,10 @@ protected:
   virtual void npt_add_virial_contribution(double energy) const = 0;
 #endif
 };
+
+std::shared_ptr<DipolarP3M>
+new_dipolar_p3m(P3MParameters &&p3m_params,
+                TuningParameters const &tuning_params, double prefactor,
+                bool single_precision, Arch arch);
 
 #endif // ESPRESSO_DP3M

--- a/src/core/magnetostatics/dp3m.impl.hpp
+++ b/src/core/magnetostatics/dp3m.impl.hpp
@@ -21,19 +21,26 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_DP3M
 
 #include "magnetostatics/dp3m.hpp"
 
+#include "ParticleRange.hpp"
+#include "communication.hpp"
+#include "p3m/FFTBackendLegacy.hpp"
+#include "p3m/FFTBuffersLegacy.hpp"
 #include "p3m/common.hpp"
 #include "p3m/data_struct.hpp"
 #include "p3m/interpolation.hpp"
 
-#include "ParticleRange.hpp"
-
 #include <utils/Vector.hpp>
+
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+#include <Kokkos_Core.hpp>
+#include <omp.h>
+#endif
 
 #include <cstddef>
 #include <memory>
@@ -61,6 +68,17 @@ struct p3m_data_struct_dipoles : public p3m_data_struct<FloatType> {
   std::vector<FloatType> ks_scalar;
 
   p3m_interpolation_cache inter_weights;
+
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+  Kokkos::View<FloatType ***, Kokkos::LayoutRight, Kokkos::HostSpace>
+      rs_fields_kokkos;
+
+  void init_labels() {
+    assert(ks_scalar.empty());
+    rs_fields_kokkos = decltype(rs_fields_kokkos)(
+        "p3m_data_struct_dipoles::rs_fields_kokkos", 0, 0, 0);
+  }
+#endif
 };
 
 template <typename FloatType, Arch Architecture>
@@ -71,23 +89,26 @@ struct DipolarP3MImpl : public DipolarP3M {
   p3m_data_struct_dipoles<FloatType> &dp3m;
 
 private:
-  /** @brief Coulomb P3M meshes and FFT algorithm. */
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+  // kokkos handle must outlive kokkos data structures from other class members
+  std::shared_ptr<KokkosHandle> m_kokkos_handle;
+#endif
+  /** @brief Dipolar P3M meshes and FFT algorithm. */
   std::unique_ptr<p3m_data_struct_dipoles<FloatType>> dp3m_impl;
-  int tune_timings;
-  std::pair<std::optional<int>, std::optional<int>> tune_limits;
-  bool tune_verbose;
+  TuningParameters tuning;
   bool m_is_tuned;
 
 public:
   DipolarP3MImpl(
       std::unique_ptr<p3m_data_struct_dipoles<FloatType>> &&dp3m_handle,
-      double prefactor, int tune_timings, bool tune_verbose,
-      decltype(tune_limits) tune_limits)
+      TuningParameters tuning_params, double prefactor)
       : DipolarP3M(dp3m_handle->params), dp3m{*dp3m_handle},
-        dp3m_impl{std::move(dp3m_handle)}, tune_timings{tune_timings},
-        tune_limits{std::move(tune_limits)}, tune_verbose{tune_verbose} {
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+        m_kokkos_handle{::kokkos_handle},
+#endif
+        dp3m_impl{std::move(dp3m_handle)}, tuning{std::move(tuning_params)} {
 
-    if (tune_timings <= 0) {
+    if (tuning.timings <= 0) {
       throw std::domain_error("Parameter 'timings' must be > 0");
     }
     if (dp3m.params.mesh != Utils::Vector3i::broadcast(dp3m.params.mesh[0])) {
@@ -96,6 +117,9 @@ public:
     m_is_tuned = not dp3m.params.tuning;
     dp3m.params.tuning = false;
     set_prefactor(prefactor);
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    dp3m.init_labels();
+#endif
   }
 
   void init() override {
@@ -108,7 +132,7 @@ public:
 
   [[nodiscard]] bool is_tuned() const noexcept override { return m_is_tuned; }
   [[nodiscard]] bool is_gpu() const noexcept override {
-    return Architecture == Arch::GPU;
+    return Architecture != Arch::CPU;
   }
   [[nodiscard]] bool is_double_precision() const noexcept override {
     return std::is_same_v<FloatType, double>;
@@ -131,6 +155,21 @@ public:
 
   void dipole_assign(ParticleRange const &particles) override;
 
+private:
+  void prepare_fft_mesh() {
+    dp3m.inter_weights.reset(dp3m.params.cao);
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    using execution_space = Kokkos::DefaultExecutionSpace;
+    auto const num_threads = execution_space().concurrency();
+    Kokkos::realloc(Kokkos::WithoutInitializing, dp3m.rs_fields_kokkos,
+                    num_threads, 3, dp3m.local_mesh.size);
+    Kokkos::deep_copy(dp3m.rs_fields_kokkos, FloatType{0});
+#endif // ESPRESSO_SHARED_MEMORY_PARALLELISM
+    for (auto &rs_mesh_field : dp3m.mesh.rs_fields) {
+      std::ranges::fill(rs_mesh_field, FloatType{0});
+    }
+  }
+
 protected:
   /** Compute the k-space part of forces and energies. */
   double long_range_kernel(bool force_flag, bool energy_flag,
@@ -147,18 +186,5 @@ protected:
   void npt_add_virial_contribution(double energy) const override;
 #endif
 };
-
-template <typename FloatType, Arch Architecture,
-          template <typename> class FFTBackendImpl,
-          template <typename> class P3MFFTMeshImpl, class... Args>
-std::shared_ptr<DipolarP3M> new_dp3m_handle(P3MParameters &&p3m,
-                                            Args &&...args) {
-  auto obj = std::make_shared<DipolarP3MImpl<FloatType, Architecture>>(
-      std::make_unique<p3m_data_struct_dipoles<FloatType>>(std::move(p3m)),
-      std::forward<Args>(args)...);
-  obj->dp3m.template make_mesh_instance<P3MFFTMeshImpl<FloatType>>();
-  obj->dp3m.template make_fft_instance<FFTBackendImpl<FloatType>>();
-  return obj;
-}
 
 #endif // ESPRESSO_DP3M

--- a/src/core/p3m/FFTBackendLegacy.cpp
+++ b/src/core/p3m/FFTBackendLegacy.cpp
@@ -54,7 +54,7 @@ void FFTBackendLegacy<FloatType>::forward_fft(FloatType *rs_mesh) {
 
 template <typename FloatType>
 void FFTBackendLegacy<FloatType>::backward_fft(FloatType *rs_mesh) {
-  fft->backward_fft(::comm_cart, rs_mesh, check_complex_residuals);
+  fft->backward_fft(::comm_cart, rs_mesh);
 }
 
 template class FFTBackendLegacy<float>;

--- a/src/core/p3m/FFTBackendLegacy.hpp
+++ b/src/core/p3m/FFTBackendLegacy.hpp
@@ -48,7 +48,6 @@ class FFTBackendLegacy : public FFTBackend<FloatType> {
                 "FFTW only implements float and double");
   std::unique_ptr<fft::fft_data_struct<FloatType>> fft;
   using FFTBackend<FloatType>::local_mesh;
-  using FFTBackend<FloatType>::check_complex_residuals;
   int ca_mesh_size = -1;
   int ks_pnum = -1;
 

--- a/src/core/p3m/common.cpp
+++ b/src/core/p3m/common.cpp
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #if defined(ESPRESSO_P3M) or defined(ESPRESSO_DP3M)
 
@@ -89,10 +89,10 @@ void P3MLocalMesh::calc_local_ca_mesh(P3MParameters const &params,
     margin[(i * 2) + 1] = ind[i] - in_ur[i];
 
   /* grid dimension */
-  size = 1;
+  size = 1ull;
   for (i = 0; i < 3; i++) {
     dim[i] = ind[i] - ld_ind[i] + 1;
-    size *= dim[i];
+    size *= static_cast<std::size_t>(dim[i]);
   }
 
   /* reduce inner grid indices from global to local */

--- a/src/core/p3m/common.hpp
+++ b/src/core/p3m/common.hpp
@@ -50,11 +50,12 @@ inline auto constexpr P3M_EPSILON_METALLIC = 0.0;
 #include "LocalBox.hpp"
 
 #include <cstddef>
+#include <optional>
 #include <span>
 #include <stdexcept>
 
 /** @brief P3M kernel architecture. */
-enum class Arch { CPU, GPU };
+enum class Arch { CPU, CUDA };
 
 /** @brief Structure to hold P3M parameters and some dependent variables. */
 struct P3MParameters {
@@ -177,8 +178,8 @@ struct P3MLocalMesh {
   /** dimension (size) of local mesh including halo layers. */
   Utils::Vector3i dim;
   Utils::Vector3i dim_no_halo;
-  /** number of local mesh points. */
-  int size;
+  /** number of local mesh points including halo layers. */
+  std::size_t size;
   /** index of lower left corner of the
       local mesh in the global mesh. */
   Utils::Vector3i ld_ind;
@@ -242,6 +243,12 @@ template <typename FloatType> struct P3MFFTMesh {
 
   /** @brief number of permutations in k_space */
   int ks_pnum = 0;
+};
+
+struct TuningParameters {
+  int timings;
+  std::pair<std::optional<int>, std::optional<int>> limits;
+  bool verbose;
 };
 
 #endif // defined(ESPRESSO_P3M) or defined(ESPRESSO_DP3M)

--- a/src/core/p3m/data_struct.hpp
+++ b/src/core/p3m/data_struct.hpp
@@ -122,7 +122,6 @@ protected:
   P3MLocalMesh const &local_mesh;
 
 public:
-  bool check_complex_residuals = false;
   explicit FFTBackend(P3MLocalMesh const &local_mesh)
       : local_mesh{local_mesh} {}
   virtual ~FFTBackend() = default;
@@ -147,7 +146,6 @@ protected:
   P3MLocalMesh const &local_mesh;
 
 public:
-  bool check_complex_residuals = false;
   explicit FFTBuffers(P3MLocalMesh const &local_mesh)
       : local_mesh{local_mesh} {}
   virtual ~FFTBuffers() = default;

--- a/src/core/p3m/interpolation.hpp
+++ b/src/core/p3m/interpolation.hpp
@@ -21,12 +21,19 @@
 
 #pragma once
 
+#include <config/config.hpp>
+
 #include <utils/index.hpp>
 #include <utils/math/bspline.hpp>
+
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+#include <Kokkos_Core.hpp>
+#endif
 
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <iterator>
 #include <span>
 #include <tuple>
 #include <utility>
@@ -35,7 +42,7 @@
 /**
  * @brief Interpolation weights for one point.
  *
- * Interpolation weights and  grid offset for one point.
+ * Interpolation weights and grid offset for one point.
  *
  * @tparam cao Interpolation order.
  */
@@ -44,6 +51,13 @@ template <int cao> struct InterpolationWeights {
   int ind;
   /** Weights for the directions */
   Utils::Array<double, cao> w_x, w_y, w_z;
+};
+
+template <int cao> struct InterpolationWeightsView {
+  /** Linear index of the corner of the interpolation cube. */
+  int ind;
+  /** Weights for the directions */
+  std::span<double const, cao> w_x, w_y, w_z;
 };
 
 /**
@@ -55,16 +69,38 @@ template <int cao> struct InterpolationWeights {
 class p3m_interpolation_cache {
   int m_cao = 0;
   /** Charge fractions for mesh assignment. */
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+  Kokkos::View<double *, Kokkos::LayoutRight, Kokkos::HostSpace> ca_frac;
+  std::vector<double> ca_frac_spillover;
+#else
   std::vector<double> ca_frac;
+#endif
   /** index of first mesh point for charge assignment. */
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+  Kokkos::View<int *, Kokkos::LayoutRight, Kokkos::HostSpace> ca_fmp;
+  std::vector<int> ca_fmp_spillover;
+#else
   std::vector<int> ca_fmp;
+#endif
 
 public:
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+  p3m_interpolation_cache()
+      : ca_frac("p3m_interpolation_cache::ca_frac", 0, 0),
+        ca_fmp("p3m_interpolation_cache::ca_fmp", 0, 0) {}
+#endif
+
   /**
    * @brief Number of points in the cache.
    * @return Number of points currently in the cache.
    */
-  auto size() const { return ca_fmp.size(); }
+  auto size() const {
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    return ca_fmp.size() + ca_fmp_spillover.size();
+#else
+    return ca_fmp.size();
+#endif
+  }
 
   /**
    * @brief Charge assignment order the weights are for.
@@ -78,10 +114,23 @@ public:
    * @param size Number of elements.
    */
   void zfill(std::size_t size) {
+    auto const size_frac = size * static_cast<std::size_t>(m_cao * 3);
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    if (ca_fmp.size() != size or ca_frac.size() != size_frac) {
+      Kokkos::realloc(Kokkos::WithoutInitializing, ca_fmp, size);
+      Kokkos::realloc(Kokkos::WithoutInitializing, ca_frac, size_frac);
+    }
+    assert(ca_frac_spillover.empty());
+    assert(ca_fmp_spillover.empty());
+    // data must be contiguous in memory
+    assert(size == 0 or
+           (std::distance(&ca_fmp(0), &ca_fmp(size - 1)) == size - 1));
+#else
     assert(ca_frac.empty());
     assert(ca_fmp.empty());
     ca_fmp.resize(size);
-    ca_frac.resize(size * static_cast<std::size_t>(m_cao * 3));
+    ca_frac.resize(size_frac);
+#endif
   }
 
   /**
@@ -91,14 +140,22 @@ public:
    *         set at last call to @ref p3m_interpolation_cache::reset.
    * @param weights Interpolation weights to store.
    */
-  template <int cao> void store(const InterpolationWeights<cao> &weights) {
+  template <int cao> void store(InterpolationWeights<cao> const &weights) {
     assert(cao == m_cao);
 
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    ca_fmp_spillover.emplace_back(weights.ind);
+    auto it = std::back_inserter(ca_frac_spillover);
+    std::ranges::copy(weights.w_x, it);
+    std::ranges::copy(weights.w_y, it);
+    std::ranges::copy(weights.w_z, it);
+#else
     ca_fmp.emplace_back(weights.ind);
     auto it = std::back_inserter(ca_frac);
     std::ranges::copy(weights.w_x, it);
     std::ranges::copy(weights.w_y, it);
     std::ranges::copy(weights.w_z, it);
+#endif
   }
 
   /**
@@ -110,18 +167,25 @@ public:
    * @param weights Interpolation weights to store.
    */
   template <int cao>
-  void store_at(std::size_t p_index, const InterpolationWeights<cao> &weights) {
+  void store_at(std::size_t p_index, InterpolationWeights<cao> const &weights) {
     assert(cao == m_cao);
-    assert(p_index < size());
+    assert(p_index < ca_fmp.size());
 
+    auto copy_weights = [](InterpolationWeights<cao> const &src, auto dst) {
+      std::copy_n(src.w_x.data(), cao, dst);
+      std::advance(dst, cao);
+      std::copy_n(src.w_y.data(), cao, dst);
+      std::advance(dst, cao);
+      std::copy_n(src.w_z.data(), cao, dst);
+    };
+
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    ca_fmp(p_index) = weights.ind;
+#else
     ca_fmp[p_index] = weights.ind;
-    auto it = ca_frac.begin();
-    std::advance(it, p_index * static_cast<std::size_t>(m_cao * 3));
-    std::ranges::copy(weights.w_x, it);
-    std::advance(it, m_cao);
-    std::ranges::copy(weights.w_y, it);
-    std::advance(it, m_cao);
-    std::ranges::copy(weights.w_z, it);
+#endif
+    auto const offset = p_index * static_cast<std::size_t>(cao * 3);
+    copy_weights(weights, ca_frac.data() + offset);
   }
 
   /**
@@ -135,21 +199,35 @@ public:
    * @param p_index Index of the entry to load.
    * @return Interpolation weights.
    */
-  template <int cao> InterpolationWeights<cao> load(std::size_t p_index) const {
+  template <int cao>
+  InterpolationWeightsView<cao> load(std::size_t p_index) const {
     assert(cao == m_cao);
     assert(p_index < size());
 
-    InterpolationWeights<cao> ret;
-    ret.ind = ca_fmp[p_index];
-
-    auto const view = std::span(std::as_const(ca_frac));
-    auto const offset = 3ul * p_index * static_cast<std::size_t>(cao);
-
-    std::ranges::copy(view.subspan(offset + 0ul * cao, cao), ret.w_x.begin());
-    std::ranges::copy(view.subspan(offset + 1ul * cao, cao), ret.w_y.begin());
-    std::ranges::copy(view.subspan(offset + 2ul * cao, cao), ret.w_z.begin());
-
-    return ret;
+    int index = -1;
+    double const *ptr = nullptr;
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    if (p_index >= ca_fmp.size()) {
+      p_index -= ca_fmp.size();
+      index = ca_fmp_spillover[p_index];
+      auto const offset = p_index * static_cast<std::size_t>(cao * 3);
+      ptr = std::as_const(ca_frac_spillover).data() + offset;
+    } else {
+      index = ca_fmp(p_index);
+      auto const offset = p_index * static_cast<std::size_t>(cao * 3);
+      ptr = std::as_const(ca_frac).data() + offset;
+    }
+#else
+    index = ca_fmp[p_index];
+    auto const offset = p_index * static_cast<std::size_t>(cao * 3);
+    ptr = std::as_const(ca_frac).data() + offset;
+#endif
+    std::span<double const, cao> w_x(ptr, cao);
+    std::advance(ptr, cao);
+    std::span<double const, cao> w_y(ptr, cao);
+    std::advance(ptr, cao);
+    std::span<double const, cao> w_z(ptr, cao);
+    return {index, w_x, w_y, w_z};
   }
 
   /**
@@ -159,8 +237,15 @@ public:
    */
   void reset(int cao) {
     m_cao = cao;
+#ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
+    Kokkos::realloc(Kokkos::WithoutInitializing, ca_fmp, 0ul);
+    Kokkos::realloc(Kokkos::WithoutInitializing, ca_frac, 0ul);
+    ca_frac_spillover.clear();
+    ca_fmp_spillover.clear();
+#else
     ca_frac.clear();
     ca_fmp.clear();
+#endif
   }
 };
 
@@ -222,9 +307,9 @@ p3m_calculate_interpolation_weights(const Utils::Vector3d &position,
  * @param weights Set of weights
  * @param kernel The kernel to run.
  */
-template <int cao, class Kernel>
+template <int cao, template <int> class WeightsStorage, class Kernel>
 void p3m_interpolate(P3MLocalMesh const &local_mesh,
-                     InterpolationWeights<cao> const &weights, Kernel kernel) {
+                     WeightsStorage<cao> const &weights, Kernel kernel) {
   auto q_ind = weights.ind;
   for (int i0 = 0; i0 < cao; i0++) {
     auto const w_x = weights.w_x[i0];

--- a/src/core/pressure_inline.hpp
+++ b/src/core/pressure_inline.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #include "bonded_interactions/bonded_interaction_data.hpp"
 #include "magnetostatics/dipoles.hpp"
@@ -66,15 +66,13 @@ inline void add_non_bonded_pair_virials(
   if (do_nonbonded(p1, p2))
 #endif
   {
-    ParticleForce pf{};
-    pf.f = calc_central_radial_force(ia_params, d, dist) +
+    auto f = calc_non_central_force(p1, p2, ia_params, d, dist).f;
+    f += calc_central_radial_force(ia_params, d, dist);
 #ifdef ESPRESSO_THOLE
-           thole_pair_force(p1, p2, ia_params, d, dist, bonded_ias,
-                            kernel_forces) +
+    f +=
+        thole_pair_force(p1, p2, ia_params, d, dist, bonded_ias, kernel_forces);
 #endif
-           Utils::Vector3d{};
-    pf += calc_non_central_force(p1, p2, ia_params, d, dist);
-    auto const stress = Utils::tensor_product(d, pf.f);
+    auto const stress = Utils::tensor_product(d, f);
     obs_pressure.add_non_bonded_contribution(p1.type(), p2.type(), p1.mol_id(),
                                              p2.mol_id(), flatten(stress));
   }

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -41,7 +41,6 @@ namespace utf = boost::unit_test;
 #include "cuda/utils.hpp"
 #include "electrostatics/coulomb.hpp"
 #include "electrostatics/p3m.hpp"
-#include "electrostatics/p3m.impl.hpp"
 #include "energy_inline.hpp"
 #include "forces_inline.hpp"
 #include "galilei/Galilei.hpp"
@@ -49,7 +48,6 @@ namespace utf = boost::unit_test;
 #include "integrators/Propagation.hpp"
 #include "magnetostatics/dipoles.hpp"
 #include "magnetostatics/dp3m.hpp"
-#include "magnetostatics/dp3m.impl.hpp"
 #include "nonbonded_interactions/lj.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "observables/ParticleVelocities.hpp"
@@ -250,8 +248,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
 
     // set up P3M
     auto const prefactor = 2.;
-    auto const mesh_range = std::pair<std::optional<int>, std::optional<int>>{
-        std::nullopt, std::nullopt};
+    auto tuning = TuningParameters{1, {std::nullopt, std::nullopt}, false};
     auto p3m = P3MParameters{false,
                              0.0,
                              3.5,
@@ -260,8 +257,8 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
                              5,
                              0.615,
                              1e-3};
-    auto solver = new_coulomb_p3m<double, Arch::CPU>(
-        std::move(p3m), prefactor, 1, false, mesh_range, true);
+    auto solver =
+        new_coulomb_p3m(std::move(p3m), tuning, prefactor, false, Arch::CPU);
     add_actor(comm, espresso::system, system.coulomb.impl->solver, solver,
               [&system]() { system.on_coulomb_change(); });
     BOOST_CHECK(not solver->is_gpu());
@@ -320,8 +317,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
 
     // set up P3M
     auto const prefactor = 2.;
-    auto const mesh_range = std::pair<std::optional<int>, std::optional<int>>{
-        std::nullopt, std::nullopt};
+    auto tuning = TuningParameters{1, {std::nullopt, std::nullopt}, false};
     auto p3m = P3MParameters{false,
                              0.0,
                              3.5,
@@ -331,8 +327,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
                              0.615,
                              1e-3};
     auto solver =
-        new_dp3m_handle<double, Arch::CPU, FFTBackendLegacy, FFTBuffersLegacy>(
-            std::move(p3m), prefactor, 1, false, mesh_range);
+        new_dipolar_p3m(std::move(p3m), tuning, prefactor, false, Arch::CPU);
     add_actor(comm, espresso::system, system.dipoles.impl->solver, solver,
               [&system]() { system.on_dipoles_change(); });
     BOOST_CHECK(not solver->is_gpu());

--- a/src/python/espressomd/electrostatics.py
+++ b/src/python/espressomd/electrostatics.py
@@ -140,7 +140,6 @@ class _P3MBase(ElectrostaticInteraction):
                 "mesh_off": [-1., -1., -1.],
                 "prefactor": 0.,
                 "check_neutrality": True,
-                "check_complex_residuals": True,
                 "tune": True,
                 "timings": 10,
                 "verbose": True}
@@ -220,9 +219,6 @@ class P3M(_P3MBase):
     check_neutrality : :obj:`bool`, optional
         Raise a warning if the system is not electrically neutral when
         set to ``True`` (default).
-    check_complex_residuals: :obj:`bool`, optional
-        Raise a warning if the backward Fourier transform has non-zero
-        complex residuals when set to ``True`` (default).
     single_precision : :obj:`bool`
         Use single-precision floating-point arithmetic.
 
@@ -279,9 +275,6 @@ class P3MGPU(_P3MBase):
     check_neutrality : :obj:`bool`, optional
         Raise a warning if the system is not electrically neutral when
         set to ``True`` (default).
-    check_complex_residuals: :obj:`bool`, optional
-        Raise a warning if the backward Fourier transform has non-zero
-        complex residuals when set to ``True`` (default).
 
     """
     _so_name = "Coulomb::CoulombP3MGPU"

--- a/src/script_interface/electrostatics/CoulombP3M.hpp
+++ b/src/script_interface/electrostatics/CoulombP3M.hpp
@@ -19,14 +19,13 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_P3M
 
 #include "Actor.hpp"
 
 #include "core/electrostatics/p3m.hpp"
-#include "core/electrostatics/p3m.impl.hpp"
 
 #include "script_interface/get_value.hpp"
 
@@ -41,11 +40,9 @@ namespace Coulomb {
 
 template <Arch Architecture>
 class CoulombP3M : public Actor<CoulombP3M<Architecture>, ::CoulombP3M> {
-  int m_tune_timings;
+  TuningParameters m_tuning;
   bool m_tune;
-  bool m_tune_verbose;
   bool m_single_precision;
-  std::pair<std::optional<int>, std::optional<int>> m_tune_limits;
 
 public:
   using Base = Actor<CoulombP3M<Architecture>, ::CoulombP3M>;
@@ -85,12 +82,12 @@ public:
         {"is_tuned", AutoParameter::read_only,
          [this]() { return actor()->is_tuned(); }},
         {"verbose", AutoParameter::read_only,
-         [this]() { return m_tune_verbose; }},
+         [this]() { return m_tuning.verbose; }},
         {"timings", AutoParameter::read_only,
-         [this]() { return m_tune_timings; }},
+         [this]() { return m_tuning.timings; }},
         {"tune_limits", AutoParameter::read_only,
          [this]() {
-           auto const &[range_min, range_max] = m_tune_limits;
+           auto const &[range_min, range_max] = m_tuning.limits;
            std::vector<Variant> retval = {
                range_min ? Variant{*range_min} : Variant{None{}},
                range_max ? Variant{*range_max} : Variant{None{}},
@@ -103,9 +100,9 @@ public:
 
   void do_construct(VariantMap const &params) override {
     m_tune = get_value<bool>(params, "tune");
-    m_tune_timings = get_value<int>(params, "timings");
-    m_tune_verbose = get_value<bool>(params, "verbose");
-    m_tune_limits = {std::nullopt, std::nullopt};
+    m_tuning.timings = get_value<int>(params, "timings");
+    m_tuning.verbose = get_value<bool>(params, "verbose");
+    m_tuning.limits = {std::nullopt, std::nullopt};
     if (params.contains("tune_limits")) {
       auto const &variant = params.at("tune_limits");
       std::size_t range_length = 0u;
@@ -113,17 +110,17 @@ public:
         auto const range = get_value<std::vector<int>>(variant);
         range_length = range.size();
         if (range_length == 2u) {
-          m_tune_limits = {range[0u], range[1u]};
+          m_tuning.limits = {range[0u], range[1u]};
         }
       } else {
         auto const range = get_value<std::vector<Variant>>(variant);
         range_length = range.size();
         if (range_length == 2u) {
           if (not is_none(range[0u])) {
-            m_tune_limits.first = get_value<int>(range[0u]);
+            m_tuning.limits.first = get_value<int>(range[0u]);
           }
           if (not is_none(range[1u])) {
-            m_tune_limits.second = get_value<int>(range[1u]);
+            m_tuning.limits.second = get_value<int>(range[1u]);
           }
         }
       }
@@ -131,20 +128,16 @@ public:
         if (range_length != 2u) {
           throw std::invalid_argument("Parameter 'tune_limits' needs 2 values");
         }
-        if (m_tune_limits.first and *m_tune_limits.first <= 0) {
+        if (m_tuning.limits.first and *m_tuning.limits.first <= 0) {
           throw std::domain_error("Parameter 'tune_limits' must be > 0");
         }
-        if (m_tune_limits.second and *m_tune_limits.second <= 0) {
+        if (m_tuning.limits.second and *m_tuning.limits.second <= 0) {
           throw std::domain_error("Parameter 'tune_limits' must be > 0");
         }
       });
     }
     auto const single_precision = get_value<bool>(params, "single_precision");
     context()->parallel_try_catch([&]() {
-      if (Architecture == Arch::GPU and not single_precision) {
-        throw std::invalid_argument(
-            "P3M GPU only implemented in single-precision mode");
-      }
       auto p3m = P3MParameters{!get_value_or<bool>(params, "is_tuned", !m_tune),
                                get_value<double>(params, "epsilon"),
                                get_value<double>(params, "r_cut"),
@@ -153,26 +146,11 @@ public:
                                get_value<int>(params, "cao"),
                                get_value<double>(params, "alpha"),
                                get_value<double>(params, "accuracy")};
-      make_handle(single_precision, std::move(p3m),
-                  get_value<double>(params, "prefactor"), m_tune_timings,
-                  m_tune_verbose, m_tune_limits);
+      m_actor = new_coulomb_p3m(std::move(p3m), m_tuning,
+                                get_value<double>(params, "prefactor"),
+                                single_precision, Architecture);
     });
     set_charge_neutrality_tolerance(params);
-  }
-
-private:
-  template <typename FloatType, class... Args>
-  void make_handle_impl(Args &&...args) {
-    m_actor =
-        new_coulomb_p3m<FloatType, Architecture>(std::forward<Args>(args)...);
-  }
-  template <class... Args>
-  void make_handle(bool single_precision, Args &&...args) {
-    if (single_precision) {
-      make_handle_impl<float, Args...>(std::forward<Args>(args)...);
-    } else {
-      make_handle_impl<double, Args...>(std::forward<Args>(args)...);
-    }
   }
 };
 

--- a/src/script_interface/electrostatics/CoulombP3M.hpp
+++ b/src/script_interface/electrostatics/CoulombP3M.hpp
@@ -44,7 +44,6 @@ class CoulombP3M : public Actor<CoulombP3M<Architecture>, ::CoulombP3M> {
   int m_tune_timings;
   bool m_tune;
   bool m_tune_verbose;
-  bool m_check_complex_residuals;
   bool m_single_precision;
   std::pair<std::optional<int>, std::optional<int>> m_tune_limits;
 
@@ -99,8 +98,6 @@ public:
            return retval;
          }},
         {"tune", AutoParameter::read_only, [this]() { return m_tune; }},
-        {"check_complex_residuals", AutoParameter::read_only,
-         [this]() { return m_check_complex_residuals; }},
     });
   }
 
@@ -142,8 +139,6 @@ public:
         }
       });
     }
-    m_check_complex_residuals =
-        get_value<bool>(params, "check_complex_residuals");
     auto const single_precision = get_value<bool>(params, "single_precision");
     context()->parallel_try_catch([&]() {
       if (Architecture == Arch::GPU and not single_precision) {
@@ -160,7 +155,7 @@ public:
                                get_value<double>(params, "accuracy")};
       make_handle(single_precision, std::move(p3m),
                   get_value<double>(params, "prefactor"), m_tune_timings,
-                  m_tune_verbose, m_tune_limits, m_check_complex_residuals);
+                  m_tune_verbose, m_tune_limits);
     });
     set_charge_neutrality_tolerance(params);
   }

--- a/src/script_interface/electrostatics/ElectrostaticLayerCorrection.hpp
+++ b/src/script_interface/electrostatics/ElectrostaticLayerCorrection.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_P3M
 
@@ -44,7 +44,7 @@ class ElectrostaticLayerCorrection
 
   using BaseSolver = std::variant<
 #ifdef ESPRESSO_CUDA
-      std::shared_ptr<CoulombP3M<Arch::GPU>>,
+      std::shared_ptr<CoulombP3M<Arch::CUDA>>,
 #endif // ESPRESSO_CUDA
       std::shared_ptr<CoulombP3M<Arch::CPU>>>;
   BaseSolver m_solver;
@@ -86,7 +86,7 @@ public:
     auto so_ptr = get_value<ObjectRef>(params, "actor");
     context()->parallel_try_catch([&]() {
 #ifdef ESPRESSO_CUDA
-      if (auto so = std::dynamic_pointer_cast<CoulombP3M<Arch::GPU>>(so_ptr)) {
+      if (auto so = std::dynamic_pointer_cast<CoulombP3M<Arch::CUDA>>(so_ptr)) {
         solver = so->actor();
         m_solver = so;
         return;

--- a/src/script_interface/electrostatics/initialize.cpp
+++ b/src/script_interface/electrostatics/initialize.cpp
@@ -19,7 +19,7 @@
 
 #include "initialize.hpp"
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_ELECTROSTATICS
 
@@ -51,7 +51,7 @@ void initialize(Utils::Factory<ObjectHandle> *om) {
 #ifdef ESPRESSO_P3M
   om->register_new<CoulombP3M<Arch::CPU>>("Coulomb::CoulombP3M");
 #ifdef ESPRESSO_CUDA
-  om->register_new<CoulombP3M<Arch::GPU>>("Coulomb::CoulombP3MGPU");
+  om->register_new<CoulombP3M<Arch::CUDA>>("Coulomb::CoulombP3MGPU");
 #endif
   om->register_new<ElectrostaticLayerCorrection>(
       "Coulomb::ElectrostaticLayerCorrection");

--- a/src/script_interface/magnetostatics/DipolarP3M.hpp
+++ b/src/script_interface/magnetostatics/DipolarP3M.hpp
@@ -19,16 +19,13 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_DP3M
 
 #include "Actor.hpp"
 
 #include "core/magnetostatics/dp3m.hpp"
-#include "core/magnetostatics/dp3m.impl.hpp"
-#include "core/p3m/FFTBackendLegacy.hpp"
-#include "core/p3m/FFTBuffersLegacy.hpp"
 
 #include "script_interface/get_value.hpp"
 
@@ -47,10 +44,8 @@ namespace Dipoles {
 
 template <Arch Architecture>
 class DipolarP3M : public Actor<DipolarP3M<Architecture>, ::DipolarP3M> {
-  int m_tune_timings;
-  std::pair<std::optional<int>, std::optional<int>> m_tune_limits;
+  TuningParameters m_tuning;
   bool m_tune;
-  bool m_tune_verbose;
 
 public:
   using Base = Actor<DipolarP3M<Architecture>, ::DipolarP3M>;
@@ -89,12 +84,12 @@ public:
         {"is_tuned", AutoParameter::read_only,
          [this]() { return actor()->is_tuned(); }},
         {"verbose", AutoParameter::read_only,
-         [this]() { return m_tune_verbose; }},
+         [this]() { return m_tuning.verbose; }},
         {"timings", AutoParameter::read_only,
-         [this]() { return m_tune_timings; }},
+         [this]() { return m_tuning.timings; }},
         {"tune_limits", AutoParameter::read_only,
          [this]() {
-           auto const &[range_min, range_max] = m_tune_limits;
+           auto const &[range_min, range_max] = m_tuning.limits;
            std::vector<Variant> retval = {
                range_min ? Variant{*range_min} : Variant{None{}},
                range_max ? Variant{*range_max} : Variant{None{}},
@@ -107,9 +102,9 @@ public:
 
   void do_construct(VariantMap const &params) override {
     m_tune = get_value<bool>(params, "tune");
-    m_tune_timings = get_value<int>(params, "timings");
-    m_tune_verbose = get_value<bool>(params, "verbose");
-    m_tune_limits = {std::nullopt, std::nullopt};
+    m_tuning.timings = get_value<int>(params, "timings");
+    m_tuning.verbose = get_value<bool>(params, "verbose");
+    m_tuning.limits = {std::nullopt, std::nullopt};
     if (params.contains("tune_limits")) {
       auto const &variant = params.at("tune_limits");
       std::size_t range_length = 0u;
@@ -117,17 +112,17 @@ public:
         auto const range = get_value<std::vector<int>>(variant);
         range_length = range.size();
         if (range_length == 2u) {
-          m_tune_limits = {range[0u], range[1u]};
+          m_tuning.limits = {range[0u], range[1u]};
         }
       } else {
         auto const range = get_value<std::vector<Variant>>(variant);
         range_length = range.size();
         if (range_length == 2u) {
           if (not is_none(range[0u])) {
-            m_tune_limits.first = get_value<int>(range[0u]);
+            m_tuning.limits.first = get_value<int>(range[0u]);
           }
           if (not is_none(range[1u])) {
-            m_tune_limits.second = get_value<int>(range[1u]);
+            m_tuning.limits.second = get_value<int>(range[1u]);
           }
         }
       }
@@ -135,10 +130,10 @@ public:
         if (range_length != 2u) {
           throw std::invalid_argument("Parameter 'tune_limits' needs 2 values");
         }
-        if (m_tune_limits.first and *m_tune_limits.first <= 0) {
+        if (m_tuning.limits.first and *m_tuning.limits.first <= 0) {
           throw std::domain_error("Parameter 'tune_limits' must be > 0");
         }
-        if (m_tune_limits.second and *m_tune_limits.second <= 0) {
+        if (m_tuning.limits.second and *m_tuning.limits.second <= 0) {
           throw std::domain_error("Parameter 'tune_limits' must be > 0");
         }
       });
@@ -154,25 +149,10 @@ public:
                                get_value<int>(params, "cao"),
                                get_value<double>(params, "alpha"),
                                get_value<double>(params, "accuracy")};
-      make_handle(single_precision, std::move(p3m),
-                  get_value<double>(params, "prefactor"), m_tune_timings,
-                  m_tune_verbose, m_tune_limits);
+      m_actor = new_dipolar_p3m(std::move(p3m), m_tuning,
+                                get_value<double>(params, "prefactor"),
+                                single_precision, Architecture);
     });
-  }
-
-private:
-  template <typename FloatType, class... Args>
-  void make_handle_impl(Args &&...args) {
-    m_actor = new_dp3m_handle<FloatType, Architecture, FFTBackendLegacy,
-                              FFTBuffersLegacy>(std::forward<Args>(args)...);
-  }
-  template <class... Args>
-  void make_handle(bool single_precision, Args &&...args) {
-    if (single_precision) {
-      make_handle_impl<float, Args...>(std::forward<Args>(args)...);
-    } else {
-      make_handle_impl<double, Args...>(std::forward<Args>(args)...);
-    }
   }
 };
 

--- a/testsuite/python/coulomb_cloud_wall.py
+++ b/testsuite/python/coulomb_cloud_wall.py
@@ -83,8 +83,7 @@ class CoulombCloudWall(ut.TestCase):
     @utx.skipIfMissingFeatures(["P3M"])
     def test_p3m_cpu_single_precision(self):
         self.system.electrostatics.solver = espressomd.electrostatics.P3M(
-            **self.p3m_params, prefactor=3., tune=False, single_precision=True,
-            check_complex_residuals=False)
+            **self.p3m_params, prefactor=3., tune=False, single_precision=True)
         self.system.integrator.run(0)
         self.compare("p3m", prefactor=3., force_tol=2e-3, energy_tol=1e-3)
 

--- a/testsuite/python/coulomb_interface.py
+++ b/testsuite/python/coulomb_interface.py
@@ -59,8 +59,7 @@ class Test(ut.TestCase):
             system.electrostatics, espressomd.electrostatics.P3M,
             dict(prefactor=2., epsilon=0., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,
                  cao=2, mesh=[8, 10, 8], alpha=12., accuracy=0.01, tune=False,
-                 check_neutrality=True, charge_neutrality_tolerance=7e-12,
-                 check_complex_residuals=False))
+                 check_neutrality=True, charge_neutrality_tolerance=7e-12))
         test_p3m_cpu_non_metallic = tests_common.generate_test_for_actor_class(
             system.electrostatics, espressomd.electrostatics.P3M,
             dict(prefactor=2., epsilon=3., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,
@@ -79,8 +78,7 @@ class Test(ut.TestCase):
             system.electrostatics, espressomd.electrostatics.P3MGPU,
             dict(prefactor=2., epsilon=0., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,
                  cao=2, mesh=[8, 10, 8], alpha=12., accuracy=0.01, tune=False,
-                 check_neutrality=True, charge_neutrality_tolerance=7e-12,
-                 check_complex_residuals=False))
+                 check_neutrality=True, charge_neutrality_tolerance=7e-12))
         test_p3m_gpu_non_metallic = tests_common.generate_test_for_actor_class(
             system.electrostatics, espressomd.electrostatics.P3MGPU,
             dict(prefactor=2., epsilon=3., mesh_off=[0.6, 0.7, 0.8], r_cut=1.5,

--- a/testsuite/python/icc_interface.py
+++ b/testsuite/python/icc_interface.py
@@ -143,8 +143,7 @@ class Test(ut.TestCase):
     def test_exceptions_large_r_cut(self):
         icc, (_, p) = self.setup_icc_particles_and_solver(
             max_iterations=1, convergence=10.)
-        p3m = espressomd.electrostatics.P3M(
-            check_complex_residuals=False, **self.valid_p3m_parameters())
+        p3m = espressomd.electrostatics.P3M(**self.valid_p3m_parameters())
 
         self.system.electrostatics.solver = p3m
         self.system.electrostatics.extension = icc

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -153,7 +153,6 @@ if espressomd.has_features('P3M') and ('P3M' in modes or 'ELC' in modes):
         cao=1,
         alpha=1.0,
         r_cut=1.0,
-        check_complex_residuals=False,
         timings=15,
         tune_limits=[8, 12],
         tune=False)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -889,7 +889,6 @@ class CheckpointTest(ut.TestCase):
                      'timings': 15, 'check_neutrality': True,
                      'tune_limits': [8, 12],
                      'single_precision': single_precision,
-                     'check_complex_residuals': False,
                      'charge_neutrality_tolerance': 1e-12}
         for key in reference:
             self.assertIn(key, state)
@@ -907,7 +906,6 @@ class CheckpointTest(ut.TestCase):
                          'cao': 1, 'alpha': 1.0, 'r_cut': 1.0, 'tune': False,
                          'timings': 15, 'check_neutrality': True,
                          'tune_limits': [8, 12],
-                         'check_complex_residuals': False,
                          'charge_neutrality_tolerance': 7e-12}
         elc_reference = {'gap_size': 6.0, 'maxPWerror': 0.1,
                          'delta_mid_top': 0.9, 'delta_mid_bot': 0.1,


### PR DESCRIPTION
Roll out Kokkos algorithms in the P3M code. Prepare P3M code for real-to-complex FFT refactoring.

API change: optional P3M argument `check_complex_residuals` was removed.