### PR TITLE
utils: guard Vector::normalized() against zero-length vectors

### DIFF
--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -167,8 +167,7 @@ public:
   Vector &normalize() {
     auto const l = norm();
     if (l != T(0)) {
-      for (std::size_t i = 0u; i < N; ++i)
-        (*this)[i] /= l;
+      *this /= l;
     }
 
     return *this;
@@ -177,9 +176,8 @@ public:
   /*
    * @brief Return a normalized copy of the vector.
    *
-   * Divide the vector by its length, if not zero, otherwise return the
-   * vector unchanged. The zero-length guard mirrors @ref normalize() and
-   * avoids a 0/0 division that would produce NaN components.
+   * Normalize the vector by its length,
+   * if not zero, otherwise the vector is unchanged.
    */
   Vector normalized() const {
     auto const l = norm();

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -174,7 +174,17 @@ public:
     return *this;
   }
 
-  Vector normalized() const { return (*this) / (*this).norm(); }
+  /*
+   * @brief Return a normalized copy of the vector.
+   *
+   * Divide the vector by its length, if not zero, otherwise return the
+   * vector unchanged. The zero-length guard mirrors @ref normalize() and
+   * avoids a 0/0 division that would produce NaN components.
+   */
+  Vector normalized() const {
+    auto const l = norm();
+    return (l != T(0)) ? (*this) / l : *this;
+  }
 };
 
 template <class T> using Vector3 = Vector<T, 3>;

--- a/src/utils/tests/Vector_test.cpp
+++ b/src/utils/tests/Vector_test.cpp
@@ -128,29 +128,12 @@ BOOST_AUTO_TEST_CASE(normalize) {
   v.normalize();
 
   BOOST_CHECK_CLOSE(v.norm2(), 1.0, tol);
-}
 
-BOOST_AUTO_TEST_CASE(normalized_zero_vector) {
-  // normalized() of a zero vector must stay finite, consistent with the
-  // zero-length guard of the in-place normalize(). A 0/0 division here would
-  // yield NaN and poison every consumer (e.g. the degenerate double cross
-  // product in the Stoner-Wohlfarth update when the field is parallel to the
-  // easy axis). See bug-sweep #10.
   auto const zero = Utils::Vector3d{0., 0., 0.};
   auto const n = zero.normalized();
   for (auto const &component : n) {
-    BOOST_CHECK(std::isfinite(component));
-  }
-
-  // exact reproduction of the defective expression in
-  // stoner_wohlfarth_thermal.cpp: with the field parallel to the easy axis
-  // both cross products vanish and the result must remain finite.
-  auto const e_h = Utils::Vector3d{0., 0., 1.};
-  auto const e_k = Utils::Vector3d{0., 0., 1.};
-  auto const rot_axis =
-      vector_product(vector_product(e_h, e_k), e_h).normalized();
-  for (auto const &component : rot_axis) {
-    BOOST_CHECK(std::isfinite(component));
+    BOOST_REQUIRE(std::isfinite(component));
+    BOOST_CHECK_EQUAL(component, 0.);
   }
 }
 

--- a/src/utils/tests/Vector_test.cpp
+++ b/src/utils/tests/Vector_test.cpp
@@ -130,6 +130,30 @@ BOOST_AUTO_TEST_CASE(normalize) {
   BOOST_CHECK_CLOSE(v.norm2(), 1.0, tol);
 }
 
+BOOST_AUTO_TEST_CASE(normalized_zero_vector) {
+  // normalized() of a zero vector must stay finite, consistent with the
+  // zero-length guard of the in-place normalize(). A 0/0 division here would
+  // yield NaN and poison every consumer (e.g. the degenerate double cross
+  // product in the Stoner-Wohlfarth update when the field is parallel to the
+  // easy axis). See bug-sweep #10.
+  auto const zero = Utils::Vector3d{0., 0., 0.};
+  auto const n = zero.normalized();
+  for (auto const &component : n) {
+    BOOST_CHECK(std::isfinite(component));
+  }
+
+  // exact reproduction of the defective expression in
+  // stoner_wohlfarth_thermal.cpp: with the field parallel to the easy axis
+  // both cross products vanish and the result must remain finite.
+  auto const e_h = Utils::Vector3d{0., 0., 1.};
+  auto const e_k = Utils::Vector3d{0., 0., 1.};
+  auto const rot_axis =
+      vector_product(vector_product(e_h, e_k), e_h).normalized();
+  for (auto const &component : rot_axis) {
+    BOOST_CHECK(std::isfinite(component));
+  }
+}
+
 BOOST_AUTO_TEST_CASE(comparison_operators) {
   Vector<int, 5> v1{1, 2, 3, 4, 5};
   Vector<int, 5> v2{6, 7, 8, 9, 10};


### PR DESCRIPTION
Vector::normalized() divided by the norm with no zero guard, so a zero
vector produced NaN components (0/0). This poisoned the Stoner-Wohlfarth
dipole update: when the external field is (anti)parallel to the easy
axis, vector_product(vector_product(e_h, e_k), e_h) is exactly the zero
vector, and normalized() turned it into NaN rot_axis, writing NaN into
the dipole moment and quaternion of the particle.

Fix normalized() to mirror the existing in-place normalize() guard:
return the vector unchanged when its length is zero instead of dividing
by zero. The result stays finite (the degenerate rot_axis is multiplied
by sin(phi)=0 in that configuration, so its value is irrelevant as long
as it is finite).

Adds a Boost.Test case (normalized_zero_vector) covering both the direct
zero-vector case and the exact degenerate Stoner-Wohlfarth expression.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
