### PR TITLE
Make ELC tuning follow literature error-formula

### DIFF
--- a/src/core/electrostatics/elc.cpp
+++ b/src/core/electrostatics/elc.cpp
@@ -961,22 +961,23 @@ double ElectrostaticLayerCorrection::tune_far_cut() const {
   auto const box_l_y_inv = box_geo.length_inv()[1];
   auto const min_inv_boxl = std::min(box_l_x_inv, box_l_y_inv);
   auto const box_l_z = box_geo.length()[2];
+  auto const h = elc.box_h;
   // adjust lz according to dielectric layer method
-  auto const lz =
-      (elc.dielectric_contrast_on) ? elc.box_h + elc.space_layer : box_l_z;
+  auto const lz = (elc.dielectric_contrast_on) ? h + elc.space_layer : box_l_z;
 
   auto tuned_far_cut = min_inv_boxl;
   double err;
   do {
+    // following equation 18 in arnold02d
     auto const pref = 2. * std::numbers::pi * tuned_far_cut;
     auto const sum = pref + 2. * (box_l_x_inv + box_l_y_inv);
-    auto const den = -expm1(-pref * lz);
-    auto const num1 = exp(pref * (elc.box_h - lz));
-    auto const num2 = exp(-pref * (elc.box_h + lz));
+    auto const den = expm1(pref * lz);
+    auto const num1 = exp(pref * h);
+    auto const num2 = 1. / num1; // exp(-pref * h);
 
     err = 0.5 / den *
-          (num1 * (sum + 1. / (lz - elc.box_h)) / (lz - elc.box_h) +
-           num2 * (sum + 1. / (lz + elc.box_h)) / (lz + elc.box_h));
+          (num1 / (lz - h) * (sum + 1. / (lz - h)) +
+           num2 / (lz + h) * (sum + 1. / (lz + h)));
 
     tuned_far_cut += min_inv_boxl;
   } while (err > elc.maxPWerror and tuned_far_cut < maximal_far_cut);


### PR DESCRIPTION
While searching for the error-formulas for ELCIC I noticed, that during the refactorings a long time ago I introduced an error in the tuning, which causes both the ELC and ELCIC to tune to slightly too small summation limits, but nothing wrong enough we caught in our CI.

I compared the energy and force results to a similar system as we have in our testsuite, the energy-distance curve of a single dipole in front of an infinite dielectric wall, which came up during the ELCIC Python reimplementation work currently in progress. (Script: [elc_analytic.py](https://github.com/user-attachments/files/26384451/elc_analytic.py)) Because I shrank the system significantly compared to our testsuite, a 2D Ewald sum is used as a comparison to include the contribution of the periodic images, which I verified for its correctness for the energies. The force-code for the Ewald is only generated and **unverified**, so I wouldn't take the reference forces too seriously without further verification, however, I included them for completeness, and to document my surprise about how the force-differences look like very close to the surface.

The results without my PR:
[elc_analytic_current.pdf](https://github.com/user-attachments/files/26384687/elc_analytic_current.pdf)

and after my PR:
[elc_analytic_new.pdf](https://github.com/user-attachments/files/26384682/elc_analytic_new.pdf)

One can see that we are slightly closer to our requested pairwise errors for the largest accuracy I selected, but mainly, we follow the equation in the paper again (noting that our `tuned_far_cut` is already scaled by $1/L$) and with the exception that the formula in the paper is written for a cubic box of length $L$, which is why our `sum`-part in the code is slightly, but reduces to the one in the paper for a cubic box.

I also verified that this does not influence #3001.

Description of changes:
- Made the ELC error formula follow the literature equation in https://pubs.aip.org/jcp/article/117/6/2496/459826/Electrostatics-in-periodic-slab-geometries-I