### PR TITLE
analysis: raise instead of NaN for empty particle types

### DIFF
--- a/src/core/analysis/statistics.cpp
+++ b/src/core/analysis/statistics.cpp
@@ -38,7 +38,6 @@
 #include <utils/math/sqr.hpp>
 #include <utils/mpi/gather_buffer.hpp>
 
-#include <boost/mpi/collectives/all_reduce.hpp>
 #include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/collectives/reduce.hpp>
 
@@ -172,13 +171,12 @@ Utils::Vector3d center_of_mass(System::System const &system, int p_type) {
     }
   }
   Utils::Vector3d com{};
+  double mass = 1.; // placeholder value to avoid division by zero
   boost::mpi::reduce(::comm_cart, local_com, com, std::plus<>(), 0);
-  // The total mass is needed on every rank: it guards the division below and
-  // the throw must be collective (all ranks throw together) so the calling
-  // script interface code does not deadlock on a subsequent MPI collective.
-  auto const mass =
-      boost::mpi::all_reduce(::comm_cart, local_mass, std::plus<>());
-  if (mass == 0.) {
+  boost::mpi::reduce(::comm_cart, local_mass, mass, std::plus<>(), 0);
+  auto invalid_mass = (mass == 0.);
+  boost::mpi::broadcast(::comm_cart, invalid_mass, 0);
+  if (invalid_mass) {
     throw std::runtime_error(
         "Cannot calculate the center of mass: no particle with non-zero mass "
         "of the given type(s) was found");

--- a/src/core/analysis/statistics.cpp
+++ b/src/core/analysis/statistics.cpp
@@ -38,6 +38,7 @@
 #include <utils/math/sqr.hpp>
 #include <utils/mpi/gather_buffer.hpp>
 
+#include <boost/mpi/collectives/all_reduce.hpp>
 #include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/collectives/reduce.hpp>
 
@@ -47,6 +48,7 @@
 #include <functional>
 #include <limits>
 #include <numbers>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -170,9 +172,17 @@ Utils::Vector3d center_of_mass(System::System const &system, int p_type) {
     }
   }
   Utils::Vector3d com{};
-  double mass = 1.; // placeholder value to avoid division by zero
   boost::mpi::reduce(::comm_cart, local_com, com, std::plus<>(), 0);
-  boost::mpi::reduce(::comm_cart, local_mass, mass, std::plus<>(), 0);
+  // The total mass is needed on every rank: it guards the division below and
+  // the throw must be collective (all ranks throw together) so the calling
+  // script interface code does not deadlock on a subsequent MPI collective.
+  auto const mass =
+      boost::mpi::all_reduce(::comm_cart, local_mass, std::plus<>());
+  if (mass == 0.) {
+    throw std::runtime_error(
+        "Cannot calculate the center of mass: no particle with non-zero mass "
+        "of the given type(s) was found");
+  }
   return com / mass;
 }
 
