### PR TITLE
Add EK species/container tau cross-check

### DIFF
--- a/src/script_interface/walberla/EKContainer.hpp
+++ b/src/script_interface/walberla/EKContainer.hpp
@@ -103,6 +103,12 @@ class EKContainer : public ObjectList<EKSpecies, EK::Container> {
         throw std::runtime_error(
             "Cannot mix single and double precision kernels");
       }
+      auto const tau_container = m_ek_container->get_tau();
+      auto const tau_species = get_value<double>(obj_ptr->get_parameter("tau"));
+      if (tau_species != tau_container) {
+        throw std::runtime_error(
+            "EK species and EK container must have the same tau");
+      }
       ek_throw_if_expired(obj_ptr->get_mpi_cart_comm_observer());
       m_ek_container->add(obj_ptr->get_ekinstance());
     });

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -333,6 +333,22 @@ class EKTest:
             ek_solver_incompatible)
         self.assertEqual(len(self.system.ekcontainer), 1)
 
+    def test_ek_tau_mismatch_exception(self):
+        # the species derives all of its MD<->lattice conversion factors from
+        # its own tau, while the integrator and the MD-tau veto use the
+        # container tau; a mismatch silently produces wrong physics, so adding
+        # a species whose tau differs from the container tau must be rejected
+        self.assertAlmostEqual(
+            self.system.ekcontainer.tau, self.params["tau"], delta=self.atol)
+        ek_species_mismatch = self.make_default_ek_species(
+            tau=2. * self.params["tau"])
+        with self.assertRaisesRegex(RuntimeError, "same tau"):
+            self.system.ekcontainer.add(ek_species_mismatch)
+        self.assertEqual(len(self.system.ekcontainer), 0)
+        # a species with the matching tau can still be added
+        self.system.ekcontainer.add(self.make_default_ek_species())
+        self.assertEqual(len(self.system.ekcontainer), 1)
+
     def test_ek_solver_exceptions(self):
         ek_solver = self.system.ekcontainer.solver
         ek_species = self.make_default_ek_species()

--- a/testsuite/python/ek_interface.py
+++ b/testsuite/python/ek_interface.py
@@ -332,21 +332,9 @@ class EKTest:
             self.system.ekcontainer.solver,
             ek_solver_incompatible)
         self.assertEqual(len(self.system.ekcontainer), 1)
-
-    def test_ek_tau_mismatch_exception(self):
-        # the species derives all of its MD<->lattice conversion factors from
-        # its own tau, while the integrator and the MD-tau veto use the
-        # container tau; a mismatch silently produces wrong physics, so adding
-        # a species whose tau differs from the container tau must be rejected
-        self.assertAlmostEqual(
-            self.system.ekcontainer.tau, self.params["tau"], delta=self.atol)
-        ek_species_mismatch = self.make_default_ek_species(
-            tau=2. * self.params["tau"])
-        with self.assertRaisesRegex(RuntimeError, "same tau"):
-            self.system.ekcontainer.add(ek_species_mismatch)
-        self.assertEqual(len(self.system.ekcontainer), 0)
-        # a species with the matching tau can still be added
-        self.system.ekcontainer.add(self.make_default_ek_species())
+        # the tau value must match for units conversion
+        with self.assertRaisesRegex(RuntimeError, "EK species and EK container must have the same tau"):
+            self.system.ekcontainer.add(self.make_default_ek_species(tau=200.))
         self.assertEqual(len(self.system.ekcontainer), 1)
 
     def test_ek_solver_exceptions(self):


### PR DESCRIPTION
EKContainer::add_in_core validated only floating-point precision and the
MPI Cartesian-communicator observer, never comparing the new species' tau
against the container's tau. An EKSpecies derives all of its MD<->lattice
conversion factors (diffusion, flux, energy, external e-field) from its own
tau, while the integrator and the MD-tau veto use the container tau. When
the two differ, effective diffusion/flux/mobility are wrong by a factor of
tau_species/tau_container with no error raised: ekcontainer.add(species)
succeeded silently.

Add a tau comparison inside the existing parallel_try_catch lambda, next to
the precision/observer checks, throwing std::runtime_error when the species
tau differs from the container tau. The check runs under the same
coordinated parallel_try_catch on every rank, so it cannot diverge. This
PREVENTs the inconsistent input rather than silently rescaling baked-in
conversion factors, matching how every other add-time mismatch in this path
is treated and the documented contract that tau must be an integer multiple
of the MD time step on both classes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
