### PR TITLE
Remove script interface overhead and MPI+OpenMP overhead

### DIFF
--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -15,7 +15,6 @@
 # serve to show the default.
 
 import sys
-import importlib
 import docutils
 import sphinx.util.docutils
 
@@ -278,48 +277,10 @@ class SpdxRole(sphinx.util.docutils.SphinxRole):
 # https://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
 autodoc_mock_imports = ['featuredefs', 'matplotlib', 'OpenGL', 'vtk', 'zndraw', 'znsocket', 'znjson']
 
-
-def _resolve_class(obj):
-    """Return the class that owns a bound method ``obj``, or ``None``."""
-    module = getattr(obj, "__module__", None)
-    qualname = getattr(obj, "__qualname__", "")
-    if not module or "." not in qualname:
-        return None
-    try:
-        owner = importlib.import_module(module)
-        for part in qualname.split(".")[:-1]:
-            owner = getattr(owner, part)
-    except (ImportError, AttributeError):
-        return None
-    return owner if isinstance(owner, type) else None
-
-
-# pylint: disable=unused-argument
-def skip_duplicate_bound_methods(app, what, name, obj, skip, options):
-    """
-    Let ``sphinx.ext.napoleon`` be the single source for documented bound methods.
-
-    ``ScriptInterfaceHelper._install_bound_method`` synthesizes docstring-less
-    methods for the names in ``_so_bind_methods``. When such methods are also
-    listed in the class docstring's numpydoc "Methods" section, ``.. method::``
-    directives are emitted for them; documenting the (empty) members with
-    autodoc as well triggers a "duplicate object description" warning.
-    """
-    if skip:
-        return None
-    owner = _resolve_class(obj)
-    if owner is None:
-        return None
-    if name in getattr(owner, "_so_bind_methods", ()):
-        return True
-    return None
-
-
 def setup(app):
     app.add_css_file('blockquotes.css')
     app.add_css_file('custom.css')
     app.add_role('spdx', SpdxRole())
-    app.connect('autodoc-skip-member', skip_duplicate_bound_methods)
 
 
 # -- Options for Cython ---------------------------------------------------

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -294,6 +294,7 @@ def _resolve_class(obj):
     return owner if isinstance(owner, type) else None
 
 
