### PR TITLE
Improve waLBerla integration

### DIFF
--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -122,16 +122,16 @@ CommunicationEnvironment::CommunicationEnvironment(
   m_is_mpi_gpu_aware |= (cray_mpich_gpu_env and *cray_mpich_gpu_env == "1");
 #endif // defined(_CRAYC) or defined(__cray__)
 
+#ifdef ESPRESSO_WALBERLA
+  walberla::mpi_init();
+#endif
+
   communicator.full_initialization();
 
   m_callbacks =
       std::make_shared<Communication::MpiCallbacks>(comm_cart, m_mpi_env);
 
   ErrorHandling::init_error_handling(comm_cart);
-
-#ifdef ESPRESSO_WALBERLA
-  walberla::mpi_init();
-#endif
 
 #ifdef ESPRESSO_CUDA
   cuda_on_program_start();
@@ -161,7 +161,8 @@ CommunicationEnvironment::~CommunicationEnvironment() {
 }
 
 Communicator::Communicator()
-    : comm{::comm_cart}, node_grid{}, this_node{::this_node}, size{-1} {}
+    : comm{::comm_cart}, node_grid{}, this_node{::this_node}, size{-1},
+      locked_for_checkpointing{false} {}
 
 void Communicator::init_comm_cart() {
   auto constexpr reorder = false;
@@ -169,6 +170,9 @@ void Communicator::init_comm_cart() {
   this_node = comm.rank();
   // check topology validity
   std::ignore = Utils::Mpi::cart_neighbors<3>(comm);
+#ifdef ESPRESSO_WALBERLA
+  walberla::mpi_reinit(node_grid.data());
+#endif
 }
 
 void Communicator::full_initialization() {
@@ -180,6 +184,7 @@ void Communicator::full_initialization() {
 }
 
 void Communicator::set_node_grid(Utils::Vector3i const &value) {
+  assert(not locked_for_checkpointing);
   node_grid = value;
   init_comm_cart();
 }

--- a/src/core/communication.hpp
+++ b/src/core/communication.hpp
@@ -88,6 +88,7 @@ struct Communicator {
   int &this_node;
   /** @brief The MPI world size. */
   int size;
+  bool locked_for_checkpointing;
 
   Communicator();
   void init_comm_cart();

--- a/src/core/ek/EKNone.hpp
+++ b/src/core/ek/EKNone.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "system/Leaf.hpp"
+
 #include "utils.hpp"
 
 namespace System {
@@ -27,7 +29,7 @@ class System;
 
 namespace EK {
 
-struct EKNone {
+struct EKNone : public System::Leaf<EKNone> {
   bool is_ready_for_propagation() const { throw NoEKActive{}; }
   void propagate() { throw NoEKActive{}; }
   double get_tau() const { throw NoEKActive{}; }

--- a/src/core/ek/EKWalberla.hpp
+++ b/src/core/ek/EKWalberla.hpp
@@ -19,9 +19,11 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_WALBERLA
+
+#include "system/Leaf.hpp"
 
 #include <utils/Vector.hpp>
 
@@ -42,7 +44,7 @@ class System;
 
 namespace EK {
 
-struct EKWalberla {
+struct EKWalberla : public System::Leaf<EKWalberla> {
   using ek_container_type = EKContainer<EKinWalberlaBase>;
   using ek_reactions_type = EKReactions<walberla::EKReactionBase>;
   std::shared_ptr<ek_container_type> ek_container;

--- a/src/core/ek/Solver.cpp
+++ b/src/core/ek/Solver.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #include "ek/Implementation.hpp"
 #include "ek/Solver.hpp"
@@ -57,7 +57,13 @@ static void check_solver(std::unique_ptr<Solver::Implementation> const &ptr) {
 
 bool Solver::is_solver_set() const { return EK::is_solver_set(impl); }
 
-void Solver::reset() { System::get_system().ek.impl->solver = std::nullopt; }
+void Solver::reset() {
+  if (impl->solver) {
+    std::visit([this](auto &ptr) { ptr->detach_system(m_system.lock()); },
+               *impl->solver);
+    impl->solver = std::nullopt;
+  }
+}
 
 bool Solver::is_ready_for_propagation() const {
   return is_solver_set() and
@@ -140,6 +146,7 @@ double Solver::get_tau() const {
 template <> void Solver::set<EKNone>(std::shared_ptr<EKNone> ek_instance) {
   assert(impl);
   assert(not impl->solver.has_value());
+  ek_instance->bind_system(m_system.lock());
   impl->solver = ek_instance;
 }
 
@@ -149,6 +156,7 @@ void Solver::set<EKWalberla>(std::shared_ptr<EKWalberla> ek_instance) {
   assert(impl);
   assert(not impl->solver.has_value());
   auto const &system = get_system();
+  ek_instance->bind_system(m_system.lock());
   ek_instance->sanity_checks(system);
   impl->solver = ek_instance;
 }

--- a/src/core/lb/LBNone.hpp
+++ b/src/core/lb/LBNone.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "system/Leaf.hpp"
+
 #include "utils.hpp"
 
 #include <functional>
@@ -31,7 +33,7 @@ class System;
 
 namespace LB {
 
-struct LBNone {
+struct LBNone : public System::Leaf<LBNone> {
   void propagate() { throw NoLBActive{}; }
   void ghost_communication() { throw NoLBActive{}; }
   void ghost_communication_pdf() { throw NoLBActive{}; }

--- a/src/core/lb/LBWalberla.cpp
+++ b/src/core/lb/LBWalberla.cpp
@@ -142,9 +142,7 @@ void LBWalberla::sanity_checks(System::System const &system) const {
 void LBWalberla::on_lees_edwards_change() { update_collision_model(); }
 
 void LBWalberla::update_collision_model() {
-  auto const energy_conversion =
-      Utils::int_pow<2>(lb_params->get_agrid() / lb_params->get_tau());
-  auto const kT = lb_fluid->get_kT() * energy_conversion;
+  auto const kT = lb_fluid->get_kT();
   auto const seed = lb_fluid->get_seed();
   update_collision_model(*lb_fluid, *lb_params, kT, seed);
 }
@@ -152,7 +150,7 @@ void LBWalberla::update_collision_model() {
 void LBWalberla::update_collision_model(LBWalberlaBase &lb,
                                         LBWalberlaParams &params, double kT,
                                         unsigned int seed) {
-  auto const &system = ::System::get_system();
+  auto const &system = get_system();
   auto le_protocol = system.lees_edwards->get_protocol();
   if (le_protocol and
       not std::holds_alternative<LeesEdwards::Off>(*le_protocol)) {

--- a/src/core/lb/LBWalberla.hpp
+++ b/src/core/lb/LBWalberla.hpp
@@ -19,9 +19,11 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #ifdef ESPRESSO_WALBERLA
+
+#include "system/Leaf.hpp"
 
 #include <utils/Vector.hpp>
 
@@ -49,7 +51,7 @@ private:
   double m_tau;
 };
 
-struct LBWalberla {
+struct LBWalberla : public System::Leaf<LBWalberla> {
   std::shared_ptr<LBWalberlaBase> lb_fluid;
   std::shared_ptr<LBWalberlaParams> lb_params;
   LBWalberla(std::shared_ptr<LBWalberlaBase> lb_fluid_,
@@ -99,9 +101,9 @@ struct LBWalberla {
   void on_temperature_change() const {}
   void on_lees_edwards_change();
   void update_collision_model();
-  static void update_collision_model(LBWalberlaBase &instance,
-                                     LBWalberlaParams &params, double kT,
-                                     unsigned int seed);
+  void update_collision_model(LBWalberlaBase &instance,
+                              LBWalberlaParams &params, double kT,
+                              unsigned int seed);
 };
 
 } // namespace LB

--- a/src/core/lb/Solver.cpp
+++ b/src/core/lb/Solver.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #include "lb/Implementation.hpp"
 #include "lb/Solver.hpp"
@@ -65,7 +65,11 @@ static void check_solver(std::unique_ptr<Solver::Implementation> const &ptr) {
 bool Solver::is_solver_set() const { return LB::is_solver_set(impl); }
 
 void Solver::reset() {
-  System::get_system().lb.impl->solver = std::nullopt;
+  if (impl->solver) {
+    std::visit([this](auto &ptr) { ptr->detach_system(m_system.lock()); },
+               *impl->solver);
+    impl->solver = std::nullopt;
+  }
   m_conv = Conversions{};
 }
 
@@ -317,6 +321,7 @@ Utils::Vector3d Solver::get_momentum() const {
 template <> void Solver::set<LBNone>(std::shared_ptr<LBNone> lb_instance) {
   assert(impl);
   assert(not impl->solver.has_value());
+  lb_instance->bind_system(m_system.lock());
   impl->solver = lb_instance;
 }
 
@@ -328,6 +333,7 @@ void Solver::set<LBWalberla>(std::shared_ptr<LBWalberlaBase> lb_fluid,
   assert(not impl->solver.has_value());
   auto const &system = get_system();
   auto lb_instance = std::make_shared<LBWalberla>(lb_fluid, lb_params);
+  lb_instance->bind_system(m_system.lock());
   lb_instance->sanity_checks(system);
   auto const &lebc = system.box_geo->lees_edwards_bc();
   lb_fluid->check_lebc(lebc.shear_direction, lebc.shear_plane_normal);

--- a/src/core/observables/SanityChecksLB.hpp
+++ b/src/core/observables/SanityChecksLB.hpp
@@ -28,7 +28,7 @@
 
 namespace Observables {
 
-/** @brief Bookkeeping of the box gometry and LB object memory address. */
+/** @brief Bookkeeping of the box geometry and LB object memory address. */
 class SanityChecksLB {
   Utils::Vector3d m_box_l = Utils::Vector3d::broadcast(0.);
   double m_agrid = 0.;

--- a/src/python/espressomd/checkpointing.py
+++ b/src/python/espressomd/checkpointing.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import collections
 import inspect
 import pickle
 import re
@@ -24,6 +23,22 @@ import signal
 import pathlib
 from . import utils
 from . import script_interface
+
+
+@script_interface.script_interface_register
+class CheckpointerContext(script_interface.ScriptInterfaceHelper):
+    _so_name = "CellSystem::CheckpointerContext"
+    _so_creation_policy = "GLOBAL"
+
+    def _get_node_grid(self):
+        return self.call_method("get_node_grid")
+
+    def __enter__(self):
+        self.call_method("acquire_lock")
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.call_method("release_lock")
 
 
 class Checkpoint:
@@ -201,7 +216,7 @@ class Checkpoint:
 
         """
         # get attributes of registered objects
-        checkpoint_data = collections.OrderedDict()
+        checkpoint_data = {}
         for obj_name in self.checkpoint_objects:
             checkpoint_data[obj_name] = self._getattr_submodule(
                 self.calling_module, obj_name, None)
@@ -212,7 +227,9 @@ class Checkpoint:
         checkpoint_file = self.root / f"{checkpoint_index}.checkpoint"
         checkpoint_file_tmp = checkpoint_file.with_suffix(".checkpoint.tmp")
         with checkpoint_file_tmp.open("wb") as f:
-            pickle.dump(checkpoint_data, f, -1)
+            pickler = pickle.Pickler(f, protocol=pickle.HIGHEST_PROTOCOL)
+            pickler.dump(CheckpointerContext()._get_node_grid())
+            pickler.dump(checkpoint_data)
         checkpoint_file_tmp.rename(checkpoint_file)
 
     def load(self, checkpoint_index=None):
@@ -231,7 +248,9 @@ class Checkpoint:
 
         checkpoint_file = self.root / f"{checkpoint_index}.checkpoint"
         with checkpoint_file.open("rb") as f:
-            checkpoint_data = pickle.load(f)
+            unpickler = pickle.Unpickler(f)
+            with CheckpointerContext(node_grid=unpickler.load()):
+                checkpoint_data = unpickler.load()
 
         for key in checkpoint_data:
             self._setattr_submodule(

--- a/src/python/espressomd/detail/walberla.py
+++ b/src/python/espressomd/detail/walberla.py
@@ -34,9 +34,12 @@ class LatticeWalberla(ScriptInterfaceHelper):
     ----------
     agrid : :obj:`float`
         Lattice constant. The box size in every direction must be an integer
-        multiple of ``agrid``. Cannot be provided together with ``lattice``.
+        multiple of ``agrid``.
     n_ghost_layers : :obj:`int`, optional
         Lattice ghost layer thickness in units of ``agrid``.
+    box_l : (3,) array_like of :obj:`float`, optional
+        Domain size. If omitted, the currently active ESPResSo system's
+        :attr:`~espressomd.system.System.box_l` will be used.
     blocks_per_mpi_rank : (3,) array_like of :obj:`int`, optional
         Distribute more than one block to each MPI rank.
         Meant to improve cache locality. Experimental.

--- a/src/python/espressomd/lb.py
+++ b/src/python/espressomd/lb.py
@@ -28,6 +28,12 @@ import espressomd.shapes
 import espressomd.code_features
 
 
+@script_interface_register
+class Container(ScriptInterfaceHelper):
+    _so_name = "LB::Container"
+    _so_bind_methods = ("clear",)
+
+
 class VelocityBounceBack:
     """
     Hold velocity information for the velocity bounce back boundary

--- a/src/python/espressomd/particle_data.py
+++ b/src/python/espressomd/particle_data.py
@@ -439,7 +439,7 @@ class ParticleHandle(ScriptInterfaceHelper):
         return pdict
 
     def __str__(self):
-        res = collections.OrderedDict()
+        res = {}
         # Id and pos first, then the rest
         res["id"] = self.id
         res["pos"] = self.pos
@@ -451,8 +451,7 @@ class ParticleHandle(ScriptInterfaceHelper):
             else:
                 res[attr] = tmp
 
-        # Get rid of OrderedDict in output
-        return str(res).replace("OrderedDict(", "ParticleHandle(")
+        return f"{self.__class__.__name__}({res})"
 
     def add_exclusion(self, partner):
         """

--- a/src/python/espressomd/system.py
+++ b/src/python/espressomd/system.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2022 The ESPResSo project
+# Copyright (C) 2013-2026 The ESPResSo project
 #
 # This file is part of ESPResSo.
 #
@@ -18,7 +18,6 @@
 #
 
 import numpy as np
-import collections
 
 # pylint: disable=unused-import
 from . import accumulators
@@ -29,11 +28,13 @@ from . import cuda_init
 from . import collision_detection
 from . import comfixed
 from . import constraints
+from . import electrokinetics
 from . import electrostatics
 from . import magnetostatics
 from . import galilei
 from . import interactions
 from . import integrate
+from . import lb
 from . import lees_edwards
 from . import particle_data
 from . import thermostat
@@ -65,6 +66,8 @@ class System(ScriptInterfaceHelper):
     non_bonded_inter: :class:`espressomd.interactions.NonBondedInteractions`
     part: :class:`espressomd.particle_data.ParticleList`
     thermostat: :class:`espressomd.thermostat.Thermostat`
+    ekcontainer: :class:`espressomd.electrokinetics.EKContainer`
+        EK system (diffusion-advection-reaction models).
     box_l: (3,) array_like of :obj:`float`
         Dimensions of the simulation box.
     periodicity: (3,) array_like of :obj:`bool`
@@ -139,9 +142,6 @@ class System(ScriptInterfaceHelper):
             super().__init__(_regular_constructor=True, **kwargs)
             if has_features("CUDA"):
                 self.cuda_init_handle = cuda_init.CudaInitHandle()
-            if has_features("WALBERLA"):
-                self._lb = None
-                self._ekcontainer = None
 
             # lock class
             self.call_method("lock_system_creation")
@@ -166,27 +166,12 @@ class System(ScriptInterfaceHelper):
         return so
 
     def __getstate__(self):
-        checkpointable_properties = []
-        if has_features("WALBERLA"):
-            checkpointable_properties += ["_lb", "_ekcontainer"]
-
-        odict = collections.OrderedDict()
-        for property_name in checkpointable_properties:
-            odict[property_name] = System.__getattribute__(self, property_name)
-        return odict
+        return {}
 
     def __setstate__(self, params):
         # initialize Python-only members
         for property_name in params.keys():
             System.__setattr__(self, property_name, params[property_name])
-        # note: several members can only be instantiated once
-        if has_features("WALBERLA"):
-            if self._lb is not None:
-                lb, self._lb = self._lb, None
-                self.lb = lb
-            if self._ekcontainer is not None:
-                ekcontainer, self._ekcontainer = self._ekcontainer, None
-                self.ekcontainer = ekcontainer
         self.call_method("lock_system_creation")
 
     @property
@@ -255,44 +240,15 @@ class System(ScriptInterfaceHelper):
     @property
     def lb(self):
         """
-        LB solver.
+        Lattice-Boltzmann method.
 
+        Type: :class:`espressomd.lb.LBFluidWalberla`
         """
-        assert_features("WALBERLA")
-        return self._lb
+        return self.lbcontainer.solver
 
     @lb.setter
     def lb(self, lb):
-        assert_features("WALBERLA")
-        if lb != self._lb:
-            if self._lb is not None:
-                self._lb.call_method("deactivate")
-                self._lb = None
-            if lb is not None:
-                lb.call_method("activate")
-                self._lb = lb
-
-    @property
-    def ekcontainer(self):
-        """
-        EK system (diffusion-advection-reaction models).
-
-        Type: :class:`espressomd.electrokinetics.EKContainer`
-
-        """
-        assert_features("WALBERLA")
-        return self._ekcontainer
-
-    @ekcontainer.setter
-    def ekcontainer(self, ekcontainer):
-        assert_features("WALBERLA")
-        if ekcontainer != self._ekcontainer:
-            if self._ekcontainer is not None:
-                self._ekcontainer.call_method("deactivate")
-                self._ekcontainer = None
-            if ekcontainer is not None:
-                ekcontainer.call_method("activate")
-                self._ekcontainer = ekcontainer
+        self.lbcontainer.solver = lb
 
     def change_volume_and_rescale_particles(self, d_new, dir="xyz"):
         """Change box size and rescale particle coordinates.

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2022 The ESPResSo project
+# Copyright (C) 2016-2026 The ESPResSo project
 #
 # This file is part of ESPResSo.
 #
@@ -32,11 +32,13 @@ add_subdirectory(cluster_analysis)
 add_subdirectory(code_info)
 add_subdirectory(collision_detection)
 add_subdirectory(constraints)
+add_subdirectory(ek)
 add_subdirectory(electrostatics)
 add_subdirectory(galilei)
 add_subdirectory(h5md)
 add_subdirectory(integrators)
 add_subdirectory(interactions)
+add_subdirectory(lb)
 add_subdirectory(lees_edwards)
 add_subdirectory(magnetostatics)
 add_subdirectory(math)

--- a/src/script_interface/cell_system/CellSystem.cpp
+++ b/src/script_interface/cell_system/CellSystem.cpp
@@ -88,6 +88,10 @@ CellSystem::CellSystem() {
            auto const error_msg = std::string("Parameter 'node_grid'");
            auto const old_node_grid = ::communicator.node_grid;
            auto const new_node_grid = get_value<Utils::Vector3i>(v);
+           if (::communicator.locked_for_checkpointing) {
+             assert(new_node_grid == old_node_grid);
+             return;
+           }
            auto const n_nodes_old = Utils::product(old_node_grid);
            auto const n_nodes_new = Utils::product(new_node_grid);
            if (n_nodes_new != n_nodes_old) {
@@ -323,6 +327,24 @@ void CellSystem::configure(Particles::ParticleHandle &particle) {
 
 void CellSystem::configure(Particles::ParticleSlice &slice) {
   slice.attach(m_system);
+}
+
+void CheckpointerContext::do_construct(VariantMap const &params) {
+  m_node_grid = get_value_or(params, "node_grid", ::communicator.node_grid);
+}
+
+Variant CheckpointerContext::do_call_method(std::string const &name,
+                                            VariantMap const &params) {
+  if (name == "get_node_grid") {
+    return ::communicator.node_grid;
+  }
+  if (name == "acquire_lock") {
+    ::communicator.set_node_grid(m_node_grid);
+    ::communicator.locked_for_checkpointing = true;
+  } else if (name == "release_lock") {
+    ::communicator.locked_for_checkpointing = false;
+  }
+  return {};
 }
 
 } // namespace CellSystem

--- a/src/script_interface/cell_system/CellSystem.hpp
+++ b/src/script_interface/cell_system/CellSystem.hpp
@@ -112,5 +112,12 @@ private:
   }
 };
 
+class CheckpointerContext : public ObjectHandle {
+  Utils::Vector3i m_node_grid;
+  void do_construct(VariantMap const &params) override;
+  Variant do_call_method(std::string const &name,
+                         VariantMap const &params) override;
+};
+
 } // namespace CellSystem
 } // namespace ScriptInterface

--- a/src/script_interface/cell_system/initialize.cpp
+++ b/src/script_interface/cell_system/initialize.cpp
@@ -26,6 +26,7 @@ namespace CellSystem {
 
 void initialize(Utils::Factory<ObjectHandle> *om) {
   om->register_new<CellSystem>("CellSystem::CellSystem");
+  om->register_new<CheckpointerContext>("CellSystem::CheckpointerContext");
 }
 
 } // namespace CellSystem

--- a/src/script_interface/ek/CMakeLists.txt
+++ b/src/script_interface/ek/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2026 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+target_sources(espresso_script_interface PRIVATE initialize.cpp)

--- a/src/script_interface/ek/Container.hpp
+++ b/src/script_interface/ek/Container.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <config/config.hpp>
+
+#include <script_interface/ScriptInterface.hpp>
+#include <script_interface/auto_parameters/AutoParameter.hpp>
+#include <script_interface/system/Leaf.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace ScriptInterface::EK {
+
+class Container : public AutoParameters<Container, System::Leaf> {
+public:
+  Container() {
+    add_parameters({
+        {"solver",
+         [](Variant const &v) {
+           if (not is_none(v)) {
+             throw WriteError("solver");
+           }
+         },
+         []() { return Variant{None{}}; }},
+    });
+  }
+};
+
+} // namespace ScriptInterface::EK

--- a/src/script_interface/ek/initialize.cpp
+++ b/src/script_interface/ek/initialize.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config/config.hpp>
+
+#include "Container.hpp"
+
+#include <script_interface/ObjectHandle.hpp>
+
+#include <utils/Factory.hpp>
+
+namespace ScriptInterface::EK {
+
+void initialize(Utils::Factory<ObjectHandle> *om) {
+  om->register_new<Container>("EK::Container");
+}
+
+} // namespace ScriptInterface::EK

--- a/src/script_interface/ek/initialize.hpp
+++ b/src/script_interface/ek/initialize.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <config/config.hpp>
+
+namespace ScriptInterface::EK {
+void initialize(Utils::Factory<ObjectHandle> *om);
+} // namespace ScriptInterface::EK

--- a/src/script_interface/initialize.cpp
+++ b/src/script_interface/initialize.cpp
@@ -29,11 +29,13 @@
 #include "code_info/initialize.hpp"
 #include "collision_detection/initialize.hpp"
 #include "constraints/initialize.hpp"
+#include "ek/initialize.hpp"
 #include "electrostatics/initialize.hpp"
 #include "galilei/initialize.hpp"
 #include "h5md/initialize.hpp"
 #include "integrators/initialize.hpp"
 #include "interactions/initialize.hpp"
+#include "lb/initialize.hpp"
 #include "lees_edwards/initialize.hpp"
 #include "magnetostatics/initialize.hpp"
 #include "math/initialize.hpp"
@@ -60,9 +62,11 @@ void initialize(Utils::Factory<ObjectHandle> *f) {
   Constraints::initialize(f);
   Coulomb::initialize(f);
   Dipoles::initialize(f);
+  EK::initialize(f);
   Galilei::initialize(f);
   Integrators::initialize(f);
   Interactions::initialize(f);
+  LB::initialize(f);
   LeesEdwards::initialize(f);
   Math::initialize(f);
   MPIIO::initialize(f);

--- a/src/script_interface/lb/CMakeLists.txt
+++ b/src/script_interface/lb/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2026 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+target_sources(espresso_script_interface PRIVATE initialize.cpp)

--- a/src/script_interface/lb/Container.hpp
+++ b/src/script_interface/lb/Container.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023-2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <config/config.hpp>
+
+#include <script_interface/ScriptInterface.hpp>
+#include <script_interface/auto_parameters/AutoParameter.hpp>
+#include <script_interface/system/Leaf.hpp>
+
+#include "core/system/System.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace ScriptInterface::LB {
+
+class Container : public AutoParameters<Container, System::Leaf> {
+  ObjectRef m_solver;
+  std::unique_ptr<VariantMap> m_params;
+
+  void detach_solver() {
+    if (m_solver) {
+      m_solver->do_call_method("deactivate", {});
+      std::dynamic_pointer_cast<System::Leaf>(m_solver)->detach_system();
+    }
+    m_solver.reset();
+  }
+
+  void bind_solver() {
+    auto system = m_system.lock();
+    std::dynamic_pointer_cast<System::Leaf>(m_solver)->bind_system(system);
+    m_solver->do_call_method("activate", {});
+  }
+
+  void on_bind_system(::System::System &) override {
+    auto const &params = *m_params;
+    for (auto const &key : get_parameter_insertion_order()) {
+      if (params.contains(key)) {
+        do_set_parameter(key.c_str(), params.at(key));
+      }
+    }
+    m_params.reset();
+  }
+
+public:
+  Container() {
+    add_parameters({
+        {"solver",
+         [this](Variant const &v) {
+           if (is_none(v)) {
+             detach_solver();
+           } else {
+             auto new_solver = get_value<ObjectRef>(v);
+             auto old_solver = m_solver;
+             detach_solver();
+             try {
+               m_solver = new_solver;
+               context()->parallel_try_catch([this]() { bind_solver(); });
+             } catch (...) {
+               detach_solver();
+               m_solver = old_solver;
+               if (m_solver) {
+                 bind_solver();
+               }
+               throw;
+             }
+           }
+         },
+         [this]() { return m_solver ? Variant{m_solver} : Variant{None{}}; }},
+    });
+  }
+
+  void do_construct(VariantMap const &params) override {
+    m_params = std::make_unique<VariantMap>(params);
+  }
+
+protected:
+  Variant do_call_method(std::string const &name, VariantMap const &) override {
+    if (name == "clear") {
+      detach_solver();
+      return {};
+    }
+    return {};
+  }
+};
+
+} // namespace ScriptInterface::LB

--- a/src/script_interface/lb/initialize.cpp
+++ b/src/script_interface/lb/initialize.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config/config.hpp>
+
+#include "Container.hpp"
+
+#include <script_interface/ObjectHandle.hpp>
+
+#include <utils/Factory.hpp>
+
+namespace ScriptInterface::LB {
+
+void initialize(Utils::Factory<ObjectHandle> *om) {
+  om->register_new<Container>("LB::Container");
+}
+
+} // namespace ScriptInterface::LB

--- a/src/script_interface/lb/initialize.hpp
+++ b/src/script_interface/lb/initialize.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <config/config.hpp>
+
+namespace ScriptInterface::LB {
+void initialize(Utils::Factory<ObjectHandle> *om);
+} // namespace ScriptInterface::LB

--- a/src/script_interface/system/System.cpp
+++ b/src/script_interface/system/System.cpp
@@ -19,7 +19,7 @@
 
 #include "System.hpp"
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #include "core/BoxGeometry.hpp"
 #include "core/Particle.hpp"
@@ -45,12 +45,14 @@
 #include "script_interface/cell_system/CellSystem.hpp"
 #include "script_interface/collision_detection/CollisionDetection.hpp"
 #include "script_interface/constraints/Constraints.hpp"
+#include "script_interface/ek/Container.hpp"
 #include "script_interface/electrostatics/Container.hpp"
 #include "script_interface/galilei/ComFixed.hpp"
 #include "script_interface/galilei/Galilei.hpp"
 #include "script_interface/integrators/IntegratorHandle.hpp"
 #include "script_interface/interactions/BondedInteractions.hpp"
 #include "script_interface/interactions/NonBondedInteractions.hpp"
+#include "script_interface/lb/Container.hpp"
 #include "script_interface/lees_edwards/LeesEdwards.hpp"
 #include "script_interface/magnetostatics/Container.hpp"
 #include "script_interface/particle_data/ParticleHandle.hpp"
@@ -125,6 +127,8 @@ struct System::Leaves {
 #ifdef ESPRESSO_DIPOLES
   std::shared_ptr<Dipoles::Container> magnetostatics;
 #endif
+  std::shared_ptr<LB::Container> lb;
+  std::shared_ptr<EK::Container> ek;
   std::shared_ptr<Particles::ParticleList> part;
 
   ~Leaves() {
@@ -201,6 +205,7 @@ System::System() : m_instance{}, m_leaves{std::make_unique<Leaves>()} {
          m_instance->oif_global->max_oif_objects = get_value<int>(v);
        },
        [this]() { return m_instance->oif_global->max_oif_objects; }},
+
   });
   // note: the order of leaves matters! e.g. bonds depend on thermostats,
   // and thus a thermostat object must be instantiated before the bonds
@@ -225,6 +230,50 @@ System::System() : m_instance{}, m_leaves{std::make_unique<Leaves>()} {
 #ifdef ESPRESSO_DIPOLES
   add_parameter("magnetostatics", &Leaves::magnetostatics);
 #endif
+  add_parameter("lbcontainer", &Leaves::lb);
+  add_parameters({
+      {"ekcontainer",
+       [this](Variant const &v) {
+         if (is_none(v)) {
+           m_leaves->ek->do_call_method("deactivate", {});
+           if (not context()->is_head_node()) {
+             return;
+           }
+           set_parameter("ekcontainer",
+                         context()->make_shared("EK::Container", {}));
+         } else {
+           auto const detach_solver = [this]() {
+             auto &solver = m_leaves->ek;
+             if (solver) {
+               solver->do_call_method("deactivate", {});
+               solver->detach_system();
+             }
+             solver.reset();
+           };
+           auto const bind_solver = [this]() {
+             auto &solver = m_leaves->ek;
+             if (solver) {
+               solver->bind_system(m_instance);
+               solver->do_call_method("activate", {});
+             }
+           };
+           auto &solver = m_leaves->ek;
+           auto new_solver = get_value<std::shared_ptr<EK::Container>>(v);
+           auto old_solver = solver;
+           detach_solver();
+           try {
+             solver = new_solver;
+             context()->parallel_try_catch([&]() { bind_solver(); });
+           } catch (...) {
+             detach_solver();
+             solver = old_solver;
+             bind_solver();
+             throw;
+           }
+         }
+       },
+       [this]() { return m_leaves->ek; }},
+  });
   add_parameter("part", &Leaves::part);
 }
 
@@ -322,6 +371,8 @@ void System::do_construct(VariantMap const &params) {
 #ifdef ESPRESSO_DIPOLES
     do_set_default_parameter<Dipoles::Container>("magnetostatics");
 #endif
+    do_set_default_parameter<LB::Container>("lbcontainer");
+    do_set_default_parameter<EK::Container>("ekcontainer");
     do_set_default_parameter<Particles::ParticleList>("part");
   } else {
     for (auto const &key : get_parameter_insertion_order()) {

--- a/src/script_interface/walberla/EKContainer.hpp
+++ b/src/script_interface/walberla/EKContainer.hpp
@@ -106,6 +106,7 @@ class EKContainer : public ObjectList<EKSpecies, EK::Container> {
         throw std::runtime_error(
             "Cannot mix single and double precision kernels");
       }
+      ek_throw_if_expired(obj_ptr->get_mpi_cart_comm_observer());
       m_ek_container->add(obj_ptr->get_ekinstance());
     });
   }

--- a/src/script_interface/walberla/EKContainer.hpp
+++ b/src/script_interface/walberla/EKContainer.hpp
@@ -39,6 +39,7 @@
 
 #include <script_interface/ObjectList.hpp>
 #include <script_interface/ScriptInterface.hpp>
+#include <script_interface/ek/Container.hpp>
 
 #include <cassert>
 #include <memory>
@@ -48,8 +49,8 @@
 
 namespace ScriptInterface::walberla {
 
-class EKContainer : public ObjectList<EKSpecies> {
-  using Base = ObjectList<EKSpecies>;
+class EKContainer : public ObjectList<EKSpecies, EK::Container> {
+  using Base = ObjectList<EKSpecies, EK::Container>;
   using Base::value_type;
 
   std::variant<
@@ -205,17 +206,13 @@ protected:
   Variant do_call_method(std::string const &method,
                          VariantMap const &parameters) override {
     if (method == "activate") {
-      context()->parallel_try_catch([this]() {
-        ::System::get_system().ek.set<::EK::EKWalberla>(m_ek_instance);
-      });
+      get_system().ek.set<::EK::EKWalberla>(m_ek_instance);
       m_is_active = true;
       return {};
     }
     if (method == "deactivate") {
-      if (m_is_active) {
-        ::System::get_system().ek.reset();
-        m_is_active = false;
-      }
+      get_system().ek.reset();
+      m_is_active = false;
       return {};
     }
 

--- a/src/script_interface/walberla/EKSpecies.cpp
+++ b/src/script_interface/walberla/EKSpecies.cpp
@@ -26,6 +26,8 @@
 #include "errorhandling.hpp"
 
 #include <walberla_bridge/electrokinetics/ek_walberla_init.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
+#include <walberla_bridge/walberla_init.hpp>
 
 #include <boost/mpi.hpp>
 #include <boost/mpi/collectives/all_reduce.hpp>
@@ -175,6 +177,7 @@ void EKSpecies::do_construct(VariantMap const &params) {
     m_conv_flux = tau * Utils::int_pow<2>(agrid);
     m_density = density * m_conv_density;
     make_instance(params);
+    m_mpi_cart_comm_observer = ::walberla::get_mpi_cart_comm_observer();
     for (auto &vtk : m_vtk_writers) {
       vtk->attach_to_lattice(m_instance, get_lattice_to_md_units_conversion());
     }

--- a/src/script_interface/walberla/EKSpecies.hpp
+++ b/src/script_interface/walberla/EKSpecies.hpp
@@ -30,6 +30,7 @@
 #include <walberla_bridge/LatticeModel.hpp>
 #include <walberla_bridge/LatticeWalberla.hpp>
 #include <walberla_bridge/electrokinetics/EKinWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
 
 #include <script_interface/ScriptInterface.hpp>
 
@@ -37,6 +38,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -51,9 +53,18 @@ class EKVTKHandle : public VTKHandleBase<::EKinWalberlaBase> {
   }
 };
 
+inline void
+ek_throw_if_expired(std::optional<ResourceObserver> const &mpi_obs) {
+  if (not(mpi_obs and mpi_obs->is_valid())) {
+    throw std::runtime_error(
+        "the MPI Cartesian communicator of this EK object has expired");
+  }
+}
+
 class EKSpecies : public LatticeModel<::EKinWalberlaBase, EKVTKHandle> {
 protected:
   using Base = LatticeModel<::EKinWalberlaBase, EKVTKHandle>;
+  std::optional<ResourceObserver> m_mpi_cart_comm_observer;
   double m_conv_diffusion;
   double m_conv_ext_efield;
   double m_conv_energy;
@@ -138,6 +149,9 @@ public:
 
   [[nodiscard]] auto get_ekinstance() const { return m_instance; }
   [[nodiscard]] auto get_lattice() const { return m_lattice; }
+  [[nodiscard]] auto get_mpi_cart_comm_observer() const {
+    return m_mpi_cart_comm_observer;
+  }
 
   Variant do_call_method(std::string const &method,
                          VariantMap const &parameters) override;

--- a/src/script_interface/walberla/EKSpeciesNode.cpp
+++ b/src/script_interface/walberla/EKSpeciesNode.cpp
@@ -27,6 +27,7 @@
 #include "LatticeIndices.hpp"
 
 #include <walberla_bridge/electrokinetics/EKinWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
 
 #include <utils/Vector.hpp>
 #include <utils/mpi/reduce_optional.hpp>
@@ -59,6 +60,10 @@ Variant EKSpeciesNode::do_call_method(std::string const &name,
     }
     m_index = index;
     return 0;
+  }
+  if (not name.starts_with("get_")) {
+    context()->parallel_try_catch(
+        [&]() { ek_throw_if_expired(m_mpi_cart_comm_observer); });
   }
   if (name == "set_density") {
     auto const dens = get_value<double>(params, "value");

--- a/src/script_interface/walberla/EKSpeciesNode.hpp
+++ b/src/script_interface/walberla/EKSpeciesNode.hpp
@@ -30,11 +30,13 @@
 #include <script_interface/auto_parameters/AutoParameters.hpp>
 
 #include <walberla_bridge/electrokinetics/EKinWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
 
 #include <utils/Vector.hpp>
 
 #include <cassert>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -42,6 +44,7 @@ namespace ScriptInterface::walberla {
 
 class EKSpeciesNode : public AutoParameters<EKSpeciesNode, LatticeIndices> {
   std::shared_ptr<::EKinWalberlaBase> m_ek_species;
+  std::optional<ResourceObserver> m_mpi_cart_comm_observer;
   Utils::Vector3i m_index;
   Utils::Vector3i m_grid_size;
   double m_conv_dens;
@@ -57,6 +60,7 @@ public:
     auto const ek_sip =
         get_value<std::shared_ptr<EKSpecies>>(params, "parent_sip");
     m_ek_species = ek_sip->get_ekinstance();
+    m_mpi_cart_comm_observer = ek_sip->get_mpi_cart_comm_observer();
     assert(m_ek_species);
     m_conv_dens = ek_sip->get_conversion_factor_density();
     m_conv_flux = ek_sip->get_conversion_factor_flux();

--- a/src/script_interface/walberla/EKSpeciesSlice.cpp
+++ b/src/script_interface/walberla/EKSpeciesSlice.cpp
@@ -26,6 +26,8 @@
 
 #include "LatticeSlice.impl.hpp"
 
+#include <walberla_bridge/utils/ResourceManager.hpp>
+
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -52,6 +54,11 @@ Variant EKSpeciesSlice::do_call_method(std::string const &name,
       });
     }
     return m_shape_val.at(name);
+  }
+
+  if (not name.starts_with("get_")) {
+    context()->parallel_try_catch(
+        [&]() { ek_throw_if_expired(m_mpi_cart_comm_observer); });
   }
 
   // slice getter/setter callback

--- a/src/script_interface/walberla/EKSpeciesSlice.hpp
+++ b/src/script_interface/walberla/EKSpeciesSlice.hpp
@@ -32,6 +32,7 @@
 
 #include <walberla_bridge/LatticeWalberla.hpp>
 #include <walberla_bridge/electrokinetics/EKinWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
 
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
@@ -113,6 +114,7 @@ class EKSpeciesSlice : public LatticeSlice<EKFieldSerializer> {
   using LatticeModel = ::EKinWalberlaBase;
   std::shared_ptr<LatticeModel> m_ek_species;
   std::shared_ptr<EKSpecies> m_ek_sip;
+  std::optional<ResourceObserver> m_mpi_cart_comm_observer;
   double m_conv_dens;
   double m_conv_flux;
   std::unordered_map<std::string, std::vector<int>> m_shape_val;
@@ -121,6 +123,7 @@ public:
   void do_construct(VariantMap const &params) override {
     m_ek_sip = get_value<std::shared_ptr<EKSpecies>>(params, "parent_sip");
     m_ek_species = m_ek_sip->get_ekinstance();
+    m_mpi_cart_comm_observer = m_ek_sip->get_mpi_cart_comm_observer();
     assert(m_ek_species);
     m_conv_dens = m_ek_sip->get_conversion_factor_density();
     m_conv_flux = m_ek_sip->get_conversion_factor_flux();

--- a/src/script_interface/walberla/LBFluid.cpp
+++ b/src/script_interface/walberla/LBFluid.cpp
@@ -68,21 +68,19 @@ std::unordered_map<std::string, int> const LBVTKHandle::obs_map = {
 Variant LBFluid::do_call_method(std::string const &name,
                                 VariantMap const &params) {
   if (name == "activate") {
-    context()->parallel_try_catch([this]() {
-      ::System::get_system().lb.set<::LB::LBWalberla>(m_instance, m_lb_params);
-    });
+    auto &system = get_system();
+    system.lb.set<::LB::LBWalberla>(m_instance, m_lb_params);
+    system.lb.update_collision_model();
     m_is_active = true;
     return {};
   }
   if (name == "deactivate") {
-    if (m_is_active) {
-      ::System::get_system().lb.reset();
-      m_is_active = false;
-    }
+    get_system().lb.reset();
+    m_is_active = false;
     return {};
   }
   if (name == "add_force_at_pos") {
-    auto const &box_geo = *::System::get_system().box_geo;
+    auto const &box_geo = *get_system().box_geo;
     auto const pos = get_value<Utils::Vector3d>(params, "pos");
     auto const f = get_value<Utils::Vector3d>(params, "force");
     auto const folded_pos = box_geo.folded_position(pos);
@@ -117,7 +115,7 @@ Variant LBFluid::do_call_method(std::string const &name,
   }
   if (name == "clear_boundaries") {
     m_instance->clear_boundaries();
-    ::System::get_system().on_lb_boundary_conditions_change();
+    get_system().on_lb_boundary_conditions_change();
     return {};
   }
   if (name == "add_boundary_from_shape") {
@@ -203,8 +201,7 @@ void LBFluid::do_construct(VariantMap const &params) {
       throw std::domain_error("Parameter 'kinematic_viscosity' must be >= 0");
     }
     make_instance(params);
-    ::LB::LBWalberla::update_collision_model(*m_instance, *m_lb_params, lb_kT,
-                                             static_cast<unsigned int>(seed));
+    m_instance->set_collision_model(lb_kT, seed);
     m_instance->set_external_force(lb_ext_f);
     m_instance->ghost_communication();
     for (auto &vtk : m_vtk_writers) {
@@ -236,7 +233,7 @@ std::vector<Variant> LBFluid::get_average_pressure_tensor() const {
 }
 
 Variant LBFluid::get_interpolated_velocity(Utils::Vector3d const &pos) const {
-  auto const &box_geo = *::System::get_system().box_geo;
+  auto const &box_geo = *get_system().box_geo;
   auto const lb_pos = box_geo.folded_position(pos) * m_conv_dist;
   auto const result = m_instance->get_velocity_at_pos(lb_pos);
   return Utils::Mpi::reduce_optional(context()->get_comm(), result) /

--- a/src/script_interface/walberla/LBFluid.cpp
+++ b/src/script_interface/walberla/LBFluid.cpp
@@ -35,6 +35,8 @@
 #include <walberla_bridge/LatticeWalberla.hpp>
 #include <walberla_bridge/lattice_boltzmann/LeesEdwardsPack.hpp>
 #include <walberla_bridge/lattice_boltzmann/lb_walberla_init.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
+#include <walberla_bridge/walberla_init.hpp>
 
 #include <utils/Vector.hpp>
 #include <utils/matrix.hpp>
@@ -69,6 +71,8 @@ Variant LBFluid::do_call_method(std::string const &name,
                                 VariantMap const &params) {
   if (name == "activate") {
     auto &system = get_system();
+    context()->parallel_try_catch(
+        [&]() { lb_throw_if_expired(m_mpi_cart_comm_observer); });
     system.lb.set<::LB::LBWalberla>(m_instance, m_lb_params);
     system.lb.update_collision_model();
     m_is_active = true;
@@ -78,6 +82,10 @@ Variant LBFluid::do_call_method(std::string const &name,
     get_system().lb.reset();
     m_is_active = false;
     return {};
+  }
+  if (not name.starts_with("get_")) {
+    context()->parallel_try_catch(
+        [&]() { lb_throw_if_expired(m_mpi_cart_comm_observer); });
   }
   if (name == "add_force_at_pos") {
     auto const &box_geo = *get_system().box_geo;
@@ -201,6 +209,7 @@ void LBFluid::do_construct(VariantMap const &params) {
       throw std::domain_error("Parameter 'kinematic_viscosity' must be >= 0");
     }
     make_instance(params);
+    m_mpi_cart_comm_observer = ::walberla::get_mpi_cart_comm_observer();
     m_instance->set_collision_model(lb_kT, seed);
     m_instance->set_external_force(lb_ext_f);
     m_instance->ghost_communication();

--- a/src/script_interface/walberla/LBFluid.hpp
+++ b/src/script_interface/walberla/LBFluid.hpp
@@ -35,6 +35,7 @@
 
 #include <walberla_bridge/LatticeModel.hpp>
 #include <walberla_bridge/lattice_boltzmann/LBWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
 
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
@@ -42,6 +43,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -57,10 +59,19 @@ class LBVTKHandle : public VTKHandleBase<::LBWalberlaBase> {
   }
 };
 
+inline void
+lb_throw_if_expired(std::optional<ResourceObserver> const &mpi_obs) {
+  if (not(mpi_obs and mpi_obs->is_valid())) {
+    throw std::runtime_error(
+        "the MPI Cartesian communicator of this LB object has expired");
+  }
+}
+
 class LBFluid : public LatticeModel<::LBWalberlaBase, LBVTKHandle> {
 protected:
   using Base = LatticeModel<::LBWalberlaBase, LBVTKHandle>;
   std::shared_ptr<::LB::LBWalberlaParams> m_lb_params;
+  std::optional<ResourceObserver> m_mpi_cart_comm_observer;
   bool m_is_active;
   double m_conv_dist;
   double m_conv_visc;
@@ -131,6 +142,9 @@ public:
 
   [[nodiscard]] auto get_lb_fluid() const { return m_instance; }
   [[nodiscard]] auto get_lb_params() const { return m_lb_params; }
+  [[nodiscard]] auto get_mpi_cart_comm_observer() const {
+    return m_mpi_cart_comm_observer;
+  }
 
   ::LatticeModel::units_map
   get_lattice_to_md_units_conversion() const override {

--- a/src/script_interface/walberla/LBFluid.hpp
+++ b/src/script_interface/walberla/LBFluid.hpp
@@ -28,6 +28,8 @@
 #include "VTKHandle.hpp"
 
 #include "core/lb/LBWalberla.hpp"
+#include "core/lb/Solver.hpp"
+#include "core/system/System.hpp"
 
 #include <script_interface/ScriptInterface.hpp>
 

--- a/src/script_interface/walberla/LBFluidNode.cpp
+++ b/src/script_interface/walberla/LBFluidNode.cpp
@@ -23,6 +23,8 @@
 
 #include "LBFluidNode.hpp"
 
+#include <walberla_bridge/utils/ResourceManager.hpp>
+
 #include <utils/Vector.hpp>
 #include <utils/matrix.hpp>
 #include <utils/mpi/reduce_optional.hpp>
@@ -44,6 +46,10 @@ static bool is_boundary_all_reduce(boost::mpi::communicator const &comm,
 
 Variant LBFluidNode::do_call_method(std::string const &name,
                                     VariantMap const &params) {
+  if (not name.starts_with("get_")) {
+    context()->parallel_try_catch(
+        [&]() { lb_throw_if_expired(m_mpi_cart_comm_observer); });
+  }
   if (name == "set_velocity_at_boundary") {
     if (is_none(params.at("value"))) {
       m_lb_fluid->remove_node_from_boundary(m_index);

--- a/src/script_interface/walberla/LBFluidNode.hpp
+++ b/src/script_interface/walberla/LBFluidNode.hpp
@@ -31,12 +31,14 @@
 #include <script_interface/auto_parameters/AutoParameters.hpp>
 
 #include <walberla_bridge/lattice_boltzmann/LBWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
 
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
 
 #include <cassert>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -44,6 +46,7 @@ namespace ScriptInterface::walberla {
 
 class LBFluidNode : public AutoParameters<LBFluidNode, LatticeIndices> {
   std::shared_ptr<::LBWalberlaBase> m_lb_fluid;
+  std::optional<ResourceObserver> m_mpi_cart_comm_observer;
   Utils::Vector3i m_index;
   Utils::Vector3i m_grid_size;
   double m_conv_dens;
@@ -61,6 +64,7 @@ public:
     auto const lb_sip =
         get_value<std::shared_ptr<LBFluid>>(params, "parent_sip");
     m_lb_fluid = lb_sip->get_lb_fluid();
+    m_mpi_cart_comm_observer = lb_sip->get_mpi_cart_comm_observer();
     auto const lb_params = lb_sip->get_lb_params();
     auto const tau = lb_params->get_tau();
     auto const agrid = lb_params->get_agrid();

--- a/src/script_interface/walberla/LBFluidSlice.cpp
+++ b/src/script_interface/walberla/LBFluidSlice.cpp
@@ -25,6 +25,8 @@
 
 #include "LatticeSlice.impl.hpp"
 
+#include <walberla_bridge/utils/ResourceManager.hpp>
+
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -55,6 +57,11 @@ Variant LBFluidSlice::do_call_method(std::string const &name,
   }
   if (name == "get_lattice_speed") {
     return 1. / m_conv_velocity;
+  }
+
+  if (not name.starts_with("get_")) {
+    context()->parallel_try_catch(
+        [&]() { lb_throw_if_expired(m_mpi_cart_comm_observer); });
   }
 
   // slice getter/setter callback

--- a/src/script_interface/walberla/LBFluidSlice.hpp
+++ b/src/script_interface/walberla/LBFluidSlice.hpp
@@ -32,6 +32,7 @@
 
 #include <walberla_bridge/LatticeWalberla.hpp>
 #include <walberla_bridge/lattice_boltzmann/LBWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
 
 #include <utils/Vector.hpp>
 #include <utils/math/int_pow.hpp>
@@ -101,6 +102,7 @@ class LBFluidSlice : public LatticeSlice<LBFieldSerializer> {
   using LatticeModel = ::LBWalberlaBase;
   std::shared_ptr<LatticeModel> m_lb_fluid;
   std::shared_ptr<LBFluid> m_lb_sip;
+  std::optional<ResourceObserver> m_mpi_cart_comm_observer;
   double m_conv_dens;
   double m_conv_press;
   double m_conv_force;
@@ -111,6 +113,7 @@ public:
   void do_construct(VariantMap const &params) override {
     m_lb_sip = get_value<std::shared_ptr<LBFluid>>(params, "parent_sip");
     m_lb_fluid = m_lb_sip->get_lb_fluid();
+    m_mpi_cart_comm_observer = m_lb_sip->get_mpi_cart_comm_observer();
     auto const lb_params = m_lb_sip->get_lb_params();
     auto const tau = lb_params->get_tau();
     auto const agrid = lb_params->get_agrid();

--- a/src/script_interface/walberla/LatticeModel.hpp
+++ b/src/script_interface/walberla/LatticeModel.hpp
@@ -25,6 +25,7 @@
 
 #include <script_interface/ScriptInterface.hpp>
 #include <script_interface/auto_parameters/AutoParameters.hpp>
+#include <script_interface/system/Leaf.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -35,7 +36,8 @@
 namespace ScriptInterface::walberla {
 
 template <class Method, class VTKHandle>
-class LatticeModel : public AutoParameters<LatticeModel<Method, VTKHandle>> {
+class LatticeModel
+    : public AutoParameters<LatticeModel<Method, VTKHandle>, System::Leaf> {
 protected:
   std::shared_ptr<LatticeWalberla> m_lattice;
   std::shared_ptr<Method> m_instance;

--- a/src/script_interface/walberla/LatticeWalberla.hpp
+++ b/src/script_interface/walberla/LatticeWalberla.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 The ESPResSo project
+ * Copyright (C) 2021-2026 The ESPResSo project
  *
  * This file is part of ESPResSo.
  *
@@ -53,16 +53,19 @@ public:
          [this]() { return static_cast<int>(m_lattice->get_ghost_layers()); }},
         {"shape", AutoParameter::read_only,
          [this]() { return m_lattice->get_grid_dimensions(); }},
-        {"_box_l", AutoParameter::read_only, [this]() { return m_box_l; }},
+        {"box_l", AutoParameter::read_only, [this]() { return m_box_l; }},
         {"blocks_per_mpi_rank", AutoParameter::read_only,
          [this]() { return m_blocks_per_mpi_rank; }},
     });
   }
 
   void do_construct(VariantMap const &args) override {
-    auto const &box_geo = *::System::get_system().box_geo;
     m_agrid = get_value<double>(args, "agrid");
-    m_box_l = get_value_or<Utils::Vector3d>(args, "_box_l", box_geo.length());
+    if (args.contains("box_l")) {
+      m_box_l = get_value<Utils::Vector3d>(args, "box_l");
+    } else {
+      m_box_l = ::System::get_system().box_geo->length();
+    }
     m_blocks_per_mpi_rank =
         get_value<Utils::Vector3i>(args, "blocks_per_mpi_rank");
     auto const n_ghost_layers = get_value<int>(args, "n_ghost_layers");

--- a/src/walberla_bridge/include/walberla_bridge/utils/ResourceManager.hpp
+++ b/src/walberla_bridge/include/walberla_bridge/utils/ResourceManager.hpp
@@ -81,3 +81,24 @@ public:
     m_resources.emplace(std::make_unique<ResourceLockImpl<T>>(resource));
   }
 };
+
+/**
+ * @brief Observer to monitor the lifetime of a shared resource.
+ *
+ * A shared resource whose lifetime isn't managed via a smart pointer
+ * can become a dangling reference. When a resource is centrally managed,
+ * e.g. via a singleton, the singleton interface can be adapted to keep
+ * track of the shared resources lifetime via an "observer" object
+ * that shares the same lifetime.
+ *
+ * This class wraps a type-erased non-owning observer that cannot be promoted
+ * to a shared handle.
+ */
+struct ResourceObserver {
+  template <typename T>
+  ResourceObserver(std::shared_ptr<T> const &status) : m_status(status) {}
+  bool is_valid() const { return m_status.use_count() != 0; }
+
+private:
+  std::weak_ptr<void> m_status;
+};

--- a/src/walberla_bridge/include/walberla_bridge/walberla_init.hpp
+++ b/src/walberla_bridge/include/walberla_bridge/walberla_init.hpp
@@ -31,7 +31,13 @@ void mpi_init();
 /** @brief Release waLBerla's MPI manager and environment. */
 void mpi_deinit();
 
+/** @brief Re-initialize waLBerla's MPI Cartesian communicator. */
+void mpi_reinit(int const *cart_topol);
+
 /** @brief Get a lock on waLBerla's global resources for VTK. */
 std::unique_ptr<ResourceManager> get_vtk_dependent_resources();
+
+/** @brief Get an observer on waLBerla's MPI Cartesian communicator status. */
+ResourceObserver get_mpi_cart_comm_observer();
 
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
@@ -589,7 +589,7 @@ private:
 
   void kernel_migration() {}
 
-  void updated_boundary_fields() {
+  void update_boundary_fields() {
     m_boundary_flux->boundary_update();
     m_boundary_density->boundary_update();
   }
@@ -609,7 +609,7 @@ public:
   void integrate(std::size_t potential_id, std::size_t velocity_id,
                  std::size_t force_id, double lb_density) override {
 
-    updated_boundary_fields();
+    update_boundary_fields();
 
     if (get_diffusion() == 0.)
       return;

--- a/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
@@ -48,6 +48,8 @@
 #include <walberla_bridge/BlockAndCell.hpp>
 #include <walberla_bridge/LatticeWalberla.hpp>
 #include <walberla_bridge/electrokinetics/EKinWalberlaBase.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
+#include <walberla_bridge/walberla_init.hpp>
 
 #include <utils/Vector.hpp>
 
@@ -300,6 +302,7 @@ protected:
   std::shared_ptr<FullCommunicator> m_full_communication;
   std::shared_ptr<BoundaryFullCommunicator> m_boundary_communicator;
   std::bitset<GhostComm::SIZE> m_pending_ghost_comm;
+  ResourceObserver m_mpi_cart_comm_observer;
   template <class Field>
   using PackInfo =
       typename FieldTrait<FloatType, Architecture>::template PackInfo<Field>;
@@ -312,7 +315,8 @@ public:
       : m_diffusion(FloatType_c(diffusion)), m_kT(FloatType_c(kT)),
         m_valency(FloatType_c(valency)), m_ext_efield(ext_efield),
         m_advection(advection), m_friction_coupling(friction_coupling),
-        m_seed(seed), m_lattice(std::move(lattice)) {
+        m_seed(seed), m_lattice(std::move(lattice)),
+        m_mpi_cart_comm_observer(get_mpi_cart_comm_observer()) {
 
     auto const &blocks = m_lattice->get_blocks();
     auto const n_ghost_layers = m_lattice->get_ghost_layers();
@@ -453,6 +457,7 @@ public:
 
   void ghost_communication() override {
     if (m_pending_ghost_comm.test(GhostComm::DENS)) {
+      assert(m_mpi_cart_comm_observer.is_valid());
       (*m_full_communication)();
       m_pending_ghost_comm.reset(GhostComm::DENS);
     }
@@ -461,6 +466,7 @@ public:
 
   void ghost_communication_boundary() {
     if (m_pending_ghost_comm.test(GhostComm::FLB)) {
+      assert(m_mpi_cart_comm_observer.is_valid());
       m_boundary_communicator->communicate();
       m_pending_ghost_comm.reset(GhostComm::FLB);
     }
@@ -609,6 +615,7 @@ public:
   void integrate(std::size_t potential_id, std::size_t velocity_id,
                  std::size_t force_id, double lb_density) override {
 
+    assert(m_mpi_cart_comm_observer.is_valid());
     update_boundary_fields();
 
     if (get_diffusion() == 0.)

--- a/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
@@ -61,6 +61,8 @@
 #include <walberla_bridge/LatticeWalberla.hpp>
 #include <walberla_bridge/lattice_boltzmann/LBWalberlaBase.hpp>
 #include <walberla_bridge/lattice_boltzmann/LeesEdwardsPack.hpp>
+#include <walberla_bridge/utils/ResourceManager.hpp>
+#include <walberla_bridge/walberla_init.hpp>
 
 #include <utils/Vector.hpp>
 #include <utils/index.hpp>
@@ -350,6 +352,7 @@ protected:
   std::shared_ptr<RegularFullCommunicator> m_laf_communicator;
   std::shared_ptr<PDFStreamingCommunicator> m_pdf_streaming_communicator;
   std::bitset<GhostComm::SIZE> m_pending_ghost_comm;
+  ResourceObserver m_mpi_cart_comm_observer;
 
   // collision sweep
   std::shared_ptr<CollisionModel> m_collision_model;
@@ -448,7 +451,8 @@ public:
                  double density)
       : m_viscosity(FloatType_c(viscosity)), m_density(FloatType_c(density)),
         m_kT(FloatType{0}), m_seed(0u), m_zc_to_md(density),
-        m_zc_to_lb(1. / density), m_lattice(std::move(lattice)) {
+        m_zc_to_lb(1. / density), m_lattice(std::move(lattice)),
+        m_mpi_cart_comm_observer(get_mpi_cart_comm_observer()) {
 
     auto const &blocks = m_lattice->get_blocks();
     auto const n_ghost_layers = m_lattice->get_ghost_layers();
@@ -576,6 +580,7 @@ private:
   }
 
   void integrate_pull_scheme() {
+    assert(m_mpi_cart_comm_observer.is_valid());
     auto const &blocks = get_lattice().get_blocks();
     // Reset force fields
     integrate_reset_force(blocks);
@@ -621,6 +626,7 @@ public:
 
   void ghost_communication() override {
     if (m_pending_ghost_comm.any()) {
+      assert(m_mpi_cart_comm_observer.is_valid());
       ghost_communication_boundary();
       ghost_communication_pdf();
       ghost_communication_laf();
@@ -630,6 +636,7 @@ public:
 
   void ghost_communication_pdf() override {
     if (m_pending_ghost_comm.test(GhostComm::PDF)) {
+      assert(m_mpi_cart_comm_observer.is_valid());
       m_pdf_communicator->communicate();
       if (has_lees_edwards_bc()) {
         auto const &blocks = get_lattice().get_blocks();
@@ -641,6 +648,7 @@ public:
 
   void ghost_communication_vel() override {
     if (m_pending_ghost_comm.test(GhostComm::VEL)) {
+      assert(m_mpi_cart_comm_observer.is_valid());
       m_vel_communicator->communicate();
       if (has_lees_edwards_bc()) {
         auto const &blocks = get_lattice().get_blocks();
@@ -652,6 +660,7 @@ public:
 
   void ghost_communication_laf() override {
     if (m_pending_ghost_comm.test(GhostComm::LAF)) {
+      assert(m_mpi_cart_comm_observer.is_valid());
       m_laf_communicator->communicate();
       if (has_lees_edwards_bc()) {
         auto const &blocks = get_lattice().get_blocks();
@@ -663,12 +672,14 @@ public:
 
   void ghost_communication_boundary() {
     if (m_pending_ghost_comm.test(GhostComm::UBB)) {
+      assert(m_mpi_cart_comm_observer.is_valid());
       m_boundary_communicator->communicate();
       m_pending_ghost_comm.reset(GhostComm::UBB);
     }
   }
 
   void ghost_communication_full() {
+    assert(m_mpi_cart_comm_observer.is_valid());
     m_full_communicator->communicate();
     if (has_lees_edwards_bc()) {
       apply_lees_edwards_interpolation();

--- a/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
@@ -314,6 +314,12 @@ protected:
   FlagUID const Boundary_flag{"boundary"};
   bool m_has_boundaries{false};
 
+  // lattice
+  std::shared_ptr<LatticeWalberla> m_lattice;
+
+  // boundaries
+  std::shared_ptr<BoundaryModel> m_boundary;
+
   /**
    * @brief Full communicator.
    * We use the D3Q27 directions to update cells along the diagonals during
@@ -345,10 +351,16 @@ protected:
   std::shared_ptr<PDFStreamingCommunicator> m_pdf_streaming_communicator;
   std::bitset<GhostComm::SIZE> m_pending_ghost_comm;
 
-  // ResetForce sweep + external force handling
+  // collision sweep
+  std::shared_ptr<CollisionModel> m_collision_model;
+
+  // force reset sweep + external force handling
   std::shared_ptr<ResetForce<PdfField, VectorField>> m_reset_force;
 
-  // Lees Edwards boundary interpolation
+  // velocity update sweep
+  std::shared_ptr<UpdateVelFromPDF> m_update_velocities_from_pdf;
+
+  // Lees-Edwards boundary interpolation
   std::shared_ptr<LeesEdwardsPack> m_lees_edwards_callbacks;
   std::shared_ptr<InterpolateAndShiftAtBoundary<_PdfField, FloatType>>
       m_lees_edwards_pdf_interpol_sweep;
@@ -356,18 +368,6 @@ protected:
       m_lees_edwards_vel_interpol_sweep;
   std::shared_ptr<InterpolateAndShiftAtBoundary<_VectorField, FloatType>>
       m_lees_edwards_last_applied_force_interpol_sweep;
-
-  // Collision sweep
-  std::shared_ptr<CollisionModel> m_collision_model;
-
-  // Velocity update sweep
-  std::shared_ptr<UpdateVelFromPDF> m_update_velocities_from_pdf;
-
-  // boundaries
-  std::shared_ptr<BoundaryModel> m_boundary;
-
-  // lattice
-  std::shared_ptr<LatticeWalberla> m_lattice;
 
 #if defined(__CUDACC__)
   std::shared_ptr<gpu::HostFieldAllocator<FloatType>> m_host_field_allocator;
@@ -407,13 +407,13 @@ protected:
       auto field_id = gpu::addGPUFieldToStorage<GPUField>(
           blocks, tag, Field::F_SIZE, field::fzyx, n_ghost_layers);
       if constexpr (std::is_same_v<Field, _VectorField>) {
-        for (auto block = blocks->begin(); block != blocks->end(); ++block) {
-          auto field = block->template getData<GPUField>(field_id);
+        for (auto &block : *blocks) {
+          auto field = block.template getData<GPUField>(field_id);
           lbm::accessor::Vector::initialize(field, Vector3<FloatType>{0});
         }
       } else if constexpr (std::is_same_v<Field, _PdfField>) {
-        for (auto block = blocks->begin(); block != blocks->end(); ++block) {
-          auto field = block->template getData<GPUField>(field_id);
+        for (auto &block : *blocks) {
+          auto field = block.template getData<GPUField>(field_id);
           lbm::accessor::Population::initialize(
               field, std::array<FloatType, Stencil::Size>{});
         }
@@ -571,8 +571,8 @@ private:
 
   void integrate_update_velocities_from_pdf(
       std::shared_ptr<BlockStorage> const &blocks) {
-    for (auto b = blocks->begin(); b != blocks->end(); ++b)
-      (*m_update_velocities_from_pdf)(&*b);
+    for (auto &block : *blocks)
+      (*m_update_velocities_from_pdf)(&block);
   }
 
   void integrate_pull_scheme() {

--- a/src/walberla_bridge/src/walberla_init.cpp
+++ b/src/walberla_bridge/src/walberla_init.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 The ESPResSo project
+ * Copyright (C) 2019-2026 The ESPResSo project
  *
  * This file is part of ESPResSo.
  *
@@ -30,23 +30,44 @@
 static std::shared_ptr<walberla::mpi::MPIManager> walberla_mpi_comm;
 /** @brief waLBerla MPI environment. */
 static std::shared_ptr<walberla::mpi::Environment> walberla_mpi_env;
+/**
+ * @brief waLBerla MPI Cartesian communicator observer.
+ * It is purposefully decoupled from @ref walberla_mpi_comm.
+ * We are not tracking the lifetime of @ref walberla_mpi_comm itself,
+ * but the lifetime of its ownership by the waLBerla MPI singleton.
+ */
+static std::shared_ptr<int> walberla_mpi_cart_comm_observer;
 
 namespace walberla {
 
 void mpi_init() {
   assert(::walberla_mpi_env == nullptr);
   assert(::walberla_mpi_comm == nullptr);
+  assert(::walberla_mpi_cart_comm_observer == nullptr);
   int argc = 0;
   char **argv = nullptr;
   ::walberla_mpi_env = std::make_shared<walberla::mpi::Environment>(argc, argv);
-  ::walberla_mpi_comm = walberla::MPIManager::instance();
+  ::walberla_mpi_comm = walberla::mpi::MPIManager::instance();
+  ::walberla_mpi_cart_comm_observer = std::make_shared<int>(0);
+}
+
+void mpi_reinit(int const *const cart_topol) {
+  assert(::walberla_mpi_env.use_count() >= 1);
+  assert(::walberla_mpi_comm.use_count() >= 1);
+  assert(::walberla_mpi_cart_comm_observer.use_count() == 1);
+  ::walberla_mpi_comm->resetMPI();
+  ::walberla_mpi_comm->createCartesianComm(cart_topol[0], cart_topol[1],
+                                           cart_topol[2], true, true, true);
+  ::walberla_mpi_cart_comm_observer = std::make_shared<int>(0);
 }
 
 void mpi_deinit() {
   assert(::walberla_mpi_env.use_count() >= 1);
   assert(::walberla_mpi_comm.use_count() >= 1);
+  assert(::walberla_mpi_cart_comm_observer.use_count() == 1);
   ::walberla_mpi_env.reset();
   ::walberla_mpi_comm.reset();
+  ::walberla_mpi_cart_comm_observer.reset();
 }
 
 std::unique_ptr<ResourceManager> get_vtk_dependent_resources() {
@@ -56,6 +77,11 @@ std::unique_ptr<ResourceManager> get_vtk_dependent_resources() {
   // waLBerla MPI environment (destructor depends on the MPI communicator)
   vtk_dependencies->acquire_lock(::walberla_mpi_env);
   return vtk_dependencies;
+}
+
+ResourceObserver get_mpi_cart_comm_observer() {
+  assert(walberla_mpi_cart_comm_observer.use_count() <= 1);
+  return walberla_mpi_cart_comm_observer;
 }
 
 } // namespace walberla

--- a/src/walberla_bridge/tests/ResourceManager_test.cpp
+++ b/src/walberla_bridge/tests/ResourceManager_test.cpp
@@ -75,3 +75,11 @@ BOOST_AUTO_TEST_CASE(destruction_order) {
   BOOST_CHECK_EQUAL(Testing::logger[6], "~A()");
   BOOST_CHECK_EQUAL(Testing::logger[7], "~C()");
 }
+
+BOOST_AUTO_TEST_CASE(observer) {
+  auto resource = std::make_shared<int>(0);
+  auto observer = ResourceObserver(resource);
+  BOOST_CHECK(observer.is_valid());
+  resource.reset();
+  BOOST_CHECK(not observer.is_valid());
+}

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -558,6 +558,33 @@ class EKTest:
         with self.assertRaisesRegex(ValueError, "Parameter 'seed' is required for thermalized EKSpecies"):
             self.ek_species_class(**make_kwargs(thermalized=True))
 
+        # when ekcontainer is None, no solver can be attached
+        self.system.ekcontainer = None
+        self.system.ekcontainer.solver = None
+        with self.assertRaisesRegex(RuntimeError, "Parameter 'solver' is read-only"):
+            self.system.ekcontainer.solver = espressomd.electrokinetics.EKNone(
+                lattice=self.lattice)
+        self.assertIsNone(self.system.ekcontainer.solver)
+
+    def test_rollback(self):
+        """check rollback to a valid state when setter fails"""
+        node_grid = np.copy(self.system.cell_system.node_grid)
+        world_size = np.prod(node_grid)
+        if world_size <= 4:
+            wrong_box_l = [1., 1., 7.] if world_size == 1 else 2. * node_grid
+            lattice1 = espressomd.electrokinetics.LatticeWalberla(
+                n_ghost_layers=2, agrid=1., box_l=self.system.box_l)
+            lattice2 = espressomd.electrokinetics.LatticeWalberla(
+                n_ghost_layers=2, agrid=1., box_l=wrong_box_l)
+            solver_valid = espressomd.electrokinetics.EKNone(lattice=lattice1)
+            solver_wrong = espressomd.electrokinetics.EKNone(lattice=lattice2)
+            self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
+                tau=self.system.time_step, solver=solver_valid)
+            with self.assertRaisesRegex(RuntimeError, "waLBerla and ESPResSo disagree about domain decomposition"):
+                self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
+                    tau=self.system.time_step, solver=solver_wrong)
+            self.assertEqual(self.system.ekcontainer.solver, solver_valid)
+
     def test_bool_operations_on_node(self):
         ekspecies = self.make_default_ek_species()
         # test __eq()__ where a node is equal to itself and not equal to any

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -356,8 +356,6 @@ class EKTest:
         with self.assertRaisesRegex(RuntimeError, "MD cell geometry change not supported by EK"):
             self.system.box_l = [1., 2., 3.]
         np.testing.assert_allclose(np.copy(self.system.box_l), 6., atol=1e-7)
-        with self.assertRaisesRegex(RuntimeError, "MPI topology change not supported by EK"):
-            self.system.cell_system.node_grid = self.system.cell_system.node_grid
 
     def test_ek_reactants(self):
         ek_species = self.make_default_ek_species()
@@ -584,6 +582,43 @@ class EKTest:
                 self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
                     tau=self.system.time_step, solver=solver_wrong)
             self.assertEqual(self.system.ekcontainer.solver, solver_valid)
+
+    def test_node_grid_change(self):
+        """check MPI Cartesian communicator invalidation"""
+        node_grid = np.copy(self.system.cell_system.node_grid)
+        # create a species, slice and node for the current MPI topology
+        ek_solver = espressomd.electrokinetics.EKNone(lattice=self.lattice)
+        ek_species = self.make_default_ek_species()
+        ek_node = ek_species[0, 0, 0]
+        ek_slice = ek_species[0:5, 0:5, 0:5]
+        self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
+            tau=self.system.time_step, solver=ek_solver)
+        self.system.ekcontainer.add(ek_species)
+        # veto node grid change
+        with self.assertRaisesRegex(RuntimeError, "MPI topology change not supported by EK"):
+            self.system.cell_system.node_grid = node_grid
+        self.system.ekcontainer = None
+        # invalidate MPI Cartesian communicator
+        self.system.cell_system.node_grid = node_grid
+        # create a new species
+        ek_solver_new = espressomd.electrokinetics.EKNone(lattice=self.lattice)
+        ek_species_new = self.make_default_ek_species()
+        self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
+            tau=self.system.time_step, solver=ek_solver_new)
+        self.system.ekcontainer.add(ek_species_new)
+        # prevent binding of an expired EK object
+        with self.assertRaisesRegex(RuntimeError, "the MPI Cartesian communicator of this EK object has expired"):
+            self.system.ekcontainer.add(ek_species)
+        self.assertEqual(len(self.system.ekcontainer), 1)
+        self.assertEqual(self.system.ekcontainer[0], ek_species_new)
+        # expired MPI communicator doesn't prevent read access to the fields
+        _ = ek_node.density
+        _ = ek_slice.density
+        # expired MPI communicator prevents write access to the fields
+        for handle in [ek_node, ek_slice,
+                       ek_species[0, 0, 0], ek_species[0:5, 0:5, 0:5]]:
+            with self.assertRaisesRegex(RuntimeError, "the MPI Cartesian communicator of this EK object has expired"):
+                handle.density = 1.
 
     def test_bool_operations_on_node(self):
         ekspecies = self.make_default_ek_species()

--- a/testsuite/python/lattice.py
+++ b/testsuite/python/lattice.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021-2023 The ESPResSo project
+# Copyright (C) 2021-2026 The ESPResSo project
 #
 # This file is part of ESPResSo.
 #
@@ -31,37 +31,41 @@ class Test(ut.TestCase):
     Basic tests of the block forest.
 
     """
-    system = espressomd.System(box_l=[12., 4., 4.])
 
     def test_interface(self):
         LatticeWalberla = espressomd.lb.LatticeWalberla
+        box_l = np.array([12., 4., 4.])
 
         # check getters
         for n_ghost_layers in range(10):
-            obj = LatticeWalberla(agrid=1., n_ghost_layers=n_ghost_layers)
+            obj = LatticeWalberla(
+                agrid=1., n_ghost_layers=n_ghost_layers, box_l=box_l)
             self.assertEqual(obj.n_ghost_layers, n_ghost_layers)
         for agrid in (0.5, 1., 2.):
-            obj = LatticeWalberla(agrid=agrid, n_ghost_layers=1)
+            obj = LatticeWalberla(agrid=agrid, n_ghost_layers=1, box_l=box_l)
             self.assertEqual(obj.agrid, agrid)
-            target_shape = np.asarray(self.system.box_l, dtype=int) / obj.agrid
+            target_shape = np.asarray(box_l, dtype=int) / obj.agrid
             np.testing.assert_array_equal(obj.shape, target_shape)
 
         # check exception mechanism
-        obj = LatticeWalberla(agrid=1., n_ghost_layers=1)
+        obj = LatticeWalberla(agrid=1., n_ghost_layers=1, box_l=box_l)
         with self.assertRaisesRegex(RuntimeError, "Parameter 'agrid' is read-only"):
             obj.agrid = 2.
+        with self.assertRaisesRegex(RuntimeError, "Parameter 'box_l' is read-only"):
+            obj.box_l = box_l
         with self.assertRaisesRegex(RuntimeError, "Parameter 'n_ghost_layers' is read-only"):
             obj.n_ghost_layers = 2
         with self.assertRaisesRegex(ValueError, "Parameter 'n_ghost_layers' must be >= 0"):
-            LatticeWalberla(agrid=1., n_ghost_layers=-1)
+            LatticeWalberla(agrid=1., n_ghost_layers=-1, box_l=box_l)
         with self.assertRaisesRegex(ValueError, "Parameter 'agrid' must be > 0"):
-            LatticeWalberla(agrid=0., n_ghost_layers=1)
+            LatticeWalberla(agrid=0., n_ghost_layers=1, box_l=box_l)
         with self.assertRaisesRegex(ValueError, "Parameter 'agrid' must be > 0"):
-            LatticeWalberla(agrid=-1., n_ghost_layers=1)
+            LatticeWalberla(agrid=-1., n_ghost_layers=1, box_l=box_l)
         with self.assertRaisesRegex(ValueError, "Parameter 'blocks_per_mpi_rank' must be >= 1"):
-            LatticeWalberla(agrid=1., blocks_per_mpi_rank=[1, 0, 1])
+            LatticeWalberla(
+                agrid=1., blocks_per_mpi_rank=[1, 0, 1], box_l=box_l)
         with self.assertRaisesRegex(ValueError, "Parameter 'shape' must be derived from espressomd.shapes.Shape"):
-            obj = LatticeWalberla(agrid=1., n_ghost_layers=1)
+            obj = LatticeWalberla(agrid=1., n_ghost_layers=1, box_l=box_l)
             next(obj.get_node_indices_inside_shape(10))
 
 

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -265,6 +265,35 @@ class LBTest:
         with self.assertRaisesRegex(ValueError, "Parameter 'seed' must be >= 0"):
             self.lb_class(**make_kwargs(kT=0., seed=-42))
 
+    def test_rollback(self):
+        """check rollback to a valid state when setter fails"""
+        node_grid = np.copy(self.system.cell_system.node_grid)
+        world_size = np.prod(node_grid)
+        if world_size <= 4:
+            wrong_box_l = [1., 1., 7.] if world_size == 1 else 2. * node_grid
+            lattice1 = espressomd.lb.LatticeWalberla(
+                n_ghost_layers=1, agrid=1., box_l=self.system.box_l)
+            lattice2 = espressomd.lb.LatticeWalberla(
+                n_ghost_layers=1, agrid=1., box_l=wrong_box_l)
+            kwargs = self.params.copy()
+            del kwargs["agrid"]
+            solver_valid = self.lb_class(lattice=lattice1, **kwargs)
+            solver_wrong = self.lb_class(lattice=lattice2, **kwargs)
+            self.system.lb = solver_valid
+            with self.assertRaisesRegex(RuntimeError, "waLBerla and ESPResSo disagree about domain decomposition"):
+                self.system.lb = solver_wrong
+            self.assertEqual(self.system.lb, solver_valid)
+
+    def test_lbcontainer(self):
+        self.assertIsInstance(self.system.lbcontainer, espressomd.lb.Container)
+        self.assertIsNone(self.system.lbcontainer.solver)
+        lbf = self.lb_class(kT=1.0, seed=42, **self.params, **self.lb_params)
+        self.system.lb = lbf
+        self.assertIsInstance(self.system.lbcontainer, espressomd.lb.Container)
+        self.system.lbcontainer.clear()
+        self.assertIsInstance(self.system.lbcontainer, espressomd.lb.Container)
+        self.assertIsNone(self.system.lbcontainer.solver)
+
     def test_node_exceptions(self):
         lbf = self.lb_class(**self.params, **self.lb_params)
         self.system.lb = lbf
@@ -857,7 +886,6 @@ class LBTest:
 @utx.skipIfMissingFeatures("WALBERLA")
 class LBTestWalberlaDoublePrecisionCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": False}
     atol = 1e-10
     rtol = 1e-7
@@ -866,7 +894,6 @@ class LBTestWalberlaDoublePrecisionCPU(LBTest, ut.TestCase):
 @utx.skipIfMissingFeatures("WALBERLA")
 class LBTestWalberlaSinglePrecisionCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": True}
     atol = 5e-6
     rtol = 2e-4
@@ -876,7 +903,6 @@ class LBTestWalberlaSinglePrecisionCPU(LBTest, ut.TestCase):
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class LBTestWalberlaDoublePrecisionGPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberlaGPU
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": False}
     atol = 1e-10
     rtol = 1e-7
@@ -886,7 +912,6 @@ class LBTestWalberlaDoublePrecisionGPU(LBTest, ut.TestCase):
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class LBTestWalberlaSinglePrecisionGPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberlaGPU
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": True}
     atol = 5e-6
     rtol = 2e-4
@@ -895,7 +920,6 @@ class LBTestWalberlaSinglePrecisionGPU(LBTest, ut.TestCase):
 @utx.skipIfMissingFeatures("WALBERLA")
 class LBTestWalberlaDoublePrecisionBlocksCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     blocks_per_mpi_rank = [2, 2, 2]
     lb_params = {"single_precision": False,
                  "blocks_per_mpi_rank": blocks_per_mpi_rank}
@@ -906,7 +930,6 @@ class LBTestWalberlaDoublePrecisionBlocksCPU(LBTest, ut.TestCase):
 @utx.skipIfMissingFeatures("WALBERLA")
 class LBTestWalberlaSinglePrecisionBlocksCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     blocks_per_mpi_rank = [2, 2, 2]
     lb_params = {"single_precision": True,
                  "blocks_per_mpi_rank": blocks_per_mpi_rank}

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -284,6 +284,35 @@ class LBTest:
                 self.system.lb = solver_wrong
             self.assertEqual(self.system.lb, solver_valid)
 
+    def test_node_grid_change(self):
+        """check MPI Cartesian communicator invalidation"""
+        node_grid = np.copy(self.system.cell_system.node_grid)
+        # create a lbf, slice and node for the current MPI topology
+        lbf = self.lb_class(**self.params, **self.lb_params)
+        lbnode = lbf[0, 0, 0]
+        lbslice = lbf[0:5, 0:5, 0:5]
+        self.system.lb = lbf
+        # veto node grid change
+        with self.assertRaisesRegex(RuntimeError, "MPI topology change not supported by LB"):
+            self.system.cell_system.node_grid = node_grid
+        self.system.lb = None
+        # invalidate MPI Cartesian communicator
+        self.system.cell_system.node_grid = node_grid
+        # create a new lbf
+        lbf_new = self.lb_class(**self.params, **self.lb_params)
+        self.system.lb = lbf_new
+        # prevent binding of an expired LB object
+        with self.assertRaisesRegex(RuntimeError, "the MPI Cartesian communicator of this LB object has expired"):
+            self.system.lb = lbf
+        self.assertEqual(self.system.lb, lbf_new)
+        # expired MPI communicator doesn't prevent read access to the fields
+        _ = lbnode.velocity
+        _ = lbslice.pressure_tensor_neq
+        # expired MPI communicator prevents write access to the fields
+        for handle in [lbnode, lbslice, lbf[0, 0, 0], lbf[0:5, 0:5, 0:5]]:
+            with self.assertRaisesRegex(RuntimeError, "the MPI Cartesian communicator of this LB object has expired"):
+                handle.velocity = [1., 2., 3.]
+
     def test_lbcontainer(self):
         self.assertIsInstance(self.system.lbcontainer, espressomd.lb.Container)
         self.assertIsNone(self.system.lbcontainer.solver)
@@ -499,8 +528,6 @@ class LBTest:
         with self.assertRaisesRegex(RuntimeError, "MD cell geometry change not supported by LB"):
             self.system.box_l = [1., 2., 3.]
         np.testing.assert_allclose(np.copy(self.system.box_l), 6., atol=1e-7)
-        with self.assertRaisesRegex(RuntimeError, "MPI topology change not supported by LB"):
-            self.system.cell_system.node_grid = self.system.cell_system.node_grid
 
     def test_grid_index(self):
         lbf = self.lb_class(**self.params, **self.lb_params)

--- a/testsuite/python/lb_lees_edwards.py
+++ b/testsuite/python/lb_lees_edwards.py
@@ -33,7 +33,7 @@ system.time_step = 0.01
 
 class LBContextManager:
     """
-    Add an LB actor and remove it from the actor list at the end.
+    Add an LB solver and remove it at the end.
     """
 
     def __init__(self, **kwargs):

--- a/testsuite/python/lb_slice.py
+++ b/testsuite/python/lb_slice.py
@@ -173,14 +173,12 @@ class LBTest:
 @utx.skipIfMissingFeatures("WALBERLA")
 class LBTestWalberlaDoublePrecisionCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": False}
 
 
 @utx.skipIfMissingFeatures("WALBERLA")
 class LBTestWalberlaSinglePrecisionCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": True}
 
 
@@ -188,7 +186,6 @@ class LBTestWalberlaSinglePrecisionCPU(LBTest, ut.TestCase):
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class LBTestWalberlaDoublePrecisionGPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberlaGPU
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": False}
 
 
@@ -196,21 +193,18 @@ class LBTestWalberlaDoublePrecisionGPU(LBTest, ut.TestCase):
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class LBTestWalberlaSinglePrecisionGPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberlaGPU
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": True}
 
 
 @utx.skipIfMissingFeatures("WALBERLA")
 class LBTestWalberlaDoublePrecisionBlocksCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": False, "blocks_per_mpi_rank": [1, 1, 2]}
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class LBTestWalberlaSinglePrecisionBlocksCPU(LBTest, ut.TestCase):
     lb_class = espressomd.lb.LBFluidWalberla
-    lb_lattice_class = espressomd.lb.LatticeWalberla
     lb_params = {"single_precision": True, "blocks_per_mpi_rank": [1, 1, 2]}
 
 


### PR DESCRIPTION
Fixes #5224

Description of changes:
- synchronize ESPResSo and waLBerla MPI Cartesian communicators
- remove waLBerla's dependency on ESPResSo global variables that will be removed in the future
- remove workarounds in the Python integration of waLBerla and roll out the `System::Leaf` pattern
- decouple checkpointing of the global state (MPI Cartesian communicators) from ESPResSo objects