### PR TITLE
Fix regressions in the build system and FPE instrumentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,23 @@ target_compile_options(
     $<$<AND:$<BOOL:${ESPRESSO_WARNINGS_ARE_ERRORS}>,$<COMPILE_LANGUAGE:CXX>>:-Werror>
     $<$<AND:$<BOOL:${ESPRESSO_WARNINGS_ARE_ERRORS}>,$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>>:--Werror=all-warnings>
     $<$<AND:$<BOOL:${ESPRESSO_WARNINGS_ARE_ERRORS}>,$<COMPILE_LANG_AND_ID:CUDA,Clang,IntelLLVM>>:-Werror>
+)
+# cmake-format: on
+
+#
+# Compiler optimizations
+#
+
+# cmake-format: off
+target_compile_options(
+  espresso_compiler_flags
+  INTERFACE
+    # prevent loop auto-vectorization when doing so can introduce invalid math;
+    # for example, when a loop body contains a conditional to skip divisions by
+    # zero, the conditional can be ignored (speculative execution) to get better
+    # performance with SIMD types, and the invalid values are masked afterwards
+    # (but the SIGFPE signal is still sent as a side effect)
+    $<$<AND:$<BOOL:${ESPRESSO_BUILD_WITH_FPE}>,$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>>:-ftrapping-math>
     # configurations for NVCC
     $<$<AND:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>,$<CONFIG:Debug>>:-g -G>
     $<$<AND:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>,$<CONFIG:Release>>:-Xptxas=-O3 -Xcompiler=-O3 -DNDEBUG>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,7 +673,6 @@ if(ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM)
     set(Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION ON CACHE BOOL "")
     set(Kokkos_ENABLE_HWLOC ON CACHE BOOL "")
     set(Kokkos_ENABLE_DEPRECATED_CODE_5 OFF CACHE BOOL "")
-    set(Kokkos_ARCH_NATIVE ON CACHE BOOL "")
     FetchContent_MakeAvailable(kokkos)
     set(BUILD_SHARED_LIBS ${ESPRESSO_BUILD_SHARED_LIBS_DEFAULT})
     set(CMAKE_SHARED_LIBRARY_PREFIX "${ESPRESSO_SHARED_LIBRARY_PREFIX}")
@@ -688,6 +687,11 @@ if(ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM)
                 LIBRARY DESTINATION "${ESPRESSO_INSTALL_LIBDIR}")
       endif()
     endforeach()
+    # mark kokkos headers as system headers to disable compiler diagnostics
+    set_property(
+      TARGET kokkos APPEND
+      PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+               $<TARGET_PROPERTY:kokkos,INTERFACE_INCLUDE_DIRECTORIES>)
   endif()
 
   if(NOT EXISTS ${FETCHCONTENT_BASE_DIR}/cabana-src)
@@ -704,6 +708,11 @@ if(ESPRESSO_BUILD_WITH_SHARED_MEMORY_PARALLELISM)
     # cmake-format: on
     set(Cabana_REQUIRE_HEFFTE ${ESPRESSO_BUILD_WITH_FFTW} CACHE BOOL "")
     FetchContent_MakeAvailable(cabana)
+    # mark Cabana headers as system headers to disable compiler diagnostics
+    set_property(
+      TARGET Core APPEND
+      PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+               $<TARGET_PROPERTY:Core,INTERFACE_INCLUDE_DIRECTORIES>)
   endif()
 endif()
 

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -1029,19 +1029,27 @@ The build type is controlled by ``-D CMAKE_BUILD_TYPE=<type>`` where
 * ``Debug``: for debugging in GDB
 * ``Coverage``: for code coverage
 
+In addition, third-party libraries may provide additional options that control performance.
+For example, ``-D Kokkos_ARCH_NATIVE=ON`` enables microarchitecture-specific optimizations,
+such as ``-march=native -mtune=native`` on x86 or ``-mcpu=native`` on ARM,
+in both the Kokkos library and |es|.
+These optimization flags are suitable for homogeneous computing environments,
+e.g. HPC clusters, but not for environments with heterogeneous computing resources,
+since different hardware may not share the same instruction set.
+
 Cluster users and HPC developers may be interested in manually editing the
