### PR TITLE
Fix EKin slice/node getters and VTK output

### DIFF
--- a/doc/sphinx/ek.rst
+++ b/doc/sphinx/ek.rst
@@ -238,6 +238,23 @@ The CPU implementation of the EK has an extra flag ``single_precision`` to
 use single-precision floating point values. These are approximately 10%
 faster than double-precision, at the cost of a small loss in precision.
 
+To enable GPU acceleration, pass argument ``gpu=True`` to EK species and EK solvers.
+Please note that the GPU implementation uses single-precision floating point operations by default.
+This decreases the accuracy of calculations compared to the CPU implementation,
+which uses double-precision floating point operations by default.
+On GPUs that support double-precision floating point operations,
+argument ``single_precision=False`` can be added to improve precision.
+
+Multi-GPU support is activated by invoking the following expression before the creation
+of the first EK GPU instance::
+
+    system.cuda_init_handle.call_method("set_device_id_per_rank")
+
+The EK solver and all EK species in the same EK container need to use consistent
+floating-point precision and CPU/GPU kernels.
+
+For further information on CUDA support see section :ref:`CUDA acceleration`.
+
 .. _Checkpointing EK:
 
 Checkpointing

--- a/src/python/espressomd/electrokinetics.py
+++ b/src/python/espressomd/electrokinetics.py
@@ -51,6 +51,9 @@ class EKFFT(ScriptInterfaceHelper):
         Use GPU implementation.
     single_precision : :obj:`bool`, optional
         Use single-precision floating-point arithmetic.
+
+    Methods
+    -------
     add_vtk_writer()
         Attach a VTK writer.
 
@@ -134,10 +137,34 @@ class EKNone(ScriptInterfaceHelper, espressomd.detail.walberla.LatticeModel):
             File path to read from.
         binary : :obj:`bool`
             Whether to read in binary or ASCII mode.