+# pylint: disable=unused-argument
 def skip_duplicate_bound_methods(app, what, name, obj, skip, options):
     """
     Let ``sphinx.ext.napoleon`` be the single source for documented bound methods.

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -15,6 +15,7 @@
 # serve to show the default.
 
 import sys
+import importlib
 import docutils
 import sphinx.util.docutils
 
@@ -277,11 +278,47 @@ class SpdxRole(sphinx.util.docutils.SphinxRole):
 # https://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
 autodoc_mock_imports = ['featuredefs', 'matplotlib', 'OpenGL', 'vtk', 'zndraw', 'znsocket', 'znjson']
 
-# Add custom stylesheets
+
+def _resolve_class(obj):
+    """Return the class that owns a bound method ``obj``, or ``None``."""
+    module = getattr(obj, "__module__", None)
+    qualname = getattr(obj, "__qualname__", "")
+    if not module or "." not in qualname:
+        return None
+    try:
+        owner = importlib.import_module(module)
+        for part in qualname.split(".")[:-1]:
+            owner = getattr(owner, part)
+    except (ImportError, AttributeError):
+        return None
+    return owner if isinstance(owner, type) else None
+
+
+def skip_duplicate_bound_methods(app, what, name, obj, skip, options):
+    """
+    Let ``sphinx.ext.napoleon`` be the single source for documented bound methods.
+
+    ``ScriptInterfaceHelper._install_bound_method`` synthesizes docstring-less
+    methods for the names in ``_so_bind_methods``. When such methods are also
+    listed in the class docstring's numpydoc "Methods" section, ``.. method::``
+    directives are emitted for them; documenting the (empty) members with
+    autodoc as well triggers a "duplicate object description" warning.
+    """
+    if skip:
+        return None
+    owner = _resolve_class(obj)
+    if owner is None:
+        return None
+    if name in getattr(owner, "_so_bind_methods", ()):
+        return True
+    return None
+
+
 def setup(app):
     app.add_css_file('blockquotes.css')
     app.add_css_file('custom.css')
     app.add_role('spdx', SpdxRole())
+    app.connect('autodoc-skip-member', skip_duplicate_bound_methods)
 
 
 # -- Options for Cython ---------------------------------------------------

--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -1281,7 +1281,20 @@ To generate a nested graph that can be interacted with in a web browser:
 
 .. code-block:: bash
 
-    py-spy record -o profile.svg -- ./pypresso ../samples/p3m.py --cpu
+    OMP_NUM_THREADS=1 OMP_PROC_BIND=true OMP_PLACES=0 py-spy record \
+        -o profile.svg -- ./pypresso ../samples/p3m.py --cpu
+
+Use Ctrl+F in the web browser to highlight blocks matching a function name.
+Pass option ``--native`` to capture C++ function names; to get accurate traces
+with minimal overhead, build |es| with
+``-D CMAKE_CXX_FLAGS="-g -fno-omit-frame-pointer" -D CMAKE_BUILD_TYPE=Release``.
+
+To record samples in a format that can be analyzed by AI agents, run::
+
+.. code-block:: bash
+
+    OMP_NUM_THREADS=1 OMP_PROC_BIND=true OMP_PLACES=0 py-spy record \
+        --native -f raw -o profile.folded -- ./pypresso ../samples/p3m.py --cpu
 
 ____
 

--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -257,6 +257,7 @@ public:
     for (auto &[fp, handle] : static_callbacks()) {
       m_func_ptr_to_id[fp] = m_callback_map.add(handle.get());
     }
+    m_skip_worker_nodes = m_comm.size() == 1;
   }
 
   ~MpiCallbacks() {
@@ -380,6 +381,9 @@ public:
       /* enable only if fp can be called with the provided arguments */
     requires(std::is_void_v<decltype(fp(args...))>)
   {
+    if (m_skip_worker_nodes) {
+      return;
+    }
     const int id = m_func_ptr_to_id.at(reinterpret_cast<void (*)()>(fp));
 
     call(id, std::forward<ArgRef>(args)...);
@@ -414,6 +418,7 @@ public:
    * so that the head node can issue call().
    */
   void loop() const {
+    assert(m_comm.rank() != 0);
     for (;;) {
       /* Communicate callback id and parameters */
       boost::mpi::packed_iarchive ia(m_comm);
@@ -473,6 +478,9 @@ private:
    * called by their pointer.
    */
   std::unordered_map<void (*)(), int> m_func_ptr_to_id;
+
+  /** Workers dispatch can be skipped when world size is 1. */
+  bool m_skip_worker_nodes;
 };
 
 template <class... Args>

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -29,15 +29,23 @@
 
 #include <boost/mpi/collectives/reduce.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <functional>
 #include <span>
 #include <vector>
 
-Observable_stat::Observable_stat(std::size_t chunk_size, std::size_t n_bonded,
-                                 int max_type)
-    : m_data{}, m_chunk_size{chunk_size} {
+void Observable_stat::reset(std::size_t n_bonded, int max_type) {
+  if (n_bonded == m_n_bonded and max_type == m_max_type and
+      not m_data.empty()) {
+    std::ranges::fill(m_data, 0.);
+    return;
+  }
+
+  m_n_bonded = n_bonded;
+  m_max_type = max_type;
+
   // number of chunks for different interaction types
   constexpr std::size_t n_coulomb = 2;
   constexpr std::size_t n_dipolar = 2;
@@ -51,11 +59,11 @@ Observable_stat::Observable_stat(std::size_t chunk_size, std::size_t n_bonded,
 #else
   constexpr std::size_t n_dpd = 0;
 #endif
-  auto const n_non_bonded = get_non_bonded_offset(max_type, max_type) + 1ul;
   constexpr std::size_t n_ext_fields = 1;  // reduction over all fields
   constexpr std::size_t n_kinetic_lin = 1; // linear kinetic contribution
   constexpr std::size_t n_kinetic_rot = 1; // angular kinetic contribution
 
+  auto const n_non_bonded = get_non_bonded_offset(max_type, max_type) + 1ul;
   auto const n_elements = n_kinetic_lin + n_kinetic_rot + n_bonded +
                           2ul * n_non_bonded + n_coulomb + n_dipolar + n_vs +
                           n_ext_fields + n_dpd;

--- a/src/core/Observable_stat.hpp
+++ b/src/core/Observable_stat.hpp
@@ -33,6 +33,10 @@ class Observable_stat {
   std::vector<double> m_data;
   /** Number of doubles per data item */
   std::size_t m_chunk_size;
+  /** Number of non-bonded interactions */
+  std::size_t m_n_bonded;
+  /** Number of particle types */
+  int m_max_type;
 
   std::size_t get_non_bonded_offset(int type1, int type2) const;
 
@@ -44,7 +48,17 @@ class Observable_stat {
   }
 
 public:
-  Observable_stat(std::size_t chunk_size, std::size_t n_bonded, int max_type);
+  Observable_stat(std::size_t chunk_size, std::size_t n_bonded, int max_type)
+      : m_data{}, m_chunk_size{chunk_size}, m_n_bonded{n_bonded},
+        m_max_type{max_type} {
+    reset(n_bonded, max_type);
+  }
+
+  /**
+   * @brief Reinitialize the underlying storage.
+   * If the new data layout is unchanged, no reallocation takes place.
+   */
+  void reset(std::size_t n_bonded, int max_type);
 
   auto get_chunk_size() const { return m_chunk_size; }
 

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -35,6 +35,7 @@
 #include "communication.hpp"
 #include "ghosts.hpp"
 #include "integrators/Propagation.hpp"
+#include "kokkos_helpers.hpp"
 #include "lees_edwards/lees_edwards.hpp"
 #include "particle_enumeration.hpp"
 #include "particle_reduction.hpp"
@@ -159,10 +160,10 @@ void CellStructure::rebuild_local_properties(double const pair_cutoff) {
         Kokkos::Experimental::create_scatter_view(get_local_torque()));
 #endif
     Kokkos::realloc(get_id_to_index(), get_cached_max_local_particle_id() + 1);
-    Kokkos::deep_copy(get_id_to_index(), -1);
+    kokkos_deep_copy(execution_space{}, get_id_to_index(), -1);
     // Resize particle views using AoSoA_pack's resize method
     m_aosoa->resize(num_part);
-    Kokkos::deep_copy(m_aosoa->flags, uint8_t{0});
+    kokkos_deep_copy(execution_space{}, m_aosoa->flags, uint8_t{0});
     m_verlet_list_cabana->reallocData(num_part, max_counts);
   } else { // local properties are initialized
     m_local_force = std::make_unique<ForceType>("local_force", num_part);
@@ -177,11 +178,11 @@ void CellStructure::rebuild_local_properties(double const pair_cutoff) {
         Kokkos::view_alloc(execution_space{}, Kokkos::WithoutInitializing,
                            "id_to_index"),
         get_cached_max_local_particle_id() + 1);
-    Kokkos::deep_copy(execution_space{}, get_id_to_index(), -1);
+    kokkos_deep_copy(execution_space{}, get_id_to_index(), -1);
     // Create AoSoA_pack and initialize with resize
     m_aosoa = std::make_unique<AoSoA_pack>();
     m_aosoa->resize(num_part);
-    Kokkos::deep_copy(m_aosoa->flags, uint8_t{0});
+    kokkos_deep_copy(execution_space{}, m_aosoa->flags, uint8_t{0});
 
     m_verlet_list_cabana =
         std::make_unique<ListType>(0ul, num_part, max_counts);
@@ -197,26 +198,26 @@ void CellStructure::reset_local_force_and_torque() {
 #ifdef ESPRESSO_CALIPER
   CALI_CXX_MARK_FUNCTION;
 #endif
-  Kokkos::deep_copy(get_local_force(), 0.);
+  kokkos_deep_copy(execution_space{}, get_local_force(), 0.);
   m_scatter_force->reset();
 #ifdef ESPRESSO_ROTATION
-  Kokkos::deep_copy(get_local_torque(), 0.);
+  kokkos_deep_copy(execution_space{}, get_local_torque(), 0.);
   m_scatter_torque->reset();
 #endif
 }
 
 void CellStructure::reset_local_properties() {
-  Kokkos::deep_copy(get_local_force(), 0.);
+  kokkos_deep_copy(execution_space{}, get_local_force(), 0.);
   m_scatter_force->reset();
 #ifdef ESPRESSO_ROTATION
-  Kokkos::deep_copy(get_local_torque(), 0.);
+  kokkos_deep_copy(execution_space{}, get_local_torque(), 0.);
   m_scatter_torque->reset();
 #endif
 #ifdef ESPRESSO_NPT
-  Kokkos::deep_copy(get_local_virial(), 0.);
+  kokkos_deep_copy(execution_space{}, get_local_virial(), 0.);
   m_scatter_virial->reset();
 #endif
-  Kokkos::deep_copy(get_aosoa().flags, uint8_t{0});
+  kokkos_deep_copy(execution_space{}, get_aosoa().flags, uint8_t{0});
 }
 
 void CellStructure::update_bond_storage(int &pair_count, int &angle_count,

--- a/src/core/cell_system/CellStructure.hpp
+++ b/src/core/cell_system/CellStructure.hpp
@@ -209,7 +209,6 @@ private:
   std::unique_ptr<ListType> m_verlet_list_cabana;
   /** particle properties using individual Kokkos Views */
   std::unique_ptr<AoSoA_pack> m_aosoa;
-  /** The local id-to-index for aosoa data */
   std::vector<Particle *> m_unique_particles;
   std::shared_ptr<KokkosHandle> m_kokkos_handle;
 

--- a/src/core/cell_system/particle_enumeration.hpp
+++ b/src/core/cell_system/particle_enumeration.hpp
@@ -23,6 +23,7 @@
 
 #include "Cell.hpp"
 #include "CellStructure.hpp"
+#include "kokkos_helpers.hpp"
 
 #include <Kokkos_Core.hpp>
 
@@ -51,10 +52,8 @@ inline void enumerate_local_particles(CellStructure const &cs,
                           return acc + cell->particles().size();
                         });
 
-    Kokkos::parallel_for(
-        "enumerate_local_particles",
-        Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
-            std::size_t{0}, local_cells.size()),
+    kokkos_parallel_range_for(
+        "enumerate_local_particles", std::size_t{0}, local_cells.size(),
         [&](auto cell_idx) {
           auto const base_offset = cell_offsets[cell_idx];
           auto &cell_particles = local_cells[cell_idx]->particles();

--- a/src/core/electrostatics/icc.cpp
+++ b/src/core/electrostatics/icc.cpp
@@ -133,7 +133,7 @@ void ICCStar::iteration() {
     cell_structure.ghosts_reduce_forces();
     // force reduction
     Kokkos::Experimental::contribute(local_force, scatter_force);
-    kokkos_parallel_range_for<Kokkos::RangePolicy<execution_space>>(
+    kokkos_parallel_range_for<execution_space>(
         "reduction", std::size_t{0}, unique_particles.size(),
         [&local_force, &unique_particles](std::size_t const i) {
           auto &force = unique_particles.at(i)->force();

--- a/src/core/electrostatics/p3m.impl.definitions.hpp
+++ b/src/core/electrostatics/p3m.impl.definitions.hpp
@@ -58,6 +58,7 @@
 #include "communication.hpp"
 #include "errorhandling.hpp"
 #include "integrators/Propagation.hpp"
+#include "kokkos_helpers.hpp"
 #include "npt.hpp"
 #include "p3m/send_mesh.hpp"
 #include "particle_reduction.hpp"
@@ -386,10 +387,11 @@ template <int cao> struct AssignCharge {
   void operator()(auto &p3m, auto &cell_structure) {
     using CoulombP3MState = std::remove_reference_t<decltype(p3m)>;
     using value_type = CoulombP3MState::value_type;
+    using execution_space = Kokkos::DefaultHostExecutionSpace;
     auto const &aosoa = cell_structure.get_aosoa();
     auto const n_part = cell_structure.count_local_particles();
     p3m.inter_weights.zfill(n_part); // allocate buffer for parallel write
-    kokkos_parallel_range_for(
+    kokkos_parallel_range_for<execution_space>(
         "InterpolateCharges", std::size_t{0u}, n_part, [&](auto p_index) {
           auto constexpr memory_order = Utils::MemoryOrder::ROW_MAJOR;
           auto const tid = omp_get_thread_num();
@@ -405,18 +407,16 @@ template <int cao> struct AssignCharge {
               });
         });
     Kokkos::fence();
-    using execution_space = Kokkos::DefaultHostExecutionSpace;
     int num_threads = execution_space().concurrency();
-    Kokkos::RangePolicy<execution_space> policy(std::size_t{0},
-                                                p3m.local_mesh.size);
-    Kokkos::parallel_for("ReduceInterpolatedCharges", policy,
-                         [&p3m, num_threads](std::size_t const i) {
-                           value_type acc{};
-                           for (int tid = 0; tid < num_threads; ++tid) {
-                             acc += p3m.rs_charge_density_kokkos(tid, i);
-                           }
-                           p3m.rs_charge_density.at(i) += acc;
-                         });
+    kokkos_parallel_range_for<execution_space>(
+        "ReduceInterpolatedCharges", std::size_t{0}, p3m.local_mesh.size,
+        [&p3m, num_threads](std::size_t const i) {
+          value_type acc{};
+          for (int tid = 0; tid < num_threads; ++tid) {
+            acc += p3m.rs_charge_density_kokkos(tid, i);
+          }
+          p3m.rs_charge_density.at(i) += acc;
+        });
     Kokkos::fence();
   }
 };
@@ -448,6 +448,7 @@ template <int cao> struct AssignForces {
                   CellStructure &cell_structure) const {
 
     assert(cao == p3m.inter_weights.cao());
+    using execution_space = Kokkos::DefaultHostExecutionSpace;
 
     auto const kernel = [&p3m](auto pref, auto &p_force, std::size_t p_index) {
       auto const weights = p3m.inter_weights.template load<cao>(p_index);
@@ -469,7 +470,7 @@ template <int cao> struct AssignForces {
     auto const n_part = cell_structure.count_local_particles();
     auto const &aosoa = cell_structure.get_aosoa();
     auto scatter_force = cell_structure.get_scatter_force();
-    kokkos_parallel_range_for(
+    kokkos_parallel_range_for<execution_space>(
         "AssignForces", std::size_t{0u}, n_part, [&](std::size_t p_index) {
           if (auto const pref = aosoa.charge(p_index) * force_prefac) {
             kernel(pref, scatter_force, p_index);
@@ -696,17 +697,18 @@ double CoulombP3MImpl<FloatType, Architecture, FFTConfig>::long_range_kernel(
     // add dipole forces
     // Eq. (3.19) @cite deserno00b
     if (box_dipole) {
+      using execution_space = Kokkos::DefaultHostExecutionSpace;
       auto const dm = prefactor * pref * box_dipole.value();
       auto const n_part = cell_structure.count_local_particles();
-      kokkos_parallel_range_for("AssignForcesBoxDipole", std::size_t{0u},
-                                n_part,
-                                [&aosoa, &scatter_force, dm](auto p_index) {
-                                  auto access = scatter_force.access();
-                                  auto const q = aosoa.charge(p_index);
-                                  access(p_index, 0) -= q * dm[0];
-                                  access(p_index, 1) -= q * dm[1];
-                                  access(p_index, 2) -= q * dm[2];
-                                });
+      kokkos_parallel_range_for<execution_space>(
+          "AssignForcesBoxDipole", std::size_t{0u}, n_part,
+          [&aosoa, &scatter_force, dm](auto p_index) {
+            auto access = scatter_force.access();
+            auto const q = aosoa.charge(p_index);
+            access(p_index, 0) -= q * dm[0];
+            access(p_index, 1) -= q * dm[1];
+            access(p_index, 2) -= q * dm[2];
+          });
     }
   }
 

--- a/src/core/electrostatics/p3m.impl.hpp
+++ b/src/core/electrostatics/p3m.impl.hpp
@@ -28,6 +28,7 @@
 #include "electrostatics/p3m.hpp"
 
 #include "communication.hpp"
+#include "kokkos_helpers.hpp"
 #include "p3m/P3MFFTBackend.hpp"
 #include "p3m/common.hpp"
 #include "p3m/data_struct.hpp"
@@ -219,7 +220,8 @@ public:
     auto const num_threads = execution_space().concurrency();
     Kokkos::realloc(Kokkos::WithoutInitializing, p3m.rs_charge_density_kokkos,
                     num_threads, p3m.local_mesh.size);
-    Kokkos::deep_copy(p3m.rs_charge_density_kokkos, FloatType{0});
+    kokkos_deep_copy(execution_space{}, p3m.rs_charge_density_kokkos,
+                     FloatType{0});
     std::ranges::fill(p3m.rs_charge_density, FloatType{0});
   }
 

--- a/src/core/energy.cpp
+++ b/src/core/energy.cpp
@@ -30,6 +30,7 @@
 #include "energy_cabana.hpp"
 #include "energy_inline.hpp"
 #include "integrators/Propagation.hpp"
+#include "kokkos_helpers.hpp"
 #include "nonbonded_interactions/VerletCriterion.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
 #include "short_range_cabana.hpp"
@@ -48,19 +49,33 @@
 #include <span>
 #include <vector>
 
+struct EnergyObservable {
+  using execution_space = Kokkos::DefaultHostExecutionSpace;
+  std::unique_ptr<Observable_stat> observable;
+  Kokkos::View<double **, Kokkos::LayoutRight, execution_space> local;
+};
+
 namespace System {
 
-std::shared_ptr<Observable_stat> System::calculate_energy() {
+Observable_stat const &System::calculate_energy() {
 
-  auto obs_energy_ptr = std::make_shared<Observable_stat>(
-      1ul, static_cast<std::size_t>(bonded_ias->get_next_key()),
-      nonbonded_ias->get_max_seen_particle_type());
-
-  if (long_range_interactions_sanity_checks()) {
-    return obs_energy_ptr;
+  if (not m_obs_energy) {
+    auto const n_threads = EnergyObservable::execution_space{}.concurrency();
+    m_obs_energy = std::make_shared<EnergyObservable>();
+    m_obs_energy->observable = std::make_unique<Observable_stat>(1ul, 0ul, 0);
+    m_obs_energy->local =
+        decltype(m_obs_energy->local)("local_energy", n_threads, 1ul);
   }
 
-  auto &obs_energy = *obs_energy_ptr;
+  auto &local_energy = m_obs_energy->local;
+  auto &obs_energy = *m_obs_energy->observable;
+  obs_energy.reset(static_cast<std::size_t>(bonded_ias->get_next_key()),
+                   nonbonded_ias->get_max_seen_particle_type());
+
+  if (long_range_interactions_sanity_checks()) {
+    return obs_energy;
+  }
+
 #if defined(ESPRESSO_CUDA) and                                                 \
     (defined(ESPRESSO_ELECTROSTATICS) or defined(ESPRESSO_DIPOLES))
   gpu->clear_energy_on_device();
@@ -97,13 +112,16 @@ std::shared_ptr<Observable_stat> System::calculate_energy() {
       static_cast<std::size_t>(bonded_ias->get_next_key()),
       std::size_t(nonbonded_ias->get_max_seen_particle_type() + 1)};
 
-  using execution_space = Kokkos::DefaultHostExecutionSpace;
-  Kokkos::View<double **, Kokkos::LayoutRight, execution_space> local_energy(
-      "local_energy", execution_space().concurrency(), layout.total);
+  using exec = Kokkos::DefaultHostExecutionSpace;
+  if (local_energy.extent(1) != layout.total) {
+    Kokkos::realloc(Kokkos::WithoutInitializing, local_energy,
+                    exec{}.concurrency(), layout.total);
+  }
+  kokkos_deep_copy(exec{}, local_energy, 0.);
+
   auto const &unique_particles = cell_structure->get_unique_particles();
   auto const n_particles = unique_particles.size();
-  Kokkos::View<int *, Kokkos::LayoutRight, execution_space> mol_id("mol_id",
-                                                                   n_particles);
+  Kokkos::View<int *, Kokkos::LayoutRight, exec> mol_id("mol_id", n_particles);
   for (std::size_t i = 0; i < n_particles; ++i) {
     mol_id(i) = unique_particles[i]->mol_id();
   }
@@ -166,7 +184,7 @@ std::shared_ptr<Observable_stat> System::calculate_energy() {
 #endif
 
   obs_energy.mpi_reduce();
-  return obs_energy_ptr;
+  return obs_energy;
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 

--- a/src/core/error_handling/RuntimeErrorCollector.cpp
+++ b/src/core/error_handling/RuntimeErrorCollector.cpp
@@ -74,7 +74,7 @@ int RuntimeErrorCollector::count() const {
                                 std::plus<>());
 }
 
-int RuntimeErrorCollector::count(RuntimeError::ErrorLevel level) {
+int RuntimeErrorCollector::count_local(RuntimeError::ErrorLevel level) {
   return static_cast<int>(std::ranges::count_if(
       m_errors, [level](auto const &e) { return e.level() >= level; }));
 }

--- a/src/core/error_handling/RuntimeErrorCollector.hpp
+++ b/src/core/error_handling/RuntimeErrorCollector.hpp
@@ -57,7 +57,7 @@ public:
    * @param level Severity filter.
    * @return Number of messages that match the filter.
    */
-  int count(RuntimeError::ErrorLevel level);
+  int count_local(RuntimeError::ErrorLevel level);
 
   /**
    * @brief Reset error messages.

--- a/src/core/errorhandling.cpp
+++ b/src/core/errorhandling.cpp
@@ -46,7 +46,6 @@ namespace ErrorHandling {
 static std::unique_ptr<RuntimeErrorCollector> runtimeErrorCollector;
 
 void init_error_handling(boost::mpi::communicator const &comm) {
-
   runtimeErrorCollector = std::make_unique<RuntimeErrorCollector>(comm);
 }
 
@@ -77,6 +76,29 @@ std::vector<RuntimeError> mpi_gather_runtime_errors_all(bool is_head_node) {
   runtimeErrorCollector->gather_local();
   return {};
 }
+
+static void mpi_poll_runtime_messages_local() {
+  bool has_any_message =
+      runtimeErrorCollector->count_local(
+          ErrorHandling::RuntimeError::ErrorLevel::WARNING) != 0;
+  boost::mpi::reduce(runtimeErrorCollector->comm(), has_any_message,
+                     std::logical_or<bool>(), 0);
+}
+
+REGISTER_CALLBACK(mpi_poll_runtime_messages_local)
+
+bool mpi_poll_runtime_messages() {
+  bool has_any_message =
+      runtimeErrorCollector->count_local(
+          ErrorHandling::RuntimeError::ErrorLevel::WARNING) != 0;
+  bool has_any_message_global = has_any_message;
+  if (runtimeErrorCollector->comm().size() > 1) {
+    ::Communication::mpiCallbacks().call(mpi_poll_runtime_messages_local);
+    boost::mpi::reduce(runtimeErrorCollector->comm(), has_any_message,
+                       has_any_message_global, std::logical_or<bool>(), 0);
+  }
+  return has_any_message_global;
+}
 } // namespace ErrorHandling
 
 void errexit() {
@@ -87,7 +109,7 @@ void errexit() {
 
 int check_runtime_errors_local() {
   using namespace ErrorHandling;
-  return runtimeErrorCollector->count(RuntimeError::ErrorLevel::ERROR);
+  return runtimeErrorCollector->count_local(RuntimeError::ErrorLevel::ERROR);
 }
 
 int check_runtime_errors(boost::mpi::communicator const &comm) {

--- a/src/core/errorhandling.hpp
+++ b/src/core/errorhandling.hpp
@@ -100,5 +100,12 @@ RuntimeErrorStream _runtimeMessageStream(RuntimeError::ErrorLevel level,
 std::vector<RuntimeError> mpi_gather_runtime_errors();
 /** @brief Gather messages on main rank. Call on all ranks. */
 std::vector<RuntimeError> mpi_gather_runtime_errors_all(bool is_head_node);
+/**
+ * @brief Check whether there is at least 1 flying runtime messages on any node.
+ * This has to be called on the head node.
+ *
+ * @return true if at least one message was found.
+ */
+bool mpi_poll_runtime_messages();
 
 } // namespace ErrorHandling

--- a/src/core/forces_cabana.hpp
+++ b/src/core/forces_cabana.hpp
@@ -408,7 +408,7 @@ template <bool HasCoulomb> struct SpecializedForcesKernel {
 #endif
 #endif
 
-  ESPRESSO_ATTR_ALWAYS_INLINE KOKKOS_INLINE_FUNCTION void
+  ESPRESSO_ATTR_ALWAYS_INLINE inline void
   operator()(std::size_t const i) const {
     auto const n_neighbors = counts(i);
     if (n_neighbors == 0)
@@ -438,7 +438,9 @@ template <bool HasCoulomb> struct SpecializedForcesKernel {
     double dx0[tile_size], dx1[tile_size], dx2[tile_size], dsq[tile_size];
 
     for (int base = 0; base < n_neighbors; base += tile_size) {
-      auto const m = Kokkos::min(tile_size, n_neighbors - base);
+      // ``+tile_size`` creates a prvalue and avoids an ODR-use of a host-space
+      // variable from device code (Kokkos::min() takes arguments by const &T)
+      auto const m = Kokkos::min(+tile_size, n_neighbors - base);
 
       // Pass 1: scalar gather of the tile's neighbor positions.
       for (int t = 0; t < m; ++t) {

--- a/src/core/kokkos_helpers.hpp
+++ b/src/core/kokkos_helpers.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025-2026 The ESPResSo project
+ *
+ * This file is part of ESPResSo.
+ *
+ * ESPResSo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ESPResSo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <type_traits>
+
+#include <Kokkos_Core.hpp>
+
+/**
+ * @brief Wrapper for ``Kokkos::deep_copy`` that skips fork/join when
+ * the number of threads is 1.
+ */
+ESPRESSO_ATTR_ALWAYS_INLINE inline void
+kokkos_deep_copy(auto const &exec_space, auto const &view, auto const &value) {
+  using View = std::remove_cvref_t<decltype(view)>;
+  if constexpr (Kokkos::SpaceAccessibility<
+                    Kokkos::DefaultHostExecutionSpace,
+                    typename View::memory_space>::accessible) {
+    if (Kokkos::num_threads() == 1 and view.span_is_contiguous()) {
+      std::fill_n(view.data(), view.span(),
+                  static_cast<typename View::value_type>(value));
+      return;
+    }
+  }
+  Kokkos::deep_copy(exec_space, view, value);
+}
+
+/**
+ * @brief Wrapper for ``Kokkos::parallel_for`` that skips fork/join when
+ * the number of threads is 1.
+ */
+template <class ExecutionSpace = Kokkos::DefaultHostExecutionSpace>
+ESPRESSO_ATTR_ALWAYS_INLINE inline void
+kokkos_parallel_range_for(auto const &name, auto start, auto end,
+                          auto const &kernel) {
+  if (Kokkos::num_threads() > 1) {
+    Kokkos::RangePolicy<ExecutionSpace> policy(start, end);
+    Kokkos::parallel_for(name, policy, kernel);
+  } else {
+    for (auto p_index = start; p_index < end; ++p_index) {
+      kernel(p_index);
+    }
+  }
+}

--- a/src/core/magnetostatics/dp3m_heffte.hpp
+++ b/src/core/magnetostatics/dp3m_heffte.hpp
@@ -27,12 +27,14 @@
 
 #include "magnetostatics/dp3m.hpp"
 
-#include "communication.hpp"
 #include "p3m/FFTBackendLegacy.hpp"
 #include "p3m/FFTBuffersLegacy.hpp"
 #include "p3m/common.hpp"
 #include "p3m/data_struct.hpp"
 #include "p3m/interpolation.hpp"
+
+#include "communication.hpp"
+#include "kokkos_helpers.hpp"
 
 #include <utils/Vector.hpp>
 
@@ -239,7 +241,7 @@ private:
     auto const num_threads = execution_space().concurrency();
     Kokkos::realloc(Kokkos::WithoutInitializing, dp3m.rs_fields_kokkos,
                     num_threads, 3, dp3m.local_mesh.size);
-    Kokkos::deep_copy(dp3m.rs_fields_kokkos, FloatType{0});
+    kokkos_deep_copy(execution_space{}, dp3m.rs_fields_kokkos, FloatType{0});
     for (auto &rs_mesh_field : dp3m.mesh.rs_fields) {
       std::ranges::fill(rs_mesh_field, FloatType{0});
     }

--- a/src/core/magnetostatics/dp3m_heffte.impl.hpp
+++ b/src/core/magnetostatics/dp3m_heffte.impl.hpp
@@ -49,6 +49,7 @@
 #include "communication.hpp"
 #include "errorhandling.hpp"
 #include "integrators/Propagation.hpp"
+#include "kokkos_helpers.hpp"
 #include "npt.hpp"
 #include "system/System.hpp"
 #include "tuning.hpp"
@@ -184,11 +185,12 @@ template <int cao> struct AssignDipole {
   void operator()(auto &dp3m, auto &cell_structure) {
     using DipolarP3MState = std::remove_reference_t<decltype(dp3m)>;
     using value_type = DipolarP3MState::value_type;
+    using execution_space = Kokkos::DefaultHostExecutionSpace;
     auto const &aosoa = cell_structure.get_aosoa();
     auto const &unique_particles = cell_structure.get_unique_particles();
     auto const n_part = cell_structure.count_local_particles();
     dp3m.inter_weights.zfill(n_part); // allocate buffer for parallel write
-    kokkos_parallel_range_for(
+    kokkos_parallel_range_for<execution_space>(
         "InterpolateDipoles", std::size_t{0u}, n_part, [&](auto p_index) {
           auto constexpr memory_order = Utils::MemoryOrder::ROW_MAJOR;
           auto const tid = omp_get_thread_num();
@@ -206,23 +208,21 @@ template <int cao> struct AssignDipole {
               });
         });
     Kokkos::fence();
-    using execution_space = Kokkos::DefaultHostExecutionSpace;
     int num_threads = execution_space().concurrency();
-    Kokkos::RangePolicy<execution_space> policy(std::size_t{0},
-                                                dp3m.local_mesh.size);
-    Kokkos::parallel_for("ReduceInterpolatedDipoles", policy,
-                         [&dp3m, num_threads](std::size_t const i) {
-                           for (int dir = 0; dir < 3; ++dir) {
-                             value_type acc{};
-                             for (int tid = 0; tid < num_threads; ++tid) {
-                               acc += dp3m.rs_fields_kokkos(tid, dir, i);
-                             }
-                             dp3m.mesh.rs_fields[dir][i] += acc;
+    kokkos_parallel_range_for<execution_space>(
+        "ReduceInterpolatedDipoles", std::size_t{0}, dp3m.local_mesh.size,
+        [&dp3m, num_threads](std::size_t const i) {
+          for (int dir = 0; dir < 3; ++dir) {
+            value_type acc{};
+            for (int tid = 0; tid < num_threads; ++tid) {
+              acc += dp3m.rs_fields_kokkos(tid, dir, i);
+            }
+            dp3m.mesh.rs_fields[dir][i] += acc;
 #ifdef ESPRESSO_DP3M_HEFFTE_CROSS_CHECKS
-                             dp3m.heffte.rs_dipole_density[dir][i] += acc;
+            dp3m.heffte.rs_dipole_density[dir][i] += acc;
 #endif
-                           }
-                         });
+          }
+        });
     Kokkos::fence();
   }
 };
@@ -242,6 +242,7 @@ template <int cao> struct AssignTorques {
                   CellStructure &cell_structure) const {
 
     assert(cao == dp3m.inter_weights.cao());
+    using execution_space = Kokkos::DefaultHostExecutionSpace;
 
     auto const kernel = [d_rs, &dp3m](auto const &pref, auto &p_torque,
                                       std::size_t p_index) {
@@ -263,7 +264,7 @@ template <int cao> struct AssignTorques {
     auto const n_part = dp3m.inter_weights.size();
     auto const &unique_particles = cell_structure.get_unique_particles();
     auto scatter_torque = cell_structure.get_scatter_torque();
-    kokkos_parallel_range_for(
+    kokkos_parallel_range_for<execution_space>(
         "AssignTorques", std::size_t{0u}, n_part, [&](std::size_t p_index) {
           auto const &p = *unique_particles.at(p_index);
           if (p.dipm() != 0.) {
@@ -278,6 +279,7 @@ template <int cao> struct AssignForcesDip {
                   CellStructure &cell_structure) const {
 
     assert(cao == dp3m.inter_weights.cao());
+    using execution_space = Kokkos::DefaultHostExecutionSpace;
 
     auto const kernel = [d_rs, &dp3m](auto const &pref, auto &p_force,
                                       std::size_t p_index) {
@@ -298,7 +300,7 @@ template <int cao> struct AssignForcesDip {
     auto const n_part = dp3m.inter_weights.size();
     auto const &unique_particles = cell_structure.get_unique_particles();
     auto scatter_force = cell_structure.get_scatter_force();
-    kokkos_parallel_range_for(
+    kokkos_parallel_range_for<execution_space>(
         "AssignForcesDip", std::size_t{0u}, n_part, [&](std::size_t p_index) {
           auto const &p = *unique_particles.at(p_index);
           if (p.dipm() != 0.) {

--- a/src/core/observables/EnergyObservable.hpp
+++ b/src/core/observables/EnergyObservable.hpp
@@ -33,7 +33,7 @@ public:
   std::vector<std::size_t> shape() const override { return {1u}; }
   std::vector<double>
   operator()(boost::mpi::communicator const &) const override {
-    return {System::get_system().calculate_energy()->accumulate(0u)};
+    return {System::get_system().calculate_energy().accumulate(0u)};
   }
 };
 

--- a/src/core/observables/PressureObservable.hpp
+++ b/src/core/observables/PressureObservable.hpp
@@ -33,10 +33,10 @@ public:
   std::vector<std::size_t> shape() const override { return {1u}; }
   std::vector<double>
   operator()(boost::mpi::communicator const &) const override {
-    auto const obs = System::get_system().calculate_pressure();
+    auto const &obs = System::get_system().calculate_pressure();
 
-    return {(obs->accumulate(0., 0u) + obs->accumulate(0., 4u) +
-             obs->accumulate(0., 8u)) /
+    return {(obs.accumulate(0., 0u) + obs.accumulate(0., 4u) +
+             obs.accumulate(0., 8u)) /
             3.};
   }
 };

--- a/src/core/observables/PressureTensor.hpp
+++ b/src/core/observables/PressureTensor.hpp
@@ -33,12 +33,12 @@ public:
   std::vector<std::size_t> shape() const override { return {3u, 3u}; }
   std::vector<double>
   operator()(boost::mpi::communicator const &) const override {
-    auto const obs = System::get_system().calculate_pressure();
+    auto const &obs = System::get_system().calculate_pressure();
 
     std::vector<double> result;
     result.reserve(9);
     for (std::size_t i = 0u; i < 9u; ++i) {
-      result.emplace_back(obs->accumulate(0., i));
+      result.emplace_back(obs.accumulate(0., i));
     }
     return result;
   }

--- a/src/core/pressure.cpp
+++ b/src/core/pressure.cpp
@@ -29,6 +29,7 @@
 #include "cell_system/CellStructure.hpp"
 #include "electrostatics/coulomb.hpp"
 #include "integrators/Propagation.hpp"
+#include "kokkos_helpers.hpp"
 #include "magnetostatics/dipoles.hpp"
 #include "nonbonded_interactions/VerletCriterion.hpp"
 #include "nonbonded_interactions/nonbonded_interaction_data.hpp"
@@ -48,18 +49,32 @@
 #include <cstddef>
 #include <memory>
 
+struct PressureObservable {
+  using execution_space = Kokkos::DefaultHostExecutionSpace;
+  std::unique_ptr<Observable_stat> observable;
+  Kokkos::View<double **, Kokkos::LayoutRight, execution_space> local;
+};
+
 namespace System {
-std::shared_ptr<Observable_stat> System::calculate_pressure() {
 
-  auto obs_pressure_ptr = std::make_shared<Observable_stat>(
-      9ul, static_cast<std::size_t>(bonded_ias->get_next_key()),
-      nonbonded_ias->get_max_seen_particle_type());
+Observable_stat const &System::calculate_pressure() {
 
-  if (long_range_interactions_sanity_checks()) {
-    return obs_pressure_ptr;
+  if (not m_obs_pressure) {
+    auto const n_threads = PressureObservable::execution_space{}.concurrency();
+    m_obs_pressure = std::make_shared<PressureObservable>();
+    m_obs_pressure->observable = std::make_unique<Observable_stat>(9ul, 0ul, 0);
+    m_obs_pressure->local =
+        decltype(m_obs_pressure->local)("local_pressure", n_threads, 9ul);
   }
 
-  auto &obs_pressure = *obs_pressure_ptr;
+  auto &local_pressure = m_obs_pressure->local;
+  auto &obs_pressure = *m_obs_pressure->observable;
+  obs_pressure.reset(static_cast<std::size_t>(bonded_ias->get_next_key()),
+                     nonbonded_ias->get_max_seen_particle_type());
+
+  if (long_range_interactions_sanity_checks()) {
+    return obs_pressure;
+  }
 
   on_observable_calc();
 
@@ -96,8 +111,11 @@ std::shared_ptr<Observable_stat> System::calculate_pressure() {
       std::size_t(nonbonded_ias->get_max_seen_particle_type() + 1)};
 
   using exec = Kokkos::DefaultHostExecutionSpace;
-  Kokkos::View<double **, Kokkos::LayoutRight, exec> local_pressure(
-      "local_pressure", exec().concurrency(), layout.total * 9);
+  if (local_pressure.extent(1) != layout.total * 9ul) {
+    Kokkos::realloc(Kokkos::WithoutInitializing, local_pressure,
+                    exec{}.concurrency(), layout.total * 9ul);
+  }
+  kokkos_deep_copy(exec{}, local_pressure, 0.);
 
   auto const &unique_particles = cell_structure->get_unique_particles();
   auto const n_particles = unique_particles.size();
@@ -182,6 +200,7 @@ std::shared_ptr<Observable_stat> System::calculate_pressure() {
   obs_pressure.rescale(volume);
 
   obs_pressure.mpi_reduce();
-  return obs_pressure_ptr;
+  return obs_pressure;
 }
+
 } // namespace System

--- a/src/core/reaction_methods/ReactionAlgorithm.cpp
+++ b/src/core/reaction_methods/ReactionAlgorithm.cpp
@@ -669,9 +669,9 @@ void ReactionAlgorithm::setup_bookkeeping_of_empty_pids() {
 
 double ReactionAlgorithm::calculate_potential_energy() const {
   auto &system = System::get_system();
-  auto const obs = system.calculate_energy();
-  auto const kinetic_energy = obs->kinetic_lin[0] + obs->kinetic_rot[0];
-  auto pot = obs->accumulate(-kinetic_energy);
+  auto const &obs = system.calculate_energy();
+  auto const kinetic_energy = obs.kinetic_lin[0] + obs.kinetic_rot[0];
+  auto pot = obs.accumulate(-kinetic_energy);
   boost::mpi::broadcast(m_comm, pot, 0);
   return pot;
 }

--- a/src/core/short_range_cabana.hpp
+++ b/src/core/short_range_cabana.hpp
@@ -27,6 +27,7 @@
 #include "bond_forces_kokkos.hpp"
 #include "custom_verlet_list.hpp"
 #include "forces_cabana.hpp"
+#include "kokkos_helpers.hpp"
 
 #include <Cabana_Core.hpp>
 #include <Cabana_NeighborList.hpp>
@@ -39,21 +40,6 @@
 #include <iterator>
 #include <span>
 #include <utility>
-
-template <class KokkosRangePolicy =
-              Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>>
-ESPRESSO_ATTR_ALWAYS_INLINE inline void
-kokkos_parallel_range_for(auto const &name, auto start, auto end,
-                          auto const &kernel) {
-  if (Kokkos::num_threads() > 1) {
-    KokkosRangePolicy policy(start, end);
-    Kokkos::parallel_for(name, policy, kernel);
-  } else {
-    for (auto p_index = start; p_index < end; ++p_index) {
-      kernel(p_index);
-    }
-  }
-}
 
 ESPRESSO_ATTR_ALWAYS_INLINE inline void
 commit_particle(Particle const &p, auto const index,
@@ -171,16 +157,12 @@ ESPRESSO_ATTR_ALWAYS_INLINE inline void link_cell_kokkos(
     }
   };
 
-  Kokkos::parallel_for("intra",
-                       Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
-                           std::size_t{0}, cells.size()),
-                       intra_kernel);
+  kokkos_parallel_range_for<Kokkos::DefaultHostExecutionSpace>(
+      "intra", std::size_t{0}, cells.size(), intra_kernel);
   Kokkos::fence();
 
-  Kokkos::parallel_for("inter",
-                       Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
-                           std::size_t{0}, cells.size()),
-                       inter_kernel);
+  kokkos_parallel_range_for<Kokkos::DefaultHostExecutionSpace>(
+      "inter", std::size_t{0}, cells.size(), inter_kernel);
   Kokkos::fence();
 }
 
@@ -195,7 +177,6 @@ update_cabana_state(CellStructure &cell_structure,
 #ifdef ESPRESSO_CALIPER
   CALI_CXX_MARK_FUNCTION;
 #endif
-  using policy_type = Kokkos::RangePolicy<execution_space>;
   auto const rebuild = cell_structure.prepare_verlet_list_cabana(pair_cutoff);
   auto const &unique_particles = cell_structure.get_unique_particles();
   auto const n_part = unique_particles.size();
@@ -219,7 +200,7 @@ update_cabana_state(CellStructure &cell_structure,
     // before the sweep repopulates it (read O(1) at the dispatch gate).
     aosoa.reset_any_exclusion();
 #endif
-    kokkos_parallel_range_for<policy_type>(
+    kokkos_parallel_range_for<execution_space>(
         "AoSoA write", std::size_t{0}, n_part,
         [&unique_particles, &aosoa, &id_to_index, &cell_structure, &pair_count,
          &angle_count, &dihedral_count](int const index) {
@@ -232,38 +213,43 @@ update_cabana_state(CellStructure &cell_structure,
           }
         });
     Kokkos::fence();
+    using host_space = Kokkos::DefaultHostExecutionSpace;
     auto &bs = cell_structure.bond_state();
-    auto &pair_bond_list = bs.pair_list;
-    Kokkos::parallel_for("resolve_pair_bond_indices",
-                         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
-                             std::size_t{0}, pair_count),
-                         [&pair_bond_list, &id_to_index](int idx) {
-                           for (int col = 0; col < 2; ++col) {
-                             pair_bond_list(idx, col) =
-                                 id_to_index(pair_bond_list(idx, col));
-                           }
-                         });
-    auto &angle_bond_list = bs.angle_list;
-    Kokkos::parallel_for("resolve_angle_bond_indices",
-                         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
-                             std::size_t{0}, angle_count),
-                         [&angle_bond_list, &id_to_index](int idx) {
-                           for (int col = 0; col < 3; ++col) {
-                             angle_bond_list(idx, col) =
-                                 id_to_index(angle_bond_list(idx, col));
-                           }
-                         });
-    auto &dihedral_bond_list = bs.dihedral_list;
-    Kokkos::parallel_for("resolve_dihedral_bond_indices",
-                         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
-                             std::size_t{0}, dihedral_count),
-                         [&dihedral_bond_list, &id_to_index](int idx) {
-                           for (int col = 0; col < 4; ++col) {
-                             dihedral_bond_list(idx, col) =
-                                 id_to_index(dihedral_bond_list(idx, col));
-                           }
-                         });
-    Kokkos::fence();
+    if (pair_count) {
+      auto &pair_bond_list = bs.pair_list;
+      kokkos_parallel_range_for<host_space>(
+          "resolve_pair_bond_indices", std::size_t{0}, pair_count,
+          [&pair_bond_list, &id_to_index](int idx) {
+            for (int col = 0; col < 2; ++col) {
+              pair_bond_list(idx, col) = id_to_index(pair_bond_list(idx, col));
+            }
+          });
+    }
+    if (angle_count) {
+      auto &angle_bond_list = bs.angle_list;
+      kokkos_parallel_range_for<host_space>(
+          "resolve_angle_bond_indices", std::size_t{0}, angle_count,
+          [&angle_bond_list, &id_to_index](int idx) {
+            for (int col = 0; col < 3; ++col) {
+              angle_bond_list(idx, col) =
+                  id_to_index(angle_bond_list(idx, col));
+            }
+          });
+    }
+    if (dihedral_count) {
+      auto &dihedral_bond_list = bs.dihedral_list;
+      kokkos_parallel_range_for<host_space>(
+          "resolve_dihedral_bond_indices", std::size_t{0}, dihedral_count,
+          [&dihedral_bond_list, &id_to_index](int idx) {
+            for (int col = 0; col < 4; ++col) {
+              dihedral_bond_list(idx, col) =
+                  id_to_index(dihedral_bond_list(idx, col));
+            }
+          });
+    }
+    if (pair_count != 0 or angle_count != 0 or dihedral_count != 0) {
+      Kokkos::fence();
+    }
 #ifdef ESPRESSO_CALIPER
     CALI_MARK_END("AoSoA commit full");
 #endif
@@ -317,7 +303,7 @@ update_cabana_state(CellStructure &cell_structure,
     // before the sweep repopulates it (read O(1) at the dispatch gate).
     aosoa.reset_any_exclusion();
 #endif
-    kokkos_parallel_range_for<policy_type>(
+    kokkos_parallel_range_for<execution_space>(
         "AoSoA write", std::size_t{0}, n_part,
         [&unique_particles, &aosoa](int const index) {
           auto const &p = *unique_particles.at(index);
@@ -334,12 +320,11 @@ update_cabana_state(CellStructure &cell_structure,
 template <class execution_space = Kokkos::DefaultHostExecutionSpace>
 ESPRESSO_ATTR_ALWAYS_INLINE inline void
 update_aosoa_charges(CellStructure &cell_structure) {
-  using policy_type = Kokkos::RangePolicy<execution_space>;
   auto const &unique_particles = cell_structure.get_unique_particles();
   auto const n_part = unique_particles.size();
   auto &aosoa = cell_structure.get_aosoa();
 
-  kokkos_parallel_range_for<policy_type>(
+  kokkos_parallel_range_for<execution_space>(
       "Views update charges", std::size_t{0}, n_part,
       [&unique_particles, &aosoa](std::size_t const index) {
         aosoa.charge(index) = unique_particles.at(index)->q();
@@ -374,32 +359,27 @@ void cabana_short_range(auto const &pair_bonds_kernel,
 #ifdef ESPRESSO_CALIPER
     CALI_MARK_BEGIN("cabana_bond_loop");
 #endif
+    using host_space = Kokkos::DefaultHostExecutionSpace;
     auto const n_pair_bonds = cell_structure.get_local_pair_bond_numbers();
     auto const n_angle_bonds = cell_structure.get_local_angle_bond_numbers();
     auto const n_dihedral_bonds =
         cell_structure.get_local_dihedral_bond_numbers();
     if (n_pair_bonds > 0) {
-      Kokkos::parallel_for( // loop over bonds
-          "for_each_local_pair_bonds",
-          Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(std::size_t{0},
-                                                                 n_pair_bonds),
-          pair_bonds_kernel);
-      Kokkos::fence();
+      kokkos_parallel_range_for<host_space>("for_each_local_pair_bonds",
+                                            std::size_t{0}, n_pair_bonds,
+                                            pair_bonds_kernel);
     }
     if (n_angle_bonds > 0) {
-      Kokkos::parallel_for( // loop over bonds
-          "for_each_local_angle_bonds",
-          Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(std::size_t{0},
-                                                                 n_angle_bonds),
-          angle_bonds_kernel);
-      Kokkos::fence();
+      kokkos_parallel_range_for<host_space>("for_each_local_angle_bonds",
+                                            std::size_t{0}, n_angle_bonds,
+                                            angle_bonds_kernel);
     }
     if (n_dihedral_bonds > 0) {
-      Kokkos::parallel_for( // loop over bonds
-          "for_each_local_dihedral_bonds",
-          Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
-              std::size_t{0}, n_dihedral_bonds),
-          dihedral_bonds_kernel);
+      kokkos_parallel_range_for<host_space>("for_each_local_dihedral_bonds",
+                                            std::size_t{0}, n_dihedral_bonds,
+                                            dihedral_bonds_kernel);
+    }
+    if (n_pair_bonds != 0 or n_angle_bonds != 0 or n_dihedral_bonds != 0) {
       Kokkos::fence();
     }
 #ifdef ESPRESSO_CALIPER
@@ -418,6 +398,14 @@ void cabana_short_range(auto const &pair_bonds_kernel,
       auto const n_particles = cell_structure.get_unique_particles().size();
       if (verlet_pair_loop) {
         verlet_pair_loop(verlet_list, n_particles);
+      } else if (Kokkos::num_threads() == 1) {
+        using NL = Cabana::NeighborList<CellStructure::ListType>;
+        for (std::size_t i = 0; i < n_particles; ++i) {
+          auto const nn = NL::numNeighbor(verlet_list, i);
+          for (std::size_t n = 0; n < nn; ++n) {
+            nonbonded_kernel(i, NL::getNeighbor(verlet_list, i, n));
+          }
+        }
       } else {
         Kokkos::RangePolicy<execution_space> policy(std::size_t{0},
                                                     n_particles);

--- a/src/core/system/System.cpp
+++ b/src/core/system/System.cpp
@@ -25,6 +25,7 @@
 #include "BoxGeometry.hpp"
 #include "GpuParticleData.hpp"
 #include "LocalBox.hpp"
+#include "Observable_stat.hpp"
 #include "PropagationMode.hpp"
 #include "accumulators/AutoUpdateAccumulators.hpp"
 #include "bonded_interactions/bonded_interaction_data.hpp"

--- a/src/core/system/System.hpp
+++ b/src/core/system/System.hpp
@@ -73,6 +73,8 @@ struct InstantaneousPressure;
 #ifdef ESPRESSO_CUDA
 class GpuParticleData;
 #endif
+struct EnergyObservable;
+struct PressureObservable;
 
 namespace System {
 
@@ -153,10 +155,10 @@ public:
   bool long_range_interactions_sanity_checks() const;
 
   /** @brief Calculate the total energy. */
-  std::shared_ptr<Observable_stat> calculate_energy();
+  Observable_stat const &calculate_energy();
 
   /** @brief Calculate the pressure from a virial expansion. */
-  std::shared_ptr<Observable_stat> calculate_pressure();
+  Observable_stat const &calculate_pressure();
 
 #ifdef ESPRESSO_NPT
   /** @brief Synchronize NpT state such as instantaneous and average pressure */
@@ -356,6 +358,8 @@ protected:
    * to be available on the same node (through ghosts).
    */
   double min_global_cut;
+  std::shared_ptr<EnergyObservable> m_obs_energy;
+  std::shared_ptr<PressureObservable> m_obs_pressure;
 
   void update_local_geo();
 #ifdef ESPRESSO_ELECTROSTATICS

--- a/src/core/system/System.impl.hpp
+++ b/src/core/system/System.impl.hpp
@@ -26,6 +26,7 @@
 #include "lb/Implementation.hpp"
 
 #include "GpuParticleData.hpp"
+#include "Observable_stat.hpp"
 #include "accumulators/AutoUpdateAccumulators.hpp"
 #include "bond_breakage/bond_breakage.hpp"
 #include "bonded_interactions/bonded_interaction_data.hpp"

--- a/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
+++ b/src/core/unit_tests/EspressoSystemStandAlone_test.cpp
@@ -238,12 +238,12 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
     remove_translational_motion(system);
     for (int i = 0; i < 5; ++i) {
       set_particle_v(pid2, {static_cast<double>(i), 0., 0.});
-      auto const obs_energy = system.calculate_energy();
+      auto const &obs_energy = system.calculate_energy();
       auto const p_opt = copy_particle_to_head_node(comm, system, pid2);
       if (rank == 0) {
         auto const &p = *p_opt;
         auto const kinetic_energy = 0.5 * p.mass() * p.v().norm2();
-        BOOST_CHECK_CLOSE(obs_energy->kinetic_lin[0], kinetic_energy, tol);
+        BOOST_CHECK_CLOSE(obs_energy.kinetic_lin[0], kinetic_energy, tol);
       }
     }
   }
@@ -284,9 +284,9 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
       // at very short distances, the real-space contribution to
       // the energy is much larger than the k-space contribution
       auto const energy_ref = -prefactor * 0.25 / r;
-      auto const obs_energy = system.calculate_energy();
+      auto const &obs_energy = system.calculate_energy();
       if (rank == 0) {
-        auto const energy_p3m = obs_energy->coulomb[0] + obs_energy->coulomb[1];
+        auto const energy_p3m = obs_energy.coulomb[0] + obs_energy.coulomb[1];
         BOOST_CHECK_CLOSE(energy_p3m, energy_ref, 0.002);
       }
       if (n_nodes != 3) {
@@ -309,9 +309,9 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
     solver->detach_system(espresso::system);
     system.coulomb.impl->solver = std::nullopt;
     system.on_coulomb_change();
-    auto const obs_energy = system.calculate_energy();
+    auto const &obs_energy = system.calculate_energy();
     if (rank == 0) {
-      auto const energy_p3m = obs_energy->coulomb[0] + obs_energy->coulomb[1];
+      auto const energy_p3m = obs_energy.coulomb[0] + obs_energy.coulomb[1];
       BOOST_CHECK_EQUAL(energy_p3m, 0.);
     }
   }
@@ -353,9 +353,9 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
       // at very short distances, the real-space contribution to
       // the energy is much larger than the k-space contribution
       auto const energy_ref = -prefactor * 0.25 / Utils::int_pow<3>(r);
-      auto const obs_energy = system.calculate_energy();
+      auto const &obs_energy = system.calculate_energy();
       if (rank == 0) {
-        auto const energy_p3m = obs_energy->dipolar[0] + obs_energy->dipolar[1];
+        auto const energy_p3m = obs_energy.dipolar[0] + obs_energy.dipolar[1];
         BOOST_CHECK_CLOSE(energy_p3m, energy_ref, 0.002);
       }
       if (n_nodes != 3) {
@@ -376,9 +376,9 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
     solver->detach_system(espresso::system);
     system.dipoles.impl->solver = std::nullopt;
     system.on_dipoles_change();
-    auto const obs_energy = system.calculate_energy();
+    auto const &obs_energy = system.calculate_energy();
     if (rank == 0) {
-      auto const energy_p3m = obs_energy->dipolar[0] + obs_energy->dipolar[1];
+      auto const energy_p3m = obs_energy.dipolar[0] + obs_energy.dipolar[1];
       BOOST_CHECK_EQUAL(energy_p3m, 0.);
     }
   }
@@ -410,14 +410,14 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
     auto const lj_energy = 4.0 * eps * (Utils::sqr(frac6) - frac6 + shift);
 
     // measure energies
-    auto const obs_energy = system.calculate_energy();
+    auto const &obs_energy = system.calculate_energy();
     if (rank == 0) {
       for (int i = 0; i < n_pairs + 1; ++i) {
         // particles were set up with type == mol_id
         auto const ref_inter = (i == lj_pair_ab) ? lj_energy : 0.;
         auto const ref_intra = (i == lj_pair_bb) ? lj_energy : 0.;
-        BOOST_CHECK_CLOSE(obs_energy->non_bonded_inter[i], ref_inter, 1e-10);
-        BOOST_CHECK_CLOSE(obs_energy->non_bonded_intra[i], ref_intra, 1e-10);
+        BOOST_CHECK_CLOSE(obs_energy.non_bonded_inter[i], ref_inter, 1e-10);
+        BOOST_CHECK_CLOSE(obs_energy.non_bonded_intra[i], ref_intra, 1e-10);
       }
     }
   }
@@ -451,7 +451,7 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
     insert_particle_bond(pid2, fene_bond_id, {pid3});
 
     // measure energies
-    auto const obs_energy = system.calculate_energy();
+    auto const &obs_energy = system.calculate_energy();
     if (rank == 0) {
       auto const none_energy = 0.0;
       auto const harm_energy =
@@ -459,9 +459,9 @@ BOOST_FIXTURE_TEST_CASE(espresso_system_stand_alone, ParticleFactory) {
       auto const fene_energy =
           -0.5 * fene_bond.k * Utils::sqr(fene_bond.drmax) *
           std::log(1.0 - Utils::sqr((dist - fene_bond.r0) / fene_bond.drmax));
-      BOOST_CHECK_CLOSE(obs_energy->bonded[none_bond_id], none_energy, 0.0);
-      BOOST_CHECK_CLOSE(obs_energy->bonded[harm_bond_id], harm_energy, 1e-10);
-      BOOST_CHECK_CLOSE(obs_energy->bonded[fene_bond_id], fene_energy, 1e-10);
+      BOOST_CHECK_CLOSE(obs_energy.bonded[none_bond_id], none_energy, 0.0);
+      BOOST_CHECK_CLOSE(obs_energy.bonded[harm_bond_id], harm_energy, 1e-10);
+      BOOST_CHECK_CLOSE(obs_energy.bonded[fene_bond_id], fene_energy, 1e-10);
     }
   }
 

--- a/src/core/unit_tests/MpiCallbacks_test.cpp
+++ b/src/core/unit_tests/MpiCallbacks_test.cpp
@@ -35,6 +35,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace utf = boost::unit_test;
+
 static std::weak_ptr<boost::mpi::environment> mpi_env;
 static bool called = false;
 
@@ -49,6 +51,12 @@ struct GlobalConfig {
   }
   ~GlobalConfig() { m_mpi_env.reset(); }
 };
+
+// Decorator to skip tests when the number of MPI ranks is 1
+boost::test_tools::assertion_result has_2_or_more_mpi_ranks(utf::test_unit_id) {
+  boost::mpi::communicator world;
+  return world.size() >= 2;
+}
 
 BOOST_TEST_GLOBAL_CONFIGURATION(GlobalConfig);
 BOOST_AUTO_TEST_SUITE(suite)
@@ -232,6 +240,7 @@ BOOST_AUTO_TEST_CASE(call_all) {
   BOOST_CHECK(called);
 }
 
+BOOST_TEST_DECORATOR(*utf::precondition(has_2_or_more_mpi_ranks))
 BOOST_AUTO_TEST_CASE(check_exceptions) {
   auto cb1 = []() {};
   auto cb2 = []() {};

--- a/src/core/unit_tests/RuntimeErrorCollector_test.cpp
+++ b/src/core/unit_tests/RuntimeErrorCollector_test.cpp
@@ -65,8 +65,8 @@ BOOST_AUTO_TEST_CASE(count) {
   /* There should now be one error and world.size() warnings */
   auto const n_local_errors = static_cast<int>(world.rank() == rank_of_error);
   auto const n_local_warnings = n_local_errors + 1;
-  BOOST_REQUIRE_EQUAL(rec.count(ErrorLevel::ERROR), n_local_errors);
-  BOOST_REQUIRE_EQUAL(rec.count(ErrorLevel::WARNING), n_local_warnings);
+  BOOST_REQUIRE_EQUAL(rec.count_local(ErrorLevel::ERROR), n_local_errors);
+  BOOST_REQUIRE_EQUAL(rec.count_local(ErrorLevel::WARNING), n_local_warnings);
 
   /* Clear list of errors */
   world.barrier();

--- a/src/core/unit_tests/p3m_test.cpp
+++ b/src/core/unit_tests/p3m_test.cpp
@@ -144,12 +144,12 @@ template <auto... Pack> void test_all_p3m_fft_configs() {
         tuning, prefactor);
     add_actor(comm, espresso::system, system.coulomb.impl->solver, solver,
               [&system]() { system.on_coulomb_change(); });
-    auto const obs_energy = system.calculate_energy();
+    auto const &obs_energy = system.calculate_energy();
     system.integrate(0, INTEG_REUSE_FORCES_NEVER);
     if (rank == 0) {
       BOOST_TEST_CONTEXT(Utils::demangle<FFTConfig>()) {
         auto constexpr energy_ref = -0.114744451;
-        auto const energy_k_space = obs_energy->coulomb[1];
+        auto const energy_k_space = obs_energy.coulomb[1];
         BOOST_CHECK_CLOSE(energy_k_space, energy_ref, 1e-6);
       }
     }
@@ -218,12 +218,12 @@ template <auto... Pack> void test_all_dp3m_fft_configs() {
     solver->dp3m.template make_fft_instance<FFTBackendLegacy<double>>();
     add_actor(comm, espresso::system, system.dipoles.impl->solver, solver,
               [&system]() { system.on_dipoles_change(); });
-    auto const obs_energy = system.calculate_energy();
+    auto const &obs_energy = system.calculate_energy();
     system.integrate(0, INTEG_REUSE_FORCES_NEVER);
     if (rank == 0) {
       BOOST_TEST_CONTEXT(Utils::demangle<FFTConfig>()) {
         auto constexpr energy_ref = -0.0052257342364;
-        auto const energy_k_space = obs_energy->dipolar[1];
+        auto const energy_k_space = obs_energy.dipolar[1];
         BOOST_CHECK_CLOSE(energy_k_space, energy_ref, 1e-6);
       }
     }

--- a/src/python/espressomd/accumulators.py
+++ b/src/python/espressomd/accumulators.py
@@ -314,6 +314,15 @@ class Correlator(_AccumulatorBase):
         update these weights with ``obs.args = [...]``, you'll have to
         provide already squared values! Other correlation operations
         will ignore these values.
+
+    Methods
+    -------
+    update()
+        Update the correlator (get the current values from the observable(s)).
+    finalize()
+        Trigger a compression for the last remaining values in the buffer.
+        After that, the correlator can no longer be updated.
+
     """
 
     _so_name = "Accumulators::Correlator"

