### PR TITLE
Rename and document `Analysis.particle_energy()`

### DIFF
--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -50,7 +50,18 @@ For example, ::
     >>> print(energy["bonded"])
     >>> print(energy["non_bonded"])
 
+.. _Particle non-bonded energy:
 
+Particle non-bonded energy
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+:meth:`espressomd.analyze.Analysis.particle_non_bonded_energy`
+
+Returns the non-bonded (short-range) energy contribution of a single particle.
+
+.. note::
+   :meth:`espressomd.analyze.Analysis.particle_energy` is a deprecated alias.
+   Use :meth:`espressomd.analyze.Analysis.particle_non_bonded_energy` instead.
+   
 .. _Momentum of the system:
 
 Momentum of the System

--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -56,7 +56,7 @@ Particle non-bonded energy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 :meth:`espressomd.analyze.Analysis.particle_non_bonded_energy`
 
-Returns the non-bonded (short-range) energy contribution of a single particle.
+Returns the non-bonded energy contribution from a single particle.
 
 .. _Momentum of the system:
 

--- a/doc/sphinx/analysis.rst
+++ b/doc/sphinx/analysis.rst
@@ -58,10 +58,6 @@ Particle non-bonded energy
 
 Returns the non-bonded (short-range) energy contribution of a single particle.
 
-.. note::
-   :meth:`espressomd.analyze.Analysis.particle_energy` is a deprecated alias.
-   Use :meth:`espressomd.analyze.Analysis.particle_non_bonded_energy` instead.
-   
 .. _Momentum of the system:
 
 Momentum of the System

--- a/doc/sphinx/inter_non-bonded.rst
+++ b/doc/sphinx/inter_non-bonded.rst
@@ -641,25 +641,22 @@ Thole correction
 
     Requires features ``THOLE`` and ``ELECTROSTATICS``.
 
-.. note::
-
-    ``THOLE`` is only implemented for the P3M electrostatics solver.
-
 The Thole correction is closely related to simulations involving
 :ref:`Particle polarizability with thermalized cold Drude oscillators`.
 In this context, it is used to correct for overestimation of
 induced dipoles at short distances. Ultimately, it alters the short-range
-electrostatics of P3M to result in a damped Coulomb interaction potential
-:math:`V(r) = \frac{q_1 q_2}{r} \cdot (1- e^{-s r} (1 + \frac{s r}{2}) )`.  The
-Thole scaling coefficient :math:`s` is related to the polarizabilities
+electrostatics to result in a damped Coulomb interaction potential
+:math:`V(r) = C\frac{q_1 q_2}{r} \cdot (1- e^{-s r} (1 + \frac{s r}{2}) )`
+derived from the charge density :math:`\varphi^\prime_1` in :cite:`thole81a`.
+The Thole scaling coefficient :math:`s` is related to the polarizabilities
 :math:`\alpha` and Thole damping parameters :math:`a` of the interacting
 species via :math:`s = \frac{ (a_i + a_j) / 2 }{ (\alpha_i \alpha_j)^{1/6} }`.
 Note that for the Drude oscillators, the Thole correction should be applied
 only for the dipole part :math:`\pm q_d` added by the Drude charge and not on
 the total core charge, which can be different for polarizable ions. Also note
 that the Thole correction acts between all dipoles, intra- and intermolecular.