+
+    add_vtk_writer()
+        Attach a VTK writer.
+
+        Parameters
+        ----------
+        vtk : :class:`espressomd.electrokinetics.VTKOutput`
+            VTK writer.
+
+    remove_vtk_writer()
+        Detach a VTK writer.
+
+        Parameters
+        ----------
+        vtk : :class:`espressomd.electrokinetics.VTKOutput`
+            VTK writer.
+
+    clear_vtk_writers()
+        Detach all VTK writers.
     """
     _so_name = "walberla::EKNone"
     _so_features = ("WALBERLA",)
     _so_creation_policy = "GLOBAL"
+    _so_bind_methods = (
+        "add_vtk_writer",
+        "remove_vtk_writer",
+        "clear_vtk_writers",
+    )
 
     def __init__(self, *args, **kwargs):
         _check_lattice_blocks(self.__class__.__name__, kwargs)

--- a/src/script_interface/walberla/EKContainer.hpp
+++ b/src/script_interface/walberla/EKContainer.hpp
@@ -43,6 +43,7 @@
 #include <cassert>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <variant>
 
@@ -140,7 +141,11 @@ class EKContainer : public ObjectList<EKSpecies, EK::Container> {
       solver = std::move(ptr);
     }
 #endif // ESPRESSO_WALBERLA_FFT
-    assert(solver.has_value());
+    if (not solver.has_value()) {
+      context()->parallel_try_catch([]() {
+        throw std::invalid_argument("EK solver is of the wrong type");
+      });
+    }
     return *solver;
   }
 
@@ -170,6 +175,8 @@ public:
          [this]() { return m_ek_reactions; }},
         {"is_active", AutoParameter::read_only,
          [this]() { return m_is_active; }},
+        {"gpu", AutoParameter::read_only,
+         [this]() { return m_ek_container->is_gpu(); }},
     });
   }
 
@@ -178,13 +185,16 @@ public:
   void do_construct(VariantMap const &params) override {
     m_is_active = false;
     auto const tau = get_value<double>(params, "tau");
-    context()->parallel_try_catch([tau]() {
+    context()->parallel_try_catch([&]() {
       if (tau <= 0.) {
         throw std::domain_error("Parameter 'tau' must be > 0");
       }
+      if (not params.contains("solver")) {
+        throw std::runtime_error("Parameter 'solver' is required; use EKNone "
+                                 "if all species are electrically neutral");
+      }
     });
-    m_poisson_solver = extract_solver(
-        params.contains("solver") ? params.at("solver") : Variant{none});
+    m_poisson_solver = extract_solver(params.at("solver"));
     m_ek_container = std::make_shared<::EK::EKWalberla::ek_container_type>(
         tau, std::visit(GetPoissonSolverCoreInstance{}, m_poisson_solver));
     m_ek_reactions = get_value<decltype(m_ek_reactions)>(params, "reactions");

--- a/src/script_interface/walberla/EKFFT.hpp
+++ b/src/script_interface/walberla/EKFFT.hpp
@@ -50,7 +50,6 @@ namespace ScriptInterface::walberla {
 class EKFFT : public EKPoissonSolver {
 protected:
   std::unique_ptr<ResourceManager> m_resources_lock;
-  std::shared_ptr<LatticeWalberla> m_lattice;
   double m_conv_permittivity;
   bool m_gpu;
   bool m_single_precision;
@@ -97,7 +96,6 @@ public:
     m_lattice = get_value<decltype(m_lattice)>(args, "lattice");
     m_vtk_writers =
         get_value_or<decltype(m_vtk_writers)>(args, "vtk_writers", {});
-
     make_instance(args), m_resources_lock = std::make_unique<ResourceManager>();
     // MPI communicator is needed to destroy the FFT plans
     m_resources_lock->acquire_lock(::communication_environment->get_mpi_env());
@@ -123,6 +121,8 @@ public:
         {"lattice", AutoParameter::read_only, [this]() { return m_lattice; }},
         {"shape", AutoParameter::read_only,
          [this]() { return m_instance->get_lattice().get_grid_dimensions(); }},
+        {"vtk_writers", AutoParameter::read_only,
+         [this]() { return serialize_vtk_writers(); }},
     });
   }
 

--- a/src/script_interface/walberla/EKIndexedReactionSlice.cpp
+++ b/src/script_interface/walberla/EKIndexedReactionSlice.cpp
@@ -47,8 +47,8 @@ Variant EKIndexedReactionSlice::do_call_method(std::string const &name,
     auto const attr = get_value<std::string>(params, "name");
     if (not m_shape_val.contains(attr)) {
       context()->parallel_try_catch([&]() {
-        throw std::runtime_error("Unknown EK indexed reaction property '" +
-                                 attr + "'");
+        std::string const class_prop{"EK indexed reaction property"};
+        throw std::runtime_error("Unknown " + class_prop + " '" + attr + "'");
       });
     }
     return m_shape_val.at(attr);

--- a/src/script_interface/walberla/EKNone.hpp
+++ b/src/script_interface/walberla/EKNone.hpp
@@ -48,8 +48,6 @@
 namespace ScriptInterface::walberla {
 
 class EKNone : public EKPoissonSolver {
-  std::shared_ptr<::walberla::PoissonSolver> m_instance;
-  std::shared_ptr<LatticeWalberla> m_lattice;
   bool m_gpu;
   bool m_single_precision;
 
@@ -90,11 +88,18 @@ public:
     m_gpu = get_value_or<bool>(args, "gpu", false);
     m_single_precision = get_value_or<bool>(args, "single_precision", m_gpu);
     m_lattice = get_value<decltype(m_lattice)>(args, "lattice");
+    m_vtk_writers =
+        get_value_or<decltype(m_vtk_writers)>(args, "vtk_writers", {});
     auto const agrid = get_value<double>(m_lattice->get_parameter("agrid"));
     m_tau = get_value<double>(args, "tau");
     set_potential_conversion(agrid, m_tau);
-
     make_instance(args);
+    for (auto &vtk : m_vtk_writers) {
+      vtk->attach_to_lattice(m_instance, get_lattice_to_md_units_conversion());
+    }
+  }
+
+  EKNone() {
     add_parameters({
         {"tau", AutoParameter::read_only, [this]() { return m_tau; }},
         {"single_precision", AutoParameter::read_only,
@@ -103,6 +108,8 @@ public:
         {"lattice", AutoParameter::read_only, [this]() { return m_lattice; }},
         {"shape", AutoParameter::read_only,
          [this]() { return m_instance->get_lattice().get_grid_dimensions(); }},
+        {"vtk_writers", AutoParameter::read_only,
+         [this]() { return serialize_vtk_writers(); }},
     });
   }
 

--- a/src/walberla_bridge/include/walberla_bridge/electrokinetics/EKContainer.hpp
+++ b/src/walberla_bridge/include/walberla_bridge/electrokinetics/EKContainer.hpp
@@ -55,6 +55,10 @@ private:
       throw std::runtime_error("EKSpecies lattice incompatible with existing "
                                "Poisson solver lattice");
     }
+    if (new_ek_species->is_gpu() != m_poisson_solver->is_gpu()) {
+      throw std::runtime_error("The EK species and the EK solver need to all "
+                               "be on either the CPU or GPU");
+    }
   }
 
   void sanity_checks(
@@ -65,6 +69,10 @@ private:
                             old_ek_species->get_lattice())) {
         throw std::runtime_error("Poisson solver lattice incompatible with "
                                  "existing EKSpecies lattice");
+      }
+      if (new_ek_solver->is_gpu() != old_ek_species->is_gpu()) {
+        throw std::runtime_error("The EK species and the EK solver need to all "
+                                 "be on either the CPU or GPU");
       }
     }
   }
@@ -80,13 +88,6 @@ public:
   void add(std::shared_ptr<EKSpecies> const &ek_species) {
     assert(not contains(ek_species));
     sanity_checks(ek_species);
-    if (!m_ekcontainer.empty()) {
-      if (ek_species->is_gpu() != m_is_gpu) {
-        throw std::runtime_error(
-            "All EK Species need to be on de same device.");
-      }
-    }
-    m_is_gpu = ek_species->is_gpu();
     m_ekcontainer.emplace_back(ek_species);
   }
 
@@ -108,7 +109,9 @@ public:
     m_poisson_solver = solver;
   }
 
-  [[nodiscard]] bool is_gpu() const noexcept { return m_is_gpu; }
+  [[nodiscard]] bool is_gpu() const noexcept {
+    return m_poisson_solver->is_gpu();
+  }
 
   [[nodiscard]] double get_tau() const noexcept { return m_tau; }
 

--- a/src/walberla_bridge/include/walberla_bridge/electrokinetics/PoissonSolver.hpp
+++ b/src/walberla_bridge/include/walberla_bridge/electrokinetics/PoissonSolver.hpp
@@ -83,7 +83,6 @@ public:
   [[nodiscard]] virtual bool is_double_precision() const noexcept = 0;
 
 protected:
-  void integrate_vtk_writers() override {}
   void register_vtk_field_filters(walberla::vtk::VTKOutput &) override {}
 };
 

--- a/src/walberla_bridge/include/walberla_bridge/electrokinetics/PoissonSolver.hpp
+++ b/src/walberla_bridge/include/walberla_bridge/electrokinetics/PoissonSolver.hpp
@@ -73,10 +73,6 @@ public:
                                    std::vector<double> const &potential) = 0;
   virtual void ghost_communication() = 0;
 
-  void register_vtk_field_writers(walberla::vtk::VTKOutput &,
-                                  LatticeModel::units_map const &,
-                                  int) override {}
-
   virtual void setup_fft(bool use_gpu_aware) = 0;
 
   [[nodiscard]] virtual bool is_gpu() const noexcept = 0;

--- a/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
@@ -58,6 +58,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -586,8 +587,7 @@ private:
 
 protected:
   void integrate_vtk_writers() override {
-    for (auto const &it : m_vtk_auto) {
-      auto &vtk_handle = it.second;
+    for (auto const &vtk_handle : m_vtk_auto | std::views::values) {
       if (vtk_handle->enabled) {
         vtk::writeFiles(vtk_handle->ptr)();
         vtk_handle->execution_count++;
@@ -1087,9 +1087,12 @@ public:
   }
 
   void register_vtk_field_filters(walberla::vtk::VTKOutput &vtk_obj) override {
-    field::FlagFieldCellFilter<FlagField> fluid_filter(m_flag_field_density_id);
-    fluid_filter.addFlag(Boundary_flag);
-    vtk_obj.addCellExclusionFilter(fluid_filter);
+    field::FlagFieldCellFilter<FlagField> dens_filter(m_flag_field_density_id);
+    field::FlagFieldCellFilter<FlagField> flux_filter(m_flag_field_flux_id);
+    dens_filter.addFlag(Boundary_flag);
+    flux_filter.addFlag(Boundary_flag);
+    vtk_obj.addCellExclusionFilter(dens_filter);
+    vtk_obj.addCellExclusionFilter(flux_filter);
   }
 
 protected:

--- a/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/electrokinetics/EKinWalberlaImpl.hpp
@@ -669,6 +669,10 @@ public:
   [[nodiscard]] std::optional<double>
   get_node_density(Utils::Vector3i const &node,
                    bool consider_ghosts = false) const override {
+    if (m_boundary_density->node_is_boundary(node)) {
+      return m_boundary_density->get_node_value_at_boundary(node);
+    }
+
     auto bc = get_block_and_cell(get_lattice(), node, consider_ghosts);
 
     if (!bc)
@@ -700,10 +704,15 @@ public:
 #ifndef NDEBUG
           values_size += bci->numCells();
 #endif
-          auto kernel = [&values, &out](unsigned const block_index,
-                                        unsigned const local_index,
-                                        Utils::Vector3i const &) {
-            out[local_index] = double_c(values[block_index]);
+          auto kernel = [this, &values, &out](unsigned const block_index,
+                                              unsigned const local_index,
+                                              Utils::Vector3i const &node) {
+            if (m_boundary_density->node_is_boundary(node)) {
+              out[local_index] =
+                  m_boundary_density->get_node_value_at_boundary(node);
+            } else {
+              out[local_index] = double_c(values[block_index]);
+            }
           };
 
           copy_block_buffer(*bci, *ci, block_offset, lower_corner, kernel);
@@ -745,6 +754,10 @@ public:
   [[nodiscard]] std::optional<Utils::Vector3d>
   get_node_flux_vector(Utils::Vector3i const &node,
                        bool consider_ghosts = false) const override {
+    if (m_boundary_flux->node_is_boundary(node)) {
+      return to_vector3d(m_boundary_flux->get_node_value_at_boundary(node));
+    }
+
     auto bc = get_block_and_cell(get_lattice(), node, consider_ghosts);
 
     if (!bc)

--- a/src/walberla_bridge/src/electrokinetics/PoissonSolverFFT.hpp
+++ b/src/walberla_bridge/src/electrokinetics/PoissonSolverFFT.hpp
@@ -247,6 +247,9 @@ public:
       auto fourier =
           block.template getData<PotentialFourier>(m_potential_fourier_id);
 
+      ek::accessor::Scalar::initialize(potential, FloatType{0});
+      ek::accessor::Scalar::initialize(potential_ghosts, FloatType{0});
+
       kernel_greens =
           gpu::make_kernel(multiply_by_greens_function<FloatType, ComplexType>);
       kernel_greens.addFieldIndexingParam(
@@ -263,7 +266,7 @@ public:
 
 #else  // __CUDACC__
     m_potential_field_with_ghosts_id = field::addToStorage<PotentialField>(
-        blocks, "potential field with ghosts", 0., field::fzyx,
+        blocks, "potential field with ghosts", FloatType{0}, field::fzyx,
         get_lattice().get_ghost_layers());
 #endif // __CUDACC__
 
@@ -494,7 +497,7 @@ public:
         }
         for (int y = 0; y < dim[1]; y++) {
           for (int z = 0; z < dim[2]; z++) {
-            m_potential[pos_to_linear_index(x, y, z, dim)] = FloatType(0.0);
+            m_potential[pos_to_linear_index(x, y, z, dim)] = FloatType{0};
           }
         }
       }
@@ -506,7 +509,7 @@ public:
       for (auto &block : *get_lattice().get_blocks()) {
         auto field =
             block.template getData<PotentialField>(m_potential_field_id);
-        ek::accessor::Scalar::initialize(field, FloatType_c(0.));
+        ek::accessor::Scalar::initialize(field, FloatType{0});
       }
     }
 #endif

--- a/src/walberla_bridge/src/electrokinetics/PoissonSolverFFT.hpp
+++ b/src/walberla_bridge/src/electrokinetics/PoissonSolverFFT.hpp
@@ -78,6 +78,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -519,8 +520,7 @@ public:
 
 protected:
   void integrate_vtk_writers() override {
-    for (auto const &it : m_vtk_auto) {
-      auto &vtk_handle = it.second;
+    for (auto const &vtk_handle : m_vtk_auto | std::views::values) {
       if (vtk_handle->enabled) {
         vtk::writeFiles(vtk_handle->ptr)();
         vtk_handle->execution_count++;

--- a/src/walberla_bridge/src/electrokinetics/PoissonSolverNone.hpp
+++ b/src/walberla_bridge/src/electrokinetics/PoissonSolverNone.hpp
@@ -73,6 +73,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -123,7 +124,7 @@ public:
 #endif // __CUDACC__
   }
 
-  void setup_fft(bool use_gpu_aware) override {}
+  void setup_fft(bool) override {}
 
   [[nodiscard]] bool is_gpu() const noexcept override {
     return Architecture == lbmpy::Arch::GPU;
@@ -235,8 +236,7 @@ public:
 
 protected:
   void integrate_vtk_writers() override {
-    for (auto const &it : m_vtk_auto) {
-      auto &vtk_handle = it.second;
+    for (auto const &vtk_handle : m_vtk_auto | std::views::values) {
       if (vtk_handle->enabled) {
         vtk::writeFiles(vtk_handle->ptr)();
         vtk_handle->execution_count++;

--- a/src/walberla_bridge/src/electrokinetics/PoissonSolverNone.hpp
+++ b/src/walberla_bridge/src/electrokinetics/PoissonSolverNone.hpp
@@ -224,10 +224,94 @@ public:
   }
   void ghost_communication() override {}
 
-  void solve() override {}
+  void solve() override { integrate_vtk_writers(); }
 
   void add_charge_to_field(std::size_t id, double valency) override {}
   void reset_charge_field() override {}
+
+protected:
+  void integrate_vtk_writers() override {
+    for (auto const &it : m_vtk_auto) {
+      auto &vtk_handle = it.second;
+      if (vtk_handle->enabled) {
+        vtk::writeFiles(vtk_handle->ptr)();
+        vtk_handle->execution_count++;
+      }
+    }
+  }
+
+protected:
+  template <typename VecType, uint_t F_SIZE_ARG, typename OutputType>
+  class VTKWriter : public vtk::BlockCellDataWriter<OutputType, F_SIZE_ARG> {
+  public:
+    VTKWriter(ConstBlockDataID const &block_id, std::string const &id,
+              FloatType unit_conversion)
+        : vtk::BlockCellDataWriter<OutputType, F_SIZE_ARG>(id),
+          m_conversion(unit_conversion), m_content{} {}
+
+  protected:
+    void configure() override { WALBERLA_ASSERT_NOT_NULLPTR(this->block_); }
+
+    std::size_t get_first_index(cell_idx_t const x, cell_idx_t const y,
+                                cell_idx_t const z) {
+      return (static_cast<std::size_t>(x) * m_dims[2] * m_dims[1] +
+              static_cast<std::size_t>(y) * m_dims[2] +
+              static_cast<std::size_t>(z)) *
+             F_SIZE_ARG;
+    }
+
+    FloatType m_conversion;
+    VecType m_content;
+    Vector3<uint_t> m_dims;
+
+  public:
+    void set_content(VecType content) { m_content = content; }
+
+    void set_dims(Vector3<uint_t> dims) { m_dims = dims; }
+  };
+
+  template <typename OutputType = float>
+  class PotentialVTKWriter
+      : public VTKWriter<std::vector<FloatType>, 1u, OutputType> {
+  public:
+    using Base = VTKWriter<std::vector<FloatType>, 1u, OutputType>;
+    using Base::Base;
+    using Base::evaluate;
+
+  protected:
+    OutputType evaluate(cell_idx_t const x, cell_idx_t const y,
+                        cell_idx_t const z, cell_idx_t const) override {
+      WALBERLA_ASSERT(!this->m_content.empty());
+      auto const potential = this->m_content[this->get_first_index(x, y, z)];
+      return numeric_cast<OutputType>(this->m_conversion * potential);
+    }
+  };
+
+public:
+  void register_vtk_field_writers(walberla::vtk::VTKOutput &vtk_obj,
+                                  LatticeModel::units_map const &units,
+                                  int flag_observables) override {
+    if (flag_observables & static_cast<int>(EKPoissonOutputVTK::potential)) {
+      auto const unit_conversion = FloatType_c(units.at("potential"));
+      auto const blocks = get_lattice().get_blocks();
+      WALBERLA_ASSERT_NOT_NULLPTR(blocks);
+      auto potential_writer = make_shared<PotentialVTKWriter<float>>(
+          m_potential_field_id, "potential", unit_conversion);
+      auto before_function = [this, blocks, potential_writer]() {
+        for (auto &block : *blocks) {
+          auto *potential_field =
+              block.template getData<PotentialField>(m_potential_field_id);
+          auto const bci = potential_field->xyzSize();
+          potential_writer->set_content(
+              walberla::ek::accessor::Scalar::get(potential_field, bci));
+          potential_writer->set_dims(Vector3<uint_t>(
+              uint_c(bci.xSize()), uint_c(bci.ySize()), uint_c(bci.zSize())));
+        }
+      };
+      vtk_obj.addBeforeFunction(std::move(before_function));
+      vtk_obj.addCellDataWriter(potential_writer);
+    }
+  }
 };
 
 } // namespace walberla

--- a/src/walberla_bridge/src/electrokinetics/PoissonSolverNone.hpp
+++ b/src/walberla_bridge/src/electrokinetics/PoissonSolverNone.hpp
@@ -112,9 +112,13 @@ public:
     m_potential_field_id = gpu::addGPUFieldToStorage<PotentialField>(
         blocks, "potential field", 1u, field::fzyx,
         get_lattice().get_ghost_layers());
+    for (auto &block : *blocks) {
+      auto field = block.template getData<PotentialField>(m_potential_field_id);
+      ek::accessor::Scalar::initialize(field, FloatType{0});
+    }
 #else  // __CUDACC__
     m_potential_field_id = field::addToStorage<PotentialField>(
-        blocks, "potential field", 0., field::fzyx,
+        blocks, "potential field", FloatType{0}, field::fzyx,
         get_lattice().get_ghost_layers());
 #endif // __CUDACC__
   }

--- a/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
+++ b/src/walberla_bridge/src/lattice_boltzmann/LBWalberlaImpl.hpp
@@ -71,6 +71,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -293,8 +294,7 @@ public:
 
 protected:
   void integrate_vtk_writers() override {
-    for (auto const &it : m_vtk_auto) {
-      auto &vtk_handle = it.second;
+    for (auto const &vtk_handle : m_vtk_auto | std::views::values) {
       if (vtk_handle->enabled) {
         vtk::writeFiles(vtk_handle->ptr)();
         vtk_handle->execution_count++;

--- a/src/walberla_bridge/tests/EKinWalberlaImpl_unit_tests.cpp
+++ b/src/walberla_bridge/tests/EKinWalberlaImpl_unit_tests.cpp
@@ -206,6 +206,7 @@ BOOST_DATA_TEST_CASE(node_flux_boundary, bdata::make(all_eks()), ek_generator) {
       BOOST_CHECK(!ek->set_node_flux_boundary(node, flux));
       ek->ghost_communication();
       BOOST_CHECK(!ek->get_node_flux_at_boundary(node));
+      BOOST_CHECK(!ek->get_node_flux_vector(node));
       BOOST_CHECK(!ek->remove_node_from_flux_boundary(node));
       ek->ghost_communication();
       BOOST_CHECK(!ek->get_node_is_flux_boundary(node));

--- a/testsuite/python/ek_bulk_reactions.py
+++ b/testsuite/python/ek_bulk_reactions.py
@@ -63,7 +63,7 @@ class EKTest:
             n_ghost_layers=1, agrid=self.AGRID)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.ek_params)
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)
 

--- a/testsuite/python/ek_diffusion.py
+++ b/testsuite/python/ek_diffusion.py
@@ -50,7 +50,7 @@ class EKTest:
         Testing EK for simple diffusion of a point droplet
         """
 
