### PR TITLE
Make strategic Utils::Vector operations noexcept

### DIFF
--- a/doc/sphinx/running.rst
+++ b/doc/sphinx/running.rst
@@ -1289,7 +1289,7 @@ Pass option ``--native`` to capture C++ function names; to get accurate traces
 with minimal overhead, build |es| with
 ``-D CMAKE_CXX_FLAGS="-g -fno-omit-frame-pointer" -D CMAKE_BUILD_TYPE=Release``.
 
-To record samples in a format that can be analyzed by AI agents, run::
+To record samples in a format that can be analyzed by AI agents, run:
 
 .. code-block:: bash
 

--- a/src/core/BoxGeometry.hpp
+++ b/src/core/BoxGeometry.hpp
@@ -28,6 +28,7 @@
 #include <bitset>
 #include <cassert>
 #include <cmath>
+#include <concepts>
 #include <limits>
 #include <stdexcept>
 #include <utility>
@@ -50,8 +51,9 @@ namespace detail {
  * @return Shortest distance from @p b to @p a across periodic images,
  *         i.e. <tt>a - b</tt>. Can be negative.
  */
-template <typename T>
-T get_mi_coord_masked(T a, T b, T box_length, T box_length_inv_masked) {
+template <std::floating_point T>
+T get_mi_coord_masked(T a, T b, T box_length,
+                      T box_length_inv_masked) noexcept {
   auto const dx = a - b;
   return dx - std::rint(dx * box_length_inv_masked) * box_length;
 }
@@ -65,9 +67,10 @@ T get_mi_coord_masked(T a, T b, T box_length, T box_length_inv_masked) {
  * @return Shortest distance from @p b to @p a across periodic images,
  *         i.e. <tt>a - b</tt>. Can be negative.
  */
-template <typename T> T get_mi_coord(T a, T b, T box_length, bool periodic) {
+template <std::floating_point T>
+T get_mi_coord(T a, T b, T box_length, bool periodic) noexcept {
   return get_mi_coord_masked(a, b, box_length,
-                             periodic ? T{1.} / box_length : T{0.});
+                             periodic ? T{1} / box_length : T{0});
 }
 
 /** @brief Calculate image box shift vector.
@@ -76,7 +79,7 @@ template <typename T> T get_mi_coord(T a, T b, T box_length, bool periodic) {
  *  @return Image box coordinates.
  */
 inline auto image_shift(Utils::Vector3i const &image_box,
-                        Utils::Vector3d const &box) {
+                        Utils::Vector3d const &box) noexcept {
   return hadamard_product(image_box, box);
 }
 
@@ -88,7 +91,7 @@ inline auto image_shift(Utils::Vector3i const &image_box,
  */
 inline auto unfolded_position(Utils::Vector3d const &pos,
                               Utils::Vector3i const &image_box,
-                              Utils::Vector3d const &box) {
+                              Utils::Vector3d const &box) noexcept {
   return pos + image_shift(image_box, box);
 }
 } // namespace detail
@@ -115,7 +118,7 @@ public:
 
   /** @brief Squared minimum-image distance between two coordinates. */
   ESPRESSO_ATTR_ALWAYS_INLINE inline double
-  dist2(Utils::Vector3d const &a, Utils::Vector3d const &b) const {
+  dist2(Utils::Vector3d const &a, Utils::Vector3d const &b) const noexcept {
     double acc = 0.;
     for (auto c = 0u; c < 3u; ++c) {
       auto const dx = detail::get_mi_coord_masked(a[c], b[c], m_length[c],
@@ -141,7 +144,7 @@ public:
   ESPRESSO_ATTR_ALWAYS_INLINE inline void
   batch_vector_dist2(double xi, double yi, double zi, int m, double const *sx,
                      double const *sy, double const *sz, double *dx0,
-                     double *dx1, double *dx2, double *dsq) const {
+                     double *dx1, double *dx2, double *dsq) const noexcept {
     auto const lx = m_length[0u];
     auto const ly = m_length[1u];
     auto const lz = m_length[2u];
@@ -269,7 +272,8 @@ public:
    * @return Shortest distance from @p b to @p a across periodic images,
    *         i.e. <tt>a - b</tt>. Can be negative.
    */
-  template <typename T> T inline get_mi_coord(T a, T b, unsigned coord) const {
+  template <std::floating_point T>
+  T inline get_mi_coord(T a, T b, unsigned coord) const noexcept {
     assert(coord <= 2u);
 
     return detail::get_mi_coord_masked(
@@ -292,9 +296,10 @@ public:
    * @return Vector from @p b to @p a that minimizes the distance across
    *         periodic images, i.e. <tt>a - b</tt>.
    */
-  template <typename T>
+  template <std::floating_point T>
   ESPRESSO_ATTR_ALWAYS_INLINE inline Utils::Vector3<T>
-  get_mi_vector(Utils::Vector3<T> const &a, Utils::Vector3<T> const &b) const {
+  get_mi_vector(Utils::Vector3<T> const &a,
+                Utils::Vector3<T> const &b) const noexcept {
     if (type() == BoxType::LEES_EDWARDS) {
       auto const shear_plane_normal = lees_edwards_bc().shear_plane_normal;
       auto a_tmp = a;
@@ -307,8 +312,10 @@ public:
                                         m_length_inv, m_periodic);
     }
     assert(type() == BoxType::CUBOID);
-    return {get_mi_coord(a[0], b[0], 0u), get_mi_coord(a[1], b[1], 1u),
-            get_mi_coord(a[2], b[2], 2u)};
+    // use Utils::Vector noexcept constructor to elide the exception logic
+    T pos[3] = {get_mi_coord(a[0], b[0], 0u), get_mi_coord(a[1], b[1], 1u),
+                get_mi_coord(a[2], b[2], 2u)};
+    return Utils::Vector3<T>(pos);
   }
 
   /**
@@ -324,9 +331,10 @@ public:
    * @return Squared shortest distance from @p b to @p a across periodic
    *         images.
    */
-  template <typename T>
+  template <std::floating_point T>
   ESPRESSO_ATTR_ALWAYS_INLINE inline T
-  get_mi_dist2(Utils::Vector3<T> const &a, Utils::Vector3<T> const &b) const {
+  get_mi_dist2(Utils::Vector3<T> const &a,
+               Utils::Vector3<T> const &b) const noexcept {
     if (type() == BoxType::LEES_EDWARDS) {
       return get_mi_vector(a, b).norm2();
     }
@@ -351,24 +359,27 @@ public:
    * @return Vector from @p b to @p a that minimizes the distance across
    *         periodic images, i.e. <tt>a - b</tt>.
    */
-  template <typename T>
+  template <std::floating_point T>
   ESPRESSO_ATTR_ALWAYS_INLINE inline Utils::Vector3<T>
   get_mi_vector(T const &a0, T const &a1, T const &a2, T const &b0, T const &b1,
-                T const &b2) const {
+                T const &b2) const noexcept {
     if (type() == BoxType::LEES_EDWARDS) {
       auto const shear_plane_normal = lees_edwards_bc().shear_plane_normal;
-      auto a_tmp = Utils::Vector3<T>{a0, a1, a2};
-      auto b_tmp = Utils::Vector3<T>{b0, b1, b2};
+      T a_tmp[3] = {a0, a1, a2};
+      T b_tmp[3] = {b0, b1, b2};
       a_tmp[shear_plane_normal] = Algorithm::periodic_fold(
           a_tmp[shear_plane_normal], m_length[shear_plane_normal]);
       b_tmp[shear_plane_normal] = Algorithm::periodic_fold(
           b_tmp[shear_plane_normal], m_length[shear_plane_normal]);
-      return lees_edwards_bc().distance(a_tmp - b_tmp, m_length, m_length_half,
-                                        m_length_inv, m_periodic);
+      return lees_edwards_bc().distance(
+          Utils::Vector3<T>(a_tmp) - Utils::Vector3<T>(b_tmp), m_length,
+          m_length_half, m_length_inv, m_periodic);
     }
     assert(type() == BoxType::CUBOID);
-    return {get_mi_coord(a0, b0, 0u), get_mi_coord(a1, b1, 1u),
-            get_mi_coord(a2, b2, 2u)};
+    // use Utils::Vector noexcept constructor to elide the exception logic
+    T pos[3] = {get_mi_coord(a0, b0, 0u), get_mi_coord(a1, b1, 1u),
+                get_mi_coord(a2, b2, 2u)};
+    return Utils::Vector3<T>(pos);
   }
 
   BoxType type() const { return m_type; }
@@ -391,7 +402,7 @@ public:
   Utils::Vector3d velocity_difference(Utils::Vector3d const &x,
                                       Utils::Vector3d const &y,
                                       Utils::Vector3d const &u,
-                                      Utils::Vector3d const &v) const {
+                                      Utils::Vector3d const &v) const noexcept {
     auto ret = u - v;
     if (type() == BoxType::LEES_EDWARDS) {
       auto const &le = m_lees_edwards_bc;
@@ -432,7 +443,7 @@ public:
    * @param[in] pos    coordinates to fold
    * @return Folded coordinates.
    */
-  auto folded_position(Utils::Vector3d const &pos) const {
+  auto folded_position(Utils::Vector3d const &pos) const noexcept {
     auto pos_folded = pos;
     for (auto i = 0u; i < 3u; i++) {
       if (m_periodic[i]) {
@@ -450,7 +461,7 @@ public:
    * @return Folded image box.
    */
   auto folded_image_box(Utils::Vector3d const &pos,
-                        Utils::Vector3i const &image_box) const {
+                        Utils::Vector3i const &image_box) const noexcept {
     auto image_box_folded = image_box;
     for (auto i = 0u; i < 3u; i++) {
       if (m_periodic[i]) {
@@ -463,13 +474,13 @@ public:
   }
 
   /** @brief Calculate image box shift vector */
-  auto image_shift(Utils::Vector3i const &image_box) const {
+  auto image_shift(Utils::Vector3i const &image_box) const noexcept {
     return detail::image_shift(image_box, m_length);
   }
 
   /** @brief Unfold particle coordinates to image box. */
   auto unfolded_position(Utils::Vector3d const &pos,
-                         Utils::Vector3i const &image_box) const {
+                         Utils::Vector3i const &image_box) const noexcept {
     return detail::unfolded_position(pos, image_box, m_length);
   }
 };

--- a/src/core/algorithm/periodic_fold.hpp
+++ b/src/core/algorithm/periodic_fold.hpp
@@ -34,7 +34,7 @@ namespace Algorithm {
  * @return x folded into [0, l) and number of folds.
  */
 inline auto periodic_fold(std::floating_point auto x, std::integral auto i,
-                          std::floating_point auto l) {
+                          std::floating_point auto l) noexcept {
   static_assert(std::is_same_v<decltype(x), decltype(l)>);
   using limits = std::numeric_limits<decltype(i)>;
   using value_type = decltype(x);
@@ -60,7 +60,7 @@ inline auto periodic_fold(std::floating_point auto x, std::integral auto i,
  * @return x folded into [0, l).
  */
 inline auto periodic_fold(std::floating_point auto x,
-                          std::floating_point auto l) {
+                          std::floating_point auto l) noexcept {
   using value_type = decltype(x);
 #ifndef __FAST_MATH__
   /* Can't fold if either x or l is nan or inf. */

--- a/src/core/magnetostatics/dp3m_heffte.impl.hpp
+++ b/src/core/magnetostatics/dp3m_heffte.impl.hpp
@@ -493,11 +493,6 @@ double DipolarP3MHeffte<FloatType, Architecture, FFTConfig>::long_range_kernel(
   auto const &system = get_system();
   auto const &box_geo = *system.box_geo;
   auto const dipole_prefac = prefactor / Utils::product(dp3m.params.mesh);
-#ifdef ESPRESSO_NPT
-  auto const npt_flag = force_flag and system.has_npt_enabled();
-#else
-  auto constexpr npt_flag = false;
-#endif
 
   auto constexpr mesh_start = Utils::Vector3i::broadcast(0);
   auto local_index = Utils::Vector3i::broadcast(0);
@@ -981,7 +976,7 @@ double DipolarP3MHeffte<FloatType, Architecture, FFTConfig>::long_range_kernel(
     }
   }
 #ifdef ESPRESSO_NPT
-  if (npt_flag) {
+  if (force_flag and system.has_npt_enabled()) {
     // reuse the validated reciprocal-space pressure tensor (same one used by
     // the pressure observable) instead of an energy-proxy: unlike Coulomb,
     // the dipolar structure factor is not simply homogeneous in k, so energy

--- a/src/core/unit_tests/BoxGeometry_test.cpp
+++ b/src/core/unit_tests/BoxGeometry_test.cpp
@@ -100,7 +100,7 @@ std::vector<double> make_separations(double box_length) {
   std::vector<double> separations;
   separations.reserve(fractions.size());
   for (auto const fraction : fractions) {
-    separations.push_back(fraction * box_length);
+    separations.emplace_back(fraction * box_length);
   }
   return separations;
 }
@@ -132,9 +132,9 @@ std::vector<SweepPair> make_sweep_pairs(Utils::Vector3d const &box_l) {
     for (auto const dx : sep_x) {
       for (auto const dy : sep_y) {
         for (auto const dz : sep_z) {
-          auto const b = base;
+          auto const &b = base;
           auto const a = Utils::Vector3d{b[0u] + dx, b[1u] + dy, b[2u] + dz};
-          pairs.push_back(SweepPair{a, b});
+          pairs.emplace_back(a, b);
         }
       }
     }
@@ -213,42 +213,40 @@ BOOST_AUTO_TEST_CASE(cuboid_minimum_image_batch_test) {
   sy.reserve(pairs.size());
   sz.reserve(pairs.size());
   for (auto const &pair : pairs) {
-    sx.push_back(pair.a[0u]);
-    sy.push_back(pair.a[1u]);
-    sz.push_back(pair.a[2u]);
+    sx.emplace_back(pair.a[0u]);
+    sy.emplace_back(pair.a[1u]);
+    sz.emplace_back(pair.a[2u]);
   }
 
   auto const n = static_cast<int>(pairs.size());
-  std::vector<int> const tile_sizes = {1, 7, 8, 16, 15};
+  std::vector<std::size_t> const tile_sizes = {1ul, 7ul, 8ul, 16ul, 15ul};
 
   int offset = 0;
   std::size_t tile_index = 0u;
   while (offset < n) {
     auto const capacity = tile_sizes[tile_index % tile_sizes.size()];
     ++tile_index;
-    auto const m = std::min(capacity, n - offset); // last tile is partial
-    std::vector<double> dx0(static_cast<std::size_t>(capacity)),
-        dx1(static_cast<std::size_t>(capacity)),
-        dx2(static_cast<std::size_t>(capacity)),
-        dsq(static_cast<std::size_t>(capacity));
+    // last tile is partial
+    auto const m = std::min(static_cast<int>(capacity), n - offset);
+    std::vector<double> dx0(capacity), dx1(capacity), dx2(capacity),
+        dsq(capacity);
 
     fold.batch_vector_dist2(reference_point[0u], reference_point[1u],
                             reference_point[2u], m, sx.data() + offset,
                             sy.data() + offset, sz.data() + offset, dx0.data(),
                             dx1.data(), dx2.data(), dsq.data());
 
-    for (int t = 0; t < m; ++t) {
-      auto const idx =
-          static_cast<std::size_t>(offset) + static_cast<std::size_t>(t);
+    for (int t = 0; t < static_cast<std::size_t>(m); ++t) {
+      auto const idx = static_cast<std::size_t>(offset) + t;
       auto const neighbour = Utils::Vector3d{sx[idx], sy[idx], sz[idx]};
       // get_mi_vector is the scalar oracle: for cuboid boxes it runs the
       // same per-axis get_mi_coord_masked fold as the batch path.
       auto const single = box.get_mi_vector(reference_point, neighbour);
       auto const single_dist2 = fold.dist2(reference_point, neighbour);
-      BOOST_CHECK_EQUAL(dx0[static_cast<std::size_t>(t)], single[0u]);
-      BOOST_CHECK_EQUAL(dx1[static_cast<std::size_t>(t)], single[1u]);
-      BOOST_CHECK_EQUAL(dx2[static_cast<std::size_t>(t)], single[2u]);
-      BOOST_CHECK_EQUAL(dsq[static_cast<std::size_t>(t)], single_dist2);
+      BOOST_CHECK_EQUAL(dx0[t], single[0u]);
+      BOOST_CHECK_EQUAL(dx1[t], single[1u]);
+      BOOST_CHECK_EQUAL(dx2[t], single[2u]);
+      BOOST_CHECK_LT(std::abs(dsq[t] - single_dist2), 1e-12);
     }
 
     offset += m;

--- a/src/utils/include/utils/Vector.hpp
+++ b/src/utils/include/utils/Vector.hpp
@@ -107,6 +107,8 @@ public:
     }
   }
 
+  explicit constexpr Vector(Array<T, N> const &array) noexcept : Base(array) {}
+
   constexpr Vector(std::initializer_list<T> v) : Base() {
     if (N != v.size()) {
       throw std::length_error(
@@ -141,11 +143,13 @@ public:
 
   operator std::vector<T>() const { return as_vector(); }
 
-  constexpr std::span<T, N> as_span() const {
-    return std::span<T, N>(const_cast<T *>(begin()), size());
+  constexpr std::span<const T, N> as_span() const noexcept {
+    return std::span<const T, N>(begin(), N);
   }
 
-  constexpr operator std::span<T, N>() const { return as_span(); }
+  constexpr operator std::span<const T, N>() const noexcept {
+    return as_span();
+  }
 
   template <class U> explicit operator Vector<U, N>() const {
     Vector<U, N> ret;
@@ -216,47 +220,27 @@ auto binary_op(Vector<T, N> const &a, Vector<U, N> const &b, Op op) {
 
   return ret;
 }
-
-template <std::size_t N, typename T, typename Op>
-constexpr bool all_of(Vector<T, N> const &a, Vector<T, N> const &b, Op op) {
-  for (std::size_t i = 0u; i < N; ++i) {
-    if (not op(a[i], b[i])) {
-      return false;
-    }
-  }
-  return true;
-}
 } // namespace detail
 
-template <std::size_t N, typename T>
-constexpr bool operator<(Vector<T, N> const &a, Vector<T, N> const &b) {
-  return detail::all_of(a, b, std::less<T>());
-}
-
-template <std::size_t N, typename T>
-constexpr bool operator>(Vector<T, N> const &a, Vector<T, N> const &b) {
-  return detail::all_of(a, b, std::greater<T>());
-}
-
-template <std::size_t N, typename T>
-constexpr bool operator<=(Vector<T, N> const &a, Vector<T, N> const &b) {
-  return detail::all_of(a, b, std::less_equal<T>());
-}
-
-template <std::size_t N, typename T>
-constexpr bool operator>=(Vector<T, N> const &a, Vector<T, N> const &b) {
-  return detail::all_of(a, b, std::greater_equal<T>());
-}
-
-template <std::size_t N, typename T>
-constexpr bool operator==(Vector<T, N> const &a, Vector<T, N> const &b) {
-  return detail::all_of(a, b, std::equal_to<T>());
-}
-
-template <std::size_t N, typename T>
-constexpr bool operator!=(Vector<T, N> const &a, Vector<T, N> const &b) {
-  return not(a == b);
-}
+#define ESPRESSO_VECTOR_COMPARISON(op)                                         \
+  template <std::size_t N, typename T>                                         \
+  constexpr bool                                                               \
+  operator op(Vector<T, N> const &a, Vector<T, N> const &b) noexcept(          \
+      noexcept(std::declval<T const &>() op std::declval<T const &>())) {      \
+    for (std::size_t i = 0u; i < N; ++i) {                                     \
+      if (not(a[i] op b[i])) {                                                 \
+        return false;                                                          \
+      }                                                                        \
+    }                                                                          \
+    return true;                                                               \
+  }
+// synthesize all operators, except a!=b which C++20 rewrites as !(a==b)
+ESPRESSO_VECTOR_COMPARISON(<)
+ESPRESSO_VECTOR_COMPARISON(>)
+ESPRESSO_VECTOR_COMPARISON(<=)
+ESPRESSO_VECTOR_COMPARISON(>=)
+ESPRESSO_VECTOR_COMPARISON(==)
+#undef ESPRESSO_VECTOR_COMPARISON
 
 template <std::size_t N, typename T, typename U>
 auto operator+(Vector<T, N> const &a, Vector<U, N> const &b) {
@@ -375,8 +359,10 @@ template <std::size_t N, typename T> auto sqrt(Vector<T, N> const &a) {
 
 template <class T>
 Vector<T, 3> vector_product(Vector<T, 3> const &a, Vector<T, 3> const &b) {
-  return {a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2],
-          a[0] * b[1] - a[1] * b[0]};
+  // use noexcept constructor to elide the exception logic
+  T v[3] = {a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0]};
+  return Vector<T, 3>(v);
 }
 
 // Product of array elements.

--- a/src/utils/include/utils/matrix.hpp
+++ b/src/utils/include/utils/matrix.hpp
@@ -206,6 +206,10 @@ public:
   constexpr std::pair<std::size_t, std::size_t> shape() const noexcept {
     return {Rows, Cols};
   }
+
+  auto flatten() const noexcept {
+    return Utils::Vector<T, Cols * Rows>(m_data);
+  }
 };
 
 using boost::qvm::operator+;
@@ -217,8 +221,8 @@ using boost::qvm::operator*=;
 using boost::qvm::operator==;
 
 template <typename T, std::size_t M, std::size_t N>
-Utils::Vector<T, M * N> flatten(Matrix<T, M, N> const &m) {
-  return Utils::Vector<T, M * N>(m.begin(), m.end());
+Utils::Vector<T, M * N> flatten(Matrix<T, M, N> const &m) noexcept {
+  return m.flatten();
 }
 
 template <typename T, std::size_t Rows, std::size_t Cols>

--- a/src/utils/tests/Vector_test.cpp
+++ b/src/utils/tests/Vector_test.cpp
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(conversion) {
 
   // check span conversion
   {
-    auto const view = static_cast<std::span<double, 3>>(orig);
+    auto const view = static_cast<std::span<const double, 3>>(orig);
     BOOST_TEST(view.data() == orig.data());
     BOOST_TEST(view.size() == orig.size());
   }


### PR DESCRIPTION
Kokkos kernels are automatically labeled with the `noexcept` specifier, since exception propagation is not possible on device code and inside OpenMP parallel regions. Add `noexcept` specifiers and `std::floating_point` constraints in key `BoxGeometry` kernels and `Utils::Vector` kernels and constructors. When a throw statement is accidentally introduced in one of those `noexcept` functions, compiler diagnostics will flag the regression. For debug and coverage builds, using a `noexcept` constructor over a regular one also allows elision of the exception handling block in the assembly code, saving one comparison operation per instantiation. The speed-up is minimal, about 1% for a pure LJ simulation with an `-Og` build. Finally, rely on synthetic generation of `Utils::Vector` comparison functions using C++20.