### PR TITLE
core/p3m: fix influence function zeroing valid k-modes for odd mesh sizes

### DIFF
--- a/src/core/p3m/influence_function.hpp
+++ b/src/core/p3m/influence_function.hpp
@@ -166,13 +166,21 @@ std::vector<FloatType> grid_influence_function(
   }
 
   auto const wavevector = (2. * std::numbers::pi) * inv_box_l;
-  auto const half_mesh = params.mesh / 2;
   auto indices = Utils::Vector3i{};
 
+  /* Skip G_opt only for DC (index == 0) and, for even mesh, the Nyquist mode
+   * (index == mesh/2). The old half_mesh % test was incorrect for odd mesh
+   * sizes: e.g. mesh=5 gives half_mesh=2, so i%2==0 matched {0,2,4} and
+   * silently zeroed valid k-modes. */
+  auto const is_dc_or_nyquist = [&](std::size_t d) {
+    return (indices[d] == 0u) ||
+           (params.mesh[d] % 2 == 0 &&
+            indices[d] == static_cast<std::size_t>(params.mesh[d] / 2));
+  };
+
   for_each_3d(n_start, n_stop, indices, [&]() {
-    if ((indices[0u] % half_mesh[0u] != 0) or
-        (indices[1u] % half_mesh[1u] != 0) or
-        (indices[2u] % half_mesh[2u] != 0)) {
+    if (not(is_dc_or_nyquist(0u) and is_dc_or_nyquist(1u) and
+            is_dc_or_nyquist(2u))) {
       auto const k =
           Utils::Vector3d{{shifts[0u][indices[0u]] * wavevector[0u],
                            shifts[1u][indices[1u]] * wavevector[1u],

--- a/src/core/p3m/influence_function_dipolar.hpp
+++ b/src/core/p3m/influence_function_dipolar.hpp
@@ -151,17 +151,25 @@ std::vector<FloatType> grid_influence_function_dipolar(
 
   auto const offset = calc_p3m_mesh_shift(params.mesh, false)[0];
   auto const d_op = calc_p3m_mesh_shift(params.mesh, true)[0];
-  auto const half_mesh = params.mesh / 2;
   auto indices = Utils::Vector3i{};
   auto shift_off = Utils::Vector3i{};
   auto d_op_off = Utils::Vector3i{};
 
+  /* Skip G_opt only for DC (index == 0) and, for even mesh, the Nyquist mode
+   * (index == mesh/2). The old half_mesh % test was incorrect for odd mesh
+   * sizes: e.g. mesh=5 gives half_mesh=2, so i%2==0 matched {0,2,4} and
+   * silently zeroed valid k-modes. */
+  auto const is_dc_or_nyquist = [&](std::size_t d) {
+    return (indices[d] == 0u) ||
+           (params.mesh[d] % 2 == 0 &&
+            indices[d] == static_cast<std::size_t>(params.mesh[d] / 2));
+  };
+
   for_each_3d(
       n_start, n_stop, indices,
       [&]() {
-        if (((indices[0u] % half_mesh[0u] != 0) or
-             (indices[1u] % half_mesh[1u] != 0) or
-             (indices[2u] % half_mesh[2u] != 0))) {
+        if (not(is_dc_or_nyquist(0u) and is_dc_or_nyquist(1u) and
+                is_dc_or_nyquist(2u))) {
           auto const index =
               Utils::get_linear_index<memory_order>(indices - n_start, size);
           g[index] = FloatType(
@@ -218,19 +226,27 @@ inline double grid_influence_function_self_energy(
 
   auto const offset = calc_p3m_mesh_shift(params.mesh, false)[0];
   auto const d_op = calc_p3m_mesh_shift(params.mesh, true)[0];
-  auto const half_mesh = params.mesh / 2;
   auto indices = Utils::Vector3i{};
   auto shift_off = Utils::Vector3i{};
   auto d_op_off = Utils::Vector3i{};
   auto index = std::size_t(0u);
   auto energy = 0.;
 
+  /* Skip self-energy accumulation only for DC (index == 0) and, for even mesh,
+   * the Nyquist mode (index == mesh/2). The old half_mesh % test was incorrect
+   * for odd mesh sizes: e.g. mesh=5 gives half_mesh=2, so i%2==0 matched
+   * {0,2,4} and silently zeroed valid k-modes. */
+  auto const is_dc_or_nyquist = [&](std::size_t d) {
+    return (indices[d] == 0u) ||
+           (params.mesh[d] % 2 == 0 &&
+            indices[d] == static_cast<std::size_t>(params.mesh[d] / 2));
+  };
+
   for_each_3d(
       n_start, n_stop, indices,
       [&]() {
-        if (((indices[0u] % half_mesh[0u] != 0) or
-             (indices[1u] % half_mesh[1u] != 0) or
-             (indices[2u] % half_mesh[2u] != 0))) {
+        if (not(is_dc_or_nyquist(0u) and is_dc_or_nyquist(1u) and
+                is_dc_or_nyquist(2u))) {
           auto const U2 = G_opt_dipolar_self_energy<m>(params, shift_off);
           energy += static_cast<double>(g[index]) * U2 * d_op_off.norm2();
         }

--- a/testsuite/python/p3m_madelung.py
+++ b/testsuite/python/p3m_madelung.py
@@ -311,6 +311,69 @@ class Test(ut.TestCase):
                 self.system.electrostatics.solver = p3m
                 check()
 
+    @utx.skipIfMissingFeatures(["P3M"])
+    def test_influence_function_odd_mesh(self):
+        """
+        Regression test for odd mesh sizes in P3M influence function.
+
+        For odd mesh m, the old condition ``i % (m/2) == 0`` incorrectly
+        zeroed valid k-modes (e.g. mesh=5 -> half_mesh=2, zeroing indices
+        {0, 2, 4} instead of only the DC mode {0}).  This caused forces to
+        be spuriously near-zero for odd meshes.  The fix replaces the modulo
+        test with an explicit check for DC (index == 0) and, for even mesh
+        only, the Nyquist mode (index == mesh/2).
+        """
+        box_length = 10.
+        self.system.box_l = [box_length, box_length, box_length]
+        self.system.time_step = 0.01
+        self.system.cell_system.skin = 0.4
+
+        # Two opposite charges – guaranteed non-zero electrostatic force
+        p_pos = np.array([[2., 5., 5.], [8., 5., 5.]])
+        q_vals = [+1., -1.]
+        for pos, q in zip(p_pos, q_vals):
+            self.system.part.add(pos=pos, q=q)
+
+        # Manually specified P3M parameters for mesh=[5,5,5] (odd), no tuning.
+        # alpha chosen so that the real-space sum converges well within r_cut.
+        p3m_odd = espressomd.electrostatics.P3M(
+            prefactor=1., mesh=[5, 5, 5], cao=1,
+            r_cut=3.28125, alpha=0.455, accuracy=0.01, tune=False)
+        self.system.electrostatics.solver = p3m_odd
+        self.system.integrator.run(0)
+
+        forces_odd = self.system.part.all().f.copy()
+
+        # Forces must be non-zero and finite for all particles
+        self.assertTrue(np.all(np.isfinite(forces_odd)),
+                        "Forces are not finite with odd mesh=[5,5,5]")
+        force_magnitudes_odd = np.linalg.norm(forces_odd, axis=1)
+        for i, fmag in enumerate(force_magnitudes_odd):
+            self.assertGreater(fmag, 0.,
+                               f"Force on particle {i} is zero with odd mesh=[5,5,5]")
+
+        # Cross-check: even mesh=[4,4,4] should produce forces of the same
+        # order of magnitude (both are crude approximations; we only check
+        # that odd and even give comparable, non-zero results).
+        self.system.electrostatics.clear()
+        p3m_even = espressomd.electrostatics.P3M(
+            prefactor=1., mesh=[4, 4, 4], cao=1,
+            r_cut=3.18, alpha=0.5115, accuracy=0.01, tune=False)
+        self.system.electrostatics.solver = p3m_even
+        self.system.integrator.run(0)
+
+        forces_even = self.system.part.all().f.copy()
+        force_magnitudes_even = np.linalg.norm(forces_even, axis=1)
+
+        # Both should be within two orders of magnitude of each other
+        for i, (f_odd, f_even) in enumerate(
+                zip(force_magnitudes_odd, force_magnitudes_even)):
+            ratio = f_odd / f_even if f_even > 0. else 0.
+            self.assertGreater(ratio, 1e-2,
+                               f"Odd-mesh force on particle {i} is "
+                               f"unreasonably small compared to even mesh "
+                               f"({f_odd:.3e} vs {f_even:.3e})")
+
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
The influence-function skip condition `indices[d] % (mesh/2) == 0` correctly
identifies only DC and Nyquist for even meshes, but for odd meshes it
spuriously zeroes legitimate low/mid-frequency modes, corrupting dipolar
P3M forces and energies.

**Fix:** replace the modulo shortcut with an `is_dc_or_nyquist` lambda that
returns true only for index == 0 (DC) or (mesh even AND index == mesh/2,
Nyquist), in both `influence_function.hpp` and `influence_function_dipolar.hpp`.

**Regression test:** `test_influence_function_odd_mesh` added to
`testsuite/python/p3m_madelung.py`.

Fixes bug #9 of the adversarial core bug sweep.