-        decimal_precision = 7 if self.lattice_params["single_precision"] else 10
+        decimal_precision = 7 if self.ek_params["single_precision"] else 10
 
         lattice = espressomd.electrokinetics.Lattice(
             n_ghost_layers=1, agrid=self.AGRID)
@@ -58,10 +58,10 @@ class EKTest:
         ekspecies = espressomd.electrokinetics.EKSpecies(
             lattice=lattice, density=0.0, valency=0.0, advection=False,
             diffusion=self.DIFFUSION_COEFFICIENT, friction_coupling=False,
-            tau=self.TAU, **self.lattice_params)
+            tau=self.TAU, **self.ek_params)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.ek_params)
 
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)
@@ -121,24 +121,24 @@ class EKTest:
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKDiffusionDoublePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": False}
+    ek_params = {"single_precision": False, "gpu": False}
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKDiffusionSinglePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": False}
+    ek_params = {"single_precision": True, "gpu": False}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKDiffusionDoublePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": True}
+    ek_params = {"single_precision": False, "gpu": True}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKDiffusionSinglePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": True}
+    ek_params = {"single_precision": True, "gpu": True}
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_diffusive_flux.py
+++ b/testsuite/python/ek_diffusive_flux.py
@@ -56,10 +56,10 @@ class EKDiffusiveFlux:
         ekspecies = espressomd.electrokinetics.EKSpecies(
             lattice=lattice, density=0.0, kT=kT, valency=0.,
             diffusion=self.DIFFUSION_COEFFICIENT, friction_coupling=False,
-            advection=False, tau=self.TAU, **self.lattice_params)
+            advection=False, tau=self.TAU, **self.ek_params)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.ek_params)
 
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)
@@ -70,7 +70,7 @@ class EKDiffusiveFlux:
 
         self.system.integrator.run(1)
 
-        atol = 3e-9 if self.lattice_params["single_precision"] else 7e-12
+        atol = 3e-9 if self.ek_params["single_precision"] else 7e-12
 
         offset = np.array([-1, 0, 1])
         normalization_factor = 1.0 + 2. * np.sqrt(2) + 4.0 / 3.0 * np.sqrt(3)
@@ -90,24 +90,24 @@ class EKDiffusiveFlux:
 
 @utx.skipIfMissingFeatures(["WALBERLA", "WALBERLA_FFT"])
 class EKTestWalberlaDoublePrecisionCPU(EKDiffusiveFlux, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": False}
+    ek_params = {"single_precision": False, "gpu": False}
 
 
 @utx.skipIfMissingFeatures(["WALBERLA", "WALBERLA_FFT"])
 class EKTestWalberlaSinglePrecisionCPU(EKDiffusiveFlux, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": False}
+    ek_params = {"single_precision": True, "gpu": False}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "WALBERLA_FFT", "CUDA"])
 class EKTestWalberlaDoublePrecisionGPU(EKDiffusiveFlux, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": True}
+    ek_params = {"single_precision": False, "gpu": True}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "WALBERLA_FFT", "CUDA"])
 class EKTestWalberlaSinglePrecisionGPU(EKDiffusiveFlux, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": True}
+    ek_params = {"single_precision": True, "gpu": True}
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_diffusive_flux.py
+++ b/testsuite/python/ek_diffusive_flux.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import itertools
 import numpy as np
 import unittest as ut
 import unittest_decorators as utx
@@ -73,20 +74,18 @@ class EKDiffusiveFlux:
 
         offset = np.array([-1, 0, 1])
         normalization_factor = 1.0 + 2. * np.sqrt(2) + 4.0 / 3.0 * np.sqrt(3)
-        for x in offset:
-            for y in offset:
-                for z in offset:
-                    direction = np.array([x, y, z])
-                    local_flux = np.array(ekspecies[direction + center].flux)
-                    dist = np.linalg.norm(direction)
-                    if dist > 0:
-                        ref_flux = direction / normalization_factor * \
-                            self.DIFFUSION_COEFFICIENT / dist / 2.0 / self.AGRID
-                        np.testing.assert_allclose(
-                            local_flux, ref_flux, rtol=0.0, atol=atol)
-                    else:
-                        np.testing.assert_allclose(
-                            local_flux, np.zeros(3), rtol=0.0, atol=2 * atol)
+        fluxes = np.copy(ekspecies[:, :, :].flux)
+        for direction in itertools.product(offset, repeat=3):
+            local_flux = fluxes[*(direction + center)]
+            dist = np.linalg.norm(direction)
+            if dist > 0:
+                ref_flux = direction / normalization_factor * \
+                    self.DIFFUSION_COEFFICIENT / dist / 2.0 / self.AGRID
+                np.testing.assert_allclose(
+                    local_flux, ref_flux, rtol=0.0, atol=atol)
+            else:
+                np.testing.assert_allclose(
+                    local_flux, np.zeros(3), rtol=0.0, atol=2 * atol)
 
 
 @utx.skipIfMissingFeatures(["WALBERLA", "WALBERLA_FFT"])

--- a/testsuite/python/ek_fixeddensity.py
+++ b/testsuite/python/ek_fixeddensity.py
@@ -58,7 +58,7 @@ class EKTest:
             tau=self.TAU, **self.lattice_params)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.lattice_params)
 
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)

