### PR TITLE
Documentation for 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,25 +14,26 @@ or [Savannah](https://savannah.nongnu.org/projects/espressomd) until release 3.3
 
 ## [5.0.0] - 2026-02-26
 
-This is a major release. New features were added, deprecated features were removed.
+This is a major release. New features were added and deprecated features were removed.
 The API has changed, and some of these changes are silent, i.e. warnings aren't
 necessarily emitted when running a script designed for ESPResSo 4.x that relies
-on features that have significantly changed in in ESPResSo 5.0.
+on features that have significantly changed in ESPResSo 5.0.
 
 Highlights of the release include:
 
-* rewrite of lattice-Boltzmann and electrokinetic using solvers backed
+* rewrite of lattice-Boltzmann and electrokinetics using solvers backed
   by the waLBerla framework. For LB, this includes enhanced capabilities
   including vectorization support on the CPU and multi-GPU support,
   per-cell boundary conditions to build arbitrary geometries,
   per-particle friction coefficients, and Lees-Edwards boundary conditions.
 * faster writing of simulation trajectories using the H5MD file format,
   particularly in parallel simulations.
-* per-particle selection of equation of motion.
-* the thermalized Stoner-Wolfarth model for magnetodynamics, and the
+* per-particle selection of equations of motion.
+* the thermalized Stoner–Wohlfarth model for magnetodynamics, and the
   ability to obtain local magnetic fields at the particles' positions.
-* virtual sites tracking the center of mass of a group of particles.
-* initial support for shared-memory paralellism for some scenarios.
+* virtual sites tracking the center of mass of a group of particles
+  for umbrella sampling.
+* initial support for shared-memory parallelism for some scenarios.
 * several new tutorials, e.g., on the sedimentation of particles in a
   fluid, the Boltzmann inversion technique, electrode modelling,
   and machine-learned inter-atomic potentials.

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -632,7 +632,8 @@ Please cite both :cite:t:`weeber24a` and :cite:t:`weik19a`
 for |es| 4.0 and later, or both :cite:t:`arnold13a` and :cite:t:`limbach06a`
 (BibTeX keys ``arnold13a`` and ``limbach06a`` in :file:`doc/bibliography.bib`)
 for |es| 2.0 to 3.3.
-Starting with ESPResSo 5.0, please also cite the exact release published on Zenodo.
+Starting with |es| 5.0, please also cite the exact release published in
+the `Zenodo dataset "ESPResSo" <https://doi.org/10.5281/zenodo.18791182>`_.
 
 To find the version number, use the following command:
 
@@ -648,11 +649,13 @@ publications, using the BibTeX entries indicated in this user guide.
 
 A complete citation would look like this:
 
-    Simulations were carried out with ESPResSo 5.0.0[23,24] using the ICC\*
+    Simulations were carried out with ESPResSo 5.0.0[22,23,24] using the ICC\*
     algorithm[25].
 
     | ____________
 
+    | [22] J.-N. Grad, F. Weik, A. Reinauer, *et al.* ESPResSo, version 5.0.0.
+      Zenodo, Feb 2026. doi:\ `10.5281/zenodo.18791183 <https://doi.org/10.5281/zenodo.18791183>`_.
     | [23] R. Weeber, J.-N. Grad, D. Beyer *et al.* ESPResSo, a versatile
       open-source software package for simulating soft matter systems.
       In M. Yáñez and R. J. Boyd, eds, *Comprehensive Computational Chemistry*,

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -204,7 +204,7 @@ The codepace can be accessed from the terminal via the `GitHub CLI ssh command
 <https://cli.github.com/manual/gh_codespace_ssh>`__
 or from a web browser (default), which uses the VS Code IDE.
 Instructions to build |es| and execute the tutorials are available
-in file :file:`.devcontainer/Readme.md`.
+in file `.devcontainer/Readme.md <https://github.com/espressomd/espresso/blob/python/.devcontainer/Readme.md>`__.
 
 
 .. _Parallel computing:

--- a/src/config/features.def
+++ b/src/config/features.def
@@ -2,33 +2,18 @@
 # Copyright (C) 2013-2026 The ESPResSo project
 # Copyright (C) 2012 Olaf Lenz
 #
-# This file is part of ESPResSo.
-#
-# ESPResSo is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# ESPResSo is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
 #
 
 # Feature definitions
 #
 # The definitions are used for
-# * generation of src/config-features.hpp, which checks the sanity of
+# * generation of config-features.hpp, which checks the sanity of
 #   the various features and their combinations
 # * generation of myconfig-sample.hpp
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
 #
 # Lines commented with '/* ... */' or '//' are copied to myconfig-sample.hpp
 # Lines commented with '#' are ignored


### PR DESCRIPTION
Description of changes:
- fix typos in the changelog of v5.0.0
- provide link to Zenodo release
- provide link to Codespaces instructions
- restore FSFAP license in `features.def`