### PR TITLE
observables: honor documented LBVelocityProfile optional defaults

### DIFF
--- a/src/script_interface/observables/LBProfileObservable.hpp
+++ b/src/script_interface/observables/LBProfileObservable.hpp
@@ -92,10 +92,6 @@ public:
 
   void do_construct(VariantMap const &params) override {
     ObjectHandle::context()->parallel_try_catch([&]() {
-      // The sampling/offset/allow_empty_bins parameters are documented as
-      // optional with concrete defaults; honor them via get_value_or so that
-      // relying on the documented API does not raise a missing-parameter error
-      // (matching the convention used by the cylindrical profile observables).
       m_observable = std::make_shared<CoreLBObs>(
           get_value_or<double>(params, "sampling_delta_x", 1.),
           get_value_or<double>(params, "sampling_delta_y", 1.),

--- a/src/script_interface/observables/LBProfileObservable.hpp
+++ b/src/script_interface/observables/LBProfileObservable.hpp
@@ -26,6 +26,7 @@
 
 #include "Observable.hpp"
 #include "core/observables/LBProfileObservable.hpp"
+#include "script_interface/get_value.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -91,14 +92,27 @@ public:
 
   void do_construct(VariantMap const &params) override {
     ObjectHandle::context()->parallel_try_catch([&]() {
-      m_observable =
-          make_shared_from_args<CoreLBObs, double, double, double, double,
-                                double, double, int, int, int, double, double,
-                                double, double, double, double, bool>(
-              params, "sampling_delta_x", "sampling_delta_y",
-              "sampling_delta_z", "sampling_offset_x", "sampling_offset_y",
-              "sampling_offset_z", "n_x_bins", "n_y_bins", "n_z_bins", "min_x",
-              "max_x", "min_y", "max_y", "min_z", "max_z", "allow_empty_bins");
+      // The sampling/offset/allow_empty_bins parameters are documented as
+      // optional with concrete defaults; honor them via get_value_or so that
+      // relying on the documented API does not raise a missing-parameter error
+      // (matching the convention used by the cylindrical profile observables).
+      m_observable = std::make_shared<CoreLBObs>(
+          get_value_or<double>(params, "sampling_delta_x", 1.),
+          get_value_or<double>(params, "sampling_delta_y", 1.),
+          get_value_or<double>(params, "sampling_delta_z", 1.),
+          get_value_or<double>(params, "sampling_offset_x", 0.),
+          get_value_or<double>(params, "sampling_offset_y", 0.),
+          get_value_or<double>(params, "sampling_offset_z", 0.),
+          get_value<int>(params, "n_x_bins"),
+          get_value<int>(params, "n_y_bins"),
+          get_value<int>(params, "n_z_bins"),
+          get_value<double>(params, "min_x"),
+          get_value<double>(params, "max_x"),
+          get_value<double>(params, "min_y"),
+          get_value<double>(params, "max_y"),
+          get_value<double>(params, "min_z"),
+          get_value<double>(params, "max_z"),
+          get_value_or<bool>(params, "allow_empty_bins", false));
     });
   }
 

--- a/testsuite/python/observables.py
+++ b/testsuite/python/observables.py
@@ -242,11 +242,7 @@ class Observables(ut.TestCase):
             espressomd.observables.TotalForce(ids=id_list).calculate())
 
     def test_lb_velocity_profile_optional_defaults(self):
-        # The optional sampling/offset/allow_empty_bins parameters are
-        # documented as having defaults (sampling_delta_*=1.0,
-        # sampling_offset_*=0.0, allow_empty_bins=False). Relying on the
-        # documented API by omitting them must succeed and the read-only
-        # getters must report exactly those defaults.
+        # check default arguments
         required = dict(
             n_x_bins=10, n_y_bins=10, n_z_bins=10,
             min_x=0., max_x=10., min_y=0., max_y=10., min_z=0., max_z=10.)
@@ -259,7 +255,7 @@ class Observables(ut.TestCase):
         self.assertEqual(observable.sampling_offset_z, 0.0)
         self.assertFalse(observable.allow_empty_bins)
 
-        # Explicitly supplied optional values must still round-trip.
+        # explicitly supplied optional values must round-trip
         observable = espressomd.observables.LBVelocityProfile(
             sampling_delta_x=0.5, sampling_delta_y=0.25, sampling_delta_z=2.0,
             sampling_offset_x=0.1, sampling_offset_y=0.2, sampling_offset_z=0.3,

--- a/testsuite/python/observables.py
+++ b/testsuite/python/observables.py
@@ -241,6 +241,37 @@ class Observables(ut.TestCase):
             np.sum(particles.f, axis=0),
             espressomd.observables.TotalForce(ids=id_list).calculate())
 
+    def test_lb_velocity_profile_optional_defaults(self):
+        # The optional sampling/offset/allow_empty_bins parameters are
+        # documented as having defaults (sampling_delta_*=1.0,
+        # sampling_offset_*=0.0, allow_empty_bins=False). Relying on the
+        # documented API by omitting them must succeed and the read-only
+        # getters must report exactly those defaults.
+        required = dict(
+            n_x_bins=10, n_y_bins=10, n_z_bins=10,
+            min_x=0., max_x=10., min_y=0., max_y=10., min_z=0., max_z=10.)
+        observable = espressomd.observables.LBVelocityProfile(**required)
+        self.assertEqual(observable.sampling_delta_x, 1.0)
+        self.assertEqual(observable.sampling_delta_y, 1.0)
+        self.assertEqual(observable.sampling_delta_z, 1.0)
+        self.assertEqual(observable.sampling_offset_x, 0.0)
+        self.assertEqual(observable.sampling_offset_y, 0.0)
+        self.assertEqual(observable.sampling_offset_z, 0.0)
+        self.assertFalse(observable.allow_empty_bins)
+
+        # Explicitly supplied optional values must still round-trip.
+        observable = espressomd.observables.LBVelocityProfile(
+            sampling_delta_x=0.5, sampling_delta_y=0.25, sampling_delta_z=2.0,
+            sampling_offset_x=0.1, sampling_offset_y=0.2, sampling_offset_z=0.3,
+            allow_empty_bins=True, **required)
+        self.assertEqual(observable.sampling_delta_x, 0.5)
+        self.assertEqual(observable.sampling_delta_y, 0.25)
+        self.assertEqual(observable.sampling_delta_z, 2.0)
+        self.assertEqual(observable.sampling_offset_x, 0.1)
+        self.assertEqual(observable.sampling_offset_y, 0.2)
+        self.assertEqual(observable.sampling_offset_z, 0.3)
+        self.assertTrue(observable.allow_empty_bins)
+
 
 if __name__ == "__main__":
     ut.main()


### PR DESCRIPTION
LBProfileObservable::do_construct built the core observable via
make_shared_from_args, which resolves every parameter with get_value and
throws "Parameter '...' is missing." when an optional one is omitted. The
sampling_delta_*/sampling_offset_*/allow_empty_bins parameters are documented
as optional with concrete defaults (1.0/0.0/False), so following the documented
API (e.g. LBVelocityProfile(n_x_bins=..., min_x=..., max_x=..., ...)) raised a
RuntimeError instead of constructing the observable.

Construct the observable explicitly with std::make_shared, using get_value_or
to supply the documented defaults for the seven optional parameters while
keeping get_value for the required n_*_bins / min_* / max_*. This mirrors the
convention already used by the cylindrical profile observables. Added a
regression test in testsuite/python/observables.py that constructs
LBVelocityProfile relying on the defaults and asserts the read-only getters
return them, plus a round-trip check with explicit values.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
