### PR TITLE
Fix regressions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -333,7 +333,6 @@ enable=dangerous-default-value, # W0102
        unused-argument, # W0613
        unused-wildcard-import, # W0614
        deprecated-method, # W1505
-       cyclic-import, # R0401
        trailing-comma-tuple, # R1707
        bad-classmethod-argument, # C0202
        undefined-variable, # E0602

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -644,7 +644,9 @@ endif()
 #
 
 set(ESPRESSO_OPENMP_COMPONENTS CXX)
-if(ESPRESSO_BUILD_WITH_CUDA)
+if(ESPRESSO_BUILD_WITH_CUDA AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL NVHPC)
+  # FindOpenMP doesn't fully support NVHPC+CUDA as of CMake 4.3, see ticket:
+  # https://gitlab.kitware.com/cmake/cmake/-/work_items/23003
   list(APPEND ESPRESSO_OPENMP_COMPONENTS CUDA)
 endif()
 # ESPResSo and Kokkos require some of the new features from OpenMP 5.0, but a

--- a/doc/tutorials/boltzmann_inversion/boltzmann_inversion.ipynb
+++ b/doc/tutorials/boltzmann_inversion/boltzmann_inversion.ipynb
@@ -77,7 +77,7 @@
     "import espressomd.observables\n",
     "\n",
     "plt.rcParams.update({'font.size': 14})\n",
-    "required_features = [\"LENNARD_JONES\", \"ELECTROSTATICS\"]\n",
+    "required_features = [\"LENNARD_JONES\", \"ELECTROSTATICS\", \"TABULATED\"]\n",
     "espressomd.assert_features(required_features)"
    ]
   },

--- a/doc/tutorials/grand_canonical_monte_carlo/CMakeLists.txt
+++ b/doc/tutorials/grand_canonical_monte_carlo/CMakeLists.txt
@@ -20,5 +20,5 @@
 espresso_add_tutorial(
   TARGET tutorial_grand_canonical_monte_carlo FILE
   "grand_canonical_monte_carlo.ipynb" HTML_RUN VAR_SUBST
-  "\"p3m_params={'mesh':20,'cao':4,'r_cut':5.05}\"" DEPENDS
+  "\"p3m_params={'mesh':20,'cao':4,'r_cut':5.1}\"" DEPENDS
   figures/schematic.svg)

--- a/doc/tutorials/grand_canonical_monte_carlo/grand_canonical_monte_carlo.ipynb
+++ b/doc/tutorials/grand_canonical_monte_carlo/grand_canonical_monte_carlo.ipynb
@@ -782,7 +782,7 @@
     "system.integrator.set_vv()\n",
     "\n",
     "p3m_params = {\"mesh\": 20}\n",
-    "p3m = espressomd.electrostatics.P3M(prefactor=L_BJERRUM * KT, accuracy=2.5e-3, **p3m_params)\n",
+    "p3m = espressomd.electrostatics.P3M(prefactor=L_BJERRUM * KT, accuracy=3e-3, **p3m_params)\n",
     "system.electrostatics.solver = p3m\n",
     "system.integrator.run(steps_per_loop)\n",
     "\n",

--- a/maintainer/benchmarks/lb.py
+++ b/maintainer/benchmarks/lb.py
@@ -69,7 +69,9 @@ assert args.volume_fraction < np.pi / (3 * np.sqrt(2)), \
 assert "box_l" not in args or args.particles_per_core == 0, \
     "Argument --box_l requires --particles_per_core=0"
 
-required_features = ["LENNARD_JONES", "WALBERLA"]
+required_features = ["WALBERLA"]
+if args.particles_per_core > 0:
+    required_features.append("LENNARD_JONES")
 if args.gpu:
     required_features.append("CUDA")
 espressomd.assert_features(required_features)
@@ -93,6 +95,8 @@ lj_cut = lj_sig * 2**(1. / 6.)  # cutoff distance
 n_proc = system.cell_system.get_state()["n_nodes"]
 n_part = n_proc * args.particles_per_core
 if n_part == 0:
