### PR TITLE
utils: fix linear_interpolation reading one past end at top of range

### DIFF
--- a/src/utils/include/utils/linear_interpolation.hpp
+++ b/src/utils/include/utils/linear_interpolation.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 
@@ -33,9 +34,10 @@ namespace Utils {
 template <typename T, typename Container>
 T linear_interpolation(Container const &table, T hi, T offset, T x) {
   auto const dind = (x - offset) * hi;
-  auto const ind = static_cast<int>(dind);
+  auto const ind =
+      std::min(static_cast<int>(dind), static_cast<int>(table.size()) - 2);
   assert(ind <= dind);
-  assert((ind >= 0) and (static_cast<std::size_t>(ind) < table.size()));
+  assert((ind >= 0) and (static_cast<std::size_t>(ind) < table.size() - 1));
   auto const dx = dind - static_cast<T>(ind);
   auto const uind = static_cast<unsigned int>(ind);
 

--- a/src/utils/tests/linear_interpolation_test.cpp
+++ b/src/utils/tests/linear_interpolation_test.cpp
@@ -36,3 +36,14 @@ BOOST_AUTO_TEST_CASE(interpolation) {
   BOOST_CHECK_SMALL(linear_interpolation(table, 1., 1., 3. - 1e-12) - 9.,
                     1e-10);
 }
+
+BOOST_AUTO_TEST_CASE(interpolation_at_endpoint) {
+  using Utils::linear_interpolation;
+  // tabulated values for f(x) = x^2, x in [1, 3], step 1
+  auto const table = std::vector<double>{{1., 4., 9.}};
+  constexpr auto tol = 1e-12;
+  // Querying exactly at the maximum x (x == maxval == 3.0) must not read
+  // one past the end of the table; it should return table.back() == 9.
+  auto const result = linear_interpolation(table, 1., 1., 3.);
+  BOOST_CHECK_SMALL(result - 9., tol);
+}


### PR DESCRIPTION
`linear_interpolation` returned `table[uind] * (1-dx) + table[uind+1] * dx`.
When `x == maxval` (the clamped upper bound), `uind == table.size()-1` and
`table[uind+1]` is an out-of-bounds heap read.  Although `dx == 0` makes the
OOB read coefficient zero, it is ASan-flagged UB.  `TabulatedPotential` always
clamps to the closed interval `[minval, maxval]`, so `x == maxval` is a normal
path for any tabulated potential evaluated at or beyond the cutoff.

**Fix:** clamp `ind` to at most `table.size()-2` in `linear_interpolation`
(`src/utils/include/utils/linear_interpolation.hpp`).

**Regression test:** `interpolation_at_endpoint` case added to
`src/utils/tests/linear_interpolation_test.cpp`.

Fixes bug #17 of the adversarial core bug sweep.