-``espresso_cpp_flags`` target in the top-level ``CMakeLists.txt`` file for
+``espresso_compiler_flags`` target in the top-level ``CMakeLists.txt`` file for
 finer control over compiler flags. The variable declaration is followed
 by a series of conditionals to enable or disable compiler-specific flags.
 Compiler flags passed to CMake via the ``-D CMAKE_CXX_FLAGS`` option
 (such as ``cmake . -D CMAKE_CXX_FLAGS="-ffast-math -fno-finite-math-only"``)
-will appear in the compiler command before the flags in ``espresso_cpp_flags``,
+will appear in the compiler command before the flags in ``espresso_compiler_flags``,
 and will therefore have lower precedence.
 
 Be aware that fast-math mode can break |es|. It is incompatible with the
 ``ADDITIONAL_CHECKS`` feature due to the loss of precision in the LB code
 on CPU. The Clang 10 compiler breaks field couplings with ``-ffast-math``.
-The Intel compiler enables the ``-fp-model fast=1`` flag by default;
+The IntelLLVM compiler enables the ``-fp-model fast=1`` flag by default;
 it can be disabled by adding the ``-fp-model=strict`` flag.
 
 |es| currently doesn't fully support link-time optimization (LTO).

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -877,9 +877,13 @@ of an abnormal floating-point operation. This is achieved by sending a signal
 that can be caught in GDB to allow inspection of the failing code.
 
 When FPE instrumentation is enabled, most script interface calls will be
-monitored for abnormal mathematical operations. One can select which subset
-of CPU exceptions will trap by explicitly providing a bitmask to the FPE
-handler constructor, like so:
+monitored for abnormal mathematical operations.
+Some |es| features have to call third-party libraries that are known
+to occasionally raise CPU flags; to handle these exceptional cases,
+|es| will temporarily disable any active FPE monitoring during calls
+to the affected libraries.
+One can select which subset of CPU exceptions will trap by explicitly
+providing a bitmask to the FPE handler constructor, like so:
 
 .. code-block:: c++
 

--- a/src/config/features.def
+++ b/src/config/features.def
@@ -84,6 +84,7 @@ THOLE                           requires ELECTROSTATICS
 SCAFACOS_DIPOLES                requires SCAFACOS
 SCAFACOS_DIPOLES                implies DIPOLES
 SCAFACOS                        requires ELECTROSTATICS
+SCAFACOS                        requires not FPE
 
 /* Debugging */
 ADDITIONAL_CHECKS

--- a/src/core/electrostatics/p3m_gpu_cuda.cu
+++ b/src/core/electrostatics/p3m_gpu_cuda.cu
@@ -56,6 +56,8 @@
 #include "p3m/math.hpp"
 #include "system/System.hpp"
 
+#include <instrumentation/fe_trap.hpp>
+
 #include <utils/math/bspline.hpp>
 #include <utils/math/int_pow.hpp>
 #include <utils/math/sqr.hpp>