+    if not hasattr(args, "box_l"):
+        args.box_l = [32]
     box_l = 3 * args.box_l if len(args.box_l) == 1 else args.box_l
     agrid = 1.
     lb_grid = box_l

--- a/src/core/analysis/statistics.cpp
+++ b/src/core/analysis/statistics.cpp
@@ -200,6 +200,7 @@ Utils::Vector9d gyration_tensor(System::System const &system,
 
   Utils::Vector9d mat{};
   if (::comm_cart.rank() == 0) {
+    assert(not buf_pos.empty());
     auto const center =
         std::accumulate(buf_pos.begin(), buf_pos.end(), Utils::Vector3d{}) /
         static_cast<double>(buf_pos.size());

--- a/src/core/dpd.cpp
+++ b/src/core/dpd.cpp
@@ -72,14 +72,12 @@ void InteractionsNonBonded::dpd_init(double kT, double time_step) {
   }
 }
 
-Utils::Vector3d
-dpd_pair_force(Utils::Vector3d const &p1_position,
-               Utils::Vector3d const &p1_velocity, int const &p1_id,
-               Utils::Vector3d const &p2_position,
-               Utils::Vector3d const &p2_velocity, int const &p2_id,
-               DPDThermostat const &dpd, BoxGeometry const &box_geo,
-               IA_parameters const &ia_params, Utils::Vector3d const &d,
-               double dist, double dist2) {
+Utils::Vector3d dpd_pair_force(
+    Utils::Vector3d const &p1_position, Utils::Vector3d const &p1_velocity,
+    int p1_id, Utils::Vector3d const &p2_position,
+    Utils::Vector3d const &p2_velocity, int p2_id, DPDThermostat const &dpd,
+    BoxGeometry const &box_geo, IA_parameters const &ia_params,
+    Utils::Vector3d const &d, double dist, double dist2) {
   if (ia_params.dpd.radial.cutoff <= 0.0 && ia_params.dpd.trans.cutoff <= 0.0) {
     return {};
   }

--- a/src/core/dpd.hpp
+++ b/src/core/dpd.hpp
@@ -67,14 +67,12 @@ inline Utils::Vector3d dpd_pair_force(DPDParameters const &params,
   return {};
 }
 
-Utils::Vector3d
-dpd_pair_force(Utils::Vector3d const &p1_position,
-               Utils::Vector3d const &p1_velocity, int const &p1_id,
-               Utils::Vector3d const &p2_position,
-               Utils::Vector3d const &p2_velocity, int const &p2_id,
-               DPDThermostat const &dpd, BoxGeometry const &box_geo,
-               IA_parameters const &ia_params, Utils::Vector3d const &d,
-               double dist, double dist2);
+Utils::Vector3d dpd_pair_force(
+    Utils::Vector3d const &p1_position, Utils::Vector3d const &p1_velocity,
+    int p1_id, Utils::Vector3d const &p2_position,
+    Utils::Vector3d const &p2_velocity, int p2_id, DPDThermostat const &dpd,
+    BoxGeometry const &box_geo, IA_parameters const &ia_params,
+    Utils::Vector3d const &d, double dist, double dist2);
 
 Utils::Vector9d dpd_stress(System::System &system,
                            boost::mpi::communicator const &comm);

--- a/src/core/electrostatics/mmm-modpsi.cpp
+++ b/src/core/electrostatics/mmm-modpsi.cpp
@@ -94,7 +94,7 @@ static void preparePolygammaOdd(int n, double binom,
 }
 
 void CoulombMMM1D::create_mod_psi_up_to(int new_n) {
-  auto const old_n = static_cast<int>(modPsi.size() >> 1);
+  auto const old_n = static_cast<int>(modPsi.size() / 2ul);
   if (new_n > old_n) {
     modPsi.resize(2 * new_n);
 

--- a/src/core/electrostatics/mmm1d.cpp
+++ b/src/core/electrostatics/mmm1d.cpp
@@ -188,7 +188,7 @@ Utils::Vector3d CoulombMMM1D::pair_force(double q1q2, Utils::Vector3d const &d,
                                          double dist) const {
   auto constexpr c_2pi = 2. * std::numbers::pi;
   auto const &box_geo = *get_system().box_geo;
-  auto const n_modPsi = static_cast<int>(modPsi.size()) >> 1;
+  auto const n_modPsi = static_cast<int>(modPsi.size() / 2ul);
   auto const rxy2 = d[0] * d[0] + d[1] * d[1];
   auto const rxy2_d = rxy2 * uz2;
   auto const z_d = d[2] * box_geo.length_inv()[2];
@@ -278,7 +278,7 @@ double CoulombMMM1D::pair_energy(double const q1q2, Utils::Vector3d const &d,
 
   auto constexpr c_2pi = 2. * std::numbers::pi;
   auto const &box_geo = *get_system().box_geo;
-  auto const n_modPsi = static_cast<int>(modPsi.size()) >> 1;
+  auto const n_modPsi = static_cast<int>(modPsi.size() / 2ul);
   auto const rxy2 = d[0] * d[0] + d[1] * d[1];
   auto const rxy2_d = rxy2 * uz2;
   auto const z_d = d[2] * box_geo.length_inv()[2];

--- a/src/core/immersed_boundary/ibm_tribend.cpp
+++ b/src/core/immersed_boundary/ibm_tribend.cpp
@@ -54,7 +54,7 @@ IBMTribend::calc_forces(BoxGeometry const &box_geo, Utils::Vector3d const &pos1,
   n2 /= Aj;
 
   // Get the prefactor for the force term
-  auto const sc = std::min(1.0, n1 * n2);
+  auto const sc = std::clamp(n1 * n2, -1., 1.);
 
   // Get theta as angle between normals
   auto const direc = vector_product(n1, n2);
@@ -108,7 +108,7 @@ void IBMTribend::initialize(BoxGeometry const &box_geo,
     auto const n2 = n2l / n2l.norm();
 
     // calculate theta0 by taking the acos of the scalar n1*n2
-    auto const sc = std::min(1., n1 * n2);
+    auto const sc = std::clamp(n1 * n2, -1., 1.);
 
     theta0 = std::acos(sc);
 

--- a/src/core/immersed_boundary/ibm_triel.cpp
+++ b/src/core/immersed_boundary/ibm_triel.cpp
@@ -84,7 +84,10 @@ IBMTriel::calc_forces(Utils::Vector3d const &vec1,
 
   // Check for sanity
   if ((lp - lp0 > maxDist) || (l - l0 > maxDist)) {
-    return {};
+    return std::nullopt;
+  }
+  if (lp == 0.0 || l == 0.0) {
+    return std::nullopt;
   }
 
   // angles between these vectors; calculated directly via the products

--- a/src/core/integrate.cpp
+++ b/src/core/integrate.cpp
@@ -317,7 +317,7 @@ void System::System::integrator_sanity_checks() const {
 }
 
 #ifdef ESPRESSO_WALBERLA
-void walberla_tau_sanity_checks(std::string method, double tau,
+void walberla_tau_sanity_checks(std::string const &method, double tau,
                                 double time_step) {
   if (time_step <= 0.) {
     return;
@@ -337,7 +337,7 @@ void walberla_tau_sanity_checks(std::string method, double tau,
                                 std::to_string(factor));
 }
 
-void walberla_agrid_sanity_checks(std::string method,
+void walberla_agrid_sanity_checks(std::string const &method,
                                   Utils::Vector3d const &geo_left,
                                   Utils::Vector3d const &geo_right,
                                   Utils::Vector3d const &lattice_left,

--- a/src/core/integrate.hpp
+++ b/src/core/integrate.hpp
@@ -54,9 +54,9 @@
 /**@}*/
 
 #ifdef ESPRESSO_WALBERLA
-void walberla_tau_sanity_checks(std::string method, double tau,
+void walberla_tau_sanity_checks(std::string const &method, double tau,
                                 double time_step);
-void walberla_agrid_sanity_checks(std::string method,
+void walberla_agrid_sanity_checks(std::string const &method,
                                   Utils::Vector3d const &geo_left,
                                   Utils::Vector3d const &geo_right,
                                   Utils::Vector3d const &lattice_left,

--- a/src/core/integrators/velocity_verlet_npt_MTK.cpp
+++ b/src/core/integrators/velocity_verlet_npt_MTK.cpp
@@ -37,8 +37,6 @@
 #include <cmath>
 #include <functional>
 
-static constexpr Utils::Vector3i nptgeom_dir{{1, 2, 4}};
-
 /**
  * @brief Scale and communicate instantaneous NpT pressure and
  * propagate the conjugate momentum for volume.
@@ -209,7 +207,7 @@ velocity_verlet_npt_propagate_vel_MTK(NptIsoParameters const &nptiso,
   for (auto &p : particles) {
     for (auto j = 0u; j < 3u; ++j) {
       if (!p.is_fixed_along(j)) {
-        if (nptiso.geometry & ::nptgeom_dir[j]) {
+        if (nptiso.geometry & NptIsoParameters::nptgeom_dir[j]) {
           p.v()[j] *= propagater;
           npt_inst_pressure.p_vel[j] += Utils::sqr(p.v()[j]) * p.mass();
         }

--- a/src/core/io/mpiio/mpiio.cpp
+++ b/src/core/io/mpiio/mpiio.cpp
@@ -164,8 +164,8 @@ static void mpiio_dump_array(const std::string &fn, T const *arr,
   }
   auto const offset =
       static_cast<MPI_Offset>(pref) * static_cast<MPI_Offset>(sizeof(T));
-  ret = MPI_File_set_view(f, offset, MPI_T, MPI_T, const_cast<char *>("native"),
-                          MPI_INFO_NULL);
+  char datarep[] = "native"; // non-const typed string
+  ret = MPI_File_set_view(f, offset, MPI_T, MPI_T, datarep, MPI_INFO_NULL);
   ret |= MPI_File_write_all(f, arr, static_cast<int>(len), MPI_T,
                             MPI_STATUS_IGNORE);
   static_cast<void>(ret and fatal_error("Could not write file", fn, &f, ret));
@@ -347,9 +347,8 @@ static void mpiio_read_array(const std::string &fn, T *arr, std::size_t len,
   }
   auto const offset =
       static_cast<MPI_Offset>(pref) * static_cast<MPI_Offset>(sizeof(T));
-  ret = MPI_File_set_view(f, offset, MPI_T, MPI_T, const_cast<char *>("native"),
-                          MPI_INFO_NULL);
-
+  char datarep[] = "native"; // non-const typed string
+  ret = MPI_File_set_view(f, offset, MPI_T, MPI_T, datarep, MPI_INFO_NULL);
   ret |= MPI_File_read_all(f, arr, static_cast<int>(len), MPI_T,
                            MPI_STATUS_IGNORE);
   static_cast<void>(ret and fatal_error("Could not read file", fn, &f, ret));

--- a/src/core/npt.cpp
+++ b/src/core/npt.cpp
@@ -66,7 +66,7 @@ void NptIsoParameters::coulomb_dipole_sanity_checks(
 NptIsoParameters::NptIsoParameters(double ext_pressure, double piston,
                                    Utils::Vector<bool, 3> const &rescale,
                                    bool cubic_box)
-    : piston{piston}, inv_piston{piston}, p_ext{ext_pressure},
+    : piston{piston}, inv_piston{1. / piston}, p_ext{ext_pressure},
       cubic_box{cubic_box} {
 
   if (ext_pressure < 0.0) {

--- a/src/core/p3m/TuningAlgorithm.hpp
+++ b/src/core/p3m/TuningAlgorithm.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #if defined(ESPRESSO_P3M) || defined(ESPRESSO_DP3M)
 

--- a/src/core/p3m/TuningLogger.hpp
+++ b/src/core/p3m/TuningLogger.hpp
@@ -19,10 +19,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ESPRESSO_SRC_CORE_P3M_TUNING_LOGGER_HPP
-#define ESPRESSO_SRC_CORE_P3M_TUNING_LOGGER_HPP
+#pragma once
 
-#include "config/config.hpp"
+#include <config/config.hpp>
 
 #if defined(ESPRESSO_P3M) || defined(ESPRESSO_DP3M)
 
@@ -53,7 +52,7 @@ public:
   }
 
   template <typename... Types>
-  void log_skip(std::string reason, Types... parameter_set) const {
+  void log_skip(std::string const &reason, Types... parameter_set) const {
     if (m_verbose) {
       row(parameter_set...);
       std::printf(" %s\n", reason.c_str());
@@ -117,7 +116,7 @@ public:
     }
   }
 
-  auto get_name() const { return m_name; }
+  auto const &get_name() const { return m_name; }
 
 private:
   bool m_verbose;
@@ -132,5 +131,3 @@ private:
 };
 
 #endif // ESPRESSO_P3M or ESPRESSO_DP3M
-
-#endif

--- a/src/core/system/System.hpp
+++ b/src/core/system/System.hpp
@@ -159,12 +159,6 @@ public:
   std::shared_ptr<Observable_stat> calculate_pressure();
 
 #ifdef ESPRESSO_NPT
-  /** @brief get the instantaneous pressure with (q(t+dt), p(t+dt/2))*/
-  double get_instantaneous_pressure();
-
-  /** @brief get the instantaneous virial pressure with q(t+dt)*/
-  double get_instantaneous_pressure_virial();
-
   /** @brief Synchronize NpT state such as instantaneous and average pressure */
   void synchronize_npt_state();
   /** @brief Reinitialize the NpT state. */

--- a/src/python/espressomd/thermostat.py
+++ b/src/python/espressomd/thermostat.py
@@ -147,41 +147,52 @@ class Thermostat(ScriptInterfaceHelper):
 
 @script_interface_register
 class Langevin(ScriptInterfaceHelper):
+    """Langevin thermostat."""
     _so_name = "Thermostat::Langevin"
     _so_creation_policy = "GLOBAL"
 
 
 @script_interface_register
 class Brownian(ScriptInterfaceHelper):
+    """Brownian thermostat."""
     _so_name = "Thermostat::Brownian"
     _so_creation_policy = "GLOBAL"
 
 
 @script_interface_register
 class IsotropicNpt(ScriptInterfaceHelper):
+    """NPT thermostat."""
     _so_name = "Thermostat::IsotropicNpt"
     _so_creation_policy = "GLOBAL"
+    _so_features = ("NPT",)
 
 
 @script_interface_register
 class Stokesian(ScriptInterfaceHelper):
+    """Stokesian thermostat."""
     _so_name = "Thermostat::Stokesian"
     _so_creation_policy = "GLOBAL"
+    _so_features = ("STOKESIAN_DYNAMICS",)
 
 
 @script_interface_register
 class LBThermostat(ScriptInterfaceHelper):
+    """Lattice-Boltzmann thermostat."""
     _so_name = "Thermostat::LB"
     _so_creation_policy = "GLOBAL"
+    _so_features = ("WALBERLA",)
 
 
 @script_interface_register
 class DPDThermostat(ScriptInterfaceHelper):
+    """DPD thermostat."""
     _so_name = "Thermostat::DPD"
     _so_creation_policy = "GLOBAL"
+    _so_features = ("DPD",)
 
 
 @script_interface_register
 class ThermalizedBond(ScriptInterfaceHelper):
+    """Thermalized bond thermostat."""
     _so_name = "Thermostat::ThermalizedBond"
     _so_creation_policy = "GLOBAL"

--- a/src/script_interface/particle_data/ParticleSlice.cpp
+++ b/src/script_interface/particle_data/ParticleSlice.cpp
@@ -106,7 +106,7 @@ set_particles_positions(std::vector<int> const &pids,
                         std::vector<Utils::Vector3d> const &positions) {
   for (std::size_t i = 0; i < pids.size(); ++i) {
     auto const pid = pids[i];
-    auto const pos = positions[i];
+    auto const &pos = positions[i];
     particle_checks(pid, pos);
     set_particle_pos(pid, pos);
   }

--- a/src/script_interface/thermostat/thermostat.hpp
+++ b/src/script_interface/thermostat/thermostat.hpp
@@ -706,6 +706,11 @@ public:
       get_system().on_temperature_change();
       return {};
     }
+    if (context()->is_head_node()) {
+      throw std::runtime_error(
+          "Unknown method " + name +
+          "(). Hint: a feature is probably not compiled in.");
+    }
     return {};
   }
 

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -22,7 +22,8 @@
 include(espresso_unit_test)
 
 espresso_unit_test(SRC Vector_test.cpp DEPENDS espresso::utils)
-if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL NVHPC AND "cxx_std_23" IN_LIST
+                                                CMAKE_CXX_COMPILE_FEATURES
    AND (NOT CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM
         OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2024.0.0))
   target_compile_features(Vector_test PUBLIC cxx_std_23)

--- a/testsuite/python/ibm.py
+++ b/testsuite/python/ibm.py
@@ -135,6 +135,29 @@ class IBM(ut.TestCase):
         # check not bonded particles. Positions should still be distorted
         np.testing.assert_allclose(np.copy(non_bound.pos), distorted_pos)
 
+    def test_triel_bond_breakage(self):
+        system = self.system
+
+        p1 = system.part.add(pos=[1, 4, 4])
+        p2 = system.part.add(pos=[1, 4, 5])
+        p3 = system.part.add(pos=[1, 5, 5])
+        all_partcls = system.part.all()
+
+        tri = espressomd.interactions.IBM_Triel(
+            ind1=p1.id, ind2=p2.id, ind3=p3.id, elasticLaw="Skalak", k1=15.,
+            k2=0., maxDist=1.)
+        system.bonded_inter.add(tri)
+        p1.add_bond((tri, p2, p3))
+        with self.assertRaisesRegex(Exception, "bond broken between particles 0, 1, 2"):
+            # stretch bonds too far
+            all_partcls.pos = all_partcls.pos + np.array((
+                (0., 0., 0.), system.box_l / 4., (0., 0., 0.)))
+            system.integrator.run(0, recalc_forces=True)
+        with self.assertRaisesRegex(Exception, "bond broken between particles 0, 1, 2"):
+            # collapse particles onto each other (angle is undefined)
+            all_partcls.pos = np.zeros((3, 3))
+            system.integrator.run(0, recalc_forces=True)
+
     def test_volcons(self):
         '''Check volume conservation forces on a simple mesh (cube).'''
         system = self.system

--- a/testsuite/python/integrator_exceptions.py
+++ b/testsuite/python/integrator_exceptions.py
@@ -21,6 +21,9 @@ import espressomd.interactions
 import espressomd.lees_edwards
 import espressomd.shapes
 import espressomd.propagation
+import espressomd.thermostat
+import espressomd.integrate
+import espressomd.code_features
 import os
 import numpy as np
 import unittest as ut
@@ -60,7 +63,6 @@ class Test(ut.TestCase):
         with self.assertRaisesRegex(ValueError, 'cannot reuse old forces and recalculate forces'):
             self.system.integrator.run(recalc_forces=True, reuse_forces=True)
         self.assertIsNone(self.system.integrator.integrator.call_method("unk"))
-        self.assertIsNone(self.system.thermostat.call_method("unk"))
         self.assertIsNone(self.system.thermostat.kT)
         if espressomd.has_features("WCA"):
             wca = self.system.non_bonded_inter[0, 0].wca
@@ -275,6 +277,31 @@ class Test(ut.TestCase):
             self.system.thermostat.set_brownian(kT=1., gamma=1., seed=42)
         with self.assertRaisesRegex(RuntimeError, f"Parameter 'kT' is read-only"):
             self.system.thermostat.kT = 2.
+
+    def test_missing_features(self):
+        thermostats = {
+            "STOKESIAN_DYNAMICS": ("set_stokesian", "Stokesian"),
+            "DPD": ("set_dpd", "DPDThermostat"),
+            "NPT": ("set_npt", "IsotropicNpt"),
+            "WALBERLA": ("set_lb", "LBThermostat"),
+        }
+        integrators = {
+            "STOKESIAN_DYNAMICS": ("set_stokesian_dynamics", "StokesianDynamics"),
+            "NPT": ("set_isotropic_npt", "VelocityVerletIsotropicNPT"),
+        }
+        FeaturesError = espressomd.code_features.FeaturesError
+        for feature, (method, class_name) in thermostats.items():
+            if not espressomd.has_features(feature):
+                with self.assertRaisesRegex(RuntimeError, rf"Unknown method {method}\(\). Hint: a feature is probably not compiled in"):
+                    getattr(self.system.thermostat, method)()
+                with self.assertRaisesRegex(RuntimeError, feature):
+                    getattr(espressomd.thermostat, class_name)()
+        for feature, (method, class_name) in integrators.items():
+            if not espressomd.has_features(feature):
+                with self.assertRaisesRegex(FeaturesError, feature):
+                    getattr(self.system.integrator, method)()
+                with self.assertRaisesRegex(FeaturesError, feature):
+                    getattr(espressomd.integrate, class_name)()
 
 
 if __name__ == "__main__":

--- a/testsuite/tutorials/test_grand_canonical_monte_carlo.py
+++ b/testsuite/tutorials/test_grand_canonical_monte_carlo.py
@@ -23,7 +23,7 @@ import numpy as np
 
 tutorial, skipIfMissingFeatures = importlib_wrapper.configure_and_import(
     "@TUTORIALS_DIR@/grand_canonical_monte_carlo/grand_canonical_monte_carlo.py",
-    p3m_params={"mesh": 20, "cao": 4, "r_cut": 5.05})
+    p3m_params={"mesh": 20, "cao": 4, "r_cut": 5.1})
 
 
 @skipIfMissingFeatures
@@ -35,8 +35,9 @@ class Tutorial(ut.TestCase):
         sim_xi_minus = tutorial.partition_coefficients_negative_ideal_array
         sim_xi_plus = tutorial.universal_partition_coefficients_positive_ideal
         ref_xi_minus = tutorial.analytical_solution(ratios)
+        # large fluctuations are expected at low particle numbers
         np.testing.assert_allclose(
-            sim_xi_plus, ref_xi_minus, rtol=0.2)
+            np.log(sim_xi_minus), np.log(ref_xi_minus), rtol=0.25)
         np.testing.assert_allclose(
             sim_xi_minus, sim_xi_plus, rtol=1e-5, atol=1e-5)
 


### PR DESCRIPTION
Description of changes:
- make small CMake adjustments for the NVHPC compiler toolchain
- reduce anti-patterns in the C++ core and handle an edge case in the immersed boundaries method
- add missing feature guards and raise an exception when setting a thermostat that is not compiled in
- relax tolerances of the Grand canonical tutorial test case to reduce the frequency of CI failures

AI disclosure: some of the C++ corrections were suggested by Claude Sonnet based on a local copy of the ISO C++ guidelines. These suggestions were manually verified for correctness.