### PR TITLE
magnetostatics: require 'prefactor' for DipolarP3M

### DIFF
--- a/src/python/espressomd/magnetostatics.py
+++ b/src/python/espressomd/magnetostatics.py
@@ -160,7 +160,7 @@ class DipolarP3M(MagnetostaticInteraction):
             raise TypeError("Parameter 'tune' has to be a boolean")
 
     def required_keys(self):
-        return {"accuracy"}
+        return {"prefactor", "accuracy"}
 
     def default_params(self):
         return {"cao": -1,

--- a/testsuite/python/dipolar_interface.py
+++ b/testsuite/python/dipolar_interface.py
@@ -128,6 +128,10 @@ class Test(ut.TestCase):
         MDLC = espressomd.magnetostatics.DLC
         dp3m_params = dict(prefactor=1., epsilon=0.1, accuracy=1e-6,
                            mesh=[49, 49, 49], cao=7, r_cut=4.5, alpha=0.9)
+        with self.assertRaisesRegex(RuntimeError, "Parameter 'prefactor' is missing"):
+            espressomd.magnetostatics.DipolarP3M(
+                **{key: value for key, value in dp3m_params.items()
+                   if key != 'prefactor'})
         with self.assertRaisesRegex(ValueError, "Parameter 'prefactor' must be > 0"):
             espressomd.magnetostatics.DipolarP3M(
                 **{**dp3m_params, 'prefactor': -2.})


### PR DESCRIPTION
DipolarP3M.required_keys() returned only {"accuracy"}, so omitting the
prefactor silently passed the Python required-keys check. default_params()
then injected prefactor=0.0, the base float type check accepted it, and the
value reached the core, which threw the misleading
ValueError "Parameter 'prefactor' must be > 0" instead of the clean,
documented RuntimeError "Parameter 'prefactor' is missing".

Add 'prefactor' to DipolarP3M.required_keys() so the missing-key contract is
enforced at the Python layer before the placeholder default is applied. This
mirrors the established convention of electrostatics P3M
(required_keys() -> {"prefactor", "accuracy"}) and the sibling
DipolarDirectSum (required_keys() -> {"prefactor"}).

Extend test_exceptions_p3m in testsuite/python/dipolar_interface.py to assert
that constructing DipolarP3M without a prefactor raises the clean
RuntimeError "Parameter 'prefactor' is missing".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
