### PR TITLE
Cabana: base max neighbor estimation on local density

### DIFF
--- a/src/core/LocalBox.hpp
+++ b/src/core/LocalBox.hpp
@@ -61,6 +61,11 @@ public:
   /** Return cell structure type. */
   auto const &cell_structure_type() const { return m_cell_structure_type; }
 
+  /** Volume of the local box. */
+  double volume() const {
+    return m_local_box_l[0] * m_local_box_l[1] * m_local_box_l[2];
+  }
+
   /** Set cell structure type. */
   void set_cell_structure_type(CellStructureType cell_structure_type) {
     m_cell_structure_type = cell_structure_type;

--- a/src/core/LocalBox.hpp
+++ b/src/core/LocalBox.hpp
@@ -62,9 +62,7 @@ public:
   auto const &cell_structure_type() const { return m_cell_structure_type; }
 
   /** Volume of the local box. */
-  double volume() const {
-    return m_local_box_l[0] * m_local_box_l[1] * m_local_box_l[2];
-  }
+  auto volume() const { return Utils::product(m_local_box_l); }
 
   /** Set cell structure type. */
   void set_cell_structure_type(CellStructureType cell_structure_type) {

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -63,6 +63,7 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
+#include <numbers>
 #include <optional>
 #include <ranges>
 #include <set>
@@ -100,15 +101,27 @@ void CellStructure::set_kokkos_handle(std::shared_ptr<KokkosHandle> handle) {
 }
 
 static auto estimate_max_counts(double pair_cutoff,
-                                std::size_t number_of_unique_particles) {
+                                std::size_t number_of_unique_particles,
+                                double local_box_volume,
+                                std::size_t num_local_particles) {
   if (std::isinf(pair_cutoff)) {
     return number_of_unique_particles;
   }
   if (pair_cutoff < 0.) {
     pair_cutoff = 0.;
   }
-  auto const volume = Utils::int_pow<3>(pair_cutoff);
-  auto max_counts = static_cast<std::size_t>(std::ceil(8. * volume));
+  // Estimate number of neighbors based on local density and cutoff sphere
+  // volume n_neighbors = rho * (4/3) * pi * r^3 where rho = n_particles /
+  // volume
+  auto const local_density =
+      (local_box_volume > 0. && num_local_particles > 0)
+          ? static_cast<double>(num_local_particles) / local_box_volume
+          : 0.;
+  auto const cutoff_sphere_volume =
+      (4. / 3.) * std::numbers::pi * Utils::int_pow<3>(pair_cutoff);
+  const double fluctuation_factor = 2.;
+  auto max_counts = static_cast<std::size_t>(
+      std::ceil(fluctuation_factor * local_density * cutoff_sphere_volume));
   std::size_t constexpr threshold_num = 16;
   if (max_counts < threshold_num) {
     max_counts = std::min(threshold_num, number_of_unique_particles);
@@ -124,9 +137,11 @@ void CellStructure::rebuild_local_properties(double const pair_cutoff) {
   using execution_space = Kokkos::DefaultExecutionSpace;
   auto const num_threads = execution_space().concurrency();
   auto const num_part = get_unique_particles().size();
-  auto max_counts = estimate_max_counts(pair_cutoff, num_part);
-#ifdef ESPRESSO_COLLISION_DETECTION
   auto const &system = get_system();
+  auto const local_box_volume = system.local_geo->volume();
+  auto max_counts = estimate_max_counts(pair_cutoff, num_part, local_box_volume,
+                                        get_num_local_particles_cached());
+#ifdef ESPRESSO_COLLISION_DETECTION
   if (system.has_collision_detection_enabled()) {
     // TODO: use other types of Verlet list data structures
     max_counts = num_part * 2ul;
@@ -220,6 +235,7 @@ void CellStructure::set_index_map() {
   }
   registered_index.clear();
   m_cached_max_local_particle_id = max_id;
+  m_num_local_particles_cached = unique_particles.size();
 }
 
 #endif // ESPRESSO_SHARED_MEMORY_PARALLELISM

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -59,6 +59,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
@@ -110,8 +111,8 @@ static auto estimate_max_counts(double pair_cutoff,
   if (pair_cutoff < 0.) {
     pair_cutoff = 0.;
   }
-  // Estimate number of neighbors based on local density and cutoff sphere
-  // volume n_neighbors = rho * (4/3) * pi * r^3 where rho = n_particles /
+  // Estimate number of neighbors based on local density and cutoff sphere:
+  // volume n_neighbors = rho * (4/3) * pi * r^3, where rho = n_particles /
   // volume
   auto const local_density =
       (local_box_volume > 0. && num_local_particles > 0)
@@ -119,8 +120,8 @@ static auto estimate_max_counts(double pair_cutoff,
           : 0.;
   auto const cutoff_sphere_volume =
       (4. / 3.) * std::numbers::pi * Utils::int_pow<3>(pair_cutoff);
-  const double fluctuation_factor =
-      2.; // account for local fluctuations. Empirical.
+  // account for local fluctuations. Empirical.
+  auto const fluctuation_factor = 2.;
   auto max_counts = static_cast<std::size_t>(
       std::ceil(fluctuation_factor * local_density * cutoff_sphere_volume));
   std::size_t constexpr threshold_num = 16;

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -119,7 +119,8 @@ static auto estimate_max_counts(double pair_cutoff,
           : 0.;
   auto const cutoff_sphere_volume =
       (4. / 3.) * std::numbers::pi * Utils::int_pow<3>(pair_cutoff);
-  const double fluctuation_factor = 2.;
+  const double fluctuation_factor =
+      2.; // account for local fluctuations. Empirical.
   auto max_counts = static_cast<std::size_t>(
       std::ceil(fluctuation_factor * local_density * cutoff_sphere_volume));
   std::size_t constexpr threshold_num = 16;

--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <cassert>
 #include <concepts>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <memory>

--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -200,6 +200,7 @@ private:
   double m_verlet_reuse = 0.;
 #ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
   int m_cached_max_local_particle_id = 0;
+  std::size_t m_num_local_particles_cached = 0;
   int m_max_id = 0;
   std::unique_ptr<Kokkos::View<int *>> m_id_to_index;
   std::unique_ptr<ForceType> m_local_force;
@@ -457,6 +458,9 @@ public:
 #ifdef ESPRESSO_SHARED_MEMORY_PARALLELISM
   int get_cached_max_local_particle_id() const {
     return m_cached_max_local_particle_id;
+  }
+  std::size_t get_num_local_particles_cached() const {
+    return m_num_local_particles_cached;
   }
 #endif
 

--- a/src/core/custom_verlet_list.hpp
+++ b/src/core/custom_verlet_list.hpp
@@ -205,8 +205,7 @@ public:
   //! Get the maximum number of neighbors per particle.
   KOKKOS_INLINE_FUNCTION
   static std::size_t maxNeighbor(list_type const &list) {
-    // Stored during neighbor search.
-    return list.max_n;
+    return list.neighbors.extent(1);
   }
 
   //! Get the number of neighbors for a given particle index.

--- a/src/core/short_range_cabana.hpp
+++ b/src/core/short_range_cabana.hpp
@@ -211,11 +211,15 @@ update_cabana_state(CellStructure &cell_structure, auto const &verlet_criterion,
                 // inter cell loop
                 verlet_list.addNeighbor(i, j);
               });
+
           if (verlet_list.hasOverflow()) {
             cell_structure.use_verlet_list = false;
             runtimeWarningMsg()
                 << "Verlet list overflow detected: neighbor count exceeded "
-                   "max_counts. Falling back to the link cell algorithm.";
+                   "max_counts. Falling back to the link cell algorithm. "
+                   "Configured max is "
+                << Cabana::NeighborList<CellStructure::ListType>::maxNeighbor(
+                       verlet_list);
           }
         },
         rebuild_vl);

--- a/testsuite/python/cell_system.py
+++ b/testsuite/python/cell_system.py
@@ -94,33 +94,18 @@ class CellSystem(ut.TestCase):
             n_square_types={1}, cutoff_regular=0)
         self.check_node_grid()
 
-    @utx.skipIfMissingFeatures(["LENNARD_JONES", "SHARED_MEMORY_PARALLELISM"])
+    @utx.skipIfMissingFeatures(["WCA", "SHARED_MEMORY_PARALLELISM"])
     def test_verlet_list_overflow(self):
         system = self.system
         system.part.clear()
-
-        system.non_bonded_inter[0, 0].lennard_jones.set_params(
-            sigma=0.01, epsilon=1., cutoff=1.0, shift="auto")
-
-        n_small = int(5 * system.volume())
-        system.part.add(pos=np.random.random((n_small, 3)) * system.box_l)
-
-        system.time_step = 0.01
-        system.cell_system.skin = 0.1
-
-        system.integrator.set_steepest_descent(
-            f_max=1, max_displacement=0.01, gamma=1E-10)
-        system.integrator.run(200)
-
+        system.part.add(pos=[[0, 0, 0]] * 1000)      
+        system.non_bonded_inter[0, 0].wca.set_params(
+            epsilon=1, sigma=.01)
         system.integrator.set_vv()
 
-        # with link cell, there is no exception and warning
-        system.cell_system.use_verlet_lists = False
-        self.system.integrator.run(0, recalc_forces=True)
-
-        # with Verlet lists, there is a warning and 'use_verlet_list' changes
         system.cell_system.use_verlet_lists = True
-        self.system.integrator.run(0, recalc_forces=True)
+        system.time_step = 0.01
+        self.system.integrator.run(0)
         self.assertFalse(system.cell_system.use_verlet_lists)
 
 

--- a/testsuite/python/cell_system.py
+++ b/testsuite/python/cell_system.py
@@ -98,9 +98,9 @@ class CellSystem(ut.TestCase):
     def test_verlet_list_overflow(self):
         system = self.system
         system.part.clear()
-        system.part.add(pos=[[0, 0, 0]] * 1000)      
-        system.non_bonded_inter[0, 0].wca.set_params(
-            epsilon=1, sigma=.01)
+        # place all particles on top of each other
+        system.part.add(pos=[[0, 0, 0]] * 1000)
+        system.non_bonded_inter[0, 0].wca.set_params(epsilon=1., sigma=0.01)
         system.integrator.set_vv()
 
         system.cell_system.use_verlet_lists = True


### PR DESCRIPTION
For the Cabana based Verlet list, we need to know the maximum number of neighbors any particle has before the list creation is begun.
The existing code made an assumption about the local density (it considered the number of particles but not the local box size). Hence, the code failed for high densities, e.g., for a dpd fluid, and fell back to linked cell.

This PR bases the heuristics on the local partilce denisty (local here means: for the mpi rank)