--- a/src/python/espressomd/cluster_analysis.py
+++ b/src/python/espressomd/cluster_analysis.py
@@ -42,7 +42,7 @@ class Cluster(ScriptInterfaceHelper):
     longest_distance()
         Longest distance between any combination of two particles in the cluster
 
-    fractal_dimension(dr)
+    fractal_dimension()
         Estimates the cluster's fractal dimension by fitting the number of
         particles :math:`n` in spheres of growing radius around the center of mass
         to :math:`c*r_g^d`, where :math:`r_g` is the radius of gyration of the

--- a/src/python/espressomd/code_info.py
+++ b/src/python/espressomd/code_info.py
@@ -29,27 +29,30 @@ class _CodeInfo(ScriptInterfaceHelper):
     )
 
 
+_code_info_instance = _CodeInfo()
+
+
 def build_type():
     """
     Get the CMake build type of this build of ESPResSo.
     Can be e.g. Debug, Release, RelWithAssert, RelWithDebInfo, Coverage, etc.
     """
-    return _CodeInfo().build_type()
+    return _code_info_instance.build_type()
 
 
 def features():
     """Get the list of features available in this build of ESPResSo."""
-    return _CodeInfo().features()
+    return _code_info_instance.features()
 
 
 def all_features():
     """Get the list of all features that can be activated in ESPResSo."""
