### PR TITLE
core: fix non-finite FENE energy under compression

### DIFF
--- a/src/core/bonded_interactions/fene.hpp
+++ b/src/core/bonded_interactions/fene.hpp
@@ -97,7 +97,7 @@ inline std::optional<double> FeneBond::energy(Utils::Vector3d const &dx) const {
   double const dr = dx.norm() - r0;
 
   /* check bond stretching */
-  if (dr >= drmax) {
+  if (std::abs(dr) >= drmax) {
     return {};
   }
 

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -78,6 +78,7 @@ espresso_unit_test(SRC BondList_test.cpp DEPENDS espresso::core)
 espresso_unit_test(SRC energy_test.cpp DEPENDS espresso::core)
 espresso_unit_test(SRC bonded_interactions_map_test.cpp DEPENDS espresso::core)
 espresso_unit_test(SRC bond_breakage_test.cpp DEPENDS espresso::core)
+espresso_unit_test(SRC fene_test.cpp DEPENDS espresso::core)
 if(ESPRESSO_BUILD_WITH_WALBERLA)
   espresso_unit_test(SRC lb_particle_coupling_test.cpp DEPENDS espresso::core
                      Boost::mpi MPI::MPI_CXX NUM_PROC 2)

--- a/src/core/unit_tests/fene_test.cpp
+++ b/src/core/unit_tests/fene_test.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2010-2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE "FENE bond"
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include "bonded_interactions/fene.hpp"
+
+#include <utils/Vector.hpp>
+
+#include <cmath>
+#include <optional>
+
+/** Reference: a stretched bond inside the allowed range returns the analytic
+ *  FENE energy and a non-empty force. This guards the common case and makes
+ *  sure the compression fix below does not break ordinary evaluation. */
+BOOST_AUTO_TEST_CASE(fene_energy_matches_analytic_within_range) {
+  auto const k = 2.0;
+  auto const drmax = 1.5;
+  auto const r0 = 2.0;
+  FeneBond const fene{k, drmax, r0};
+
+  // stretched bond: len = 3.0 -> dr = +1.0, |dr| < drmax
+  auto const dx_stretch = Utils::Vector3d{{3.0, 0.0, 0.0}};
+  auto const dr_stretch = dx_stretch.norm() - r0;
+  auto const expected_stretch =
+      -0.5 * k * drmax * drmax *
+      std::log(1.0 - dr_stretch * dr_stretch / (drmax * drmax));
+  auto const energy_stretch = fene.energy(dx_stretch);
+  BOOST_REQUIRE(energy_stretch.has_value());
+  BOOST_CHECK_CLOSE(*energy_stretch, expected_stretch, 1e-10);
+  BOOST_CHECK(fene.force(dx_stretch).has_value());
+
+  // compressed bond still inside the range: len = 1.0 -> dr = -1.0, |dr| <
+  // drmax
+  auto const dx_compress = Utils::Vector3d{{1.0, 0.0, 0.0}};
+  auto const dr_compress = dx_compress.norm() - r0;
+  auto const expected_compress =
+      -0.5 * k * drmax * drmax *
+      std::log(1.0 - dr_compress * dr_compress / (drmax * drmax));
+  auto const energy_compress = fene.energy(dx_compress);
+  BOOST_REQUIRE(energy_compress.has_value());
+  BOOST_CHECK_CLOSE(*energy_compress, expected_compress, 1e-10);
+  BOOST_CHECK(fene.force(dx_compress).has_value());
+}
+
+/** Bug-sweep #9: FENE energy must be symmetric with the force under
+ *  compression. r_0 > d_r_max is a supported configuration. For a bond
+ *  compressed below r_0 - d_r_max we have dr <= -drmax, so the bond is broken
+ *  and both force() and energy() must return an empty optional. Before the fix,
+ *  energy()'s one-sided guard `dr >= drmax` was not taken and the energy
+ *  evaluated log(1 - dr^2/drmax^2) = log(negative) = NaN inside a non-empty
+ *  optional that was then silently summed into the total energy. */
+BOOST_AUTO_TEST_CASE(fene_energy_symmetric_under_compression) {
+  auto const k = 1.0;
+  auto const drmax = 1.0;
+  auto const r0 = 2.0;
+  FeneBond const fene{k, drmax, r0};
+
+  // len = 0.5 -> dr = -1.5, |dr| = 1.5 >= drmax (compressed beyond the range)
+  auto const dx = Utils::Vector3d{{0.5, 0.0, 0.0}};
+
+  auto const force = fene.force(dx);
+  auto const energy = fene.energy(dx);
+
+  // force() already returns {} for |dr| >= drmax (bond broken).
+  BOOST_CHECK(!force.has_value());
+
+  // energy() must mirror force(): empty optional, not a non-empty NaN.
+  BOOST_CHECK(!energy.has_value());
+
+  // Defensive: if energy ever returns a value it must be finite (never NaN).
+  if (energy.has_value()) {
+    BOOST_CHECK(std::isfinite(*energy));
+  }
+}

--- a/src/core/unit_tests/fene_test.cpp
+++ b/src/core/unit_tests/fene_test.cpp
@@ -28,10 +28,10 @@
 #include <cmath>
 #include <optional>
 
-/** Reference: a stretched bond inside the allowed range returns the analytic
- *  FENE energy and a non-empty force. This guards the common case and makes
- *  sure the compression fix below does not break ordinary evaluation. */
-BOOST_AUTO_TEST_CASE(fene_energy_matches_analytic_within_range) {
+/* A stretched FENE bond inside the allowed range returns the analytic
+ * energy and a non-empty force. This guards the common case and makes
+ * sure the compression fix below does not break ordinary evaluation. */
+BOOST_AUTO_TEST_CASE(fene_matches_analytic) {
   auto const k = 2.0;
   auto const drmax = 1.5;
   auto const r0 = 2.0;
@@ -48,8 +48,7 @@ BOOST_AUTO_TEST_CASE(fene_energy_matches_analytic_within_range) {
   BOOST_CHECK_CLOSE(*energy_stretch, expected_stretch, 1e-10);
   BOOST_CHECK(fene.force(dx_stretch).has_value());
 
-  // compressed bond still inside the range: len = 1.0 -> dr = -1.0, |dr| <
-  // drmax
+  // compressed bond still within range: len = 1.0 -> dr = -1.0, |dr| < drmax
   auto const dx_compress = Utils::Vector3d{{1.0, 0.0, 0.0}};
   auto const dr_compress = dx_compress.norm() - r0;
   auto const expected_compress =
@@ -61,33 +60,29 @@ BOOST_AUTO_TEST_CASE(fene_energy_matches_analytic_within_range) {
   BOOST_CHECK(fene.force(dx_compress).has_value());
 }
 
-/** Bug-sweep #9: FENE energy must be symmetric with the force under
- *  compression. r_0 > d_r_max is a supported configuration. For a bond
- *  compressed below r_0 - d_r_max we have dr <= -drmax, so the bond is broken
- *  and both force() and energy() must return an empty optional. Before the fix,
- *  energy()'s one-sided guard `dr >= drmax` was not taken and the energy
- *  evaluated log(1 - dr^2/drmax^2) = log(negative) = NaN inside a non-empty
- *  optional that was then silently summed into the total energy. */
-BOOST_AUTO_TEST_CASE(fene_energy_symmetric_under_compression) {
+/* FENE energy must be symmetric with the force under compression.
+ * r_0 > d_r_max is a supported configuration. For a bond compressed
+ * below r_0 - d_r_max we have dr <= -drmax, so the bond is broken
+ * and both force() and energy() must return an empty optional. */
+BOOST_AUTO_TEST_CASE(fene_symmetric_break) {
   auto const k = 1.0;
   auto const drmax = 1.0;
   auto const r0 = 2.0;
   FeneBond const fene{k, drmax, r0};
 
+  // len = 3.5 -> dr = 1.5, |dr| = 1.5 >= drmax (stretched beyond the range)
+  auto const dx_stretch = Utils::Vector3d{{3.5, 0.0, 0.0}};
+
+  auto const force_stretch = fene.force(dx_stretch);
+  auto const energy_stretch = fene.energy(dx_stretch);
+  BOOST_REQUIRE(!force_stretch.has_value());
+  BOOST_REQUIRE(!energy_stretch.has_value());
+
   // len = 0.5 -> dr = -1.5, |dr| = 1.5 >= drmax (compressed beyond the range)
-  auto const dx = Utils::Vector3d{{0.5, 0.0, 0.0}};
+  auto const dx_compress = Utils::Vector3d{{0.5, 0.0, 0.0}};
 
-  auto const force = fene.force(dx);
-  auto const energy = fene.energy(dx);
-
-  // force() already returns {} for |dr| >= drmax (bond broken).
-  BOOST_CHECK(!force.has_value());
-
-  // energy() must mirror force(): empty optional, not a non-empty NaN.
-  BOOST_CHECK(!energy.has_value());
-
-  // Defensive: if energy ever returns a value it must be finite (never NaN).
-  if (energy.has_value()) {
-    BOOST_CHECK(std::isfinite(*energy));
-  }
+  auto const force_compress = fene.force(dx_compress);
+  auto const energy_compress = fene.energy(dx_compress);
+  BOOST_REQUIRE(!force_compress.has_value());
+  BOOST_REQUIRE(!energy_compress.has_value());
 }

--- a/testsuite/python/interactions_bonded.py
+++ b/testsuite/python/interactions_bonded.py
@@ -288,11 +288,15 @@ class InteractionsBondedTest(ut.TestCase):
             p1.bonds = (fene, p4)  # dist 4.0
             with self.assertRaisesRegex(Exception, error_msg.format(1, 4)):
                 system.integrator.run(0, recalc_forces=True)
+            with self.assertRaisesRegex(Exception, error_msg.format(1, 4)):
+                self.assertEqual(self.system.analysis.energy()["total"], 0.)
             p1.delete_all_bonds()
 
             p2.bonds = (fene, p4)  # dist 3.0
             with self.assertRaisesRegex(Exception, error_msg.format(2, 4)):
                 system.integrator.run(0, recalc_forces=True)
+            with self.assertRaisesRegex(Exception, error_msg.format(2, 4)):
+                self.assertEqual(self.system.analysis.energy()["total"], 0.)
             p2.delete_all_bonds()
 
         with self.subTest(msg="FENE bond breaks on compression"):
@@ -300,12 +304,16 @@ class InteractionsBondedTest(ut.TestCase):
             # Expect bond breakage
             with self.assertRaisesRegex(Exception, error_msg.format(1, 2)):
                 system.integrator.run(0, recalc_forces=True)
+            with self.assertRaisesRegex(Exception, error_msg.format(1, 2)):
+                self.assertEqual(self.system.analysis.energy()["total"], 0.)
             p1.delete_all_bonds()
 
             p3.bonds = (fene, p4)  # dist 1.0
             # Expect bond breakage
             with self.assertRaisesRegex(Exception, error_msg.format(3, 4)):
                 system.integrator.run(0, recalc_forces=True)
+            with self.assertRaisesRegex(Exception, error_msg.format(3, 4)):
+                self.assertEqual(self.system.analysis.energy()["total"], 0.)
             p3.delete_all_bonds()
 
     @ut.skipIf(system.cell_system.get_state()["n_nodes"] < 2,


### PR DESCRIPTION
FeneBond::force() guards bond breakage with `std::abs(dr) >= drmax`
(made symmetric in PR #5195), but FeneBond::energy() still used the
one-sided guard `dr >= drmax`. For a bond compressed below r_0 - d_r_max
(dr <= -drmax, a supported config since r_0 > d_r_max is allowed), the
energy guard was not taken and `log(1 - dr*dr/drmax^2)` received a
non-positive argument, returning NaN/-inf wrapped in a non-empty optional.
That value was silently summed into the total energy with no
bond_broken_error and no NaN sanitization.

Mirror the force() guard so energy() returns an empty optional
(bond-broken) for compression beyond drmax, keeping force and energy
symmetric.

Adds src/core/unit_tests/fene_test.cpp covering the analytic energy
within range and the compression symmetry between force() and energy().

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