@@ -200,7 +210,11 @@ Utils::Vector9d gyration_tensor(System::System const &system,
 
   Utils::Vector9d mat{};
   if (::comm_cart.rank() == 0) {
-    assert(not buf_pos.empty());
+    if (buf_pos.empty()) {
+      throw std::runtime_error(
+          "Cannot calculate the gyration tensor: no particle of the given "
+          "type(s) was found");
+    }
     auto const center =
         std::accumulate(buf_pos.begin(), buf_pos.end(), Utils::Vector3d{}) /
         static_cast<double>(buf_pos.size());

--- a/src/script_interface/analysis/Analysis.cpp
+++ b/src/script_interface/analysis/Analysis.cpp
@@ -167,9 +167,13 @@ Variant Analysis::do_call_method(std::string const &name,
   }
   if (name == "center_of_mass") {
     auto const p_type = get_value<int>(parameters, "p_type");
-    context()->parallel_try_catch([&]() { check_particle_type(p_type); });
-    auto const local = center_of_mass(get_system(), p_type);
-    return mpi_reduce_sum(context()->get_comm(), local).as_vector();
+    Variant output;
+    context()->parallel_try_catch([&]() {
+      check_particle_type(p_type);
+      auto const local = center_of_mass(get_system(), p_type);
+      output = mpi_reduce_sum(context()->get_comm(), local).as_vector();
+    });
+    return output;
   }
   if (name == "angular_momentum") {
     auto const p_type = get_value<int>(parameters, "p_type");
@@ -216,17 +220,25 @@ Variant Analysis::do_call_method(std::string const &name,
   }
   if (name == "gyration_tensor") {
     auto const p_types = get_value<std::vector<int>>(parameters, "p_types");
-    for (auto const p_type : p_types) {
-      context()->parallel_try_catch([&]() { check_particle_type(p_type); });
-    }
-    auto const mat = gyration_tensor(get_system(), p_types);
-    return std::vector<double>(mat.begin(), mat.end());
+    Variant output;
+    context()->parallel_try_catch([&]() {
+      for (auto const p_type : p_types) {
+        check_particle_type(p_type);
+      }
+      auto const mat = gyration_tensor(get_system(), p_types);
+      output = std::vector<double>(mat.begin(), mat.end());
+    });
+    return output;
   }
   if (name == "moment_of_inertia_matrix") {
     auto const p_type = get_value<int>(parameters, "p_type");
-    context()->parallel_try_catch([&]() { check_particle_type(p_type); });
-    auto const local = moment_of_inertia_matrix(get_system(), p_type);
-    return mpi_reduce_sum(context()->get_comm(), local).as_vector();
+    Variant output;
+    context()->parallel_try_catch([&]() {
+      check_particle_type(p_type);
+      auto const local = moment_of_inertia_matrix(get_system(), p_type);
+      output = mpi_reduce_sum(context()->get_comm(), local).as_vector();
+    });
+    return output;
   }
   if (name == "structure_factor") {
     auto const order = get_value<int>(parameters, "sf_order");

--- a/src/script_interface/analysis/Analysis.cpp
+++ b/src/script_interface/analysis/Analysis.cpp
@@ -167,13 +167,13 @@ Variant Analysis::do_call_method(std::string const &name,
   }
   if (name == "center_of_mass") {
     auto const p_type = get_value<int>(parameters, "p_type");
-    Variant output;
+    Variant result;
     context()->parallel_try_catch([&]() {
       check_particle_type(p_type);
       auto const local = center_of_mass(get_system(), p_type);
-      output = mpi_reduce_sum(context()->get_comm(), local).as_vector();
+      result = mpi_reduce_sum(context()->get_comm(), local).as_vector();
     });
-    return output;
+    return result;
   }
   if (name == "angular_momentum") {
     auto const p_type = get_value<int>(parameters, "p_type");
@@ -220,25 +220,25 @@ Variant Analysis::do_call_method(std::string const &name,
   }
   if (name == "gyration_tensor") {
     auto const p_types = get_value<std::vector<int>>(parameters, "p_types");
-    Variant output;
+    Variant result;
     context()->parallel_try_catch([&]() {
       for (auto const p_type : p_types) {
         check_particle_type(p_type);
       }
       auto const mat = gyration_tensor(get_system(), p_types);
-      output = std::vector<double>(mat.begin(), mat.end());
+      result = std::vector<double>(mat.begin(), mat.end());
     });
-    return output;
+    return result;
   }
   if (name == "moment_of_inertia_matrix") {
     auto const p_type = get_value<int>(parameters, "p_type");
-    Variant output;
+    Variant result;
     context()->parallel_try_catch([&]() {
       check_particle_type(p_type);
       auto const local = moment_of_inertia_matrix(get_system(), p_type);
-      output = mpi_reduce_sum(context()->get_comm(), local).as_vector();
+      result = mpi_reduce_sum(context()->get_comm(), local).as_vector();
     });
-    return output;
+    return result;
   }
   if (name == "structure_factor") {
     auto const order = get_value<int>(parameters, "sf_order");

--- a/testsuite/python/analyze_mass_related.py
+++ b/testsuite/python/analyze_mass_related.py
@@ -148,6 +148,33 @@ class AnalyzeMassRelated(ut.TestCase):
                 self.system.analysis.calc_rg(chain_start=0, number_of_chains=1,
                                              chain_length=len(self.system.part))
 
+    def test_empty_but_seen_type(self):
+        """A particle type that was seen (so it passes the type-range check)
+        but currently has no particles must not silently produce NaN (a
+        division by zero) in the mass-related analysis routines. The routines
+        must raise instead.
+
+        See bug-sweep #47: ``check_particle_type`` only verifies that
+        ``0 <= p_type <= max_seen_particle_type`` and ``max_seen`` is never
+        decremented when particles are removed, so a seen-then-deleted type
+        passes validation while contributing an empty buffer / zero total mass.
+        """
+        # Pick a brand new type, make it "seen", then empty it again.
+        empty_type = max(self.system.part.all().type) + 17
+        p = self.system.part.add(pos=[1., 1., 1.], type=empty_type)
+        p.remove()
+
+        # ``center_of_mass`` has no assert, so on the unfixed code it returns a
+        # vector of NaN (0/0) instead of raising. Check it first so the test
+        # fails cleanly on the unfixed code without triggering the (RelWith-
+        # Assert) abort inside ``gyration_tensor``.
+        with self.assertRaises(Exception):
+            self.system.analysis.center_of_mass(p_type=empty_type)
+        with self.assertRaises(Exception):
+            self.system.analysis.gyration_tensor(p_type=empty_type)
+        with self.assertRaises(Exception):
+            self.system.analysis.moment_of_inertia_matrix(p_type=empty_type)
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/analyze_mass_related.py
+++ b/testsuite/python/analyze_mass_related.py
@@ -149,30 +149,21 @@ class AnalyzeMassRelated(ut.TestCase):
                                              chain_length=len(self.system.part))
 
     def test_empty_but_seen_type(self):
-        """A particle type that was seen (so it passes the type-range check)
-        but currently has no particles must not silently produce NaN (a
-        division by zero) in the mass-related analysis routines. The routines
-        must raise instead.
-
-        See bug-sweep #47: ``check_particle_type`` only verifies that
-        ``0 <= p_type <= max_seen_particle_type`` and ``max_seen`` is never
-        decremented when particles are removed, so a seen-then-deleted type
-        passes validation while contributing an empty buffer / zero total mass.
         """
-        # Pick a brand new type, make it "seen", then empty it again.
+        A particle type that was seen (so it passes the type-range check)
+        but currently has no particles must not divide by zero in mass-related
+        analysis routines.
+        """
+        # create a new type, make it "seen", then make it empty
         empty_type = max(self.system.part.all().type) + 17
         p = self.system.part.add(pos=[1., 1., 1.], type=empty_type)
         p.remove()
 
-        # ``center_of_mass`` has no assert, so on the unfixed code it returns a
-        # vector of NaN (0/0) instead of raising. Check it first so the test
-        # fails cleanly on the unfixed code without triggering the (RelWith-
-        # Assert) abort inside ``gyration_tensor``.
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "no particle with non-zero mass of the given type"):
             self.system.analysis.center_of_mass(p_type=empty_type)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "no particle of the given type"):
             self.system.analysis.gyration_tensor(p_type=empty_type)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "no particle with non-zero mass of the given type"):
             self.system.analysis.moment_of_inertia_matrix(p_type=empty_type)
 
 


### PR DESCRIPTION
check_particle_type only verifies 0 <= p_type <= max_seen_particle_type,
and max_seen is never decremented when particles are removed. A
seen-then-deleted type (or any populated-then-emptied type) therefore
passes validation while contributing an empty buffer / zero total mass.

On such a type the analysis routines divided by zero:
- center_of_mass returned com/mass = 0/0 = NaN (the `double mass = 1.`
  placeholder was a red herring: boost::mpi::reduce overwrites the root's
  output with the reduced sum, so it never prevented the division).
- gyration_tensor divided by buf_pos.size() == 0; its non-empty
  precondition was only a release-stripped assert(), so it produced NaN
  in Release and aborted in RelWithAssert.
moment_of_inertia_matrix inherits center_of_mass, so it threw too.

Fix (PREVENT, matching the subsystem convention where bad analysis
preconditions throw):
- center_of_mass: all_reduce the total mass to every rank and throw a
  std::runtime_error when it is zero. The throw is collective so the
  script interface does not deadlock on the following MPI collective.
- gyration_tensor: replace the assert with a real throw on rank 0.
- Analysis.cpp: move the core calls and their MPI collectives inside
  context()->parallel_try_catch (mirroring calc_rg) so the new throws
  are marshalled correctly across MPI.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