--- a/testsuite/python/ek_fixedflux.py
+++ b/testsuite/python/ek_fixedflux.py
@@ -47,7 +47,7 @@ class EKTest:
         Testing the EK fixed flux boundaries to test the fixed inflow into a non-periodic box.
         """
 
-        decimal_precision = 5 if self.lattice_params["single_precision"] else 7
+        decimal_precision = 5 if self.ek_params["single_precision"] else 7
 
         lattice = espressomd.electrokinetics.Lattice(
             n_ghost_layers=1, agrid=self.AGRID)
@@ -55,10 +55,10 @@ class EKTest:
         ekspecies = espressomd.electrokinetics.EKSpecies(
             lattice=lattice, density=0.0, diffusion=self.DIFFUSION_COEFFICIENT,
             valency=0.0, advection=False, friction_coupling=False,
-            tau=self.TAU, **self.lattice_params)
+            tau=self.TAU, **self.ek_params)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.ek_params)
 
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)
@@ -110,24 +110,24 @@ class EKTest:
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKFixedFluxDoublePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": False}
+    ek_params = {"single_precision": False, "gpu": False}
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKFixedFluxSinglePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": False}
+    ek_params = {"single_precision": True, "gpu": False}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKFixedFluxDoublePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": True}
+    ek_params = {"single_precision": False, "gpu": True}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKFixedFluxSinglePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": True}
+    ek_params = {"single_precision": True, "gpu": True}
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_fluctuations.py
+++ b/testsuite/python/ek_fluctuations.py
@@ -40,7 +40,7 @@ class EKTest:
         self.system.ekcontainer.clear()
 
     def test_fluctuation(self):
-        decimal_precision = 1 if self.lattice_params["single_precision"] else 9
+        decimal_precision = 1 if self.ek_params["single_precision"] else 9
 
         lattice = espressomd.electrokinetics.Lattice(
             n_ghost_layers=1, agrid=self.AGRID)
@@ -50,10 +50,10 @@ class EKTest:
         species = espressomd.electrokinetics.EKSpecies(
             lattice=lattice, density=self.DENSITY, valency=0.0, advection=False,
             diffusion=self.DIFFUSION_COEFFICIENT, friction_coupling=False,
-            tau=self.TAU, thermalized=True, seed=42, **self.lattice_params)
+            tau=self.TAU, thermalized=True, seed=42, **self.ek_params)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.ek_params)
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)
         self.system.ekcontainer.add(species)
@@ -125,24 +125,24 @@ class EKTest:
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKFluctuationsDoublePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": False}
+    ek_params = {"single_precision": False, "gpu": False}
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKFluctuationsSinglePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": False}
+    ek_params = {"single_precision": True, "gpu": False}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKFluctuationsDoublePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": True}
+    ek_params = {"single_precision": False, "gpu": True}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKFluctuationsSinglePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": True}
+    ek_params = {"single_precision": True, "gpu": True}
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_indexed_reactions.py
+++ b/testsuite/python/ek_indexed_reactions.py
@@ -66,7 +66,7 @@ class EKTest:
             n_ghost_layers=1, agrid=self.AGRID)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.ek_params)
 
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)
@@ -75,14 +75,14 @@ class EKTest:
             lattice=lattice, density=self.INITIAL_DENSITIES[0],
             diffusion=self.DIFFUSION_COEFFICIENTS[0], valency=0.0,
             advection=False, friction_coupling=False,
-            tau=self.TAU, **self.lattice_params)
+            tau=self.TAU, **self.ek_params)
         self.system.ekcontainer.add(species_A)
 
         species_B = espressomd.electrokinetics.EKSpecies(
             lattice=lattice, density=self.INITIAL_DENSITIES[1],
             diffusion=self.DIFFUSION_COEFFICIENTS[1], valency=0.0,
             advection=False, friction_coupling=False,
-            tau=self.TAU, **self.lattice_params)
+            tau=self.TAU, **self.ek_params)
         self.system.ekcontainer.add(species_B)
 
         coeffs_left = [-1.0, 1.0]
@@ -161,24 +161,24 @@ class EKTest:
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKReactionDoublePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": False}
+    ek_params = {"single_precision": False, "gpu": False}
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKReactionSinglePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": False}
+    ek_params = {"single_precision": True, "gpu": False}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKReactionDoublePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": True}
+    ek_params = {"single_precision": False, "gpu": True}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKReactionSinglePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": True}
+    ek_params = {"single_precision": True, "gpu": True}
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -221,6 +221,9 @@ class EKTest:
             ek_slice.potential = 0.1
 
     def test_ek_none_solver(self):
+        is_gpu = self.ek_params["gpu"]
+        self.assertEqual(self.system.ekcontainer.gpu, is_gpu)
+        self.assertEqual(self.system.ekcontainer.solver.gpu, is_gpu)
         ek_solver = espressomd.electrokinetics.EKNone(
             lattice=self.lattice, tau=self.params["tau"], **self.ek_params)
         self.assertEqual(
@@ -295,6 +298,41 @@ class EKTest:
                 ek_small_gl_species.add_boundary_from_shape(
                     shape=wall_shape, value=[1., 2., 3.], boundary_type=espressomd.electrokinetics.FluxBoundary)
 
+        self.system.ekcontainer.add(ek_species)
+        with self.assertRaisesRegex(RuntimeError, "This object is already present in the list"):
+            self.system.ekcontainer.add(ek_species)
+        self.system.ekcontainer.remove(ek_species)
+        with self.assertRaisesRegex(RuntimeError, "This object is absent from the list"):
+            self.system.ekcontainer.remove(ek_species)
+
+        if espressomd.has_features("CUDA"):
+            self.system.ekcontainer.clear()
+            # cannot add a CPU species if the solver is on the GPU
+            ek_species_incompatible = self.make_default_ek_species(
+                gpu=not self.ek_params["gpu"])
+            with self.assertRaisesRegex(RuntimeError, "The EK species and the EK solver need to all be on either the CPU or GPU"):
+                self.system.ekcontainer.add(ek_species_incompatible)
+            self.assertEqual(len(self.system.ekcontainer), 0)
+            # cannot replace a CPU solver by a GPU solver if there is at least
+            # one species in the container
+            self.system.ekcontainer.add(self.make_default_ek_species())
+            ek_solver_incompatible = espressomd.electrokinetics.EKNone(
+                lattice=self.lattice, tau=self.params["tau"],
+                single_precision=self.ek_params["single_precision"],
+                gpu=not self.ek_params["gpu"])
+            old_ek_solver = self.system.ekcontainer.solver
+            with self.assertRaisesRegex(RuntimeError, "The EK species and the EK solver need to all be on either the CPU or GPU"):
+                self.system.ekcontainer.solver = ek_solver_incompatible
+            self.assertEqual(self.system.ekcontainer.solver, old_ek_solver)
+            # if no species are present, a GPU container can become a CPU one
+            self.system.ekcontainer.clear()
+            self.system.ekcontainer.solver = ek_solver_incompatible
+            self.system.ekcontainer.add(ek_species_incompatible)
+            self.assertEqual(
+                self.system.ekcontainer.solver,
+                ek_solver_incompatible)
+            self.assertEqual(len(self.system.ekcontainer), 1)
+
     def test_ek_solver_exceptions(self):
         ek_solver = self.system.ekcontainer.solver
         ek_species = self.make_default_ek_species()
@@ -324,6 +362,10 @@ class EKTest:
             espressomd.electrokinetics.EKNone(
                 lattice=incompatible_lattice, tau=self.params["tau"],
                 **self.ek_params)
+        with self.assertRaisesRegex(ValueError, "EK solver is of the wrong type"):
+            self.system.ekcontainer.solver = ek_species
+        with self.assertRaisesRegex(RuntimeError, "Parameter 'solver' is required; use EKNone if all species are electrically neutral"):
+            espressomd.electrokinetics.EKContainer(tau=1.)
 
         if espressomd.has_features("WALBERLA_FFT"):
             ek_solver = self.ek_solver_class(

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -464,7 +464,7 @@ class EKTest:
                                     "ESPResSo array properties return non-writable arrays"):
             locked[0, 0, 0] = True
 
-        # set a 2D sub-slice (integer dim collapses from the shape) and read back
+        # set a 2D slice (integer dim collapses from the shape) and read back
         ek_reaction[1, :, :] = True
         result = ek_reaction[1, :, :].is_boundary
         self.assertEqual(result.shape, (ny, nz))
@@ -570,6 +570,7 @@ class EKTest:
 
     def test_grid_index(self):
         ek_species = self.make_default_ek_species()
+        ek_solver = self.system.ekcontainer.solver
         ek_reactant = espressomd.electrokinetics.EKReactant(
             ekspecies=ek_species, stoech_coeff=-2.0, order=2.0)
         ek_reaction = espressomd.electrokinetics.EKIndexedReaction(
@@ -584,6 +585,7 @@ class EKTest:
             self.assertTrue(ek_reaction[0, 0, 0])
             self.assertEqual(ek_reaction[tuple(n)], ek_reaction[0, 0, 0])
             self.assertEqual(ek_species[tuple(n)], ek_species[0, 0, 0])
+            self.assertEqual(ek_solver[tuple(n)], ek_solver[0, 0, 0])
             for offset in (int_shape[i] + 1, -(int_shape[i] + 1)):
                 n = [0, 0, 0]
                 n[i] += offset
@@ -592,18 +594,21 @@ class EKTest:
                     ek_reaction[tuple(n)]
                 with self.assertRaisesRegex(IndexError, err_msg):
                     ek_species[tuple(n)]
+                with self.assertRaisesRegex(IndexError, err_msg):
+                    ek_solver[tuple(n)]
         # node index
-        node = ek_species[1, 2, 3]
-        with self.assertRaisesRegex(RuntimeError, "Parameter 'index' is read-only"):
-            node.index = [2, 4, 6]
-        np.testing.assert_array_equal(node.index, [1, 2, 3])
-        retval = node.call_method("override_index", index=[2, 4, 6])
-        self.assertEqual(retval, 0)
-        np.testing.assert_array_equal(node.index, [2, 4, 6])
-        retval = node.call_method("override_index", index=[0, 0, shape[2]])
-        self.assertEqual(retval, 1)
-        np.testing.assert_array_equal(node.index, [2, 4, 6])
-        np.testing.assert_array_equal(ek_species[-1, -1, -1].index, shape - 1)
+        for ek_obj in [ek_species, ek_solver]:
+            node = ek_obj[1, 2, 3]
+            with self.assertRaisesRegex(RuntimeError, "Parameter 'index' is read-only"):
+                node.index = [2, 4, 6]
+            np.testing.assert_array_equal(node.index, [1, 2, 3])
+            retval = node.call_method("override_index", index=[2, 4, 6])
+            self.assertEqual(retval, 0)
+            np.testing.assert_array_equal(node.index, [2, 4, 6])
+            retval = node.call_method("override_index", index=[0, 0, shape[2]])
+            self.assertEqual(retval, 1)
+            np.testing.assert_array_equal(node.index, [2, 4, 6])
+            np.testing.assert_array_equal(ek_obj[-1, -1, -1].index, shape - 1)
 
     def test_runtime_exceptions(self):
         # set up a valid species

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -305,33 +305,33 @@ class EKTest:
         with self.assertRaisesRegex(RuntimeError, "This object is absent from the list"):
             self.system.ekcontainer.remove(ek_species)
 
-        if espressomd.has_features("CUDA"):
-            self.system.ekcontainer.clear()
-            # cannot add a CPU species if the solver is on the GPU
-            ek_species_incompatible = self.make_default_ek_species(
-                gpu=not self.ek_params["gpu"])
-            with self.assertRaisesRegex(RuntimeError, "The EK species and the EK solver need to all be on either the CPU or GPU"):
-                self.system.ekcontainer.add(ek_species_incompatible)
-            self.assertEqual(len(self.system.ekcontainer), 0)
-            # cannot replace a CPU solver by a GPU solver if there is at least
-            # one species in the container
-            self.system.ekcontainer.add(self.make_default_ek_species())
-            ek_solver_incompatible = espressomd.electrokinetics.EKNone(
-                lattice=self.lattice, tau=self.params["tau"],
-                single_precision=self.ek_params["single_precision"],
-                gpu=not self.ek_params["gpu"])
-            old_ek_solver = self.system.ekcontainer.solver
-            with self.assertRaisesRegex(RuntimeError, "The EK species and the EK solver need to all be on either the CPU or GPU"):
-                self.system.ekcontainer.solver = ek_solver_incompatible
-            self.assertEqual(self.system.ekcontainer.solver, old_ek_solver)
-            # if no species are present, a GPU container can become a CPU one
-            self.system.ekcontainer.clear()
-            self.system.ekcontainer.solver = ek_solver_incompatible
+    @utx.skipIfMissingGPU()
+    def test_ek_container_exceptions(self):
+        # cannot add a CPU species if the solver is on the GPU
+        ek_species_incompatible = self.make_default_ek_species(
+            gpu=not self.ek_params["gpu"])
+        with self.assertRaisesRegex(RuntimeError, "The EK species and the EK solver need to all be on either the CPU or GPU"):
             self.system.ekcontainer.add(ek_species_incompatible)
-            self.assertEqual(
-                self.system.ekcontainer.solver,
-                ek_solver_incompatible)
-            self.assertEqual(len(self.system.ekcontainer), 1)
+        self.assertEqual(len(self.system.ekcontainer), 0)
+        # cannot replace a CPU solver by a GPU solver if there is at least
+        # one species in the container
+        self.system.ekcontainer.add(self.make_default_ek_species())
+        ek_solver_incompatible = espressomd.electrokinetics.EKNone(
+            lattice=self.lattice, tau=self.params["tau"],
+            single_precision=self.ek_params["single_precision"],
+            gpu=not self.ek_params["gpu"])
+        old_ek_solver = self.system.ekcontainer.solver
+        with self.assertRaisesRegex(RuntimeError, "The EK species and the EK solver need to all be on either the CPU or GPU"):
+            self.system.ekcontainer.solver = ek_solver_incompatible
+        self.assertEqual(self.system.ekcontainer.solver, old_ek_solver)
+        # if no species are present, a GPU container can become a CPU one
+        self.system.ekcontainer.clear()
+        self.system.ekcontainer.solver = ek_solver_incompatible
+        self.system.ekcontainer.add(ek_species_incompatible)
+        self.assertEqual(
+            self.system.ekcontainer.solver,
+            ek_solver_incompatible)
+        self.assertEqual(len(self.system.ekcontainer), 1)
 
     def test_ek_solver_exceptions(self):
         ek_solver = self.system.ekcontainer.solver

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -233,6 +233,7 @@ class EKTest:
         self.assertIsInstance(self.system.ekcontainer.solver,
                               espressomd.electrokinetics.EKNone)
         self.assertEqual(self.system.ekcontainer.solver, ek_solver)
+        self.assertIsNone(ek_solver.call_method("unknown"))
 
         np.testing.assert_allclose(
             np.copy(ek_solver[:, :, :].potential), 0., atol=self.atol)
@@ -487,6 +488,15 @@ class EKTest:
         ek_reaction[3:5, :, :] = values
         np.testing.assert_array_equal(
             ek_reaction[3:5, :, :].is_boundary, values)
+
+        # getters
+        ek_slice = ek_reaction[0:2, -4:-1, 1:2]
+        np.testing.assert_array_equal(
+            np.copy(ek_slice.call_method("get_slice_size")), [2, 3, 1])
+        np.testing.assert_array_equal(
+            np.copy(ek_slice.call_method("get_slice_ranges")),
+            [[0, 8, 1], [2, 11, 2]])
+        self.assertEqual(ek_slice.call_method("get_reaction_sip"), ek_reaction)
 
         # wrong shape raises ValueError
         with self.assertRaisesRegex(ValueError,

--- a/testsuite/python/ek_noflux.py
+++ b/testsuite/python/ek_noflux.py
@@ -47,7 +47,7 @@ class EKTest:
         Testing the EK noflux boundaries to not leak density outside of a sphere.
         """
 