@@ -613,11 +615,20 @@ void p3m_gpu_init(std::shared_ptr<P3MGpuParams> &data, int cao,
     cuda_safe_mem(cudaMalloc((void **)&(p3m_gpu_data.G_hat),
                              cmesh_size * sizeof(REAL_TYPE)));
 
-    if (cufftPlan3d(&(data->p3m_fft.forw_plan), mesh[0], mesh[1], mesh[2],
-                    FFT_PLAN_FORW_FLAG) != CUFFT_SUCCESS or
-        cufftPlan3d(&(data->p3m_fft.back_plan), mesh[0], mesh[1], mesh[2],
-                    FFT_PLAN_BACK_FLAG) != CUFFT_SUCCESS) {
-      throw std::runtime_error("Unable to create fft plan");
+    {
+#ifdef ESPRESSO_FPE
+      // cuFFT builds device kernels using CUDA-JIT
+      // (https://docs.nvidia.com/cuda/archive/13.1.1/cufft/#plan-initialization-time)
+      // please note this operation is not guaranteed to succeed for all
+      // mesh sizes, and in rare cases, it can send the SIGFPE signal
+      auto const trap_pause = fe_trap::make_shared_pause_scoped();
+#endif
+      if (cufftPlan3d(&(data->p3m_fft.forw_plan), mesh[0], mesh[1], mesh[2],
+                      FFT_PLAN_FORW_FLAG) != CUFFT_SUCCESS or
+          cufftPlan3d(&(data->p3m_fft.back_plan), mesh[0], mesh[1], mesh[2],
+                      FFT_PLAN_BACK_FLAG) != CUFFT_SUCCESS) {
+        throw std::runtime_error("Unable to create fft plan");
+      }
     }
   }
 

--- a/src/instrumentation/include/instrumentation/fe_trap.hpp
+++ b/src/instrumentation/include/instrumentation/fe_trap.hpp
@@ -36,6 +36,7 @@
  * the duration of a scoped block. Exception traps are set when the object
  * is created; when getting out-of-scope, either normally or during stack
  * unwinding, the exception traps are automatically reset.
+ * This idiom is called "scope-based resource management".
  *
  * Please note "exception" and "exception handling" have a specific meaning
  * in this context and are completely unrelated to C++ exceptions.
@@ -91,6 +92,7 @@ class fe_trap {
   };
   static global_state_params global_state;
 
+  /** @brief Scope-based handle to manage an exception trap lifetime. */
   struct scoped_instance {
     explicit scoped_instance(std::shared_ptr<fe_trap> ptr)
         : m_resource{std::move(ptr)} {}
@@ -99,10 +101,27 @@ class fe_trap {
     scoped_instance &operator=(scoped_instance const &) = delete;
     scoped_instance &operator=(scoped_instance &&) noexcept = default;
     bool is_unique() const { return m_resource->is_unique(); }
+    bool is_active() const { return m_resource->is_active(); }
     int get_flags() const { return m_resource->get_flags(); }
+    auto &get_trap() { return *m_resource; }
+    auto const &get_trap() const { return *m_resource; }
+    bool operator==(scoped_instance const &) const = default;
 
   private:
     std::shared_ptr<fe_trap> m_resource;
+  };
+
+  /** @brief Scope-based handle to temporarily disable an exception trap. */
+  struct scoped_pause {
+    std::weak_ptr<fe_trap> m_resource;
+    explicit scoped_pause(std::shared_ptr<fe_trap> ptr) : m_resource{ptr} {
+      ptr->deactivate();
+    }
+    ~scoped_pause() {
+      if (auto const ptr = m_resource.lock()) {
+        ptr->activate();
+      }
+    }
   };
 
   struct deleter {
@@ -112,9 +131,15 @@ class fe_trap {
 
   int m_flags;
   bool m_unique;
+  bool m_active; // this flag is not strictly equivalent to `not m_pause`
+  std::weak_ptr<scoped_pause> m_pause;
 
-  fe_trap(std::optional<int> excepts, bool unique);
-  ~fe_trap();
+  fe_trap(std::optional<int> excepts, bool unique)
+      : m_flags{parse_excepts(excepts)}, m_unique{unique}, m_active{false},
+        m_pause{} {
+    activate();
+  }
+  ~fe_trap() { deactivate(); }
 
   static int parse_excepts(std::optional<int> excepts);
 
@@ -127,6 +152,8 @@ public:
   int get_flags() const { return m_flags; }
   /** @brief Check if this handle is a unique handle. */
   bool is_unique() const { return m_unique; }
+  /** @brief Check if this handle has a currrently active trap. */
+  bool is_active() const { return m_active; }
 
   /**
    * @brief Generate a unique trap with the lifetime of the current scope.
@@ -142,6 +169,25 @@ public:
    */
   static scoped_instance
   make_shared_scoped(std::optional<int> excepts = std::nullopt);
+
+  /**
+   * @brief Generate a shared handle to temporarily disable any currently
+   * active exception trap for the lifetime of the current scope.
+   * If exception trap is currently active, return a null pointer.
+   */
+  static std::shared_ptr<scoped_pause> make_shared_pause_scoped();
+
+  /** @brief Manually activate the exception trap. */
+  void activate();
+
+  /**
+   * @brief Manually deactivate the exception trap.
+   * Useful when calling a third-party library that is known to send signals.
+   * This should only be used in exceptional cases
+   * (@ref make_shared_pause_scoped provides a scope-based alternative).
+   * Call @ref activate() to re-activate the exception trap.
+   */
+  void deactivate();
 };
 
 #endif // ESPRESSO_FPE

--- a/src/instrumentation/src/fe_trap.cpp
+++ b/src/instrumentation/src/fe_trap.cpp
@@ -39,10 +39,12 @@
 
 fe_trap::global_state_params fe_trap::global_state{{}, {}};
 
-fe_trap::fe_trap(std::optional<int> excepts, bool unique) {
+void fe_trap::activate() {
+  if (m_active) {
+    return;
+  }
 #if defined(ESPRESSO_FPE_USING_GLIBC_X86_64)
   {
-    m_flags = parse_excepts(excepts);
     [[maybe_unused]] auto const status = feenableexcept(m_flags);
     // note: status should be 0 since we use the singleton pattern
     assert(status == 0);
@@ -50,7 +52,6 @@ fe_trap::fe_trap(std::optional<int> excepts, bool unique) {
 #elif defined(ESPRESSO_FPE_USING_APPLE_ARM_64)
   {
     using fpcr_t = decltype(std::fenv_t::__fpcr);
-    m_flags = parse_excepts(excepts);
     std::fenv_t env;
     {
       [[maybe_unused]] auto const status = std::fegetenv(&env);
@@ -65,10 +66,13 @@ fe_trap::fe_trap(std::optional<int> excepts, bool unique) {
 #else
 #error "FE not supported"
 #endif
-  m_unique = unique;
+  m_active = true;
 }
 
-fe_trap::~fe_trap() {
+void fe_trap::deactivate() {
+  if (not m_active) {
+    return;
+  }
 #if defined(ESPRESSO_FPE_USING_GLIBC_X86_64)
   {
     [[maybe_unused]] auto const status = fedisableexcept(m_flags);
@@ -94,6 +98,7 @@ fe_trap::~fe_trap() {
 #else
 #error "FE not supported"
 #endif
+  m_active = false;
 }
 
 int fe_trap::parse_excepts(std::optional<int> excepts) {
@@ -134,6 +139,19 @@ fe_trap::make_shared_scoped(std::optional<int> excepts) {
   auto watched = std::shared_ptr<fe_trap>(raw_ptr, deleter{});
   fe_trap::global_state.observer = watched;
   return fe_trap::scoped_instance(watched);
+}
+
+std::shared_ptr<fe_trap::scoped_pause> fe_trap::make_shared_pause_scoped() {
+  std::lock_guard<std::mutex> lock(fe_trap::global_state.mutex);
+  if (auto watched = fe_trap::global_state.observer.lock()) {
+    if (auto pause = watched->m_pause.lock()) {
+      return pause;
+    }
+    auto pause = std::make_shared<scoped_pause>(watched);
+    watched->m_pause = pause;
+    return pause;
+  }
+  return {};
 }
 
 #endif // ESPRESSO_FPE

--- a/src/instrumentation/tests/fe_trap_test.cpp
+++ b/src/instrumentation/tests/fe_trap_test.cpp
@@ -100,6 +100,7 @@ BOOST_AUTO_TEST_CASE(trap_by_signal) {
   {
     auto const trap = fe_trap::make_unique_scoped();
     BOOST_REQUIRE(trap.is_unique());
+    BOOST_REQUIRE(trap.is_active());
     value = 0.;
     while (sigsetjmp(::jmp_env, 1) == 0) {
       // LCOV_EXCL_START
@@ -117,6 +118,7 @@ BOOST_AUTO_TEST_CASE(trap_by_signal) {
   {
     auto const trap = fe_trap::make_shared_scoped();
     BOOST_REQUIRE(not trap.is_unique());
+    BOOST_REQUIRE(trap.is_active());
     value = 0.;
     while (sigsetjmp(::jmp_env, 1) == 0) {
       // LCOV_EXCL_START
@@ -136,6 +138,8 @@ BOOST_AUTO_TEST_CASE(trap_by_signal) {
     {
       auto const trap2 = fe_trap::make_shared_scoped(FE_UNDERFLOW);
       BOOST_REQUIRE_EQUAL(trap1.get_flags(), trap2.get_flags());
+      BOOST_REQUIRE(trap1 == trap2);
+      BOOST_REQUIRE(&trap1.get_trap() == &trap2.get_trap());
       value = 0.;
       while (sigsetjmp(::jmp_env, 1) == 0) {
         // LCOV_EXCL_START
@@ -150,6 +154,62 @@ BOOST_AUTO_TEST_CASE(trap_by_signal) {
       ::last_signal_status = 0;
       ::last_signal_code = 0;
     }
+  }
+
+  // check trap deactivation
+  {
+    {
+      // if no global trap exists, then no global pause exists
+      auto const trap_pause = fe_trap::make_shared_pause_scoped();
+      BOOST_REQUIRE(not trap_pause);
+    }
+    auto trap = fe_trap::make_unique_scoped();
+    BOOST_REQUIRE(trap.is_unique());
+    BOOST_REQUIRE(trap.is_active());
+    {
+      // temporarily deactivate trap
+      auto trap_pause = fe_trap::make_shared_pause_scoped();
+      BOOST_REQUIRE(trap_pause);
+      BOOST_REQUIRE(not trap.is_active());
+      // without instrumentation, abnormal operations are allowed
+      value = 1. / bad_denominator;
+      value = std::exp(bad_exponent);
+      // there is only one global trap, which manages a shared pause handle
+      auto shared_trap_pause = fe_trap::make_shared_pause_scoped();
+      BOOST_REQUIRE(shared_trap_pause);
+      BOOST_REQUIRE(shared_trap_pause.get() == trap_pause.get());
+    }
+    BOOST_REQUIRE(trap.is_active());
+    {
+      // manually deactivate trap
+      trap.get_trap().deactivate();
+      BOOST_REQUIRE(not trap.is_active());
+      // without instrumentation, abnormal operations are allowed
+      value = 1. / bad_denominator;
+      value = std::exp(bad_exponent);
+      // deactivating twice is safe (no-op)
+      trap.get_trap().deactivate();
+      BOOST_REQUIRE(!trap.is_active());
+      // manually reactivate trap
+      trap.get_trap().activate();
+      BOOST_REQUIRE(trap.is_active());
+      // reactivating twice is safe (no-op)
+      trap.get_trap().activate();
+      BOOST_REQUIRE(trap.is_active());
+    }
+    value = 0.;
+    while (sigsetjmp(::jmp_env, 1) == 0) {
+      // LCOV_EXCL_START
+      value = 2.;
+      value = 0. / bad_denominator;
+      // LCOV_EXCL_STOP
+    }
+    BOOST_CHECK_EQUAL(::last_signal_status, SIGFPE);
+    BOOST_CHECK_EQUAL(::last_signal_code, FPE_FLTINV);
+    BOOST_REQUIRE(not std::isnan(value));
+    BOOST_REQUIRE_EQUAL(value, 2.);
+    ::last_signal_status = 0;
+    ::last_signal_code = 0;
   }
 
   // reset default signal handler

--- a/src/script_interface/walberla/EKFFT.hpp
+++ b/src/script_interface/walberla/EKFFT.hpp
@@ -37,6 +37,8 @@
 #include <script_interface/auto_parameters/AutoParameters.hpp>
 #include <script_interface/code_info/CodeInfo.hpp>
 
+#include <instrumentation/fe_trap.hpp>
+
 #include <utils/math/int_pow.hpp>
 
 #include <memory>
@@ -71,8 +73,18 @@ protected:
     }
     m_instance = make_new_instance(m_lattice->lattice(), permittivity,
                                    m_single_precision);
-    m_instance->setup_fft(m_gpu and
-                          ::communication_environment->is_mpi_gpu_aware());
+    {
+#ifdef ESPRESSO_FPE
+      // cuFFT builds device kernels using CUDA-JIT
+      // (https://docs.nvidia.com/cuda/archive/13.1.1/cufft/#plan-initialization-time)
+      // please note this operation is not guaranteed to succeed for all
+      // mesh sizes, and in rare cases, it can send the SIGFPE signal
+      auto const trap_pause = fe_trap::make_shared_pause_scoped();
+#endif
+      auto const use_gpu_aware =
+          m_gpu and ::communication_environment->is_mpi_gpu_aware();
+      m_instance->setup_fft(use_gpu_aware);
+    }
   }
 
 public:

--- a/src/walberla_bridge/src/electrokinetics/PoissonSolverFFT.hpp
+++ b/src/walberla_bridge/src/electrokinetics/PoissonSolverFFT.hpp
@@ -330,6 +330,28 @@ public:
     }
 #endif
     reset_charge_field();
+#if not defined(__CUDACC__)
+    if constexpr (Architecture == lbmpy::Arch::CPU) {
+      // make FFT plan
+      heffte->fft->forward(m_potential.data(), m_potential_fourier.data(),
+                           heffte->buffer->data());
+    }
+#endif
+#if defined(__CUDACC__)
+    if constexpr (Architecture == lbmpy::Arch::GPU) {
+      for (auto &block : *get_lattice().get_blocks()) {
+        auto potential =
+            block.template getData<PotentialField>(m_potential_field_id);
+        auto fourier =
+            block.template getData<PotentialFourier>(m_potential_fourier_id);
+        FloatType *_data_potential = potential->dataAt(0, 0, 0, 0);
+        ComplexType *_data_fourier = fourier->dataAt(0, 0, 0, 0);
+        // make FFT plan
+        heffte->fft->forward(_data_potential, _data_fourier,
+                             heffte->buffer->data());
+      }
+    }
+#endif
   }
 
   [[nodiscard]] std::optional<double>

--- a/testsuite/python/cell_system.py
+++ b/testsuite/python/cell_system.py
@@ -95,6 +95,8 @@ class CellSystem(ut.TestCase):
         self.check_node_grid()
 
     @utx.skipIfMissingFeatures(["WCA", "SHARED_MEMORY_PARALLELISM"])
+    @ut.skipIf(espressomd.has_features("FPE"),
+               "cannot run with FPE instrumentation")
     def test_verlet_list_overflow(self):
         system = self.system
         system.part.clear()


### PR DESCRIPTION
Description of changes:
- the Kokkos library was accidentally set up to enable hardware-dependent optimizations, which can cause trouble for HTCondor users, since they typically have access to computing resources with heterogeneous hardware
- compiler diagnostics are no longer emitted inside the Kokkos and Cabana libraries when included via the FetchContent mechanism, for consistency with the FindPackage mechanism
- FPE instrumentation is now temporarily disabled when calling third-party libraries known to raise exception flags
- FPE instrumentation is now disabled for features and test cases that explicitly rely on floating-point exceptions