### PR TITLE
core/accumulators: fix Correlator::finalize() discarding compression results

### DIFF
--- a/src/core/accumulators/Correlator.cpp
+++ b/src/core/accumulators/Correlator.cpp
@@ -474,10 +474,12 @@ int Correlator::finalize(boost::mpi::communicator const &comm) {
         newest[i + 1] = (newest[i + 1] + 1) % (m_tau_lin + 1);
         n_vals[i + 1] += 1;
 
-        (*compressA)(A[i][(newest[i] + 1) % (m_tau_lin + 1)],
-                     A[i][(newest[i] + 2) % (m_tau_lin + 1)]);
-        (*compressB)(B[i][(newest[i] + 1) % (m_tau_lin + 1)],
-                     B[i][(newest[i] + 2) % (m_tau_lin + 1)]);
+        A[i + 1][newest[i + 1]] =
+            (*compressA)(A[i][(newest[i] + 1) % (m_tau_lin + 1)],
+                         A[i][(newest[i] + 2) % (m_tau_lin + 1)]);
+        B[i + 1][newest[i + 1]] =
+            (*compressB)(B[i][(newest[i] + 1) % (m_tau_lin + 1)],
+                         B[i][(newest[i] + 2) % (m_tau_lin + 1)]);
       }
       newest[ll] = (newest[ll] + 1) % (m_tau_lin + 1);
 

--- a/testsuite/python/accumulator_correlator.py
+++ b/testsuite/python/accumulator_correlator.py
@@ -109,6 +109,56 @@ class CorrelatorTest(ut.TestCase):
         for i in range(corr.shape[0]):
             np.testing.assert_array_almost_equal(corr[i], [v**2 * tau[i]**2])
 
+    def test_finalize_preserves_long_lag_tail(self):
+        """
+        Bug #2: a particle moving with constant velocity ``v`` from the
+        origin has position ``r(t) = v*t``, so the componentwise
+        square-distance autocorrelation is analytically
+        ``C(tau) = (v*tau)**2`` at *every* hierarchy level (the linear
+        compression of two linearly-growing positions is again linear in
+        time). With ``tau_lin=10`` and ``tau_max=2`` the hierarchy depth is
+        >= 2 (multi-block), so ``finalize()`` exercises the buggy compression
+        loop. After ``finalize()`` the *entire* result array, including the
+        long-lag tail that finalize touches, must still equal ``(v*tau)**2``.
+
+        On buggy HEAD the discarded compression results leave the
+        higher-level slots holding stale (older, smaller) positions, so the
+        long-lag tail is corrupted while the short-lag entries (filled by
+        ``update()``, which assigns correctly) remain correct.
+        """
+        s = self.system
+        v = np.array([1., 2., 3.])
+        p = s.part.add(pos=(0., 0., 0.), v=v)
+
+        obs = espressomd.observables.ParticlePositions(ids=(p.id,))
+        acc = espressomd.accumulators.Correlator(
+            obs1=obs, tau_lin=10, tau_max=2., delta_N=1, system=s,
+            corr_operation="square_distance_componentwise")
+
+        # accumulate enough samples to fully populate the higher hierarchy
+        # levels (the long-lag tail), so finalize() has data to compress
+        s.integrator.run(1000)
+        s.auto_update_accumulators.add(acc)
+        s.integrator.run(2000)
+
+        # trigger the buggy compression path
+        acc.finalize()
+
+        corr = acc.result()
+        tau = self.calc_tau(s.time_step, acc.tau_lin, corr.shape[0])
+        sizes = acc.sample_sizes()
+
+        # sanity: the long-lag tail must actually carry samples, otherwise
+        # the test would be vacuous and not exercise the bug
+        self.assertGreater(sizes[-1], 0)
+
+        # the analytic correlation holds for every lag, short and long
+        for i in range(corr.shape[0]):
+            np.testing.assert_array_almost_equal(
+                corr[i], [v**2 * tau[i]**2],
+                err_msg=f"finalized correlation wrong at lag index {i} "
+                f"(tau={tau[i]}, n_samples={sizes[i]})")
+
     def test_tensor_product(self):
         s = self.system
         v = np.array([1, 2, 3])


### PR DESCRIPTION
In `finalize()` the compress calls did not assign their return values, so
the higher-hierarchy buffer slots (`A[i+1][newest[i+1]]`,
`B[i+1][newest[i+1]]`) were never updated.  The subsequent correlation loop
read stale ring-buffer data into the long-lag-time tail, silently corrupting
results for any multi-block correlator (`hierarchy_depth >= 2`, the standard
`tau_max/dt >= tau_lin` case).

**Fix:** assign the compress results in `finalize()` (lines 477-480 of
`src/core/accumulators/Correlator.cpp`), mirroring the identical assignment
already present in `update()`.

**Regression test:** `test_finalize_preserves_long_lag_tail` added to the
`CorrelatorTest` class in `testsuite/python/accumulator_correlator.py`.

Fixes bug #2 of the adversarial bug sweep.