-    return _CodeInfo().all_features()
+    return _code_info_instance.all_features()
 
 
 def scafacos_methods():
     """Lists long-range methods available in the ScaFaCoS library."""
-    return _CodeInfo().scafacos_methods()
+    return _code_info_instance.scafacos_methods()
 
 
 def toolchain():
@@ -59,4 +62,4 @@ def toolchain():
     in time and can change when a custom ``FindPackage`` updates its API.
     Use this method only for debugging purposes.
     """
-    return _CodeInfo().toolchain()
+    return _code_info_instance.toolchain()

--- a/src/python/espressomd/interactions.py
+++ b/src/python/espressomd/interactions.py
@@ -1482,7 +1482,7 @@ class BondedInteractions(ScriptObjectMap):
         Parameters
         ----------
         bond: :class:`espressomd.interactions.BondedInteraction`
-            Either a bond object...
+            The bond object to register.
 
         """
 

--- a/src/python/espressomd/lb.py
+++ b/src/python/espressomd/lb.py
@@ -118,7 +118,7 @@ class LBFluid(ScriptInterfaceHelper, espressomd.detail.walberla.LatticeModel):
         v : (3,) array_like :obj:`float`
             The LB fluid velocity at ``pos``.
 
-    add_force_at_pos():
+    add_force_at_pos()
         Adds a force to the fluid at given position.
 
         Parameters

