### PR TITLE
Rewrite features parser and config file generator

### DIFF
--- a/src/config/featuredefs.py
+++ b/src/config/featuredefs.py
@@ -22,19 +22,19 @@
 This module parses the feature definition file :file:`features.def`.
 """
 import fileinput
+import graphlib
+import io
 import re
 
 
-class SyntaxError(Exception):
+class DefinitionError(Exception):
 
-    def __init__(self, message, instead):
+    def __init__(self, message, context):
         self.message = message
-        self.filename = fileinput.filename()
-        self.lineno = fileinput.filelineno()
-        self.instead = instead
+        self.filename, self.lineno, self.instead = context
 
     def __str__(self):
-        return f"self.filename: {self.lineno:>2}: {self.message} in the following line:\n{self.instead}"  # nopep8
+        return f"{self.filename}: {self.lineno:>2}: {self.message} in the following line:\n{self.instead}"  # nopep8
 
 
 def toCPPExpr(expr):
@@ -61,8 +61,17 @@ class defs:
         # list of external features
         externals = set()
 
-        for line in fileinput.input(filename):
+        buffer = None
+        if isinstance(filename, io.StringIO):
+            buffer = filename
+            filename = "<io.StringIO>"
+        else:
+            buffer = fileinput.input(filename)
+
+        for lineno, line in enumerate(buffer):
             line = line.strip()
+            context = (filename, lineno, line)
+
             # Ignore empty and comment lines
             if not line or line.startswith(('#', '//', '/*')):
                 assert not line.startswith('/*') or line.endswith('*/')
@@ -86,48 +95,50 @@ class defs:
                 # derived
                 if keyword == 'equals':
                     if rest is None:
-                        raise SyntaxError("<feature> equals <expr>", line)
+                        raise DefinitionError(
+                            "<feature> equals <expr>", context)
                     if feature in derived:
-                        raise SyntaxError(
-                            "Derived feature is already defined above:", line)
+                        raise DefinitionError(
+                            "Derived feature is already defined above:", context)
                     if feature in externals:
-                        raise SyntaxError(
-                            "Derived feature is already defined as external above:", line)
+                        raise DefinitionError(
+                            "Derived feature is already defined as external above:", context)
                     derived.add(feature)
                     derivations.append((feature, rest, toCPPExpr(rest)))
 
                 # externals
                 elif keyword == 'external':
                     if rest is not None:
-                        raise SyntaxError("<feature> external", line)
+                        raise DefinitionError("<feature> external", context)
                     if feature in derived:
-                        raise SyntaxError(
-                            "External feature is already defined as derived above:", line)
+                        raise DefinitionError(
+                            "External feature is already defined as derived above:", context)
                     implied = set(map((lambda x_y: x_y[1]), implications))
                     if feature in implied:
-                        raise SyntaxError(
-                            "External feature is implied above:", line)
+                        raise DefinitionError(
+                            "External feature is implied above:", context)
                     externals.add(feature)
 
                 # implications
                 elif keyword == 'implies':
                     if rest is None:
-                        raise SyntaxError(
-                            "<feature> implies [<feature>...]", line)
+                        raise DefinitionError(
+                            "<feature> implies [<feature>...]", context)
                     tokens = rest.split()
                     for implied in tokens:
                         if implied.endswith(','):
                             implied = implied[:-1]
                         if implied in externals:
-                            raise SyntaxError(
-                                "Implied feature %s is already defined as external above:" % feature, line)
+                            raise DefinitionError(
+                                f"Implied feature {implied} is already defined as external above:", context)
 
                         implications.append((feature, implied))
 
                 # requires
                 elif keyword == 'requires':
                     if rest is None:
-                        raise SyntaxError("<feature> requires <expr>", line)
+                        raise DefinitionError(
+                            "<feature> requires <expr>", context)
                     requirements.append((feature, rest, toCPPExpr(rest)))
 
         # allfeatures minus externals and derived
@@ -141,31 +152,37 @@ class defs:
         self.derived = derived
         self.derivations = derivations
         self.externals = externals
+        self.implications_topologically_ordered = self.process_implications()
 
-    def check_validity(self, activated):
-        """Check whether a set of features is valid.
-        Returns None if it is not and the set of features including implied features if it is.
+    def process_implications(self):
         """
-        newset = activated.copy()
+        Detect transitive chains in the graph of implication rules.
+        Topological ordering is used to guarantee that any feature ``D`` is
+        defined before any dependent rule ``D -> E`` is evaluated, such that
+        a chain ``C -> D -> E`` works correctly when the preprocessor reads
+        the feature config file from top to bottom. When multiple rules
+        independently imply the same feature, they can be folded with syntax
+        ``#if defined(A) or defined(B)`` to reduce the config file size.
+        """
+        graph = {}
+        for feature, implied_feature in self.implications:
+            graph.setdefault(feature, set())
+            graph.setdefault(implied_feature, set()).add(feature)
 
