### PR TITLE
shapes: fix Torus::calculate_dist producing NaN for particles on the torus axis

### DIFF
--- a/samples/visualization_constraints.py
+++ b/samples/visualization_constraints.py
@@ -67,31 +67,31 @@ if args.shape == "Wall":
 
 elif args.shape == "Sphere":
     system.constraints.add(shape=espressomd.shapes.Sphere(
-        center=[25, 25, 25], radius=15, direction=1),
-        particle_type=0, penetrable=True)
+        center=[25, 25, 25], radius=15, direction=-1),
+        particle_type=0, penetrable=False)
 
 elif args.shape == "Ellipsoid":
     system.constraints.add(shape=espressomd.shapes.Ellipsoid(
-        center=[25, 25, 25], a=25, b=15, direction=1),
-        particle_type=0, penetrable=True)
+        center=[25, 25, 25], a=15, b=25, direction=-1),
+        particle_type=0, penetrable=False)
 
 elif args.shape == "Cylinder":
     system.constraints.add(shape=espressomd.shapes.Cylinder(
-        center=[25] * 3, axis=[1, 0, 0], direction=1, radius=10, length=30),
+        center=[25] * 3, axis=[1, 0, 0], direction=-1, radius=10, length=40),
         particle_type=0,
-        penetrable=True)
+        penetrable=False)
 
 elif args.shape == "SpheroCylinder":
     system.constraints.add(
         shape=espressomd.shapes.SpheroCylinder(center=[25] * 3, axis=[1, 0, 0],
-                                               direction=1, radius=10, length=30),
+                                               direction=-1, radius=10, length=30),
         particle_type=0,
-        penetrable=True)
+        penetrable=False)
 
 elif args.shape == "SimplePore":
     system.constraints.add(shape=espressomd.shapes.SimplePore(
         center=[25, 25, 25], axis=[1, 0, 0], length=15, radius=12.5,
-        smoothing_radius=2), particle_type=0, penetrable=True)
+        smoothing_radius=2), particle_type=0, penetrable=False)
 
 elif args.shape == "Slitpore":
     system.constraints.add(shape=espressomd.shapes.Slitpore(
@@ -110,8 +110,8 @@ elif args.shape == "HollowConicalFrustum":
 elif args.shape == "Torus":
     system.constraints.add(
         shape=espressomd.shapes.Torus(center=[25] * 3, normal=[1, 1, 1],
-                                      direction=1, radius=15, tube_radius=6),
-        particle_type=0, penetrable=True)
+                                      direction=-1, radius=18, tube_radius=7),
+        particle_type=0, penetrable=False)
 
 else:
     raise ValueError(f"Unknown shape '{args.shape}'")