--- a/src/python/espressomd/reaction_methods.py
+++ b/src/python/espressomd/reaction_methods.py
@@ -63,7 +63,6 @@ class ReactionAlgorithm(ScriptInterfaceHelper):
     according the Maxwell-Boltzmann distribution. In this step the mass of the
     new particle is assumed to equal 1.
 
-
     Parameters
     ----------
     kT : :obj:`float`
@@ -242,8 +241,9 @@ class ReactionAlgorithm(ScriptInterfaceHelper):
     change_reaction_constant()
         Changes the reaction constant of a given reaction
         (for both the forward and backward reactions).
-        The ``reaction_id`` which is assigned to a reaction
-        depends on the order in which :meth:`add_reaction` was called.
+        The ``reaction_id`` which is assigned to a reaction depends on the order
+        in which :meth:`~espressomd.reaction_methods.ReactionAlgorithm.add_reaction`
+        was called.
         The 0th reaction has ``reaction_id=0``, the next added
         reaction needs to be addressed with ``reaction_id=1``, etc.
 

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -79,6 +79,7 @@ cdef extern from "script_interface/get_value.hpp" namespace "ScriptInterface":
 
 cdef extern from "script_interface/code_info/CodeInfo.hpp" namespace "ScriptInterface::CodeInfo":
     void check_features(const vector[string] & features) except +
