### PR TITLE
observables: reject nonexistent particle ids (bug-sweep #23)

### DIFF
--- a/src/core/observables/PidObservable.cpp
+++ b/src/core/observables/PidObservable.cpp
@@ -19,15 +19,63 @@
 #include "PidObservable.hpp"
 
 #include "ParticleTraits.hpp"
+#include "cell_system/CellStructure.hpp"
 #include "fetch_particles.hpp"
+#include "system/System.hpp"
 
+#include <boost/mpi/collectives/all_reduce.hpp>
 #include <boost/mpi/communicator.hpp>
 
+#include <functional>
+#include <sstream>
+#include <stdexcept>
 #include <vector>
 
 namespace Observables {
+
+/** Validate that every requested particle id corresponds to an existing
+ *  particle. The documented precondition for an observable is that its ids
+ *  refer to existing particles; otherwise @ref fetch_particles silently drops
+ *  the missing ids, which downstream leads to an out-of-bounds read in the
+ *  chain observables and silently-wrong results in the map observables.
+ *
+ *  The check is collective so it cannot deadlock: every rank participates in
+ *  the same reductions and throws the same exception, which is surfaced to
+ *  Python via the script interface's parallel_try_catch wrapper.
+ */
+static void check_particle_ids_exist(boost::mpi::communicator const &comm,
+                                     std::vector<int> const &ids) {
+  auto const &cell_structure = *System::get_system().cell_structure;
+  auto local_count = 0;
+  for (auto const pid : ids) {
+    auto const *ptr = cell_structure.get_local_particle(pid);
+    if (ptr != nullptr and not ptr->is_ghost()) {
+      ++local_count;
+    }
+  }
+  auto const global_count =
+      boost::mpi::all_reduce(comm, local_count, std::plus<int>{});
+  if (global_count != static_cast<int>(ids.size())) {
+    // Identify the first missing id (collectively) for a helpful message.
+    for (auto const pid : ids) {
+      auto const *ptr = cell_structure.get_local_particle(pid);
+      auto const present = (ptr != nullptr and not ptr->is_ghost()) ? 1 : 0;
+      auto const total =
+          boost::mpi::all_reduce(comm, present, std::plus<int>{});
+      if (total == 0) {
+        std::stringstream error_msg;
+        error_msg << "Particle with id " << pid << " does not exist; "
+                  << "the observable cannot be computed because it references "
+                  << "particle ids that do not exist.";
+        throw std::runtime_error(error_msg.str());
+      }
+    }
+  }
+}
+
 std::vector<double>
 PidObservable::operator()(boost::mpi::communicator const &comm) const {
+  check_particle_ids_exist(comm, ids());
   auto const &local_particles = fetch_particles(ids());
   return this->evaluate(comm, local_particles,
                         ParticleObservables::traits<Particle>{});

--- a/testsuite/python/observable_chain.py
+++ b/testsuite/python/observable_chain.py
@@ -19,6 +19,8 @@ import unittest as ut
 import espressomd
 import numpy as np
 import espressomd.observables
+import sys
+import subprocess
 
 
 def cos_persistence_angles(positions):
@@ -243,6 +245,83 @@ class ObservableTests(ut.TestCase):
         for i in range(3):
             with self.assertRaises(RuntimeError):
                 espressomd.observables.CosPersistenceAngles(ids=np.arange(i))
+
+    def test_nonexistent_id_is_rejected(self):
+        """
+        Bug #23: the documented "(existing) particle" precondition for
+        observable ids is unenforced. Passing a nonexistent id to a
+        get_all_particle_positions-family chain observable (here
+        ParticleDistances) makes fetch_particles silently drop the id, so
+        detail::get_argsort produces an out-of-range index that
+        detail::get_all_particle_positions consumes as an out-of-bounds read
+        (assert-abort in debug builds, garbage/SIGSEGV in release).
+
+        Correct behavior is a clear RuntimeError at calculate() time.
+        """
+        # Only particles 0..n_parts-1 exist; 99 does not.
+        nonexistent = 99
+        self.assertNotIn(nonexistent, list(range(self.n_parts)))
+        obs = espressomd.observables.ParticleDistances(
+            ids=[0, 1, 2, nonexistent])
+        self.system.integrator.run(0)
+        with self.assertRaises(RuntimeError):
+            obs.calculate()
+        # Removing the offending particle is not possible here (it never
+        # existed), but valid ids must still work afterwards.
+        obs_ok = espressomd.observables.ParticleDistances(ids=[0, 1, 2])
+        np.testing.assert_array_equal(obs_ok.calculate().shape, (2,))
+
+    @ut.skipIf(
+        system.cell_system.get_state()["n_nodes"] > 1,
+        "subprocess re-initializes espressomd; only safe outside an MPI run")
+    def test_nonexistent_id_does_not_crash_subprocess(self):
+        """
+        Bug #23 (crash-safety): the out-of-bounds read on the unfixed code can
+        abort or segfault the whole process. Run the trigger out-of-process so
+        a crash surfaces as a non-zero/negative return code rather than as a
+        clean Python exception. After the fix the child must exit cleanly and
+        report that the nonexistent id was REJECTED with an exception.
+
+        This runs only single-rank; the multi-rank collective existence check
+        is exercised by ``test_nonexistent_id_is_rejected``.
+        """
+        child_script = r"""
+import espressomd
+import espressomd.observables
+
+system = espressomd.System(box_l=[10., 10., 10.])
+system.time_step = 0.01
+system.cell_system.skin = 0.4
+for i in range(3):
+    system.part.add(pos=[1. + i, 1. + i, 1. + i], id=i)
+system.integrator.run(0)
+try:
+    obs = espressomd.observables.ParticleDistances(ids=[0, 1, 2, 99])
+    res = obs.calculate()
+except Exception as err:
+    print("REJECTED:" + type(err).__name__)
+else:
+    print("NO_REJECTION:" + str(res))
+"""
+        # Run the child with the same interpreter/environment as the parent
+        # (pypresso sets PYTHONPATH in os.environ, inherited by the child).
+        proc = subprocess.run(
+            [sys.executable, "-c", child_script],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True, timeout=300)
+        out = proc.stdout + proc.stderr
+        self.assertGreaterEqual(
+            proc.returncode, 0,
+            msg=f"child killed by signal {-proc.returncode} (OOB/crash); "
+            f"output was:\n{out}")
+        self.assertEqual(
+            proc.returncode, 0,
+            msg=f"child exited with code {proc.returncode}; output:\n{out}")
+        self.assertIn(
+            "REJECTED:", proc.stdout,
+            msg=f"nonexistent observable id was not rejected with an "
+            f"exception (OOB read / silently-wrong result); "
+            f"output:\n{out}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The documented "(existing) particle" precondition for observable ids was
enforced by no layer (Python, script interface, or core). Passing a
nonexistent id to a get_all_particle_positions-family chain observable
(ParticleDistances, BondAngles, BondDihedrals, CosPersistenceAngles, RDF)
made fetch_particles silently drop the missing id, so detail::get_argsort
produced an out-of-range index that detail::get_all_particle_positions
consumed as an out-of-bounds vector read (assert-abort in debug builds,
heap garbage or SIGSEGV in release). The Map family (ParticlePositions/
Velocities/Forces) returned silently-wrong values via the same dropped id.

Add a collective existence check at the single chokepoint
PidObservable::operator(), which runs before fetch_particles() for every
particle-based observable. It counts locally-present, non-ghost particles
matching the requested ids, all_reduce()s the count across ranks, and if it
does not equal ids().size() throws std::runtime_error naming the first
missing id. The reductions are collective on every rank, so there is no MPI
deadlock, and the exception is surfaced to Python via the script interface's
parallel_try_catch wrapper. This mirrors the existing precedent in
script_interface/analysis/Analysis.cpp::check_topology.

Extend testsuite/python/observable_chain.py with a multi-rank in-process
test asserting RuntimeError for a nonexistent id, and a single-rank
subprocess crash-safety test that treats an abort/segfault as failure.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
