### PR TITLE
Bump dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,10 @@ if(ESPRESSO_BUILD_WITH_CCACHE)
   endif()
 endif()
 
+set(ESPRESSO_NUMPY_SITEARCH ""
+    CACHE FILEPATH
+          "NumPy's third-party platform dependent installation directory")
+
 # Write compile commands to file, for various tools...
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -317,6 +321,24 @@ if(ESPRESSO_BUILD_WITH_PYTHON)
     message(WARNING "We strongly recommend using Cython 3.0.8 or later")
   endif()
   find_program(IPYTHON_EXECUTABLE NAMES jupyter ipython3 ipython)
+  if(NOT DEFINED CACHE{ESPRESSO_NUMPY_SITEARCH}
+     OR "$CACHE{ESPRESSO_NUMPY_SITEARCH}" STREQUAL "")
+    block(SCOPE_FOR VARIABLES PROPAGATE ESPRESSO_NUMPY_SITEARCH)
+    execute_process(
+      COMMAND ${Python_EXECUTABLE} -c "import numpy;print(numpy.__file__)"
+      OUTPUT_VARIABLE numpy_init_path ERROR_VARIABLE numpy_init_error
+      RESULT_VARIABLE numpy_init_result)
+    if(NOT ${numpy_init_result} EQUAL 0)
+      message(FATAL_ERROR "Cannot import numpy:\n${numpy_init_error}")
+    endif()
+    cmake_path(GET numpy_init_path PARENT_PATH numpy_path)
+    cmake_path(GET numpy_path PARENT_PATH numpy_sitearch)
+    set(ESPRESSO_NUMPY_SITEARCH "${numpy_sitearch}"
+        CACHE FILEPATH
+              "NumPy's third-party platform dependent installation directory"
+              FORCE)
+    endblock()
+  endif()
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,20 @@ set(CMAKE_CXX_FLAGS_RELWITHASSERT "${CMAKE_CXX_FLAGS_RELWITHASSERT} -O3 -g")
 set(ESPRESSO_BUILD_SHARED_LIBS_DEFAULT OFF)
 set(BUILD_SHARED_LIBS ${ESPRESSO_BUILD_SHARED_LIBS_DEFAULT})
 
+# shared objects require position-independent code in static libraries
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # On Mac OS X, first look for other packages, then frameworks
 set(CMAKE_FIND_FRAMEWORK LAST)
 
 # avoid applying patches twice with FetchContent
 set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+
+# customize default options based on basic information
+set(ESPRESSO_BUILD_WITH_WALBERLA_AVX_DEFAULT OFF)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "[xX]86")
+  set(ESPRESSO_BUILD_WITH_WALBERLA_AVX_DEFAULT ON)
+endif()
 
 # ##############################################################################
 # User input options
@@ -91,10 +100,10 @@ option(ESPRESSO_BUILD_WITH_SCAFACOS "Build with ScaFaCoS support" OFF)
 option(ESPRESSO_BUILD_WITH_STOKESIAN_DYNAMICS "Build with Stokesian Dynamics"
        OFF)
 option(ESPRESSO_BUILD_WITH_NLOPT "Build with NLopt support" OFF)
-option(ESPRESSO_BUILD_WITH_WALBERLA
-       "Build with waLBerla lattice-Boltzmann support" OFF)
+option(ESPRESSO_BUILD_WITH_WALBERLA "Build with waLBerla support" ON)
 option(ESPRESSO_BUILD_WITH_WALBERLA_AVX
-       "Build waLBerla lattice-Boltzmann with AVX vectorization" OFF)
+       "Build waLBerla kernels with AVX2 vectorization"
+       ${ESPRESSO_BUILD_WITH_WALBERLA_AVX_DEFAULT})
 option(ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM
        "Build with shared memory parallelism support" OFF)
 option(ESPRESSO_BUILD_BENCHMARKS "Enable benchmarks" OFF)