+    string check_features_msg(const vector[string] & features)
 
 cdef void init(const shared_ptr[MpiCallbacks] &)
 cdef void deinit()

--- a/src/python/espressomd/script_interface.pxd
+++ b/src/python/espressomd/script_interface.pxd
@@ -78,7 +78,6 @@ cdef extern from "script_interface/get_value.hpp" namespace "ScriptInterface":
     T get_value[T](const Variant &) except +
 
 cdef extern from "script_interface/code_info/CodeInfo.hpp" namespace "ScriptInterface::CodeInfo":
-    void check_features(const vector[string] & features) except +
     string check_features_msg(const vector[string] & features)
 
 cdef void init(const shared_ptr[MpiCallbacks] &)

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -643,15 +643,15 @@ class ScriptObjectList(ScriptInterfaceHelper):
     """
 
     def __getitem__(self, key):
-        return self.call_method("get_elements")[key]
+        return self.call_method(b"get_elements")[key]
 
     def __iter__(self):
-        elements = self.call_method("get_elements")
+        elements = self.call_method(b"get_elements")
         for e in elements:
             yield e
 
     def __len__(self):
-        return self.call_method("size")
+        return self.call_method(b"size")
 
 
 class ScriptObjectMap(ScriptInterfaceHelper):
@@ -677,22 +677,22 @@ class ScriptObjectMap(ScriptInterfaceHelper):
         Remove all elements.
 
         """
-        self.call_method("clear")
+        self.call_method(b"clear")
 
     def __len__(self):
-        return self.call_method("size")
+        return self.call_method(b"size")
 
     def __getitem__(self, key):
-        return self.call_method("get", key=key)
+        return self.call_method(b"get", key=key)
 
     def __setitem__(self, key, value):
-        self.call_method("insert", key=key, object=value)
+        self.call_method(b"insert", key=key, object=value)
 
     def __delitem__(self, key):
-        self.call_method("erase", key=key)
+        self.call_method(b"erase", key=key)
 
     def keys(self):
-        return self.call_method("keys")
+        return self.call_method(b"keys")
 
     def __iter__(self):
         for k in self.keys():

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -567,8 +567,9 @@ class ScriptInterfaceHelper(PScriptInterface):
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
+        cls.__doc__, docstrings = cls._extract_method_docstrings()
         for method_name in cls._so_bind_methods:
-            cls._install_bound_method(method_name)
+            cls._install_bound_method(method_name, docstrings.get(method_name))
 
         cdef vector[string] features_vec
         if cls._so_features:
@@ -579,7 +580,69 @@ class ScriptInterfaceHelper(PScriptInterface):
                 cls._so_features_error = msg
 
     @classmethod
