### PR TITLE
Improve compiler support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,10 @@ set_property(
   TARGET espresso_compiler_flags APPEND
   PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_${ESPRESSO_MINIMAL_CXX_STANDARD})
 
+add_library(espresso_kokkos_compiler_flags INTERFACE)
+add_library(espresso::kokkos::compiler_flags ALIAS
+            espresso_kokkos_compiler_flags)
+
 #
 # AVX2 support
 #
@@ -280,13 +284,20 @@ if(ESPRESSO_BUILD_WITH_CUDA)
   endif()
   if(NOT DEFINED ESPRESSO_CMAKE_CUDA_ARCHITECTURES)
     if("$ENV{CUDAARCHS}" STREQUAL "")
-      # 1. sm_61: GTX-1000 series (Pascal)
-      # 2. sm_75: RTX-2000 series (Turing)
-      # 3. sm_86: RTX-3000 series (Ampere)
-      # 4. sm_89: RTX-4000 series (Ada)
-      # 5. sm_90: H100 series (Hopper)
-      # 6. sm_120: RTX-5000 series (Blackwell)
+      # cmake-format: off
+      # sm_60: P100 series (Pascal)
+      # sm_61: GTX-1000 series (Pascal)
+      # sm_70: V100 series (Volta)
+      # sm_75: RTX-2000 series (Turing)
+      # sm_86: RTX-3000 series (Ampere)
+      # sm_89: RTX-4000 series (Ada)
+      # sm_90: H100 series (Hopper)
+      # sm_120: RTX-5000 series (Blackwell)
+      # cmake-format: on
       set(ESPRESSO_CUDA_ARCHITECTURES "75;86;89")
+      if(Kokkos_ENABLE_CUDA)
+        set(ESPRESSO_CUDA_ARCHITECTURES "86")
+      endif()
     else()
       set(ESPRESSO_CUDA_ARCHITECTURES "$ENV{CUDAARCHS}")
     endif()
@@ -294,6 +305,14 @@ if(ESPRESSO_BUILD_WITH_CUDA)
         CACHE INTERNAL "")
   endif()
   set(CMAKE_CUDA_ARCHITECTURES "${ESPRESSO_CMAKE_CUDA_ARCHITECTURES}")
+  list(LENGTH CMAKE_CUDA_ARCHITECTURES ESPRESSO_CMAKE_CUDA_ARCHITECTURES_LEN)
+  if(Kokkos_ENABLE_CUDA AND ESPRESSO_CMAKE_CUDA_ARCHITECTURES_LEN GREATER 1
+     AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
+    message(
+      FATAL_ERROR
+        "Kokkos can only be built against a single CUDA architecture when using the nvcc_wrapper, got CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}"
+    )
+  endif()
   cmake_path(GET CUDA_cuda_driver_LIBRARY PARENT_PATH ESPRESSO_LIBCUDA_RPATH)
   cmake_path(GET CUDA_cudart_LIBRARY PARENT_PATH ESPRESSO_LIBCUDART_RPATH)
   macro(espresso_add_cuda_rpaths)
@@ -465,8 +484,8 @@ target_compile_options(
     $<$<AND:$<BOOL:${ESPRESSO_BUILD_WITH_HDF5}>,$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,CrayClang,AppleClang,IntelLLVM>>:-Wno-old-style-cast>
     $<$<AND:$<BOOL:${ESPRESSO_BUILD_WITH_HDF5}>,$<COMPILE_LANG_AND_ID:CXX,NVHPC>>:--diag_suppress=storage_class_not_first>
     $<$<AND:$<VERSION_LESS:${ESPRESSO_MINIMAL_CXX_STANDARD},23>,$<COMPILE_LANG_AND_ID:CXX,NVHPC>>:--diag_suppress=bad_pp_directive_keyword>
-    $<$<COMPILE_LANG_AND_ID:CXX,NVHPC>:--diag_suppress=code_is_unreachable>
-    $<$<COMPILE_LANG_AND_ID:CXX,NVHPC>:--diag_suppress=loop_not_reachable>
+    $<$<COMPILE_LANG_AND_ID:CXX,NVHPC,NVIDIA>:--diag_suppress=code_is_unreachable>
+    $<$<COMPILE_LANG_AND_ID:CXX,NVHPC,NVIDIA>:--diag_suppress=loop_not_reachable>
     # disable GCC's C++17 processor-specific ABI warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94383)
     $<$<AND:$<COMPILE_LANG_AND_ID:CXX,GNU>,$<IN_LIST:${CMAKE_SYSTEM_PROCESSOR},arm;arm64;aarch64;aarch64_be;powerpc64le>>:-Wno-psabi>
     # warnings are errors
@@ -701,10 +720,11 @@ if(NOT DEFINED Kokkos_FOUND OR NOT ${Kokkos_FOUND})
     OVERRIDE_FIND_PACKAGE
   )
   # cmake-format: on
-  set(BUILD_SHARED_LIBS ON)
+  set(BUILD_SHARED_LIBS OFF)
   set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
   set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "")
   set(Kokkos_ENABLE_OPENMP ON CACHE BOOL "")