-        # handle implications
-        for feature, implied in self.implications:
-            if feature in newset and implied not in newset:
-                newset.add(implied)
-
-        # handle requirements
-        featurevars = dict()
-        derived = list(map((lambda x_y_z: x_y_z[0]), self.derivations))
-        allfeatures = self.features.union(derived, self.externals)
-        for feature in allfeatures:
-            featurevars[feature] = feature in newset
-
-        for feature, expr, _ in self.requirements:
-            if feature in newset:
-                if not eval(expr, featurevars):
-                    return None
-
-        return newset
+        ts = graphlib.TopologicalSorter(graph)
+        ts.prepare()
+        rounds = []
+        while ts.is_active():
+            rules = {}
+            # process rules that can be independently satisfied in this round
+            for node in sorted(ts.get_ready()):
+                for feature, implied_feature in self.implications:
+                    if feature == node:
+                        rules.setdefault(implied_feature, set()).add(feature)
+                ts.done(node)
+            if rules:
+                rounds.append(rules)
+        return rounds
 
 
 class cmakedefs:

--- a/src/config/gen_featureconfig.py
+++ b/src/config/gen_featureconfig.py
@@ -104,17 +104,17 @@ hfile.write("""\
 /* Handle implications */
 /***********************/
 """)
-implication_template = string.Template("""
-// $feature implies $implied
-#if defined(ESPRESSO_$feature) && !defined(ESPRESSO_$implied)
-#define ESPRESSO_$implied
-#endif
-""")
-for feature, implied in sorted(defs.implications):
-    hfile.write(implication_template.substitute(
-        feature=feature, implied=implied))
-
-hfile.write("\n")
+for rules in defs.implications_topologically_ordered:
+    for implied in sorted(rules.keys()):
+        implying = sorted(rules[implied])
+        condition = " || ".join(f"defined(ESPRESSO_{s})" for s in implying)
+        if len(implying) > 1:
+            condition = f"({condition})"
+        hfile.write(
+            f"#if !defined(ESPRESSO_{implied}) && {condition}\n"
+            f"#define ESPRESSO_{implied}\n"
+            f"#endif\n\n"
+        )
 
 # output warnings if internal features are set manually
 hfile.write("""\
@@ -133,6 +133,7 @@ derivation_template = string.Template("""
 for feature, expr, cppexpr in sorted(defs.derivations):
     hfile.write(derivation_template.substitute(
         feature=feature, cppexpr=cppexpr, expr=expr))
+hfile.write("\n")
 
 # generate compiler errors when incompatible features are selected
 hfile.write("""\

--- a/testsuite/scripts/CMakeLists.txt
+++ b/testsuite/scripts/CMakeLists.txt
@@ -23,6 +23,7 @@ endfunction(SCRIPTS_TEST)
 
 scripts_test(FILE test_notebook_links.py)
 scripts_test(FILE test_check_myconfig.py)
+scripts_test(FILE test_featuredefs.py)
 
 add_custom_target(
   check_scripts JOB_POOL console

--- a/testsuite/scripts/test_featuredefs.py
+++ b/testsuite/scripts/test_featuredefs.py
@@ -1,0 +1,182 @@
+#
+# Copyright (C) 2026 The ESPResSo project
+#
+# This file is part of ESPResSo.
+#
+# ESPResSo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ESPResSo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import io
+import sys
+import graphlib
+import importlib
+import unittest as ut
+
+sys.path.insert(0, "@CMAKE_SOURCE_DIR@/src/config")
+module = importlib.import_module("featuredefs")
+
+
+class Test(ut.TestCase):
+
+    def test_parser(self):
+        ruleset = "A\nB implies C,D,\nE requires F and not G\nG equals H or J and not K\nL external\nM external"
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.allfeatures, set("ABEGLM"))
+        self.assertEqual(obj.implications, [("B", "C,D")])
+        self.assertEqual(
+            obj.requirements, [
+                ("E", "F and not G", "defined(ESPRESSO_F) && ! defined(ESPRESSO_G)")])
+        self.assertEqual(obj.derived, set("G"))
+        self.assertEqual(
+            obj.derivations, [
+                ("G", "H or J and not K",
+                 "defined(ESPRESSO_H) || defined(ESPRESSO_J) && ! defined(ESPRESSO_K)")])
+        self.assertEqual(obj.externals, set("LM"))
+
+    def test_implications_topological_ordering(self):
+        # ruleset: A -> B
+        # round 1
+        # B must be resolved by A
+        ruleset = "A implies B"
+        round1 = {"B": {"A"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1])
+        # ruleset: A -> B, C -> D
+        # round 1
+        # B must be resolved by A
+        # D must be resolved by C
+        ruleset = "A implies B\nC implies D"
+        round1 = {"B": {"A"}, "D": {"C"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1])
+        # ruleset: A -> C, B -> C
+        # round 1
+        # C must be resolved by A
+        # C must be resolved by B
+        ruleset = "A implies C\nB implies C"
+        round1 = {"C": {"A", "B"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1])
+        # ruleset: A -> B, B -> C
+        # round 1
+        # B must be resolved by A
+        # round 2
+        # C must be resolved by B
+        ruleset = "A implies B\nB implies C"
+        round1 = {"B": {"A"}}
+        round2 = {"C": {"B"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1, round2])
+        # ruleset: A -> B, B -> {C, D}, E -> C
+        # round 1
+        # B must be resolved by A
+        # C must be resolved by E
+        # round 2
+        # D must be resolved by B
+        # C must be resolved by B
+        ruleset = "A implies B\nB implies C, D\nE implies C"
+        round1 = {"B": {"A"}, "C": {"E"}}
+        round2 = {"C": {"B"}, "D": {"B"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1, round2])
+        # ruleset: A -> B, B -> {C, D}, E -> C, F -> C
+        # round 1
+        # B must be resolved by A
+        # C must be resolved by E
+        # C must be resolved by F
+        # round 2
+        # D must be resolved by B
+        # C must be resolved by B
+        ruleset = "A implies B\nB implies C, D\nE implies C\nF implies C"
+        round1 = {"B": {"A"}, "C": {"E", "F"}}
+        round2 = {"C": {"B"}, "D": {"B"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1, round2])
+        # ruleset: A -> {B, G}, B -> {C, D}, E -> C, F -> C, G -> C
+        # round 1
+        # B must be resolved by A
+        # G must be resolved by A
+        # C must be resolved by E
+        # C must be resolved by F
+        # round 2
+        # D must be resolved by B
+        # C must be resolved by B
+        # C must be resolved by G
+        ruleset = "A implies B, G\nB implies C, D\nE implies C\nF implies C\nG implies C"
+        round1 = {"B": {"A"}, "C": {"E", "F"}, "G": {"A"}}
+        round2 = {"C": {"B", "G"}, "D": {"B"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1, round2])
+        # ruleset: A -> {B, C}, B -> {C, D}, E -> C, F -> C
+        # round 1
+        # B must be resolved by A
+        # C must be resolved by A
+        # C must be resolved by E
+        # C must be resolved by F
+        # round 2
+        # D must be resolved by B
+        # C must be resolved by B
+        ruleset = "A implies B, C\nB implies C, D\nE implies C\nF implies C"
+        round1 = {"B": {"A"}, "C": {"E", "F", "A"}}
+        round2 = {"C": {"B"}, "D": {"B"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1, round2])
+        # ruleset: A -> {B, C}, B -> D, C -> D, D -> E
+        # round 1
+        # B must be resolved by A
+        # C must be resolved by A
+        # round 2
+        # D must be resolved by B
+        # D must be resolved by C
+        # round 3
+        # E must be resolved by D
+        ruleset = "A implies B, C\nB implies D\nC implies D\nD implies E"
+        round1 = {"B": {"A"}, "C": {"A"}}
+        round2 = {"D": {"B", "C"}}
+        round3 = {"E": {"D"}}
+        obj = module.defs(io.StringIO(ruleset))
+        self.assertEqual(obj.process_implications(), [round1, round2, round3])
+
+    def test_exceptions(self):
+        # detect syntax errors
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  0: <feature> equals <expr> in the following line:\nA equals"):
+            module.defs(io.StringIO("A equals "))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  1: Derived feature is already defined above: in the following line:\nA equals C"):
+            module.defs(io.StringIO("A equals B\nA equals C"))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  1: Derived feature is already defined as external above: in the following line:\nA equals B"):
+            module.defs(io.StringIO("A external\nA equals B"))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  0: <feature> external in the following line:\nA external B"):
+            module.defs(io.StringIO("A external B"))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  1: External feature is already defined as derived above: in the following line:\nA external"):
+            module.defs(io.StringIO("A equals B\nA external"))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  1: External feature is implied above: in the following line:\nB external"):
+            module.defs(io.StringIO("A implies B\nB external"))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  0: <feature> implies \\[<feature>...\\] in the following line:\nA implies"):
+            module.defs(io.StringIO("A implies "))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  1: Implied feature B is already defined as external above: in the following line:\nA implies B,"):
+            module.defs(io.StringIO("B external\nA implies B,"))
+        with self.assertRaisesRegex(module.DefinitionError, "<io.StringIO>:  0: <feature> requires <expr> in the following line:\nA requires"):
+            module.defs(io.StringIO("A requires "))
+
+        # detect cyclic dependencies
+        ruleset = "A implies B\nB implies A"
+        with self.assertRaises(graphlib.CycleError):
+            module.defs(io.StringIO(ruleset))
+        ruleset = "A implies B\nB implies C\nC implies A"
+        with self.assertRaises(graphlib.CycleError):
+            module.defs(io.StringIO(ruleset))
+
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
Process feature implication rules in topological order to guarantee that transitive chains are always evaluated. Add test case to check the features parser. Remove unused features checker.