-    def _install_bound_method(cls, method_name):
+    def _extract_method_docstrings(cls):
+        """
+        Extract the "Methods" section from the class docstring, and parse each
+        method definition. Those that match existing synthetic method names are
+        removed from the docstring and returned in a dictionary.
+        """
+        import inspect
+        import textwrap
+        cls_doc = cls.__doc__
+        if not cls_doc or "\n" not in cls_doc:
+            return (cls.__doc__, {})
+        cls_doc = inspect.cleandoc(cls_doc)
+        cls_doc_lines = cls_doc.split("\n")
+        sections = []
+        last = len(cls_doc_lines)
+        for lineno, line in reversed(list(enumerate(cls_doc_lines))):
+            if len(line) >= 3 and set(line.rstrip()) == {"-"}:
+                start = lineno - 1
+                section_title = cls_doc_lines[start].strip()
+                sections.insert(0, (section_title, start, last))
+                last = start
+        for section_title, start, end in sections:
+            if section_title != "Methods":
+                continue
+            split_blocks = ["\n".join(cls_doc_lines[:start]),
+                            "\n".join(cls_doc_lines[start:end]),
+                            "\n".join(cls_doc_lines[end:])]
+            break
+        else:
+            return (cls.__doc__, {})
+        method_section_lines = textwrap.dedent(split_blocks[1]).split("\n")
+        method_lines = method_section_lines[2:]
+        method_names = []
+        method_docstrings = []
+        for line in method_lines:
+            line = line.rstrip()
+            if not line.startswith(" ") and "(" in line:
+                method_name = line.split("(", 1)[0]
+                assert method_name.isidentifier(), f"{method_name!r} isn't a suitable name for a class method (in docstring of {cls})"  # nopep8
+                method_names.append(method_name)
+                method_docstrings.append([line])
+            elif method_docstrings:
+                method_docstrings[-1].append(line)
+            else:
+                assert line == "", f"malformed docstring in {cls}, cannot interpret {line!r}"  # nopep8
+        extra_methods = []
+        result = {}
+        for name, docstring in zip(method_names, method_docstrings):
+            if name in cls._so_bind_methods:
+                result[name] = "\n".join(docstring[1:]).rstrip()
+            else:
+                # preserve synthetic methods unrelated to the C++ interface
+                extra_methods.append("\n".join(docstring))
+        if extra_methods:
+            split_blocks[1] = "\n".join(
+                method_section_lines[:2] + extra_methods)
+        else:
+            split_blocks[1] = ""
+        cls_doc = textwrap.indent("\n".join(split_blocks), 4 * " ")
+        return (cls_doc, result)
+
+    @classmethod
+    def _install_bound_method(cls, method_name, docstring):
         """
         Bind C++ methods declared in ``_so_bind_methods`` to the Python class.
         This factory method compiles a code object whose ``co_name`` is the
@@ -599,6 +662,7 @@ class ScriptInterfaceHelper(PScriptInterface):
         fn = namespace[method_name]
         fn.__qualname__ = f"{cls.__qualname__}.{method_name}"
         fn.__module__ = cls.__module__
+        fn.__doc__ = docstring
         setattr(cls, method_name, fn)
 
     def __reduce__(self):

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -254,108 +254,127 @@ def fast_tiling(value, n):
 cdef Variant python_object_to_variant(value) except *:
     """Convert Python objects to C++ Variant objects."""
 
+    # The order is important, the object character should
+    # be preserved even if the PScriptInterface derived class
+    # is iterable
+    if value is None:
+        return Variant()
+    if isinstance(value, np.ndarray) and value.ndim == 0:
+        value = value.item()
+    if isinstance(value, (bool, np.bool_)):
+        return make_variant[cbool](value)
+    if isinstance(value, int):
+        return make_variant[int](value)
+    if isinstance(value, float):
+        return make_variant[double](value)
+    if isinstance(value, PScriptInterface):
+        return make_variant(( < PObjectRef > value.get_sip()).sip)
+    if isinstance(value, (str, bytes, np.bytes_)):
+        return make_variant[string](utils.to_bytes(value))
+    if isinstance(value, pathlib.Path):
+        return make_variant[path](path(str(value).encode()))
+    if isinstance(value, dict):
+        return _dict_object_to_variant(value)
+    if isinstance(value, np.ndarray):
+        return _numpy_object_to_variant(value)
+    return _python_object_to_variant_non_trivial_cases(value)
+
+
+cdef Variant _dict_object_to_variant(value) except *:
+    cdef unordered_map[int, Variant] map_int2var
+    cdef unordered_map[string, Variant] map_str2var
+    if all(map(lambda x: isinstance(x, (int, np.integer)), value.keys())):
+        for key, value in value.items():
+            map_int2var[int(key)] = python_object_to_variant(value)
+        return make_variant[unordered_map[int, Variant]](map_int2var)
+    if all(map(lambda x: isinstance(x, (str, bytes)), value.keys())):
+        for key, value in value.items():
+            key_bytes = utils.to_bytes(key)
+            map_str2var[key_bytes] = python_object_to_variant(value)
+        return make_variant[unordered_map[string, Variant]](map_str2var)
+    for k, v in value.items():
+        if not isinstance(k, (str, bytes, int, np.integer)):
+            raise TypeError(
+                f"No conversion from type "
+                f"'dict_item([({type(k).__name__}, {type(v).__name__})])'"
+                f" to 'Variant[std::unordered_map<int, Variant>]' or"
+                f" to 'Variant[std::unordered_map<std::string, Variant>]'")
+    raise AssertionError("dev note: a type is missing in the for loop above")
+
+
+cdef Variant _numpy_object_to_variant(value) except *:
     cdef vector[Variant] vec_variant
     cdef vector[int] vec_int
     cdef vector[double] vec_double
-    cdef unordered_map[int, Variant] map_int2var
-    cdef unordered_map[string, Variant] map_str2var
-    cdef PObjectRef oref
     cdef int[::1] view_int
     cdef int[:, ::1] view_int_2d
     cdef int * data_int
     cdef double[::1] view_double
     cdef double[:, ::1] view_double_2d
     cdef double * data_double
-    cdef path fs_path
     cdef size_t index
     cdef size_t nrows
+    cdef size_t bufsize
+
+    if isinstance(value, array_variant):
+        if value.dtype.kind == "i":
+            view_int = np.ascontiguousarray(value, dtype=np.int32)
+            data_int = &view_int[0]
+            vec_int.assign(data_int, data_int + len(view_int))
+            return make_variant[vector[int]](vec_int)
+        if value.dtype.kind == "f":
+            view_double = np.ascontiguousarray(value, dtype=np.float64)
+            data_double = &view_double[0]
+            vec_double.assign(data_double, data_double + len(view_double))
+            return make_variant[vector[double]](vec_double)
+    if value.ndim == 1:
+        if value.dtype.kind == "f":
+            vec_double.reserve(len(value))
+            for e in value:
+                vec_double.push_back(e)
+            return make_variant[vector[double]](vec_double)
+        if value.dtype.kind == "i":
+            vec_int.reserve(len(value))
+            for e in value:
+                vec_int.push_back(e)
+            return make_variant[vector[int]](vec_int)
+    if value.ndim == 2:
+        if value.dtype.kind == "i":
+            nrows = value.shape[0]
+            bufsize = value.shape[1]
+            vec_variant.reserve(nrows)
+            vec_int.reserve(bufsize)
+            view_int_2d = np.ascontiguousarray(value, dtype=np.int32)
+            for index in range(nrows):
+                data_int = &view_int_2d[index, 0]
+                vec_int.assign(data_int, data_int + bufsize)
+                vec_variant.emplace_back(
+                    make_variant[vector[int]](vec_int))
+            return make_variant[vector[Variant]](vec_variant)
+        if value.dtype.kind == "f":
+            nrows = value.shape[0]
+            bufsize = value.shape[1]
+            vec_variant.reserve(nrows)
+            vec_double.reserve(bufsize)
+            view_double_2d = np.ascontiguousarray(value, dtype=np.float64)
+            for index in range(nrows):
+                data_double = &view_double_2d[index, 0]
+                vec_double.assign(data_double, data_double + bufsize)
+                vec_variant.emplace_back(
+                    make_variant[vector[double]](vec_double))
+            return make_variant[vector[Variant]](vec_variant)
+
+    return _python_object_to_variant_non_trivial_cases(value)
+
+
+cdef Variant _python_object_to_variant_non_trivial_cases(value) except *:
+    cdef vector[Variant] vec_variant
+    cdef vector[int] vec_int
+    cdef vector[double] vec_double
     cdef size_t bufsize
     cdef Vector3d vector3d
     cdef Vector3i vector3i
 
-    if value is None:
-        return Variant()
-
-    if isinstance(value, np.ndarray) and value.ndim == 0:
-        value = value.item()
-
-    # The order is important, the object character should
-    # be preserved even if the PScriptInterface derived class
-    # is iterable.
-    if isinstance(value, PScriptInterface):
-        oref = value.get_sip()
-        return make_variant(oref.sip)
-    if isinstance(value, dict):
-        if all(map(lambda x: isinstance(x, (int, np.integer)), value.keys())):
-            for key, value in value.items():
-                map_int2var[int(key)] = python_object_to_variant(value)
-            return make_variant[unordered_map[int, Variant]](map_int2var)
-        if all(map(lambda x: isinstance(x, (str, bytes)), value.keys())):
-            for key, value in value.items():
-                key_bytes = utils.to_bytes(key)
-                map_str2var[key_bytes] = python_object_to_variant(value)
-            return make_variant[unordered_map[string, Variant]](map_str2var)
-        for k, v in value.items():
-            if not isinstance(k, (str, bytes, int, np.integer)):
-                raise TypeError(
-                    f"No conversion from type "
-                    f"'dict_item([({type(k).__name__}, {type(v).__name__})])'"
-                    f" to 'Variant[std::unordered_map<int, Variant>]' or"
-                    f" to 'Variant[std::unordered_map<std::string, Variant>]'")
-        assert False, "dev note: a type is missing in the for loop above"
-    if isinstance(value, (str, bytes)):
-        return make_variant[string](utils.to_bytes(value))
-    if isinstance(value, pathlib.Path):
-        fs_path.assign(utils.to_bytes(str(value)))
-        return make_variant[path](fs_path)
-    if isinstance(value, np.ndarray):
-        if isinstance(value, array_variant):
-            if np.issubdtype(value.dtype, np.signedinteger):
-                view_int = np.ascontiguousarray(value, dtype=np.int32)
-                data_int = &view_int[0]
-                vec_int.assign(data_int, data_int + len(view_int))
-                return make_variant[vector[int]](vec_int)
-            if np.issubdtype(value.dtype, np.floating):
-                view_double = np.ascontiguousarray(value, dtype=np.float64)
-                data_double = &view_double[0]
-                vec_double.assign(data_double, data_double + len(view_double))
-                return make_variant[vector[double]](vec_double)
-        if value.ndim == 1:
-            if np.issubdtype(value.dtype, np.floating):
-                vec_double.reserve(len(value))
-                for e in value:
-                    vec_double.push_back(e)
-                return make_variant[vector[double]](vec_double)
-            if np.issubdtype(value.dtype, np.signedinteger):
-                vec_int.reserve(len(value))
-                for e in value:
-                    vec_int.push_back(e)
-                return make_variant[vector[int]](vec_int)
-        if value.ndim == 2:
-            if np.issubdtype(value.dtype, np.signedinteger):
-                nrows = value.shape[0]
-                bufsize = value.shape[1]
-                vec_variant.reserve(nrows)
-                vec_int.reserve(bufsize)
-                view_int_2d = np.ascontiguousarray(value, dtype=np.int32)
-                for index in range(nrows):
-                    data_int = &view_int_2d[index, 0]
-                    vec_int.assign(data_int, data_int + bufsize)
-                    vec_variant.emplace_back(
-                        make_variant[vector[int]](vec_int))
-                return make_variant[vector[Variant]](vec_variant)
-            if np.issubdtype(value.dtype, np.floating):
-                nrows = value.shape[0]
-                bufsize = value.shape[1]
-                vec_variant.reserve(nrows)
-                vec_double.reserve(bufsize)
-                view_double_2d = np.ascontiguousarray(value, dtype=np.float64)
-                for index in range(nrows):
-                    data_double = &view_double_2d[index, 0]
-                    vec_double.assign(data_double, data_double + bufsize)
-                    vec_variant.emplace_back(
-                        make_variant[vector[double]](vec_double))
-                return make_variant[vector[Variant]](vec_variant)
     if hasattr(value, "__iter__"):
         bufsize = len(value)
         if bufsize == 0:
@@ -383,8 +402,6 @@ cdef Variant python_object_to_variant(value) except *:
         for e in value:
             vec_variant.emplace_back(python_object_to_variant(e))
         return make_variant[vector[Variant]](vec_variant)
-    if isinstance(value, (type(True), np.bool_)):
-        return make_variant[cbool](value)
     if np.issubdtype(np.dtype(type(value)), np.signedinteger):
         return make_variant[int](value)
     if np.issubdtype(np.dtype(type(value)), np.floating):
@@ -396,6 +413,30 @@ cdef Variant python_object_to_variant(value) except *:
 cdef variant_to_python_object(const Variant & value):
     """Convert C++ Variant objects to Python objects."""
 
+    # handle inexpensive types first
+    if is_none(value):
+        return None
+    if is_type[cbool](value):
+        return get_value[cbool](value)
+    if is_type[size_t](value):
+        return get_value[size_t](value)
+    if is_type[int](value):
+        return get_value[int](value)
+    if is_type[double](value):
+        return get_value[double](value)
+    if is_type[string](value):
+        return utils.to_str(get_value[string](value))
+    if is_type[path](value):
+        filepath = utils.to_str(get_value[path](value).generic_string())
+        return pathlib.Path(filepath)
+    if is_type[vector[int]](value):
+        return get_value[vector[int]](value)
+    if is_type[vector[double]](value):
+        return np.array(get_value[vector[double]](value))
+
+    return variant_to_python_object_non_trivial_cases(value)
+
+cdef variant_to_python_object_non_trivial_cases(const Variant & value):
     cdef vector[Variant] vec
     cdef unordered_map[int, Variant] map_int2var
     cdef unordered_map[string, Variant] map_str2var
@@ -410,35 +451,19 @@ cdef variant_to_python_object(const Variant & value):
     cdef cnp.ndarray[cnp.float64_t, ndim = 2] arrayNvec3d
     cdef size_t index
     cdef size_t nrows
-    if is_none(value):
-        return None
-    if is_type[cbool](value):
-        return get_value[cbool](value)
-    if is_type[int](value):
-        return get_value[int](value)
-    if is_type[double](value):
-        return get_value[double](value)
-    if is_type[string](value):
-        return utils.to_str(get_value[string](value))
-    if is_type[path](value):
-        filepath = utils.to_str(get_value[path](value).generic_string())
-        return pathlib.Path(filepath)
-    if is_type[vector[int]](value):
-        return get_value[vector[int]](value)
-    if is_type[vector[double]](value):
-        return np.array(get_value[vector[double]](value))
-    if is_type[Vector3b](value):
-        vec3b = get_value[Vector3b](value)
-        return utils.array_locked([vec3b[0], vec3b[1], vec3b[2]])
-    if is_type[Vector3i](value):
-        vec3i = get_value[Vector3i](value)
-        return utils.array_locked([vec3i[0], vec3i[1], vec3i[2]])
-    if is_type[Vector4d](value):
-        vec4d = get_value[Vector4d](value)
-        return utils.array_locked([vec4d[0], vec4d[1], vec4d[2], vec4d[3]])
+
     if is_type[Vector3d](value):
         vec3d = get_value[Vector3d](value)
         return utils.array_locked([vec3d[0], vec3d[1], vec3d[2]])
+    if is_type[Vector3i](value):
+        vec3i = get_value[Vector3i](value)
+        return utils.array_locked([vec3i[0], vec3i[1], vec3i[2]])
+    if is_type[Vector3b](value):
+        vec3b = get_value[Vector3b](value)
+        return utils.array_locked([vec3b[0], vec3b[1], vec3b[2]])
+    if is_type[Vector4d](value):
+        vec4d = get_value[Vector4d](value)
+        return utils.array_locked([vec4d[0], vec4d[1], vec4d[2], vec4d[3]])
     if is_type[Vector2d](value):
         vec2d = get_value[Vector2d](value)
         return utils.array_locked([vec2d[0], vec2d[1]])
@@ -508,9 +533,6 @@ cdef variant_to_python_object(const Variant & value):
                 pair_str2var.second)
 
         return res
-
-    if is_type[size_t](value):
-        return get_value[size_t](value)
 
     raise TypeError("Unknown type")
 

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -27,6 +27,7 @@ import pathlib
 from . import utils
 from .utils cimport Vector3b, Vector3i, Vector2d, Vector3d, Vector4d
 from .utils cimport path
+from .utils cimport mpi_poll_runtime_messages
 cimport cpython.object
 cnp.import_array()
 
@@ -104,7 +105,7 @@ cdef class PScriptInterface:
             self.set_sip(
                 _om.get().make_shared(
                     policy_,
-                    utils.to_bytes(name),
+                    name.encode(),
                     out_params))
             utils.handle_errors(f"Raised during instantiation of '{name}'")
 
@@ -153,7 +154,7 @@ cdef class PScriptInterface:
 
         Parameters
         ----------
-        method : :obj:`str`
+        method : :obj:`str` or :obj:`bytes`
             Name of the core method.
         handle_errors_message : :obj:`str`, optional
             Custom error message for runtime errors raised in a MPI context.
@@ -171,7 +172,9 @@ cdef class PScriptInterface:
 
         # the internal buffer of a cython bytestring object can be accessed as
         # a raw char pointer, but then the bytestring object must be kept alive
-        method_name_bytes_counted_reference = utils.to_bytes(method)
+        method_name_bytes_counted_reference = method
+        if not type(method) is bytes:
+            method_name_bytes_counted_reference = utils.to_bytes(method)
         cdef char * method_name_char = method_name_bytes_counted_reference
 
         if with_nogil:
@@ -180,9 +183,10 @@ cdef class PScriptInterface:
         else:
             result = handle.call_method(method_name_char, parameters)
         result_py = variant_to_python_object(result)
-        if handle_errors_message is None:
-            handle_errors_message = f"Raised while calling method {method}()"
-        utils.handle_errors(handle_errors_message)
+        if mpi_poll_runtime_messages():
+            if handle_errors_message is None:
+                handle_errors_message = f"Raised while calling method {method_name_bytes_counted_reference.decode()}()"  # nopep8
+            utils.handle_errors(handle_errors_message)
         return result_py
 
     def name(self):
@@ -219,10 +223,8 @@ cdef class PScriptInterface:
 
 
 class array_variant(np.ndarray):
-
     """
     Returns a numpy.ndarray that will be serialized as a ``std::vector``.
-
     """
 
     def __new__(cls, input_array):

--- a/src/python/espressomd/script_interface.pyx
+++ b/src/python/espressomd/script_interface.pyx
@@ -547,7 +547,6 @@ def _unpickle_so_class(so_name, state):
         f"C++ class '{so_name}' is not associated to any Python class " \
         "(hint: the corresponding 'import espressomd.*' may be missing)"
     so = _python_class_by_so_name[so_name](sip=so_ptr)
-    so.define_bound_methods()
 
     return so
 
@@ -556,18 +555,51 @@ class ScriptInterfaceHelper(PScriptInterface):
     _so_name = None
     _so_features = ()
     _so_bind_methods = ()
+    _so_features_error = None
     _so_checkpointable = True
     _so_creation_policy = "GLOBAL"
 
     def __init__(self, **kwargs):
-        cdef vector[string] features_vec
-        if self._so_features:
-            for feature in self._so_features:
-                features_vec.push_back(utils.to_bytes(feature))
-            check_features(features_vec)
+        if self._so_features_error:
+            raise RuntimeError(self._so_features_error)
         super().__init__(self._so_name, policy=self._so_creation_policy,
                          **kwargs)
-        self.define_bound_methods()
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        for method_name in cls._so_bind_methods:
+            cls._install_bound_method(method_name)
+
+        cdef vector[string] features_vec
+        if cls._so_features:
+            for feature in cls._so_features:
+                features_vec.push_back(feature.encode())
+            msg = utils.to_str(check_features_msg(features_vec))
+            if msg:
+                cls._so_features_error = msg
+
+    @classmethod
+    def _install_bound_method(cls, method_name):
+        """
+        Bind C++ methods declared in ``_so_bind_methods`` to the Python class.
+        This factory method compiles a code object whose ``co_name`` is the
+        method name. It would be easier to declare a local Python function,
+        but it would inherit the code object of the current scope, and code
+        profilers would make this factory method ``_install_bound_method``
+        appear in the traceback of every call to ``call_method``, which would
+        be confusing to new developers and AI coding agents. By binding a
+        distinct code object, the traceback features the correct method name.
+        """
+        assert method_name.isidentifier(), f"{method_name!r} isn't a suitable name for a function"  # nopep8
+        filename = f"<espressomd bound method: {cls.__qualname__}.{method_name}>"  # nopep8
+        src = (f"def {method_name}(self, **kwargs):\n"
+               f"    return self.call_method({method_name.encode()!r}, **kwargs)\n")
+        namespace = {}
+        exec(compile(src, filename, "exec"), namespace)
+        fn = namespace[method_name]
+        fn.__qualname__ = f"{cls.__qualname__}.{method_name}"
+        fn.__module__ = cls.__module__
+        setattr(cls, method_name, fn)
 
     def __reduce__(self):
         assert self._so_checkpointable, f"Class '{self.__class__.__name__}' doesn't support checkpointing"  # nopep8
@@ -597,17 +629,6 @@ class ScriptInterfaceHelper(PScriptInterface):
             raise RuntimeError(f"Parameter '{attr}' is read-only")
         else:
             super().__delattr__(attr)
-
-    def generate_caller(self, method_name):
-        def template_method(**kwargs):
-            res = self.call_method(method_name, **kwargs)
-            return res
-
-        return template_method
-
-    def define_bound_methods(self):
-        for method_name in self._so_bind_methods:
-            setattr(self, method_name, self.generate_caller(method_name))
 
 
 class ScriptObjectList(ScriptInterfaceHelper):

--- a/src/python/espressomd/utils.pxd
+++ b/src/python/espressomd/utils.pxd
@@ -42,6 +42,7 @@ cdef extern from "error_handling/RuntimeError.hpp":
 
 cdef extern from "errorhandling.hpp" namespace "ErrorHandling":
     cdef vector[CoreRuntimeError] mpi_gather_runtime_errors()
+    cdef cbool mpi_poll_runtime_messages()
 
 cdef extern from "utils/Vector.hpp" namespace "Utils":
     cppclass Vector2d:

--- a/src/python/espressomd/utils.pyx
+++ b/src/python/espressomd/utils.pyx
@@ -84,6 +84,19 @@ def check_type_or_throw_except(x, n, t, msg):
                 f"{msg} -- Item {i} was of type {type(x[i]).__name__}")
 
 
+# map of the most common function keyword argument names, converted to bytes
+cdef dict _fast_map_str2bytes = {x: x.encode() for x in [
+    "id", "type", "pos", "v", "f", "q", "dipm", "dip", "quat", "director",
+    "mass", "omega_lab", "omega_body", "torque_lab", "fix", "rotation",
+    "pos_folded", "image_box", "by_id", "by_ids", "part", "steps",
+    "pid", "pids", "ptype", "box_l", "properties", "add_particle",
+    "get_highest_particle_id", "integrator", "id_selection", "cell_system",
+    "analysis", "integrate", "recalc_forces", "reuse_forces",
+    "get_particle_ids", "name", "get_param_parallel", "calculate_energy",
+    "non_bonded_inter", "index", "_index", "node_sip", "parent_sip", "shape",
+    "slice_lower_corner", "slice_upper_corner"]}
+
+
 def to_bytes(s):
     """
     Return a Cython bytes object which contains the information of the provided
