### PR TITLE
Tie thermal Stoner-Wohlfarth to Langevin

### DIFF
--- a/doc/sphinx/magnetodynamics.rst
+++ b/doc/sphinx/magnetodynamics.rst
@@ -122,6 +122,7 @@ to use the ``Propagation.ROT_VS_INDEPENDENT`` propagation mode.
 
     system = espressomd.System(box_l=[10.0, 10.0, 10.0])
     system.time_step = 0.001  # MD time step in simulation units
+    system.thermostat.set_langevin(kT=1., gamma=75., gamma_rotation=25., seed=42)
 
     # One particle with thermal Stoner-Wohlfarth enabled
     p1 = system.part.add(pos=[1, 1, 1])

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -267,11 +267,11 @@ void System::System::integrator_sanity_checks() const {
 #endif // ESPRESSO_ROTATION
 
 #ifdef ESPRESSO_THERMAL_STONER_WOHLFARTH
-  if (thermo_switch == THERMO_OFF) {
+  if ((thermo_switch & THERMO_LANGEVIN) == 0) {
     for (auto const &p : cell_structure->local_particles()) {
       if (p.stoner_wohlfarth_is_enabled()) {
-        runtimeErrorMsg()
-            << "The thermal Stoner-Wohlfarth model requires a thermostat";
+        runtimeErrorMsg() << "The thermal Stoner-Wohlfarth model requires the "
+                             "Langevin thermostat";
         break;
       }
     }

--- a/src/core/magnetostatics/stoner_wohlfarth_thermal.cpp
+++ b/src/core/magnetostatics/stoner_wohlfarth_thermal.cpp
@@ -174,12 +174,11 @@ static auto get_external_field() {
  * @param kT Thermal energy from thermostat.
  * @param noise Uniform random number in (0,1) used for the kinetic MC step.
  */
-static void stoner_wohlfarth_no_field(Particle &p, Utils::Vector3d const &e_k,
-                                      double const kT, double const noise) {
-
+void stoner_wohlfarth_no_field(Particle &p, Utils::Vector3d const &e_k,
+                               double const kT, double const noise) {
   auto constexpr pi = std::numbers::pi_v<double>;
   auto const ani_param = p.magnetic_anisotropy_energy() / kT;
-  auto const tau_inv = p.stoner_wohlfarth_tau0_inv() * exp(-ani_param);
+  auto const tau_inv = p.stoner_wohlfarth_tau0_inv() * std::exp(-ani_param);
   auto const p12 = 1. - std::exp(-p.stoner_wohlfarth_dt_incr() * tau_inv);
   auto const kernel = [&](bool flip) {
     auto const sat_mag = (flip ? -1. : +1.) * p.saturation_magnetization();
@@ -270,13 +269,13 @@ void run_magnetodynamics(CellStructure &cell_structure,
     if (not p_ref) {
       return;
     }
-    assert(thermostat.thermo_switch != THERMO_OFF);
+    assert(thermostat.thermo_switch & THERMO_LANGEVIN);
+    auto const &langevin = *thermostat.langevin;
     auto const e_k = p_ref->calc_director();
     auto const ext_fld_dpl = ext_fld + p.dip_fld();
     auto const random_ints =
         Random::philox_4_uint64s<RNGSalt::THERMAL_STONER_WOHLFARTH>(
-            thermostat.get_philox_counter(), thermostat.get_philox_seed(),
-            p.id());
+            langevin.rng_counter(), langevin.rng_seed(), p.id());
     auto const noise = Utils::uniform(random_ints[0]);
     if (ext_fld_dpl.norm2() == 0.) {
       stoner_wohlfarth_no_field(p, e_k, kT, noise);

--- a/src/core/thermostat.cpp
+++ b/src/core/thermostat.cpp
@@ -87,62 +87,6 @@ void Thermostat::Thermostat::philox_counter_increment() {
   }
 }
 
-uint64_t Thermostat::Thermostat::get_philox_counter() const {
-  if (thermo_switch & THERMO_LANGEVIN) {
-    return langevin->rng_counter();
-  }
-  if (thermo_switch & THERMO_BROWNIAN) {
-    return brownian->rng_counter();
-  }
-#ifdef ESPRESSO_NPT
-  if (thermo_switch & THERMO_NPT_ISO) {
-    return npt_iso->rng_counter();
-  }
-#endif
-#ifdef ESPRESSO_DPD
-  if (thermo_switch & THERMO_DPD) {
-    return dpd->rng_counter();
-  }
-#endif
-#ifdef ESPRESSO_STOKESIAN_DYNAMICS
-  if (thermo_switch & THERMO_SD) {
-    return stokesian->rng_counter();
-  }
-#endif
-  if (thermo_switch & THERMO_BOND) {
-    return thermalized_bond->rng_counter();
-  }
-  return 0;
-}
-
-uint32_t Thermostat::Thermostat::get_philox_seed() const {
-  if (thermo_switch & THERMO_LANGEVIN) {
-    return langevin->rng_seed();
-  }
-  if (thermo_switch & THERMO_BROWNIAN) {
-    return brownian->rng_seed();
-  }
-#ifdef ESPRESSO_NPT
-  if (thermo_switch & THERMO_NPT_ISO) {
-    return npt_iso->rng_seed();
-  }
-#endif
-#ifdef ESPRESSO_DPD
-  if (thermo_switch & THERMO_DPD) {
-    return dpd->rng_seed();
-  }
-#endif
-#ifdef ESPRESSO_STOKESIAN_DYNAMICS
-  if (thermo_switch & THERMO_SD) {
-    return stokesian->rng_seed();
-  }
-#endif
-  if (thermo_switch & THERMO_BOND) {
-    return thermalized_bond->rng_seed();
-  }
-  return 0;
-}
-
 void Thermostat::Thermostat::lb_coupling_deactivate() {
   if (lb) {
     if (get_system().lb.is_solver_set() and ::comm_cart.rank() == 0 and

--- a/src/core/thermostat.hpp
+++ b/src/core/thermostat.hpp
@@ -371,7 +371,7 @@ struct DPDThermostat : public BaseThermostat {};
 #ifdef ESPRESSO_STOKESIAN_DYNAMICS
 /** Thermostat for Stokesian dynamics. */
 struct StokesianThermostat : public BaseThermostat {
-  StokesianThermostat() { rng_initialize(0); }
+  StokesianThermostat() { rng_initialize(uint32_t{0u}); }
 };
 #endif
 
@@ -399,11 +399,6 @@ public:
   /** Increment RNG counters */
   void philox_counter_increment();
 
-  /** Get RNG counter */
-  uint64_t get_philox_counter() const;
-
-  /** Get RNG seed */
-  uint32_t get_philox_seed() const;
   /** Initialize constants of all thermostats. */
   void recalc_prefactors(double time_step);
 

--- a/src/core/unit_tests/rotation_test.cpp
+++ b/src/core/unit_tests/rotation_test.cpp
@@ -17,10 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_MODULE rotation test
+#define BOOST_TEST_MODULE "Particle rotation test"
 #define BOOST_TEST_DYN_LINK
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_ROTATION
 
@@ -251,6 +251,65 @@ BOOST_AUTO_TEST_CASE(convert_dip_to_quat_test) {
   }
 }
 #endif // ESPRESSO_DIPOLES
+
+#ifdef ESPRESSO_THERMAL_STONER_WOHLFARTH
+// prototype of the function to test
+void stoner_wohlfarth_no_field(Particle &p, Utils::Vector3d const &e_k,
+                               double kT, double noise);
+
+static void prepare_tsw_flip(Particle &p, double phi0) {
+  p.dipm() = 0.5;
+  p.quat() = {1., 2., 3., 4.};
+  p.stoner_wohlfarth_phi_0() = phi0;
+}
+
+static void check_tsw_flip(auto const &p, auto const &quat, double dipm) {
+  for (unsigned int i : {0u, 1u, 2u, 3u}) {
+    BOOST_CHECK_CLOSE(p.quat()[i], quat[i], tol);
+  }
+  BOOST_CHECK_CLOSE(p.dipm(), dipm, tol);
+}
+
+BOOST_AUTO_TEST_CASE(stoner_wohlfarth_no_field_test) {
+  using Utils::convert_director_to_quaternion;
+  auto const kT = 1.;
+  auto const sat_mag = 0.65;
+  auto const e_k = Utils::Vector3d{{1., 2., 3.}};
+  auto const quat_ref_up = convert_director_to_quaternion(sat_mag * e_k);
+  auto const quat_ref_down = convert_director_to_quaternion(-sat_mag * e_k);
+  auto const dipm_ref = (sat_mag * e_k).norm();
+  auto p = Particle();
+  p.magnetic_anisotropy_energy() = 1.;
+  p.stoner_wohlfarth_tau0_inv() = 1.;
+  p.stoner_wohlfarth_dt_incr() = 1.;
+  p.saturation_magnetization() = sat_mag;
+  for (auto phi0 : {0., 0.01, -0.01}) {
+    {
+      prepare_tsw_flip(p, phi0);
+      stoner_wohlfarth_no_field(p, e_k, kT, 0.);
+      check_tsw_flip(p, quat_ref_down, dipm_ref);
+    }
+    {
+      prepare_tsw_flip(p, phi0);
+      stoner_wohlfarth_no_field(p, e_k, kT, 1.);
+      check_tsw_flip(p, quat_ref_up, dipm_ref);
+    }
+  }
+  for (auto phi0 : {std::numbers::pi_v<double>, 3.1, 3.2}) {
+    {
+      prepare_tsw_flip(p, phi0);
+      stoner_wohlfarth_no_field(p, e_k, kT, 0.);
+      check_tsw_flip(p, quat_ref_up, dipm_ref);
+    }
+    {
+      prepare_tsw_flip(p, phi0);
+      stoner_wohlfarth_no_field(p, e_k, kT, 1.);
+      check_tsw_flip(p, quat_ref_down, dipm_ref);
+    }
+  }
+}
+#endif // ESPRESSO_THERMAL_STONER_WOHLFARTH
+
 #else  // ESPRESSO_ROTATION
 int main(int argc, char **argv) {}
 #endif // ESPRESSO_ROTATION

--- a/src/script_interface/thermostat/thermostat.hpp
+++ b/src/script_interface/thermostat/thermostat.hpp
@@ -706,9 +706,6 @@ public:
       get_system().on_temperature_change();
       return {};
     }
-    if (name == "is_off") {
-      return m_handle->thermo_switch == THERMO_OFF;
-    }
     return {};
   }
 

--- a/testsuite/python/integrator_exceptions.py
+++ b/testsuite/python/integrator_exceptions.py
@@ -86,7 +86,7 @@ class Test(ut.TestCase):
             p1.vs_auto_relate_to(p0)
             p1.propagation = Propagation.TRANS_VS_RELATIVE | Propagation.ROT_VS_INDEPENDENT
             magnetodynamics = p1.magnetodynamics
-            with self.assertRaisesRegex(Exception, "The thermal Stoner-Wohlfarth model requires a thermostat"):
+            with self.assertRaisesRegex(Exception, "The thermal Stoner-Wohlfarth model requires the Langevin thermostat"):
                 magnetodynamics["is_enabled"] = True
                 p1.magnetodynamics = magnetodynamics
                 self.system.integrator.run(0, recalc_forces=True)

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -316,7 +316,7 @@ break_spec = espressomd.bond_breakage.BreakageSpec(
 system.bond_breakage[strong_harmonic_bond._bond_id] = break_spec
 
 # create Stoner-Wohlfarth particles
-if not system.thermostat.call_method("is_off") and espressomd.has_features(
+if 'THERM.LANGEVIN' in modes and espressomd.has_features(
         ['THERMAL_STONER_WOHLFARTH', 'EXTERNAL_FORCES']):
     magnetodynamics_params = {
         "is_enabled": True, "anisotropy_field_inv": 0.175,

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -62,7 +62,6 @@ class CheckpointTest(ut.TestCase):
     checkpoint.load(0)
     checkpoint.save(1)
     n_nodes = system.cell_system.get_state()["n_nodes"]
-    has_any_thermostat = not system.thermostat.call_method("is_off")
 
     @classmethod
     def setUpClass(cls):
@@ -794,7 +793,7 @@ class CheckpointTest(ut.TestCase):
             np.copy(p_real.vs_relative[2]), [1., 0., 0., 0.], atol=1e-10)
 
     @utx.skipIfMissingFeatures(['THERMAL_STONER_WOHLFARTH', 'EXTERNAL_FORCES'])
-    @ut.skipIf(not has_any_thermostat, 'no thermostat available')
+    @ut.skipIf('THERM.LANGEVIN' not in modes, 'missing a suitable thermostat')
     def test_thermal_stoner_wohlfarth_virtual_sites(self):
         p_real, p_virt = system.part.by_ids([11, 12])
         self.assertEqual(p_virt.magnetodynamics["is_enabled"],


### PR DESCRIPTION
Description of changes:
- thermal Stoner-Wohlfarth now requires the Langevin thermostat
- improve code coverage of thermal Stoner-Wohlfarth