-        decimal_precision = 7 if self.lattice_params["single_precision"] else 10
+        decimal_precision = 7 if self.ek_params["single_precision"] else 10
 
         lattice = espressomd.electrokinetics.Lattice(
             n_ghost_layers=2, agrid=self.AGRID)
@@ -55,10 +55,10 @@ class EKTest:
         ekspecies = espressomd.electrokinetics.EKSpecies(
             lattice=lattice, density=0.0, diffusion=self.DIFFUSION_COEFFICIENT,
             valency=0.0, advection=False, friction_coupling=False,
-            tau=self.TAU, **self.lattice_params)
+            tau=self.TAU, **self.ek_params)
 
         eksolver = espressomd.electrokinetics.EKNone(
-            lattice=lattice, tau=self.TAU)
+            lattice=lattice, tau=self.TAU, **self.ek_params)
 
         self.system.ekcontainer = espressomd.electrokinetics.EKContainer(
             tau=self.TAU, solver=eksolver)
@@ -100,24 +100,24 @@ class EKTest:
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKNoFluxDoublePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": False}
+    ek_params = {"single_precision": False, "gpu": False}
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])
 class EKNoFluxSinglePrecisionCPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": False}
+    ek_params = {"single_precision": True, "gpu": False}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKNoFluxDoublePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": False, "gpu": True}
+    ek_params = {"single_precision": False, "gpu": True}
 
 
 @utx.skipIfMissingGPU()
 @utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
 class EKNoFluxSinglePrecisionGPU(EKTest, ut.TestCase):
-    lattice_params = {"single_precision": True, "gpu": True}
+    ek_params = {"single_precision": True, "gpu": True}
 
 
 if __name__ == "__main__":

--- a/testsuite/python/ek_slice.py
+++ b/testsuite/python/ek_slice.py
@@ -96,6 +96,10 @@ class EKTest:
             self.assertIsNone(flux)
         np.testing.assert_array_almost_equal(
             ek_flux_slice, np.vstack([flux_ref.flux, np.zeros((8, 3))]))
+        np.testing.assert_array_almost_equal(
+            np.copy(ek_species[1, 1, 0].flux), flux_ref.flux)
+        np.testing.assert_array_almost_equal(
+            np.copy(ek_species[1, 2, 0].flux), np.zeros((3,)))
 
         # density boundary on slice
         output_boundary_shape = ek_species[0:-1, 1:, 1:].density_boundary.shape

--- a/testsuite/python/ek_slice.py
+++ b/testsuite/python/ek_slice.py
@@ -117,11 +117,18 @@ class EKTest:
         dens_ref = espressomd.electrokinetics.DensityBoundary(1e-6)
         ek_species[2:3, 1:, 0].density_boundary = dens_ref
         ek_species[2:3, 2:, 0].density_boundary = None
+        ek_density_slice = np.copy(ek_species[2, 1:, 0].density)
         for dens in ek_species[2:3, 1, 0].density_boundary.flatten():
             np.testing.assert_array_almost_equal(
                 dens.density, dens_ref.density)
         for dens in ek_species[2:3, 2:, 0:2].density_boundary.flatten():
             self.assertIsNone(dens)
+        np.testing.assert_array_almost_equal(
+            ek_density_slice, [dens_ref.density] + 8 * [2.])
+        np.testing.assert_array_almost_equal(
+            np.copy(ek_species[2, 1, 0].density), dens_ref.density)
+        np.testing.assert_array_almost_equal(
+            np.copy(ek_species[2, 2, 0].density), 2.)
 
         # is_boundary on slice
         output_boundary_shape = ek_species[1:, 1:, 1:].is_boundary.shape

--- a/testsuite/python/ek_slice.py
+++ b/testsuite/python/ek_slice.py
@@ -88,11 +88,14 @@ class EKTest:
         flux_ref = espressomd.electrokinetics.FluxBoundary([1e-6, 2e-6, 3e-6])
         ek_species[1:2, 1:, 0].flux_boundary = flux_ref
         ek_species[1:2, 2:, 0].flux_boundary = None
+        ek_flux_slice = np.copy(ek_species[1, 1:, 0].flux)
         for flux in ek_species[1:2, 1, 0].flux_boundary.flatten():
             np.testing.assert_array_almost_equal(
                 flux.flux, flux_ref.flux)
         for flux in ek_species[1:2, 2:, 0:2].flux_boundary.flatten():
             self.assertIsNone(flux)
+        np.testing.assert_array_almost_equal(
+            ek_flux_slice, np.vstack([flux_ref.flux, np.zeros((8, 3))]))
 
         # density boundary on slice
         output_boundary_shape = ek_species[0:-1, 1:, 1:].density_boundary.shape

--- a/testsuite/python/lattice_vtk.py
+++ b/testsuite/python/lattice_vtk.py
@@ -41,7 +41,7 @@ class TestVTK:
     system.cell_system.skin = 0.4
 
     def setUp(self):
-        self.lattice = self.lattice_class(n_ghost_layers=1, agrid=0.5)
+        self.lattice = self.lattice_class(n_ghost_layers=2, agrid=0.5)
         self.actor = self.add_actor()
 
     def tearDown(self):
@@ -293,8 +293,8 @@ class TestLBVTK(TestVTK):
                     grids_b[label_density][2:-2, :, :], lb_density,
                     rtol=1e-7, atol=0.)
                 # check that boundary cell values are written correctly
-                # density and velocity in boundary region are available via
-                # the boundary mask; the interior data matches the filtered output
+                # density and velocity in boundary region are available via the
+                # boundary mask; the interior data matches the filtered output
                 flat_boundary_mask = np.asarray(
                     grids_b["boundary"]).ravel().astype(bool)
                 np.testing.assert_allclose(
@@ -372,6 +372,14 @@ class TestEKVTK(TestVTK):
             center=self.system.box_l // 2, radius=2.)
         actor.add_boundary_from_shape(
             shape=sphere, value=0.0, boundary_type=espressomd.electrokinetics.DensityBoundary)
+        actor[2, 0, 0].flux_boundary = espressomd.electrokinetics.FluxBoundary(
+            [0.01, -0.01, 0.02])
+        if isinstance(self.solver, espressomd.electrokinetics.EKNone):
+            kx, ky, kz = np.pi / self.lattice.shape
+            self.solver[:, :, :].potential = np.fromfunction(
+                lambda i, j, k: np.cos(i * kx) *
+                np.cos(j * ky) * np.cos(k * kz),
+                self.lattice.shape, dtype=float)
 
         n_steps = 100
         shape = tuple(self.lattice.shape)
@@ -646,6 +654,29 @@ class EKWalberlaVTKSinglePrecisionGPU(TestEKVTK, ut.TestCase):
     ek_solver = espressomd.electrokinetics.EKFFT
     ek_params = {"single_precision": True, "gpu": True}
     vtk_id = "ek_single_precision_gpu"
+
+
+@utx.skipIfMissingFeatures(["WALBERLA"])
+class EKWalberlaVTKSinglePrecisionEKNoneCPU(TestEKVTK, ut.TestCase):
+    vtk_class = espressomd.electrokinetics.VTKOutput
+    vtk_poisson_class = espressomd.electrokinetics.VTKPoissonOutput
+    lattice_class = espressomd.electrokinetics.Lattice
+    ek_class = espressomd.electrokinetics.EKSpecies
+    ek_solver = espressomd.electrokinetics.EKNone
+    ek_params = {"single_precision": True, "gpu": False}
+    vtk_id = "ek_single_precision_eknone_cpu"
+
+
+@utx.skipIfMissingGPU()
+@utx.skipIfMissingFeatures(["WALBERLA", "CUDA"])
+class EKWalberlaVTKSinglePrecisionEKNoneGPU(TestEKVTK, ut.TestCase):
+    vtk_class = espressomd.electrokinetics.VTKOutput
+    vtk_poisson_class = espressomd.electrokinetics.VTKPoissonOutput
+    lattice_class = espressomd.electrokinetics.Lattice
+    ek_class = espressomd.electrokinetics.EKSpecies
+    ek_solver = espressomd.electrokinetics.EKNone
+    ek_params = {"single_precision": True, "gpu": True}
+    vtk_id = "ek_single_precision_eknone_gpu"
 
 
 @utx.skipIfMissingFeatures(["WALBERLA"])

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -101,10 +101,10 @@ if lbf_class:
 
     if not le_active:
         ek_solver_class = espressomd.electrokinetics.EKNone
-        ek_solver_params = {
-            "tau": system.time_step, "single_precision": False, "gpu": False}
+        ek_params = {"single_precision": False, "gpu": False}
         if "LB.GPU" in modes:
-            ek_solver_params["gpu"] = True
+            ek_params["gpu"] = True
+        ek_solver_params = {"tau": system.time_step, **ek_params}
         if espressomd.has_features("WALBERLA_FFT") and cpt_mode == 1:
             ek_solver_class = espressomd.electrokinetics.EKFFT
             ek_solver_params["permittivity"] = 0.1
@@ -112,7 +112,7 @@ if lbf_class:
         ek_species = espressomd.electrokinetics.EKSpecies(
             lattice=lb_lattice, density=1.5, kT=2.0, diffusion=0.2, valency=0.1,
             advection=False, friction_coupling=False, ext_efield=[0.1, 0.2, 0.3],
-            single_precision=False, tau=system.time_step)
+            tau=system.time_step, **ek_params)
         ekcontainer = espressomd.electrokinetics.EKContainer(
             solver=ek_solver, tau=ek_species.tau)
         ekcontainer.add(ek_species)

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -89,7 +89,7 @@ if espressomd.has_features('WALBERLA') and 'LB.WALBERLA' in modes:
     lb_lattice_blocks_per_mpi = espressomd.lb.Lattice(
         **lb_lattice_kwargs)
 if lbf_class:
-    lbf_cpt_mode = 0 if 'LB.ASCII' in modes else 1
+    cpt_mode = 0 if 'LB.ASCII' in modes else 1
     lbf = lbf_class(
         lattice=lb_lattice, kinematic_viscosity=1.3, density=1.5,
         tau=system.time_step, gpu='LB.GPU' in modes)
@@ -105,7 +105,7 @@ if lbf_class:
             "tau": system.time_step, "single_precision": False, "gpu": False}
         if "LB.GPU" in modes:
             ek_solver_params["gpu"] = True
-        if espressomd.has_features("WALBERLA_FFT") and "LB.ASCII" in modes:
+        if espressomd.has_features("WALBERLA_FFT") and cpt_mode == 1:
             ek_solver_class = espressomd.electrokinetics.EKFFT
             ek_solver_params["permittivity"] = 0.1
         ek_solver = ek_solver_class(lattice=lb_lattice, **ek_solver_params)
@@ -429,17 +429,17 @@ if lbf_class:
         'abc,d->abcd', grid_3D, np.arange(1, 4))
     # save LB checkpoint file
     lbf_cpt_path = checkpoint.root / "lb.cpt"
-    lbf.save_checkpoint(str(lbf_cpt_path), lbf_cpt_mode)
+    lbf.save_checkpoint(str(lbf_cpt_path), cpt_mode)
     if not le_active:
         # save EK checkpoint file
         ek_species[:, :, :].density = grid_3D
         if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
             ek_solver[:, :, :].potential = 0.25 * grid_3D
         ek_cpt_path = checkpoint.root / "ek.cpt"
-        ek_species.save_checkpoint(str(ek_cpt_path), lbf_cpt_mode)
+        ek_species.save_checkpoint(str(ek_cpt_path), cpt_mode)
         if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
             ek_none_cpt_path = checkpoint.root / "ek_none.cpt"
