### PR TITLE
utils/math: fix zero_magnitude_error for cylinder axis anti-parallel to z

### DIFF
--- a/src/utils/include/utils/math/coordinate_transformation.hpp
+++ b/src/utils/include/utils/math/coordinate_transformation.hpp
@@ -149,7 +149,14 @@ inline Vector3d transform_vector_cartesian_to_cylinder(Vector3d const &vec,
                                                        Vector3d const &pos) {
   auto constexpr z_axis = Vector3d{{0., 0., 1.}};
   auto const angle = angle_between(axis, z_axis);
-  auto const rotation_axis = Utils::vector_product(axis, z_axis).normalize();
+  auto const cross = Utils::vector_product(axis, z_axis);
+  auto const cross_norm = cross.norm();
+  // When axis is (anti-)parallel to z, the cross product is zero.
+  // For angle==0 (parallel) vec_rotate is the identity regardless of
+  // rotation_axis. For angle==pi (anti-parallel) rotate 180° around any x-y
+  // plane axis; use [1,0,0].
+  auto const rotation_axis =
+      (cross_norm > 0.) ? cross / cross_norm : Vector3d{{1., 0., 0.}};
   auto const rotated_pos = vec_rotate(rotation_axis, angle, pos);
   auto const rotated_vec = vec_rotate(rotation_axis, angle, vec);
   auto const r = std::sqrt(rotated_pos[0] * rotated_pos[0] +

--- a/src/utils/tests/coordinate_transformation_test.cpp
+++ b/src/utils/tests/coordinate_transformation_test.cpp
@@ -239,3 +239,37 @@ BOOST_AUTO_TEST_CASE(cylinder_to_cartesian_with_axis_with_phi_2_test) {
     }
   }
 }
+
+BOOST_AUTO_TEST_CASE(
+    transform_vector_cartesian_to_cylinder_degenerate_axis_test) {
+  constexpr auto eps = 1e-14;
+
+  // Parallel case: axis == z_axis == [0,0,1]. The cross product is zero but
+  // the rotation angle is 0 so vec_rotate is the identity regardless of the
+  // fallback rotation_axis. Must not throw.
+  {
+    auto const axis = Vector3d{{0., 0., 1.}};
+    auto const pos = Vector3d{{1., 0., 0.}};
+    auto const vec = Vector3d{{1., 0., 0.}};
+    Vector3d result;
+    BOOST_CHECK_NO_THROW(
+        result = Utils::transform_vector_cartesian_to_cylinder(vec, axis, pos));
+    for (auto i = 0u; i < 3u; ++i) {
+      BOOST_CHECK(std::isfinite(result[i]));
+    }
+  }
+
+  // Anti-parallel case: axis == -z_axis == [0,0,-1]. The cross product is
+  // zero and the rotation angle is pi. The fix falls back to [1,0,0] as the
+  // rotation axis and must not throw. For pos=[1,0,0] and vec=[1,0,0] (radial
+  // in +x), the r-component of the cylindrical result must equal 1.
+  {
+    auto const axis = Vector3d{{0., 0., -1.}};
+    auto const pos = Vector3d{{1., 0., 0.}};
+    auto const vec = Vector3d{{1., 0., 0.}};
+    Vector3d result;
+    BOOST_CHECK_NO_THROW(
+        result = Utils::transform_vector_cartesian_to_cylinder(vec, axis, pos));
+    BOOST_CHECK_SMALL(result[0] - 1., eps);
+  }
+}

--- a/src/utils/tests/coordinate_transformation_test.cpp
+++ b/src/utils/tests/coordinate_transformation_test.cpp
@@ -261,15 +261,22 @@ BOOST_AUTO_TEST_CASE(
 
   // Anti-parallel case: axis == -z_axis == [0,0,-1]. The cross product is
   // zero and the rotation angle is pi. The fix falls back to [1,0,0] as the
-  // rotation axis and must not throw. For pos=[1,0,0] and vec=[1,0,0] (radial
-  // in +x), the r-component of the cylindrical result must equal 1.
+  // rotation axis and must not throw.
+  //
+  // For axis=-z, pos=[1,0,0]: e_r=[1,0,0], e_phi=[0,-1,0], e_z=[0,0,-1].
+  // With vec=[2,3,5] the expected cylindrical components are:
+  //   v_r   = vec·e_r   =  2
+  //   v_phi = vec·e_phi = -3
+  //   v_z   = vec·e_z   = -5
   {
     auto const axis = Vector3d{{0., 0., -1.}};
     auto const pos = Vector3d{{1., 0., 0.}};
-    auto const vec = Vector3d{{1., 0., 0.}};
+    auto const vec = Vector3d{{2., 3., 5.}};
     Vector3d result;
     BOOST_CHECK_NO_THROW(
         result = Utils::transform_vector_cartesian_to_cylinder(vec, axis, pos));
-    BOOST_CHECK_SMALL(result[0] - 1., eps);
+    BOOST_CHECK_SMALL(result[0] - 2., eps); // v_r
+    BOOST_CHECK_SMALL(result[1] + 3., eps); // v_phi
+    BOOST_CHECK_SMALL(result[2] + 5., eps); // v_z
   }
 }


### PR DESCRIPTION
`transform_vector_cartesian_to_cylinder` computed the rotation axis as
`vector_product(axis, z_axis).normalize()`.  When `axis` is anti-parallel to
z (`[0,0,-1]`), the cross product is the zero vector and `normalize()`
throws `zero_magnitude_error`, making any cylindrical vector observable
with a `-z` axis unusable.

**Fix:** guard against the degenerate case in
`src/utils/include/utils/math/coordinate_transformation.hpp`; fall back to
`[1,0,0]` when the cross-product norm is zero.  For `angle==0` (parallel)
`vec_rotate` is the identity regardless; for `angle==π` (anti-parallel)
rotating 180° around `[1,0,0]` correctly maps `-z` to `+z`.

**Regression test:** `transform_vector_cartesian_to_cylinder_degenerate_axis_test`
added to `src/utils/tests/coordinate_transformation_test.cpp` (Boost.Test) —
covers both parallel and anti-parallel degenerate axes, verifying no exception
is thrown and the r-component is numerically correct.

Fixes bug #28 of the adversarial bug sweep.