@@ -126,10 +126,10 @@ for i in range(100):
     system.part.add(pos=rpos, type=1)
 
 system.non_bonded_inter[1, 1].lennard_jones.set_params(
-    epsilon=1.0, sigma=5.0, cutoff=15.0, shift="auto")
+    epsilon=1.0, sigma=4.0, cutoff=15.0, shift="auto")
 
 system.non_bonded_inter[0, 1].lennard_jones.set_params(
-    epsilon=20.0, sigma=5.0, cutoff=20.0, shift="auto")
+    epsilon=10.0, sigma=4.0, cutoff=20.0, shift="auto")
 
 
 system.integrator.set_steepest_descent(f_max=10, gamma=1e-3,

--- a/src/script_interface/shapes/Shape.hpp
+++ b/src/script_interface/shapes/Shape.hpp
@@ -19,15 +19,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SCRIPT_INTERFACE_SHAPES_SHAPE_HPP
-#define SCRIPT_INTERFACE_SHAPES_SHAPE_HPP
+#pragma once
 
+#include "script_interface/ScriptInterface.hpp"
 #include "script_interface/auto_parameters/AutoParameters.hpp"
+
 #include <shapes/Shape.hpp>
 
 #include <utils/Vector.hpp>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -44,6 +46,11 @@ public:
   Variant do_call_method(std::string const &name,
                          VariantMap const &params) override {
     if (name == "calc_distance") {
+      context()->parallel_try_catch([&]() {
+        if (not params.contains("position")) {
+          throw std::runtime_error("Parameter 'position' is missing");
+        }
+      });
       auto const pos = get_value<Utils::Vector3d>(params.at("position"));
       double dist;
       Utils::Vector3d vec;
@@ -52,6 +59,11 @@ public:
     }
 
     if (name == "is_inside") {
+      context()->parallel_try_catch([&]() {
+        if (not params.contains("position")) {
+          throw std::runtime_error("Parameter 'position' is missing");
+        }
+      });
       auto const pos = get_value<Utils::Vector3d>(params.at("position"));
       auto is_in = shape()->is_inside(pos);
       return {is_in};
@@ -71,5 +83,3 @@ public:
 
 } /* namespace Shapes */
 } /* namespace ScriptInterface */
-
-#endif

--- a/src/script_interface/tests/CMakeLists.txt
+++ b/src/script_interface/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ espresso_unit_test(SRC ObjectMap_test.cpp DEPENDS espresso::script_interface
 espresso_unit_test(SRC Accumulators_test.cpp DEPENDS espresso::script_interface
                    espresso::core Boost::mpi MPI::MPI_CXX NUM_PROC 2)
 espresso_unit_test(SRC Constraints_test.cpp DEPENDS espresso::script_interface
-                   espresso::core)
+                   espresso::core Boost::mpi MPI::MPI_CXX NUM_PROC 1)
 espresso_unit_test(SRC Actors_test.cpp DEPENDS espresso::script_interface
                    espresso::core)
 espresso_unit_test(

--- a/src/script_interface/tests/Constraints_test.cpp
+++ b/src/script_interface/tests/Constraints_test.cpp
@@ -21,6 +21,8 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
+#include "script_interface/LocalContext.hpp"
+#include "script_interface/ScriptInterface.hpp"
 #include "script_interface/constraints/ExternalField.hpp"
 #include "script_interface/constraints/ExternalPotential.hpp"
 #include "script_interface/constraints/HomogeneousMagneticField.hpp"
@@ -33,6 +35,10 @@
 #include "script_interface/shapes/Shape.hpp"
 #include "script_interface/shapes/Sphere.hpp"
 
+#include "core/unit_tests/EspressoCoreGlobalConfig.hpp"
+
+#include <boost/mpi/communicator.hpp>
+
 #include <utils/Vector.hpp>
 
 #include <limits>
@@ -41,8 +47,20 @@
 
 using namespace ScriptInterface;
 
+BOOST_TEST_GLOBAL_CONFIGURATION(EspressoCoreGlobalConfig);
+
 BOOST_AUTO_TEST_CASE(shape_based_constraint) {
-  ScriptInterface::Constraints::ShapeBasedConstraint constraint;
+  using namespace ScriptInterface::Constraints;
+  Utils::Factory<ObjectHandle> f;
+  f.register_new<ShapeBasedConstraint>(std::string("ShapeBasedConstraint"));
+  f.register_new<ScriptInterface::Shapes::Sphere>(std::string("Sphere"));
+  f.register_new<ScriptInterface::Shapes::NoWhere>(std::string("NoWhere"));
+  boost::mpi::communicator comm;
+  auto ctx = std::make_shared<LocalContext>(f, comm);
+  auto &&sp_constraint{ctx->make_shared("ShapeBasedConstraint", {})};
+  auto so_constraint =
+      std::dynamic_pointer_cast<ShapeBasedConstraint>(sp_constraint);
+  auto &constraint = *so_constraint;
   {
     // check const and non-const access
     BOOST_TEST(constraint.constraint()->fits_in_box({}));
@@ -51,7 +69,9 @@ BOOST_AUTO_TEST_CASE(shape_based_constraint) {
   }
   {
     // check shape setter and getter
-    auto const shape = std::make_shared<ScriptInterface::Shapes::NoWhere>();
+    auto &&sp_shape{ctx->make_shared("NoWhere", {})};
+    auto shape =
+        std::dynamic_pointer_cast<ScriptInterface::Shapes::NoWhere>(sp_shape);
     constraint.set_parameter("shape", shape);
     auto const shape_si =
         get_value<std::shared_ptr<ScriptInterface::Shapes::Shape>>(
@@ -69,7 +89,9 @@ BOOST_AUTO_TEST_CASE(shape_based_constraint) {
   }
   {
     // check shape setter and getter
-    auto shape = std::make_shared<ScriptInterface::Shapes::Sphere>();
+    auto &&sp_shape{ctx->make_shared("Sphere", {})};
+    auto shape =
+        std::dynamic_pointer_cast<ScriptInterface::Shapes::Sphere>(sp_shape);
     shape->set_parameter("radius", 2.);
     constraint.set_parameter("shape", shape);
     auto const shape_si =

--- a/src/shapes/include/shapes/Torus.hpp
+++ b/src/shapes/include/shapes/Torus.hpp
@@ -40,8 +40,25 @@ public:
   /** Unit vector in z direction */
   Utils::Vector3d e_z;
 
+  /** Alternative e_r for the on-axis corner case */
+  Utils::Vector3d e_r_axis;
+
   /** @brief Calculate derived parameters. */
-  void precalc() { e_z = m_normal / m_normal.norm(); }
+  void precalc() {
+    e_z = m_normal / m_normal.norm();
+
+    /* Find a vector orthogonal to e_z via Gram-Schmidt.
+       Since {1,0,0} and {0,1,0} are independent, e_z cannot be
+       parallel to both of them. */
+    if ((Utils::Vector3d{1., 0., 0.} * e_z) < 1.)
+      e_r_axis = Utils::Vector3d{1., 0., 0.} -
+                 (e_z * Utils::Vector3d{1., 0., 0.}) * e_z;
+    else
+      e_r_axis = Utils::Vector3d{0., 1., 0.} -
+                 (e_z * Utils::Vector3d{0., 1., 0.}) * e_z;
+
+    e_r_axis.normalize();
+  }
 
 public:
   Torus()

--- a/src/shapes/include/shapes/Torus.hpp
+++ b/src/shapes/include/shapes/Torus.hpp
@@ -50,13 +50,13 @@ public:
     /* Find a vector orthogonal to e_z via Gram-Schmidt.
        Since {1,0,0} and {0,1,0} are independent, e_z cannot be
        parallel to both of them. */
-    if ((Utils::Vector3d{1., 0., 0.} * e_z) < 1.)
-      e_r_axis = Utils::Vector3d{1., 0., 0.} -
-                 (e_z * Utils::Vector3d{1., 0., 0.}) * e_z;
-    else
-      e_r_axis = Utils::Vector3d{0., 1., 0.} -
-                 (e_z * Utils::Vector3d{0., 1., 0.}) * e_z;
-
+    if (e_z[0] < 1.) {
+      Utils::Vector3d constexpr u_x{{1., 0., 0.}};
+      e_r_axis = u_x - (e_z * u_x) * e_z;
+    } else {
+      Utils::Vector3d constexpr u_y{{0., 1., 0.}};
+      e_r_axis = u_y - (e_z * u_y) * e_z;
+    }
     e_r_axis.normalize();
   }
 

--- a/src/shapes/src/Torus.cpp
+++ b/src/shapes/src/Torus.cpp
@@ -33,7 +33,12 @@ void Torus::calculate_dist(const Utils::Vector3d &pos, double &dist,
   auto const r = r_vec.norm();
 
   dist = (std::sqrt(Utils::sqr(r - m_rad) + z * z) - m_tube_rad) * m_direction;
-  Utils::Vector3d const dir_vec = c_dist - r_vec * m_rad / r;
+
+  /* If exactly on the symmetry axis (r == 0), r_vec / r is undefined (0/0).
+     Use the precomputed e_r_axis as a fallback, matching the convention in
+     Cylinder::calculate_dist. */
+  auto const e_r = (r == 0) ? e_r_axis : r_vec / r;
+  Utils::Vector3d const dir_vec = c_dist - e_r * m_rad;
   auto const dir_vec_norm = dir_vec / dir_vec.norm();
   vec = dir_vec_norm * std::abs(dist);
 }

--- a/src/shapes/src/Torus.cpp
+++ b/src/shapes/src/Torus.cpp
@@ -27,7 +27,7 @@ void Torus::calculate_dist(const Utils::Vector3d &pos, double &dist,
                            Utils::Vector3d &vec) const {
   /* Coordinate transform to cylinder coords
      with origin at m_center. */
-  Utils::Vector3d const c_dist = pos - m_center;
+  auto const c_dist = pos - m_center;
   auto const z = e_z * c_dist;
   auto const r_vec = c_dist - z * e_z;
   auto const r = r_vec.norm();
@@ -37,8 +37,8 @@ void Torus::calculate_dist(const Utils::Vector3d &pos, double &dist,
   /* If exactly on the symmetry axis (r == 0), r_vec / r is undefined (0/0).
      Use the precomputed e_r_axis as a fallback, matching the convention in
      Cylinder::calculate_dist. */
-  auto const e_r = (r == 0) ? e_r_axis : r_vec / r;
-  Utils::Vector3d const dir_vec = c_dist - e_r * m_rad;
+  auto const e_r = (r == 0.) ? e_r_axis : r_vec / r;
+  auto const dir_vec = c_dist - e_r * m_rad;
   auto const dir_vec_norm = dir_vec / dir_vec.norm();
   vec = dir_vec_norm * std::abs(dist);
 }

--- a/src/shapes/src/Torus.cpp
+++ b/src/shapes/src/Torus.cpp
@@ -23,6 +23,44 @@
 
 namespace Shapes {
 
+/*
+ * ASCII diagram of the cross-section of the torus.
+ * Only the rightmost circle is shown.
+ *
+ * Points:
+ * - O is the torus center
+ * - C is the torus core center
+ * - Z is an arbitrary point on the revolution axis
+ * - B is the inner equator
+ * - A is the point for which the normal vector is calculated
+ * - V is the projection of point A on the segment OC
+ *
+ * Vectors:
+ * - c_dist is segment OA
+ * - dir_vec is segment CA
+ * - r_vec is segment OV
+ * - z is segment VA
+ * - e_z is segment OZ
+ *
+ *  Z
+ *  |         A
+ *  |        /|\
+ *  |       / | \
+ *  |      /  |  \
+ *  |     /   |   \   .....
+ *  |    /    |    ..
+ *  |   /     |  .  \
+ *  |  /      | .    \
+ *  | /       | .     \
+ *  |/        |.       \
+ *  +---------++--------+
+ *  O        V .B       C
+ *              .
+ *              .
+ *               .
+ *                 ..
+ *                    .....
+ */
 void Torus::calculate_dist(const Utils::Vector3d &pos, double &dist,
                            Utils::Vector3d &vec) const {
   /* Coordinate transform to cylinder coords
@@ -38,8 +76,15 @@ void Torus::calculate_dist(const Utils::Vector3d &pos, double &dist,
      Use the precomputed e_r_axis as a fallback, matching the convention in
      Cylinder::calculate_dist. */
   auto const e_r = (r == 0.) ? e_r_axis : r_vec / r;
-  auto const dir_vec = c_dist - e_r * m_rad;
-  auto const dir_vec_norm = dir_vec / dir_vec.norm();
-  vec = dir_vec_norm * std::abs(dist);
+  /* Compute surface normal (distance vector from core circle) */
+  auto const dir_vec = r_vec - e_r * m_rad + z * e_z;
+  auto const dir_vec_norm = dir_vec.norm();
+  if (dir_vec_norm < 1e-14) {
+    /* Position is on the core circle, any orientation is possible,
+       return the vector pointing to the torus center */
+    vec = dist * c_dist / c_dist.norm();
+  } else {
+    vec = dir_vec * (m_direction * dist / dir_vec_norm);
+  }
 }
 } // namespace Shapes

--- a/src/shapes/unit_tests/CMakeLists.txt
+++ b/src/shapes/unit_tests/CMakeLists.txt
@@ -28,3 +28,4 @@ espresso_unit_test(SRC Ellipsoid_test.cpp DEPENDS espresso::shapes
 espresso_unit_test(SRC Sphere_test.cpp DEPENDS espresso::shapes espresso::utils)
 espresso_unit_test(SRC NoWhere_test.cpp DEPENDS espresso::shapes
                    espresso::utils)
+espresso_unit_test(SRC Torus_test.cpp DEPENDS espresso::shapes espresso::utils)

--- a/src/shapes/unit_tests/Torus_test.cpp
+++ b/src/shapes/unit_tests/Torus_test.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2010-2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE torus test
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <shapes/Torus.hpp>
+#include <utils/Vector.hpp>
+
+#include <cmath>
+
+BOOST_AUTO_TEST_CASE(torus_axis_no_nan) {
+  Shapes::Torus t;
+  t.m_center = {5., 5., 5.};
+  t.set_normal({0., 0., 1.});
+  t.set_radius(3.);
+  t.set_tube_radius(1.);
+  t.direction() = 1.0;
+
+  /* Point on the torus symmetry axis: r == 0 in torus frame */
+  Utils::Vector3d const pos{5., 5., 4.};
+  double dist{};
+  Utils::Vector3d vec{};
+
+  t.calculate_dist(pos, dist, vec);
+
+  BOOST_CHECK(std::isfinite(dist));
+  BOOST_CHECK(std::isfinite(vec[0]));
+  BOOST_CHECK(std::isfinite(vec[1]));
+  BOOST_CHECK(std::isfinite(vec[2]));
+}

--- a/testsuite/python/constraint_shape_based.py
+++ b/testsuite/python/constraint_shape_based.py
@@ -1039,6 +1039,10 @@ class ShapeBasedConstraintTest(ut.TestCase):
         system = self.system
         box_l = self.box_l
         wall = espressomd.shapes.Wall(normal=[0., 1., 0.], dist=0.)
+        with self.assertRaisesRegex(RuntimeError, "Parameter 'position' is missing"):
+            wall.calc_distance(pos=[1, 1, 1])
+        with self.assertRaisesRegex(RuntimeError, "Parameter 'position' is missing"):
+            wall.is_inside(pos=[1, 1, 1])
         constraint = espressomd.constraints.ShapeBasedConstraint(
             shape=wall, particle_type=1)
         system.constraints.add(constraint)

--- a/testsuite/python/shapes.py
+++ b/testsuite/python/shapes.py
@@ -63,6 +63,55 @@ class ShapeTests(ut.TestCase):
         self.assertAlmostEqual(union.calc_distance(
             position=[1, 2, 6.5])[0], 6.5)
 
+    def test_torus(self):
+        """
+        Check the torus shape. Nomenclature: phi for the toroidal direction
+        and theta for the poloidal direction.
+        """
+        # check points on the revolution axis, using the intercept theorem
+        shape = espressomd.shapes.Torus(
+            normal=[0, 0, 1], direction=1, radius=1.5, tube_radius=0.1)
+        for z in np.arange(-5, 6):
+            dist, vec = shape.calc_distance(
+                position=[0., 0., z * shape.radius])
+            h = np.sqrt((z * shape.radius)**2 + shape.radius**2)
+            np.testing.assert_allclose(dist, h - shape.tube_radius)
+            np.testing.assert_allclose(
+                np.copy(vec), dist / h * shape.radius * np.array([-1., 0., z]))
+
+        shape = espressomd.shapes.Torus(center=[15] * 3, normal=[0, 0, 1],
+                                        direction=1, radius=10., tube_radius=1.)
+        # check points on the tube surface, at different altitudes
+        for phi in np.linspace(0., 2. * np.pi, 65):
+            origin = np.copy(shape.center) + [shape.radius, 0., 0.]
+            for r in np.linspace(0., 2. * shape.tube_radius, 11)[1:]:
+                if np.abs(r - shape.tube_radius) < 1e-6:
+                    continue
+                ref_dist = shape.tube_radius - r
+                for theta in np.linspace(0., 2. * np.pi, 65):
+                    unit_vec = np.array([np.cos(theta), 0., np.sin(theta)])
+                    dist, vec = shape.calc_distance(
+                        position=origin + r * unit_vec)
+                    np.testing.assert_allclose(dist, -ref_dist)
+                    np.testing.assert_allclose(
+                        np.copy(vec), -ref_dist * unit_vec, atol=1e-10)
+            # check points exactly on the tube surface
+            r = shape.tube_radius
+            for theta in np.linspace(0., 2. * np.pi, 65):
+                unit_vec = np.array([np.cos(theta), 0., np.sin(theta)])
+                dist, vec = shape.calc_distance(position=origin + r * unit_vec)
+                np.testing.assert_allclose(dist, 0., atol=1e-14)
+                np.testing.assert_allclose(np.copy(vec), 0., atol=1e-14)
+
+        # check points on the core circle; angle is undefined and by default
+        # the vector will point toward the torus center
+        for phi in np.linspace(0., 2. * np.pi, 65):
+            unit_vec = np.array([np.cos(phi), np.sin(phi), 0.])
+            dist, vec = shape.calc_distance(
+                position=shape.center + shape.radius * unit_vec)
+            ref_vec = -shape.tube_radius * unit_vec
+            np.testing.assert_allclose(np.copy(vec), ref_vec, atol=1e-14)
+
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
When a particle lies on the torus symmetry axis (`r == 0`), `r_vec` is the zero
vector and `r_vec * m_rad / r` computes `0 * inf = NaN`, propagating NaN into
the constraint force direction.  Sibling axial shapes (`Cylinder`, `SimplePore`,
`SpheroCylinder`) all branch on `r == 0` to avoid the division.

**Fix:** add an `e_r_axis` member computed via Gram-Schmidt; replace the bare
`r_vec * m_rad / r` with `e_r * m_rad` where
`e_r = (r == 0) ? e_r_axis : r_vec / r`
(`src/shapes/include/shapes/Torus.hpp`, `src/shapes/src/Torus.cpp`).

**Regression test:** `src/shapes/unit_tests/Torus_test.cpp` (Boost.Test).

Fixes bug #14 of the adversarial core bug sweep.