@@ -883,7 +892,7 @@ if(ESPRESSO_BUILD_WITH_WALBERLA)
   FetchContent_Declare(
     walberla
     GIT_REPOSITORY https://i10git.cs.fau.de/walberla/walberla.git
-    GIT_TAG        fc081850 # v7.2 with patches
+    GIT_TAG        007e77e0 # v7.2 with patches
   )
   # cmake-format: on
   string(REGEX REPLACE "([/\\]walberla)-src$" "\\1-build" walberla_BINARY_DIR
@@ -910,8 +919,7 @@ if(ESPRESSO_BUILD_WITH_WALBERLA)
     set(WALBERLA_BUILD_WITH_OPENMP on CACHE BOOL "")
   endif()
   set(WALBERLA_BUILD_WITH_FASTMATH off CACHE BOOL "")
-  set(BUILD_SHARED_LIBS ON)
-  set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
+  set(BUILD_SHARED_LIBS OFF)
   FetchContent_MakeAvailable(walberla)
   set(BUILD_SHARED_LIBS ${ESPRESSO_BUILD_SHARED_LIBS_DEFAULT})
   set(CMAKE_SHARED_LIBRARY_PREFIX "${ESPRESSO_SHARED_LIBRARY_PREFIX}")
@@ -924,18 +932,6 @@ if(ESPRESSO_BUILD_WITH_WALBERLA)
   if(WALBERLA_BUILD_WITH_CUDA)
     list(APPEND WALBERLA_LIBS walberla::gpu)
   endif()
-  set(WALBERLA_LIBS_EXPORT
-      ${WALBERLA_LIBS} lodepng walberla::boundary walberla::executiontree
-      walberla::geometry walberla::lbm walberla::timeloop)
-  # install all waLBerla shared objects
-  foreach(target_alias IN LISTS WALBERLA_LIBS_EXPORT)
-    string(REPLACE "::" "_" target_name ${target_alias})
-    get_target_property(target_type ${target_name} TYPE)
-    if(${target_type} STREQUAL "SHARED_LIBRARY")
-      install(TARGETS ${target_name}
-              LIBRARY DESTINATION "${ESPRESSO_INSTALL_LIBDIR}")
-    endif()
-  endforeach()
   if(ESPRESSO_BUILD_WITH_WALBERLA_AVX)
     function(espresso_avx_flags_callback COMPILER_AVX2_FLAG)
       target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,9 @@ if(ESPRESSO_BUILD_WITH_PYTHON)
   find_program(IPYTHON_EXECUTABLE NAMES jupyter ipython3 ipython)
   if(NOT DEFINED CACHE{ESPRESSO_NUMPY_SITEARCH}
      OR "$CACHE{ESPRESSO_NUMPY_SITEARCH}" STREQUAL "")
+    # NumPy isn't necessarily installed in Python_SITEARCH. EasyBuild packages
+    # NumPy within SciPy-bundle, for example. Cython needs to include NumPy's
+    # parent directory to properly detect file numpy/__init__.pxd.
     block(SCOPE_FOR VARIABLES PROPAGATE ESPRESSO_NUMPY_SITEARCH)
     execute_process(
       COMMAND ${Python_EXECUTABLE} -c "import numpy;print(numpy.__file__)"

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -26,7 +26,7 @@ sys.path.insert(0, '@CMAKE_BINARY_DIR@/src/python')
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '3.5'
+needs_sphinx = '7.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -677,7 +677,8 @@ or (at your option) any later version (:spdx:`GPL-3.0-or-later`).
 
 |es| contains code that is not provided under the GNU GPLv3, but is governed
 by other open source license terms which are compatible with the GNU GPLv3,
-including, but not limited to, Apache License 2.0 (:spdx:`Apache-2.0`)
+including, but not limited to, Apache License 2.0 (:spdx:`Apache-2.0`),
+Revised BSD License (:spdx:`BSD-3-Clause`),
 and FSF All Permissive License (:spdx:`FSFAP`).
 Such third party codes feature a header containing the license
 (or a link to its full text) and a list of the copyright holders.

--- a/maintainer/walberla_kernels/Readme.md
+++ b/maintainer/walberla_kernels/Readme.md
@@ -18,8 +18,8 @@ source codegen/bin/activate
 python3 -m pip install -c "$(git rev-parse --show-toplevel)/requirements.txt" \
     numpy cython sympy islpy jinja2 setuptools packaging
 python3 -m pip install \
-  git+https://i10git.cs.fau.de/jngrad/lbmpy.git@5018a189398551b44644cf91b3f2c33ded8e348d \
-  git+https://i10git.cs.fau.de/jngrad/pystencils.git@dfd203a3f6318f5fb4cfa09f9f8c12bb45463bd7
+  git+https://i10git.cs.fau.de/pycodegen/lbmpy.git@e9efe343e42858f11c8844795326efa4f00681df \
+  git+https://i10git.cs.fau.de/jngrad/pystencils.git@e851f4e322d0c7771802169e7afac83b7f7da868
 deactivate
 ```
 

--- a/maintainer/walberla_kernels/custom_additional_extensions.py
+++ b/maintainer/walberla_kernels/custom_additional_extensions.py
@@ -271,6 +271,7 @@ def generate_boundary(
         field_name="",
         layout='fzyx',
         template_file="templates/Boundary_ek_reactions.tmpl.h",
+        context_params=None,
         **create_kernel_params,
 ):
     struct_name = "IndexInfo"
@@ -313,6 +314,10 @@ def generate_boundary(
         strides=(1, 1),
     )
 
+    if context_params is None:
+        context_params = {}
+    bc_force = hasattr(
+        boundary_object, "calculate_force_on_boundary") and boundary_object.calculate_force_on_boundary
     if assignment:
         kernel_config = ps.CreateKernelConfig(
             index_fields=[index_field], target=target, **create_kernel_params
@@ -336,8 +341,6 @@ def generate_boundary(
         if not kernel_creation_function:
             kernel_creation_function = create_boundary_kernel
 
-        bc_force = hasattr(
-            boundary_object, "calculate_force_on_boundary") and boundary_object.calculate_force_on_boundary
         if bc_force:
             force_vector_type = np.dtype(
                 [(f"F_{i}", np.float64) for i in range(dim)], align=True)
@@ -376,12 +379,16 @@ def generate_boundary(
         "dim": dim,
         "target": target.name.lower(),
         "namespace": namespace,
-        "inner_or_boundary": boundary_object.inner_or_boundary,
+        "inner_or_boundary": boundary_object.inner_or_boundary if boundary_object is not None else None,
         "single_link": False,
         "calculate_force": bc_force,
         "additional_data_handler": additional_data_handler,
-        'layout': layout,
+        "layout": layout,
+        "parameters_to_ignore": [],
     }
+    context.update(context_params)
+    if "stencil_info" not in context_params and additional_data_handler is not None:
+        context["stencil_info"] = additional_data_handler.stencil_info
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader("pystencils_walberla"), undefined=jinja2.StrictUndefined

--- a/maintainer/walberla_kernels/generate_ek_kernels.py
+++ b/maintainer/walberla_kernels/generate_ek_kernels.py
@@ -45,7 +45,7 @@ parser.add_argument("--kernels", nargs="+", type=str, default="all",
 args = parser.parse_args()
 
 # Make sure we have the correct versions of the required dependencies
-for module, requirement in [(ps, "==1.3.7"), (lbmpy, "==1.3.7")]:
+for module, requirement in [(ps, "==1.4.0"), (lbmpy, "==1.4.0")]:
     assert packaging.specifiers.SpecifierSet(requirement).contains(module.__version__), \
         f"{module.__name__} version {module.__version__} " \
         f"doesn't match requirement {requirement}"
@@ -210,6 +210,13 @@ with code_generation_context.CodeGeneration() as ctx:
 
     data_type = "float64" if ctx.double_accuracy else "float32"
 
+    dirichlet_stencil = lbmpy.stencils.LBStencil(
+        stencil=((0, 0, 0),), theta0=0.)
+    dirichlet = custom_additional_extensions.Dirichlet_Custom(
+        lambda *args: None, data_type=data_type_np)
+    dirichlet_additional_data = custom_additional_extensions.DirichletAdditionalDataHandler(
+        dirichlet_stencil, dirichlet)
+
     if "diffusion" in args.kernels:
         for midfix, fluctuation in (("", False), ("Thermalized", True)):
             cpu_vectorize_info["cpu_prepend_opt_remove_conditionals"] = False
@@ -311,13 +318,7 @@ with code_generation_context.CodeGeneration() as ctx:
                        patch_boundary_kernel, processor_suffix)
 
         # generate dynamic fixed density
-        dirichlet_stencil = lbmpy.stencils.LBStencil(stencil=((0, 0, 0),))
-        dirichlet = custom_additional_extensions.Dirichlet_Custom(
-            lambda *args: None, data_type=data_type_np)
-        dirichlet_additional_data = custom_additional_extensions.DirichletAdditionalDataHandler(
-            dirichlet_stencil, dirichlet)
         class_name = f"Dirichlet_{precision_suffix}{processor_suffix}"
-
         pystencils_walberla.boundary.generate_boundary(
             generation_context=ctx,
             class_name=class_name,
@@ -337,7 +338,6 @@ with code_generation_context.CodeGeneration() as ctx:
 
     if "reactions" in args.kernels:
         # ek reactions
-        dirichlet_stencil = lbmpy.stencils.LBStencil(stencil=((0, 0, 0),))
         for i in range(1, max_num_reactants + 1):
             assignments = list(reaction_obj.generate_reaction(num_reactants=i))
             class_name = f"ReactionKernelBulk_{i}_{precision_suffix}{processor_suffix}"  # nopep8
@@ -352,7 +352,10 @@ with code_generation_context.CodeGeneration() as ctx:
                 generation_context=ctx,
                 stencil=dirichlet_stencil,
                 class_name=class_name,
-                dim=dim,
+                context_params={
+                    "stencil_info": dirichlet_additional_data.stencil_info,
+                    "parameters_to_ignore": ["indexVectorSize", "indexVectorID"],
+                },
                 target=target,
                 assignment=assignments,
                 template_file="templates/Boundary.tmpl.h")

--- a/maintainer/walberla_kernels/generate_lb_kernels.py
+++ b/maintainer/walberla_kernels/generate_lb_kernels.py
@@ -39,7 +39,7 @@ parser.add_argument("--kernels", nargs="+", type=str, default="all",
 args = parser.parse_args()
 
 # Make sure we have the correct versions of the required dependencies
-for module, requirement in [(ps, "==1.3.7"), (lbmpy, "==1.3.7")]:
+for module, requirement in [(ps, "==1.4.0"), (lbmpy, "==1.4.0")]:
     assert packaging.specifiers.SpecifierSet(requirement).contains(module.__version__), \
         f"{module.__name__} version {module.__version__} " \
         f"doesn't match requirement {requirement}"

--- a/maintainer/walberla_kernels/templates/Boundary.tmpl.h
+++ b/maintainer/walberla_kernels/templates/Boundary.tmpl.h
@@ -245,8 +245,8 @@ public:
     {%- endif %}
 
     {{class_name}}( const std::shared_ptr<StructuredBlockForest> & blocks,
-                   {{kernel|generate_constructor_parameters(['indexVector', 'indexVectorSize', 'forceVector', 'forceVectorSize'])}}{{additional_data_handler.constructor_arguments}})
-        : {{additional_data_handler.initialiser_list}} {{ kernel|generate_constructor_initializer_list(['indexVector', 'indexVectorSize', 'forceVector', 'forceVectorSize']) }}
+                   {{kernel|generate_constructor_parameters(['indexVector', 'indexVectorSize', 'forceVector', 'forceVectorSize'])}}{%- if additional_data_handler != None -%}{{additional_data_handler.constructor_arguments}}{%- endif -%})
+        : {%- if additional_data_handler != None -%}{{additional_data_handler.initialiser_list}}{%- endif -%} {{ kernel|generate_constructor_initializer_list(['indexVector', 'indexVectorSize', 'forceVector', 'forceVectorSize']) }}
     {
         auto createIdxVector = []( IBlock * const , StructuredBlockStorage * const ) { return new IndexVectors(); };
         indexVectorID = blocks->addStructuredBlockData< IndexVectors >( createIdxVector, "IndexField_{{class_name}}");
@@ -255,6 +255,14 @@ public:
         forceVectorID = blocks->addStructuredBlockData< ForceVector >( createForceVector, "forceVector_{{class_name}}");
         {%- endif %}
     }
+
+    {% if "ReactionKernelIndexed" in class_name %}
+    {{class_name}}( {{kernel|generate_constructor_parameters(parameters_to_ignore=parameters_to_ignore)}})
+      : {{ kernel|generate_constructor_initializer_list(parameters_to_ignore=parameters_to_ignore) }}
+    {}
+    {%- endif %}
+
+    {{ kernel| generate_destructor(class_name) |indent(3) }}
 
     void run (
         {{- ["IBlock * block", kernel.kernel_selection_parameters, ["gpuStream_t stream = nullptr"] if target == 'gpu' else []] | type_identifier_list -}}
@@ -316,12 +324,12 @@ public:
                             FlagUID boundaryFlagUID, FlagUID domainFlagUID)
     {
         for( auto &block : *blocks )
-            fillFromFlagField<FlagField_T>({{additional_data_handler.additional_arguments_for_fill_function}}&block, flagFieldID, boundaryFlagUID, domainFlagUID );
+            fillFromFlagField<FlagField_T>({%- if additional_data_handler != None -%}{{additional_data_handler.additional_arguments_for_fill_function}}{%- endif -%} &block, flagFieldID, boundaryFlagUID, domainFlagUID );
     }
 
 
     template<typename FlagField_T>
-    void fillFromFlagField({{additional_data_handler.additional_parameters_for_fill_function}}IBlock * block, ConstBlockDataID flagFieldID,
+    void fillFromFlagField({%- if additional_data_handler != None -%}{{additional_data_handler.additional_parameters_for_fill_function}}{%- endif -%} IBlock * block, ConstBlockDataID flagFieldID,
                             FlagUID boundaryFlagUID, FlagUID domainFlagUID )
     {
         auto * indexVectors = block->getData< IndexVectors > ( indexVectorID );
@@ -330,10 +338,10 @@ public:
         auto & indexVectorOuter = indexVectors->indexVector(IndexVectors::OUTER);
         {% if calculate_force -%}
         auto * forceVector = block->getData< ForceVector > ( forceVectorID );
-        {%- endif %}
+        {% endif %}
 
         auto * flagField = block->getData< FlagField_T > ( flagFieldID );
-        {{additional_data_handler.additional_field_data|indent(4)}}
+        {% if additional_data_handler != None -%}{{additional_data_handler.additional_field_data|indent(4)}}{%- endif %}
 
         if( !(flagField->flagExists(boundaryFlagUID) and
               flagField->flagExists(domainFlagUID) ))
@@ -351,7 +359,7 @@ public:
 
         {% if inner_or_boundary -%}
         {% if layout == "fzyx" -%}
-        {%- for dirIdx, dirVec, offset in additional_data_handler.stencil_info %}
+        {%- for dirIdx, dirVec, offset in stencil_info %}
         for( auto it = flagField->beginWithGhostLayerXYZ( cell_idx_c( flagField->nrOfGhostLayers() - 1 ) ); it != flagField->end(); ++it )
         {
            if( ! isFlagSet(it, domainFlag) || isFlagSet(it, boundaryFlag) )
@@ -360,10 +368,12 @@ public:
            if ( isFlagSet( it.neighbor({{offset}} {%if dim == 3%}, 0 {%endif %}), boundaryFlag ) )
            {
               auto element = {{StructName}}(it.x(), it.y(), {%if dim == 3%} it.z(), {%endif %} {{dirIdx}} );
+              {% if additional_data_handler != None -%}
               {{"auto const InitialisationAdditionalData = elementInitialiser(Cell(it.x() + %(x)s, it.y() + %(y)s, it.z() + %(z)s), blocks, *block);" | format(x=dirVec[0], y=dirVec[1], z=dirVec[2]) | replace("+ -", "-")}}
               element.vel_0 = InitialisationAdditionalData[0];
               element.vel_1 = InitialisationAdditionalData[1];
               element.vel_2 = InitialisationAdditionalData[2];
+              {% endif -%}
               indexVectorAll.emplace_back( element );
               if( inner.contains( it.x(), it.y(), it.z() ) )
                  indexVectorInner.emplace_back( element );
@@ -377,14 +387,16 @@ public:
         {
             if( ! isFlagSet(it, domainFlag) || isFlagSet(it, boundaryFlag) )
                 continue;
-            {%- for dirIdx, dirVec, offset in additional_data_handler.stencil_info %}
+            {%- for dirIdx, dirVec, offset in stencil_info %}
             if ( isFlagSet( it.neighbor({{offset}} {%if dim == 3%}, 0 {%endif %}), boundaryFlag ) )
             {
                 auto element = {{StructName}}(it.x(), it.y(), {%if dim == 3%} it.z(), {%endif %} {{dirIdx}} );
+                {% if additional_data_handler != None -%}
                 {{"auto const InitialisationAdditionalData = elementInitialiser(Cell(it.x() + %(x)s, it.y() + %(y)s, it.z() + %(z)s), blocks, *block);" | format(x=dirVec[0], y=dirVec[1], z=dirVec[2]) | replace("+ -", "-")}}
                 element.vel_0 = InitialisationAdditionalData[0];
                 element.vel_1 = InitialisationAdditionalData[1];
                 element.vel_2 = InitialisationAdditionalData[2];
+                {% endif -%}
                 indexVectorAll.emplace_back( element );
                 if( inner.contains( it.x(), it.y(), it.z() ) )
                     indexVectorInner.emplace_back( element );
@@ -409,14 +421,14 @@ public:
             {% endif %}
             if( ! isFlagSet(it, boundaryFlag) )
                 continue;
-            {%- for dirIdx, dirVec, offset in additional_data_handler.stencil_info %}
+            {%- for dirIdx, dirVec, offset in stencil_info %}
             if ( flagWithGLayers.contains(it.x() + cell_idx_c({{dirVec[0]}}), it.y() + cell_idx_c({{dirVec[1]}}), it.z() + cell_idx_c({{dirVec[2]}})) && isFlagSet( it.neighbor({{offset}} {%if dim == 3%}, 0 {%endif %}), domainFlag ) )
             {
                 {% if single_link -%}
                 sum_x += cell_idx_c({{dirVec[0]}}); sum_y += cell_idx_c({{dirVec[1]}}); {%if dim == 3%} sum_z += cell_idx_c({{dirVec[2]}}); {%endif %}
                 {% else %}
                 auto element = {{StructName}}(it.x(), it.y(), {%if dim == 3%} it.z(), {%endif %} {{dirIdx}} );
-                {{additional_data_handler.data_initialisation(dirIdx)|indent(16)}}
+                {% if additional_data_handler != None -%}{{additional_data_handler.data_initialisation(dirIdx)|indent(16)}}{%- endif %}
                 indexVectorAll.emplace_back( element );
                 if( inner.contains( it.x(), it.y(), it.z() ) )
                     indexVectorInner.emplace_back( element );
@@ -430,7 +442,7 @@ public:
             dot = 0.0; maxn = 0.0; calculated_idx = 0;
             if(sum_x != 0 or sum_y !=0 {%if dim == 3%} or sum_z !=0 {%endif %})
             {
-            {%- for dirIdx, dirVec, offset in additional_data_handler.stencil_info %}
+            {%- for dirIdx, dirVec, offset in stencil_info %}
                 dx = {{dirVec[0]}}; dy = {{dirVec[1]}}; {%if dim == 3%} dz = {{dirVec[2]}}; {% endif %}
                 dot = {{dtype}}( dx*sum_x + dy*sum_y {%if dim == 3%} + dz*sum_z {% endif %});
                 if (dot > maxn)
@@ -469,15 +481,17 @@ private:
     {% if calculate_force -%}
     BlockDataID forceVectorID;
     {%- endif %}
-    {{additional_data_handler.additional_member_variable|indent(4)}}
+    {%- if additional_data_handler != None -%}{{additional_data_handler.additional_member_variable|indent(4)}}{%- endif -%}
 
 {% if calculate_force -%}
 public:
+    {%- if additional_data_handler != None %}
     static constexpr std::array<std::array<int, {{additional_data_handler.Q}}u>, {{dim}}u> neighborOffset = { {
         {% for i in range(dim) -%}
             { {{additional_data_handler.neighbor_directions[i][1:-1]}} },
         {%- endfor %}
     } };
+    {%- endif %}
 
     auto const & getForceVector(IBlock const *block) const {
         auto const * forceVector = block->getData<ForceVector>(forceVectorID);

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ vtk>=9.1.0
 PyOpenGL>=3.1.5
 pygame>=2.1.2
 # waLBerla dependencies
-pystencils==1.3.7
-lbmpy==1.3.7
-sympy>=1.12.1
+pystencils==1.4.0
+lbmpy==1.4.0
+sympy==1.12.1
 islpy>=2024
 jinja2>=3.1.2
 # CI-related

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -94,6 +94,7 @@ foreach(cython_file ${cython_SRC})
         --directive embedsignature=True
         --directive binding=True
         --include-dir ${Python_SITEARCH}
+        --include-dir ${ESPRESSO_NUMPY_SITEARCH}
         --include-dir ${CMAKE_CURRENT_SOURCE_DIR}
         --output-file ${outputpath}
         ${cython_file}

--- a/src/python/espressomd/CMakeLists.txt
+++ b/src/python/espressomd/CMakeLists.txt
@@ -86,14 +86,20 @@ foreach(cython_file ${cython_SRC})
   cmake_path(GET relpath PARENT_PATH subfolder)
   cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR ${subfolder} "${basename}.cpp"
              OUTPUT_VARIABLE outputpath)
+  # cmake-format: off
   add_custom_command(
     OUTPUT ${outputpath}
     COMMAND
-      ${CYTHON_EXECUTABLE} -3 --cplus --directive embedsignature=True
-      --directive binding=True -I ${CMAKE_CURRENT_SOURCE_DIR} -I
-      ${CMAKE_CURRENT_BINARY_DIR} ${cython_file} -o ${outputpath}
+      ${CYTHON_EXECUTABLE} -3 --cplus
+        --directive embedsignature=True
+        --directive binding=True
+        --include-dir ${Python_SITEARCH}
+        --include-dir ${CMAKE_CURRENT_SOURCE_DIR}
+        --output-file ${outputpath}
+        ${cython_file}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
     DEPENDS ${cython_file} ${cython_HEADER})
+  # cmake-format: on
   set(target "espressomd_${basename}")
   add_library(${target} SHARED ${outputpath})
   if(NOT "${subfolder}" STREQUAL "")

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/AdvectiveFluxKernel_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/ContinuityKernel_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelThermalized_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_double_precision_CUDA.h
@@ -18,9 +18,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -39,8 +39,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostaticThermalized_single_precision_CUDA.h
@@ -18,9 +18,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -39,8 +39,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernelWithElectrostatic_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/DiffusiveFluxKernel_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "Dirichlet_double_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -135,8 +133,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "Dirichlet_double_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -40,8 +40,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -95,8 +93,12 @@ public:
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -168,8 +170,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "Dirichlet_single_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -135,8 +133,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "Dirichlet_single_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/Dirichlet_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -40,8 +40,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -95,8 +93,12 @@ public:
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -168,8 +170,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_double_precision.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_double_precision_CUDA.cu
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_double_precision_CUDA.cuh
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_double_precision_CUDA.cuh
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_single_precision.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_single_precision_CUDA.cu
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_single_precision_CUDA.cuh
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/EK_FieldAccessors_single_precision_CUDA.cuh
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "FixedFlux_double_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -137,8 +135,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "FixedFlux_double_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -40,8 +40,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -98,8 +96,12 @@ public:
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -170,8 +172,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "FixedFlux_single_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -137,8 +135,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "FixedFlux_single_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FixedFlux_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -40,8 +40,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif
@@ -98,8 +96,12 @@ public:
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -170,8 +172,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(blocks, &*blockIt, flagFieldID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(blocks, &block, flagFieldID,
                                      boundaryFlagUID, domainFlagUID);
   }
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/FrictionCouplingKernel_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/myintrin.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/myintrin.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021, Michael Kuron.
+Copyright 2019-2023, Michael Kuron.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -29,18 +29,22 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// kernel generated with pystencils v1.4, lbmpy v1.4+1.g3fc1c8f.dirty, sympy
+// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
+
 /**
  * @file
  * Philox counter-based RNG utility functions.
  * Adapted from the pystencils source file
- * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/39c214af/pystencils/include/myintrin.h
+ * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/ca4890a67757f066fc310b94b4b17b9f1b497ac2/src/pystencils/include/myintrin.h
  */
 
 #pragma once
 
-#if defined(__SSE2__) || defined(_MSC_VER)
+#if defined(__SSE2__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 QUALIFIERS __m128 _my_cvtepu32_ps(const __m128i v) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm_cvtepu32_ps(v);
 #else
   __m128i v2 = _mm_srli_epi32(v, 1);
@@ -50,29 +54,16 @@ QUALIFIERS __m128 _my_cvtepu32_ps(const __m128i v) {
   return _mm_add_ps(_mm_add_ps(v2f, v2f), v1f);
 #endif
 }
-
-QUALIFIERS void _MY_TRANSPOSE4_EPI32(__m128i &R0, __m128i &R1, __m128i &R2,
-                                     __m128i &R3) {
-  __m128i T0, T1, T2, T3;
-  T0 = _mm_unpacklo_epi32(R0, R1);
-  T1 = _mm_unpacklo_epi32(R2, R3);
-  T2 = _mm_unpackhi_epi32(R0, R1);
-  T3 = _mm_unpackhi_epi32(R2, R3);
-  R0 = _mm_unpacklo_epi64(T0, T1);
-  R1 = _mm_unpackhi_epi64(T0, T1);
-  R2 = _mm_unpacklo_epi64(T2, T3);
-  R3 = _mm_unpackhi_epi64(T2, T3);
-}
 #endif
 
-#if defined(__SSE4_1__) || defined(_MSC_VER)
-#if !defined(__AVX512VL__) && defined(__GNUC__) && __GNUC__ >= 5 &&            \
-    !defined(__clang__)
+#if defined(__SSE4_1__) || (defined(_MSC_VER) && !defined(_M_ARM64))
+#if !defined(__AVX512VL__) && !defined(__AVX10_1__) && defined(__GNUC__) &&    \
+    __GNUC__ >= 5 && !defined(__clang__)
 __attribute__((optimize("no-associative-math")))
 #endif
 QUALIFIERS __m128d
 _my_cvtepu64_pd(const __m128i x) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm_cvtepu64_pd(x);
 #elif defined(__clang__)
   return __builtin_convertvector(
@@ -109,7 +100,7 @@ QUALIFIERS __m256d _my256_set_m128d(__m128d hi, __m128d lo) {
 }
 
 QUALIFIERS __m256 _my256_cvtepu32_ps(const __m256i v) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm256_cvtepu32_ps(v);
 #else
   __m256i v2 = _mm256_srli_epi32(v, 1);
@@ -120,13 +111,13 @@ QUALIFIERS __m256 _my256_cvtepu32_ps(const __m256i v) {
 #endif
 }
 
-#if !defined(__AVX512VL__) && defined(__GNUC__) && __GNUC__ >= 5 &&            \
-    !defined(__clang__)
+#if !defined(__AVX512VL__) && !defined(__AVX10_1__) && defined(__GNUC__) &&    \
+    __GNUC__ >= 5 && !defined(__clang__)
 __attribute__((optimize("no-associative-math")))
 #endif
 QUALIFIERS __m256d
 _my256_cvtepu64_pd(const __m256i x) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm256_cvtepu64_pd(x);
 #elif defined(__clang__)
   return __builtin_convertvector(
@@ -146,7 +137,7 @@ _my256_cvtepu64_pd(const __m256i x) {
 }
 #endif
 
-#ifdef __AVX512F__
+#if defined(__AVX512F__) || defined(__AVX10_512BIT__)
 QUALIFIERS __m512i _my512_set_m128i(__m128i d, __m128i c, __m128i b,
                                     __m128i a) {
   return _mm512_inserti32x4(

--- a/src/walberla_bridge/src/electrokinetics/generated_kernels/philox_rand.h
+++ b/src/walberla_bridge/src/electrokinetics/generated_kernels/philox_rand.h
@@ -1,6 +1,6 @@
 /*
 Copyright 2010-2011, D. E. Shaw Research. All rights reserved.
-Copyright 2019-2021, Michael Kuron.
+Copyright 2019-2024, Michael Kuron.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -30,31 +30,40 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// kernel generated with pystencils v1.4, lbmpy v1.4+1.g3fc1c8f.dirty, sympy
+// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
+
 /**
  * @file
  * Philox counter-based RNG from @cite salmon11a.
  * Adapted from the pystencils source file
- * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/896b4192/pystencils/include/philox_rand.h
+ * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/b4d7ef7cb5b499f3fa55ebfcd598ac7d6e11a3db/src/pystencils/include/philox_rand.h
  */
 
-#include <cstdint>
+#pragma once
 
-#if defined(__SSE2__) || defined(_MSC_VER)
+#if !defined(__OPENCL_VERSION__) && !defined(__HIPCC_RTC__)
+#if defined(__SSE2__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 #include <emmintrin.h> // SSE2
 #endif
 #ifdef __AVX2__
 #include <immintrin.h> // AVX*
-#elif defined(__SSE4_1__) || defined(_MSC_VER)
+#elif defined(__SSE4_1__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 #include <smmintrin.h> // SSE4
 #ifdef __FMA__
 #include <immintrin.h> // FMA
 #endif
 #endif
 
+#if defined(_MSC_VER) && defined(_M_ARM64)
+#define __ARM_NEON
+#endif
+
 #ifdef __ARM_NEON
 #include <arm_neon.h>
 #endif
-#ifdef __ARM_FEATURE_SVE
+#if defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SME)
 #include <arm_sve.h>
 #endif
 
@@ -70,15 +79,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-#if defined(__CUDA_ARCH__) || defined(__clang__) && defined(__CUDA__)
-#if defined(__clang__) && defined(QUALIFIERS)
-#undef QUALIFIERS
+#ifdef __riscv_v
+#include <riscv_vector.h>
 #endif
-#define QUALIFIERS static __forceinline__ __device__
+#endif
+
+#if defined(__ARM_FEATURE_SME) && defined(__ARM_FEATURE_SVE)
+#define SVE_QUALIFIERS __arm_streaming_compatible
+#elif defined(__ARM_FEATURE_SME)
+#define SVE_QUALIFIERS __arm_streaming
 #else
-#if defined(__clang__) && defined(QUALIFIERS)
-#undef QUALIFIERS
+#define SVE_QUALIFIERS
 #endif
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) ||               \
+    defined(__clang__) && defined(__CUDA__)
+#define QUALIFIERS static __forceinline__ __device__
+#elif defined(__OPENCL_VERSION__)
+#define QUALIFIERS static inline
+#else
 #define QUALIFIERS inline
 #include "myintrin.h"
 #endif
@@ -90,8 +109,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TWOPOW53_INV_DOUBLE (1.1102230246251565e-16)
 #define TWOPOW32_INV_FLOAT (2.3283064e-10f)
 
+#ifdef __OPENCL_VERSION__
+#include "opencl_stdint.h"
+typedef uint32_t uint32;
+typedef uint64_t uint64;
+#else
+#ifndef __HIPCC_RTC__
+#include <cstdint>
+#endif
 typedef std::uint32_t uint32;
 typedef std::uint64_t uint64;
+#endif
 
 #if defined(__ARM_FEATURE_SVE) && defined(__ARM_FEATURE_SVE_BITS) &&           \
     __ARM_FEATURE_SVE_BITS > 0
@@ -99,16 +127,20 @@ typedef svfloat32_t svfloat32_st
     __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
 typedef svfloat64_t svfloat64_st
     __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-#elif defined(__ARM_FEATURE_SVE)
+#elif defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SME)
 typedef svfloat32_t svfloat32_st;
 typedef svfloat64_t svfloat64_st;
 #endif
 
 QUALIFIERS uint32 mulhilo32(uint32 a, uint32 b, uint32 *hip) {
-#ifndef __CUDA_ARCH__
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__) &&             \
+    (!defined(__clang__) || !defined(__CUDA__))
   // host code
 #if defined(__powerpc__) && (!defined(__clang__) || defined(__xlC__))
   *hip = __mulhwu(a, b);
+  return a * b;
+#elif defined(__OPENCL_VERSION__)
+  *hip = mul_hi(a, b);
   return a * b;
 #else
   uint64 product = ((uint64)a) * ((uint64)b);
@@ -140,13 +172,18 @@ QUALIFIERS void _philox4x32bumpkey(uint32 *key) {
 }
 
 QUALIFIERS double _uniform_double_hq(uint32 x, uint32 y) {
-  double z = (double)((uint64)x ^ ((uint64)y << (53 - 32)));
+  uint64 z = (uint64)x ^ ((uint64)y << (53 - 32));
   return z * TWOPOW53_INV_DOUBLE + (TWOPOW53_INV_DOUBLE / 2.0);
 }
 
 QUALIFIERS void philox_double2(uint32 ctr0, uint32 ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
-                               double &rnd1, double &rnd2) {
+#ifdef __OPENCL_VERSION__
+                               double *rnd1, double *rnd2)
+#else
+                               double &rnd1, double &rnd2)
+#endif
+{
   uint32 key[2] = {key0, key1};
   uint32 ctr[4] = {ctr0, ctr1, ctr2, ctr3};
   _philox4x32round(ctr, key); // 1
@@ -169,14 +206,25 @@ QUALIFIERS void philox_double2(uint32 ctr0, uint32 ctr1, uint32 ctr2,
   _philox4x32bumpkey(key);
   _philox4x32round(ctr, key); // 10
 
+#ifdef __OPENCL_VERSION__
+  *rnd1 = _uniform_double_hq(ctr[0], ctr[1]);
+  *rnd2 = _uniform_double_hq(ctr[2], ctr[3]);
+#else
   rnd1 = _uniform_double_hq(ctr[0], ctr[1]);
   rnd2 = _uniform_double_hq(ctr[2], ctr[3]);
+#endif
 }
 
 QUALIFIERS void philox_float4(uint32 ctr0, uint32 ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
+#ifdef __OPENCL_VERSION__
+                              float *rnd1, float *rnd2, float *rnd3,
+                              float *rnd4)
+#else
                               float &rnd1, float &rnd2, float &rnd3,
-                              float &rnd4) {
+                              float &rnd4)
+#endif
+{
   uint32 key[2] = {key0, key1};
   uint32 ctr[4] = {ctr0, ctr1, ctr2, ctr3};
   _philox4x32round(ctr, key); // 1
@@ -199,14 +247,23 @@ QUALIFIERS void philox_float4(uint32 ctr0, uint32 ctr1, uint32 ctr2,
   _philox4x32bumpkey(key);
   _philox4x32round(ctr, key); // 10
 
-  rnd1 = (float)(ctr[0]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
-  rnd2 = (float)(ctr[1]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
-  rnd3 = (float)(ctr[2]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
-  rnd4 = (float)(ctr[3]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+#ifdef __OPENCL_VERSION__
+  *rnd1 = ctr[0] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  *rnd2 = ctr[1] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  *rnd3 = ctr[2] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  *rnd4 = ctr[3] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+#else
+  rnd1 = ctr[0] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  rnd2 = ctr[1] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  rnd3 = ctr[2] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  rnd4 = ctr[3] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+#endif
 }
 
-#ifndef __CUDA_ARCH__
-#if defined(__SSE4_1__) || defined(_MSC_VER)
+#if !defined(__CUDA_ARCH__) && !defined(__OPENCL_VERSION__) &&                 \
+    !defined(__HIP_DEVICE_COMPILE__) &&                                        \
+    (!defined(__clang__) || !defined(__CUDA__))
+#if defined(__SSE4_1__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 QUALIFIERS void _philox4x32round(__m128i *ctr, __m128i *key) {
   __m128i lohi0a = _mm_mul_epu32(ctr[0], _mm_set1_epi32(PHILOX_M4x32_0));
   __m128i lohi0b =
@@ -391,13 +448,13 @@ QUALIFIERS void _philox4x32round(__vector unsigned int *ctr,
                                  __vector unsigned int *key) {
 #ifndef _ARCH_PWR8
   __vector unsigned int lo0 = vec_mul(ctr[0], vec_splats(PHILOX_M4x32_0));
-  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi0 = vec_mulhuw(ctr[0], vec_splats(PHILOX_M4x32_0));
+  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi1 = vec_mulhuw(ctr[2], vec_splats(PHILOX_M4x32_1));
 #elif defined(_ARCH_PWR10)
   __vector unsigned int lo0 = vec_mul(ctr[0], vec_splats(PHILOX_M4x32_0));
-  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi0 = vec_mulh(ctr[0], vec_splats(PHILOX_M4x32_0));
+  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi1 = vec_mulh(ctr[2], vec_splats(PHILOX_M4x32_1));
 #else
   __vector unsigned int lohi0a =
@@ -755,6 +812,7 @@ QUALIFIERS void philox_float4(uint32 ctr0, uint32x4_t ctr1, uint32 ctr2,
   philox_float4(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1, rnd2, rnd3, rnd4);
 }
 
+#ifndef _MSC_VER
 QUALIFIERS void philox_float4(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
                               float32x4_t &rnd1, float32x4_t &rnd2,
@@ -762,6 +820,7 @@ QUALIFIERS void philox_float4(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
   philox_float4(ctr0, vreinterpretq_u32_s32(ctr1), ctr2, ctr3, key0, key1, rnd1,
                 rnd2, rnd3, rnd4);
 }
+#endif
 
 QUALIFIERS void philox_double2(uint32 ctr0, uint32x4_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
@@ -787,6 +846,7 @@ QUALIFIERS void philox_double2(uint32 ctr0, uint32x4_t ctr1, uint32 ctr2,
                  ignore);
 }
 
+#ifndef _MSC_VER
 QUALIFIERS void philox_double2(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
                                float64x2_t &rnd1, float64x2_t &rnd2) {
@@ -794,15 +854,17 @@ QUALIFIERS void philox_double2(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
                  rnd1, rnd2);
 }
 #endif
+#endif
 
-#if defined(__ARM_FEATURE_SVE)
-QUALIFIERS void _philox4x32round(svuint32x4_t &ctr, svuint32x2_t &key) {
+#if defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SME)
+QUALIFIERS void _philox4x32round(svuint32x4_t &ctr,
+                                 svuint32x2_t &key) SVE_QUALIFIERS {
   svuint32_t lo0 =
       svmul_u32_x(svptrue_b32(), svget4_u32(ctr, 0), svdup_u32(PHILOX_M4x32_0));
-  svuint32_t lo1 =
-      svmul_u32_x(svptrue_b32(), svget4_u32(ctr, 2), svdup_u32(PHILOX_M4x32_1));
   svuint32_t hi0 = svmulh_u32_x(svptrue_b32(), svget4_u32(ctr, 0),
                                 svdup_u32(PHILOX_M4x32_0));
+  svuint32_t lo1 =
+      svmul_u32_x(svptrue_b32(), svget4_u32(ctr, 2), svdup_u32(PHILOX_M4x32_1));
   svuint32_t hi1 = svmulh_u32_x(svptrue_b32(), svget4_u32(ctr, 2),
                                 svdup_u32(PHILOX_M4x32_1));
 
@@ -820,7 +882,7 @@ QUALIFIERS void _philox4x32round(svuint32x4_t &ctr, svuint32x2_t &key) {
   ctr = svset4_u32(ctr, 3, lo0);
 }
 
-QUALIFIERS void _philox4x32bumpkey(svuint32x2_t &key) {
+QUALIFIERS void _philox4x32bumpkey(svuint32x2_t &key) SVE_QUALIFIERS {
   key = svset2_u32(
       key, 0,
       svadd_u32_x(svptrue_b32(), svget2_u32(key, 0), svdup_u32(PHILOX_W32_0)));
@@ -830,7 +892,8 @@ QUALIFIERS void _philox4x32bumpkey(svuint32x2_t &key) {
 }
 
 template <bool high>
-QUALIFIERS svfloat64_t _uniform_double_hq(svuint32_t x, svuint32_t y) {
+QUALIFIERS svfloat64_t _uniform_double_hq(svuint32_t x,
+                                          svuint32_t y) SVE_QUALIFIERS {
   // convert 32 to 64 bit
   if (high) {
     x = svzip2_u32(x, svdup_u32(0));
@@ -857,7 +920,8 @@ QUALIFIERS svfloat64_t _uniform_double_hq(svuint32_t x, svuint32_t y) {
 QUALIFIERS void philox_float4(svuint32_t ctr0, svuint32_t ctr1, svuint32_t ctr2,
                               svuint32_t ctr3, uint32 key0, uint32 key1,
                               svfloat32_st &rnd1, svfloat32_st &rnd2,
-                              svfloat32_st &rnd3, svfloat32_st &rnd4) {
+                              svfloat32_st &rnd3,
+                              svfloat32_st &rnd4) SVE_QUALIFIERS {
   svuint32x2_t key = svcreate2_u32(svdup_u32(key0), svdup_u32(key1));
   svuint32x4_t ctr = svcreate4_u32(ctr0, ctr1, ctr2, ctr3);
   _philox4x32round(ctr, key); // 1
@@ -900,7 +964,7 @@ QUALIFIERS void philox_double2(svuint32_t ctr0, svuint32_t ctr1,
                                svuint32_t ctr2, svuint32_t ctr3, uint32 key0,
                                uint32 key1, svfloat64_st &rnd1lo,
                                svfloat64_st &rnd1hi, svfloat64_st &rnd2lo,
-                               svfloat64_st &rnd2hi) {
+                               svfloat64_st &rnd2hi) SVE_QUALIFIERS {
   svuint32x2_t key = svcreate2_u32(svdup_u32(key0), svdup_u32(key1));
   svuint32x4_t ctr = svcreate4_u32(ctr0, ctr1, ctr2, ctr3);
   _philox4x32round(ctr, key); // 1
@@ -932,7 +996,8 @@ QUALIFIERS void philox_double2(svuint32_t ctr0, svuint32_t ctr1,
 QUALIFIERS void philox_float4(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
                               svfloat32_st &rnd1, svfloat32_st &rnd2,
-                              svfloat32_st &rnd3, svfloat32_st &rnd4) {
+                              svfloat32_st &rnd3,
+                              svfloat32_st &rnd4) SVE_QUALIFIERS {
   svuint32_t ctr0v = svdup_u32(ctr0);
   svuint32_t ctr2v = svdup_u32(ctr2);
   svuint32_t ctr3v = svdup_u32(ctr3);
@@ -943,7 +1008,8 @@ QUALIFIERS void philox_float4(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
 QUALIFIERS void philox_float4(uint32 ctr0, svint32_t ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
                               svfloat32_st &rnd1, svfloat32_st &rnd2,
-                              svfloat32_st &rnd3, svfloat32_st &rnd4) {
+                              svfloat32_st &rnd3,
+                              svfloat32_st &rnd4) SVE_QUALIFIERS {
   philox_float4(ctr0, svreinterpret_u32_s32(ctr1), ctr2, ctr3, key0, key1, rnd1,
                 rnd2, rnd3, rnd4);
 }
@@ -951,7 +1017,8 @@ QUALIFIERS void philox_float4(uint32 ctr0, svint32_t ctr1, uint32 ctr2,
 QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
                                svfloat64_st &rnd1lo, svfloat64_st &rnd1hi,
-                               svfloat64_st &rnd2lo, svfloat64_st &rnd2hi) {
+                               svfloat64_st &rnd2lo,
+                               svfloat64_st &rnd2hi) SVE_QUALIFIERS {
   svuint32_t ctr0v = svdup_u32(ctr0);
   svuint32_t ctr2v = svdup_u32(ctr2);
   svuint32_t ctr3v = svdup_u32(ctr3);
@@ -962,7 +1029,8 @@ QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
 
 QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
-                               svfloat64_st &rnd1, svfloat64_st &rnd2) {
+                               svfloat64_st &rnd1,
+                               svfloat64_st &rnd2) SVE_QUALIFIERS {
   svuint32_t ctr0v = svdup_u32(ctr0);
   svuint32_t ctr2v = svdup_u32(ctr2);
   svuint32_t ctr3v = svdup_u32(ctr3);
@@ -974,9 +1042,220 @@ QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
 
 QUALIFIERS void philox_double2(uint32 ctr0, svint32_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
-                               svfloat64_st &rnd1, svfloat64_st &rnd2) {
+                               svfloat64_st &rnd1,
+                               svfloat64_st &rnd2) SVE_QUALIFIERS {
   philox_double2(ctr0, svreinterpret_u32_s32(ctr1), ctr2, ctr3, key0, key1,
                  rnd1, rnd2);
+}
+#endif
+
+#if defined(__riscv_v)
+QUALIFIERS void _philox4x32round(vuint32m1_t &ctr0, vuint32m1_t &ctr1,
+                                 vuint32m1_t &ctr2, vuint32m1_t &ctr3,
+                                 vuint32m1_t key0, vuint32m1_t key1) {
+  vuint32m1_t lo0 = __riscv_vmul_vv_u32m1(
+      ctr0, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_0, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  vuint32m1_t hi0 = __riscv_vmulhu_vv_u32m1(
+      ctr0, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_0, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  vuint32m1_t lo1 = __riscv_vmul_vv_u32m1(
+      ctr2, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_1, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  vuint32m1_t hi1 = __riscv_vmulhu_vv_u32m1(
+      ctr2, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_1, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+
+  ctr0 = __riscv_vxor_vv_u32m1(
+      __riscv_vxor_vv_u32m1(hi1, ctr1, __riscv_vsetvlmax_e32m1()), key0,
+      __riscv_vsetvlmax_e32m1());
+  ctr1 = lo1;
+  ctr2 = __riscv_vxor_vv_u32m1(
+      __riscv_vxor_vv_u32m1(hi0, ctr3, __riscv_vsetvlmax_e32m1()), key1,
+      __riscv_vsetvlmax_e32m1());
+  ctr3 = lo0;
+}
+
+QUALIFIERS void _philox4x32bumpkey(vuint32m1_t &key0, vuint32m1_t &key1) {
+  key0 = __riscv_vadd_vv_u32m1(
+      key0, __riscv_vmv_v_x_u32m1(PHILOX_W32_0, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  key1 = __riscv_vadd_vv_u32m1(
+      key1, __riscv_vmv_v_x_u32m1(PHILOX_W32_1, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+}
+
+template <bool high>
+QUALIFIERS vfloat64m1_t _uniform_double_hq(vuint32m1_t x, vuint32m1_t y) {
+  // convert 32 to 64 bit
+  if (high) {
+    size_t s = __riscv_vsetvlmax_e32m1();
+    x = __riscv_vslidedown_vx_u32m1(x, s / 2, s);
+    y = __riscv_vslidedown_vx_u32m1(y, s / 2, s);
+  }
+  vuint64m1_t x64 = __riscv_vwcvtu_x_x_v_u64m1(
+      __riscv_vlmul_trunc_v_u32m1_u32mf2(x), __riscv_vsetvlmax_e64m1());
+  vuint64m1_t y64 = __riscv_vwcvtu_x_x_v_u64m1(
+      __riscv_vlmul_trunc_v_u32m1_u32mf2(y), __riscv_vsetvlmax_e64m1());
+
+  // calculate z = x ^ y << (53 - 32))
+  vuint64m1_t z =
+      __riscv_vsll_vx_u64m1(y64, 53 - 32, __riscv_vsetvlmax_e64m1());
+  z = __riscv_vxor_vv_u64m1(x64, z, __riscv_vsetvlmax_e64m1());
+
+  // convert uint64 to double
+  vfloat64m1_t rs = __riscv_vfcvt_f_xu_v_f64m1(z, __riscv_vsetvlmax_e64m1());
+  // calculate rs * TWOPOW53_INV_DOUBLE + (TWOPOW53_INV_DOUBLE/2.0)
+  rs = __riscv_vfmadd_vv_f64m1(
+      rs,
+      __riscv_vfmv_v_f_f64m1(TWOPOW53_INV_DOUBLE, __riscv_vsetvlmax_e64m1()),
+      __riscv_vfmv_v_f_f64m1(TWOPOW53_INV_DOUBLE / 2.0,
+                             __riscv_vsetvlmax_e64m1()),
+      __riscv_vsetvlmax_e64m1());
+
+  return rs;
+}
+
+QUALIFIERS void philox_float4(vuint32m1_t ctr0, vuint32m1_t ctr1,
+                              vuint32m1_t ctr2, vuint32m1_t ctr3, uint32 key0,
+                              uint32 key1, vfloat32m1_t &rnd1,
+                              vfloat32m1_t &rnd2, vfloat32m1_t &rnd3,
+                              vfloat32m1_t &rnd4) {
+  vuint32m1_t key0v = __riscv_vmv_v_x_u32m1(key0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t key1v = __riscv_vmv_v_x_u32m1(key1, __riscv_vsetvlmax_e32m1());
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 1
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 2
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 3
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 4
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 5
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 6
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 7
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 8
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 9
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 10
+
+  // convert uint32 to float
+  rnd1 = __riscv_vfcvt_f_xu_v_f32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  rnd2 = __riscv_vfcvt_f_xu_v_f32m1(ctr1, __riscv_vsetvlmax_e32m1());
+  rnd3 = __riscv_vfcvt_f_xu_v_f32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  rnd4 = __riscv_vfcvt_f_xu_v_f32m1(ctr3, __riscv_vsetvlmax_e32m1());
+  // calculate rnd * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT/2.0f)
+  rnd1 = __riscv_vfmadd_vv_f32m1(
+      rnd1,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  rnd2 = __riscv_vfmadd_vv_f32m1(
+      rnd2,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  rnd3 = __riscv_vfmadd_vv_f32m1(
+      rnd3,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  rnd4 = __riscv_vfmadd_vv_f32m1(
+      rnd4,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+}
+
+QUALIFIERS void philox_double2(vuint32m1_t ctr0, vuint32m1_t ctr1,
+                               vuint32m1_t ctr2, vuint32m1_t ctr3, uint32 key0,
+                               uint32 key1, vfloat64m1_t &rnd1lo,
+                               vfloat64m1_t &rnd1hi, vfloat64m1_t &rnd2lo,
+                               vfloat64m1_t &rnd2hi) {
+  vuint32m1_t key0v = __riscv_vmv_v_x_u32m1(key0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t key1v = __riscv_vmv_v_x_u32m1(key1, __riscv_vsetvlmax_e32m1());
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 1
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 2
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 3
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 4
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 5
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 6
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 7
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 8
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 9
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 10
+
+  rnd1lo = _uniform_double_hq<false>(ctr0, ctr1);
+  rnd1hi = _uniform_double_hq<true>(ctr0, ctr1);
+  rnd2lo = _uniform_double_hq<false>(ctr2, ctr3);
+  rnd2hi = _uniform_double_hq<true>(ctr2, ctr3);
+}
+
+QUALIFIERS void philox_float4(uint32 ctr0, vuint32m1_t ctr1, uint32 ctr2,
+                              uint32 ctr3, uint32 key0, uint32 key1,
+                              vfloat32m1_t &rnd1, vfloat32m1_t &rnd2,
+                              vfloat32m1_t &rnd3, vfloat32m1_t &rnd4) {
+  vuint32m1_t ctr0v = __riscv_vmv_v_x_u32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr2v = __riscv_vmv_v_x_u32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr3v = __riscv_vmv_v_x_u32m1(ctr3, __riscv_vsetvlmax_e32m1());
+
+  philox_float4(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1, rnd2, rnd3, rnd4);
+}
+
+QUALIFIERS void philox_float4(uint32 ctr0, vint32m1_t ctr1, uint32 ctr2,
+                              uint32 ctr3, uint32 key0, uint32 key1,
+                              vfloat32m1_t &rnd1, vfloat32m1_t &rnd2,
+                              vfloat32m1_t &rnd3, vfloat32m1_t &rnd4) {
+  philox_float4(ctr0, __riscv_vreinterpret_v_i32m1_u32m1(ctr1), ctr2, ctr3,
+                key0, key1, rnd1, rnd2, rnd3, rnd4);
+}
+
+QUALIFIERS void philox_double2(uint32 ctr0, vuint32m1_t ctr1, uint32 ctr2,
+                               uint32 ctr3, uint32 key0, uint32 key1,
+                               vfloat64m1_t &rnd1lo, vfloat64m1_t &rnd1hi,
+                               vfloat64m1_t &rnd2lo, vfloat64m1_t &rnd2hi) {
+  vuint32m1_t ctr0v = __riscv_vmv_v_x_u32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr2v = __riscv_vmv_v_x_u32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr3v = __riscv_vmv_v_x_u32m1(ctr3, __riscv_vsetvlmax_e32m1());
+
+  philox_double2(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1lo, rnd1hi, rnd2lo,
+                 rnd2hi);
+}
+
+QUALIFIERS void philox_double2(uint32 ctr0, vuint32m1_t ctr1, uint32 ctr2,
+                               uint32 ctr3, uint32 key0, uint32 key1,
+                               vfloat64m1_t &rnd1, vfloat64m1_t &rnd2) {
+  vuint32m1_t ctr0v = __riscv_vmv_v_x_u32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr2v = __riscv_vmv_v_x_u32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr3v = __riscv_vmv_v_x_u32m1(ctr3, __riscv_vsetvlmax_e32m1());
+
+  vfloat64m1_t ignore;
+  philox_double2(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1, ignore, rnd2,
+                 ignore);
+}
+
+QUALIFIERS void philox_double2(uint32 ctr0, vint32m1_t ctr1, uint32 ctr2,
+                               uint32 ctr3, uint32 key0, uint32 key1,
+                               vfloat64m1_t &rnd1, vfloat64m1_t &rnd2) {
+  philox_double2(ctr0, __riscv_vreinterpret_v_i32m1_u32m1(ctr1), ctr2, ctr3,
+                 key0, key1, rnd1, rnd2);
 }
 #endif
 
@@ -1167,7 +1446,7 @@ QUALIFIERS void philox_double2(uint32 ctr0, __m256i ctr1, uint32 ctr2,
 }
 #endif
 
-#ifdef __AVX512F__
+#if defined(__AVX512F__) || defined(__AVX10_512BIT__)
 QUALIFIERS void _philox4x32round(__m512i *ctr, __m512i *key) {
   __m512i lohi0a = _mm512_mul_epu32(ctr[0], _mm512_set1_epi32(PHILOX_M4x32_0));
   __m512i lohi0b = _mm512_mul_epu32(_mm512_srli_epi64(ctr[0], 32),
@@ -1338,3 +1617,12 @@ QUALIFIERS void philox_double2(uint32 ctr0, __m512i ctr1, uint32 ctr2,
 }
 #endif
 #endif
+
+#undef QUALIFIERS
+#undef SVE_QUALIFIERS
+#undef PHILOX_W32_0
+#undef PHILOX_W32_1
+#undef PHILOX_M4x32_0
+#undef PHILOX_M4x32_1
+#undef TWOPOW53_INV_DOUBLE
+#undef TWOPOW32_INV_FLOAT

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_1_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_2_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_3_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_4_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_double_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_5_single_precision_CUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_all.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelBulk_all.h
@@ -17,9 +17,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_1_double_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -131,11 +133,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -154,8 +156,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -218,6 +220,12 @@ public:
   double rate_coefficient_;
   double stoech_0_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_1_double_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_double_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -166,11 +172,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -189,8 +195,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -254,6 +260,12 @@ public:
   double rate_coefficient_;
   double stoech_0_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_1_single_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -131,11 +133,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -154,8 +156,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -218,6 +220,12 @@ public:
   float rate_coefficient_;
   float stoech_0_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_1_single_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_1_single_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -166,11 +172,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -189,8 +195,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -254,6 +260,12 @@ public:
   float rate_coefficient_;
   float stoech_0_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_2_double_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -136,11 +138,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -159,8 +161,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -226,6 +228,12 @@ public:
   double stoech_0_;
   double stoech_1_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_2_double_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_double_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -168,11 +174,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -191,8 +197,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -259,6 +265,12 @@ public:
   double stoech_0_;
   double stoech_1_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_2_single_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -136,11 +138,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -159,8 +161,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -226,6 +228,12 @@ public:
   float stoech_0_;
   float stoech_1_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_2_single_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_2_single_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -170,11 +176,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -193,8 +199,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -261,6 +267,12 @@ public:
   float stoech_0_;
   float stoech_1_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_3_double_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -137,11 +139,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -160,8 +162,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -230,6 +232,12 @@ public:
   double stoech_1_;
   double stoech_2_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_3_double_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_double_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -171,11 +177,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -194,8 +200,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -265,6 +271,12 @@ public:
   double stoech_1_;
   double stoech_2_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_3_single_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -136,11 +138,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -159,8 +161,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -229,6 +231,12 @@ public:
   float stoech_1_;
   float stoech_2_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_3_single_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_3_single_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -170,11 +176,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -193,8 +199,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -264,6 +270,12 @@ public:
   float stoech_1_;
   float stoech_2_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_4_double_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -140,11 +142,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -163,8 +165,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -236,6 +238,12 @@ public:
   double stoech_2_;
   double stoech_3_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_4_double_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_double_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -174,11 +180,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -197,8 +203,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -271,6 +277,12 @@ public:
   double stoech_2_;
   double stoech_3_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_4_single_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -140,11 +142,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -163,8 +165,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -236,6 +238,12 @@ public:
   float stoech_2_;
   float stoech_3_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_4_single_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_4_single_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -174,11 +180,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -197,8 +203,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -271,6 +277,12 @@ public:
   float stoech_2_;
   float stoech_3_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_5_double_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -145,11 +147,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -168,8 +170,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -244,6 +246,12 @@ public:
   double stoech_3_;
   double stoech_4_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_5_double_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_double_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -179,11 +185,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -202,8 +208,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -279,6 +285,12 @@ public:
   double stoech_3_;
   double stoech_4_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision.cpp
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_5_single_precision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -39,6 +39,7 @@
 #include <field/FlagField.h>
 #include <field/GhostLayerField.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -92,7 +93,8 @@ public:
       return other.cpuVectors_ == cpuVectors_;
     }
 
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
@@ -145,11 +147,11 @@ public:
 
   void outer(IBlock *block);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep() {
@@ -168,8 +170,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -244,6 +246,12 @@ public:
   float stoech_3_;
   float stoech_4_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision_CUDA.cu
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision_CUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "ReactionKernelIndexed_5_single_precision_CUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision_CUDA.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_5_single_precision_CUDA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2022-2023 The ESPResSo project
- * Copyright (C) 2020-2023 The waLBerla project
+ * Copyright (C) 2022-2025 The ESPResSo project
+ * Copyright (C) 2020-2025 The waLBerla project
  *
  * This file is part of ESPResSo.
  *
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.
  * Adapted from the waLBerla source file
- * https://i10git.cs.fau.de/walberla/walberla/-/blob/e12db9965373887d86aab4aaaf4dd7b38fa588e8/python/pystencils_walberla/templates/Boundary.tmpl.h
+ * https://i10git.cs.fau.de/walberla/walberla/-/blob/3e54d4f2336e47168ad87e3caaf7b3b082d86ca7/python/pystencils_walberla/templates/Boundary.tmpl.h
  */
 
 #pragma once
@@ -41,6 +41,7 @@
 #include <gpu/GPUField.h>
 #include <gpu/GPUWrapper.h>
 
+#include <array>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -101,15 +102,20 @@ public:
         }
       }
     }
-    CpuIndexVector &indexVector(Type t) { return cpuVectors_[t]; }
+    auto &indexVector(Type t) { return cpuVectors_[t]; }
+    auto const &indexVector(Type t) const { return cpuVectors_[t]; }
     IndexInfo *pointerCpu(Type t) {
       return cpuVectors_[t].empty() ? nullptr : cpuVectors_[t].data();
     }
 
     IndexInfo *pointerGpu(Type t) { return gpuVectors_[t]; }
     void syncGPU() {
-      for (auto &gpuVec : gpuVectors_)
-        WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+      for (auto &gpuVec : gpuVectors_) {
+        if (gpuVec) {
+          WALBERLA_GPU_CHECK(gpuFree(gpuVec));
+          gpuVec = nullptr;
+        }
+      }
       gpuVectors_.resize(cpuVectors_.size());
 
       WALBERLA_ASSERT_EQUAL(cpuVectors_.size(), NUM_TYPES);
@@ -179,11 +185,11 @@ public:
 
   void outer(IBlock *block, gpuStream_t stream = nullptr);
 
-  Vector3<real_t> getForce(IBlock * /*block*/) {
+  Vector3<double> getForce(IBlock * /*block*/) {
 
     WALBERLA_ABORT(
         "Boundary condition was not generated including force calculation.")
-    return Vector3<real_t>(real_c(0.0));
+    return Vector3<double>(double_c(0.0));
   }
 
   std::function<void(IBlock *)> getSweep(gpuStream_t stream = nullptr) {
@@ -202,8 +208,8 @@ public:
   void fillFromFlagField(const std::shared_ptr<StructuredBlockForest> &blocks,
                          ConstBlockDataID flagFieldID, FlagUID boundaryFlagUID,
                          FlagUID domainFlagUID) {
-    for (auto blockIt = blocks->begin(); blockIt != blocks->end(); ++blockIt)
-      fillFromFlagField<FlagField_T>(&*blockIt, flagFieldID, boundaryFlagUID,
+    for (auto &block : *blocks)
+      fillFromFlagField<FlagField_T>(&block, flagFieldID, boundaryFlagUID,
                                      domainFlagUID);
   }
 
@@ -279,6 +285,12 @@ public:
   float stoech_3_;
   float stoech_4_;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace pystencils
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_all.h
+++ b/src/walberla_bridge/src/electrokinetics/reactions/generated_kernels/ReactionKernelIndexed_all.h
@@ -17,9 +17,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit e12db9965373887d86aab4aaaf4dd7b38fa588e8
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+5.gd7100a3, sympy v1.10, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "DynamicUBBDoublePrecision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecision.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+15.g5018a18, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+5.gd7100a3, sympy v1.10, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "DynamicUBBDoublePrecisionCUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBDoublePrecisionCUDA.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+15.g5018a18, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+5.gd7100a3, sympy v1.10, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "DynamicUBBSinglePrecision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecision.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+15.g5018a18, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+5.gd7100a3, sympy v1.10, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "DynamicUBBSinglePrecisionCUDA.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/DynamicUBBSinglePrecisionCUDA.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+15.g5018a18, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit 191cf58b16b96d1d2f050dcbd9e88443995b2222
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Boundary class.

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsDoublePrecision.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsDoublePrecisionCUDA.cu
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /**
  * @file

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsDoublePrecisionCUDA.cuh
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsDoublePrecisionCUDA.cuh
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /**
  * @file

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsSinglePrecision.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /*
  * Lattice field accessors.

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsSinglePrecisionCUDA.cu
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /**
  * @file

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsSinglePrecisionCUDA.cuh
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/FieldAccessorsSinglePrecisionCUDA.cuh
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 /**
  * @file

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterDoublePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/InitialPDFsSetterSinglePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "PackInfoPdfDoublePrecision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "communication/UniformPackInfo.h"
@@ -35,8 +35,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "core/DataTypes.h"
 #include "core/cell/CellInterval.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfDoublePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "PackInfoPdfSinglePrecision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "communication/UniformPackInfo.h"
@@ -35,8 +35,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "core/DataTypes.h"
 #include "core/cell/CellInterval.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoPdfSinglePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "PackInfoVecDoublePrecision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "communication/UniformPackInfo.h"
@@ -35,8 +35,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "core/DataTypes.h"
 #include "core/cell/CellInterval.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecDoublePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "PackInfoVecSinglePrecision.h"
 #include "core/DataTypes.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "communication/UniformPackInfo.h"
@@ -35,8 +35,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include "core/DataTypes.h"
 #include "core/cell/CellInterval.h"

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/PackInfoVecSinglePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7, sympy v1.12.1,
-// lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionAVX.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionAVX.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionAVX.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionAVX.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsDoublePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionAVX.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionAVX.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionAVX.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionAVX.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepLeesEdwardsSinglePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionAVX.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionAVX.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 
@@ -25,9 +25,9 @@
 #include "core/DataTypes.h"
 #include "core/Macros.h"
 
-#include <immintrin.h>
-
 #include "philox_rand.h"
+
+#include <immintrin.h>
 
 #define FUNC_PREFIX
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionAVX.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionAVX.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedDoublePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionAVX.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionAVX.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionAVX.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionAVX.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/StreamCollideSweepThermalizedSinglePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7+13.gdfd203a, lbmpy
-// v1.3.7+10.gd3f6236, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from
-// waLBerla commit c69cb11d6a95d32b2280544d3d9abde1fe5fdbb5
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionAVX.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionAVX.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionAVX.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionAVX.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFDoublePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecision.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecision.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecision.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecision.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionAVX.cpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionAVX.cpp
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionAVX.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionAVX.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -36,8 +36,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionCUDA.cu
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionCUDA.cu
@@ -17,7 +17,7 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34, sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #include <cmath>
 

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionCUDA.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/UpdateVelFromPDFSinglePrecisionCUDA.h
@@ -17,9 +17,9 @@
 //! \\author pystencils
 //======================================================================================================================
 
-// kernel generated with pystencils v1.3.7, lbmpy v1.3.7+4.gc7d65a7, sympy
-// v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
-// 0aab9c0af2335b1f6fec75deae06e514ccb233ab
+// kernel generated with pystencils v1.4+1.ge851f4e, lbmpy v1.4+1.ge9efe34,
+// sympy v1.12.1, lbmpy_walberla/pystencils_walberla from waLBerla commit
+// 007e77e077ad9d22b5eed6f3d3118240993e553c
 
 #pragma once
 #include "core/DataTypes.h"
@@ -38,8 +38,6 @@
 
 #ifdef __GNUC__
 #define RESTRICT __restrict__
-#elif _MSC_VER
-#define RESTRICT __restrict
 #else
 #define RESTRICT
 #endif

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/myintrin.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/myintrin.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021, Michael Kuron.
+Copyright 2019-2023, Michael Kuron.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -29,18 +29,22 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// kernel generated with pystencils v1.4, lbmpy v1.4, sympy v1.12.1,
+// lbmpy_walberla/pystencils_walberla from waLBerla commit
+// b0376cce95f6817e924611cc2d9f9e2213610de6
+
 /**
  * @file
  * Philox counter-based RNG utility functions.
  * Adapted from the pystencils source file
- * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/39c214af/pystencils/include/myintrin.h
+ * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/ca4890a67757f066fc310b94b4b17b9f1b497ac2/src/pystencils/include/myintrin.h
  */
 
 #pragma once
 
-#if defined(__SSE2__) || defined(_MSC_VER)
+#if defined(__SSE2__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 QUALIFIERS __m128 _my_cvtepu32_ps(const __m128i v) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm_cvtepu32_ps(v);
 #else
   __m128i v2 = _mm_srli_epi32(v, 1);
@@ -50,29 +54,16 @@ QUALIFIERS __m128 _my_cvtepu32_ps(const __m128i v) {
   return _mm_add_ps(_mm_add_ps(v2f, v2f), v1f);
 #endif
 }
-
-QUALIFIERS void _MY_TRANSPOSE4_EPI32(__m128i &R0, __m128i &R1, __m128i &R2,
-                                     __m128i &R3) {
-  __m128i T0, T1, T2, T3;
-  T0 = _mm_unpacklo_epi32(R0, R1);
-  T1 = _mm_unpacklo_epi32(R2, R3);
-  T2 = _mm_unpackhi_epi32(R0, R1);
-  T3 = _mm_unpackhi_epi32(R2, R3);
-  R0 = _mm_unpacklo_epi64(T0, T1);
-  R1 = _mm_unpackhi_epi64(T0, T1);
-  R2 = _mm_unpacklo_epi64(T2, T3);
-  R3 = _mm_unpackhi_epi64(T2, T3);
-}
 #endif
 
-#if defined(__SSE4_1__) || defined(_MSC_VER)
-#if !defined(__AVX512VL__) && defined(__GNUC__) && __GNUC__ >= 5 &&            \
-    !defined(__clang__)
+#if defined(__SSE4_1__) || (defined(_MSC_VER) && !defined(_M_ARM64))
+#if !defined(__AVX512VL__) && !defined(__AVX10_1__) && defined(__GNUC__) &&    \
+    __GNUC__ >= 5 && !defined(__clang__)
 __attribute__((optimize("no-associative-math")))
 #endif
 QUALIFIERS __m128d
 _my_cvtepu64_pd(const __m128i x) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm_cvtepu64_pd(x);
 #elif defined(__clang__)
   return __builtin_convertvector(
@@ -109,7 +100,7 @@ QUALIFIERS __m256d _my256_set_m128d(__m128d hi, __m128d lo) {
 }
 
 QUALIFIERS __m256 _my256_cvtepu32_ps(const __m256i v) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm256_cvtepu32_ps(v);
 #else
   __m256i v2 = _mm256_srli_epi32(v, 1);
@@ -120,13 +111,13 @@ QUALIFIERS __m256 _my256_cvtepu32_ps(const __m256i v) {
 #endif
 }
 
-#if !defined(__AVX512VL__) && defined(__GNUC__) && __GNUC__ >= 5 &&            \
-    !defined(__clang__)
+#if !defined(__AVX512VL__) && !defined(__AVX10_1__) && defined(__GNUC__) &&    \
+    __GNUC__ >= 5 && !defined(__clang__)
 __attribute__((optimize("no-associative-math")))
 #endif
 QUALIFIERS __m256d
 _my256_cvtepu64_pd(const __m256i x) {
-#ifdef __AVX512VL__
+#if defined(__AVX512VL__) || defined(__AVX10_1__)
   return _mm256_cvtepu64_pd(x);
 #elif defined(__clang__)
   return __builtin_convertvector(
@@ -146,7 +137,7 @@ _my256_cvtepu64_pd(const __m256i x) {
 }
 #endif
 
-#ifdef __AVX512F__
+#if defined(__AVX512F__) || defined(__AVX10_512BIT__)
 QUALIFIERS __m512i _my512_set_m128i(__m128i d, __m128i c, __m128i b,
                                     __m128i a) {
   return _mm512_inserti32x4(

--- a/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/philox_rand.h
+++ b/src/walberla_bridge/src/lattice_boltzmann/generated_kernels/philox_rand.h
@@ -1,6 +1,6 @@
 /*
 Copyright 2010-2011, D. E. Shaw Research. All rights reserved.
-Copyright 2019-2021, Michael Kuron.
+Copyright 2019-2024, Michael Kuron.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -30,31 +30,40 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// kernel generated with pystencils v1.4, lbmpy v1.4, sympy v1.12.1,
+// lbmpy_walberla/pystencils_walberla from waLBerla commit
+// b0376cce95f6817e924611cc2d9f9e2213610de6
+
 /**
  * @file
  * Philox counter-based RNG from @cite salmon11a.
  * Adapted from the pystencils source file
- * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/896b4192/pystencils/include/philox_rand.h
+ * https://i10git.cs.fau.de/pycodegen/pystencils/-/blob/b4d7ef7cb5b499f3fa55ebfcd598ac7d6e11a3db/src/pystencils/include/philox_rand.h
  */
 
-#include <cstdint>
+#pragma once
 
-#if defined(__SSE2__) || defined(_MSC_VER)
+#if !defined(__OPENCL_VERSION__) && !defined(__HIPCC_RTC__)
+#if defined(__SSE2__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 #include <emmintrin.h> // SSE2
 #endif
 #ifdef __AVX2__
 #include <immintrin.h> // AVX*
-#elif defined(__SSE4_1__) || defined(_MSC_VER)
+#elif defined(__SSE4_1__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 #include <smmintrin.h> // SSE4
 #ifdef __FMA__
 #include <immintrin.h> // FMA
 #endif
 #endif
 
+#if defined(_MSC_VER) && defined(_M_ARM64)
+#define __ARM_NEON
+#endif
+
 #ifdef __ARM_NEON
 #include <arm_neon.h>
 #endif
-#ifdef __ARM_FEATURE_SVE
+#if defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SME)
 #include <arm_sve.h>
 #endif
 
@@ -70,15 +79,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-#if defined(__CUDA_ARCH__) || defined(__clang__) && defined(__CUDA__)
-#if defined(__clang__) && defined(QUALIFIERS)
-#undef QUALIFIERS
+#ifdef __riscv_v
+#include <riscv_vector.h>
 #endif
-#define QUALIFIERS static __forceinline__ __device__
+#endif
+
+#if defined(__ARM_FEATURE_SME) && defined(__ARM_FEATURE_SVE)
+#define SVE_QUALIFIERS __arm_streaming_compatible
+#elif defined(__ARM_FEATURE_SME)
+#define SVE_QUALIFIERS __arm_streaming
 #else
-#if defined(__clang__) && defined(QUALIFIERS)
-#undef QUALIFIERS
+#define SVE_QUALIFIERS
 #endif
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) ||               \
+    defined(__clang__) && defined(__CUDA__)
+#define QUALIFIERS static __forceinline__ __device__
+#elif defined(__OPENCL_VERSION__)
+#define QUALIFIERS static inline
+#else
 #define QUALIFIERS inline
 #include "myintrin.h"
 #endif
@@ -90,8 +109,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TWOPOW53_INV_DOUBLE (1.1102230246251565e-16)
 #define TWOPOW32_INV_FLOAT (2.3283064e-10f)
 
+#ifdef __OPENCL_VERSION__
+#include "opencl_stdint.h"
+typedef uint32_t uint32;
+typedef uint64_t uint64;
+#else
+#ifndef __HIPCC_RTC__
+#include <cstdint>
+#endif
 typedef std::uint32_t uint32;
 typedef std::uint64_t uint64;
+#endif
 
 #if defined(__ARM_FEATURE_SVE) && defined(__ARM_FEATURE_SVE_BITS) &&           \
     __ARM_FEATURE_SVE_BITS > 0
@@ -99,16 +127,20 @@ typedef svfloat32_t svfloat32_st
     __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
 typedef svfloat64_t svfloat64_st
     __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
-#elif defined(__ARM_FEATURE_SVE)
+#elif defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SME)
 typedef svfloat32_t svfloat32_st;
 typedef svfloat64_t svfloat64_st;
 #endif
 
 QUALIFIERS uint32 mulhilo32(uint32 a, uint32 b, uint32 *hip) {
-#ifndef __CUDA_ARCH__
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__) &&             \
+    (!defined(__clang__) || !defined(__CUDA__))
   // host code
 #if defined(__powerpc__) && (!defined(__clang__) || defined(__xlC__))
   *hip = __mulhwu(a, b);
+  return a * b;
+#elif defined(__OPENCL_VERSION__)
+  *hip = mul_hi(a, b);
   return a * b;
 #else
   uint64 product = ((uint64)a) * ((uint64)b);
@@ -140,13 +172,18 @@ QUALIFIERS void _philox4x32bumpkey(uint32 *key) {
 }
 
 QUALIFIERS double _uniform_double_hq(uint32 x, uint32 y) {
-  double z = (double)((uint64)x ^ ((uint64)y << (53 - 32)));
+  uint64 z = (uint64)x ^ ((uint64)y << (53 - 32));
   return z * TWOPOW53_INV_DOUBLE + (TWOPOW53_INV_DOUBLE / 2.0);
 }
 
 QUALIFIERS void philox_double2(uint32 ctr0, uint32 ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
-                               double &rnd1, double &rnd2) {
+#ifdef __OPENCL_VERSION__
+                               double *rnd1, double *rnd2)
+#else
+                               double &rnd1, double &rnd2)
+#endif
+{
   uint32 key[2] = {key0, key1};
   uint32 ctr[4] = {ctr0, ctr1, ctr2, ctr3};
   _philox4x32round(ctr, key); // 1
@@ -169,14 +206,25 @@ QUALIFIERS void philox_double2(uint32 ctr0, uint32 ctr1, uint32 ctr2,
   _philox4x32bumpkey(key);
   _philox4x32round(ctr, key); // 10
 
+#ifdef __OPENCL_VERSION__
+  *rnd1 = _uniform_double_hq(ctr[0], ctr[1]);
+  *rnd2 = _uniform_double_hq(ctr[2], ctr[3]);
+#else
   rnd1 = _uniform_double_hq(ctr[0], ctr[1]);
   rnd2 = _uniform_double_hq(ctr[2], ctr[3]);
+#endif
 }
 
 QUALIFIERS void philox_float4(uint32 ctr0, uint32 ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
+#ifdef __OPENCL_VERSION__
+                              float *rnd1, float *rnd2, float *rnd3,
+                              float *rnd4)
+#else
                               float &rnd1, float &rnd2, float &rnd3,
-                              float &rnd4) {
+                              float &rnd4)
+#endif
+{
   uint32 key[2] = {key0, key1};
   uint32 ctr[4] = {ctr0, ctr1, ctr2, ctr3};
   _philox4x32round(ctr, key); // 1
@@ -199,14 +247,23 @@ QUALIFIERS void philox_float4(uint32 ctr0, uint32 ctr1, uint32 ctr2,
   _philox4x32bumpkey(key);
   _philox4x32round(ctr, key); // 10
 
-  rnd1 = (float)(ctr[0]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
-  rnd2 = (float)(ctr[1]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
-  rnd3 = (float)(ctr[2]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
-  rnd4 = (float)(ctr[3]) * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+#ifdef __OPENCL_VERSION__
+  *rnd1 = ctr[0] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  *rnd2 = ctr[1] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  *rnd3 = ctr[2] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  *rnd4 = ctr[3] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+#else
+  rnd1 = ctr[0] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  rnd2 = ctr[1] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  rnd3 = ctr[2] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+  rnd4 = ctr[3] * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT / 2.0f);
+#endif
 }
 
-#ifndef __CUDA_ARCH__
-#if defined(__SSE4_1__) || defined(_MSC_VER)
+#if !defined(__CUDA_ARCH__) && !defined(__OPENCL_VERSION__) &&                 \
+    !defined(__HIP_DEVICE_COMPILE__) &&                                        \
+    (!defined(__clang__) || !defined(__CUDA__))
+#if defined(__SSE4_1__) || (defined(_MSC_VER) && !defined(_M_ARM64))
 QUALIFIERS void _philox4x32round(__m128i *ctr, __m128i *key) {
   __m128i lohi0a = _mm_mul_epu32(ctr[0], _mm_set1_epi32(PHILOX_M4x32_0));
   __m128i lohi0b =
@@ -391,13 +448,13 @@ QUALIFIERS void _philox4x32round(__vector unsigned int *ctr,
                                  __vector unsigned int *key) {
 #ifndef _ARCH_PWR8
   __vector unsigned int lo0 = vec_mul(ctr[0], vec_splats(PHILOX_M4x32_0));
-  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi0 = vec_mulhuw(ctr[0], vec_splats(PHILOX_M4x32_0));
+  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi1 = vec_mulhuw(ctr[2], vec_splats(PHILOX_M4x32_1));
 #elif defined(_ARCH_PWR10)
   __vector unsigned int lo0 = vec_mul(ctr[0], vec_splats(PHILOX_M4x32_0));
-  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi0 = vec_mulh(ctr[0], vec_splats(PHILOX_M4x32_0));
+  __vector unsigned int lo1 = vec_mul(ctr[2], vec_splats(PHILOX_M4x32_1));
   __vector unsigned int hi1 = vec_mulh(ctr[2], vec_splats(PHILOX_M4x32_1));
 #else
   __vector unsigned int lohi0a =
@@ -755,6 +812,7 @@ QUALIFIERS void philox_float4(uint32 ctr0, uint32x4_t ctr1, uint32 ctr2,
   philox_float4(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1, rnd2, rnd3, rnd4);
 }
 
+#ifndef _MSC_VER
 QUALIFIERS void philox_float4(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
                               float32x4_t &rnd1, float32x4_t &rnd2,
@@ -762,6 +820,7 @@ QUALIFIERS void philox_float4(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
   philox_float4(ctr0, vreinterpretq_u32_s32(ctr1), ctr2, ctr3, key0, key1, rnd1,
                 rnd2, rnd3, rnd4);
 }
+#endif
 
 QUALIFIERS void philox_double2(uint32 ctr0, uint32x4_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
@@ -787,6 +846,7 @@ QUALIFIERS void philox_double2(uint32 ctr0, uint32x4_t ctr1, uint32 ctr2,
                  ignore);
 }
 
+#ifndef _MSC_VER
 QUALIFIERS void philox_double2(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
                                float64x2_t &rnd1, float64x2_t &rnd2) {
@@ -794,15 +854,17 @@ QUALIFIERS void philox_double2(uint32 ctr0, int32x4_t ctr1, uint32 ctr2,
                  rnd1, rnd2);
 }
 #endif
+#endif
 
-#if defined(__ARM_FEATURE_SVE)
-QUALIFIERS void _philox4x32round(svuint32x4_t &ctr, svuint32x2_t &key) {
+#if defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SME)
+QUALIFIERS void _philox4x32round(svuint32x4_t &ctr,
+                                 svuint32x2_t &key) SVE_QUALIFIERS {
   svuint32_t lo0 =
       svmul_u32_x(svptrue_b32(), svget4_u32(ctr, 0), svdup_u32(PHILOX_M4x32_0));
-  svuint32_t lo1 =
-      svmul_u32_x(svptrue_b32(), svget4_u32(ctr, 2), svdup_u32(PHILOX_M4x32_1));
   svuint32_t hi0 = svmulh_u32_x(svptrue_b32(), svget4_u32(ctr, 0),
                                 svdup_u32(PHILOX_M4x32_0));
+  svuint32_t lo1 =
+      svmul_u32_x(svptrue_b32(), svget4_u32(ctr, 2), svdup_u32(PHILOX_M4x32_1));
   svuint32_t hi1 = svmulh_u32_x(svptrue_b32(), svget4_u32(ctr, 2),
                                 svdup_u32(PHILOX_M4x32_1));
 
@@ -820,7 +882,7 @@ QUALIFIERS void _philox4x32round(svuint32x4_t &ctr, svuint32x2_t &key) {
   ctr = svset4_u32(ctr, 3, lo0);
 }
 
-QUALIFIERS void _philox4x32bumpkey(svuint32x2_t &key) {
+QUALIFIERS void _philox4x32bumpkey(svuint32x2_t &key) SVE_QUALIFIERS {
   key = svset2_u32(
       key, 0,
       svadd_u32_x(svptrue_b32(), svget2_u32(key, 0), svdup_u32(PHILOX_W32_0)));
@@ -830,7 +892,8 @@ QUALIFIERS void _philox4x32bumpkey(svuint32x2_t &key) {
 }
 
 template <bool high>
-QUALIFIERS svfloat64_t _uniform_double_hq(svuint32_t x, svuint32_t y) {
+QUALIFIERS svfloat64_t _uniform_double_hq(svuint32_t x,
+                                          svuint32_t y) SVE_QUALIFIERS {
   // convert 32 to 64 bit
   if (high) {
     x = svzip2_u32(x, svdup_u32(0));
@@ -857,7 +920,8 @@ QUALIFIERS svfloat64_t _uniform_double_hq(svuint32_t x, svuint32_t y) {
 QUALIFIERS void philox_float4(svuint32_t ctr0, svuint32_t ctr1, svuint32_t ctr2,
                               svuint32_t ctr3, uint32 key0, uint32 key1,
                               svfloat32_st &rnd1, svfloat32_st &rnd2,
-                              svfloat32_st &rnd3, svfloat32_st &rnd4) {
+                              svfloat32_st &rnd3,
+                              svfloat32_st &rnd4) SVE_QUALIFIERS {
   svuint32x2_t key = svcreate2_u32(svdup_u32(key0), svdup_u32(key1));
   svuint32x4_t ctr = svcreate4_u32(ctr0, ctr1, ctr2, ctr3);
   _philox4x32round(ctr, key); // 1
@@ -900,7 +964,7 @@ QUALIFIERS void philox_double2(svuint32_t ctr0, svuint32_t ctr1,
                                svuint32_t ctr2, svuint32_t ctr3, uint32 key0,
                                uint32 key1, svfloat64_st &rnd1lo,
                                svfloat64_st &rnd1hi, svfloat64_st &rnd2lo,
-                               svfloat64_st &rnd2hi) {
+                               svfloat64_st &rnd2hi) SVE_QUALIFIERS {
   svuint32x2_t key = svcreate2_u32(svdup_u32(key0), svdup_u32(key1));
   svuint32x4_t ctr = svcreate4_u32(ctr0, ctr1, ctr2, ctr3);
   _philox4x32round(ctr, key); // 1
@@ -932,7 +996,8 @@ QUALIFIERS void philox_double2(svuint32_t ctr0, svuint32_t ctr1,
 QUALIFIERS void philox_float4(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
                               svfloat32_st &rnd1, svfloat32_st &rnd2,
-                              svfloat32_st &rnd3, svfloat32_st &rnd4) {
+                              svfloat32_st &rnd3,
+                              svfloat32_st &rnd4) SVE_QUALIFIERS {
   svuint32_t ctr0v = svdup_u32(ctr0);
   svuint32_t ctr2v = svdup_u32(ctr2);
   svuint32_t ctr3v = svdup_u32(ctr3);
@@ -943,7 +1008,8 @@ QUALIFIERS void philox_float4(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
 QUALIFIERS void philox_float4(uint32 ctr0, svint32_t ctr1, uint32 ctr2,
                               uint32 ctr3, uint32 key0, uint32 key1,
                               svfloat32_st &rnd1, svfloat32_st &rnd2,
-                              svfloat32_st &rnd3, svfloat32_st &rnd4) {
+                              svfloat32_st &rnd3,
+                              svfloat32_st &rnd4) SVE_QUALIFIERS {
   philox_float4(ctr0, svreinterpret_u32_s32(ctr1), ctr2, ctr3, key0, key1, rnd1,
                 rnd2, rnd3, rnd4);
 }
@@ -951,7 +1017,8 @@ QUALIFIERS void philox_float4(uint32 ctr0, svint32_t ctr1, uint32 ctr2,
 QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
                                svfloat64_st &rnd1lo, svfloat64_st &rnd1hi,
-                               svfloat64_st &rnd2lo, svfloat64_st &rnd2hi) {
+                               svfloat64_st &rnd2lo,
+                               svfloat64_st &rnd2hi) SVE_QUALIFIERS {
   svuint32_t ctr0v = svdup_u32(ctr0);
   svuint32_t ctr2v = svdup_u32(ctr2);
   svuint32_t ctr3v = svdup_u32(ctr3);
@@ -962,7 +1029,8 @@ QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
 
 QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
-                               svfloat64_st &rnd1, svfloat64_st &rnd2) {
+                               svfloat64_st &rnd1,
+                               svfloat64_st &rnd2) SVE_QUALIFIERS {
   svuint32_t ctr0v = svdup_u32(ctr0);
   svuint32_t ctr2v = svdup_u32(ctr2);
   svuint32_t ctr3v = svdup_u32(ctr3);
@@ -974,9 +1042,220 @@ QUALIFIERS void philox_double2(uint32 ctr0, svuint32_t ctr1, uint32 ctr2,
 
 QUALIFIERS void philox_double2(uint32 ctr0, svint32_t ctr1, uint32 ctr2,
                                uint32 ctr3, uint32 key0, uint32 key1,
-                               svfloat64_st &rnd1, svfloat64_st &rnd2) {
+                               svfloat64_st &rnd1,
+                               svfloat64_st &rnd2) SVE_QUALIFIERS {
   philox_double2(ctr0, svreinterpret_u32_s32(ctr1), ctr2, ctr3, key0, key1,
                  rnd1, rnd2);
+}
+#endif
+
+#if defined(__riscv_v)
+QUALIFIERS void _philox4x32round(vuint32m1_t &ctr0, vuint32m1_t &ctr1,
+                                 vuint32m1_t &ctr2, vuint32m1_t &ctr3,
+                                 vuint32m1_t key0, vuint32m1_t key1) {
+  vuint32m1_t lo0 = __riscv_vmul_vv_u32m1(
+      ctr0, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_0, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  vuint32m1_t hi0 = __riscv_vmulhu_vv_u32m1(
+      ctr0, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_0, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  vuint32m1_t lo1 = __riscv_vmul_vv_u32m1(
+      ctr2, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_1, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  vuint32m1_t hi1 = __riscv_vmulhu_vv_u32m1(
+      ctr2, __riscv_vmv_v_x_u32m1(PHILOX_M4x32_1, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+
+  ctr0 = __riscv_vxor_vv_u32m1(
+      __riscv_vxor_vv_u32m1(hi1, ctr1, __riscv_vsetvlmax_e32m1()), key0,
+      __riscv_vsetvlmax_e32m1());
+  ctr1 = lo1;
+  ctr2 = __riscv_vxor_vv_u32m1(
+      __riscv_vxor_vv_u32m1(hi0, ctr3, __riscv_vsetvlmax_e32m1()), key1,
+      __riscv_vsetvlmax_e32m1());
+  ctr3 = lo0;
+}
+
+QUALIFIERS void _philox4x32bumpkey(vuint32m1_t &key0, vuint32m1_t &key1) {
+  key0 = __riscv_vadd_vv_u32m1(
+      key0, __riscv_vmv_v_x_u32m1(PHILOX_W32_0, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  key1 = __riscv_vadd_vv_u32m1(
+      key1, __riscv_vmv_v_x_u32m1(PHILOX_W32_1, __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+}
+
+template <bool high>
+QUALIFIERS vfloat64m1_t _uniform_double_hq(vuint32m1_t x, vuint32m1_t y) {
+  // convert 32 to 64 bit
+  if (high) {
+    size_t s = __riscv_vsetvlmax_e32m1();
+    x = __riscv_vslidedown_vx_u32m1(x, s / 2, s);
+    y = __riscv_vslidedown_vx_u32m1(y, s / 2, s);
+  }
+  vuint64m1_t x64 = __riscv_vwcvtu_x_x_v_u64m1(
+      __riscv_vlmul_trunc_v_u32m1_u32mf2(x), __riscv_vsetvlmax_e64m1());
+  vuint64m1_t y64 = __riscv_vwcvtu_x_x_v_u64m1(
+      __riscv_vlmul_trunc_v_u32m1_u32mf2(y), __riscv_vsetvlmax_e64m1());
+
+  // calculate z = x ^ y << (53 - 32))
+  vuint64m1_t z =
+      __riscv_vsll_vx_u64m1(y64, 53 - 32, __riscv_vsetvlmax_e64m1());
+  z = __riscv_vxor_vv_u64m1(x64, z, __riscv_vsetvlmax_e64m1());
+
+  // convert uint64 to double
+  vfloat64m1_t rs = __riscv_vfcvt_f_xu_v_f64m1(z, __riscv_vsetvlmax_e64m1());
+  // calculate rs * TWOPOW53_INV_DOUBLE + (TWOPOW53_INV_DOUBLE/2.0)
+  rs = __riscv_vfmadd_vv_f64m1(
+      rs,
+      __riscv_vfmv_v_f_f64m1(TWOPOW53_INV_DOUBLE, __riscv_vsetvlmax_e64m1()),
+      __riscv_vfmv_v_f_f64m1(TWOPOW53_INV_DOUBLE / 2.0,
+                             __riscv_vsetvlmax_e64m1()),
+      __riscv_vsetvlmax_e64m1());
+
+  return rs;
+}
+
+QUALIFIERS void philox_float4(vuint32m1_t ctr0, vuint32m1_t ctr1,
+                              vuint32m1_t ctr2, vuint32m1_t ctr3, uint32 key0,
+                              uint32 key1, vfloat32m1_t &rnd1,
+                              vfloat32m1_t &rnd2, vfloat32m1_t &rnd3,
+                              vfloat32m1_t &rnd4) {
+  vuint32m1_t key0v = __riscv_vmv_v_x_u32m1(key0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t key1v = __riscv_vmv_v_x_u32m1(key1, __riscv_vsetvlmax_e32m1());
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 1
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 2
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 3
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 4
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 5
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 6
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 7
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 8
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 9
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 10
+
+  // convert uint32 to float
+  rnd1 = __riscv_vfcvt_f_xu_v_f32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  rnd2 = __riscv_vfcvt_f_xu_v_f32m1(ctr1, __riscv_vsetvlmax_e32m1());
+  rnd3 = __riscv_vfcvt_f_xu_v_f32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  rnd4 = __riscv_vfcvt_f_xu_v_f32m1(ctr3, __riscv_vsetvlmax_e32m1());
+  // calculate rnd * TWOPOW32_INV_FLOAT + (TWOPOW32_INV_FLOAT/2.0f)
+  rnd1 = __riscv_vfmadd_vv_f32m1(
+      rnd1,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  rnd2 = __riscv_vfmadd_vv_f32m1(
+      rnd2,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  rnd3 = __riscv_vfmadd_vv_f32m1(
+      rnd3,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+  rnd4 = __riscv_vfmadd_vv_f32m1(
+      rnd4,
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT, __riscv_vsetvlmax_e32m1()),
+      __riscv_vfmv_v_f_f32m1(TWOPOW32_INV_FLOAT / 2.0,
+                             __riscv_vsetvlmax_e32m1()),
+      __riscv_vsetvlmax_e32m1());
+}
+
+QUALIFIERS void philox_double2(vuint32m1_t ctr0, vuint32m1_t ctr1,
+                               vuint32m1_t ctr2, vuint32m1_t ctr3, uint32 key0,
+                               uint32 key1, vfloat64m1_t &rnd1lo,
+                               vfloat64m1_t &rnd1hi, vfloat64m1_t &rnd2lo,
+                               vfloat64m1_t &rnd2hi) {
+  vuint32m1_t key0v = __riscv_vmv_v_x_u32m1(key0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t key1v = __riscv_vmv_v_x_u32m1(key1, __riscv_vsetvlmax_e32m1());
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 1
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 2
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 3
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 4
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 5
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 6
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 7
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 8
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 9
+  _philox4x32bumpkey(key0v, key1v);
+  _philox4x32round(ctr0, ctr1, ctr2, ctr3, key0v, key1v); // 10
+
+  rnd1lo = _uniform_double_hq<false>(ctr0, ctr1);
+  rnd1hi = _uniform_double_hq<true>(ctr0, ctr1);
+  rnd2lo = _uniform_double_hq<false>(ctr2, ctr3);
+  rnd2hi = _uniform_double_hq<true>(ctr2, ctr3);
+}
+
+QUALIFIERS void philox_float4(uint32 ctr0, vuint32m1_t ctr1, uint32 ctr2,
+                              uint32 ctr3, uint32 key0, uint32 key1,
+                              vfloat32m1_t &rnd1, vfloat32m1_t &rnd2,
+                              vfloat32m1_t &rnd3, vfloat32m1_t &rnd4) {
+  vuint32m1_t ctr0v = __riscv_vmv_v_x_u32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr2v = __riscv_vmv_v_x_u32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr3v = __riscv_vmv_v_x_u32m1(ctr3, __riscv_vsetvlmax_e32m1());
+
+  philox_float4(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1, rnd2, rnd3, rnd4);
+}
+
+QUALIFIERS void philox_float4(uint32 ctr0, vint32m1_t ctr1, uint32 ctr2,
+                              uint32 ctr3, uint32 key0, uint32 key1,
+                              vfloat32m1_t &rnd1, vfloat32m1_t &rnd2,
+                              vfloat32m1_t &rnd3, vfloat32m1_t &rnd4) {
+  philox_float4(ctr0, __riscv_vreinterpret_v_i32m1_u32m1(ctr1), ctr2, ctr3,
+                key0, key1, rnd1, rnd2, rnd3, rnd4);
+}
+
+QUALIFIERS void philox_double2(uint32 ctr0, vuint32m1_t ctr1, uint32 ctr2,
+                               uint32 ctr3, uint32 key0, uint32 key1,
+                               vfloat64m1_t &rnd1lo, vfloat64m1_t &rnd1hi,
+                               vfloat64m1_t &rnd2lo, vfloat64m1_t &rnd2hi) {
+  vuint32m1_t ctr0v = __riscv_vmv_v_x_u32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr2v = __riscv_vmv_v_x_u32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr3v = __riscv_vmv_v_x_u32m1(ctr3, __riscv_vsetvlmax_e32m1());
+
+  philox_double2(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1lo, rnd1hi, rnd2lo,
+                 rnd2hi);
+}
+
+QUALIFIERS void philox_double2(uint32 ctr0, vuint32m1_t ctr1, uint32 ctr2,
+                               uint32 ctr3, uint32 key0, uint32 key1,
+                               vfloat64m1_t &rnd1, vfloat64m1_t &rnd2) {
+  vuint32m1_t ctr0v = __riscv_vmv_v_x_u32m1(ctr0, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr2v = __riscv_vmv_v_x_u32m1(ctr2, __riscv_vsetvlmax_e32m1());
+  vuint32m1_t ctr3v = __riscv_vmv_v_x_u32m1(ctr3, __riscv_vsetvlmax_e32m1());
+
+  vfloat64m1_t ignore;
+  philox_double2(ctr0v, ctr1, ctr2v, ctr3v, key0, key1, rnd1, ignore, rnd2,
+                 ignore);
+}
+
+QUALIFIERS void philox_double2(uint32 ctr0, vint32m1_t ctr1, uint32 ctr2,
+                               uint32 ctr3, uint32 key0, uint32 key1,
+                               vfloat64m1_t &rnd1, vfloat64m1_t &rnd2) {
+  philox_double2(ctr0, __riscv_vreinterpret_v_i32m1_u32m1(ctr1), ctr2, ctr3,
+                 key0, key1, rnd1, rnd2);
 }
 #endif
 
@@ -1167,7 +1446,7 @@ QUALIFIERS void philox_double2(uint32 ctr0, __m256i ctr1, uint32 ctr2,
 }
 #endif
 
-#ifdef __AVX512F__
+#if defined(__AVX512F__) || defined(__AVX10_512BIT__)
 QUALIFIERS void _philox4x32round(__m512i *ctr, __m512i *key) {
   __m512i lohi0a = _mm512_mul_epu32(ctr[0], _mm512_set1_epi32(PHILOX_M4x32_0));
   __m512i lohi0b = _mm512_mul_epu32(_mm512_srli_epi64(ctr[0], 32),
@@ -1338,3 +1617,12 @@ QUALIFIERS void philox_double2(uint32 ctr0, __m512i ctr1, uint32 ctr2,
 }
 #endif
 #endif
+
+#undef QUALIFIERS
+#undef SVE_QUALIFIERS
+#undef PHILOX_W32_0
+#undef PHILOX_W32_1
+#undef PHILOX_M4x32_0
+#undef PHILOX_M4x32_1
+#undef TWOPOW53_INV_DOUBLE
+#undef TWOPOW32_INV_FLOAT

--- a/testsuite/python/lb_circular_couette.py
+++ b/testsuite/python/lb_circular_couette.py
@@ -143,8 +143,9 @@ class LBCouetteTest:
         a_ref, b_ref = taylor_couette(slip_vel, 0.0, cyl1.radius, cyl2.radius)
         v_phi_ref = a_ref * r + b_ref / r
         v_phi_drift = np.mean(v_phi) - np.mean(v_phi_ref)
-        np.testing.assert_allclose(v_phi_drift, 0., atol=4e-4)
-        np.testing.assert_allclose(v_phi - v_phi_drift, v_phi_ref, atol=4e-4)
+        # large drifts can be observed on x86 CPUs with -march=native
+        np.testing.assert_allclose(v_phi_drift, 0., atol=1e-3)
+        np.testing.assert_allclose(v_phi - v_phi_drift, v_phi_ref, atol=1e-3)
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])

--- a/testsuite/python/lb_circular_couette.py
+++ b/testsuite/python/lb_circular_couette.py
@@ -145,7 +145,7 @@ class LBCouetteTest:
         v_phi_drift = np.mean(v_phi) - np.mean(v_phi_ref)
         # large drifts can be observed on x86 CPUs with -march=native
         np.testing.assert_allclose(v_phi_drift, 0., atol=1e-3)
-        np.testing.assert_allclose(v_phi - v_phi_drift, v_phi_ref, atol=1e-3)
+        np.testing.assert_allclose(v_phi - v_phi_drift, v_phi_ref, atol=1e-2)
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])


### PR DESCRIPTION
Description of changes:
- migrate to lbmpy/pystencils 1.4.0
- fix CUDA memory management issues in the ekin code
- fix inconsistent position-independent compiler flags
- fix Cython flags to detect .pxd files shipped with NumPy >= 1.18.0
- enable waLBerla by default and AVX2 when an x86 architecture is detected
- adjust tolerances in flaky circular Couette flow test case