### PR TITLE
Fix checkpointing of dihedral angles

### DIFF
--- a/src/core/bonded_interactions/dihedral.hpp
+++ b/src/core/bonded_interactions/dihedral.hpp
@@ -45,7 +45,7 @@ inline constexpr auto dihe_tiny_sin_value{1e-10};
 
 /** Parameters for four-body angular potential (dihedral-angle potentials). */
 struct DihedralBond {
-  double mult;
+  int mult;
   double bend;
   double phase;
 
@@ -116,11 +116,11 @@ inline bool calc_dihedral_angle(Utils::Vector3d const &a,
 
   cosphi = aXb * bXc;
 
-  if (fabs(fabs(cosphi) - 1.) < dihe_tiny_sin_value)
+  if (std::fabs(std::fabs(cosphi) - 1.) < dihe_tiny_sin_value)
     cosphi = std::round(cosphi);
 
   /* Calculate dihedral angle */
-  phi = acos(cosphi);
+  phi = std::acos(cosphi);
   if ((aXb * c) < 0.)
     phi = 2. * std::numbers::pi - phi;
   return false;
@@ -162,14 +162,16 @@ DihedralBond::forces(Utils::Vector3d const &v12, Utils::Vector3d const &v23,
   auto const v12Xf1 = vector_product(v12, f1);
 
   /* calculate force magnitude */
-  auto fac = -bend * mult;
+  auto const mult_ = static_cast<double>(mult);
+  auto const mphi = mult_ * phi - phase;
+  auto fac = -bend * mult_;
 
   if (fabs(sin(phi)) < dihe_tiny_sin_value) {
     /* comes from taking the first term of the MacLaurin expansion of
      * sin(n * phi - phi0) and sin(phi) and then making the division */
-    sin_mphi_over_sin_phi = mult * cos(mult * phi - phase) / cos_phi;
+    sin_mphi_over_sin_phi = mult_ * std::cos(mphi) / cos_phi;
   } else {
-    sin_mphi_over_sin_phi = sin(mult * phi - phase) / sin(phi);
+    sin_mphi_over_sin_phi = std::sin(mphi) / std::sin(phi);
   }
 
   fac *= sin_mphi_over_sin_phi;
@@ -205,5 +207,6 @@ DihedralBond::energy(Utils::Vector3d const &v12, Utils::Vector3d const &v23,
     return {};
   }
 
-  return bend * (1. - cos(mult * phi - phase));
+  auto const mphi = static_cast<double>(mult) * phi - phase;
+  return bend * (1. - std::cos(mphi));
 }

--- a/src/core/forces_inline.hpp
+++ b/src/core/forces_inline.hpp
@@ -505,15 +505,17 @@ add_bonded_force(Particle &p1, int bond_id, std::span<Particle *> partners,
                  [[maybe_unused]] Utils::Vector3d *const virial,
                  Coulomb::ShortRangeForceKernel::kernel_type const *kernel) {
 
+  auto const n_partners = static_cast<int>(partners.size());
+
   // Consider for bond breakage
-  if (partners.size() == 1u) { // pair bonds
+  if (n_partners == 1) { // pair bonds
     auto d = box_geo.get_mi_vector(p1.pos(), partners[0]->pos()).norm();
     if (bond_breakage.check_and_handle_breakage(
             p1.id(), {{partners[0]->id(), std::nullopt}}, bond_id, d)) {
       return false;
     }
   }
-  if (partners.size() == 2u) { // angle bond
+  if (n_partners == 2) { // angle bond
     auto d =
         box_geo.get_mi_vector(partners[0]->pos(), partners[1]->pos()).norm();
     if (bond_breakage.check_and_handle_breakage(
@@ -524,7 +526,7 @@ add_bonded_force(Particle &p1, int bond_id, std::span<Particle *> partners,
 
   auto const &iaparams = *bonded_ia_params.at(bond_id);
 
-  switch (number_of_partners(iaparams)) {
+  switch (n_partners) {
   case 0:
     return false;
   case 1:
@@ -537,6 +539,6 @@ add_bonded_force(Particle &p1, int bond_id, std::span<Particle *> partners,
     return add_bonded_four_body_force(iaparams, box_geo, p1, *partners[0],
                                       *partners[1], *partners[2]);
   default:
-    throw BondInvalidSizeError{number_of_partners(iaparams)};
+    throw BondInvalidSizeError{n_partners};
   }
 }

--- a/src/core/lb/particle_coupling.cpp
+++ b/src/core/lb/particle_coupling.cpp
@@ -24,7 +24,6 @@
 #include "Particle.hpp"
 #include "cell_system/CellStructure.hpp"
 #include "communication.hpp"
-#include "config/config.hpp"
 #include "errorhandling.hpp"
 #include "lb/particle_coupling.hpp"
 #include "random.hpp"

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -76,6 +76,7 @@ namespace utf = boost::unit_test;
 #include <limits>
 #include <memory>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>
@@ -626,6 +627,11 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
     BOOST_CHECK_THROW(force_kernel(1u), BondUnknownTypeError);
     BOOST_CHECK_THROW(force_kernel(2u), BondUnknownTypeError);
     BOOST_CHECK_THROW(force_kernel(3u), BondUnknownTypeError);
+    BOOST_CHECK_THROW(add_bonded_force(plist[0], 0, {plist_ptr.begin(), 5ul},
+                                       *system.bonded_ias,
+                                       *system.bond_breakage, *system.box_geo,
+                                       nullptr, nullptr),
+                      BondInvalidSizeError);
 #ifdef ESPRESSO_CUDA
     BOOST_CHECK_THROW(
         invoke_skip_cuda_exceptions([]() { throw std::runtime_error(""); }),

--- a/testsuite/python/ase_interface.py
+++ b/testsuite/python/ase_interface.py
@@ -467,21 +467,21 @@ class ASEInterfaceTest(ut.TestCase):
 
 
 class FixedForceCalculator(Calculator):
-    """ASE calculator that returns fixed forces for testing."""
+    """
+    ASE calculator that returns fixed forces for testing.
+
+    Parameters
+    ----------
+    forces_array : np.ndarray
+        Array of forces with shape (n_atoms, 3)
+    energy : float, optional
+        Total energy value to return
+
+    """
 
     implemented_properties = ["energy", "forces"]
 
     def __init__(self, forces_array, energy=0.0):
-        """
-        Initialize with fixed forces array and optional energy.
-
-        Parameters
-        ----------
-        forces_array : np.ndarray
-            Array of forces with shape (n_atoms, 3)
-        energy : float, optional
-            Total energy value to return
-        """
         Calculator.__init__(self)
         self.forces_array = np.array(forces_array)
         self.energy_value = energy
@@ -523,6 +523,19 @@ class ASEIntegrationTest(ut.TestCase):
         """Clean up after each test."""
         system.part.clear()
         system.integrator.set_vv()
+
+    def test_00_subclass(self):
+        """Check the minimal interface is fully implemented."""
+        ref_energy = -1.5
+        ref_forces = np.array([
+            [2., 3., 4.],
+            [-4., 5., 6.],
+        ])
+        calculator = FixedForceCalculator(ref_forces, ref_energy)
+        calculator.calculate(properties=("forces", "energy"))
+        np.testing.assert_allclose(calculator.get_forces(None), ref_forces)
+        np.testing.assert_allclose(calculator.results["forces"], ref_forces)
+        np.testing.assert_allclose(calculator.results["energy"], ref_energy)
 
     def test_newton_second_law_integration(self):
         """Test 5-step integration to verify Newton's second law."""

--- a/testsuite/python/interactions_bonded_interface.py
+++ b/testsuite/python/interactions_bonded_interface.py
@@ -23,7 +23,9 @@ import tests_common
 import espressomd
 import espressomd.interactions
 import espressomd.code_features
+import espressomd.script_interface
 import numpy as np
+import pickle
 
 
 class BondedInteractions(ut.TestCase):
@@ -113,16 +115,26 @@ class BondedInteractions(ut.TestCase):
                 f"differ for bond id {bondId}: {outParamsRef} vs. {outParams}")
             with self.assertRaisesRegex(RuntimeError, "Bond parameters are immutable"):
                 outBond.params = {}
-            old_params = outBond.params.copy()
-            for key in (outBond.params.keys() | old_params.keys()):
-                if isinstance(old_params[key], str):
-                    self.assertEqual(outBond.params[key], old_params[key])
-                else:
-                    np.testing.assert_allclose(
-                        outBond.params[key], old_params[key], atol=1e-10)
+
+            def compare(bond, params):
+                for key in (bond.params.keys() | params.keys()):
+                    if isinstance(params[key], str):
+                        self.assertEqual(bond.params[key], params[key])
+                    else:
+                        np.testing.assert_allclose(
+                            bond.params[key], params[key], atol=1e-10)
+
+            compare(outBond, outBond.params.copy())
 
             # check no-op
             self.assertIsNone(outBond.call_method('unknown'))
+
+            # Check pickling
+            old_params = bond.params.copy()
+            SIH = espressomd.script_interface.ScriptInterfaceHelper
+            bond.__reduce__ = lambda: SIH.__reduce__(bond)
+            bond_unpickled = pickle.loads(pickle.dumps(bond))
+            compare(bond_unpickled, old_params)
 
         return func
 

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -57,6 +57,8 @@ system.force_cap = 1e8
 system.min_global_cut = 2.0
 system.max_oif_objects = 5
 n_nodes = system.cell_system.get_state()["n_nodes"]
+if 'INT.SDM' in modes and espressomd.has_features('STOKESIAN_DYNAMICS'):
+    system.periodicity = [False, False, False]
 
 # create checkpoint folder
 config.cleanup_old_checkpoint()
@@ -131,9 +133,6 @@ if espressomd.has_features('DIPOLES'):
     p1.dip = (1.3, 2.1, -6)
     p2.dip = (7.3, 6.1, -4)
 
-if espressomd.has_features('EXCLUSIONS'):
-    system.part.add(id=2, pos=[2.0, 2.0, 2.0], exclusions=[0, 1])
-
 # place particles at the interface between 2 MPI nodes
 p3 = system.part.add(id=3, pos=system.box_l / 2.0 - 1.0, type=1)
 p4 = system.part.add(id=4, pos=system.box_l / 2.0 + 1.0, type=1)
@@ -201,17 +200,18 @@ system.constraints.add(
     espressomd.constraints.HomogeneousMagneticField(H=[1., 2., 3.]))
 system.constraints.add(
     espressomd.constraints.HomogeneousFlowField(u=[1., 2., 3.], gamma=2.3))
-pot_field_data = espressomd.constraints.ElectricPotential.field_from_fn(
-    system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
-checkpoint.register("pot_field_data")
-system.constraints.add(espressomd.constraints.PotentialField(
-    field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6,
-    particle_scales={5: 6.0}))
-vec_field_data = espressomd.constraints.ForceField.field_from_fn(
-    system.box_l, np.ones(3), lambda x: 10 * np.ones(3) - x)
-checkpoint.register("vec_field_data")
-system.constraints.add(espressomd.constraints.ForceField(
-    field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4))
+if np.prod(system.periodicity):
+    pot_field_data = espressomd.constraints.ElectricPotential.field_from_fn(
+        system.box_l, np.ones(3), lambda x: np.linalg.norm(10 * np.ones(3) - x))
+    checkpoint.register("pot_field_data")
+    system.constraints.add(espressomd.constraints.PotentialField(
+        field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6,
+        particle_scales={5: 6.0}))
+    vec_field_data = espressomd.constraints.ForceField.field_from_fn(
+        system.box_l, np.ones(3), lambda x: 10 * np.ones(3) - x)
+    checkpoint.register("vec_field_data")
+    system.constraints.add(espressomd.constraints.ForceField(
+        field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4))
 union = espressomd.shapes.Union()
 union.add([espressomd.shapes.Wall(normal=[1., 0., 0.], dist=0.5),
            espressomd.shapes.Wall(normal=[0., 1., 0.], dist=1.5)])
@@ -231,7 +231,6 @@ if 'LB' not in modes:
     elif 'THERM.DPD' in modes and espressomd.has_features('DPD'):
         system.thermostat.set_dpd(kT=1.0, seed=42)
     elif 'THERM.SDM' in modes and espressomd.has_features('STOKESIAN_DYNAMICS'):
-        system.periodicity = [False, False, False]
         system.thermostat.set_stokesian(kT=1.0, seed=42)
     # set integrator
     if 'INT.NPT' in modes and espressomd.has_features('NPT'):
@@ -245,7 +244,6 @@ if 'LB' not in modes:
     elif 'INT.BD' in modes:
         system.integrator.set_brownian_dynamics()
     elif 'INT.SDM' in modes and espressomd.has_features('STOKESIAN_DYNAMICS'):
-        system.periodicity = [False, False, False]
         system.integrator.set_stokesian_dynamics(
             approximation_method='ft', viscosity=0.5, radii={0: 1.5},
             pair_mobility=False, self_mobility=True)
@@ -277,14 +275,22 @@ harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0.0, k=1.0)
 system.bonded_inter.add(harmonic_bond)
 strong_harmonic_bond = espressomd.interactions.HarmonicBond(r_0=0.0, k=5e5)
 system.bonded_inter.add(strong_harmonic_bond)
+angle_bond = espressomd.interactions.AngleCosine(bend=5e-6, phi0=3.2)
+system.bonded_inter.add(angle_bond)
+dihe_bond = espressomd.interactions.Dihedral(mult=3, bend=7e-6, phase=4.)
+system.bonded_inter.add(dihe_bond)
+p7 = system.part.add(id=2, pos=[2.0, 2.0, 2.1])
+p8 = system.part.add(id=8, pos=[2.0] * 3 + system.box_l)
 p2.add_bond((harmonic_bond, p1))
+p2.add_bond((angle_bond, p1, p7))
+p2.add_bond((dihe_bond, p1, p7, p8))
 if 'THERM.LB' in modes or 'THERM.LANGEVIN' in modes:
     # create Drude particles
     system.thermostat.set_thermalized_bond(seed=3)
     system.thermostat.thermalized_bond.call_method(
         "override_philox_counter", counter=5)
     therm_params = dict(temp_com=0.1, temp_distance=0.2, gamma_com=0.3,
-                        gamma_distance=0.5, r_cut=2.)
+                        gamma_distance=0.5, r_cut=1.8)
     therm_bond1 = espressomd.interactions.ThermalizedBond(**therm_params)
     therm_bond2 = espressomd.interactions.ThermalizedBond(**therm_params)
     system.bonded_inter.add(therm_bond1)
@@ -458,9 +464,10 @@ if lbf_class:
 
 
 # set various properties
-p8 = system.part.add(id=8, pos=[2.0] * 3 + system.box_l)
 p8.lees_edwards_offset = 0.2
 p4.v = [-1., 2., -4.]
+if espressomd.has_features('EXCLUSIONS'):
+    p7.exclusions = [0, 1]
 if espressomd.has_features('MASS'):
     p3.mass = 1.5
 if espressomd.has_features('ROTATION'):

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -447,11 +447,11 @@ class CheckpointTest(ut.TestCase):
             np.testing.assert_allclose(p1.q, 1.)
             if has_drude:
                 # check Drude particles
-                p5 = system.part.by_id(5)
+                p9 = system.part.by_id(9)
                 np.testing.assert_allclose(p2.q, +0.118, atol=1e-3)
-                np.testing.assert_allclose(p5.q, -1.118, atol=1e-3)
+                np.testing.assert_allclose(p9.q, -1.118, atol=1e-3)
                 np.testing.assert_allclose(p2.mass, 0.4)
-                np.testing.assert_allclose(p5.mass, 0.6)
+                np.testing.assert_allclose(p9.mass, 0.6)
             else:
                 np.testing.assert_allclose(p2.q, -1.)
                 np.testing.assert_allclose(p2.mass, 1.)
@@ -623,7 +623,7 @@ class CheckpointTest(ut.TestCase):
             self.assertAlmostEqual(bond.gamma_com, 0.3, delta=1e-10)
             self.assertAlmostEqual(bond.temp_distance, 0.2, delta=1e-10)
             self.assertAlmostEqual(bond.gamma_distance, 0.5, delta=1e-10)
-            self.assertAlmostEqual(bond.r_cut, 2., delta=1e-10)
+            self.assertAlmostEqual(bond.r_cut, 1.8, delta=1e-10)
 
     def test_integrator(self):
         params = system.integrator.get_params()
@@ -726,11 +726,19 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(p4.bonds[0][0].params, reference)
         self.assertAlmostEqual(
             system.bonded_inter[1].params, reference, delta=1e-1)
+        reference = {"bend": 5e-6, "phi0": 3.2}
+        self.assertEqual(p1.bonds[1][0].params, reference)
+        self.assertAlmostEqual(
+            system.bonded_inter[2].params, reference, delta=1e-6)
+        reference = {"mult": 3, "bend": 7e-6, "phase": 4.}
+        self.assertEqual(p1.bonds[2][0].params, reference)
+        self.assertAlmostEqual(
+            system.bonded_inter[3].params, reference, delta=1e-6)
         # all thermalized bonds should be identical
         if has_drude:
             reference = therm_params
-            self.assertEqual(p1.bonds[1][0].params, reference)
-            self.assertEqual(system.bonded_inter[2].params, reference)
+            self.assertEqual(p1.bonds[3][0].params, reference)
+            self.assertEqual(system.bonded_inter[4].params, reference)
             self.assertEqual(therm_bond2.params, reference)
         # immersed boundary bonds
         self.assertEqual(
@@ -776,8 +784,8 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(len(dh.drude_dict), 2)
         self.assertEqual(dh.core_type_list, [core_type])
         self.assertEqual(dh.drude_type_list, [drude_type])
-        self.assertEqual(dh.core_id_from_drude_id, {5: 1})
-        self.assertEqual(dh.drude_id_list, [5])
+        self.assertEqual(dh.core_id_from_drude_id, {9: 1})
+        self.assertEqual(dh.drude_id_list, [9])
 
     @utx.skipIfMissingFeatures(['VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE'])
     def test_virtual_sites(self):
@@ -1023,58 +1031,69 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(list(system.part.by_id(2).exclusions), [0, 1])
 
     def test_constraints(self):
-        n_contraints = 8
-        if espressomd.has_features("ELECTROSTATICS"):
-            n_contraints += 1
-        self.assertEqual(len(system.constraints), n_contraints)
-
-        c = system.constraints
         ref_shape = self.ref_box_l.astype(int) + 2
 
-        self.assertIsInstance(c[0].shape, espressomd.shapes.Sphere)
-        self.assertAlmostEqual(c[0].shape.radius, 0.1, delta=1E-10)
-        self.assertEqual(c[0].particle_type, 7)
+        n = 0
+        c = system.constraints[n]
+        self.assertIsInstance(c.shape, espressomd.shapes.Sphere)
+        self.assertAlmostEqual(c.shape.radius, 0.1, delta=1E-10)
+        self.assertEqual(c.particle_type, 7)
 
-        self.assertIsInstance(c[1].shape, espressomd.shapes.Wall)
-        np.testing.assert_allclose(np.copy(c[1].shape.normal),
+        n += 1
+        c = system.constraints[n]
+        self.assertIsInstance(c.shape, espressomd.shapes.Wall)
+        np.testing.assert_allclose(np.copy(c.shape.normal),
                                    [1. / np.sqrt(3)] * 3)
 
-        self.assertIsInstance(c[2], espressomd.constraints.Gravity)
-        np.testing.assert_allclose(np.copy(c[2].g), [1., 2., 3.])
+        n += 1
+        c = system.constraints[n]
+        self.assertIsInstance(c, espressomd.constraints.Gravity)
+        np.testing.assert_allclose(np.copy(c.g), [1., 2., 3.])
 
+        n += 1
+        c = system.constraints[n]
         self.assertIsInstance(
-            c[3], espressomd.constraints.HomogeneousMagneticField)
-        np.testing.assert_allclose(np.copy(c[3].H), [1., 2., 3.])
+            c, espressomd.constraints.HomogeneousMagneticField)
+        np.testing.assert_allclose(np.copy(c.H), [1., 2., 3.])
 
+        n += 1
+        c = system.constraints[n]
         self.assertIsInstance(
-            c[4], espressomd.constraints.HomogeneousFlowField)
-        np.testing.assert_allclose(np.copy(c[4].u), [1., 2., 3.])
-        self.assertAlmostEqual(c[4].gamma, 2.3, delta=1E-10)
+            c, espressomd.constraints.HomogeneousFlowField)
+        np.testing.assert_allclose(np.copy(c.u), [1., 2., 3.])
+        self.assertAlmostEqual(c.gamma, 2.3, delta=1E-10)
 
-        self.assertIsInstance(c[5], espressomd.constraints.PotentialField)
-        self.assertEqual(c[5].field.shape, tuple(list(ref_shape) + [1]))
-        self.assertAlmostEqual(c[5].default_scale, 1.6, delta=1E-10)
-        self.assertAlmostEqual(c[5].particle_scales[5], 6.0, delta=1E-10)
-        np.testing.assert_allclose(np.copy(c[5].origin), [-0.5, -0.5, -0.5])
-        np.testing.assert_allclose(np.copy(c[5].grid_spacing), np.ones(3))
-        ref_pot = espressomd.constraints.PotentialField(
-            field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6)
-        np.testing.assert_allclose(np.copy(c[5].field), np.copy(ref_pot.field),
-                                   atol=1e-10)
+        if np.prod(system.periodicity):
+            n += 1
+            c = system.constraints[n]
+            self.assertIsInstance(c, espressomd.constraints.PotentialField)
+            self.assertEqual(c.field.shape, tuple(list(ref_shape) + [1]))
+            self.assertAlmostEqual(c.default_scale, 1.6, delta=1E-10)
+            self.assertAlmostEqual(c.particle_scales, {5: 6.0}, delta=1E-10)
+            np.testing.assert_allclose(np.copy(c.origin), [-0.5, -0.5, -0.5])
+            np.testing.assert_allclose(np.copy(c.grid_spacing), np.ones(3))
+            ref_pot = espressomd.constraints.PotentialField(
+                field=pot_field_data, grid_spacing=np.ones(3), default_scale=1.6)
+            np.testing.assert_allclose(np.copy(c.field), np.copy(ref_pot.field),
+                                       atol=1e-10)
 
-        self.assertIsInstance(c[6], espressomd.constraints.ForceField)
-        self.assertEqual(c[6].field.shape, tuple(list(ref_shape) + [3]))
-        self.assertAlmostEqual(c[6].default_scale, 1.4, delta=1E-10)
-        np.testing.assert_allclose(np.copy(c[6].origin), [-0.5, -0.5, -0.5])
-        np.testing.assert_allclose(np.copy(c[6].grid_spacing), np.ones(3))
-        ref_vec = espressomd.constraints.ForceField(
-            field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4)
-        np.testing.assert_allclose(np.copy(c[6].field), np.copy(ref_vec.field),
-                                   atol=1e-10)
+            n += 1
+            c = system.constraints[n]
+            self.assertIsInstance(c, espressomd.constraints.ForceField)
+            self.assertEqual(c.field.shape, tuple(list(ref_shape) + [3]))
+            self.assertAlmostEqual(c.default_scale, 1.4, delta=1E-10)
+            np.testing.assert_allclose(np.copy(c.origin), [-0.5, -0.5, -0.5])
+            np.testing.assert_allclose(np.copy(c.grid_spacing), np.ones(3))
+            ref_vec = espressomd.constraints.ForceField(
+                field=vec_field_data, grid_spacing=np.ones(3), default_scale=1.4)
+            np.testing.assert_allclose(np.copy(c.field), np.copy(ref_vec.field),
+                                       atol=1e-10)
 
-        union = c[7].shape
+        n += 1
+        c = system.constraints[n]
+        union = c.shape
         self.assertIsInstance(union, espressomd.shapes.Union)
-        self.assertEqual(c[7].particle_type, 2)
+        self.assertEqual(c.particle_type, 2)
         self.assertEqual(len(union), 2)
         wall1, wall2 = union.call_method('get_elements')
         self.assertIsInstance(wall1, espressomd.shapes.Wall)
@@ -1087,13 +1106,16 @@ class CheckpointTest(ut.TestCase):
         np.testing.assert_allclose(wall2.dist, 1.5, atol=1e-10)
 
         if espressomd.has_features("ELECTROSTATICS"):
-            wave = c[n_contraints - 1]
+            n += 1
+            wave = system.constraints[n]
             self.assertIsInstance(
                 wave, espressomd.constraints.ElectricPlaneWave)
             np.testing.assert_allclose(np.copy(wave.E0), [1., -2., 3.])
             np.testing.assert_allclose(np.copy(wave.k), [-.1, .2, .3])
             self.assertAlmostEqual(wave.omega, 5., delta=1E-10)
             self.assertAlmostEqual(wave.phi, 1.4, delta=1E-10)
+
+        self.assertEqual(len(system.constraints), n + 1)
 
     @utx.skipIfMissingFeatures("WCA")
     @ut.skipIf(has_lb_mode, "LB not supported")

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -787,8 +787,8 @@ class CheckpointTest(ut.TestCase):
         self.assertEqual(dh.core_id_from_drude_id, {9: 1})
         self.assertEqual(dh.drude_id_list, [9])
 
-    @utx.skipIfMissingFeatures(['VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE'])
-    def test_virtual_sites(self):
+    @utx.skipIfMissingFeatures(['VIRTUAL_SITES_RELATIVE'])
+    def test_virtual_sites_rel(self):
         Propagation = espressomd.propagation.Propagation
         p_real = system.part.by_id(0)
         p_virt = system.part.by_id(1)
@@ -805,7 +805,7 @@ class CheckpointTest(ut.TestCase):
             np.copy(p_real.vs_relative[2]), [1., 0., 0., 0.], atol=1e-10)
 
     @utx.skipIfMissingFeatures(['VIRTUAL_SITES_CENTER_OF_MASS'])
-    def test_virtual_sites(self):
+    def test_virtual_sites_com(self):
         Propagation = espressomd.propagation.Propagation
         p_real = system.part.by_id(0)
         p_virt = system.part.by_id(8)

--- a/testsuite/python/virtual_sites_tracers_common.py
+++ b/testsuite/python/virtual_sites_tracers_common.py
@@ -37,6 +37,7 @@ class VirtualSitesTracersCommon:
     system.cell_system.skin = 0.1
 
     def setUp(self):
+        self.system.cell_system.skin = 0.1
         self.system.box_l = (self.box_lw, self.box_lw, self.box_height)
 
     def tearDown(self):
@@ -154,6 +155,28 @@ class VirtualSitesTracersCommon:
 
             system.lb = None
             system.part.clear()
+
+    def test_verlet_list_update(self):
+        """
+        Make a tracer move more than 1 Verlet list skin per time step.
+        """
+        self.set_lb()
+        system = self.system
+        tau = system.time_step
+        skin = self.agrid / 10.
+        skin_per_tau_md_units = skin / tau
+        skin_per_tau_lb_units = skin_per_tau_md_units * 3.
+        system.cell_system.skin = skin
+        self.lbf[:, :, :].velocity = [2. * skin_per_tau_lb_units, 0., 0.]
+        p = system.part.add(
+            # place away from the box origin to stay outside the halo region
+            pos=3 * [self.agrid],
+            propagation=espressomd.propagation.Propagation.TRANS_LB_TRACER)
+        system.integrator.run(1)
+        ref_pos = [self.agrid + 2. * skin, self.agrid, self.agrid]
+        ref_vel = [2. * skin_per_tau_md_units, 0., 0.]
+        np.testing.assert_array_almost_equal(np.copy(p.pos), ref_pos)
+        np.testing.assert_array_almost_equal(np.copy(p.v), ref_vel)
 
     def test_zz_exceptions_without_lb(self):
         """


### PR DESCRIPTION
Fixes #5277

Description of changes:
- fix dihedral bond checkpointing bug (regression introduced in 5.0.0)
- re-enable virtual sites relative checkpointing test (regression introduced in 5.0.0)
- improve testing of bonds, particle properties, virtual sites