-Again, the accuracy is related to the P3M accuracy and the split between
-short-range and long-range electrostatics interaction. It is configured by::
+The accuracy is related to the split between short-range and long-range
+electrostatics interaction. It is configured by::
 
     system = espressomd.System(box_l=[1, 1, 1])
     system.non_bonded_inter[type_1,type_2].thole.set_params(scaling_coeff=<float>, q1q2=<float>)

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -127,18 +127,16 @@ double System::particle_short_range_energy_contribution(int pid) {
   auto ret = 0.0;
   if (auto const p = cell_structure->get_local_particle(pid)) {
     auto const coulomb_kernel = coulomb.pair_energy_kernel();
-    auto kernel = [coulomb_kernel_ptr = get_ptr(coulomb_kernel), &ret,
-                   this](Particle const &p, Particle const &p1,
-                         Utils::Vector3d const &vec) {
+    auto kernel = [&ret, this](Particle const &p, Particle const &p1,
+                               Utils::Vector3d const &vec) {
 #ifdef ESPRESSO_EXCLUSIONS
       if (not do_nonbonded(p, p1))
         return;
 #endif
       auto const &ia_params = nonbonded_ias->get_ia_param(p.type(), p1.type());
       // Add energy for current particle pair to result
-      ret +=
-          calc_non_bonded_pair_energy(p, p1, ia_params, vec, vec.norm(),
-                                      *bonded_ias, coulomb, coulomb_kernel_ptr);
+      ret += calc_non_bonded_pair_energy(p, p1, ia_params, vec, vec.norm(),
+                                         *bonded_ias, coulomb, nullptr);
     };
     cell_structure->run_on_particle_short_range_neighbors(*p, kernel);
   }

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -335,7 +335,7 @@ class Analysis(ScriptInterfaceHelper):
         -------
         :obj:`float`
             Short-range non-bonded energy contribution of that particle.
-            
+
     particle_energy()
         Deprecated alias for :meth:`particle_non_bonded_energy`.
 

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -529,29 +529,6 @@ class Analysis(ScriptInterfaceHelper):
         """
         return self.call_method("particle_energy", pid=particle.id)
 
-    def particle_energy(self, particle):
-        """
-        Deprecated alias for :meth:`particle_non_bonded_energy`.
-
-        Parameters
-        ----------
-        particle : :class:`~espressomd.particle_data.ParticleHandle`
-
-        Returns
-        -------
-        :obj:`float`
-            Short-range non-bonded energy contribution of that particle.
-
-        """
-        import warnings
-
-        warnings.warn(
-            "particle_energy() is deprecated, use particle_non_bonded_energy() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.particle_non_bonded_energy(particle)
-
     def particle_bond_energy(self, particle, bond):
         """
         Calculate the bonded energy for the given particle and bond.

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -325,6 +325,8 @@ class Analysis(ScriptInterfaceHelper):
             and [1] contains the values of the minimal distance distribution function.
 
     particle_non_bonded_energy()
+        :no-index:
+        
         Calculate the short-range non-bonded energy contribution of a single particle.
 
         Parameters

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -327,14 +327,26 @@ class Analysis(ScriptInterfaceHelper):
     particle_non_bonded_energy()
         Calculate the short-range non-bonded energy contribution of a single particle.
 
-            Notes
-            -----
-            This includes only short-range non-bonded interaction terms (e.g. Lennard-Jones,
-            WCA, etc., depending on enabled features). Electrostatic energy contributions
-            (both short-range real-space and long-range/k-space parts) are not included.
+        Parameters
+        ----------
+        particle : :class:`~espressomd.particle_data.ParticleHandle`
 
+        Returns
+        -------
+        :obj:`float`
+            Short-range non-bonded energy contribution of that particle.
+            
     particle_energy()
         Deprecated alias for :meth:`particle_non_bonded_energy`.
+
+        Parameters
+        ----------
+        particle : :class:`~espressomd.particle_data.ParticleHandle`
+
+        Returns
+        -------
+        :obj:`float`
+            Short-range non-bonded energy contribution of that particle.
 
     """
     _so_name = "Analysis::Analysis"
@@ -520,16 +532,12 @@ class Analysis(ScriptInterfaceHelper):
 
     def particle_non_bonded_energy(self, particle):
         """
-        Calculate the non-bonded energy of a single given particle.
         Calculate the short-range non-bonded energy contribution associated with
         a single particle.
 
-        Notes
-        -----
-        This value includes short-range non-bonded interaction terms (e.g. LJ/WCA,
-        etc., depending on enabled features). It does **not** include electrostatic
-        energy contributions (neither the short-range real-space part nor any
-        long-range/k-space part).
+        This includes only short-range non-bonded interaction terms (e.g. Lennard-Jones,
+        WCA, etc., depending on enabled features). Electrostatic energy contributions
+        are not included.
 
         Parameters
         ----------
@@ -537,11 +545,9 @@ class Analysis(ScriptInterfaceHelper):
 
         Returns
         -------
-        :obj: `float`
-            Non-bonded energy of that particle
-
         :obj:`float`
             Short-range non-bonded energy contribution for that particle.
+
         """
         return self.call_method("particle_energy", pid=particle.id)
 
@@ -549,10 +555,15 @@ class Analysis(ScriptInterfaceHelper):
         """
         Deprecated alias for :meth:`particle_non_bonded_energy`.
 
-        Notes
-        -----
-        This method will be removed in a future release. Use
-        :meth:`particle_non_bonded_energy` instead.
+        Parameters
+        ----------
+        particle : :class:`~espressomd.particle_data.ParticleHandle`
+
+        Returns
+        -------
+        :obj:`float`
+            Short-range non-bonded energy contribution of that particle.
+
         """
         import warnings
 

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -511,9 +511,11 @@ class Analysis(ScriptInterfaceHelper):
         Calculate the short-range non-bonded energy contribution associated with
         a single particle.
 
-        This includes only short-range non-bonded interaction terms (e.g. Lennard-Jones,
-        WCA, etc., depending on enabled features). Electrostatic energy contributions
-        are not included.
+        This includes short-range non-bonded interaction terms (e.g. Lennard-Jones,
+        WCA, etc., depending on enabled features). Depending on enabled features
+        (notably Thole damping for Drude oscillators), electrostatics-related
+        short-range correction terms may also contribute. Long-range / k-space
+        electrostatic energy contributions are not included.
 
         Parameters
         ----------

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -517,7 +517,7 @@ class Analysis(ScriptInterfaceHelper):
         """
         observable = self.call_method("calculate_energy")
         return self._generate_summary(observable, 1, False)
-    
+
     def particle_non_bonded_energy(self, particle):
         """
         Calculate the non-bonded energy of a single given particle.

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -324,20 +324,6 @@ class Analysis(ScriptInterfaceHelper):
             Where [0] contains the midpoints of the bins,
             and [1] contains the values of the minimal distance distribution function.
 
-    particle_non_bonded_energy()
-        :no-index:
-
-        Calculate the short-range non-bonded energy contribution of a single particle.
-
-        Parameters
-        ----------
-        particle : :class:`~espressomd.particle_data.ParticleHandle`
-
-        Returns
-        -------
-        :obj:`float`
-            Short-range non-bonded energy contribution of that particle.
-
     """
     _so_name = "Analysis::Analysis"
     _so_creation_policy = "GLOBAL"

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -508,14 +508,11 @@ class Analysis(ScriptInterfaceHelper):
 
     def particle_non_bonded_energy(self, particle):
         """
-        Calculate the short-range non-bonded energy contribution associated with
-        a single particle.
+        Calculate the non-bonded energy of a single given particle.
 
-        This includes short-range non-bonded interaction terms (e.g. Lennard-Jones,
-        WCA, etc., depending on enabled features). Depending on enabled features
-        (notably Thole damping for Drude oscillators), electrostatics-related
-        short-range correction terms may also contribute. Long-range / k-space
-        electrostatic energy contributions are not included.
+        This excludes the short-range part of electrostatics and magnetostatics
+        solvers, as well as corrections implemented as non-bonded interactions
+        (e.g. :ref:`Thole correction`).
 
         Parameters
         ----------
@@ -524,7 +521,7 @@ class Analysis(ScriptInterfaceHelper):
         Returns
         -------
         :obj:`float`
-            Short-range non-bonded energy contribution for that particle.
+            Non-bonded energy of that particle
 
         """
         return self.call_method("particle_energy", pid=particle.id)

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -336,18 +336,6 @@ class Analysis(ScriptInterfaceHelper):
         :obj:`float`
             Short-range non-bonded energy contribution of that particle.
 
-    particle_energy()
-        Deprecated alias for :meth:`particle_non_bonded_energy`.
-
-        Parameters
-        ----------
-        particle : :class:`~espressomd.particle_data.ParticleHandle`
-
-        Returns
-        -------
-        :obj:`float`
-            Short-range non-bonded energy contribution of that particle.
-
     """
     _so_name = "Analysis::Analysis"
     _so_creation_policy = "GLOBAL"

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -324,6 +324,18 @@ class Analysis(ScriptInterfaceHelper):
             Where [0] contains the midpoints of the bins,
             and [1] contains the values of the minimal distance distribution function.
 
+    particle_non_bonded_energy()
+        Calculate the short-range non-bonded energy contribution of a single particle.
+
+            Notes
+            -----
+            This includes only short-range non-bonded interaction terms (e.g. Lennard-Jones,
+            WCA, etc., depending on enabled features). Electrostatic energy contributions
+            (both short-range real-space and long-range/k-space parts) are not included.
+
+    particle_energy()
+        Deprecated alias for :meth:`particle_non_bonded_energy`.
+
     """
     _so_name = "Analysis::Analysis"
     _so_creation_policy = "GLOBAL"
@@ -505,10 +517,19 @@ class Analysis(ScriptInterfaceHelper):
         """
         observable = self.call_method("calculate_energy")
         return self._generate_summary(observable, 1, False)
-
-    def particle_energy(self, particle):
+    
+    def particle_non_bonded_energy(self, particle):
         """
         Calculate the non-bonded energy of a single given particle.
+        Calculate the short-range non-bonded energy contribution associated with
+        a single particle.
+
+        Notes
+        -----
+        This value includes short-range non-bonded interaction terms (e.g. LJ/WCA,
+        etc., depending on enabled features). It does **not** include electrostatic
+        energy contributions (neither the short-range real-space part nor any
+        long-range/k-space part).
 
         Parameters
         ----------
@@ -519,8 +540,28 @@ class Analysis(ScriptInterfaceHelper):
         :obj: `float`
             Non-bonded energy of that particle
 
+        :obj:`float`
+            Short-range non-bonded energy contribution for that particle.
         """
         return self.call_method("particle_energy", pid=particle.id)
+
+    def particle_energy(self, particle):
+        """
+        Deprecated alias for :meth:`particle_non_bonded_energy`.
+
+        Notes
+        -----
+        This method will be removed in a future release. Use
+        :meth:`particle_non_bonded_energy` instead.
+        """
+        import warnings
+
+        warnings.warn(
+            "particle_energy() is deprecated, use particle_non_bonded_energy() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.particle_non_bonded_energy(particle)
 
     def particle_bond_energy(self, particle, bond):
         """

--- a/src/python/espressomd/analyze.py
+++ b/src/python/espressomd/analyze.py
@@ -326,7 +326,7 @@ class Analysis(ScriptInterfaceHelper):
 
     particle_non_bonded_energy()
         :no-index:
-        
+
         Calculate the short-range non-bonded energy contribution of a single particle.
 
         Parameters

--- a/src/python/espressomd/drude_helpers.py
+++ b/src/python/espressomd/drude_helpers.py
@@ -41,7 +41,7 @@ class DrudeHelpers:
                                    thole_damping=2.6, verbose=False):
         """
         Adds a Drude particle with specified type and mass to the system and
-        returns its `espressomd.particle_data.ParticleHandle`.
+        returns its :class:`~espressomd.particle_data.ParticleHandle`.
         Checks if different Drude particles have different types.
         Collects types/charges/polarizations/Thole factors for intramolecular
         core-Drude short-range exclusion and Thole interaction.

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -239,18 +239,19 @@ class AnalyzeEnergy(ut.TestCase):
     def test_particle_energy(self):
         self.system.non_bonded_inter.reset()
         self.system.part.clear()
+        get_non_bonded_energy = self.system.analysis.particle_non_bonded_energy
         tol = 1e-5
         p1 = self.system.part.add(pos=[0., 0., 0.], type=0, q=+1.)
         p2 = self.system.part.add(pos=[1., 0., 0.], type=0, q=-1.)
-        self.assertEqual(self.system.analysis.particle_energy(p1), 0.)
-        self.assertEqual(self.system.analysis.particle_energy(p2), 0.)
+        self.assertEqual(get_non_bonded_energy(p1), 0.)
+        self.assertEqual(get_non_bonded_energy(p2), 0.)
         # check short-range electrostatics energy is excluded
         self.system.electrostatics.solver = espressomd.electrostatics.DH(
             prefactor=1., kappa=1., r_cut=2.)
         coulomb_energy = self.system.analysis.energy()["coulomb"]
         self.assertAlmostEqual(coulomb_energy, -np.exp(-1.), delta=tol)
-        self.assertEqual(self.system.analysis.particle_energy(p1), 0.)
-        self.assertEqual(self.system.analysis.particle_energy(p2), 0.)
+        self.assertEqual(get_non_bonded_energy(p1), 0.)
+        self.assertEqual(get_non_bonded_energy(p2), 0.)
         if espressomd.has_features(["THOLE"]):
             # check Thole correction is excluded, despite being a non-bonded IA
             self.system.non_bonded_inter[0, 0].thole.set_params(
@@ -259,8 +260,8 @@ class AnalyzeEnergy(ut.TestCase):
             nbonded_energy = self.system.analysis.energy()["non_bonded"]
             self.assertAlmostEqual(coulomb_energy, -np.exp(-1.), delta=tol)
             self.assertAlmostEqual(nbonded_energy, 2. * np.exp(-3.), delta=tol)
-            self.assertEqual(self.system.analysis.particle_energy(p1), 0.)
-            self.assertEqual(self.system.analysis.particle_energy(p2), 0.)
+            self.assertEqual(get_non_bonded_energy(p1), 0.)
+            self.assertEqual(get_non_bonded_energy(p2), 0.)
 
 
 if __name__ == "__main__":

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -22,7 +22,7 @@ import unittest_decorators as utx
 import espressomd
 import espressomd.interactions
 import espressomd.electrostatics
-
+import warnings
 
 @utx.skipIfMissingFeatures("LENNARD_JONES")
 class AnalyzeEnergy(ut.TestCase):
@@ -103,7 +103,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["non_bonded_inter"], 0., delta=1e-7)
         # Test the single particle energy function
         self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
-            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
+            [self.system.analysis.particle_non_bonded_energy(p) for p in self.system.part.all()]), delta=1e-7)
         # add another pair of particles
         self.system.part.add(pos=[3, 2, 2], type=1, mol_id=7)
         self.system.part.add(pos=[4, 2, 2], type=1, mol_id=7)
@@ -130,7 +130,7 @@ class AnalyzeEnergy(ut.TestCase):
             energy["non_bonded_inter", 0, 1], 1., delta=1e-7)
         # Test the single particle energy function
         self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
-            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
+            [self.system.analysis.particle_non_bonded_energy(p) for p in self.system.part.all()]), delta=1e-7)
 
     def test_bonded(self):
         p0, p1 = self.system.part.all()
@@ -173,7 +173,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["bonded"], 3. / 2., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
-            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
+            [self.system.analysis.particle_non_bonded_energy(p) for p in self.system.part.all()]), delta=1e-7)
         if espressomd.has_features(["VIRTUAL_SITES"]):
             self.assertAlmostEqual(energy["virtual_sites"], 0., delta=1e-7)
         if espressomd.has_features(["DPD"]):
@@ -186,7 +186,7 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["bonded"], 3., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
-            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
+            [self.system.analysis.particle_non_bonded_energy(p) for p in self.system.part.all()]), delta=1e-7)
         # add another pair of particles
         self.system.part.add(pos=[1, 5, 5], type=1)
         self.system.part.add(pos=[2, 5, 5], type=1)
@@ -197,12 +197,25 @@ class AnalyzeEnergy(ut.TestCase):
         self.assertAlmostEqual(energy["bonded"], 3., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 1. + 1., delta=1e-7)
         self.assertAlmostEqual(energy["non_bonded"], 0.5 * sum(
-            [self.system.analysis.particle_energy(p) for p in self.system.part.all()]), delta=1e-7)
+            [self.system.analysis.particle_non_bonded_energy(p) for p in self.system.part.all()]), delta=1e-7)
         # check effect of particle resort
-        p0_energy_old = self.system.analysis.particle_energy(p0)
+        p0_energy_old = self.system.analysis.particle_non_bonded_energy(p0)
         p0.pos = p0.pos  # trigger particle resort
-        p0_energy_new = self.system.analysis.particle_energy(p0)
+        p0_energy_new = self.system.analysis.particle_non_bonded_energy(p0)
         self.assertAlmostEqual(p0_energy_new, p0_energy_old, delta=1e-7)
+        # Backward-compatibility check:
+        # particle_energy() is kept as a deprecated alias for
+        # particle_non_bonded_energy(). We verify that the old method
+        # still works, emits a DeprecationWarning, and returns the
+        # same value as the new method. The check is done once to
+        # avoid warning spam in the test suite.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
+            old_method = self.system.analysis.particle_energy(p0)
+            self.assertTrue(any(issubclass(x.category, DeprecationWarning) for x in w))
+
+        new_method = self.system.analysis.particle_non_bonded_energy(p0)
+        self.assertAlmostEqual(old_method, new_method, delta=1e-12)
 
     def check_electrostatics(self, p3m_class):
         p0, p1 = self.system.part.all()

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -22,7 +22,6 @@ import unittest_decorators as utx
 import espressomd
 import espressomd.interactions
 import espressomd.electrostatics
-import warnings
 
 
 @utx.skipIfMissingFeatures("LENNARD_JONES")
@@ -204,20 +203,6 @@ class AnalyzeEnergy(ut.TestCase):
         p0.pos = p0.pos  # trigger particle resort
         p0_energy_new = self.system.analysis.particle_non_bonded_energy(p0)
         self.assertAlmostEqual(p0_energy_new, p0_energy_old, delta=1e-7)
-        # Backward-compatibility check:
-        # particle_energy() is kept as a deprecated alias for
-        # particle_non_bonded_energy(). We verify that the old method
-        # still works, emits a DeprecationWarning, and returns the
-        # same value as the new method. The check is done once to
-        # avoid warning spam in the test suite.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always", DeprecationWarning)
-            old_method = self.system.analysis.particle_energy(p0)
-            self.assertTrue(
-                any(issubclass(x.category, DeprecationWarning) for x in w))
-
-        new_method = self.system.analysis.particle_non_bonded_energy(p0)
-        self.assertAlmostEqual(old_method, new_method, delta=1e-12)
 
     def check_electrostatics(self, p3m_class):
         p0, p1 = self.system.part.all()

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -24,6 +24,7 @@ import espressomd.interactions
 import espressomd.electrostatics
 import warnings
 
+
 @utx.skipIfMissingFeatures("LENNARD_JONES")
 class AnalyzeEnergy(ut.TestCase):
     system = espressomd.System(box_l=[1.0, 1.0, 1.0])
@@ -212,7 +213,8 @@ class AnalyzeEnergy(ut.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", DeprecationWarning)
             old_method = self.system.analysis.particle_energy(p0)
-            self.assertTrue(any(issubclass(x.category, DeprecationWarning) for x in w))
+            self.assertTrue(
+                any(issubclass(x.category, DeprecationWarning) for x in w))
 
         new_method = self.system.analysis.particle_non_bonded_energy(p0)
         self.assertAlmostEqual(old_method, new_method, delta=1e-12)

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2022 The ESPResSo project
+# Copyright (C) 2010-2026 The ESPResSo project
 #
 # This file is part of ESPResSo.
 #
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import numpy as np
 import unittest as ut
 import unittest_decorators as utx
 import espressomd
@@ -26,33 +27,28 @@ import espressomd.electrostatics
 
 @utx.skipIfMissingFeatures("LENNARD_JONES")
 class AnalyzeEnergy(ut.TestCase):
-    system = espressomd.System(box_l=[1.0, 1.0, 1.0])
-
+    system = espressomd.System(box_l=[20.0, 20.0, 20.0])
+    system.cell_system.skin = 0.4
+    system.time_step = 0.01
+    system.thermostat.set_langevin(kT=0., gamma=1., seed=42)
     harmonic = espressomd.interactions.HarmonicBond(r_0=0.0, k=3)
-
-    @classmethod
-    def setUpClass(cls):
-        box_l = 20
-        cls.system.box_l = [box_l, box_l, box_l]
-        cls.system.cell_system.skin = 0.4
-        cls.system.time_step = 0.01
-        cls.system.non_bonded_inter[0, 0].lennard_jones.set_params(
-            epsilon=1.0, sigma=1.0,
-            cutoff=2**(1. / 6.), shift="auto")
-        cls.system.non_bonded_inter[0, 1].lennard_jones.set_params(
-            epsilon=1.0, sigma=1.0,
-            cutoff=2**(1. / 6.), shift="auto")
-        cls.system.non_bonded_inter[1, 1].lennard_jones.set_params(
-            epsilon=1.0, sigma=1.0,
-            cutoff=2**(1. / 6.), shift="auto")
-        cls.system.thermostat.set_langevin(kT=0., gamma=1., seed=42)
-        cls.system.bonded_inter[5] = cls.harmonic
+    system.bonded_inter[5] = harmonic
 
     def setUp(self):
+        self.system.non_bonded_inter[0, 0].lennard_jones.set_params(
+            epsilon=1.0, sigma=1.0,
+            cutoff=2**(1. / 6.), shift="auto")
+        self.system.non_bonded_inter[0, 1].lennard_jones.set_params(
+            epsilon=1.0, sigma=1.0,
+            cutoff=2**(1. / 6.), shift="auto")
+        self.system.non_bonded_inter[1, 1].lennard_jones.set_params(
+            epsilon=1.0, sigma=1.0,
+            cutoff=2**(1. / 6.), shift="auto")
         self.system.part.add(pos=[1, 2, 2], type=0, mol_id=6)
         self.system.part.add(pos=[5, 2, 2], type=0, mol_id=6)
 
     def tearDown(self):
+        self.system.non_bonded_inter.reset()
         self.system.part.clear()
         if espressomd.has_features(["ELECTROSTATICS"]):
             self.system.electrostatics.clear()
@@ -238,6 +234,33 @@ class AnalyzeEnergy(ut.TestCase):
     @utx.skipIfMissingFeatures(["P3M"])
     def test_electrostatics_gpu(self):
         self.check_electrostatics(espressomd.electrostatics.P3MGPU)
+
+    @utx.skipIfMissingFeatures(["ELECTROSTATICS"])
+    def test_particle_energy(self):
+        self.system.non_bonded_inter.reset()
+        self.system.part.clear()
+        tol = 1e-5
+        p1 = self.system.part.add(pos=[0., 0., 0.], type=0, q=+1.)
+        p2 = self.system.part.add(pos=[1., 0., 0.], type=0, q=-1.)
+        self.assertEqual(self.system.analysis.particle_energy(p1), 0.)
+        self.assertEqual(self.system.analysis.particle_energy(p2), 0.)
+        # check short-range electrostatics energy is excluded
+        self.system.electrostatics.solver = espressomd.electrostatics.DH(
+            prefactor=1., kappa=1., r_cut=2.)
+        coulomb_energy = self.system.analysis.energy()["coulomb"]
+        self.assertAlmostEqual(coulomb_energy, -np.exp(-1.), delta=tol)
+        self.assertEqual(self.system.analysis.particle_energy(p1), 0.)
+        self.assertEqual(self.system.analysis.particle_energy(p2), 0.)
+        if espressomd.has_features(["THOLE"]):
+            # check Thole correction is excluded, despite being a non-bonded IA
+            self.system.non_bonded_inter[0, 0].thole.set_params(
+                scaling_coeff=2., q1q2=p1.q * p2.q)
+            coulomb_energy = self.system.analysis.energy()["coulomb"]
+            nbonded_energy = self.system.analysis.energy()["non_bonded"]
+            self.assertAlmostEqual(coulomb_energy, -np.exp(-1.), delta=tol)
+            self.assertAlmostEqual(nbonded_energy, 2. * np.exp(-3.), delta=tol)
+            self.assertEqual(self.system.analysis.particle_energy(p1), 0.)
+            self.assertEqual(self.system.analysis.particle_energy(p2), 0.)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #5039

Description of changes:
- API change: rename `Analysis.particle_energy()` to `Analysis.particle_non_bonded_energy()` to better reflect the calculated quantity (kinetic, bonded, electrostatic and magnetostatic contributions are not part of this energy)
- bugfix: Thole corrections are no longer part of the energy calculated by `Analysis.particle_non_bonded_energy()`
- improve documentation of the per-particle non-bonded energy analysis function and of the Thole correction