### PR TITLE
script_interface: fix LB node _population OOB read

### DIFF
--- a/src/script_interface/walberla/LBFluidNode.cpp
+++ b/src/script_interface/walberla/LBFluidNode.cpp
@@ -33,6 +33,7 @@
 #include <boost/mpi/communicator.hpp>
 
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -88,6 +89,13 @@ Variant LBFluidNode::do_call_method(std::string const &name,
   }
   if (name == "set_population") {
     auto const pop = get_value<std::vector<double>>(params, "value");
+    context()->parallel_try_catch([&]() {
+      if (pop.size() != m_lb_fluid->stencil_size()) {
+        throw std::runtime_error("Population must have exactly " +
+                                 std::to_string(m_lb_fluid->stencil_size()) +
+                                 " elements");
+      }
+    });
     m_lb_fluid->set_node_population(m_index, pop);
     m_lb_fluid->ghost_communication();
     return {};

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -134,6 +134,11 @@ class LBTest:
             lbf[0, 0, 0].velocity = [1, 2]
         with self.assertRaises(TypeError):
             lbf[0, 1].velocity = [1, 2, 3]
+        # check node population setter rejects wrong-length vectors
+        with self.assertRaises(RuntimeError):
+            lbf[0, 0, 0]._population = [1., 2.]
+        with self.assertRaises(RuntimeError):
+            lbf[0, 0, 0]._population = [1.] * 42
         # check node setters update cached velocities (with precision loss)
         lbnode = lbf[0, 0, 0]
         lbnode.last_applied_force = [0., 0., 0.]


### PR DESCRIPTION
The LBFluidNode "set_population" branch forwarded the user-supplied
vector to LBWalberlaBase::set_node_population verbatim, with no
length check at any layer (Python, SI, or core). The core
LBNodeAccess loop reads population[f] for f in [0, Stencil::Size)
(19 for D3Q19) via unchecked operator[], so a too-short vector (e.g.
lbf[0,0,0]._population = [1., 2.]) reads past the std::vector buffer,
injecting garbage populations or crashing. The slice path already
validates length via get_value_shape; the node path did not.

Fix: PREVENT the bad input. Before calling set_node_population, check
pop.size() == m_lb_fluid->stencil_size() inside parallel_try_catch so
the throw on the owning rank propagates uniformly to a Python
exception instead of an MPI desync. A malformed population vector is a
user error with no meaningful completion; padding/truncating would
silently inject incorrect physics. This mirrors the existing
checkpoint "population size mismatch" validation (LBFluid.cpp).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
