### PR TITLE
utils: fully reset RunningAverage in clear()

### DIFF
--- a/src/utils/include/utils/statistics/RunningAverage.hpp
+++ b/src/utils/include/utils/statistics/RunningAverage.hpp
@@ -56,7 +56,13 @@ public:
     m_max = std::max(m_max, s);
   }
 
-  void clear() { m_n = 0; }
+  void clear() {
+    m_n = 0;
+    m_old_avg = m_new_avg = 0;
+    m_old_var = m_new_var = 0;
+    m_min = std::numeric_limits<Scalar>::max();
+    m_max = -std::numeric_limits<Scalar>::max();
+  }
 
   int n() const { return m_n; }
 

--- a/src/utils/tests/RunningAverage_test.cpp
+++ b/src/utils/tests/RunningAverage_test.cpp
@@ -80,6 +80,30 @@ BOOST_AUTO_TEST_CASE(simple_variance_check) {
               std::numeric_limits<double>::epsilon());
 }
 
+BOOST_AUTO_TEST_CASE(clear_then_resample) {
+  Utils::Statistics::RunningAverage<double> avg;
+
+  /* Accumulate some samples whose variance and extrema differ from the
+   * post-clear data, so any stale state leaks into the re-sampled results. */
+  avg.add_sample(0.0);
+  avg.add_sample(10.0);
+
+  avg.clear();
+
+  BOOST_CHECK(avg.n() == 0);
+
+  /* Re-sample with a fresh data set {1, 3}: avg = 2, population variance
+   * = ((1-2)^2 + (3-2)^2) / 2 = 1, min = 1, max = 3. */
+  avg.add_sample(1.0);
+  avg.add_sample(3.0);
+
+  BOOST_CHECK(avg.n() == 2);
+  BOOST_CHECK_SMALL(avg.avg() - 2.0, 1e-12);
+  BOOST_CHECK_SMALL(avg.var() - 1.0, 1e-12);
+  BOOST_CHECK(avg.min() == 1.0);
+  BOOST_CHECK(avg.max() == 3.0);
+}
+
 BOOST_AUTO_TEST_CASE(mean_and_variance) {
   auto constexpr sample_size = sizeof(RandomSequence::values) / sizeof(double);
   Utils::Statistics::RunningAverage<double> running_average;


### PR DESCRIPTION
RunningAverage::clear() only reset the sample count m_n, leaving the
running average, variance, and min/max accumulators stale. After a
clear() followed by re-sampling, var() folded the pre-clear variance
into the new data and min()/max() returned the pre-clear extrema,
silently corrupting a reused accumulator.

Reset all members in clear() so it mirrors the constructor's clean
state. Add a clear_then_resample unit test that re-samples after
clear() and checks avg/var/min/max.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
