### PR TITLE
python/espressomd: validate ICC keyword arguments, rejecting unknown keys

### DIFF
--- a/src/python/espressomd/electrostatic_extensions.py
+++ b/src/python/espressomd/electrostatic_extensions.py
@@ -32,6 +32,10 @@ class ElectrostaticExtensions(ScriptInterfaceHelper):
             params = self.default_params()
             params.update(kwargs)
             super().__init__(**params)
+            for key in params:
+                if not self._has_parameter(key):
+                    raise RuntimeError(
+                        f"Parameter '{key}' is not a valid parameter")
         else:
             super().__init__(**kwargs)
 

--- a/testsuite/python/icc_interface.py
+++ b/testsuite/python/icc_interface.py
@@ -127,6 +127,18 @@ class Test(ut.TestCase):
             with self.assertRaisesRegex((ValueError, RuntimeError), error):
                 espressomd.electrostatic_extensions.ICC(**params)
 
+    def test_unknown_kwarg_rejected(self):
+        part_slice, normals, areas = self.add_icc_particles()
+        with self.assertRaises((RuntimeError, ValueError, TypeError)):
+            espressomd.electrostatic_extensions.ICC(
+                n_icc=len(part_slice),
+                normals=normals,
+                areas=areas,
+                epsilons=np.ones_like(areas),
+                first_id=part_slice.id[0],
+                relaxaton=0.9,  # typo: should be 'relaxation'
+            )
+
     @utx.skipIfMissingFeatures(["P3M"])
     def test_exceptions_small_r_cut(self):
         icc, _ = self.setup_icc_particles_and_solver(max_iterations=1)


### PR DESCRIPTION
`ElectrostaticExtensions.__init__` forwarded all user kwargs to
`super().__init__()` without validating them.  ICC's `valid_keys()` and
`required_keys()` were dead code.  Mistyped optional keywords such as
`relaxaton=0.9` (intended: `relaxation`) were silently ignored, causing ICC
to run with the wrong parameter and no diagnostic.

**Fix:** after `super().__init__()`, loop over the merged params dict and
call `self._has_parameter(key)` for each key; raise `RuntimeError` for any
unknown key (`src/python/espressomd/electrostatic_extensions.py`).  Mirrors
the identical validation already present in `ElectrostaticInteraction`.

**Regression test:** `test_unknown_kwarg_rejected` added to `Test` in
`testsuite/python/icc_interface.py`.

Fixes bug #41 of the adversarial bug sweep.