### PR TITLE
Startup routine for zndraw

### DIFF
--- a/src/python/espressomd/zn.py
+++ b/src/python/espressomd/zn.py
@@ -28,8 +28,6 @@ import secrets
 import time
 import urllib.parse
 import requests
-import requests.adapters
-import logging
 import typing
 import scipy.spatial.transform
 
@@ -251,26 +249,19 @@ class Visualizer():
                 stderr=subprocess.DEVNULL)
 
         # Check that the server is up
-        max_wait_iterations = 60
-        previous_logging_level = logging.root.manager.disable
-        while True:
+        request_deadline = time.monotonic() + 30
+        while time.monotonic() < request_deadline:
             try:
-                logging.disable(logging.WARNING)
-                session = requests.Session()
-                adapter = requests.adapters.HTTPAdapter(max_retries=1)
-                req = session.mount(f"{self.url}:{self.SERVER_PORT}", adapter)
-                req = session.get(f"{self.url}:{self.SERVER_PORT}/health")
-                if req.status_code == 200:
-                    logging.disable(previous_logging_level)
+                r = requests.get(
+                    f"{self.url}:{self.SERVER_PORT}/health", timeout=1)
+                if r.status_code == 200:
                     break
-            except Exception:
+            except requests.RequestException:
                 pass
-            logging.disable(previous_logging_level)
             time.sleep(0.5)
-            max_wait_iterations -= 1
-            if max_wait_iterations == 0:
-                raise RuntimeError(
-                    "ZnDraw server did not start within the expected time")
+        else:
+            raise RuntimeError(
+                "ZnDraw server did not start within the expected time")
 
         self._start_zndraw()
 
@@ -292,13 +283,14 @@ class Visualizer():
                 "Only Jupyter notebook is supported at the moment")
 
         # Wait until the session is ready
-        max_wait_iterations = 60
-        while len(self.zndraw.sessions) == 0:
+        request_deadline = time.monotonic() + 30
+        while time.monotonic() < request_deadline:
+            if len(self.zndraw.sessions) > 0:
+                break
             time.sleep(0.5)
-            max_wait_iterations -= 1
-            if max_wait_iterations == 0:
-                raise RuntimeError(
-                    "ZnDraw session did not start within the expected time")
+        else:
+            raise RuntimeError(
+                "ZnDraw session did not start within the expected time")
 
     def _start_zndraw(self):
         """

--- a/src/python/espressomd/zn.py
+++ b/src/python/espressomd/zn.py
@@ -29,6 +29,7 @@ import time
 import urllib.parse
 import typing
 import scipy.spatial.transform
+import httpx
 
 from espressomd.plugins import ase
 
@@ -241,12 +242,28 @@ class Visualizer():
         # A server is started in a subprocess, and we have to wait for it
         if self.SERVER_PORT is None:
             print("Starting ZnDraw server, this may take a few seconds")
-            self.port = port
-            self._start_server()
-            time.sleep(10)
+            Visualizer.SERVER_PORT = port
+            self.server = subprocess.Popen(
+                ["zndraw", "--no-browser", f"--port={self.SERVER_PORT}"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL)
+
+        # Check that the server is up
+        max_wait_iterations = 60
+        while True:
+            try:
+                r = httpx.get(f"{self.url}:{self.SERVER_PORT}/health")
+                if r.status_code == 200:
+                    break
+            except httpx.RequestError:
+                pass
+            time.sleep(0.5)
+            max_wait_iterations -= 1
+            if max_wait_iterations == 0:
+                raise RuntimeError(
+                    "ZnDraw server did not start within the expected time")
 
         self._start_zndraw()
-        time.sleep(2)
 
         if vector_field is not None:
             self.arrow_config = {'colormap': [[0.5, 0.9, 0.5], [0.0, 0.9, 0.5]],
@@ -265,16 +282,14 @@ class Visualizer():
             raise NotImplementedError(
                 "Only Jupyter notebook is supported at the moment")
 
-    def _start_server(self):
-        """
-        Start the ZnDraw server through a subprocess
-        """
-        Visualizer.SERVER_PORT = self.port
-
-        self.server = subprocess.Popen(["zndraw", "--no-browser", f"--port={self.port}"],
-                                       stdout=subprocess.DEVNULL,
-                                       stderr=subprocess.DEVNULL
-                                       )
+        # Wait until the session is ready
+        max_wait_iterations = 60
+        while len(self.zndraw.sessions) == 0:
+            time.sleep(0.5)
+            max_wait_iterations -= 1
+            if max_wait_iterations == 0:
+                raise RuntimeError(
+                    "ZnDraw session did not start within the expected time")
 
     def _start_zndraw(self):
         """

--- a/src/python/espressomd/zn.py
+++ b/src/python/espressomd/zn.py
@@ -27,9 +27,11 @@ import espressomd
 import secrets
 import time
 import urllib.parse
+import requests
+import requests.adapters
+import logging
 import typing
 import scipy.spatial.transform
-import httpx
 
 from espressomd.plugins import ase
 
@@ -250,13 +252,20 @@ class Visualizer():
 
         # Check that the server is up
         max_wait_iterations = 60
+        previous_logging_level = logging.root.manager.disable
         while True:
             try:
-                r = httpx.get(f"{self.url}:{self.SERVER_PORT}/health")
-                if r.status_code == 200:
+                logging.disable(logging.WARNING)
+                session = requests.Session()
+                adapter = requests.adapters.HTTPAdapter(max_retries=1)
+                req = session.mount(f"{self.url}:{self.SERVER_PORT}", adapter)
+                req = session.get(f"{self.url}:{self.SERVER_PORT}/health")
+                if req.status_code == 200:
+                    logging.disable(previous_logging_level)
                     break
-            except httpx.RequestError:
+            except Exception:
                 pass
+            logging.disable(previous_logging_level)
             time.sleep(0.5)
             max_wait_iterations -= 1
             if max_wait_iterations == 0:


### PR DESCRIPTION
I worked on a proper zndraw startup routine, so we don't need to hope anymore that the zndraw server and the session is ready. Especially, the sessions often weren't ready, which made the visualizations in the tutorial not reliably display the set camera at all times.

- Using the `/health` endpoint to properly check if the server is up
- Wait for the zndraw session to be ready in the constructor