### PR TITLE
core/io: fix H5MD charge/force sharing the same enum bit

### DIFF
--- a/src/core/io/writer/h5md_core.hpp
+++ b/src/core/io/writer/h5md_core.hpp
@@ -60,7 +60,7 @@ enum H5MDOutputFields : unsigned int {
   H5MD_OUT_VEL = 8u,
   H5MD_OUT_FORCE = 16u,
   H5MD_OUT_MASS = 32u,
-  H5MD_OUT_CHARGE = 16u,
+  H5MD_OUT_CHARGE = 64u,
   H5MD_OUT_BONDS = 128u,
   H5MD_OUT_BOX_L = 256u,
   H5MD_OUT_LE_OFF = 512u,

--- a/testsuite/python/h5md.py
+++ b/testsuite/python/h5md.py
@@ -218,6 +218,34 @@ class H5mdTests(ut.TestCase):
             self.assertIsNone(cur.get('particles/atoms/box/edges/value'))
             self.assertIsNone(cur.get('connectivity/atoms/value'))
 
+    def test_selective_fields(self):
+        """
+        Each output field must have a distinct bit, so that requesting a
+        single field only creates that field's dataset and no other.
+        Regression test for charge/force sharing the same enum bit.
+        """
+        # request charge only: force dataset must be absent
+        temp_file = self.temp_path / 'charge_only.h5'
+        h5 = espressomd.io.writer.h5md.H5md(
+            file_path=temp_file, fields=['particle.charge'])
+        h5.write()
+        h5.flush()
+        h5.close()
+        with h5py.File(temp_file, 'r') as cur:
+            self.assertIsNotNone(cur.get('particles/atoms/charge/value'))
+            self.assertIsNone(cur.get('particles/atoms/force/value'))
+
+        # request force only: charge dataset must be absent
+        temp_file = self.temp_path / 'force_only.h5'
+        h5 = espressomd.io.writer.h5md.H5md(
+            file_path=temp_file, fields=['particle.force'])
+        h5.write()
+        h5.flush()
+        h5.close()
+        with h5py.File(temp_file, 'r') as cur:
+            self.assertIsNotNone(cur.get('particles/atoms/force/value'))
+            self.assertIsNone(cur.get('particles/atoms/charge/value'))
+
     def test_box(self):
         np.testing.assert_allclose(self.py_box, self.box_l)
 


### PR DESCRIPTION
H5MD_OUT_CHARGE and H5MD_OUT_FORCE both equalled 16u in the
H5MDOutputFields enum, so every `fields & H5MD_OUT_CHARGE` test also
fired for force and vice versa. Requesting fields=['particle.charge']
silently created and wrote the force dataset too (and symmetrically),
and 'charge only' / 'force only' selections could not be expressed.

Give charge its own distinct bit (64u, previously unused; the enum
jumped 32u MASS -> 128u BONDS). H5MD_OUT_ALL already covers bit 64, so
the default 'all' selection and existing 'all' trajectories are
unaffected. Charge and force are independent particle properties that
must both be expressible, so this HANDLEs the case rather than
preventing one of the two fields.

Add a regression test (test_selective_fields in testsuite/python/
h5md.py) asserting that requesting a single field creates only that
field's dataset.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