-            ek_solver.save_checkpoint(str(ek_none_cpt_path), lbf_cpt_mode)
+            ek_solver.save_checkpoint(str(ek_none_cpt_path), cpt_mode)
     # setup VTK folder
     vtk_suffix = config.test_name
     vtk_root = pathlib.Path("vtk_out")
@@ -586,7 +586,7 @@ class TestCheckpoint(ut.TestCase):
         lbf_cpt_root = lbf_cpt_path.parent
         with self.assertRaisesRegex(RuntimeError, "could not open file"):
             invalid_path = lbf_cpt_root / "unknown_dir" / "lb.cpt"
-            lbf.save_checkpoint(invalid_path, lbf_cpt_mode)
+            lbf.save_checkpoint(invalid_path, cpt_mode)
         with self.assertRaisesRegex(RuntimeError, "unit test error"):
             lbf.save_checkpoint(lbf_cpt_root / "lb_err.cpt", -1)
         with self.assertRaisesRegex(RuntimeError, "could not write to"):
@@ -608,7 +608,7 @@ class TestCheckpoint(ut.TestCase):
         # write checkpoint file with extra data
         with open(cpt_path.format("-extra-data"), "wb") as f:
             f.write(lbf_cpt_data + lbf_cpt_data[-8:])
-        if lbf_cpt_mode == 0:
+        if cpt_mode == 0:
             boxsize, popsize, data = lbf_cpt_data.split(b"\n", 2)
             # write checkpoint file with incorrectly formatted data
             with open(cpt_path.format("-wrong-format"), "wb") as f:
@@ -632,7 +632,7 @@ class TestCheckpoint(ut.TestCase):
         ek_cpt_root = ek_cpt_path.parent
         with self.assertRaisesRegex(RuntimeError, "could not open file"):
             invalid_path = ek_cpt_root / "unknown_dir" / "ek.cpt"
-            ek_species.save_checkpoint(invalid_path, lbf_cpt_mode)
+            ek_species.save_checkpoint(invalid_path, cpt_mode)
         with self.assertRaisesRegex(RuntimeError, "unit test error"):
             ek_species.save_checkpoint(ek_cpt_root / "ek_err.cpt", -1)
         with self.assertRaisesRegex(RuntimeError, "could not write to"):
@@ -651,7 +651,7 @@ class TestCheckpoint(ut.TestCase):
         # write checkpoint file with extra data
         with open(cpt_path.format("-extra-data"), "wb") as f:
             f.write(ek_cpt_data + ek_cpt_data[-8:])
-        if lbf_cpt_mode == 0:
+        if cpt_mode == 0:
             boxsize, data = ek_cpt_data.split(b"\n", 1)
             # write checkpoint file with incorrectly formatted data
             with open(cpt_path.format("-wrong-format"), "wb") as f:
@@ -663,7 +663,7 @@ class TestCheckpoint(ut.TestCase):
         if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
             with self.assertRaisesRegex(RuntimeError, "could not open file"):
                 invalid_path = ek_cpt_root / "unknown_dir" / "ek_none.cpt"
-                ek_solver.save_checkpoint(invalid_path, lbf_cpt_mode)
+                ek_solver.save_checkpoint(invalid_path, cpt_mode)
             with self.assertRaisesRegex(RuntimeError, "unit test error"):
                 ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", -1)
             with self.assertRaisesRegex(RuntimeError, "could not write to"):
