### PR TITLE
Fix fully connected boundaries

### DIFF
--- a/src/core/cell_system/RegularDecomposition.cpp
+++ b/src/core/cell_system/RegularDecomposition.cpp
@@ -407,7 +407,7 @@ void RegularDecomposition::init_cell_interactions() {
 
   // is a cell at the system boundary in the given coord
   auto const at_boundary = [&global_size](int coord, Utils::Vector3i cell_idx) {
-    return (cell_idx[coord] == 0 or cell_idx[coord] == global_size[coord]);
+    return (cell_idx[coord] == 0 or cell_idx[coord] == global_size[coord] - 1);
   };
 
   // For the fully connected feature (cells that don't share at least a corner)


### PR DESCRIPTION
Under some hard to reproduce conditoins, we non-bonded loop misses pairs for a system with regular decomposition and Lees-Edwards shear boundaries.
Likely cause is an off-by-one error in the 
at_boundary() helper when constructing cell neighborships for the regular decompositoin with fully_connected_boundaries.


This Pr has a tentatie fix, but no unit test demonstrating the bug, yet.

