### PR TITLE
integrators: register NpT barostat as a readable parameter (bug-sweep #8)

### DIFF
--- a/src/script_interface/integrators/VelocityVerletIsoNPT.cpp
+++ b/src/script_interface/integrators/VelocityVerletIsoNPT.cpp
@@ -47,6 +47,7 @@ VelocityVerletIsoNPT::VelocityVerletIsoNPT() {
        [this]() { return get_instance().get_direction(); }},
       {"cubic_box", AutoParameter::read_only,
        [this]() { return get_instance().cubic_box; }},
+      {"barostat", AutoParameter::read_only, [this]() { return m_barostat; }},
   });
 }
 

--- a/testsuite/python/propagation_npt.py
+++ b/testsuite/python/propagation_npt.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import pickle
 import unittest as ut
 import unittest_decorators as utx
 import tests_common
@@ -63,6 +64,36 @@ class PropagationNPT:
         with self.assertRaises(Exception):
             self.system.integrator.set_isotropic_npt(
                 ext_pressure=1, piston=1, direction=[True, False])
+
+    def test_barostat_survives_serialization(self):
+        """The ``barostat`` selection (Andersen/MTK) must round-trip through
+        the script-interface serialize/deserialize path used by
+        ``save_checkpoint()``/``load_checkpoint()``. ``barostat`` is a
+        construct-time parameter of ``VelocityVerletIsoNPT``; if it is not
+        registered as an ``AutoParameter`` it is dropped on serialization and
+        silently defaults to ``'Andersen'`` on restore (bug-sweep #8).
+        """
+        system = self.system
+        system.integrator.set_isotropic_npt(
+            ext_pressure=1., piston=4., barostat=self.barostat)
+        integrator = system.integrator.integrator
+
+        # the active barostat must be readable from Python
+        self.assertEqual(integrator.get_params()["barostat"], self.barostat)
+
+        # the exact ObjectHandle serialize/deserialize round-trip performed by
+        # checkpointing: pickling the script-interface object goes through
+        # _serialize() and rebuilds it via do_construct()
+        restored = pickle.loads(pickle.dumps(integrator))
+        self.assertEqual(restored.get_params()["barostat"], self.barostat)
+
+        # re-assigning to ``integrator`` fires the IntegratorHandle setter,
+        # which calls activate() and recomputes the integ_switch from the
+        # (de)serialized barostat: it must still match the requested barostat
+        system.integrator.integrator = restored
+        self.assertEqual(
+            system.integrator.integrator.get_params()["barostat"],
+            self.barostat)
 
     @utx.skipIfMissingFeatures(["MASS", "EXTERNAL_FORCES"])
     def test_00_propagation(self):


### PR DESCRIPTION
VelocityVerletIsoNPT::do_construct reads five construct-time parameters
(ext_pressure, piston, cubic_box, direction, barostat) but add_parameters()
registered only the first four. Because ObjectHandle::serialize() emits only
registered parameters and there is no get_internal_state override, the
barostat string (m_barostat) was never serialized. On checkpoint restore (or
any script-interface deserialize), do_construct fell back to the default
'Andersen', so an MTK-configured NpT simulation silently resumed with the
Andersen barostat (a distinct propagation scheme), and the active barostat
could not be read back from Python.

Fix: register 'barostat' as a read-only AutoParameter returning m_barostat,
mirroring the existing ext_pressure/piston/direction/cubic_box entries. This
makes the value round-trip through serialize/deserialize (no longer defaulting
to Andersen) and readable via get_params(). Read-only is correct because the
barostat is only meaningful at construction, where activate() consumes it to
select the integ_switch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