@@ -679,7 +679,7 @@ class TestCheckpoint(ut.TestCase):
                 f.write(ek_none_cpt_data[:len(ek_none_cpt_data) // 2])
             with open(cpt_path.format("-extra-data"), "wb") as f:
                 f.write(ek_none_cpt_data + ek_none_cpt_data[-8:])
-            if lbf_cpt_mode == 0:
+            if cpt_mode == 0:
                 boxsize, data = ek_none_cpt_data.split(b"\n", 1)
                 with open(cpt_path.format("-wrong-format"), "wb") as f:
                     f.write(boxsize + b"\n" + b"\ntext string\n" + data)

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -100,8 +100,15 @@ if lbf_class:
     lbf.add_boundary_from_shape(wall2, (0, 0, 0))
 
     if not le_active:
-        ek_solver = espressomd.electrokinetics.EKNone(
-            lattice=lb_lattice, tau=system.time_step)
+        ek_solver_class = espressomd.electrokinetics.EKNone
+        ek_solver_params = {
+            "tau": system.time_step, "single_precision": False, "gpu": False}
+        if "LB.GPU" in modes:
+            ek_solver_params["gpu"] = True
+        if espressomd.has_features("WALBERLA_FFT") and "LB.ASCII" in modes:
+            ek_solver_class = espressomd.electrokinetics.EKFFT
+            ek_solver_params["permittivity"] = 0.1
+        ek_solver = ek_solver_class(lattice=lb_lattice, **ek_solver_params)
         ek_species = espressomd.electrokinetics.EKSpecies(
             lattice=lb_lattice, density=1.5, kT=2.0, diffusion=0.2, valency=0.1,
             advection=False, friction_coupling=False, ext_efield=[0.1, 0.2, 0.3],
@@ -426,11 +433,13 @@ if lbf_class:
     if not le_active:
         # save EK checkpoint file
         ek_species[:, :, :].density = grid_3D
-        ek_solver[:, :, :].potential = 0.25 * grid_3D
+        if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
+            ek_solver[:, :, :].potential = 0.25 * grid_3D
         ek_cpt_path = checkpoint.root / "ek.cpt"
         ek_species.save_checkpoint(str(ek_cpt_path), lbf_cpt_mode)
-        ek_none_cpt_path = checkpoint.root / "ek_none.cpt"
-        ek_solver.save_checkpoint(str(ek_none_cpt_path), lbf_cpt_mode)
+        if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
+            ek_none_cpt_path = checkpoint.root / "ek_none.cpt"
+            ek_solver.save_checkpoint(str(ek_none_cpt_path), lbf_cpt_mode)
     # setup VTK folder
     vtk_suffix = config.test_name
     vtk_root = pathlib.Path("vtk_out")
@@ -451,20 +460,34 @@ if lbf_class:
     lb_vtk_manual.write()
     if not le_active:
         # create EK VTK callbacks
-        ek_vtk_auto_id = f"auto_ek_{vtk_suffix}"
-        ek_vtk_manual_id = f"manual_ek_{vtk_suffix}"
-        config.recursive_unlink(vtk_root / ek_vtk_auto_id)
-        config.recursive_unlink(vtk_root / ek_vtk_manual_id)
-        ek_vtk_auto = espressomd.electrokinetics.VTKOutput(
-            identifier=ek_vtk_auto_id,
+        ek_vtk_species_auto_id = f"auto_ek_species_{vtk_suffix}"
+        ek_vtk_species_manual_id = f"manual_ek_species_{vtk_suffix}"
+        ek_vtk_poisson_auto_id = f"auto_ek_poisson_{vtk_suffix}"
+        ek_vtk_poisson_manual_id = f"manual_ek_poisson_{vtk_suffix}"
+        config.recursive_unlink(vtk_root / ek_vtk_species_auto_id)
+        config.recursive_unlink(vtk_root / ek_vtk_species_manual_id)
+        config.recursive_unlink(vtk_root / ek_vtk_poisson_auto_id)
+        config.recursive_unlink(vtk_root / ek_vtk_poisson_manual_id)
+        ek_vtk_species_auto = espressomd.electrokinetics.VTKOutput(
+            identifier=ek_vtk_species_auto_id,
             observables=('density',), delta_N=1, base_folder=str(vtk_root))
-        ek_species.add_vtk_writer(vtk=ek_vtk_auto)
-        ek_vtk_auto.disable()
-        ek_vtk_manual = espressomd.electrokinetics.VTKOutput(
-            identifier=ek_vtk_manual_id,
+        ek_species.add_vtk_writer(vtk=ek_vtk_species_auto)
+        ek_vtk_species_auto.disable()
+        ek_vtk_species_manual = espressomd.electrokinetics.VTKOutput(
+            identifier=ek_vtk_species_manual_id,
             observables=('density',), delta_N=0, base_folder=str(vtk_root))
-        ek_species.add_vtk_writer(vtk=ek_vtk_manual)
-        ek_vtk_manual.write()
+        ek_species.add_vtk_writer(vtk=ek_vtk_species_manual)
+        ek_vtk_species_manual.write()
+        ek_vtk_poisson_auto = espressomd.electrokinetics.VTKPoissonOutput(
+            identifier=ek_vtk_poisson_auto_id, force_pvtu=True,
+            observables=["potential"], delta_N=1, base_folder=str(vtk_root))
+        ek_solver.add_vtk_writer(vtk=ek_vtk_poisson_auto)
+        ek_vtk_poisson_auto.disable()
+        ek_vtk_poisson_manual = espressomd.electrokinetics.VTKPoissonOutput(
+            identifier=ek_vtk_poisson_manual_id, force_pvtu=True,
+            observables=["potential"], delta_N=0, base_folder=str(vtk_root))
+        ek_solver.add_vtk_writer(vtk=ek_vtk_poisson_manual)
+        ek_vtk_poisson_manual.write()
 
 
 # set various properties
@@ -538,7 +561,8 @@ class TestCheckpoint(ut.TestCase):
         if lbf_class:
             self.assertTrue(lbf_cpt_path.is_file(),
                             "LB checkpoint file not created")
-            if not le_active:
+            if not le_active and isinstance(
+                    ek_solver, espressomd.electrokinetics.EKNone):
                 self.assertTrue(ek_none_cpt_path.is_file(),
                                 "EKNone checkpoint file not created")
 
@@ -636,30 +660,31 @@ class TestCheckpoint(ut.TestCase):
             with open(cpt_path.format("-wrong-boxdim"), "wb") as f:
                 f.write(b"2" + boxsize + b"\n" + data)
 
-        with self.assertRaisesRegex(RuntimeError, "could not open file"):
-            invalid_path = ek_cpt_root / "unknown_dir" / "ek_none.cpt"
-            ek_solver.save_checkpoint(invalid_path, lbf_cpt_mode)
-        with self.assertRaisesRegex(RuntimeError, "unit test error"):
-            ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", -1)
-        with self.assertRaisesRegex(RuntimeError, "could not write to"):
-            ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", -2)
-        with self.assertRaisesRegex(ValueError, "Unknown mode -3"):
-            ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", -3)
-        with self.assertRaisesRegex(ValueError, "Unknown mode 2"):
-            ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", 2)
+        if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
+            with self.assertRaisesRegex(RuntimeError, "could not open file"):
+                invalid_path = ek_cpt_root / "unknown_dir" / "ek_none.cpt"
+                ek_solver.save_checkpoint(invalid_path, lbf_cpt_mode)
+            with self.assertRaisesRegex(RuntimeError, "unit test error"):
+                ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", -1)
+            with self.assertRaisesRegex(RuntimeError, "could not write to"):
+                ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", -2)
+            with self.assertRaisesRegex(ValueError, "Unknown mode -3"):
+                ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", -3)
+            with self.assertRaisesRegex(ValueError, "Unknown mode 2"):
+                ek_solver.save_checkpoint(ek_cpt_root / "ek_none_err.cpt", 2)
 
-        ek_none_cpt_data = ek_none_cpt_path.read_bytes()
-        cpt_path = str(checkpoint.root / "ek_none") + "{}.cpt"
-        with open(cpt_path.format("-missing-data"), "wb") as f:
-            f.write(ek_none_cpt_data[:len(ek_none_cpt_data) // 2])
-        with open(cpt_path.format("-extra-data"), "wb") as f:
-            f.write(ek_none_cpt_data + ek_none_cpt_data[-8:])
-        if lbf_cpt_mode == 0:
-            boxsize, data = ek_none_cpt_data.split(b"\n", 1)
-            with open(cpt_path.format("-wrong-format"), "wb") as f:
-                f.write(boxsize + b"\n" + b"\ntext string\n" + data)
-            with open(cpt_path.format("-wrong-boxdim"), "wb") as f:
-                f.write(b"2" + boxsize + b"\n" + data)
+            ek_none_cpt_data = ek_none_cpt_path.read_bytes()
+            cpt_path = str(checkpoint.root / "ek_none") + "{}.cpt"
+            with open(cpt_path.format("-missing-data"), "wb") as f:
+                f.write(ek_none_cpt_data[:len(ek_none_cpt_data) // 2])
+            with open(cpt_path.format("-extra-data"), "wb") as f:
+                f.write(ek_none_cpt_data + ek_none_cpt_data[-8:])
+            if lbf_cpt_mode == 0:
+                boxsize, data = ek_none_cpt_data.split(b"\n", 1)
+                with open(cpt_path.format("-wrong-format"), "wb") as f:
+                    f.write(boxsize + b"\n" + b"\ntext string\n" + data)
+                with open(cpt_path.format("-wrong-boxdim"), "wb") as f:
+                    f.write(b"2" + boxsize + b"\n" + data)
 
     def test_generator_recursive_unlink(self):
         with tempfile.TemporaryDirectory() as tmp_directory:

--- a/testsuite/python/save_checkpoint.py
+++ b/testsuite/python/save_checkpoint.py
@@ -102,7 +102,7 @@ if lbf_class:
     if not le_active:
         ek_solver_class = espressomd.electrokinetics.EKNone
         ek_params = {"single_precision": False, "gpu": False}
-        if "LB.GPU" in modes:
+        if "LB.GPU" in modes and espressomd.gpu_available():
             ek_params["gpu"] = True
         ek_solver_params = {"tau": system.time_step, **ek_params}
         if espressomd.has_features("WALBERLA_FFT") and cpt_mode == 1:

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -188,6 +188,14 @@ class CheckpointTest(ut.TestCase):
     def test_ek_species(self):
         lbf = system.lb
         n_ghost_layers = lbf.lattice.get_params()["n_ghost_layers"]
+        ek_solver_class = espressomd.electrokinetics.EKNone
+        ek_solver_params_reference = {
+            "tau": system.time_step, "single_precision": False, "gpu": False}
+        if "LB.GPU" in modes:
+            ek_solver_params_reference["gpu"] = True
+        if espressomd.has_features("WALBERLA_FFT") and "LB.ASCII" in modes:
+            ek_solver_class = espressomd.electrokinetics.EKFFT
+            ek_solver_params_reference["permittivity"] = 0.1
         if n_ghost_layers > 1:
             cpt_mode = 0 if 'LB.ASCII' in modes else 1
             cpt_path = str(self.checkpoint.root / "ek") + "{}.cpt"
@@ -197,8 +205,13 @@ class CheckpointTest(ut.TestCase):
             ek_solver = system.ekcontainer.solver
             self.assertAlmostEqual(system.ekcontainer.tau, system.time_step,
                                    delta=1e-7)
-            self.assertIsInstance(system.ekcontainer.solver,
-                                  espressomd.electrokinetics.EKNone)
+            self.assertIsInstance(ek_solver, ek_solver_class)
+            ek_solver_params = ek_solver.get_params()
+            for key in ek_solver_params_reference:
+                self.assertIn(key, ek_solver_params)
+                np.testing.assert_allclose(np.copy(ek_solver_params[key]),
+                                           ek_solver_params_reference[key],
+                                           atol=1E-7, err_msg=f"{key} differs")
 
             # check exception mechanism with corrupted LB checkpoint files
             with self.assertRaisesRegex(RuntimeError, 'EOF found'):
@@ -220,25 +233,26 @@ class CheckpointTest(ut.TestCase):
 
             ek_species.load_checkpoint(cpt_path.format(""), cpt_mode)
 
-            cpt_path = str(self.checkpoint.root / "ek_none") + "{}.cpt"
-            with self.assertRaisesRegex(RuntimeError, 'EOF found'):
-                ek_solver.load_checkpoint(
-                    cpt_path.format("-missing-data"), cpt_mode)
-            with self.assertRaisesRegex(RuntimeError, 'extra data found, expected EOF'):
-                ek_solver.load_checkpoint(
-                    cpt_path.format("-extra-data"), cpt_mode)
-            if cpt_mode == 0:
-                with self.assertRaisesRegex(RuntimeError, 'incorrectly formatted data'):
+            if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
+                cpt_path = str(self.checkpoint.root / "ek_none") + "{}.cpt"
+                with self.assertRaisesRegex(RuntimeError, 'EOF found'):
                     ek_solver.load_checkpoint(
-                        cpt_path.format("-wrong-format"), cpt_mode)
-                with self.assertRaisesRegex(RuntimeError, 'grid dimensions mismatch'):
+                        cpt_path.format("-missing-data"), cpt_mode)
+                with self.assertRaisesRegex(RuntimeError, 'extra data found, expected EOF'):
                     ek_solver.load_checkpoint(
-                        cpt_path.format("-wrong-boxdim"), cpt_mode)
-            with self.assertRaisesRegex(RuntimeError, 'could not open file'):
-                ek_solver.load_checkpoint(
-                    cpt_path.format("-unknown"), cpt_mode)
+                        cpt_path.format("-extra-data"), cpt_mode)
+                if cpt_mode == 0:
+                    with self.assertRaisesRegex(RuntimeError, 'incorrectly formatted data'):
+                        ek_solver.load_checkpoint(
+                            cpt_path.format("-wrong-format"), cpt_mode)
+                    with self.assertRaisesRegex(RuntimeError, 'grid dimensions mismatch'):
+                        ek_solver.load_checkpoint(
+                            cpt_path.format("-wrong-boxdim"), cpt_mode)
+                with self.assertRaisesRegex(RuntimeError, 'could not open file'):
+                    ek_solver.load_checkpoint(
+                        cpt_path.format("-unknown"), cpt_mode)
 
-            ek_solver.load_checkpoint(cpt_path.format(""), cpt_mode)
+                ek_solver.load_checkpoint(cpt_path.format(""), cpt_mode)
 
             precision = 8 if "LB.WALBERLA" in modes else 5
             m = np.pi / 12
@@ -250,8 +264,9 @@ class CheckpointTest(ut.TestCase):
                 (nx, ny, nz), dtype=float)
             np.testing.assert_almost_equal(
                 np.copy(ek_species[:, :, :].density), grid_3D, decimal=precision)
-            np.testing.assert_almost_equal(
-                np.copy(ek_solver[:, :, :].potential), grid_3D / 4., decimal=precision)
+            if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
+                np.testing.assert_almost_equal(
+                    np.copy(ek_solver[:, :, :].potential), grid_3D / 4., decimal=precision)
 
             state = ek_species.get_params()
             reference = {
@@ -360,13 +375,13 @@ class CheckpointTest(ut.TestCase):
 
     @utx.skipIfMissingFeatures(["WALBERLA"])
     @ut.skipIf(not has_lb_mode, "Skipping test due to missing EK mode.")
-    def test_ek_vtk(self):
+    def test_ek_species_vtk(self):
         lbf = system.lb
         n_ghost_layers = lbf.lattice.get_params()["n_ghost_layers"]
         if n_ghost_layers > 1:
             ek_species = system.ekcontainer[0]
             vtk_suffix = config.test_name
-            key_auto = f"vtk_out/auto_ek_{vtk_suffix}"
+            key_auto = f"vtk_out/auto_ek_species_{vtk_suffix}"
             vtk_auto = ek_species.vtk_writers[0]
             self.assertIsInstance(
                 vtk_auto, espressomd.electrokinetics.VTKOutput)
@@ -376,7 +391,7 @@ class CheckpointTest(ut.TestCase):
             self.assertEqual(set(vtk_auto.observables), {"density"})
             self.assertIn(
                 f"write to '{key_auto}' every 1 EK steps (disabled)>", repr(vtk_auto))
-            key_manual = f"vtk_out/manual_ek_{vtk_suffix}"
+            key_manual = f"vtk_out/manual_ek_species_{vtk_suffix}"
             vtk_manual = ek_species.vtk_writers[1]
             self.assertIsInstance(
                 vtk_manual, espressomd.electrokinetics.VTKOutput)
@@ -386,7 +401,8 @@ class CheckpointTest(ut.TestCase):
             self.assertIn(
                 f"write to '{key_manual}' on demand>", repr(vtk_manual))
             # check file numbering when resuming VTK write operations
-            vtk_root = pathlib.Path("vtk_out") / f"manual_ek_{vtk_suffix}"
+            vtk_root = pathlib.Path("vtk_out") / \
+                f"manual_ek_species_{vtk_suffix}"
             filename = "simulation_step_{}.vtu"
             self.assertTrue((vtk_root / filename.format(0)).exists())
             self.assertFalse((vtk_root / filename.format(1)).exists())
@@ -409,6 +425,62 @@ class CheckpointTest(ut.TestCase):
                     ek_density[0, 0, 0], new_density, delta=1e-5)
             (vtk_root / filename.format(1)).unlink(missing_ok=True)
             (vtk_root / filename.format(2)).unlink(missing_ok=True)
+
+    @utx.skipIfMissingFeatures(["WALBERLA"])
+    @ut.skipIf(not has_lb_mode, "Skipping test due to missing EK mode.")
+    def test_ek_solver_vtk(self):
+        lbf = system.lb
+        n_ghost_layers = lbf.lattice.get_params()["n_ghost_layers"]
+        if n_ghost_layers > 1:
+            ek_solver = system.ekcontainer.solver
+            vtk_suffix = config.test_name
+            key_auto = f"vtk_out/auto_ek_poisson_{vtk_suffix}"
+            vtk_auto = ek_solver.vtk_writers[0]
+            self.assertIsInstance(
+                vtk_auto, espressomd.electrokinetics.VTKPoissonOutput)
+            self.assertEqual(vtk_auto.vtk_uid, key_auto)
+            self.assertEqual(vtk_auto.delta_N, 1)
+            self.assertTrue(vtk_auto.force_pvtu)
+            self.assertFalse(vtk_auto.enabled)
+            self.assertEqual(set(vtk_auto.observables), {"potential"})
+            self.assertIn(
+                f"write to '{key_auto}' every 1 EK steps (disabled)>", repr(vtk_auto))
+            key_manual = f"vtk_out/manual_ek_poisson_{vtk_suffix}"
+            vtk_manual = ek_solver.vtk_writers[1]
+            self.assertIsInstance(
+                vtk_manual, espressomd.electrokinetics.VTKPoissonOutput)
+            self.assertEqual(vtk_manual.vtk_uid, key_manual)
+            self.assertEqual(vtk_manual.delta_N, 0)
+            self.assertTrue(vtk_auto.force_pvtu)
+            self.assertEqual(set(vtk_manual.observables), {"potential"})
+            self.assertIn(
+                f"write to '{key_manual}' on demand>", repr(vtk_manual))
+            # check file numbering when resuming VTK write operations
+            vtk_root = pathlib.Path("vtk_out") / \
+                f"manual_ek_poisson_{vtk_suffix}"
+            filename = "simulation_step_{}.vtu"
+            self.assertTrue((vtk_root / filename.format(0)).exists())
+            self.assertFalse((vtk_root / filename.format(1)).exists())
+            self.assertFalse((vtk_root / filename.format(2)).exists())
+            # check VTK objects are still synchronized with their EK objects
+            if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
+                old_potential = ek_solver[0, 0, 0].potential
+                new_potential = 1.5 * old_potential
+                ek_solver[0, 0, 0].potential = new_potential
+                vtk_manual.write()
+                time.sleep(0.1)  # small delay for file system write latency
+                ek_solver[0, 0, 0].potential = old_potential
+                self.assertTrue((vtk_root / filename.format(0)).exists())
+                self.assertTrue((vtk_root / filename.format(1)).exists())
+                self.assertFalse((vtk_root / filename.format(2)).exists())
+                if "espressomd.io.vtk" in sys.modules:
+                    vtk_reader = espressomd.io.vtk.VTKReader()
+                    vtk_data = vtk_reader.parse(vtk_root / filename.format(1))
+                    ek_potential = vtk_data["potential"]
+                    self.assertAlmostEqual(
+                        ek_potential[0, 0, 0], new_potential, delta=1e-5)
+                (vtk_root / filename.format(1)).unlink(missing_ok=True)
+                (vtk_root / filename.format(2)).unlink(missing_ok=True)
 
     def test_system_variables(self):
         cell_system_params = system.cell_system.get_state()

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -187,13 +187,14 @@ class CheckpointTest(ut.TestCase):
     @ut.skipIf(not has_lb_mode, "Skipping test due to missing EK mode.")
     def test_ek_species(self):
         lbf = system.lb
+        cpt_mode = 0 if "LB.ASCII" in modes else 1
         n_ghost_layers = lbf.lattice.get_params()["n_ghost_layers"]
         ek_solver_class = espressomd.electrokinetics.EKNone
         ek_solver_params_reference = {
             "tau": system.time_step, "single_precision": False, "gpu": False}
         if "LB.GPU" in modes:
             ek_solver_params_reference["gpu"] = True
-        if espressomd.has_features("WALBERLA_FFT") and "LB.ASCII" in modes:
+        if espressomd.has_features("WALBERLA_FFT") and cpt_mode == 1:
             ek_solver_class = espressomd.electrokinetics.EKFFT
             ek_solver_params_reference["permittivity"] = 0.1
         if n_ghost_layers > 1:
@@ -355,12 +356,12 @@ class CheckpointTest(ut.TestCase):
         self.assertFalse((vtk_root / filename.format(1)).exists())
         self.assertFalse((vtk_root / filename.format(2)).exists())
         # check VTK objects are still synchronized with their LB objects
-        old_density = lbf[0, 0, 0].density
+        old_density = np.copy(lbf[:, :, :].density)
         new_density = 1.5 * old_density
-        lbf[0, 0, 0].density = new_density
+        lbf[:, :, :].density = new_density
         vtk_manual.write()
         time.sleep(0.1)  # small delay for file system write latency
-        lbf[0, 0, 0].density = old_density
+        lbf[:, :, :].density = old_density
         self.assertTrue((vtk_root / filename.format(0)).exists())
         self.assertTrue((vtk_root / filename.format(1)).exists())
         self.assertFalse((vtk_root / filename.format(2)).exists())
@@ -368,8 +369,8 @@ class CheckpointTest(ut.TestCase):
             vtk_reader = espressomd.io.vtk.VTKReader()
             vtk_data = vtk_reader.parse(vtk_root / filename.format(1))
             lb_density = vtk_data["density"]
-            self.assertAlmostEqual(
-                lb_density[0, 0, 0], new_density, delta=1e-4)
+            np.testing.assert_allclose(
+                lb_density[:, :, :], new_density, atol=1e-4, rtol=0.)
         (vtk_root / filename.format(1)).unlink(missing_ok=True)
         (vtk_root / filename.format(2)).unlink(missing_ok=True)
 
@@ -408,12 +409,12 @@ class CheckpointTest(ut.TestCase):
             self.assertFalse((vtk_root / filename.format(1)).exists())
             self.assertFalse((vtk_root / filename.format(2)).exists())
             # check VTK objects are still synchronized with their EK objects
-            old_density = ek_species[0, 0, 0].density
+            old_density = np.copy(ek_species[:, :, :].density)
             new_density = 1.5 * old_density
-            ek_species[0, 0, 0].density = new_density
+            ek_species[:, :, :].density = new_density
             vtk_manual.write()
             time.sleep(0.1)  # small delay for file system write latency
-            ek_species[0, 0, 0].density = old_density
+            ek_species[:, :, :].density = old_density
             self.assertTrue((vtk_root / filename.format(0)).exists())
             self.assertTrue((vtk_root / filename.format(1)).exists())
             self.assertFalse((vtk_root / filename.format(2)).exists())
@@ -421,8 +422,8 @@ class CheckpointTest(ut.TestCase):
                 vtk_reader = espressomd.io.vtk.VTKReader()
                 vtk_data = vtk_reader.parse(vtk_root / filename.format(1))
                 ek_density = vtk_data["density"]
-                self.assertAlmostEqual(
-                    ek_density[0, 0, 0], new_density, delta=1e-5)
+                np.testing.assert_allclose(
+                    ek_density[:, :, :], new_density, atol=1e-5, rtol=0.)
             (vtk_root / filename.format(1)).unlink(missing_ok=True)
             (vtk_root / filename.format(2)).unlink(missing_ok=True)
 
@@ -464,12 +465,12 @@ class CheckpointTest(ut.TestCase):
             self.assertFalse((vtk_root / filename.format(2)).exists())
             # check VTK objects are still synchronized with their EK objects
             if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
-                old_potential = ek_solver[0, 0, 0].potential
+                old_potential = np.copy(ek_solver[:, :, :].potential)
                 new_potential = 1.5 * old_potential
-                ek_solver[0, 0, 0].potential = new_potential
+                ek_solver[:, :, :].potential = new_potential
                 vtk_manual.write()
                 time.sleep(0.1)  # small delay for file system write latency
-                ek_solver[0, 0, 0].potential = old_potential
+                ek_solver[:, :, :].potential = old_potential
                 self.assertTrue((vtk_root / filename.format(0)).exists())
                 self.assertTrue((vtk_root / filename.format(1)).exists())
                 self.assertFalse((vtk_root / filename.format(2)).exists())
@@ -477,8 +478,8 @@ class CheckpointTest(ut.TestCase):
                     vtk_reader = espressomd.io.vtk.VTKReader()
                     vtk_data = vtk_reader.parse(vtk_root / filename.format(1))
                     ek_potential = vtk_data["potential"]
-                    self.assertAlmostEqual(
-                        ek_potential[0, 0, 0], new_potential, delta=1e-5)
+                    np.testing.assert_allclose(
+                        ek_potential[:, :, :], new_potential, atol=1e-5, rtol=0.)
                 (vtk_root / filename.format(1)).unlink(missing_ok=True)
                 (vtk_root / filename.format(2)).unlink(missing_ok=True)
 

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -269,9 +269,11 @@ class CheckpointTest(ut.TestCase):
             np.testing.assert_almost_equal(
                 np.copy(ek_species[:, :, :].density), ref_density, decimal=precision)
             np.testing.assert_almost_equal(
-                np.copy(ek_species[0, :, :].flux), [1., 2., 3.], decimal=precision)
+                np.copy(ek_species[0, :, :].flux),
+                1e-3 * np.array([1., 2., 3.]), decimal=precision)
             np.testing.assert_almost_equal(
-                np.copy(ek_species[-1, :, :].flux), [4., 5., 6.], decimal=precision)
+                np.copy(ek_species[-1, :, :].flux),
+                1e-3 * np.array([4., 5., 6.]), decimal=precision)
             if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
                 np.testing.assert_almost_equal(
                     np.copy(ek_solver[:, :, :].potential), grid_3D / 4., decimal=precision)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -267,13 +267,18 @@ class CheckpointTest(ut.TestCase):
             ref_density[0, :, :] = 1.
             ref_density[-1, :, :] = 2.
             np.testing.assert_almost_equal(
-                np.copy(ek_species[:, :, :].density), ref_density, decimal=precision)
+                np.copy(ek_species[:, :, :].density),
+                ref_density, decimal=precision)
             np.testing.assert_almost_equal(
                 np.copy(ek_species[0, :, :].flux),
-                1e-3 * np.array([1., 2., 3.]), decimal=precision)
+                np.broadcast_to(1e-3 * np.array([1., 2., 3.]),
+                                ek_species[-1, :, :].flux.shape),
+                decimal=precision)
             np.testing.assert_almost_equal(
                 np.copy(ek_species[-1, :, :].flux),
-                1e-3 * np.array([4., 5., 6.]), decimal=precision)
+                np.broadcast_to(1e-3 * np.array([4., 5., 6.]),
+                                ek_species[-1, :, :].flux.shape),
+                decimal=precision)
             if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
                 np.testing.assert_almost_equal(
                     np.copy(ek_solver[:, :, :].potential), grid_3D / 4., decimal=precision)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -263,8 +263,15 @@ class CheckpointTest(ut.TestCase):
             grid_3D = np.fromfunction(
                 lambda i, j, k: np.cos(i * m) * np.cos(j * m) * np.cos(k * m),
                 (nx, ny, nz), dtype=float)
+            ref_density = np.copy(grid_3D)
+            ref_density[0, :, :] = 1.
+            ref_density[-1, :, :] = 2.
             np.testing.assert_almost_equal(
-                np.copy(ek_species[:, :, :].density), grid_3D, decimal=precision)
+                np.copy(ek_species[:, :, :].density), ref_density, decimal=precision)
+            np.testing.assert_almost_equal(
+                np.copy(ek_species[0, :, :].flux), [1., 2., 3.], decimal=precision)
+            np.testing.assert_almost_equal(
+                np.copy(ek_species[-1, :, :].flux), [4., 5., 6.], decimal=precision)
             if isinstance(ek_solver, espressomd.electrokinetics.EKNone):
                 np.testing.assert_almost_equal(
                     np.copy(ek_solver[:, :, :].potential), grid_3D / 4., decimal=precision)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -198,7 +198,7 @@ class CheckpointTest(ut.TestCase):
             ek_solver_class = espressomd.electrokinetics.EKFFT
             ek_solver_params_reference["permittivity"] = 0.1
         if n_ghost_layers > 1:
-            cpt_mode = 0 if 'LB.ASCII' in modes else 1
+            cpt_mode = 0 if "LB.ASCII" in modes else 1
             cpt_path = str(self.checkpoint.root / "ek") + "{}.cpt"
 
             self.assertEqual(len(system.ekcontainer), 1)

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -192,7 +192,7 @@ class CheckpointTest(ut.TestCase):
         ek_solver_class = espressomd.electrokinetics.EKNone
         ek_solver_params_reference = {
             "tau": system.time_step, "single_precision": False, "gpu": False}
-        if "LB.GPU" in modes:
+        if "LB.GPU" in modes and espressomd.gpu_available():
             ek_solver_params_reference["gpu"] = True
         if espressomd.has_features("WALBERLA_FFT") and cpt_mode == 1:
             ek_solver_class = espressomd.electrokinetics.EKFFT


### PR DESCRIPTION
Description of changes:
- EK node and slice getters now return the imposed value when a cell has a boundary condition
- EK GPU and EK CPU objects can no longer be mixed in the same EK container
- EKNone now writes the potential in VTK files
- EKNone GPU potential node/slice getters no longer return uninitialized data before the first time step