@@ -94,13 +107,18 @@ def to_bytes(s):
     s : :obj:`str` or :obj:`bytes`
 
     """
-    if isinstance(s, str):
+    if type(s) is str:
+        # dict lookup is much cheaper than conversion
+        if s in _fast_map_str2bytes:
+            return _fast_map_str2bytes[s]
+        return s.encode()
+    if type(s) is bytes:
+        return s
+    if isinstance(s, np.str_):
         return s.encode()
     if isinstance(s, np.bytes_):
         return bytes(s)
-    if isinstance(s, bytes):
-        return s
-    raise ValueError(f"Unknown string type {type(s)}")
+    raise TypeError(f"Unknown string type {type(s)}")
 
 
 def to_str(s):
@@ -112,13 +130,15 @@ def to_str(s):
     s : char*
 
     """
-    if isinstance(s, bytes):
+    if type(s) is bytes:
+        return s.decode()
+    if type(s) is str:
+        return s
+    if isinstance(s, np.bytes_):
         return s.decode()
     if isinstance(s, np.str_):
         return str(s)
-    if isinstance(s, str):
-        return s
-    raise ValueError(f"Unknown string type {type(s)}")
+    raise TypeError(f"Unknown bytes type {type(s)}")
 
 
 class array_locked(np.ndarray):

--- a/src/script_interface/analysis/Analysis.cpp
+++ b/src/script_interface/analysis/Analysis.cpp
@@ -314,6 +314,10 @@ Variant Analysis::do_call_method(std::string const &name,
   if (name == "calculate_pressure_tensor") {
     return m_obs_stat->do_call_method("calculate_pressure_tensor", {});
   }
+  if (name == "_observable_stat_test_fallthrough") {
+    // this is only exposed for unit testing purposes
+    return m_obs_stat->do_call_method("unknown", {});
+  }
 #ifdef ESPRESSO_NPT
   if (name == "get_instantaneous_pressure") {
     return get_system().npt_inst_pressure->p_inst[0];

--- a/src/script_interface/analysis/ObservableStat.cpp
+++ b/src/script_interface/analysis/ObservableStat.cpp
@@ -158,16 +158,16 @@ Variant ObservableStat::do_call_method(std::string const &name,
                                        VariantMap const &) {
   auto &system = get_system();
   if (name == "calculate_energy") {
-    auto const obs = system.calculate_energy();
-    return get_summary(system, *obs, false);
+    auto const &obs = system.calculate_energy();
+    return get_summary(system, obs, false);
   }
   if (name == "calculate_scalar_pressure") {
-    auto const obs = system.calculate_pressure();
-    return get_summary(system, *obs, true);
+    auto const &obs = system.calculate_pressure();
+    return get_summary(system, obs, true);
   }
   if (name == "calculate_pressure_tensor") {
-    auto const obs = system.calculate_pressure();
-    return get_summary(system, *obs, false);
+    auto const &obs = system.calculate_pressure();
+    return get_summary(system, obs, false);
   }
   return {};
 }

--- a/src/script_interface/code_info/CodeInfo.cpp
+++ b/src/script_interface/code_info/CodeInfo.cpp
@@ -98,21 +98,28 @@ Variant CodeInfo::do_call_method(std::string const &name, VariantMap const &) {
   return {};
 }
 
-void check_features(std::vector<std::string> const &features) {
+std::string check_features_msg(std::vector<std::string> const &features) {
   auto const allowed = get_feature_set(FEATURES_ALL, NUM_FEATURES_ALL);
   auto const compiled_features = get_feature_set(FEATURES, NUM_FEATURES);
   std::vector<std::string> missing_features{};
   for (auto const &feature : features) {
     if (not allowed.contains(feature)) {
-      throw std::runtime_error("Unknown feature '" + feature + "'");
+      return "Unknown feature '" + feature + "'";
     }
     if (not compiled_features.contains(feature)) {
       missing_features.emplace_back(feature);
     }
   }
   if (not missing_features.empty()) {
-    throw std::runtime_error("Missing features " +
-                             boost::algorithm::join(missing_features, ", "));
+    return "Missing features " + boost::algorithm::join(missing_features, ", ");
+  }
+  return "";
+}
+
+void check_features(std::vector<std::string> const &features) {
+  auto const error_msg = check_features_msg(features);
+  if (not error_msg.empty()) {
+    throw std::runtime_error(error_msg);
   }
 }
 

--- a/src/script_interface/code_info/CodeInfo.hpp
+++ b/src/script_interface/code_info/CodeInfo.hpp
@@ -33,7 +33,11 @@ public:
                          VariantMap const &parameters) override;
 };
 
+/** @brief Throw an exception when a feature is missing or not recognized. */
 void check_features(std::vector<std::string> const &features);
+
+/** @brief Generate a message when a feature is missing or not recognized. */
+std::string check_features_msg(std::vector<std::string> const &features);
 
 } // namespace CodeInfo
 } // namespace ScriptInterface

--- a/testsuite/python/analyze_energy.py
+++ b/testsuite/python/analyze_energy.py
@@ -264,6 +264,10 @@ class AnalyzeEnergy(ut.TestCase):
             self.assertEqual(get_non_bonded_energy(p1), 0.)
             self.assertEqual(get_non_bonded_energy(p2), 0.)
 
+    def test_fallthrough(self):
+        self.assertIsNone(
+            self.system.analysis.call_method("_observable_stat_test_fallthrough"))
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/coulomb_interface.py
+++ b/testsuite/python/coulomb_interface.py
@@ -188,6 +188,9 @@ class Test(ut.TestCase):
         if espressomd.has_features(["CUDA"]) and espressomd.gpu_available():
             with self.assertRaisesRegex(ValueError, "P3M GPU only implemented in single-precision mode"):
                 P3M(single_precision=False, gpu=True, **p3m_params)
+        if not espressomd.has_features(["CUDA"]):
+            with self.assertRaisesRegex(RuntimeError, "Missing features CUDA"):
+                P3M(single_precision=True, gpu=True, **p3m_params)
         with self.assertRaisesRegex(ValueError, "Parameter 'actor' of type Coulomb::ElectrostaticLayerCorrection isn't supported by ELC"):
             ELC(gap_size=2., maxPWerror=1., actor=elc)
         with self.assertRaisesRegex(ValueError, "Parameter 'actor' of type Coulomb::DebyeHueckel isn't supported by ELC"):

--- a/testsuite/python/script_interface.py
+++ b/testsuite/python/script_interface.py
@@ -192,6 +192,66 @@ class ScriptInterface(ut.TestCase):
         with self.assertRaises(NotImplementedError):
             a <= c
 
+    def test_extract_method_docstrings(self):
+        prelude = "    Sphere object.\n\n    More text"
+        prologue = "    Bibliography\n    ------\n    Entry 1."
+        methods_title = "    Methods\n    ----"
+
+        # check complete method list
+        methods = methods_title + "\n"
+        methods_ref = {}
+        for method_name in espressomd.shapes.Sphere._so_bind_methods:
+            methods_ref[method_name] = f"    Text of {method_name}"
+            methods += f"    {method_name}()\n    {methods_ref[method_name]}\n"
+        espressomd.shapes.Sphere.__doc__ = f"{prelude}\n{methods}\n{prologue}"
+        new_doc, result = espressomd.shapes.Sphere._extract_method_docstrings()
+        self.assertEqual(new_doc, f"{prelude}\n\n{prologue}")
+        self.assertEqual(result, methods_ref)
+        espressomd.shapes.Sphere.__doc__ = f"{prelude}\n{methods}"
+        new_doc, result = espressomd.shapes.Sphere._extract_method_docstrings()
+        self.assertEqual(new_doc, f"{prelude}\n\n")
+        self.assertEqual(result, methods_ref)
+        espressomd.shapes.Sphere.__doc__ = f"{methods}\n{prologue}"
+        new_doc, result = espressomd.shapes.Sphere._extract_method_docstrings()
+        self.assertEqual(new_doc, f"\n\n{prologue}")
+        self.assertEqual(result, methods_ref)
+
+        # check complete method list with extra synthetic methods
+        methods = methods_title + "\n"
+        for method_name in espressomd.shapes.Sphere._so_bind_methods:
+            methods += f"    {method_name}()\n    {methods_ref[method_name]}\n"
+        methods += "    zb(a)\n        Text of zb\n"
+        espressomd.shapes.Sphere.__doc__ = f"{prelude}\n{methods}\n{prologue}"
+        new_doc, result = espressomd.shapes.Sphere._extract_method_docstrings()
+        self.assertEqual(new_doc, f"{prelude}\n{methods_title}\n    zb(a)\n        Text of zb\n\n{prologue}")  # nopep8
+        self.assertEqual(result, methods_ref)
+
+        # check empty method list
+        espressomd.shapes.Sphere.__doc__ = f"{prelude}\n{prologue}"
+        new_doc, result = espressomd.shapes.Sphere._extract_method_docstrings()
+        self.assertEqual(new_doc, f"{prelude}\n{prologue}")
+        self.assertEqual(result, {})
+
+        # check docstring too short
+        espressomd.shapes.Sphere.__doc__ = "Sphere object."
+        new_doc, result = espressomd.shapes.Sphere._extract_method_docstrings()
+        self.assertEqual(new_doc, "Sphere object.")
+        self.assertEqual(result, {})
+
+        # check empty docstring
+        espressomd.shapes.Sphere.__doc__ = ""
+        new_doc, result = espressomd.shapes.Sphere._extract_method_docstrings()
+        self.assertEqual(new_doc, "")
+        self.assertEqual(result, {})
+
+        # check broken docstring
+        espressomd.shapes.Sphere.__doc__ = f"{methods_title}\n    broken\n    zb(a)\n        Text"  # nopep8
+        with self.assertRaisesRegex(AssertionError, "malformed docstring in <class 'espressomd.shapes.Sphere'>, cannot interpret 'broken'"):
+            espressomd.shapes.Sphere._extract_method_docstrings()
+        espressomd.shapes.Sphere.__doc__ = f"{methods_title}\n    wrong name(a)\n        Text"  # nopep8
+        with self.assertRaisesRegex(AssertionError, r"'wrong name' isn't a suitable name for a class method \(in docstring of <class 'espressomd.shapes.Sphere'>\)"):
+            espressomd.shapes.Sphere._extract_method_docstrings()
+
 
 if __name__ == "__main__":
     ut.main()

--- a/testsuite/python/utils.py
+++ b/testsuite/python/utils.py
@@ -96,6 +96,8 @@ class Test(ut.TestCase):
         check_to_str(np.str_("Åüb"), "Åüb")
         check_to_str(np.bytes_(b"abc"), "abc")
         check_to_str(np.bytes_(b"\xc3\x85\xc3\xbcb"), "Åüb")
+        with self.assertRaisesRegex(TypeError, "Unknown bytes type <class 'int'>"):
+            utils.to_str(55)
 
     def test_string_conversion_to_bytes(self):
         def check_to_bytes(obj, ref):
@@ -107,8 +109,12 @@ class Test(ut.TestCase):
         check_to_bytes("abc", b"abc")
         check_to_bytes("Åüb", b"\xc3\x85\xc3\xbcb")
         check_to_bytes(b"\xc3\x85\xc3\xbcb", b"\xc3\x85\xc3\xbcb")
+        check_to_bytes(np.str_("abc"), b"abc")
+        check_to_bytes(np.str_("Åüb"), b"\xc3\x85\xc3\xbcb")
         check_to_bytes(np.bytes_(b"abc"), b"abc")
         check_to_bytes(np.bytes_(b"\xc3\x85\xc3\xbcb"), b"\xc3\x85\xc3\xbcb")
+        with self.assertRaisesRegex(TypeError, "Unknown string type <class 'int'>"):
+            utils.to_bytes(55)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Description of changes:
- skip superfluous MPI serialization and communication in the MpiCallbacks framework when the world size is 1
- avoid OpenMP fork/join in `Kokkos::deep_copy` and `Kokkos::parallel_for` when using only 1 thread per rank
- improve cache re-use in the energy and pressure observables
- reduce overhead of the Python script interface
   - make conversion from C++ `Variant` to Python `ScriptInterfaceHelper` much cheaper
   - make conversion from Python `object` to C++ `Variant` much cheaper
   - make string conversion operations much cheaper by leveraging interned strings
   - bind C++ methods only once per class definition, rather than once per class instantiation
- bound C++ methods can now display their docstring in Jupyter