### PR TITLE
Code cleanup

### DIFF
--- a/src/core/MpiCallbacks.hpp
+++ b/src/core/MpiCallbacks.hpp
@@ -84,7 +84,7 @@ auto invoke(F f, boost::mpi::packed_iarchive &ia) {
 
   /* This is the local receive buffer for the parameters. We have to strip
      away const so we can actually deserialize into it. */
-  std::tuple<std::remove_const_t<std::remove_reference_t<Args>>...> params;
+  std::tuple<std::remove_cvref_t<Args>...> params;
   std::apply([&ia](auto &&...e) { ((ia >> e), ...); }, params);
 
   /* We add const here, so that parameters can only be by value

--- a/src/core/Observable_stat.cpp
+++ b/src/core/Observable_stat.cpp
@@ -33,6 +33,7 @@
 #include <cassert>
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <span>
 #include <vector>
 
@@ -82,7 +83,8 @@ void Observable_stat::reset(std::size_t n_bonded, int max_type) {
       std::span<double>(external_fields.end(), n_non_bonded * m_chunk_size);
   non_bonded_inter =
       std::span<double>(non_bonded_intra.end(), n_non_bonded * m_chunk_size);
-  assert(&*non_bonded_inter.end() == (m_data.data() + m_data.size()));
+  assert(std::to_address(non_bonded_inter.end()) ==
+         (m_data.data() + m_data.size()));
 }
 
 std::size_t Observable_stat::get_non_bonded_offset(int type1, int type2) const {

--- a/src/core/cell_system/CellStructure.cpp
+++ b/src/core/cell_system/CellStructure.cpp
@@ -39,6 +39,7 @@
 #include "kokkos_helpers.hpp"
 #include "lees_edwards/lees_edwards.hpp"
 #include "particle_enumeration.hpp"
+#include "particle_node.hpp"
 #include "particle_reduction.hpp"
 #include "system/System.hpp"
 
@@ -521,6 +522,8 @@ void CellStructure::remove_all_particles() {
 
   m_particle_index.clear();
   clear_bond_properties();
+  clear_particle_node();
+  get_system().on_particle_change();
 }
 
 /* Map the data parts flags from cells to those used internally

--- a/src/core/cell_system/HybridDecomposition.hpp
+++ b/src/core/cell_system/HybridDecomposition.hpp
@@ -77,7 +77,7 @@ class HybridDecomposition : public ParticleDecomposition {
   std::function<bool()> m_get_global_ghost_flags;
 
   bool is_n_square_type(int type_id) const {
-    return (m_n_square_types.find(type_id) != m_n_square_types.end());
+    return m_n_square_types.contains(type_id);
   }
 
 public:

--- a/src/core/cell_system/RegularDecomposition.cpp
+++ b/src/core/cell_system/RegularDecomposition.cpp
@@ -791,8 +791,8 @@ GhostComm::HaloPlan RegularDecomposition::make_halo_plan() {
     return a.first < b.first;
   };
   for (auto &[peer, bucket] : peers) {
-    std::sort(bucket.recv.begin(), bucket.recv.end(), by_key);
-    std::sort(bucket.send.begin(), bucket.send.end(), by_key);
+    std::ranges::sort(bucket.recv, by_key);
+    std::ranges::sort(bucket.send, by_key);
     NeighborComm nc;
     nc.peer = peer;
     nc.recv.reserve(bucket.recv.size());
@@ -806,8 +806,8 @@ GhostComm::HaloPlan RegularDecomposition::make_halo_plan() {
 
   // Sort the self-copies deterministically too (not required, but keeps the
   // plan reproducible run to run).
-  std::sort(local.begin(), local.end(),
-            [](auto const &a, auto const &b) { return a.first < b.first; });
+  std::ranges::sort(
+      local, [](auto const &a, auto const &b) { return a.first < b.first; });
   plan.local.reserve(local.size());
   for (auto &[key, lc] : local)
     plan.local.push_back(lc);

--- a/src/core/cells.cpp
+++ b/src/core/cells.cpp
@@ -35,7 +35,6 @@
 #include "Particle.hpp"
 #include "communication.hpp"
 #include "errorhandling.hpp"
-#include "particle_node.hpp"
 #include "system/System.hpp"
 
 #include <utils/Vector.hpp>

--- a/src/core/electrostatics/elc.cpp
+++ b/src/core/electrostatics/elc.cpp
@@ -146,13 +146,7 @@ prepare_sc_cache(ParticleRange const &particles, BoxGeometry const &box_geo,
 /*****************************************************************/
 
 static void clear_vec(double *pdc, std::size_t size) {
-  for (std::size_t i = 0; i < size; i++)
-    pdc[i] = 0.;
-}
-
-static void copy_vec(double *pdc_d, double const *pdc_s, std::size_t size) {
-  for (std::size_t i = 0; i < size; i++)
-    pdc_d[i] = pdc_s[i];
+  std::ranges::fill_n(pdc, static_cast<std::ptrdiff_t>(size), 0.);
 }
 
 static void add_vec(double *pdc_d, double const *pdc_s1, double const *pdc_s2,
@@ -179,7 +173,7 @@ static double *block(double *p, std::size_t index, std::size_t size) {
 static void distribute(std::size_t size) {
   assert(size <= 8);
   double send_buf[8];
-  copy_vec(send_buf, gblcblk, size);
+  std::ranges::copy_n(gblcblk, static_cast<std::ptrdiff_t>(size), send_buf);
   boost::mpi::all_reduce(comm_cart, send_buf, static_cast<int>(size), gblcblk,
                          std::plus<>());
 }

--- a/src/core/electrostatics/scafacos_impl.cpp
+++ b/src/core/electrostatics/scafacos_impl.cpp
@@ -40,6 +40,7 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <span>
 #include <string>
 

--- a/src/core/ghosts/HaloPlanValidator.cpp
+++ b/src/core/ghosts/HaloPlanValidator.cpp
@@ -75,7 +75,7 @@ validate_halo_plan(HaloPlan const &plan, std::span<Cell *const> local_cells,
   for (Cell *c : local_cells) {
     for (Cell *n : c->neighbors().all()) {
       ParticleList const *pl = &n->particles();
-      if (ghost_set.find(pl) != ghost_set.end()) {
+      if (ghost_set.contains(pl)) {
         referenced_ghosts.insert(pl);
       }
     }
@@ -104,7 +104,7 @@ validate_halo_plan(HaloPlan const &plan, std::span<Cell *const> local_cells,
 
     // Accumulate recv fill counts; check targets are in ghost set.
     for (ParticleList const *pl : nc.recv) {
-      if (ghost_set.find(pl) == ghost_set.end()) {
+      if (not ghost_set.contains(pl)) {
         std::ostringstream oss;
         oss << "NeighborComm peer=" << nc.peer
             << " recv target is not a ghost cell";
@@ -117,7 +117,7 @@ validate_halo_plan(HaloPlan const &plan, std::span<Cell *const> local_cells,
   // Accumulate local.dst fill counts; check targets are in ghost set.
   for (auto const &lc : plan.local) {
     ParticleList const *pl = lc.dst;
-    if (ghost_set.find(pl) == ghost_set.end()) {
+    if (not ghost_set.contains(pl)) {
       violations.emplace_back("LocalComm dst target is not a ghost cell");
     }
     ++fill_count[pl];
@@ -137,8 +137,7 @@ validate_halo_plan(HaloPlan const &plan, std::span<Cell *const> local_cells,
     auto it = fill_count.find(pl);
     int count = (it != fill_count.end()) ? it->second : 0;
     if (count == 0) {
-      if (collective_set.find(pl) == collective_set.end() &&
-          referenced_ghosts.find(pl) != referenced_ghosts.end()) {
+      if (not collective_set.contains(pl) and referenced_ghosts.contains(pl)) {
         violations.emplace_back(
             "ghost cell is never filled (missing recv/dst)");
       }
@@ -154,10 +153,10 @@ validate_halo_plan(HaloPlan const &plan, std::span<Cell *const> local_cells,
   for (Cell *c : local_cells) {
     for (Cell *n : c->neighbors().all()) {
       ParticleList const *pl = &n->particles();
-      if (ghost_set.find(pl) == ghost_set.end()) {
+      if (not ghost_set.contains(pl)) {
         continue; // not a ghost neighbor
       }
-      if (collective_set.find(pl) != collective_set.end()) {
+      if (collective_set.contains(pl)) {
         continue; // covered by the collective broadcast/reduce section
       }
       auto it = fill_count.find(pl);
@@ -177,7 +176,7 @@ validate_halo_plan(HaloPlan const &plan, std::span<Cell *const> local_cells,
       continue; // boundary cells are expected to have ghost neighbors
     }
     for (Cell *n : c->neighbors().all()) {
-      if (ghost_set.find(&n->particles()) != ghost_set.end()) {
+      if (ghost_set.contains(&n->particles())) {
         violations.emplace_back("interior cell has a ghost neighbor");
         break; // one violation per cell is sufficient
       }

--- a/src/core/observables/PairwiseDistances.hpp
+++ b/src/core/observables/PairwiseDistances.hpp
@@ -23,7 +23,6 @@
 #include "PidPairwiseDistancesObservable.hpp"
 #include "cell_system/CellStructure.hpp"
 #include "cells.hpp"
-#include "particle_node.hpp"
 #include "system/System.hpp"
 
 #include <utils/Vector.hpp>

--- a/src/core/pair_criteria/PairCriterion.hpp
+++ b/src/core/pair_criteria/PairCriterion.hpp
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ESPRESSO_SRC_CORE_PAIR_CRITERIA_PAIR_CRITERION_HPP
-#define ESPRESSO_SRC_CORE_PAIR_CRITERIA_PAIR_CRITERION_HPP
+
+#pragma once
 
 #include "Particle.hpp"
 #include "particle_node.hpp"
@@ -44,5 +44,3 @@ public:
   virtual ~PairCriterion() = default;
 };
 } // namespace PairCriteria
-
-#endif

--- a/src/core/particle_node.cpp
+++ b/src/core/particle_node.cpp
@@ -387,12 +387,6 @@ static bool maybe_move_particle(int p_id, Utils::Vector3d const &pos) {
   return true;
 }
 
-void remove_all_particles() {
-  get_cell_structure().remove_all_particles();
-  System::get_system().on_particle_change();
-  clear_particle_node();
-}
-
 void remove_particle(int p_id) {
   if (this_node == 0) {
     particle_node[p_id] = -1;

--- a/src/core/particle_node.hpp
+++ b/src/core/particle_node.hpp
@@ -96,9 +96,6 @@ void set_particle_pos(int p_id, Utils::Vector3d const &pos);
  */
 void remove_particle(int p_id);
 
-/** Remove all particles. */
-void remove_all_particles();
-
 /**
  * @brief Check if particle exists.
  *

--- a/src/core/unit_tests/p3m_test.cpp
+++ b/src/core/unit_tests/p3m_test.cpp
@@ -38,7 +38,6 @@
 #include "communication.hpp"
 #include "energy_inline.hpp"
 #include "integrate.hpp"
-#include "particle_node.hpp"
 #include "system/System.hpp"
 
 #include <utils/Vector.hpp>

--- a/src/script_interface/particle_data/ParticleList.cpp
+++ b/src/script_interface/particle_data/ParticleList.cpp
@@ -146,7 +146,7 @@ Variant ParticleList::do_call_method(std::string const &name,
     return get_maximal_particle_id();
   }
   if (name == "clear") {
-    remove_all_particles();
+    get_system().cell_structure->remove_all_particles();
     return {};
   }
   if (not context()->is_head_node()) {

--- a/src/script_interface/particle_data/ParticleList.hpp
+++ b/src/script_interface/particle_data/ParticleList.hpp
@@ -34,12 +34,6 @@ class ParticleList : public System::Leaf {
   std::weak_ptr<CellSystem::CellSystem> m_cell_structure;
   std::weak_ptr<Interactions::BondedInteractions> m_bonded_ias;
 
-  auto get_cell_structure() {
-    auto ptr = m_cell_structure.lock();
-    assert(ptr != nullptr);
-    return ptr;
-  }
-
 public:
   Variant do_call_method(std::string const &name,
                          VariantMap const &params) override;

--- a/src/utils/include/utils/serialization/memcpy_archive.hpp
+++ b/src/utils/include/utils/serialization/memcpy_archive.hpp
@@ -79,21 +79,21 @@ public:
   }
 
   void skip(std::size_t bytes) {
-    assert((insert + bytes) <= &*buf.end());
+    assert((insert + bytes) <= std::to_address(buf.end()));
     insert += bytes;
   }
 
 private:
   void read(void *data, std::size_t bytes) {
     /* check that there is enough space left in the buffer */
-    assert((insert + bytes) <= &*buf.end());
+    assert((insert + bytes) <= std::to_address(buf.end()));
     std::memcpy(data, insert, bytes);
     insert += bytes;
   }
 
   void write(const void *data, std::size_t bytes) {
     /* check that there is enough space left in the buffer */
-    assert((insert + bytes) <= &*buf.end());
+    assert((insert + bytes) <= std::to_address(buf.end()));
     std::memcpy(insert, data, bytes);
     insert += bytes;
   }


### PR DESCRIPTION
Description of changes:
- replace `&*buffer.end()` with `std::to_address(buffer.end())` to avoid dereferencing past-the-end iterators
- modernize code based on new features in C++20, remove unused code, add missing headers
- reduce `particle_node.hpp` footprint