+  set(Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OFF CACHE BOOL "")
   set(Kokkos_ENABLE_IMPL_VIEW_LEGACY ON CACHE BOOL "")
   set(Kokkos_ENABLE_COMPLEX_ALIGN ON CACHE BOOL "")
   set(Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION ON CACHE BOOL "")
@@ -725,6 +745,11 @@ if(NOT DEFINED Kokkos_FOUND OR NOT ${Kokkos_FOUND})
               LIBRARY DESTINATION "${ESPRESSO_INSTALL_LIBDIR}")
     endif()
   endforeach()
+  target_compile_options(
+    kokkoscore
+    PRIVATE
+      $<$<COMPILE_LANG_AND_ID:CXX,NVHPC>:--diag_suppress=initialization_not_reachable>
+  )
   # mark kokkos headers as system headers to disable compiler diagnostics
   set_property(
     TARGET kokkos APPEND
@@ -817,7 +842,7 @@ if(ESPRESSO_BUILD_WITH_NLOPT)
     FetchContent_Declare(
       nlopt
       GIT_REPOSITORY https://github.com/stevengj/nlopt.git
-      GIT_TAG        v2.10.0
+      GIT_TAG        v2.11.0
     )
     # cmake-format: on
     set(BUILD_SHARED_LIBS off)
@@ -831,6 +856,13 @@ if(ESPRESSO_BUILD_WITH_NLOPT)
     set(NLOPT_LUKSAN off CACHE BOOL "")
     FetchContent_MakeAvailable(nlopt)
     set(BUILD_SHARED_LIBS ${ESPRESSO_BUILD_SHARED_LIBS_DEFAULT})
+    target_compile_options(
+      nlopt
+      PRIVATE
+        $<$<COMPILE_LANG_AND_ID:C,NVHPC>:--diag_suppress=code_is_unreachable>
+        $<$<COMPILE_LANG_AND_ID:C,NVHPC>:--diag_suppress=integer_sign_change>
+        $<$<COMPILE_LANG_AND_ID:C,NVHPC>:--diag_suppress=deprecated_entity>
+        $<$<COMPILE_LANG_AND_ID:C,NVHPC>:--diag_suppress=mixed_enum_type>)
   endif()
 endif()
 
@@ -840,6 +872,12 @@ if(ESPRESSO_BUILD_WITH_VALGRIND)
   if(VALGRIND_FOUND)
     message(STATUS "Found valgrind: ${VALGRIND_INCLUDE_DIRS}")
   endif()
+endif()
+
+if(Kokkos_ENABLE_CUDA AND NOT CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+  # allow constexpr __host__ function calls in __device__ functions
+  target_compile_options(espresso_kokkos_compiler_flags
+                         INTERFACE -expt-relaxed-constexpr)
 endif()
 
 #
@@ -1038,6 +1076,12 @@ if(ESPRESSO_BUILD_WITH_WALBERLA)
         -Wno-unused-but-set-variable)
     target_link_libraries(walberla_sqlite
                           PRIVATE espresso_walberla_sqlite_compiler_flags)
+    target_compile_options(
+      sqlite3
+      PRIVATE
+        $<$<COMPILE_LANG_AND_ID:C,NVHPC>:--diag_suppress=code_is_unreachable>
+        $<$<COMPILE_LANG_AND_ID:C,NVHPC>:--diag_suppress=cast_to_qualified_type>
+        $<$<COMPILE_LANG_AND_ID:C,NVHPC>:--diag_suppress=set_but_not_used>)
   endif()
   add_library(espresso_walberla_deps INTERFACE)
   add_library(espresso::walberla_deps ALIAS espresso_walberla_deps)
@@ -1113,7 +1157,7 @@ function(espresso_set_common_target_properties)
     if(ESPRESSO_BUILD_WITH_CUDA)
       if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
         set_target_properties(${TARGET_NAME}
-                              PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+                              PROPERTIES CUDA_SEPARABLE_COMPILATION OFF)
       elseif(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
         set_target_properties(${TARGET_NAME} PROPERTIES LINKER_LANGUAGE "CXX")
       endif()

--- a/libs/Random123-1.09/include/Random123/features/nvccfeatures.h
+++ b/libs/Random123-1.09/include/Random123/features/nvccfeatures.h
@@ -59,7 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //for the device function
 #ifdef  __CUDA_ARCH__
 #ifndef R123_CUDA_DEVICE
-#define R123_CUDA_DEVICE __device__
+#define R123_CUDA_DEVICE __host__ __device__
 #endif
 
 #ifndef R123_USE_MULHILO64_CUDA_INTRIN

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_libraries(
   PUBLIC Cabana::Core Kokkos::kokkos OpenMP::OpenMP_CXX
          $<$<BOOL:${ESPRESSO_BUILD_WITH_CUDA}>:OpenMP::OpenMP_CUDA>
   PRIVATE espresso::config espresso::utils::mpi espresso::shapes
-          espresso::compiler_flags
+          espresso::compiler_flags espresso::kokkos::compiler_flags
           $<$<BOOL:${ESPRESSO_BUILD_WITH_WALBERLA}>:espresso::walberla>
           $<$<BOOL:${ESPRESSO_BUILD_WITH_NLOPT}>:nlopt>
           $<$<BOOL:${ESPRESSO_BUILD_WITH_GSL}>:GSL::gsl>

--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -133,24 +133,27 @@ struct callback_void_t final : public callback_concept_t {
   }
 };
 
-template <class F, class R, class... Args> struct FunctorTypes {
-  using functor_type = F;
-  using return_type = R;
+/** @brief Type traits for a functor. */
+template <class T> struct FunctorTypes;
+
+/** @brief Type traits for an immutable lambda. */
+template <class Class, class Ret, class... Args>
+struct FunctorTypes<Ret (Class::*)(Args...) const> {
+  using functor_type = Class;
+  using return_type = Ret;
   using argument_types = std::tuple<Args...>;
 };
 
-template <class C, class R, class... Args>
-auto functor_types_impl(R (C::*)(Args...) const) {
-  return FunctorTypes<C, R, Args...>{};
-}
+template <class Class, class Ret, class... Args>
+using functor_types_from_args = FunctorTypes<Ret (Class::*)(Args...) const>;
 
 template <class F>
-using functor_types =
-    decltype(functor_types_impl(&std::remove_reference_t<F>::operator()));
+using functor_types_from_lambda =
+    FunctorTypes<decltype(&std::remove_reference_t<F>::operator())>;
 
-template <class CRef, class C, class R, class... Args>
-auto make_model_impl(CRef &&c, FunctorTypes<C, R, Args...>) {
-  return std::make_unique<callback_void_t<C, Args...>>(std::forward<CRef>(c));
+template <class F, class C, class R, class... Args>
+auto make_model_impl(F &&f, functor_types_from_args<C, R, Args...>) {
+  return std::make_unique<callback_void_t<C, Args...>>(std::forward<F>(f));
 }
 
 /**
@@ -160,7 +163,7 @@ auto make_model_impl(CRef &&c, FunctorTypes<C, R, Args...>) {
  * to exist and can not be overloaded.
  */
 template <typename F> auto make_model(F &&f) {
-  return make_model_impl(std::forward<F>(f), functor_types<F>{});
+  return make_model_impl(std::forward<F>(f), functor_types_from_lambda<F>{});
 }
 
 /**
@@ -190,8 +193,9 @@ public:
   template <class... Args> class CallbackHandle {
   public:
     template <typename F>
-      requires(std::is_same_v<typename detail::functor_types<F>::argument_types,
-                              std::tuple<Args...>>)
+      requires std::is_same_v<typename detail::functor_types_from_lambda<
+                                  F>::argument_types,
+                              std::tuple<Args...>>
     CallbackHandle(std::shared_ptr<MpiCallbacks> cb, F &&f)
         : m_id(cb->add(std::forward<F>(f))), m_cb(std::move(cb)) {}
 
@@ -216,8 +220,7 @@ public:
     auto operator()(ArgRef &&...args) const
         /* Enable if a hypothetical function with signature void(Args..)
          * could be called with the provided arguments. */
-      requires(std::is_void_v<decltype(std::declval<void (*)(Args...)>()(
-                   std::forward<ArgRef>(args)...))>)
+      requires std::is_invocable_r_v<void, void (*)(Args...), ArgRef &&...>
     {
       if (m_cb)
         m_cb->call(m_id, std::forward<ArgRef>(args)...);

--- a/src/core/aosoa_pack.hpp
+++ b/src/core/aosoa_pack.hpp
@@ -124,11 +124,11 @@ struct CellStructure::AoSoA_pack {
       std::size_t i) const {
     Utils::Vector<T, N> result;
     auto const data = result.data();
-#if !defined(__NVCOMPILER)
-#if (defined(__GNUC__) or defined(__GNUG__)) && !defined(__clang__)
-#pragma GCC unroll 8
-#else
+#if !defined(__NVCOMPILER) && !defined(__CUDACC__)
+#if defined(__clang__)
 #pragma omp unroll
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC unroll 8
 #endif
 #endif
     for (std::size_t j = 0ul; j < N; j += 1ul) {
@@ -141,11 +141,11 @@ struct CellStructure::AoSoA_pack {
   void
   set_vector_at(Kokkos::View<T *[N], array_layout, Kokkos::HostSpace> &view,
                 std::size_t i, Utils::Vector<T, N> const &value) {
-#if !defined(__NVCOMPILER)
-#if (defined(__GNUC__) or defined(__GNUG__)) && !defined(__clang__)
-#pragma GCC unroll 8
-#else
+#if !defined(__NVCOMPILER) && !defined(__CUDACC__)
+#if defined(__clang__)
 #pragma omp unroll
+#elif defined(__GNUC__) or defined(__GNUG__)
+#pragma GCC unroll 8
 #endif
 #endif
     for (std::size_t j = 0ul; j < N; j += 1ul) {

--- a/src/core/cuda/utils.cuh
+++ b/src/core/cuda/utils.cuh
@@ -77,4 +77,4 @@ void cuda_check_errors_exit(const dim3 &block, const dim3 &grid,
   cuda_check_errors_exit(_grid, _block, #_function, __FILE__, __LINE__);
 
 #define KERNELCALL(_function, _grid, _block, ...)                              \
-  KERNELCALL_shared(_function, _grid, _block, 0, ##__VA_ARGS__)
+  KERNELCALL_shared(_function, _grid, _block, 0 __VA_OPT__(, ) __VA_ARGS__)

--- a/src/core/p3m/CMakeLists.txt
+++ b/src/core/p3m/CMakeLists.txt
@@ -35,6 +35,7 @@ if(ESPRESSO_BUILD_WITH_FFTW)
     espresso_p3m
     PRIVATE espresso::compiler_flags
             espresso::p3m::compiler_flags
+            espresso::kokkos::compiler_flags
             espresso::instrumentation
             espresso::utils
             espresso::config

--- a/src/core/p3m/FFTBuffersLegacy.cpp
+++ b/src/core/p3m/FFTBuffersLegacy.cpp
@@ -28,11 +28,13 @@
 #include "communication.hpp"
 #include "p3m/common.hpp"
 
+#include <utils/device_qualifier.hpp>
+
 #include <array>
 #include <span>
 
 template <typename FloatType>
-FFTBuffersLegacy<FloatType>::~FFTBuffersLegacy() = default;
+HOST_ONLY_QUALIFIER FFTBuffersLegacy<FloatType>::~FFTBuffersLegacy() = default;
 
 template <typename FloatType>
 void FFTBuffersLegacy<FloatType>::update_mesh_views(

--- a/src/core/p3m/FFTBuffersLegacy.hpp
+++ b/src/core/p3m/FFTBuffersLegacy.hpp
@@ -31,6 +31,8 @@
 
 #include "fft/vector.hpp"
 
+#include <utils/device_qualifier.hpp>
+
 #include <array>
 #include <type_traits>
 
@@ -49,7 +51,7 @@ class FFTBuffersLegacy : public FFTBuffers<FloatType> {
   std::array<fft::vector<FloatType>, 3u> rs_mesh_fields;
 
 public:
-  ~FFTBuffersLegacy() override;
+  HOST_ONLY_QUALIFIER ~FFTBuffersLegacy() override;
   void init_halo() override;
   void init_meshes(int ca_mesh_size) override;
   void perform_vector_halo_gather() override;

--- a/src/core/p3m/data_struct.hpp
+++ b/src/core/p3m/data_struct.hpp
@@ -27,6 +27,8 @@
 
 #include "common.hpp"
 
+#include <utils/device_qualifier.hpp>
+
 #include <array>
 #include <cassert>
 #include <memory>
@@ -105,7 +107,7 @@ protected:
 public:
   explicit FFTBuffers(P3MLocalMesh const &local_mesh)
       : local_mesh{local_mesh} {}
-  virtual ~FFTBuffers() = default;
+  virtual HOST_ONLY_QUALIFIER ~FFTBuffers() = default;
   /** @brief Initialize the meshes. */
   virtual void init_meshes(int ca_mesh_size) = 0;
   /** @brief Initialize the halo buffers. */

--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -27,6 +27,7 @@
  */
 
 #include <utils/Vector.hpp>
+#include <utils/device_qualifier.hpp>
 #include <utils/u32_to_u64.hpp>
 #include <utils/uniform.hpp>
 
@@ -35,7 +36,6 @@
 #include <cstddef>
 #include <numbers>
 #include <random>
-#include <ranges>
 #include <vector>
 
 /*
@@ -72,7 +72,8 @@ namespace Random {
  * sequence.
  */
 template <RNGSalt salt>
-auto philox_4_uint64s(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
+DEVICE_QUALIFIER auto philox_4_uint64s(uint64_t counter, uint32_t seed,
+                                       int key1, int key2 = 0) {
 
   using rng_type = r123::Philox4x64;
   using ctr_type = rng_type::ctr_type;
@@ -109,11 +110,13 @@ auto philox_4_uint64s(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
  */
 template <RNGSalt salt, std::size_t N = 3>
   requires((N >= 1) and (N <= 4))
-auto noise_uniform(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
+DEVICE_QUALIFIER auto noise_uniform(uint64_t counter, uint32_t seed, int key1,
+                                    int key2 = 0) {
   auto const integers = philox_4_uint64s<salt>(counter, seed, key1, key2);
   Utils::VectorXd<N> noise{};
-  std::ranges::transform(integers | std::ranges::views::take(N), noise.begin(),
-                         [](std::size_t v) { return Utils::uniform(v) - 0.5; });
+  for (std::size_t i = 0; i < N; ++i) {
+    noise[i] = Utils::uniform(integers[i]) - 0.5;
+  }
   return noise;
 }
 
@@ -138,18 +141,18 @@ auto noise_uniform(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
  */
 template <RNGSalt salt, std::size_t N = 3>
   requires((N >= 1) and (N <= 4))
-auto noise_gaussian(uint64_t counter, uint32_t seed, int key1, int key2 = 0) {
+DEVICE_QUALIFIER auto noise_gaussian(uint64_t counter, uint32_t seed, int key1,
+                                     int key2 = 0) {
 
   auto const integers = philox_4_uint64s<salt>(counter, seed, key1, key2);
 
   constexpr std::size_t M = (N <= 2) ? 2 : 4;
+  constexpr auto epsilon = std::numeric_limits<double>::min();
   Utils::VectorXd<M> u{};
-  std::ranges::transform(
-      integers | std::ranges::views::take(M), u.begin(), [](std::size_t value) {
-        auto constexpr epsilon = std::numeric_limits<double>::min();
-        auto res = Utils::uniform(value);
-        return (res < epsilon) ? epsilon : res;
-      });
+  for (std::size_t i = 0; i < M; ++i) {
+    auto res = Utils::uniform(integers[i]);
+    u[i] = (res < epsilon) ? epsilon : res;
+  }
 
   // Box-Muller transform code adapted from
   // https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform

--- a/src/core/unit_tests/CMakeLists.txt
+++ b/src/core/unit_tests/CMakeLists.txt
@@ -30,7 +30,7 @@ espresso_unit_test(SRC RuntimeErrorStream_test.cpp DEPENDS espresso::core
 espresso_unit_test_executable(
   NAME EspressoSystemStandAlone_test_matrix SRC
   EspressoSystemStandAlone_test.cpp DEPENDS espresso::core Boost::mpi
-  MPI::MPI_CXX)
+  MPI::MPI_CXX espresso::kokkos::compiler_flags)
 foreach(TEST_NUM_PROC 1 3 4)
   foreach(TEST_NUM_THREADS 1 2)
     if(${TEST_NUM_THREADS} LESS_EQUAL ${ESPRESSO_TEST_NT})
@@ -46,7 +46,7 @@ foreach(TEST_NUM_PROC 1 3 4)
   endforeach()
 endforeach()
 espresso_unit_test(SRC EspressoSystem_test.cpp DEPENDS espresso::core
-                   Boost::mpi NUM_PROC 2)
+                   Boost::mpi espresso::kokkos::compiler_flags NUM_PROC 2)
 espresso_unit_test(SRC ResourceCleanup_test.cpp DEPENDS espresso::core
                    Boost::mpi NUM_PROC 2)
 espresso_unit_test(SRC MpiCallbacks_test.cpp DEPENDS espresso::utils Boost::mpi
@@ -63,10 +63,12 @@ espresso_unit_test(SRC field_coupling_couplings_test.cpp DEPENDS
 espresso_unit_test(SRC field_coupling_fields_test.cpp DEPENDS espresso::utils)
 espresso_unit_test(SRC field_coupling_force_field_test.cpp DEPENDS
                    espresso::utils)
-espresso_unit_test(SRC field_layout_helpers_test.cpp DEPENDS espresso::utils
-                   espresso::core Kokkos::kokkos)
-espresso_unit_test(SRC particle_reduction_test.cpp DEPENDS espresso::utils
-                   espresso::core Boost::mpi Kokkos::kokkos)
+espresso_unit_test(
+  SRC field_layout_helpers_test.cpp DEPENDS espresso::utils espresso::core
+  Kokkos::kokkos espresso::kokkos::compiler_flags)
+espresso_unit_test(
+  SRC particle_reduction_test.cpp DEPENDS espresso::utils espresso::core
+  Boost::mpi Kokkos::kokkos espresso::kokkos::compiler_flags)
 espresso_unit_test(SRC periodic_fold_test.cpp)
 espresso_unit_test(SRC grid_test.cpp DEPENDS espresso::core)
 espresso_unit_test(SRC lees_edwards_test.cpp DEPENDS espresso::core)
@@ -96,11 +98,19 @@ endif()
 
 if(ESPRESSO_BUILD_WITH_FFTW)
   espresso_unit_test_executable(
-    NAME p3m_test_matrix SRC p3m_test.cpp DEPENDS espresso::core Boost::mpi
+    NAME
+    p3m_test_matrix
+    SRC
+    p3m_test.cpp
+    DEPENDS
+    espresso::core
+    Boost::mpi
     MPI::MPI_CXX
     $<$<BOOL:${ESPRESSO_BUILD_WITH_FFTW}>:espresso::p3m::compiler_flags>
-    $<$<BOOL:${ESPRESSO_BUILD_WITH_FFTW}>:Heffte::Heffte> Cabana::Core
-    Kokkos::kokkos)
+    $<$<BOOL:${ESPRESSO_BUILD_WITH_FFTW}>:Heffte::Heffte>
+    Cabana::Core
+    Kokkos::kokkos
+    espresso::kokkos::compiler_flags)
   foreach(TEST_NUM_PROC 1 3 4)
     foreach(TEST_NUM_THREADS 1 2)
       if(${TEST_NUM_THREADS} LESS_EQUAL ${ESPRESSO_TEST_NT})
@@ -116,7 +126,7 @@ if(ESPRESSO_BUILD_WITH_FFTW)
     endforeach()
   endforeach()
   espresso_unit_test(SRC fft_test.cpp DEPENDS espresso::utils espresso::core
-                     Kokkos::kokkos)
+                     Kokkos::kokkos espresso::kokkos::compiler_flags)
   espresso_unit_test(SRC math_test.cpp DEPENDS espresso::utils espresso::core)
 endif()
 

--- a/src/core/unit_tests/field_layout_helpers_test.cpp
+++ b/src/core/unit_tests/field_layout_helpers_test.cpp
@@ -26,6 +26,7 @@
 #include <Kokkos_Core.hpp>
 
 #include <utils/Vector.hpp>
+#include <utils/device_qualifier.hpp>
 #include <utils/index.hpp>
 
 #include <complex>
@@ -42,7 +43,7 @@ BOOST_TEST_GLOBAL_CONFIGURATION(GlobalConfig);
 BOOST_AUTO_TEST_SUITE(suite)
 
 template <Utils::MemoryOrder MemOrderReal, Utils::MemoryOrder MemOrderFourier>
-void check_add_remove_halo() {
+HOST_ONLY_QUALIFIER void check_add_remove_halo() {
   auto constexpr n_x = 3;
   auto constexpr n_y = 7;
   auto constexpr n_z = 11;

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -66,6 +66,13 @@ target_link_libraries(
 set_source_files_properties(
   ${CMAKE_CURRENT_SOURCE_DIR}/particle_data/ParticleHandle.cpp
   PROPERTIES COMPILE_OPTIONS -fno-finite-math-only)
+if(Kokkos_ENABLE_CUDA AND NOT CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+  set_source_files_properties(
+    ${CMAKE_CURRENT_SOURCE_DIR}/shapes/initialize.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/reaction_methods/initialize.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/reaction_methods/ReactionAlgorithm.cpp
+    PROPERTIES COMPILE_OPTIONS -expt-relaxed-constexpr)
+endif()
 
 target_include_directories(espresso_script_interface
                            PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/src/script_interface/interactions/NonBondedInteraction.hpp
+++ b/src/script_interface/interactions/NonBondedInteraction.hpp
@@ -54,6 +54,7 @@ class InteractionPotentialInterface
     : public AutoParameters<InteractionPotentialInterface<CoreIA>> {
 public:
   using CoreInteraction = CoreIA;
+  using CoreInteractionIAParamsPtr = CoreInteraction IA_parameters::*;
 
 protected:
   using BaseClass = AutoParameters<InteractionPotentialInterface<CoreIA>>;
@@ -69,7 +70,7 @@ protected:
   /** @brief Callback to notify changes to the interaction range. */
   std::weak_ptr<std::function<void()>> m_notify_non_bonded_ia_change;
   /** @brief Pointer to the corresponding member in a handle. */
-  virtual CoreInteraction IA_parameters::*get_ptr_offset() const = 0;
+  virtual CoreInteractionIAParamsPtr get_ptr_offset() const = 0;
   /** @brief Create a new instance using the constructor with range checks. */
   virtual void make_new_instance(VariantMap const &params) = 0;
   /** @brief Which parameter indicates whether the potential is inactive. */
@@ -152,7 +153,7 @@ public:
 #ifdef ESPRESSO_WCA
 class InteractionWCA : public InteractionPotentialInterface<::WCA_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::wca;
   }
 
@@ -188,7 +189,7 @@ public:
 #ifdef ESPRESSO_LENNARD_JONES
 class InteractionLJ : public InteractionPotentialInterface<::LJ_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::lj;
   }
 
@@ -229,7 +230,7 @@ private:
 class InteractionLJGen
     : public InteractionPotentialInterface<::LJGen_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::ljgen;
   }
 
@@ -285,7 +286,7 @@ private:
 class InteractionLJcos
     : public InteractionPotentialInterface<::LJcos_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::ljcos;
   }
 
@@ -312,7 +313,7 @@ private:
 class InteractionLJcos2
     : public InteractionPotentialInterface<::LJcos2_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::ljcos2;
   }
 
@@ -352,7 +353,7 @@ public:
 class InteractionHertzian
     : public InteractionPotentialInterface<::Hertzian_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::hertzian;
   }
 
@@ -378,7 +379,7 @@ private:
 class InteractionGaussian
     : public InteractionPotentialInterface<::Gaussian_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::gaussian;
   }
 
@@ -403,7 +404,7 @@ private:
 class InteractionBMHTF
     : public InteractionPotentialInterface<::BMHTF_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::bmhtf;
   }
 
@@ -432,7 +433,7 @@ private:
 class InteractionMorse
     : public InteractionPotentialInterface<::Morse_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::morse;
   }
 
@@ -459,7 +460,7 @@ private:
 class InteractionBuckingham
     : public InteractionPotentialInterface<::Buckingham_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::buckingham;
   }
 
@@ -489,7 +490,7 @@ private:
 class InteractionSoftSphere
     : public InteractionPotentialInterface<::SoftSphere_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::soft_sphere;
   }
 
@@ -515,7 +516,7 @@ private:
 #ifdef ESPRESSO_HAT
 class InteractionHat : public InteractionPotentialInterface<::Hat_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::hat;
   }
 
@@ -539,7 +540,7 @@ private:
 class InteractionGayBerne
     : public InteractionPotentialInterface<::GayBerne_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::gay_berne;
   }
 
@@ -571,7 +572,7 @@ private:
 class InteractionTabulated
     : public InteractionPotentialInterface<::TabulatedPotential> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::tab;
   }
 
@@ -609,7 +610,7 @@ public:
 #ifdef ESPRESSO_DPD
 class InteractionDPD : public InteractionPotentialInterface<::DPD_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::dpd;
   }
 
@@ -658,7 +659,7 @@ private:
 class InteractionThole
     : public InteractionPotentialInterface<::Thole_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::thole;
   }
 
@@ -685,7 +686,7 @@ private:
 class InteractionSmoothStep
     : public InteractionPotentialInterface<::SmoothStep_Parameters> {
 protected:
-  CoreInteraction IA_parameters::*get_ptr_offset() const override {
+  CoreInteractionIAParamsPtr get_ptr_offset() const override {
     return &::IA_parameters::smooth_step;
   }
 

--- a/src/script_interface/particle_data/ParticleHandle.cpp
+++ b/src/script_interface/particle_data/ParticleHandle.cpp
@@ -69,18 +69,18 @@ namespace ScriptInterface {
 namespace Particles {
 
 #ifdef ESPRESSO_ROTATION
-static auto constexpr contradicting_arguments_quat = std::to_array<
-    std::array<std::string_view, 3>>({
-    {"dip", "dipm",
-     "Setting 'dip' is sufficient as it defines the scalar dipole moment."},
-    {"quat", "director",
-     "Setting 'quat' is sufficient as it defines the director."},
-    {"dip", "quat",
-     "Setting 'dip' would overwrite 'quat'. Set 'quat' and 'dipm' instead."},
-    {"dip", "director",
-     "Setting 'dip' would overwrite 'director'. Set 'director' and "
-     "'dipm' instead."},
-});
+static std::array<std::array<std::string_view, 3>,
+                  4> constexpr contradicting_arguments_quat{{
+    {{"dip", "dipm",
+      "Setting 'dip' is sufficient as it defines the scalar dipole moment."}},
+    {{"quat", "director",
+      "Setting 'quat' is sufficient as it defines the director."}},
+    {{"dip", "quat",
+      "Setting 'dip' would overwrite 'quat'. Set 'quat' and 'dipm' instead."}},
+    {{"dip", "director",
+      "Setting 'dip' would overwrite 'director'. Set 'director' and "
+      "'dipm' instead."}},
+}};
 
 static void sanity_checks_rotation(VariantMap const &params) {
   // if we are not constructing a particle from a checkpoint file,

--- a/src/script_interface/tests/CMakeLists.txt
+++ b/src/script_interface/tests/CMakeLists.txt
@@ -52,10 +52,12 @@ espresso_unit_test(SRC Actors_test.cpp DEPENDS espresso::script_interface
                    espresso::core)
 espresso_unit_test(
   SRC ConstantpHEnsemble_test.cpp DEPENDS espresso::core
-  espresso::script_interface Boost::mpi MPI::MPI_CXX NUM_PROC 2)
+  espresso::script_interface espresso::kokkos::compiler_flags Boost::mpi
+  MPI::MPI_CXX NUM_PROC 2)
 espresso_unit_test(
   SRC ReactionEnsemble_test.cpp DEPENDS espresso::core
-  espresso::script_interface Boost::mpi MPI::MPI_CXX NUM_PROC 2)
+  espresso::script_interface espresso::kokkos::compiler_flags Boost::mpi
+  MPI::MPI_CXX NUM_PROC 2)
 espresso_unit_test(
   SRC ParticleSlice_test.cpp DEPENDS espresso::core espresso::script_interface
   Boost::mpi MPI::MPI_CXX NUM_PROC 1)

--- a/src/utils/include/utils/device_qualifier.hpp
+++ b/src/utils/include/utils/device_qualifier.hpp
@@ -22,11 +22,13 @@
 #if defined(__CUDACC__)
 #define DEVICE_THROW(E)
 #define DEVICE_QUALIFIER __host__ __device__
+#define HOST_ONLY_QUALIFIER __host__
 #define DEVICE_ASSERT(A) void((A))
 #else
 #include <cassert>
 #define DEVICE_THROW(E) throw(E)
 #define DEVICE_QUALIFIER
+#define HOST_ONLY_QUALIFIER
 #define DEVICE_ASSERT(A) assert((A))
 #endif
 

--- a/src/utils/include/utils/uniform.hpp
+++ b/src/utils/include/utils/uniform.hpp
@@ -18,6 +18,8 @@
 #ifndef UTILS_UNIFORM_HPP
 #define UTILS_UNIFORM_HPP
 
+#include "utils/device_qualifier.hpp"
+
 #include <cinttypes>
 #include <limits>
 
@@ -33,7 +35,7 @@ namespace Utils {
  * @param in Unsigned integer value
  * @return Mapped floating point value.
  */
-constexpr inline double uniform(uint64_t in) {
+constexpr DEVICE_QUALIFIER inline double uniform(uint64_t in) {
   auto constexpr const max = std::numeric_limits<uint64_t>::max();
   auto constexpr const fac = 1. / (static_cast<double>(max) + 1.);
 

--- a/src/walberla_bridge/CMakeLists.txt
+++ b/src/walberla_bridge/CMakeLists.txt
@@ -94,9 +94,9 @@ target_compile_options(
   espresso_walberla_compiler_flags
   INTERFACE
   $<$<COMPILE_LANG_AND_ID:CXX,CrayClang,IntelLLVM>:-Wno-reorder-ctor>
-  $<$<COMPILE_LANG_AND_ID:CXX,NVHPC>:--diag_suppress=code_is_unreachable>
-  $<$<COMPILE_LANG_AND_ID:CXX,NVHPC>:--diag_suppress=integer_sign_change>
-  $<$<COMPILE_LANG_AND_ID:CXX,NVHPC>:--diag_suppress=conversion_function_not_usable>
+  $<$<COMPILE_LANG_AND_ID:CXX,NVHPC,NVIDIA>:--diag_suppress=code_is_unreachable>
+  $<$<COMPILE_LANG_AND_ID:CXX,NVHPC,NVIDIA>:--diag_suppress=integer_sign_change>
+  $<$<COMPILE_LANG_AND_ID:CXX,NVHPC,NVIDIA>:--diag_suppress=conversion_function_not_usable>
   $<$<AND:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>,$<STREQUAL:${CUDA_HOST_COMPILER_ID},NVHPC>>:-Xcompiler=--diag_suppress=code_is_unreachable>
   $<$<AND:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>,$<STREQUAL:${CUDA_HOST_COMPILER_ID},NVHPC>>:-Xcompiler=--diag_suppress=integer_sign_change>
   $<$<AND:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>,$<STREQUAL:${CUDA_HOST_COMPILER_ID},NVHPC>>:-Xcompiler=--diag_suppress=conversion_function_not_usable>


### PR DESCRIPTION
Blocks #5392

Description of changes:
- improve nvcc toolchain support in C++ code in preparation for Kokkos with CUDA support
   - qualify short-range loop functions as host only or host+device kernels
   - not all C++20 STL features are fully supported by nvcc 12.0
- deactivate relocatable device code and separable CUDA compilation
- bump NLopt version when built from sources to get modern CMake support